### PR TITLE
Fixes #156 : update kdbx-extract

### DIFF
--- a/src/keys/CompositeKey.cpp
+++ b/src/keys/CompositeKey.cpp
@@ -18,12 +18,15 @@
 #include "CompositeKey.h"
 #include "CompositeKey_p.h"
 
-#include <QtConcurrent>
 #include <QElapsedTimer>
+#include <QFile>
+#include <QtConcurrent>
 
 #include "core/Global.h"
 #include "crypto/CryptoHash.h"
 #include "crypto/SymmetricCipher.h"
+#include "keys/FileKey.h"
+#include "keys/PasswordKey.h"
 
 CompositeKey::CompositeKey()
 {
@@ -69,6 +72,29 @@ CompositeKey& CompositeKey::operator=(const CompositeKey& key)
     }
 
     return *this;
+}
+
+/*
+ * Read a key from a line of input.
+ * If the line references a valid file
+ * path, the key is loaded from file.
+ */
+CompositeKey CompositeKey::readFromLine(QString line)
+{
+
+  CompositeKey key;
+  if (QFile::exists(line)) {
+      FileKey fileKey;
+      fileKey.load(line);
+      key.addKey(fileKey);
+  }
+  else {
+      PasswordKey password;
+      password.setPassword(line);
+      key.addKey(password);
+  }
+  return key;
+
 }
 
 QByteArray CompositeKey::rawKey() const

--- a/src/keys/CompositeKey.h
+++ b/src/keys/CompositeKey.h
@@ -19,6 +19,7 @@
 #define KEEPASSX_COMPOSITEKEY_H
 
 #include <QList>
+#include <QString>
 
 #include "keys/Key.h"
 
@@ -39,6 +40,7 @@ public:
     void addKey(const Key& key);
 
     static int transformKeyBenchmark(int msec);
+    static CompositeKey readFromLine(QString line);
 
 private:
     static QByteArray transformKeyRaw(const QByteArray& key, const QByteArray& seed,

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -83,6 +83,22 @@ void TestKeys::testComposite()
     delete compositeKey4;
 }
 
+void TestKeys::testCompositeKeyReadFromLine()
+{
+
+    QString keyFilename = QString("%1/FileKeyXml.key").arg(QString(KEEPASSX_TEST_DATA_DIR));
+
+    CompositeKey compositeFileKey = CompositeKey::readFromLine(keyFilename);
+    FileKey fileKey;
+    fileKey.load(keyFilename);
+    QCOMPARE(compositeFileKey.rawKey().size(), fileKey.rawKey().size());
+
+    CompositeKey compositePasswordKey = CompositeKey::readFromLine(QString("password"));
+    PasswordKey passwordKey(QString("password"));
+    QCOMPARE(compositePasswordKey.rawKey().size(), passwordKey.rawKey().size());
+
+}
+
 void TestKeys::testFileKey()
 {
     QFETCH(QString, type);

--- a/tests/TestKeys.h
+++ b/tests/TestKeys.h
@@ -27,6 +27,7 @@ class TestKeys : public QObject
 private Q_SLOTS:
     void initTestCase();
     void testComposite();
+    void testCompositeKeyReadFromLine();
     void testFileKey();
     void testFileKey_data();
     void testCreateFileKey();

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -18,10 +18,7 @@ include_directories(../src)
 add_executable(kdbx-extract kdbx-extract.cpp)
 target_link_libraries(kdbx-extract
                       keepassx_core
-                      ${MHD_LIBRARIES}
                       Qt5::Core
-                      Qt5::Concurrent
-                      Qt5::Widgets
                       ${GCRYPT_LIBRARIES}
                       ${ZLIB_LIBRARIES})
 

--- a/utils/kdbx-extract.cpp
+++ b/utils/kdbx-extract.cpp
@@ -33,8 +33,8 @@ int main(int argc, char **argv)
 {
     QCoreApplication app(argc, argv);
 
-    if (app.arguments().size() != 3) {
-        qCritical("Usage: kdbx-extract <password/key file> <kdbx file>");
+    if (app.arguments().size() != 2) {
+        qCritical("Usage: kdbx-extract <kdbx file>");
         return 1;
     }
 
@@ -42,19 +42,11 @@ int main(int argc, char **argv)
         qFatal("Fatal error while testing the cryptographic functions:\n%s", qPrintable(Crypto::errorString()));
     }
 
-    CompositeKey key;
-    if (QFile::exists(app.arguments().at(1))) {
-        FileKey fileKey;
-        fileKey.load(app.arguments().at(1));
-        key.addKey(fileKey);
-    }
-    else {
-        PasswordKey password;
-        password.setPassword(app.arguments().at(1));
-        key.addKey(password);
-    }
+    static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
+    QString line = inputTextStream.readLine();
+    CompositeKey key = CompositeKey::readFromLine(line);
 
-    QFile dbFile(app.arguments().at(2));
+    QFile dbFile(app.arguments().at(1));
     if (!dbFile.exists()) {
         qCritical("File does not exist.");
         return 1;

--- a/utils/kdbx-extract.cpp
+++ b/utils/kdbx-extract.cpp
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 
+#include <QCommandLineParser>
 #include <QCoreApplication>
 #include <QFile>
 #include <QStringList>
@@ -33,8 +34,16 @@ int main(int argc, char **argv)
 {
     QCoreApplication app(argc, argv);
 
-    if (app.arguments().size() != 2) {
-        qCritical("Usage: kdbx-extract <kdbx file>");
+    QCommandLineParser parser;
+    parser.setApplicationDescription(QCoreApplication::translate("main",
+                                                                 "Extract and print a KeePassXC database file."));
+    parser.addPositionalArgument("database", QCoreApplication::translate("main", "path of the database to extract."));
+    parser.addHelpOption();
+    parser.process(app);
+
+    const QStringList args = parser.positionalArguments();
+    if (args.size() != 1) {
+        parser.showHelp();
         return 1;
     }
 
@@ -46,13 +55,14 @@ int main(int argc, char **argv)
     QString line = inputTextStream.readLine();
     CompositeKey key = CompositeKey::readFromLine(line);
 
-    QFile dbFile(app.arguments().at(1));
+    QString databaseFilename = args.at(0);
+    QFile dbFile(databaseFilename);
     if (!dbFile.exists()) {
-        qCritical("File does not exist.");
+        qCritical("File %s does not exist.", qPrintable(databaseFilename));
         return 1;
     }
     if (!dbFile.open(QIODevice::ReadOnly)) {
-        qCritical("Unable to open file.");
+        qCritical("Unable to open file %s.", qPrintable(databaseFilename));
         return 1;
     }
 

--- a/utils/kdbx-merge.cpp
+++ b/utils/kdbx-merge.cpp
@@ -29,31 +29,6 @@
 #include "format/KeePass2Reader.h"
 #include "format/KeePass2Writer.h"
 #include "keys/CompositeKey.h"
-#include "keys/FileKey.h"
-#include "keys/PasswordKey.h"
-
-/*
- * Read a key from a line of input.
- * If the line references a valid file
- * path, the key is loaded from file.
- */
-CompositeKey readKeyFromLine(QString line)
-{
-
-  CompositeKey key;
-  if (QFile::exists(line)) {
-      FileKey fileKey;
-      fileKey.load(line);
-      key.addKey(fileKey);
-  }
-  else {
-      PasswordKey password;
-      password.setPassword(line);
-      key.addKey(password);
-  }
-  return key;
-
-}
 
 int main(int argc, char **argv)
 {
@@ -85,7 +60,7 @@ int main(int argc, char **argv)
     static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
 
     QString line1 = inputTextStream.readLine();
-    CompositeKey key1 = readKeyFromLine(line1);
+    CompositeKey key1 = CompositeKey::readFromLine(line1);
 
     CompositeKey key2;
     if (parser.isSet("same-password")) {
@@ -93,7 +68,7 @@ int main(int argc, char **argv)
     }
     else {
       QString line2 = inputTextStream.readLine();
-      key2 = readKeyFromLine(line2);
+      key2 = CompositeKey::readFromLine(line2);
     }
 
 


### PR DESCRIPTION
## Description 

Update kdbx-extract to use :
* QCommandLineParser
* stdin to read the password/keyfile path
* Functions moved out of the utils directory.

## Motivation and Context
After writing kdbx-merge, some required changes in kdbx-extract became apparent.

## How Has This Been Tested?
Locally for the kdbx-extract code, + added unit tests for the new function.

## Screenshots
```bash
louib@Desktop $ utils/kdbx-extract 
Usage: utils/kdbx-extract [options] database
Extract and print a KeePassXC database file.

Options:
  -h, --help  Displays this help.

Arguments:
  database    path of the database to extract.
```

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. 
- ✅ My code follows the code style of this project. 
- ✅ All new and existing tests passed.
- ✅ I have added tests to cover my changes.


I had trouble when troubleshooting why my unit tests were failing. I tried using qDebug and QWARN, to no avail. Any advice on this?