### PR TITLE
Hotfix: Use correct data dir path in Release mode

### DIFF
--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -200,11 +200,11 @@ FilePath::FilePath()
     }
     else if (!isDataDirAbsolute && testSetDir(QString("%1/../%2").arg(appDirPath, KEEPASSX_DATA_DIR))) {
     }
-    else if (!isDataDirAbsolute && testSetDir(QString("%1/../%2").arg(appDirPath, KEEPASSX_DATA_DIR))) {
-    }
     else if (!isDataDirAbsolute && testSetDir(QString("%1/%2").arg(KEEPASSX_PREFIX_DIR, KEEPASSX_DATA_DIR))) {
     }
     else if (!isDataDirAbsolute && testSetDir(QString("%1/../../share").arg(appDirPath))) {
+    }
+    else if (!isDataDirAbsolute && testSetDir(QString("%1/../../../share").arg(appDirPath))) {
     }
 #endif
 #ifdef Q_OS_MAC

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -200,7 +200,11 @@ FilePath::FilePath()
     }
     else if (!isDataDirAbsolute && testSetDir(QString("%1/../%2").arg(appDirPath, KEEPASSX_DATA_DIR))) {
     }
+    else if (!isDataDirAbsolute && testSetDir(QString("%1/../%2").arg(appDirPath, KEEPASSX_DATA_DIR))) {
+    }
     else if (!isDataDirAbsolute && testSetDir(QString("%1/%2").arg(KEEPASSX_PREFIX_DIR, KEEPASSX_DATA_DIR))) {
+    }
+    else if (!isDataDirAbsolute && testSetDir(QString("%1/../../share").arg(appDirPath))) {
     }
 #endif
 #ifdef Q_OS_MAC


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
This fix resolves issue #163 . When compiling in Release mode, the path to the data dir was not recognized when running the binary from the CMake build dir. This caused all non-system icons to not show up in the user interface which in turn caused certain tests to fail.

## Motivation and Context
Running Release-compiled binaries from the build dir is needed both for testing the application behavior in Release mode locally as well as for Travis CI.

## How Has This Been Tested?
KeePassXC was built in Release mode and run from the build dir.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**