### PR TITLE
Use placeholder for search widget.

### DIFF
--- a/src/gui/SearchWidget.ui
+++ b/src/gui/SearchWidget.ui
@@ -18,7 +18,7 @@
     <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>6</number>
    </property>
    <property name="bottomMargin">
     <number>0</number>
@@ -38,17 +38,14 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Find:</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item row="0" column="1">
-    <widget class="QLineEdit" name="searchEdit"/>
+    <widget class="QLineEdit" name="searchEdit">
+     <property name="placeholderText">
+      <string>Find:</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Switched to using the placeholder for the search widget instead of a label just beside it.

## Motivation and Context
Make the searchWidget more compact, and makes its size not dependent on the local. Also added a margin to be consistent with the rest of the UI / toolbar.

## How Has This Been Tested?
Tested locally, with different locales to make sure the translation still occurs.

## Screenshots (if appropriate):

Before:
![screenshot from 2017-01-13 21 53 14](https://cloud.githubusercontent.com/assets/3301383/21956072/37ffb38e-da46-11e6-8637-7c4dd6511f29.png)

After:
![screenshot from 2017-01-13 21 53 52](https://cloud.githubusercontent.com/assets/3301383/21956073/41299736-da46-11e6-85b1-b83565ff8fa5.png)

## Types of changes
- :white_check_mark: UI improvement

## Checklist:
- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.
