### PR TITLE
KeePassX PR Migration: #190 Search for Group Names

### DIFF
--- a/src/core/EntrySearcher.cpp
+++ b/src/core/EntrySearcher.cpp
@@ -42,7 +42,11 @@ QList<Entry*> EntrySearcher::searchEntries(const QString& searchTerm, const Grou
     const QList<Group*> children = group->children();
     for (Group* childGroup : children) {
         if (childGroup->searchingEnabled() != Group::Disable) {
-            searchResult.append(searchEntries(searchTerm, childGroup, caseSensitivity));
+            if (matchGroup(searchTerm, childGroup, caseSensitivity)) {
+                searchResult.append(childGroup->entriesRecursive());
+            } else {
+                searchResult.append(searchEntries(searchTerm, childGroup, caseSensitivity));
+            }
         }
     }
 
@@ -68,4 +72,22 @@ bool EntrySearcher::wordMatch(const QString& word, Entry* entry, Qt::CaseSensiti
             entry->username().contains(word, caseSensitivity) ||
             entry->url().contains(word, caseSensitivity) ||
             entry->notes().contains(word, caseSensitivity);
+}
+
+bool EntrySearcher::matchGroup(const QString& searchTerm, const Group* group, Qt::CaseSensitivity caseSensitivity)
+{
+    const QStringList wordList = searchTerm.split(QRegExp("\\s"), QString::SkipEmptyParts);
+    for (const QString& word : wordList) {
+        if (!wordMatch(word, group, caseSensitivity)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool EntrySearcher::wordMatch(const QString& word, const Group* group, Qt::CaseSensitivity caseSensitivity)
+{
+    return group->name().contains(word, caseSensitivity) ||
+            group->notes().contains(word, caseSensitivity);
 }

--- a/src/core/EntrySearcher.h
+++ b/src/core/EntrySearcher.h
@@ -33,6 +33,8 @@ private:
     QList<Entry*> searchEntries(const QString& searchTerm, const Group* group, Qt::CaseSensitivity caseSensitivity);
     QList<Entry*> matchEntry(const QString& searchTerm, Entry* entry, Qt::CaseSensitivity caseSensitivity);
     bool wordMatch(const QString& word, Entry* entry, Qt::CaseSensitivity caseSensitivity);
+    bool matchGroup(const QString& searchTerm, const Group* group, Qt::CaseSensitivity caseSensitivity);
+    bool wordMatch(const QString& word, const Group* group, Qt::CaseSensitivity caseSensitivity);
 };
 
 #endif // KEEPASSX_ENTRYSEARCHER_H

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -750,7 +750,7 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
 void DatabaseWidget::switchToEntryEdit()
 {
     Entry* entry = m_entryView->currentEntry();
-    Q_ASSERT(entry);
+    
     if (!entry) {
         return;
     }
@@ -761,7 +761,7 @@ void DatabaseWidget::switchToEntryEdit()
 void DatabaseWidget::switchToGroupEdit()
 {
     Group* group = m_groupView->currentGroup();
-    Q_ASSERT(group);
+    
     if (!group) {
         return;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
This is a rebased version of KeePassX pull request keepassx/keepassx#190 by @jsoref.
It allows to not only search for entries in the database, but also for their group names.

Additionally, I removed two assertions which lead to crashes when the search result was empty and KeePassXC was compiled in Debug mode.

## How Has This Been Tested?
Searching for group names of entries works as expected. All existing unit tests pass.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**