### PR TITLE
Improve UI of the search edit (resurrecting 5c7c7f54)

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -385,6 +385,11 @@ void DatabaseWidget::deleteEntries()
     }
 }
 
+void DatabaseWidget::setFocus()
+{
+	m_entryView->setFocus();
+}
+
 void DatabaseWidget::copyTitle()
 {
     Entry* currentEntry = m_entryView->currentEntry();

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -116,6 +116,7 @@ public Q_SLOTS:
     void createEntry();
     void cloneEntry();
     void deleteEntries();
+    void setFocus();
     void copyTitle();
     void copyUsername();
     void copyPassword();

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -28,16 +28,6 @@ namespace Ui {
     class SearchWidget;
 }
 
-class SearchEventFilter : public QObject
-{
-    Q_OBJECT
-signals:
-    void escapePressed();
-
-protected:
-    virtual bool eventFilter(QObject *obj, QEvent *event) override;
-};
-
 
 class SearchWidget : public QWidget
 {
@@ -53,6 +43,9 @@ public:
 signals:
     void search(const QString &text);
     void caseSensitiveChanged(bool state);
+    void escapePressed();
+    void copyPressed();
+    void downPressed();
 
 public slots:
     void databaseChanged(DatabaseWidget* dbWidget);
@@ -61,15 +54,21 @@ private slots:
     void startSearchTimer();
     void startSearch();
     void updateCaseSensitive();
+    void copyPassword();
+    void setFocusToEntry();
 
 private:
     const QScopedPointer<Ui::SearchWidget> m_ui;
     QTimer* m_searchTimer;
-    SearchEventFilter m_searchEventFilter;
+    DatabaseWidget *m_dbWidget;
 
     QAction *m_actionCaseSensitive;
 
     Q_DISABLE_COPY(SearchWidget)
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event);
+
 };
 
 #endif // SEARCHWIDGET_H

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -406,6 +406,13 @@ void TestGui::testSearch()
     // Search for "someTHING"
     QTest::keyClicks(searchTextEdit, "THING");
     QTRY_COMPARE(entryView->model()->rowCount(), 2);
+    // Press Down to focus on the entry view if at EOL
+    QTest::keyClick(searchTextEdit, Qt::Key_Left);
+    QTest::keyClick(searchTextEdit, Qt::Key_Down);
+    QTRY_VERIFY(searchTextEdit->hasFocus());
+    QTest::keyClick(searchTextEdit, Qt::Key_Down);
+    QTRY_VERIFY(entryView->hasFocus());
+    QTest::mouseClick(searchTextEdit, Qt::LeftButton);
 
     // Test case sensitive search
     searchWidget->setCaseSensitive(true);


### PR DESCRIPTION
## Description

This improves the UI of the search edit.

It was originally submitted as https://github.com/keepassx/keepassx/pull/74 and successfully merged, but the functionality got lost as the search UI was revamped in KeePassXC.

## Motivation and Context

I want the Search UI to work without bothering with the focus.

- The copy action (Control+C) when no text is selected copies the password of the current entry.  This should be reasonable when Control+B copies the username.

- Down at EOL moves the focus to the entry view.  Enter and Tab should do that, but it would be handy for user to be able to get to the third entry by hitting Down three times.

## How Has This Been Tested?

Test case is included in this PR.

## Types of changes

- :negative_squared_cross_mark: Bug fix (non-breaking change which fixes an issue)
- :white_check_mark: New feature (non-breaking change which adds functionality)
- :negative_squared_cross_mark: Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :white_check_mark: I have added tests to cover my changes.
