### PR TITLE
Add missing space in messages.

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1033,13 +1033,13 @@ void DatabaseWidget::reloadDatabaseFile()
         else {
             MessageBox::critical(this, tr("Autoreload Failed"),
                                  tr("Could not parse or unlock the new database file while attempting"
-                                    "to autoreload this database."));
+                                    " to autoreload this database."));
         }
     }
     else {
         MessageBox::critical(this, tr("Autoreload Failed"),
                              tr("Could not open the new database file while attempting to autoreload"
-                                "this database."));
+                                " this database."));
     }
 
     // Rewatch the database file


### PR DESCRIPTION
There is a missing space is those error messages.

## How Has This Been Tested?
Open 2 times the same database. Make a change in one tab, do not save. Lock from the other tab, and choose to save anyway. The error message should appear.

## Screenshots (if appropriate):
![screenshot from 2017-01-11 20 44 17](https://cloud.githubusercontent.com/assets/3301383/21874606/fa2212e0-d843-11e6-8de5-7c514b0a6cba.png)

![screenshot from 2017-01-11 21 23 48](https://cloud.githubusercontent.com/assets/3301383/21874642/455fce82-d844-11e6-90d2-6b09aa395db4.png)


## Types of changes
:white_check_mark: Bug fix
