### PR TITLE
Fix build issue for openSuse

### DIFF
--- a/src/autotype/test/CMakeLists.txt
+++ b/src/autotype/test/CMakeLists.txt
@@ -3,4 +3,4 @@ set(autotype_test_SOURCES
 )
 
 add_library(keepassx-autotype-test MODULE ${autotype_test_SOURCES})
-target_link_libraries(keepassx-autotype-test testautotype Qt5::Core Qt5::Widgets)
+target_link_libraries(keepassx-autotype-test testautotype keepassx_core Qt5::Core Qt5::Widgets)

--- a/src/autotype/xcb/CMakeLists.txt
+++ b/src/autotype/xcb/CMakeLists.txt
@@ -5,7 +5,7 @@ set(autotype_XCB_SOURCES
 )
 
 add_library(keepassx-autotype-xcb MODULE ${autotype_XCB_SOURCES})
-target_link_libraries(keepassx-autotype-xcb Qt5::Core Qt5::Widgets Qt5::X11Extras ${X11_X11_LIB} ${X11_Xi_LIB} ${X11_XTest_LIB})
+target_link_libraries(keepassx-autotype-xcb keepassx_core Qt5::Core Qt5::Widgets Qt5::X11Extras ${X11_X11_LIB} ${X11_Xi_LIB} ${X11_XTest_LIB})
 install(TARGETS keepassx-autotype-xcb
         BUNDLE DESTINATION . COMPONENT Runtime
         LIBRARY DESTINATION ${PLUGIN_INSTALL_DIR} COMPONENT Runtime)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When building KeePassXC for openSUSE in the open build service the build fails because of missing  with  undefined reference to AutoTypeExecutor::execDelay similar to https://dev.keepassx.org/issues/389 

## Description
<!--- Describe your changes in detail -->
Add the keepassx_core to the autotype plugin and its testcase.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Build a package for openSUSE 
https://build.opensuse.org/package/show/home:greenbasilisk:keepassxc/keepassxc

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See build log, for example, 
https://build.opensuse.org/build/home:greenbasilisk:keepassxc/openSUSE_Leap_42.2/x86_64/keepassxc/_log

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? If it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:` -->
<!--- Everybody loves emoji -->
- :white_check_mark: Bug fix (non-breaking change which fixes an issue)
- :negative_squared_cross_mark: New feature (non-breaking change which adds functionality)
- :negative_squared_cross_mark: Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, if it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:`. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Pull Requests that fail the [REQUIRED] field will likely be sent back for corrections or rejected  -->
- :negative_squared_cross_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :negative_squared_cross_mark: My code follows the code style of this project. [REQUIRED]
- :negative_squared_cross_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.