### PR TITLE
Feature/lock db on session lock #134

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ services: [docker]
 
 os:
   - linux
-#  - osx
+  - osx
+
+osx_image: xcode8.2
 
 # Define clang compiler without any frills
 compiler:
@@ -27,6 +29,7 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew ls | grep -wq cmake || brew install cmake; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew ls | grep -wq qt5 || brew install qt5; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew ls | grep -wq libgcrypt || brew install libgcrypt; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew ls | grep -wq libmicrohttpd || brew install libmicrohttpd; fi
 
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/usr/local/opt/qt5"; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,9 @@ find_package(Qt5Widgets       5.2 REQUIRED)
 find_package(Qt5Test          5.2 REQUIRED)
 find_package(Qt5LinguistTools 5.2 REQUIRED)
 find_package(Qt5Network       5.2 REQUIRED)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    find_package(Qt5DBus       5.2 REQUIRED)
+endif()
 set(CMAKE_AUTOMOC ON)
 
 # Debian sets the the build type to None for package builds.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,10 @@ set(keepassx_SOURCES
     core/Metadata.cpp
     core/PasswordGenerator.cpp
     core/SignalMultiplexer.cpp
+    core/ScreenLockListener.cpp
+    core/ScreenLockListener.h
+    core/ScreenLockListenerPrivate.h
+    core/ScreenLockListenerPrivate.cpp
     core/TimeDelta.cpp
     core/TimeInfo.cpp
     core/ToDbExporter.cpp
@@ -137,6 +141,24 @@ set(keepassx_SOURCES
     streams/StoreDataStream.cpp
     streams/SymmetricCipherStream.cpp
 )
+if(APPLE)
+    set(keepassx_SOURCES ${keepassx_SOURCES}
+        core/ScreenLockListenerMac.h
+        core/ScreenLockListenerMac.cpp
+        )
+endif()
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(keepassx_SOURCES ${keepassx_SOURCES}
+        core/ScreenLockListenerDBus.h
+        core/ScreenLockListenerDBus.cpp
+        )
+endif()
+if(MINGW)
+    set(keepassx_SOURCES ${keepassx_SOURCES}
+        core/ScreenLockListenerWin.h
+        core/ScreenLockListenerWin.cpp
+        )
+endif()
 
 set(keepassx_SOURCES_MAINEXE
     main.cpp
@@ -180,6 +202,16 @@ target_link_libraries(zxcvbn)
 add_library(keepassx_core STATIC ${keepassx_SOURCES})
 set_target_properties(keepassx_core PROPERTIES COMPILE_DEFINITIONS KEEPASSX_BUILDING_CORE)
 target_link_libraries(keepassx_core zxcvbn Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Network)
+
+if(APPLE)
+    target_link_libraries(keepassx_core "-framework Foundation")
+endif()
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    target_link_libraries(keepassx_core Qt5::DBus)
+endif()
+if(MINGW)
+    target_link_libraries(keepassx_core Wtsapi32.lib)
+endif()
 
 add_executable(${PROGNAME} WIN32 MACOSX_BUNDLE ${keepassx_SOURCES_MAINEXE})
 target_link_libraries(${PROGNAME}

--- a/src/core/ScreenLockListener.cpp
+++ b/src/core/ScreenLockListener.cpp
@@ -1,0 +1,11 @@
+#include "ScreenLockListener.h"
+#include "ScreenLockListenerPrivate.h"
+
+ScreenLockListener::ScreenLockListener(QWidget* parent):
+    QObject(parent){
+    m_listener = ScreenLockListenerPrivate::instance(parent);
+    connect(m_listener,SIGNAL(screenLocked()), this,SIGNAL(screenLocked()));
+}
+
+ScreenLockListener::~ScreenLockListener(){
+}

--- a/src/core/ScreenLockListener.h
+++ b/src/core/ScreenLockListener.h
@@ -1,0 +1,21 @@
+#ifndef SCREENLOCKLISTENER_H
+#define SCREENLOCKLISTENER_H
+#include <QWidget>
+
+class ScreenLockListenerPrivate;
+
+class ScreenLockListener : public QObject {
+    Q_OBJECT
+
+public:
+    ScreenLockListener(QWidget* parent=NULL);
+    ~ScreenLockListener();
+
+Q_SIGNALS:
+    void screenLocked();
+
+private:
+    ScreenLockListenerPrivate* m_listener;
+};
+
+#endif // SCREENLOCKLISTENER_H

--- a/src/core/ScreenLockListenerDBus.cpp
+++ b/src/core/ScreenLockListenerDBus.cpp
@@ -1,0 +1,66 @@
+#include "ScreenLockListenerDBus.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+
+ScreenLockListenerDBus::ScreenLockListenerDBus(QWidget *parent):
+    ScreenLockListenerMac(parent)
+{
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    QDBusConnection systemBus = QDBusConnection::systemBus();
+    sessionBus.connect(
+                "org.gnome.SessionManager", // service
+                "/org/gnome/SessionManager/Presence", // path
+                "org.gnome.SessionManager.Presence", // interface
+                "StatusChanged", // signal name
+                this, //receiver
+                SLOT(gnomeSessionStatusChanged(uint)));
+
+    systemBus.connect(
+                "org.freedesktop.login1", // service
+                "/org/freedesktop/login1", // path
+                "org.freedesktop.login1.Manager", // interface
+                "PrepareForSleep", // signal name
+                this, //receiver
+                SLOT(logindPrepareForSleep(bool)));
+
+    sessionBus.connect(
+                "com.canonical.Unity", // service
+                "/com/canonical/Unity/Session", // path
+                "com.canonical.Unity.Session", // interface
+                "Locked", // signal name
+                this, //receiver
+                SLOT(unityLocked()));
+
+    /* Currently unable to get the current user session from login1.Manager
+    QDBusInterface login1_manager_iface("org.freedesktop.login1", "/org/freedesktop/login1",
+                              "org.freedesktop.login1.Manager", systemBus);
+    if(login1_manager_iface.isValid()){
+        qint64 my_pid = QCoreApplication::applicationPid();
+        QDBusReply<QString> reply = login1_manager_iface.call("GetSessionByPID",static_cast<quint32>(my_pid));
+        if (reply.isValid()){
+            QString current_session = reply.value();
+        }
+    }
+    */
+}
+
+void ScreenLockListenerDBus::gnomeSessionStatusChanged(uint status)
+{
+    if(status != 0){
+        Q_EMIT screenLocked();
+    }
+}
+
+void ScreenLockListenerDBus::logindPrepareForSleep(bool beforeSleep)
+{
+    if(beforeSleep){
+        Q_EMIT screenLocked();
+    }
+}
+
+void ScreenLockListenerDBus::unityLocked()
+{
+    Q_EMIT screenLocked();
+}

--- a/src/core/ScreenLockListenerDBus.cpp
+++ b/src/core/ScreenLockListenerDBus.cpp
@@ -32,18 +32,6 @@ ScreenLockListenerDBus::ScreenLockListenerDBus(QWidget *parent):
                 "Locked", // signal name
                 this, //receiver
                 SLOT(unityLocked()));
-
-    /* Currently unable to get the current user session from login1.Manager
-    QDBusInterface login1_manager_iface("org.freedesktop.login1", "/org/freedesktop/login1",
-                              "org.freedesktop.login1.Manager", systemBus);
-    if(login1_manager_iface.isValid()){
-        qint64 my_pid = QCoreApplication::applicationPid();
-        QDBusReply<QString> reply = login1_manager_iface.call("GetSessionByPID",static_cast<quint32>(my_pid));
-        if (reply.isValid()){
-            QString current_session = reply.value();
-        }
-    }
-    */
 }
 
 void ScreenLockListenerDBus::gnomeSessionStatusChanged(uint status)

--- a/src/core/ScreenLockListenerDBus.cpp
+++ b/src/core/ScreenLockListenerDBus.cpp
@@ -5,7 +5,7 @@
 #include <QDBusReply>
 
 ScreenLockListenerDBus::ScreenLockListenerDBus(QWidget *parent):
-    ScreenLockListenerMac(parent)
+    ScreenLockListenerPrivate(parent)
 {
     QDBusConnection sessionBus = QDBusConnection::sessionBus();
     QDBusConnection systemBus = QDBusConnection::systemBus();

--- a/src/core/ScreenLockListenerDBus.h
+++ b/src/core/ScreenLockListenerDBus.h
@@ -2,6 +2,7 @@
 #define SCREENLOCKLISTENERDBUS_H
 #include <QObject>
 #include <QWidget>
+#include "ScreenLockListenerPrivate.h"
 
 class ScreenLockListenerDBus : public ScreenLockListenerPrivate
 {

--- a/src/core/ScreenLockListenerDBus.h
+++ b/src/core/ScreenLockListenerDBus.h
@@ -1,0 +1,18 @@
+#ifndef SCREENLOCKLISTENERDBUS_H
+#define SCREENLOCKLISTENERDBUS_H
+#include <QObject>
+#include <QWidget>
+
+class ScreenLockListenerDBus : public ScreenLockListenerPrivate
+{
+    Q_OBJECT
+public:
+    explicit ScreenLockListenerDBus(QWidget *parent = 0);
+
+private Q_SLOTS:
+    void gnomeSessionStatusChanged(uint status);
+    void logindPrepareForSleep(bool beforeSleep);
+    void unityLocked();
+};
+
+#endif // SCREENLOCKLISTENERDBUS_H

--- a/src/core/ScreenLockListenerMac.cpp
+++ b/src/core/ScreenLockListenerMac.cpp
@@ -1,0 +1,41 @@
+#include "ScreenLockListenerMac.h"
+
+#include <QMutexLocker>
+#include <CoreFoundation/CoreFoundation.h>
+
+ScreenLockListenerMac* ScreenLockListenerMac::instance(){
+    static QMutex mutex;
+    QMutexLocker lock(&mutex);
+
+    static ScreenLockListenerMac* m_ptr=NULL;
+    if (m_ptr==NULL){
+        m_ptr = new ScreenLockListenerMac();
+    }
+    return m_ptr;
+}
+
+void ScreenLockListenerMac::notificationCenterCallBack(CFNotificationCenterRef /*center*/, void */*observer*/,
+                                        CFNotificationName /*name*/, const void */*object*/, CFDictionaryRef /*userInfo*/){
+    instance()->onSignalReception();
+}
+
+ScreenLockListenerMac::ScreenLockListenerMac(QWidget* parent):
+    ScreenLockListenerPrivate(parent){
+    CFNotificationCenterRef distCenter;
+    CFStringRef screenIsLockedSignal = CFSTR("com.apple.screenIsLocked");
+    distCenter = CFNotificationCenterGetDistributedCenter();
+    if (NULL == distCenter)
+        return;
+
+    CFNotificationCenterAddObserver(
+                distCenter,
+                this, &ScreenLockListenerMac::notificationCenterCallBack,
+                screenIsLockedSignal,
+                NULL,
+                CFNotificationSuspensionBehaviorDeliverImmediately);
+}
+
+void ScreenLockListenerMac::onSignalReception()
+{
+    Q_EMIT screenLocked();
+}

--- a/src/core/ScreenLockListenerMac.h
+++ b/src/core/ScreenLockListenerMac.h
@@ -1,0 +1,24 @@
+#ifndef SCREENLOCKLISTENERMAC_H
+#define SCREENLOCKLISTENERMAC_H
+#include <QObject>
+#include <QWidget>
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#include "ScreenLockListenerPrivate.h"
+
+class ScreenLockListenerMac: public ScreenLockListenerPrivate {
+    Q_OBJECT
+
+public:
+    static ScreenLockListenerMac* instance();
+    static void notificationCenterCallBack(CFNotificationCenterRef /*center*/, void */*observer*/,
+                            CFNotificationName /*name*/, const void */*object*/, CFDictionaryRef /*userInfo*/);
+
+private:
+    ScreenLockListenerMac(QWidget* parent=NULL);
+    void onSignalReception();
+
+};
+
+#endif // SCREENLOCKLISTENERMAC_H

--- a/src/core/ScreenLockListenerPrivate.cpp
+++ b/src/core/ScreenLockListenerPrivate.cpp
@@ -15,6 +15,7 @@ ScreenLockListenerPrivate::ScreenLockListenerPrivate(QWidget* parent):
 
 ScreenLockListenerPrivate* ScreenLockListenerPrivate::instance(QWidget* parent){
 #if defined(Q_OS_OSX)
+    Q_UNUSED(parent);
     return ScreenLockListenerMac::instance();
 #endif
 #if defined(Q_OS_LINUX)

--- a/src/core/ScreenLockListenerPrivate.cpp
+++ b/src/core/ScreenLockListenerPrivate.cpp
@@ -1,0 +1,26 @@
+#include "ScreenLockListenerPrivate.h"
+#if defined(Q_OS_OSX)
+#include "ScreenLockListenerMac.h"
+#endif
+#if defined(Q_OS_LINUX)
+#include "ScreenLockListenerDBus.h"
+#endif
+#if defined(Q_OS_WIN)
+#include "ScreenLockListenerWin.h"
+#endif
+
+ScreenLockListenerPrivate::ScreenLockListenerPrivate(QWidget* parent):
+    QObject(parent){
+}
+
+ScreenLockListenerPrivate* ScreenLockListenerPrivate::instance(QWidget* parent){
+#if defined(Q_OS_OSX)
+    return ScreenLockListenerMac::instance();
+#endif
+#if defined(Q_OS_LINUX)
+    return new ScreenLockListenerDBus(parent);
+#endif
+#if defined(Q_OS_WIN)
+    return new ScreenLockListenerWin(parent);
+#endif
+}

--- a/src/core/ScreenLockListenerPrivate.h
+++ b/src/core/ScreenLockListenerPrivate.h
@@ -1,0 +1,19 @@
+#ifndef SCREENLOCKLISTENERPRIVATE_H
+#define SCREENLOCKLISTENERPRIVATE_H
+#include <QObject>
+#include <QWidget>
+
+class ScreenLockListenerPrivate : public QObject
+{
+    Q_OBJECT
+public:
+    static ScreenLockListenerPrivate* instance(QWidget *parent = 0);
+
+protected:
+    ScreenLockListenerPrivate(QWidget *parent = 0);
+
+Q_SIGNALS:
+    void screenLocked();
+};
+
+#endif // SCREENLOCKLISTENERPRIVATE_H

--- a/src/core/ScreenLockListenerWin.cpp
+++ b/src/core/ScreenLockListenerWin.cpp
@@ -1,0 +1,69 @@
+#include "ScreenLockListenerWin.h"
+#include <QApplication>
+#include <windows.h>
+#include <wtsapi32.h>
+
+/*
+ * See https://msdn.microsoft.com/en-us/library/windows/desktop/aa373196(v=vs.85).aspx
+ * See https://msdn.microsoft.com/en-us/library/aa383841(v=vs.85).aspx
+ * See https://blogs.msdn.microsoft.com/oldnewthing/20060104-50/?p=32783
+ */
+ScreenLockListenerWin::ScreenLockListenerWin(QWidget *parent) :
+    ScreenLockListenerPrivate(parent),
+    QAbstractNativeEventFilter()
+{
+    Q_ASSERT(parent!=NULL);
+    // On windows, we need to register for platform specific messages and
+    // install a message handler for them
+    QCoreApplication::instance()->installNativeEventFilter(this);
+
+    // This call requests a notification from windows when a laptop is closed
+    HPOWERNOTIFY hPnotify = RegisterPowerSettingNotification(
+                reinterpret_cast<HWND>(parent->winId()),
+                &GUID_LIDSWITCH_STATE_CHANGE, DEVICE_NOTIFY_WINDOW_HANDLE);
+    m_powernotificationhandle = reinterpret_cast<void*>(hPnotify);
+
+    // This call requests a notification for session changes
+    if (!WTSRegisterSessionNotification(
+                reinterpret_cast<HWND>(parent->winId()),
+                NOTIFY_FOR_THIS_SESSION)){
+    }
+}
+
+ScreenLockListenerWin::~ScreenLockListenerWin()
+{
+    HWND h= reinterpret_cast<HWND>(static_cast<QWidget*>(parent())->winId());
+    WTSUnRegisterSessionNotification(h);
+
+    if(m_powernotificationhandle){
+        UnregisterPowerSettingNotification(reinterpret_cast<HPOWERNOTIFY>(m_powernotificationhandle));
+    }
+}
+
+bool ScreenLockListenerWin::nativeEventFilter(const QByteArray &eventType, void *message, long *)
+{
+    if(eventType == "windows_generic_MSG" || eventType == "windows_dispatcher_MSG"){
+        MSG* m = static_cast<MSG *>(message);
+        if(m->message == WM_POWERBROADCAST){
+            const POWERBROADCAST_SETTING* setting = reinterpret_cast<const POWERBROADCAST_SETTING*>(m->lParam);
+            if (setting->PowerSetting == GUID_LIDSWITCH_STATE_CHANGE){
+                const DWORD* state = reinterpret_cast<const DWORD*>(&setting->Data);
+                if (*state == 0){
+                    Q_EMIT screenLocked();
+                    return true;
+                }
+            }
+        }
+        if(m->message == WM_WTSSESSION_CHANGE){
+            if (m->wParam==WTS_CONSOLE_DISCONNECT){
+                Q_EMIT screenLocked();
+                return true;
+            }
+            if (m->wParam==WTS_SESSION_LOCK){
+                Q_EMIT screenLocked();
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/src/core/ScreenLockListenerWin.h
+++ b/src/core/ScreenLockListenerWin.h
@@ -1,0 +1,21 @@
+#ifndef SCREENLOCKLISTENERWIN_H
+#define SCREENLOCKLISTENERWIN_H
+#include <QObject>
+#include <QWidget>
+#include <QAbstractNativeEventFilter>
+
+#include "ScreenLockListenerPrivate.h"
+
+class ScreenLockListenerWin : public ScreenLockListenerPrivate, public QAbstractNativeEventFilter
+{
+    Q_OBJECT
+public:
+    explicit ScreenLockListenerWin(QWidget *parent = 0);
+    ~ScreenLockListenerWin();
+    virtual bool nativeEventFilter(const QByteArray &eventType, void *message, long *) Q_DECL_OVERRIDE;
+
+private:
+    void * m_powernotificationhandle;
+};
+
+#endif // SCREENLOCKLISTENERWIN_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -268,6 +268,9 @@ MainWindow::MainWindow()
 
     connect(m_ui->actionAbout, SIGNAL(triggered()), SLOT(showAboutDialog()));
 
+    m_screenLockListener = new ScreenLockListener(this);
+    connect(m_screenLockListener, SIGNAL(screenLocked()), SLOT(handleScreenLock()));
+
     updateTrayIcon();
 }
 
@@ -777,4 +780,11 @@ bool MainWindow::isTrayIconEnabled() const
     return config()->get("GUI/ShowTrayIcon").toBool()
             && QSystemTrayIcon::isSystemTrayAvailable();
 #endif
+}
+
+void MainWindow::handleScreenLock()
+{
+    if (config()->get("AutoCloseOnScreenLock").toBool()){
+        lockDatabasesAfterInactivity();
+    }
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -784,7 +784,7 @@ bool MainWindow::isTrayIconEnabled() const
 
 void MainWindow::handleScreenLock()
 {
-    if (config()->get("AutoCloseOnScreenLock").toBool()){
+    if (config()->get("security/lockdatabasescreenlock").toBool()){
         lockDatabasesAfterInactivity();
     }
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -23,6 +23,7 @@
 #include <QSystemTrayIcon>
 
 #include "core/SignalMultiplexer.h"
+#include "core/ScreenLockListener.h"
 #include "gui/DatabaseWidget.h"
 
 namespace Ui {
@@ -71,6 +72,7 @@ private Q_SLOTS:
     void appExit();
     void lockDatabasesAfterInactivity();
     void repairDatabase();
+    void handleScreenLock();
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);
@@ -92,6 +94,7 @@ private:
     InactivityTimer* m_inactivityTimer;
     int m_countDefaultAttributes;
     QSystemTrayIcon* m_trayIcon;
+    ScreenLockListener* m_screenLockListener;
 
     Q_DISABLE_COPY(MainWindow)
 

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -130,6 +130,8 @@ void SettingsWidget::loadSettings()
         }
     }
 
+    m_generalUi->autoCloseOnScreenLockCheckBox->setChecked(config()->get("AutoCloseOnScreenLock").toBool());
+
     m_secUi->clearClipboardCheckBox->setChecked(config()->get("security/clearclipboard").toBool());
     m_secUi->clearClipboardSpinBox->setValue(config()->get("security/clearclipboardtimeout").toInt());
 
@@ -164,6 +166,8 @@ void SettingsWidget::saveSettings()
     config()->set("AutoTypeEntryTitleMatch",
                   m_generalUi->autoTypeEntryTitleMatchCheckBox->isChecked());
     int currentLangIndex = m_generalUi->languageComboBox->currentIndex();
+    config()->set("AutoCloseOnScreenLock", m_generalUi->autoCloseOnScreenLockCheckBox->isChecked());
+
     config()->set("GUI/Language", m_generalUi->languageComboBox->itemData(currentLangIndex).toString());
 
     config()->set("GUI/ShowTrayIcon", m_generalUi->systrayShowCheckBox->isChecked());

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -130,7 +130,6 @@ void SettingsWidget::loadSettings()
         }
     }
 
-    m_generalUi->autoCloseOnScreenLockCheckBox->setChecked(config()->get("AutoCloseOnScreenLock").toBool());
 
     m_secUi->clearClipboardCheckBox->setChecked(config()->get("security/clearclipboard").toBool());
     m_secUi->clearClipboardSpinBox->setValue(config()->get("security/clearclipboardtimeout").toInt());
@@ -138,6 +137,7 @@ void SettingsWidget::loadSettings()
     m_secUi->lockDatabaseIdleCheckBox->setChecked(config()->get("security/lockdatabaseidle").toBool());
     m_secUi->lockDatabaseIdleSpinBox->setValue(config()->get("security/lockdatabaseidlesec").toInt());
     m_secUi->lockDatabaseMinimizeCheckBox->setChecked(config()->get("security/lockdatabaseminimize").toBool());
+    m_secUi->lockDatabaseOnScreenLockCheckBox->setChecked(config()->get("security/lockdatabasescreenlock").toBool());
 
     m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
     m_secUi->passwordRepeatCheckBox->setChecked(config()->get("security/passwordsrepeat").toBool());
@@ -166,7 +166,6 @@ void SettingsWidget::saveSettings()
     config()->set("AutoTypeEntryTitleMatch",
                   m_generalUi->autoTypeEntryTitleMatchCheckBox->isChecked());
     int currentLangIndex = m_generalUi->languageComboBox->currentIndex();
-    config()->set("AutoCloseOnScreenLock", m_generalUi->autoCloseOnScreenLockCheckBox->isChecked());
 
     config()->set("GUI/Language", m_generalUi->languageComboBox->itemData(currentLangIndex).toString());
 
@@ -186,6 +185,7 @@ void SettingsWidget::saveSettings()
     config()->set("security/lockdatabaseidle", m_secUi->lockDatabaseIdleCheckBox->isChecked());
     config()->set("security/lockdatabaseidlesec", m_secUi->lockDatabaseIdleSpinBox->value());
     config()->set("security/lockdatabaseminimize", m_secUi->lockDatabaseMinimizeCheckBox->isChecked());
+    config()->set("security/lockdatabasescreenlock", m_secUi->lockDatabaseOnScreenLockCheckBox->isChecked());
 
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
     config()->set("security/passwordsrepeat", m_secUi->passwordRepeatCheckBox->isChecked());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -190,6 +190,13 @@
      </property>
     </widget>
    </item>
+   <item row="15" column="0">
+    <widget class="QCheckBox" name="autoCloseOnScreenLockCheckBox">
+     <property name="text">
+      <string>Close database when session is locked or lid is closed</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -103,6 +103,13 @@
    <item row="10" column="1">
     <widget class="QComboBox" name="languageComboBox"/>
    </item>
+   <item row="11" column="0">
+    <widget class="QCheckBox" name="systrayShowCheckBox">
+     <property name="text">
+      <string>Show a system tray icon</string>
+     </property>
+    </widget>
+   </item>
    <item row="12" column="0">
     <layout class="QHBoxLayout" name="systray1Layout">
      <property name="sizeConstraint">
@@ -182,20 +189,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="11" column="0">
-    <widget class="QCheckBox" name="systrayShowCheckBox">
-     <property name="text">
-      <string>Show a system tray icon</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0">
-    <widget class="QCheckBox" name="autoCloseOnScreenLockCheckBox">
-     <property name="text">
-      <string>Close database when session is locked or lid is closed</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>374</width>
-    <height>303</height>
+    <width>542</width>
+    <height>313</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
@@ -64,24 +64,31 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QCheckBox" name="passwordCleartextCheckBox">
      <property name="text">
       <string>Show passwords in cleartext by default</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QCheckBox" name="passwordRepeatCheckBox">
      <property name="text">
       <string>Don't require password repeat when it is visible</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QCheckBox" name="autoTypeAskCheckBox">
      <property name="text">
       <string>Always ask before performing auto-type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="lockDatabaseOnScreenLockCheckBox">
+     <property name="text">
+      <string>Lock databases when session is locked or lid is closed</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description
- Added a configuration entry in general settings called "Close database when session is locked or lid is closed"
- Added a class called ScreenLockListener with a private implementation class backed by three platform specific implementations:
  - on Mac OS the implementation uses the NSNotificationCenter C API
  - on Linux the implementation listens to DBus signals
  - on Windows the implementation registers for platform specific messages and registers a platform message handler

## Motivation and Context
Implementation of issue #134

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested on the following platforms:
- Mac OS Sierra, Qt 5.7 from online installer, XCode 8, physical laptop: Lid close triggers lock
- Ubuntu 16.10, Qt 5.7 from online installer, on Unity desktop, virtual machine: Session lock triggers lock
- Windows 7, Qt 5.7 from online installer with libraries from MSYS2, virtual machine: Session lock triggers lock

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? If it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:` -->
<!--- Everybody loves emoji -->
- :negative_squared_cross_mark: Bug fix (non-breaking change which fixes an issue)
- :white_check_mark: New feature (non-breaking change which adds functionality)
- :negative_squared_cross_mark: Breaking change (fix or feature that would cause existing functionality to change)

This change brings in the following new dependencies:
-    Mac OS: Foundation framework (always present on the platform), the build requires XCode 8
-    Linux: Qt::DBus (available on most Linux distributions nowadays)
-    Windows: wtsapi32.lib (part of the platform SDK)

## Checklist:
<!--- Go over all the following points, if it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:`. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Pull Requests that fail the [REQUIRED] field will likely be sent back for corrections or rejected  -->
- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.
