### PR TITLE
Pressing escape quits search

### DIFF
--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -41,6 +41,7 @@ SearchWidget::SearchWidget(QWidget *parent)
     connect(this, SIGNAL(escapePressed()), m_ui->searchEdit, SLOT(clear()));
 
     new QShortcut(Qt::CTRL + Qt::Key_F, this, SLOT(searchFocus()), nullptr, Qt::ApplicationShortcut);
+	new QShortcut(Qt::Key_Escape, m_ui->searchEdit, SLOT(clear()), nullptr, Qt::ApplicationShortcut);
 
     m_ui->searchEdit->installEventFilter(this);
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -481,8 +481,7 @@ void TestGui::testSearch()
     QCOMPARE(entry->title(), origTitle.append("_edited"));
 
     // Cancel search, should return to normal view
-    QTest::mouseClick(searchTextEdit, Qt::LeftButton);
-    QTest::keyClick(searchTextEdit, Qt::Key_Escape);
+    QTest::keyClick(m_mainWindow, Qt::Key_Escape);
     QTRY_COMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
 }
 


### PR DESCRIPTION
## Description
This allows for quitting search by pressing escape in the main window.

## Motivation and Context
 Everybody loves keyboard shortcuts, but there's no equivalent for the clear icon.

## How Has This Been Tested?
The updated GUI test case.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
