### PR TITLE
Fix compilation error with Qt 5.8, resolves #195

### DIFF
--- a/src/format/KeePass2XmlReader.cpp
+++ b/src/format/KeePass2XmlReader.cpp
@@ -388,7 +388,7 @@ void KeePass2XmlReader::parseBinaries()
             QString id = attr.value("ID").toString();
 
             QByteArray data;
-            if (attr.value("Compressed").compare("True", Qt::CaseInsensitive) == 0) {
+            if (attr.value("Compressed").compare(QLatin1String("True"), Qt::CaseInsensitive) == 0) {
                 data = readCompressedBinary();
             }
             else {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
This is cherry-pick of commit https://github.com/keepassx/keepassx/commit/8cd0c8555413a6bdf4b6603211cf3b930a1036a0 in KeePassX which fixes a compilation error with Qt 5.8.

This pull request resolves #195.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests pass, code still compiles.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**