### PR TITLE
Fix minimize at startup and decouple various tray and minimization options

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -113,12 +113,6 @@ void DatabaseOpenWidget::openDatabase()
 
     if (m_db) {
         Q_EMIT editFinished(true);
-        // this is a c++11 equivalent foreach construct
-        // if c++11 is not available another iteration loop style is needed!
-        for (auto widget : qApp->topLevelWidgets()) {
-            if(widget->inherits("QMainWindow"))
-                static_cast<MainWindow*>(widget)->configuredMinimizeWindow();
-        }
     }
     else {
         MessageBox::warning(this, tr("Error"), tr("Unable to open the database.").append("\n")

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -329,14 +329,16 @@ void MainWindow::openDatabase(const QString& fileName, const QString& pw, const 
     m_ui->tabWidget->openDatabase(fileName, pw, keyFile);
 }
 
-void MainWindow::configuredMinimizeWindow()
+void MainWindow::minimizeWindow()
 {
-    bool minimize = isTrayIconEnabled() &&
+    /*bool minimize = isTrayIconEnabled() &&
                     config()->get("GUI/MinimizeToTray").toBool() &&
                     config()->get("GUI/MinimizeOnClose").toBool() &&
-                    config()->get("GUI/MinimizeOnStartup").toBool();
-    if (minimize) {
+                    config()->get("GUI/MinimizeOnStartup").toBool();*/
+    if (isTrayIconEnabled() && config()->get("GUI/MinimizeToTray").toBool()) {
         hide();
+    } else {
+        setWindowState(Qt::WindowMinimized);
     }
 }
 
@@ -523,7 +525,6 @@ void MainWindow::databaseTabChanged(int tabIndex)
 void MainWindow::closeEvent(QCloseEvent* event)
 {
     bool minimizeOnClose = isTrayIconEnabled() &&
-                           config()->get("GUI/MinimizeToTray").toBool() &&
                            config()->get("GUI/MinimizeOnClose").toBool();
     if (minimizeOnClose && !appExitCalled)
     {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -331,10 +331,6 @@ void MainWindow::openDatabase(const QString& fileName, const QString& pw, const 
 
 void MainWindow::minimizeWindow()
 {
-    /*bool minimize = isTrayIconEnabled() &&
-                    config()->get("GUI/MinimizeToTray").toBool() &&
-                    config()->get("GUI/MinimizeOnClose").toBool() &&
-                    config()->get("GUI/MinimizeOnStartup").toBool();*/
     if (isTrayIconEnabled() && config()->get("GUI/MinimizeToTray").toBool()) {
         hide();
     } else {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -38,7 +38,7 @@ class MainWindow : public QMainWindow
 public:
     MainWindow();
     ~MainWindow();
-    void configuredMinimizeWindow();
+    void minimizeWindow();
 
 public Q_SLOTS:
     void openDatabase(const QString& fileName, const QString& pw = QString(),

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -74,11 +74,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     connect(m_generalUi->autoSaveAfterEveryChangeCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(enableAutoSaveOnExit(bool)));
     connect(m_generalUi->systrayShowCheckBox, SIGNAL(toggled(bool)),
-            this, SLOT(enableSystrayMinimizeToTray(bool)));
-    connect(m_generalUi->systrayMinimizeToTrayCheckBox, SIGNAL(toggled(bool)),
-            this, SLOT(enableSystrayMinimizeToTray2(bool)));
-    connect(m_generalUi->systrayMinimizeOnCloseCheckBox, SIGNAL(toggled(bool)),
-            m_generalUi->systrayMinimizeOnStartup, SLOT(setEnabled(bool)));
+            this, SLOT(enableSystray(bool)));
 
     connect(m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)),
             m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));
@@ -209,18 +205,8 @@ void SettingsWidget::enableAutoSaveOnExit(bool checked)
     m_generalUi->autoSaveOnExitCheckBox->setEnabled(!checked);
 }
 
-void SettingsWidget::enableSystrayMinimizeToTray(bool checked)
+void SettingsWidget::enableSystray(bool checked)
 {
     m_generalUi->systrayMinimizeToTrayCheckBox->setEnabled(checked);
-    bool checked2 = m_generalUi->systrayMinimizeToTrayCheckBox->checkState();
-    m_generalUi->systrayMinimizeOnCloseCheckBox->setEnabled(checked && checked2);
-    bool checked3 = m_generalUi->systrayMinimizeOnCloseCheckBox->checkState();
-    m_generalUi->systrayMinimizeOnStartup->setEnabled(checked && checked2 && checked3);
-}
-
-void SettingsWidget::enableSystrayMinimizeToTray2(bool checked)
-{
     m_generalUi->systrayMinimizeOnCloseCheckBox->setEnabled(checked);
-    bool checked2 = m_generalUi->systrayMinimizeOnCloseCheckBox->checkState();
-    m_generalUi->systrayMinimizeOnStartup->setEnabled(checked && checked2);
 }

--- a/src/gui/SettingsWidget.h
+++ b/src/gui/SettingsWidget.h
@@ -51,8 +51,7 @@ private Q_SLOTS:
     void saveSettings();
     void reject();
     void enableAutoSaveOnExit(bool checked);
-    void enableSystrayMinimizeToTray(bool checked);
-    void enableSystrayMinimizeToTray2(bool checked);
+    void enableSystray(bool checked);
 
 private:
     QWidget* const m_secWidget;

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>684</width>
-    <height>394</height>
+    <height>452</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
@@ -37,7 +37,7 @@
    <item row="2" column="0">
     <widget class="QCheckBox" name="openPreviousDatabasesOnStartupCheckBox">
      <property name="text">
-      <string>Open previous databases on startup</string>
+      <string>Load previous databases on startup</string>
      </property>
     </widget>
    </item>
@@ -113,12 +113,9 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>20</width>
+         <width>40</width>
          <height>20</height>
         </size>
        </property>
@@ -166,7 +163,7 @@
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>Hide window to system tray instead of App Exit</string>
+        <string>Hide window to system tray instead of app exit</string>
        </property>
       </widget>
      </item>
@@ -178,25 +175,9 @@
       <enum>QLayout::SetMaximumSize</enum>
      </property>
      <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>60</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QCheckBox" name="systrayMinimizeOnStartup">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
        <property name="text">
-        <string>Hide window to system tray on App start</string>
+        <string>Minimize window at application startup</string>
        </property>
       </widget>
      </item>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,11 +86,11 @@ int main(int argc, char** argv)
 #endif
 
     MainWindow mainWindow;
-    mainWindow.show();
     app.setMainWindow(&mainWindow);
-
+    mainWindow.show();
+    
     QObject::connect(&app, SIGNAL(openFile(QString)), &mainWindow, SLOT(openDatabase(QString)));
-
+    
     for (int ii=0; ii < args.length(); ii++) {
         QString filename = args[ii];
         if (!filename.isEmpty() && QFile::exists(filename)) {
@@ -111,6 +111,11 @@ int main(int argc, char** argv)
             }
         }
     }
-
+    
+    // start minimized if configured
+    if (config()->get("GUI/MinimizeOnStartup").toBool()) {
+        mainWindow.minimizeWindow();
+    }
+    
     return app.exec();
 }


### PR DESCRIPTION
This pull request resolves issues #105 and #64.

## Description
When the option to minimize KeePassXC at startup is enabled, the unlock dialog is no longer shown. Instead, the application is directly minimized to the tray or task bar (depending on whether _"Hide window to system tray when minimized"_ is enabled or not). In accordance with the new behavior, the setting _"Open previous databases on startup"_ was reworded to _"**Load** previous databases on startup"_.

The window also doesn't inadvertently hide anymore every time after unlocking a database when _"Minimize window at application startup"_ is enabled. This setting now only applies at application startup.

Furthermore, the four different settings concerning minimization and the system tray were decoupled. _"Minimize window at application startup"_ no longer depends on _"Show a system tray icon"_ and _"Hide window to system tray instead of app exit"_ does not depend on _"Hide window to system tray when minimized"_ anymore.

## How Has This Been Tested?
All possible settings combinations were tested. Since no additional functionality was added, no new unit tests were added either.

## Types of changes
<!--- What types of changes does your code introduce? If it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:` -->
<!--- Everybody loves emoji -->
- :white_check_mark: Bug fix (non-breaking change which fixes an issue)
- :negative_squared_cross_mark: New feature (non-breaking change which adds functionality)
- :white_check_mark: Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, if it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:`. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Pull Requests that fail the [REQUIRED] field will likely be sent back for corrections or rejected  -->
- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.
