### PR TITLE
Select the search text automatically when focused

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUI_TESTS=ON -DWITH_XC_HTTP=ON -DWITH_XC_AUTOTYPE=ON -DWITH_XC_YUBIKEY=ON $CMAKE_ARGS ..
   - make -j2
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then make test ARGS+="-E testgui --output-on-failure"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -a --server-args="-screen 0 800x600x24" make test ARGS+="-R testgui --output-on-failure"; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -a --server-args="-screen 0 1280x960x24" make test ARGS+="-R testgui --output-on-failure"; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make test ARGS+="--output-on-failure"; fi
 
 # Generate snapcraft build when merging into master/develop branches

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,7 @@ set(keepassx_SOURCES
     gui/PasswordGeneratorWidget.cpp
     gui/PasswordComboBox.cpp
     gui/SettingsWidget.cpp
+    gui/SearchEdit.cpp
     gui/SearchWidget.cpp
     gui/SortFilterHideProxyModel.cpp
     gui/UnlockDatabaseWidget.cpp

--- a/src/gui/SearchEdit.cpp
+++ b/src/gui/SearchEdit.cpp
@@ -1,0 +1,16 @@
+#include "SearchEdit.h"
+
+// This widget will select the whole text automatically when focused,
+// except when focused by a mouse press.
+SearchEdit::SearchEdit(QWidget *parent)
+    : QLineEdit(parent)
+{
+}
+
+void SearchEdit::focusInEvent(QFocusEvent *event)
+{
+    QLineEdit::focusInEvent(event);
+    selectAll();
+    // If this event is triggered by a mouse press, the selection will
+    // be lost by the following default mouse press handler.
+}

--- a/src/gui/SearchEdit.h
+++ b/src/gui/SearchEdit.h
@@ -1,0 +1,20 @@
+#ifndef KEEPASSX_SEARCHEDIT_H
+#define KEEPASSX_SEARCHEDIT_H
+
+#include <QLineEdit>
+
+/* namespace Ui { */
+/*     class SearchEdit; */
+/* } */
+
+class SearchEdit : public QLineEdit
+{
+    Q_OBJECT
+public:
+    SearchEdit(QWidget *parent);
+    virtual ~SearchEdit() {}
+
+protected:
+    void focusInEvent(QFocusEvent *event);
+};
+#endif // SEARCHEDIT_H

--- a/src/gui/SearchWidget.ui
+++ b/src/gui/SearchWidget.ui
@@ -48,7 +48,7 @@
     </layout>
    </item>
    <item row="0" column="1">
-    <widget class="QLineEdit" name="searchEdit"/>
+    <widget class="SearchEdit" name="searchEdit"/>
    </item>
   </layout>
  </widget>
@@ -57,5 +57,12 @@
   <tabstop>searchEdit</tabstop>
  </tabstops>
  <resources/>
+ <customwidgets>
+  <customwidget>
+   <class>SearchEdit</class>
+   <extends>QLineEdit</extends>
+   <header>gui/SearchEdit.h</header>
+  </customwidget>
+ </customwidgets>
  <connections/>
 </ui>

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -62,7 +62,7 @@ void TestGui::initTestCase()
     m_mainWindow = new MainWindow();
     m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
     m_mainWindow->show();
-    m_mainWindow->activateWindow();
+    m_mainWindow->setWindowState(Qt::WindowMaximized | Qt::WindowActive);
     Tools::wait(50);
 
     // Load the NewDatabase.kdbx file into temporary storage

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -424,7 +424,9 @@ void TestGui::testSearch()
     Entry* searchedEntry = entryView->entryFromIndex(searchedItem);
     QTRY_COMPARE(searchedEntry->password(), clipboard->text());
     // Restore focus
-    QTest::mouseClick(searchTextEdit, Qt::LeftButton);
+    QTest::keyClick(m_mainWindow, Qt::Key_F, Qt::ControlModifier);
+    QTRY_VERIFY(searchTextEdit->hasFocus());
+    QTRY_COMPARE(searchTextEdit->selectedText(), QString("someTHING"));
 
     // Test case sensitive search
     searchWidget->setCaseSensitive(true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the search bar gets the focus, the whole text is automatically selected so you can type a new search text without having to clear what's already there.

## Motivation and Context
While the PR #67 was a great improvement, my "Control+F and type a word" workflow had stopped working since then.
Most popular browsers and editors do this so you can always do a fresh search every time you invoke the "Find" action, so I think KeePassXC should, too.

## How Has This Been Tested?
The new behavior is covered by the new assertions added to the GUI test.

## Types of changes
- :negative_squared_cross_mark: Bug fix (non-breaking change which fixes an issue)
- :white_check_mark: New feature (non-breaking change which adds functionality)
- :negative_squared_cross_mark: Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :white_check_mark: I have added tests to cover my changes.
