### PR TITLE
implement {DELAY=X} in autotype

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -37,6 +37,7 @@ AutoType* AutoType::m_instance = nullptr;
 AutoType::AutoType(QObject* parent, bool test)
     : QObject(parent)
     , m_inAutoType(false)
+    , m_autoTypeDelay(0)
     , m_currentGlobalKey(static_cast<Qt::Key>(0))
     , m_currentGlobalModifiers(0)
     , m_pluginLoader(new QPluginLoader(this))
@@ -303,9 +304,10 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
 {
     QString tmpl;
     bool inTmpl = false;
+    m_autoTypeDelay = 0;
 
     for (const QChar& ch : sequence) {
-        // TODO: implement support for {{}, {}} and {DELAY=X}
+        // TODO: implement support for {{}, {}}
 
         if (inTmpl) {
             if (ch == '{') {
@@ -332,7 +334,17 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
             actions.append(new AutoTypeChar(ch));
         }
     }
-
+    if (m_autoTypeDelay > 0) {
+        QList<AutoTypeAction*>::iterator i;
+        i = actions.begin();
+        while (i != actions.end()) {
+            ++i;
+            if (i != actions.end()) {
+                i = actions.insert(i, new AutoTypeDelay(m_autoTypeDelay));
+                ++i;
+            }
+        }
+    }
     return true;
 }
 
@@ -341,6 +353,15 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
     QString tmplName = tmpl.toLower();
     int num = -1;
     QList<AutoTypeAction*> list;
+    QRegExp delayRegEx("delay=(\\d+)", Qt::CaseSensitive, QRegExp::RegExp2);
+    if (delayRegEx.exactMatch(tmplName)) {
+        num = delayRegEx.cap(1).toInt();
+
+        if (num > 0 && num < 10000) {
+            m_autoTypeDelay = num;
+        }
+        return list;
+    }
 
     QRegExp repeatRegEx("(.+) (\\d+)", Qt::CaseSensitive, QRegExp::RegExp2);
     if (repeatRegEx.exactMatch(tmplName)) {

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -69,6 +69,7 @@ private:
     bool windowMatches(const QString& windowTitle, const QString& windowPattern);
 
     bool m_inAutoType;
+    int m_autoTypeDelay;
     Qt::Key m_currentGlobalKey;
     Qt::KeyboardModifiers m_currentGlobalModifiers;
     QPluginLoader* m_pluginLoader;


### PR DESCRIPTION
{DELAY=X} sequence inserts Xms delay between each character during
autotype
## Motivation and Context
Resolves #76 


## Checklist:
<!--- Go over all the following points, if it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:`. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Pull Requests that fail the [REQUIRED] field will likely be sent back for corrections or rejected  -->
- :white_check_mark:  I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark:  My code follows the code style of this project. [REQUIRED]
- :white_check_mark:  All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.
