### PR TITLE
Reusing installation instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CMakeLists.txt.*
 build*/
+cmake

--- a/README.md
+++ b/README.md
@@ -17,21 +17,8 @@ This is a rebuild from [denk-mal's keepasshttp](https://github.com/denk-mal/keep
 
 ### Installation
 
-Right now KeePassXC does not have a precompiled executable or an installation package.<br/>
-So you must install it from its source code.
-
-**More detailed instructions are available in the INSTALL file or at the [Wiki page](https://github.com/keepassxreboot/keepassx/wiki/Install-Instruction-from-Source).**
-
-First you must download the KeePassXC source code as ZIP file or with Git.
-
-Generally you can build and install KeePassXC with the following commands from a Terminal in the KeePassXC folder
-```
-mkdir build
-cd build
-cmake -DWITH_TESTS=OFF ..
-make
-sudo make install
-```
+KeePassXC does not have a precompiled executable or an installation package yet.   
+See the [wiki](https://github.com/keepassxreboot/keepassx/wiki/Install-Instruction-from-Source) or the INSTALL.md file to install KeePassXC from its source code.
 
 
 ### Clone Repository


### PR DESCRIPTION
## Description
Reusing installation instructions.

## Motivation and Context
I was installing the project on MacOS, and stumbled upon the `Could not find a package configuration file provided by "Qt5Core" (requested version 5.2)` error. After some digging, I solved the problem, just before realizing the installation doc in the wiki already addresses it. I made this change so that the wiki version of the installation instructions (the one that seems to be the most up to date) is used.
