### PR TITLE
Enhanced search ui keypress actions

### DIFF
--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -211,6 +211,9 @@ FilePath::FilePath()
     else if (testSetDir(appDirPath + "/share")) {
     }
 #endif
+    // Last ditch test when running in the build directory (mainly for travis tests)
+    else if (testSetDir(QString(KEEPASSX_SOURCE_DIR) + "/share")) {
+    }
 
     if (m_dataPath.isEmpty()) {
         qWarning("FilePath::DataPath: can't find data dir");

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -34,12 +34,11 @@ SearchWidget::SearchWidget(QWidget *parent)
     m_searchTimer->setSingleShot(true);
 
     connect(m_ui->searchEdit, SIGNAL(textChanged(QString)), SLOT(startSearchTimer()));
-    connect(m_ui->searchEdit, SIGNAL(returnPressed()), SLOT(startSearch()));
     connect(m_ui->searchIcon, SIGNAL(triggered(QAction*)), m_ui->searchEdit, SLOT(setFocus()));
     connect(m_searchTimer, SIGNAL(timeout()), this, SLOT(startSearch()));
     connect(this, SIGNAL(escapePressed()), m_ui->searchEdit, SLOT(clear()));
 
-    new QShortcut(Qt::CTRL + Qt::Key_F, m_ui->searchEdit, SLOT(setFocus()), nullptr, Qt::ApplicationShortcut);
+    new QShortcut(Qt::CTRL + Qt::Key_F, this, SLOT(searchFocus()), nullptr, Qt::ApplicationShortcut);
 
     m_ui->searchEdit->installEventFilter(this);
 
@@ -76,14 +75,9 @@ bool SearchWidget::eventFilter(QObject *obj, QEvent *event)
             }
         }
         else if (keyEvent->matches(QKeySequence::MoveToNextLine)) {
-            // If Down is pressed at EOL in the search edit, move
-            // the focus to the entry view.
-            QLineEdit* searchEdit = m_ui->searchEdit;
-            if (!searchEdit->hasSelectedText() &&
-                searchEdit->cursorPosition() == searchEdit->text().length()) {
-                emit downPressed();
-                return true;
-            }
+            // If Down is pressed move the focus to the entry view.
+            emit downPressed();
+            return true;
         }
     }
 
@@ -96,6 +90,7 @@ void SearchWidget::connectSignals(SignalMultiplexer& mx)
     mx.connect(this, SIGNAL(caseSensitiveChanged(bool)), SLOT(setSearchCaseSensitive(bool)));
     mx.connect(this, SIGNAL(copyPressed()), SLOT(copyPassword()));
     mx.connect(this, SIGNAL(downPressed()), SLOT(setFocus()));
+    mx.connect(m_ui->searchEdit, SIGNAL(returnPressed()), SLOT(switchToEntryEdit()));
 }
 
 void SearchWidget::databaseChanged(DatabaseWidget *dbWidget)
@@ -137,4 +132,10 @@ void SearchWidget::setCaseSensitive(bool state)
 {
     m_actionCaseSensitive->setChecked(state);
     updateCaseSensitive();
+}
+
+void SearchWidget::searchFocus()
+{
+    m_ui->searchEdit->setFocus();
+    m_ui->searchEdit->selectAll();
 }

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -66,18 +66,24 @@ bool SearchWidget::eventFilter(QObject *obj, QEvent *event)
             return true;
         }
         else if (keyEvent->matches(QKeySequence::Copy)) {
-            // If Control+C is pressed in the search edit when no
-            // text is selected, copy the password of the current
-            // entry.
+            // If Control+C is pressed in the search edit when no text
+            // is selected, copy the password of the current entry
             if (!m_ui->searchEdit->hasSelectedText()) {
                 emit copyPressed();
                 return true;
             }
         }
         else if (keyEvent->matches(QKeySequence::MoveToNextLine)) {
-            // If Down is pressed move the focus to the entry view.
-            emit downPressed();
-            return true;
+            if (m_ui->searchEdit->cursorPosition() == m_ui->searchEdit->text().length()) {
+                // If down is pressed at EOL, move the focus to the entry view
+                emit downPressed();
+                return true;
+            }
+            else {
+                // Otherwise move the cursor to EOL
+                m_ui->searchEdit->setCursorPosition(m_ui->searchEdit->text().length());
+                return true;
+            }
         }
     }
 

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -34,7 +34,9 @@ SearchWidget::SearchWidget(QWidget *parent)
     m_searchTimer->setSingleShot(true);
 
     connect(m_ui->searchEdit, SIGNAL(textChanged(QString)), SLOT(startSearchTimer()));
-    connect(m_ui->searchIcon, SIGNAL(triggered(QAction*)), m_ui->searchEdit, SLOT(setFocus()));
+    connect(m_ui->searchIcon, SIGNAL(pressed()), m_ui->searchEdit, SLOT(setFocus()));
+    connect(m_ui->clearIcon, SIGNAL(pressed()), m_ui->searchEdit, SLOT(clear()));
+    connect(m_ui->clearIcon, SIGNAL(pressed()), m_ui->searchEdit, SLOT(setFocus()));
     connect(m_searchTimer, SIGNAL(timeout()), this, SLOT(startSearch()));
     connect(this, SIGNAL(escapePressed()), m_ui->searchEdit, SLOT(clear()));
 
@@ -50,6 +52,9 @@ SearchWidget::SearchWidget(QWidget *parent)
     m_ui->searchIcon->setIcon(filePath()->icon("actions", "system-search"));
     m_ui->searchIcon->setMenu(searchMenu);
     m_ui->searchIcon->setPopupMode(QToolButton::MenuButtonPopup);
+
+    m_ui->clearIcon->setIcon(filePath()->icon("actions", "edit-clear-locationbar-rtl"));
+    m_ui->clearIcon->setEnabled(false);
 }
 
 SearchWidget::~SearchWidget()
@@ -125,6 +130,9 @@ void SearchWidget::startSearch()
     if (!m_searchTimer->isActive()) {
         m_searchTimer->stop();
     }
+
+    bool hasText = m_ui->searchEdit->text().length() > 0;
+    m_ui->clearIcon->setEnabled(hasText);
 
     search(m_ui->searchEdit->text());
 }

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -48,6 +48,7 @@ signals:
     void escapePressed();
     void copyPressed();
     void downPressed();
+    void enterPressed();
 
 public slots:
     void databaseChanged(DatabaseWidget* dbWidget);
@@ -56,6 +57,7 @@ private slots:
     void startSearchTimer();
     void startSearch();
     void updateCaseSensitive();
+    void searchFocus();
 
 private:
     const QScopedPointer<Ui::SearchWidget> m_ui;

--- a/src/gui/SearchWidget.ui
+++ b/src/gui/SearchWidget.ui
@@ -34,6 +34,9 @@
      <property name="focusPolicy">
       <enum>Qt::ClickFocus</enum>
      </property>
+     <property name="text">
+      <string>Search</string>
+     </property>
      <property name="toolButtonStyle">
       <enum>Qt::ToolButtonIconOnly</enum>
      </property>

--- a/src/gui/SearchWidget.ui
+++ b/src/gui/SearchWidget.ui
@@ -10,40 +10,48 @@
     <height>34</height>
    </rect>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="leftMargin">
-    <number>0</number>
+    <number>3</number>
    </property>
    <property name="topMargin">
     <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>6</number>
+    <number>7</number>
    </property>
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QToolButton" name="searchIcon">
-       <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonIconOnly</enum>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item>
+    <widget class="QToolButton" name="searchIcon">
+     <property name="focusPolicy">
+      <enum>Qt::ClickFocus</enum>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonIconOnly</enum>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
-   <item row="0" column="1">
+   <item>
     <widget class="QLineEdit" name="searchEdit">
+     <property name="styleSheet">
+      <string notr="true">padding:3px</string>
+     </property>
      <property name="placeholderText">
-      <string>Find:</string>
+      <string>Find</string>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/src/gui/SearchWidget.ui
+++ b/src/gui/SearchWidget.ui
@@ -54,6 +54,22 @@
       <string>Find</string>
      </property>
      <property name="clearButtonEnabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="clearIcon">
+     <property name="focusPolicy">
+      <enum>Qt::ClickFocus</enum>
+     </property>
+     <property name="text">
+      <string>Clear</string>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonIconOnly</enum>
+     </property>
+     <property name="autoRaise">
       <bool>true</bool>
      </property>
     </widget>

--- a/src/gui/SearchWidget.ui
+++ b/src/gui/SearchWidget.ui
@@ -18,7 +18,7 @@
     <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>6</number>
    </property>
    <property name="bottomMargin">
     <number>0</number>
@@ -38,17 +38,14 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Find:</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item row="0" column="1">
-    <widget class="QLineEdit" name="searchEdit"/>
+    <widget class="QLineEdit" name="searchEdit">
+     <property name="placeholderText">
+      <string>Find:</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -401,7 +401,13 @@ void TestGui::testSearch()
     QTRY_COMPARE(searchTextEdit->text(), QString("ZZZ"));
     QTRY_VERIFY(m_dbWidget->isInSearchMode());
     QTRY_COMPARE(entryView->model()->rowCount(), 0);
+    // Press the search clear button
+    QToolButton* clearButton = searchWidget->findChild<QToolButton*>("clearIcon");
+    QTest::mouseClick(clearButton, Qt::LeftButton);
+    QTRY_VERIFY(searchTextEdit->text().isEmpty());
+    QTRY_VERIFY(searchTextEdit->hasFocus());
     // Escape clears searchedit and retains focus
+    QTest::keyClicks(searchTextEdit, "ZZZ");
     QTest::keyClick(searchTextEdit, Qt::Key_Escape);
     QTRY_VERIFY(searchTextEdit->text().isEmpty());
     QTRY_VERIFY(searchTextEdit->hasFocus());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Pressing down arrow will always focus on entry view
* Pressing enter opens currently selected entry
* Pressing CTRL+F focuses and selects search text

Also fixes #163 

Originally inspired by @knu

## Motivation and Context
While the PR #67 was a great improvement, my "Control+F and type a word" workflow had stopped working since then.
Most popular browsers and editors do this so you can always do a fresh search every time you invoke the "Find" action, so I think KeePassXC should, too.

## How Has This Been Tested?
The new behavior is covered by the new assertions added to the GUI test.

## Types of changes
- :negative_squared_cross_mark: Bug fix (non-breaking change which fixes an issue)
- :white_check_mark: New feature (non-breaking change which adds functionality)
- :negative_squared_cross_mark: Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :white_check_mark: I have added tests to cover my changes.
