### PR TITLE
Implement clean shutdown after receiving Unix signals, resolves #169

### DIFF
--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -72,7 +72,10 @@ public:
 
 Application::Application(int& argc, char** argv)
     : QApplication(argc, argv)
-    , m_mainWindow(nullptr), m_unixSignalNotifier(nullptr)
+    , m_mainWindow(nullptr)
+#ifdef Q_OS_UNIX
+    , m_unixSignalNotifier(nullptr)
+#endif
 {
 #if defined(Q_OS_UNIX) && !defined(Q_OS_OSX)
     installNativeEventFilter(new XcbEventFilter());

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -31,7 +31,6 @@
 #include <sys/socket.h>
 #endif
 
-class MainWindow;
 #if defined(Q_OS_UNIX) && !defined(Q_OS_OSX)
 class XcbEventFilter : public QAbstractNativeEventFilter
 {
@@ -156,6 +155,7 @@ void Application::handleUnixSignal(int sig)
 
 void Application::quitBySignal()
 {
+    m_unixSignalNotifier->setEnabled(false);
     char buf;
     ::read(unixSignalSocket[1], &buf, sizeof(buf));
     

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -21,6 +21,8 @@
 
 #include <QApplication>
 
+class QSocketNotifier;
+
 class Application : public QApplication
 {
     Q_OBJECT
@@ -34,8 +36,21 @@ public:
 Q_SIGNALS:
     void openFile(const QString& filename);
 
-private:
+private Q_SLOTS:
+    void quitBySignal();
+
+private:    
     QWidget* m_mainWindow;
+    
+#if defined(Q_OS_UNIX)
+    /**
+     * Register Unix signals such as SIGINT and SIGTERM for clean shutdown.
+     */
+    void registerUnixSignals();
+    QSocketNotifier* m_unixSignalNotifier;
+    static void handleUnixSignal(int sig);
+    static int unixSignalSocket[2];
+#endif
 };
 
 #endif // KEEPASSX_APPLICATION_H

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -37,9 +37,11 @@ Q_SIGNALS:
     void openFile(const QString& filename);
 
 private Q_SLOTS:
+#if defined(Q_OS_UNIX)
     void quitBySignal();
+#endif
 
-private:    
+private:
     QWidget* m_mainWindow;
     
 #if defined(Q_OS_UNIX)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -42,6 +42,7 @@ public:
 public Q_SLOTS:
     void openDatabase(const QString& fileName, const QString& pw = QString(),
                       const QString& keyFile = QString());
+    void appExit();
 
 protected:
      void closeEvent(QCloseEvent* event) override;
@@ -68,7 +69,6 @@ private Q_SLOTS:
     void applySettingsChanges();
     void trayIconTriggered(QSystemTrayIcon::ActivationReason reason);
     void toggleWindow();
-    void appExit();
     void lockDatabasesAfterInactivity();
     void repairDatabase();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
The database wasn't saved properly and lockfiles were not removed when receiving the signals SIGINT, SIGTERM, SIGQUIT or SIGHUP. This patch implements signal handling and performs a clean shutdown after receiving SIGINT SIGTERM or SIGQUIT and ignores SIGHUP.

Since this uses POSIX syscalls for signal and socket handling, there is no Windows implementation at the moment.

This resolves issue #169.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This patch makes sure the database is properly saved when closing KeePassXC using Ctrl+C on the terminal or when logging out of the desktop session. It also removes the lock file and therefore prevents cluttering the file system.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For testing a clean shutdown, a SIGINT was sent to the application via Ctrl+C and killall -INT keepassxc. When there were unsaved changes, KeePassXC asked the user whether to save or discard the changes and then shut down and removed the lock file.
The same behavior was tested with killall for SIGQUIT and SIGTERM as well as SIGHUP which is ignored as intended.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
