### PR TITLE
Preserve group/entry focus when replacing db.

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1081,7 +1081,7 @@ QStringList DatabaseWidget::customEntryAttributes() const
  */
 void DatabaseWidget::restoreGroupEntryFocus(Uuid groupUuid, Uuid entryUuid)
 {
-    Group* restoredGroup;
+    Group* restoredGroup = nullptr;
     const QList<Group*> groups = m_db->rootGroup()->groupsRecursive(true);
     for (Group* group : groups) {
         if (group->uuid() == groupUuid) {
@@ -1090,18 +1090,16 @@ void DatabaseWidget::restoreGroupEntryFocus(Uuid groupUuid, Uuid entryUuid)
         }
     }
 
-    if (!restoredGroup) {
-        return;
-    }
+    if (restoredGroup != nullptr) {
+      m_groupView->setCurrentGroup(restoredGroup);
 
-    m_groupView->setCurrentGroup(restoredGroup);
-
-    const QList<Entry*> entries = restoredGroup->entries();
-    for (Entry* entry : entries) {
-        if (entry->uuid() == entryUuid) {
-            m_entryView->setCurrentEntry(entry);
-            break;
-        }
+      const QList<Entry*> entries = restoredGroup->entries();
+      for (Entry* entry : entries) {
+          if (entry->uuid() == entryUuid) {
+              m_entryView->setCurrentEntry(entry);
+              break;
+          }
+      }
     }
 
 }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -722,15 +722,10 @@ void DatabaseWidget::unlockDatabase(bool accepted)
 
     replaceDatabase(db);
 
-    const QList<Group*> groups = m_db->rootGroup()->groupsRecursive(true);
-    for (Group* group : groups) {
-        if (group->uuid() == m_groupBeforeLock) {
-            m_groupView->setCurrentGroup(group);
-            break;
-        }
-    }
-
+    restoreGroupEntryFocus(m_groupBeforeLock, m_entryBeforeLock);
     m_groupBeforeLock = Uuid();
+    m_entryBeforeLock = Uuid();
+
     setCurrentWidget(m_mainWidget);
     m_unlockDatabaseWidget->clearForms();
     Q_EMIT unlockedDatabase();
@@ -943,6 +938,10 @@ void DatabaseWidget::lock()
         m_groupBeforeLock = m_db->rootGroup()->uuid();
     }
 
+    if (m_entryView->currentEntry()) {
+        m_entryBeforeLock = m_entryView->currentEntry()->uuid();
+    }
+
     clearAllWidgets();
     m_unlockDatabaseWidget->load(m_filename);
     setCurrentWidget(m_unlockDatabaseWidget);
@@ -1028,7 +1027,22 @@ void DatabaseWidget::reloadDatabaseFile()
                 }
             }
 
+            Uuid groupBeforeReload;
+            if (m_groupView && m_groupView->currentGroup()) {
+                groupBeforeReload = m_groupView->currentGroup()->uuid();
+            }
+            else {
+                groupBeforeReload = m_db->rootGroup()->uuid();
+            }
+
+            Uuid entryBeforeReload;
+            if (m_entryView && m_entryView->currentEntry()) {
+                entryBeforeReload = m_entryView->currentEntry()->uuid();
+            }
+
             replaceDatabase(db);
+            restoreGroupEntryFocus(groupBeforeReload, entryBeforeReload);
+
         }
         else {
             MessageBox::critical(this, tr("Autoreload Failed"),
@@ -1059,6 +1073,37 @@ QStringList DatabaseWidget::customEntryAttributes() const
     }
 
     return entry->attributes()->customKeys();
+}
+
+/*
+ * Restores the focus on the group and entry that was focused
+ * before the database was locked or reloaded.
+ */
+void DatabaseWidget::restoreGroupEntryFocus(Uuid groupUuid, Uuid entryUuid)
+{
+    Group* restoredGroup;
+    const QList<Group*> groups = m_db->rootGroup()->groupsRecursive(true);
+    for (Group* group : groups) {
+        if (group->uuid() == groupUuid) {
+            restoredGroup = group;
+            break;
+        }
+    }
+
+    if (!restoredGroup) {
+        return;
+    }
+
+    m_groupView->setCurrentGroup(restoredGroup);
+
+    const QList<Entry*> entries = restoredGroup->entries();
+    for (Entry* entry : entries) {
+        if (entry->uuid() == entryUuid) {
+            m_entryView->setCurrentEntry(entry);
+            break;
+        }
+    }
+
 }
 
 bool DatabaseWidget::isGroupSelected() const

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -163,6 +163,7 @@ private Q_SLOTS:
     // Database autoreload slots
     void onWatchedFileChanged();
     void reloadDatabaseFile();
+    void restoreGroupEntryFocus(Uuid groupUuid, Uuid EntryUuid);
 
 private:
     void setClipboardTextAndMinimize(const QString& text);
@@ -190,6 +191,7 @@ private:
     Group* m_newParent;
     QString m_filename;
     Uuid m_groupBeforeLock;
+    Uuid m_entryBeforeLock;
 
     // Search state
     QString m_lastSearchText;


### PR DESCRIPTION
## Description

The group and entry focus was lost when saving a new entry because of the autoreload feature.
I added the `restoreGroupEntryFocus`. While testing, I realized the entry focus was also lost when locking / unlocking the db (the group focus was preserved though), so I added that to the locking / unlocking also.

## Motivation and Context
Fixes #144 

## How Has This Been Tested?
Unit tests + tested manually that the bug was fixed on MacOS.
I did **not** test with linux yet (I will!)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
