### PR TITLE
KeePassX PR Migration: #191 Spelling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
-      "Choose the type of build, options are: None Debug Release RelWithDebInfo Debug Debugfull Profile MinSizeRel."
+      "Choose the type of build, options are: None Debug Release RelWithDebInfo Debug DebugFull Profile MinSizeRel."
       FORCE)
 endif()
 

--- a/src/autotype/test/AutoTypeTest.cpp
+++ b/src/autotype/test/AutoTypeTest.cpp
@@ -65,7 +65,7 @@ int AutoTypePlatformTest::platformEventFilter(void* event)
 
 AutoTypeExecutor* AutoTypePlatformTest::createExecutor()
 {
-    return new AutoTypeExecturorTest(this);
+    return new AutoTypeExecutorTest(this);
 }
 
 void AutoTypePlatformTest::setActiveWindowTitle(const QString& title)
@@ -127,17 +127,17 @@ bool AutoTypePlatformTest::raiseOwnWindow()
 }
 #endif
 
-AutoTypeExecturorTest::AutoTypeExecturorTest(AutoTypePlatformTest* platform)
+AutoTypeExecutorTest::AutoTypeExecutorTest(AutoTypePlatformTest* platform)
     : m_platform(platform)
 {
 }
 
-void AutoTypeExecturorTest::execChar(AutoTypeChar* action)
+void AutoTypeExecutorTest::execChar(AutoTypeChar* action)
 {
     m_platform->addActionChar(action);
 }
 
-void AutoTypeExecturorTest::execKey(AutoTypeKey* action)
+void AutoTypeExecutorTest::execKey(AutoTypeKey* action)
 {
     m_platform->addActionKey(action);
 }

--- a/src/autotype/test/AutoTypeTest.h
+++ b/src/autotype/test/AutoTypeTest.h
@@ -69,10 +69,10 @@ private:
     QString m_actionChars;
 };
 
-class AutoTypeExecturorTest : public AutoTypeExecutor
+class AutoTypeExecutorTest : public AutoTypeExecutor
 {
 public:
-    explicit AutoTypeExecturorTest(AutoTypePlatformTest* platform);
+    explicit AutoTypeExecutorTest(AutoTypePlatformTest* platform);
 
     void execChar(AutoTypeChar* action) override;
     void execKey(AutoTypeKey* action) override;

--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -247,7 +247,7 @@ int AutoTypePlatformX11::platformEventFilter(void* event)
 
 AutoTypeExecutor* AutoTypePlatformX11::createExecutor()
 {
-    return new AutoTypeExecturorX11(this);
+    return new AutoTypeExecutorX11(this);
 }
 
 QString AutoTypePlatformX11::windowTitle(Window window, bool useBlacklist)
@@ -823,17 +823,17 @@ int AutoTypePlatformX11::MyErrorHandler(Display* my_dpy, XErrorEvent* event)
 }
 
 
-AutoTypeExecturorX11::AutoTypeExecturorX11(AutoTypePlatformX11* platform)
+AutoTypeExecutorX11::AutoTypeExecutorX11(AutoTypePlatformX11* platform)
     : m_platform(platform)
 {
 }
 
-void AutoTypeExecturorX11::execChar(AutoTypeChar* action)
+void AutoTypeExecutorX11::execChar(AutoTypeChar* action)
 {
     m_platform->SendKeyPressedEvent(m_platform->charToKeySym(action->character));
 }
 
-void AutoTypeExecturorX11::execKey(AutoTypeKey* action)
+void AutoTypeExecutorX11::execKey(AutoTypeKey* action)
 {
     m_platform->SendKeyPressedEvent(m_platform->keyToKeySym(action->key));
 }

--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -24,7 +24,7 @@
 #include <xcb/xcb.h>
 
 bool AutoTypePlatformX11::m_catchXErrors = false;
-bool AutoTypePlatformX11::m_xErrorOccured = false;
+bool AutoTypePlatformX11::m_xErrorOccurred = false;
 int (*AutoTypePlatformX11::m_oldXErrorHandler)(Display*, XErrorEvent*) = nullptr;
 
 AutoTypePlatformX11::AutoTypePlatformX11()
@@ -153,7 +153,7 @@ bool AutoTypePlatformX11::registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifi
              GrabModeAsync, GrabModeAsync);
     stopCatchXErrors();
 
-    if (!m_xErrorOccured) {
+    if (!m_xErrorOccurred) {
         m_currentGlobalKey = key;
         m_currentGlobalModifiers = modifiers;
         m_currentGlobalKeycode = keycode;
@@ -556,7 +556,7 @@ void AutoTypePlatformX11::startCatchXErrors()
     Q_ASSERT(!m_catchXErrors);
 
     m_catchXErrors = true;
-    m_xErrorOccured = false;
+    m_xErrorOccurred = false;
     m_oldXErrorHandler = XSetErrorHandler(x11ErrorHandler);
 }
 
@@ -575,7 +575,7 @@ int AutoTypePlatformX11::x11ErrorHandler(Display* display, XErrorEvent* error)
     Q_UNUSED(error)
 
     if (m_catchXErrors) {
-        m_xErrorOccured = true;
+        m_xErrorOccurred = true;
     }
 
     return 1;

--- a/src/autotype/xcb/AutoTypeXCB.h
+++ b/src/autotype/xcb/AutoTypeXCB.h
@@ -119,10 +119,10 @@ private:
     bool m_loaded;
 };
 
-class AutoTypeExecturorX11 : public AutoTypeExecutor
+class AutoTypeExecutorX11 : public AutoTypeExecutor
 {
 public:
-    explicit AutoTypeExecturorX11(AutoTypePlatformX11* platform);
+    explicit AutoTypeExecutorX11(AutoTypePlatformX11* platform);
 
     void execChar(AutoTypeChar* action) override;
     void execKey(AutoTypeKey* action) override;

--- a/src/autotype/xcb/AutoTypeXCB.h
+++ b/src/autotype/xcb/AutoTypeXCB.h
@@ -100,7 +100,7 @@ private:
     uint m_currentGlobalNativeModifiers;
     int m_modifierMask;
     static bool m_catchXErrors;
-    static bool m_xErrorOccured;
+    static bool m_xErrorOccurred;
     static int (*m_oldXErrorHandler)(Display*, XErrorEvent*);
 
     static const int m_unicodeToKeysymLen;

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -449,7 +449,7 @@ void Entry::truncateHistory()
     int histMaxSize = db->metadata()->historyMaxSize();
     if (histMaxSize > -1) {
         int size = 0;
-        QSet<QByteArray> foundAttachements = attachments()->values().toSet();
+        QSet<QByteArray> foundAttachments = attachments()->values().toSet();
 
         QMutableListIterator<Entry*> i(m_history);
         i.toBack();
@@ -460,11 +460,11 @@ void Entry::truncateHistory()
             if (size <= histMaxSize) {
                 size += historyItem->attributes()->attributesSize();
 
-                const QSet<QByteArray> newAttachments = historyItem->attachments()->values().toSet() - foundAttachements;
+                const QSet<QByteArray> newAttachments = historyItem->attachments()->values().toSet() - foundAttachments;
                 for (const QByteArray& attachment : newAttachments) {
                     size += attachment.size();
                 }
-                foundAttachements += newAttachments;
+                foundAttachments += newAttachments;
             }
 
             if (size > histMaxSize) {

--- a/src/crypto/Crypto.cpp
+++ b/src/crypto/Crypto.cpp
@@ -153,14 +153,14 @@ bool Crypto::testAes256Cbc()
         return false;
     }
 
-    SymmetricCipher aes256Descrypt(SymmetricCipher::Aes256, SymmetricCipher::Cbc, SymmetricCipher::Decrypt);
-    if (!aes256Descrypt.init(key, iv)) {
-        raiseError(aes256Descrypt.errorString());
+    SymmetricCipher aes256Decrypt(SymmetricCipher::Aes256, SymmetricCipher::Cbc, SymmetricCipher::Decrypt);
+    if (!aes256Decrypt.init(key, iv)) {
+        raiseError(aes256Decrypt.errorString());
         return false;
     }
-    QByteArray decryptedText = aes256Descrypt.process(cipherText, &ok);
+    QByteArray decryptedText = aes256Decrypt.process(cipherText, &ok);
     if (!ok) {
-        raiseError(aes256Descrypt.errorString());
+        raiseError(aes256Decrypt.errorString());
         return false;
     }
     if (decryptedText != plainText) {
@@ -196,14 +196,14 @@ bool Crypto::testAes256Ecb()
         return false;
     }
 
-    SymmetricCipher aes256Descrypt(SymmetricCipher::Aes256, SymmetricCipher::Ecb, SymmetricCipher::Decrypt);
-    if (!aes256Descrypt.init(key, iv)) {
-        raiseError(aes256Descrypt.errorString());
+    SymmetricCipher aes256Decrypt(SymmetricCipher::Aes256, SymmetricCipher::Ecb, SymmetricCipher::Decrypt);
+    if (!aes256Decrypt.init(key, iv)) {
+        raiseError(aes256Decrypt.errorString());
         return false;
     }
-    QByteArray decryptedText = aes256Descrypt.process(cipherText, &ok);
+    QByteArray decryptedText = aes256Decrypt.process(cipherText, &ok);
     if (!ok) {
-        raiseError(aes256Descrypt.errorString());
+        raiseError(aes256Decrypt.errorString());
         return false;
     }
     if (decryptedText != plainText) {

--- a/src/format/KeePass2XmlWriter.cpp
+++ b/src/format/KeePass2XmlWriter.cpp
@@ -566,9 +566,9 @@ QString KeePass2XmlWriter::stripInvalidXml10Chars(QString str)
             // keep valid surrogate pair
             i--;
         }
-        else if ((uc < 0x20 && uc != 0x09 && uc != 0x0A && uc != 0x0D)  // control chracters
-                 || (uc >= 0x7F && uc <= 0x84)  // control chracters, valid but discouraged by XML
-                 || (uc >= 0x86 && uc <= 0x9F)  // control chracters, valid but discouraged by XML
+        else if ((uc < 0x20 && uc != 0x09 && uc != 0x0A && uc != 0x0D)  // control characters
+                 || (uc >= 0x7F && uc <= 0x84)  // control characters, valid but discouraged by XML
+                 || (uc >= 0x86 && uc <= 0x9F)  // control characters, valid but discouraged by XML
                  || (uc > 0xFFFD)               // noncharacter
                  || ch.isLowSurrogate()         // single low surrogate
                  || ch.isHighSurrogate())       // single high surrogate

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -333,8 +333,8 @@ void DatabaseWidget::deleteEntries()
         selectedEntries.append(m_entryView->entryFromIndex(index));
     }
 
-    bool inRecylceBin = Tools::hasChild(m_db->metadata()->recycleBin(), selectedEntries.first());
-    if (inRecylceBin || !m_db->metadata()->recycleBinEnabled()) {
+    bool inRecycleBin = Tools::hasChild(m_db->metadata()->recycleBin(), selectedEntries.first());
+    if (inRecycleBin || !m_db->metadata()->recycleBinEnabled()) {
         QMessageBox::StandardButton result;
 
         if (selected.size() == 1) {
@@ -525,10 +525,10 @@ void DatabaseWidget::deleteGroup()
         return;
     }
 
-    bool inRecylceBin = Tools::hasChild(m_db->metadata()->recycleBin(), currentGroup);
+    bool inRecycleBin = Tools::hasChild(m_db->metadata()->recycleBin(), currentGroup);
     bool isRecycleBin = (currentGroup == m_db->metadata()->recycleBin());
     bool isRecycleBinSubgroup = Tools::hasChild(currentGroup, m_db->metadata()->recycleBin());
-    if (inRecylceBin || isRecycleBin || isRecycleBinSubgroup || !m_db->metadata()->recycleBinEnabled()) {
+    if (inRecycleBin || isRecycleBin || isRecycleBinSubgroup || !m_db->metadata()->recycleBinEnabled()) {
         QMessageBox::StandardButton result = MessageBox::question(
             this, tr("Delete group?"),
             tr("Do you really want to delete the group \"%1\" for good?")

--- a/src/keys/FileKey.cpp
+++ b/src/keys/FileKey.cpp
@@ -190,18 +190,18 @@ bool FileKey::loadXml(QIODevice* device)
 
 bool FileKey::loadXmlMeta(QXmlStreamReader& xmlReader)
 {
-    bool corectVersion = false;
+    bool correctVersion = false;
 
     while (!xmlReader.error() && xmlReader.readNextStartElement()) {
         if (xmlReader.name() == "Version") {
             // TODO: error message about incompatible key file version
             if (xmlReader.readElementText() == "1.00") {
-                corectVersion = true;
+                correctVersion = true;
             }
         }
     }
 
-    return corectVersion;
+    return correctVersion;
 }
 
 QByteArray FileKey::loadXmlKey(QXmlStreamReader& xmlReader)

--- a/src/streams/qtiocompressor.cpp
+++ b/src/streams/qtiocompressor.cpp
@@ -522,11 +522,11 @@ qint64 QtIOCompressor::readData(char *data, qint64 maxSize)
         // Read data if if the input buffer is empty. There could be data in the buffer
         // from a previous readData call.
         if (d->zlibStream.avail_in == 0) {
-            qint64 bytesAvalible = d->device->read(reinterpret_cast<char *>(d->buffer), d->bufferSize);
+            qint64 bytesAvailable = d->device->read(reinterpret_cast<char *>(d->buffer), d->bufferSize);
             d->zlibStream.next_in = d->buffer;
-            d->zlibStream.avail_in = bytesAvalible;
+            d->zlibStream.avail_in = bytesAvailable;
 
-            if (bytesAvalible == -1) {
+            if (bytesAvailable == -1) {
                 d->state = QtIOCompressorPrivate::Error;
                 setErrorString(QT_TRANSLATE_NOOP("QtIOCompressor", "Error reading data from underlying device: ") + d->device->errorString());
                 return -1;
@@ -534,9 +534,9 @@ qint64 QtIOCompressor::readData(char *data, qint64 maxSize)
 
             if (d->state != QtIOCompressorPrivate::InStream) {
                 // If we are not in a stream and get 0 bytes, we are probably trying to read from an empty device.
-                if(bytesAvalible == 0)
+                if(bytesAvailable == 0)
                     return 0;
-                else if (bytesAvalible > 0)
+                else if (bytesAvailable > 0)
                     d->state = QtIOCompressorPrivate::InStream;
             }
         }

--- a/src/streams/qtiocompressor.cpp
+++ b/src/streams/qtiocompressor.cpp
@@ -135,7 +135,7 @@ void QtIOCompressorPrivate::flushZlib(int flushMode)
         if (!writeBytes(buffer, outputSize))
             return;
 
-    // If the mode is Z_FNISH we must loop until we get Z_STREAM_END,
+    // If the mode is Z_FINISH we must loop until we get Z_STREAM_END,
     // else we loop as long as zlib is able to fill the output buffer.
     } while ((flushMode == Z_FINISH && status != Z_STREAM_END) || (flushMode != Z_FINISH && zlibStream.avail_out == 0));
 

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -236,15 +236,15 @@ void TestEntryModel::testAutoTypeAssociationsModel()
 
     QCOMPARE(model->rowCount(), 0);
 
-    AutoTypeAssociations* assocications = new AutoTypeAssociations(this);
-    model->setAutoTypeAssociations(assocications);
+    AutoTypeAssociations* associations = new AutoTypeAssociations(this);
+    model->setAutoTypeAssociations(associations);
 
     QCOMPARE(model->rowCount(), 0);
 
     AutoTypeAssociations::Association assoc;
     assoc.window = "1";
     assoc.sequence = "2";
-    assocications->add(assoc);
+    associations->add(assoc);
 
     QCOMPARE(model->rowCount(), 1);
     QCOMPARE(model->data(model->index(0, 0)).toString(), QString("1"));
@@ -252,17 +252,17 @@ void TestEntryModel::testAutoTypeAssociationsModel()
 
     assoc.window = "3";
     assoc.sequence = "4";
-    assocications->update(0, assoc);
+    associations->update(0, assoc);
     QCOMPARE(model->data(model->index(0, 0)).toString(), QString("3"));
     QCOMPARE(model->data(model->index(0, 1)).toString(), QString("4"));
 
-    assocications->add(assoc);
-    assocications->remove(0);
+    associations->add(assoc);
+    associations->remove(0);
     QCOMPARE(model->rowCount(), 1);
 
     delete modelTest;
     delete model;
-    delete assocications;
+    delete associations;
 }
 
 void TestEntryModel::testProxyModel()


### PR DESCRIPTION
This is a rebase of the trivial changes in keepassx/keepassx#191 by @jsoref

## Description
The patch does not fix any bugs or adds any features. It only corrects a lot of spelling mistakes in variable names and code comments.

## How Has This Been Tested?
Code still compiles and runs.

## Types of changes
<!--- What types of changes does your code introduce? If it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:` -->
<!--- Everybody loves emoji -->
- :negative_squared_cross_mark: Bug fix (non-breaking change which fixes an issue)
- :negative_squared_cross_mark: New feature (non-breaking change which adds functionality)
- :negative_squared_cross_mark: Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, if it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:`. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Pull Requests that fail the [REQUIRED] field will likely be sent back for corrections or rejected  -->
- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.
