### PR TITLE
Replace Q_FOREACH and remove BOM

### DIFF
--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -100,8 +100,8 @@ int PasswordGenerator::getbits() const
     QVector<PasswordGroup> groups = passwordGroups();
 
     int bits = 0;
-    QVector<QChar> passwordChars;
-    Q_FOREACH (const PasswordGroup& group, groups) {
+
+    for (const PasswordGroup& group : groups) {
         bits += group.size();
     }
 

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -142,8 +142,9 @@ void SettingsWidget::loadSettings()
 
     m_secUi->autoTypeAskCheckBox->setChecked(config()->get("security/autotypeask").toBool());
 
-    Q_FOREACH (const ExtraPage& page, m_extraPages)
+    for (const ExtraPage& page : m_extraPages) {
         page.loadSettings();
+    }
 
     setCurrentRow(0);
 }
@@ -188,8 +189,9 @@ void SettingsWidget::saveSettings()
 
     config()->set("security/autotypeask", m_secUi->autoTypeAskCheckBox->isChecked());
 
-    Q_FOREACH (const ExtraPage& page, m_extraPages)
+    for (const ExtraPage& page : m_extraPages) {
         page.saveSettings();
+    }
 
     Q_EMIT editFinished(true);
 }

--- a/src/http/AccessControlDialog.cpp
+++ b/src/http/AccessControlDialog.cpp
@@ -36,8 +36,9 @@ void AccessControlDialog::setUrl(const QString &url)
 
 void AccessControlDialog::setItems(const QList<Entry *> &items)
 {
-    Q_FOREACH (Entry * entry, items)
+    for (Entry * entry : items) {
         ui->itemsList->addItem(entry->title() + " - " + entry->username());
+    }
 }
 
 bool AccessControlDialog::remember() const

--- a/src/http/Protocol.cpp
+++ b/src/http/Protocol.cpp
@@ -370,8 +370,9 @@ QVariant Response::getEntries() const
 
     QList<QVariant> res;
     res.reserve(m_entries.size());
-    Q_FOREACH (const Entry &entry, m_entries)
+    for (const Entry &entry : m_entries) {
         res.append(qobject2qvariant(&entry));
+    }
     return res;
 }
 
@@ -383,14 +384,15 @@ void Response::setEntries(const QList<Entry> &entries)
 
     QList<Entry> encryptedEntries;
     encryptedEntries.reserve(m_count);
-    Q_FOREACH (const Entry &entry, entries) {
+    for (const Entry &entry : entries) {
         Entry encryptedEntry(encrypt(entry.name(), m_cipher),
                              encrypt(entry.login(), m_cipher),
                              entry.password().isNull() ? QString() : encrypt(entry.password(), m_cipher),
                              encrypt(entry.uuid(), m_cipher));
-        Q_FOREACH (const StringField & field, entry.stringFields())
+        for (const StringField & field : entry.stringFields()) {
             encryptedEntry.addStringField(encrypt(field.key(), m_cipher),
                                           encrypt(field.value(), m_cipher));
+        }
         encryptedEntries << encryptedEntry;
     }
     m_entries = encryptedEntries;
@@ -508,8 +510,9 @@ QVariant Entry::getStringFields() const
 
     QList<QVariant> res;
     res.reserve(m_stringFields.size());
-    Q_FOREACH (const StringField &stringfield, m_stringFields)
+    for (const StringField &stringfield : m_stringFields) {
         res.append(qobject2qvariant(&stringfield));
+    }
     return res;
 }
 

--- a/src/zxcvbn/zxcvbn.cpp
+++ b/src/zxcvbn/zxcvbn.cpp
@@ -1,4 +1,4 @@
-﻿/**********************************************************************************
+/**********************************************************************************
  * C implementation of the zxcvbn password strength estimation method.
  * Copyright (c) 2015, Tony Evans
  * All rights reserved.

--- a/src/zxcvbn/zxcvbn.h
+++ b/src/zxcvbn/zxcvbn.h
@@ -1,4 +1,4 @@
-﻿#ifndef ZXCVBN_H_F98183CE2A01_INCLUDED
+#ifndef ZXCVBN_H_F98183CE2A01_INCLUDED
 #define ZXCVBN_H_F98183CE2A01_INCLUDED
 /**********************************************************************************
  * C implementation of the zxcvbn password strength estimation method.


### PR DESCRIPTION
Replace last instances of Q_FOREACH with C++11 ranged for-loops
Remove some UTF-8 BOM added by mistake

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With Q_FOREACH being obsolete soon, last instances have been converted.
Also some Byte Order Mark added by default by editor have been removed.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tried the main functionalities by hand
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? If it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:` -->
<!--- Everybody loves emoji -->
- :white_check_mark: Bug fix (non-breaking change which fixes an issue)
- :negative_squared_cross_mark: New feature (non-breaking change which adds functionality)
- :negative_squared_cross_mark: Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, if it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:`. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Pull Requests that fail the [REQUIRED] field will likely be sent back for corrections or rejected  -->
- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.
