### PR TITLE
Adjusted order of entry's context menu

### DIFF
--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -158,12 +158,12 @@
     <addaction name="actionEntryCopyUsername"/>
     <addaction name="actionEntryCopyPassword"/>
     <addaction name="menuEntryCopyAttribute"/>
+    <addaction name="actionEntryAutoType"/>
     <addaction name="actionEntryOpenUrl"/>
     <addaction name="actionEntryEdit"/>
-    <addaction name="actionEntryAutoType"/>
     <addaction name="actionEntryClone"/>
     <addaction name="actionEntryDelete"/>
-    <addaction name="actionEntryNew"/>   
+    <addaction name="actionEntryNew"/>
    </widget>
    <widget class="QMenu" name="menuGroups">
     <property name="title">

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -155,15 +155,15 @@
      <addaction name="actionEntryCopyNotes"/>
      <addaction name="separator"/>
     </widget>
-    <addaction name="actionEntryNew"/>
-    <addaction name="actionEntryClone"/>
-    <addaction name="actionEntryEdit"/>
-    <addaction name="actionEntryDelete"/>
     <addaction name="actionEntryCopyUsername"/>
     <addaction name="actionEntryCopyPassword"/>
     <addaction name="menuEntryCopyAttribute"/>
-    <addaction name="actionEntryAutoType"/>
     <addaction name="actionEntryOpenUrl"/>
+    <addaction name="actionEntryEdit"/>
+    <addaction name="actionEntryAutoType"/>
+    <addaction name="actionEntryClone"/>
+    <addaction name="actionEntryDelete"/>
+    <addaction name="actionEntryNew"/>   
    </widget>
    <widget class="QMenu" name="menuGroups">
     <property name="title">


### PR DESCRIPTION
Changes context menu entry order so that commonly used actions are at the top.

## Description
Reordered the context menu.

## Motivation and Context
The mostly commonly used actions should be at the top.

## How Has This Been Tested?
Built on a Ubuntu 16.04 workstation and hand tested the context menu

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
