### PR TITLE
Fix build for 64-bit Windows

### DIFF
--- a/utils/entropy-meter.cpp
+++ b/utils/entropy-meter.cpp
@@ -13,7 +13,9 @@ See zxcvbn/zxcvbn.cpp for complete COPYRIGHT Notice
 
 /* For pre-compiled headers under windows */
 #ifdef _WIN32
+#ifndef __MINGW32__
 #include "stdafx.h"
+#endif
 #endif
 
 static void calculate(const char *pwd, int advanced)


### PR DESCRIPTION
Building on 64-bit Windows gets to 99% and fails on this particular file due to the `stdafx.h` inclusion.
The macro in `entropy-meter.cpp` is different than `src/zxcvbn/zxcvbn.cpp`.
After copying the macro from `zxcvbn.cpp` and rebuilding, the Windows build succeeded.