### PR TITLE
Add option to minimize window after database unlock

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -674,6 +674,10 @@ void DatabaseWidget::openDatabase(bool accepted)
         delete m_keepass1OpenWidget;
         m_keepass1OpenWidget = nullptr;
         m_fileWatcher.addPath(m_filename);
+		
+		if (config()->get("MinimizeOnUnlock").toBool()) {
+			window()->showMinimized();
+		}
     }
     else {
         m_fileWatcher.removePath(m_filename);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -104,6 +104,7 @@ void SettingsWidget::loadSettings()
     m_generalUi->autoSaveOnExitCheckBox->setChecked(config()->get("AutoSaveOnExit").toBool());
     m_generalUi->autoReloadOnChangeCheckBox->setChecked(config()->get("AutoReloadOnChange").toBool());
     m_generalUi->minimizeOnCopyCheckBox->setChecked(config()->get("MinimizeOnCopy").toBool());
+    m_generalUi->minimizeOnUnlockCheckBox->setChecked(config()->get("MinimizeOnUnlock").toBool());
     m_generalUi->useGroupIconOnEntryCreationCheckBox->setChecked(config()->get("UseGroupIconOnEntryCreation").toBool());
     m_generalUi->autoTypeEntryTitleMatchCheckBox->setChecked(config()->get("AutoTypeEntryTitleMatch").toBool());
 
@@ -159,6 +160,7 @@ void SettingsWidget::saveSettings()
     config()->set("AutoSaveOnExit", m_generalUi->autoSaveOnExitCheckBox->isChecked());
     config()->set("AutoReloadOnChange", m_generalUi->autoReloadOnChangeCheckBox->isChecked());
     config()->set("MinimizeOnCopy", m_generalUi->minimizeOnCopyCheckBox->isChecked());
+    config()->set("MinimizeOnUnlock", m_generalUi->minimizeOnUnlockCheckBox->isChecked());
     config()->set("UseGroupIconOnEntryCreation",
                   m_generalUi->useGroupIconOnEntryCreationCheckBox->isChecked());
     config()->set("AutoTypeEntryTitleMatch",

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -70,40 +70,47 @@
     </widget>
    </item>
    <item row="7" column="0">
+    <widget class="QCheckBox" name="minimizeOnUnlockCheckBox">
+     <property name="text">
+      <string>Minimize after unlocking a database</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
     <widget class="QCheckBox" name="useGroupIconOnEntryCreationCheckBox">
      <property name="text">
       <string>Use group icon on entry creation</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="autoTypeShortcutLabel">
      <property name="text">
       <string>Global Auto-Type shortcut</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="ShortcutWidget" name="autoTypeShortcutWidget"/>
    </item>
-   <item row="9" column="0">
+   <item row="10" column="0">
     <widget class="QCheckBox" name="autoTypeEntryTitleMatchCheckBox">
      <property name="text">
       <string>Use entry title to match windows for global auto-type</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <widget class="QLabel" name="languageLabel">
      <property name="text">
       <string>Language</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
+   <item row="11" column="1">
     <widget class="QComboBox" name="languageComboBox"/>
    </item>
-   <item row="12" column="0">
+   <item row="13" column="0">
     <layout class="QHBoxLayout" name="systray1Layout">
      <property name="sizeConstraint">
       <enum>QLayout::SetMaximumSize</enum>
@@ -139,7 +146,7 @@
      </item>
     </layout>
    </item>
-   <item row="13" column="0">
+   <item row="14" column="0">
     <layout class="QHBoxLayout" name="systray2Layout">
      <property name="sizeConstraint">
       <enum>QLayout::SetMaximumSize</enum>
@@ -169,7 +176,7 @@
      </item>
     </layout>
    </item>
-   <item row="14" column="0">
+   <item row="15" column="0">
     <layout class="QHBoxLayout" name="systray3Layout">
      <property name="sizeConstraint">
       <enum>QLayout::SetMaximumSize</enum>
@@ -183,7 +190,7 @@
      </item>
     </layout>
    </item>
-   <item row="11" column="0">
+   <item row="12" column="0">
     <widget class="QCheckBox" name="systrayShowCheckBox">
      <property name="text">
       <string>Show a system tray icon</string>


### PR DESCRIPTION
## Description
This adds an option in settings to automatically minimize the window when a database is unlocked.  This is to allow a user to bring back the old functionality where the window would minimize on start after asking for a password.  This functionality is also currently in KeePass2 on Windows.

## Motivation and Context
A few users have complained about the recent change where the minimize on start no longer allowed the user to unlock the database first.  This provides an option to restore that ability.

## How Has This Been Tested?
This has been tested on KDE installed on Gentoo Linux.
I first opened KeePassXC with the option disabled, then entered my password.  It then showed the window containing all of my credentials.  I enabled the option in settings, closed KeePassXC and restarted it, then entered my password.  The window minimized to the tray.

## Screenshots (if appropriate):
![keepassxc](https://cloud.githubusercontent.com/assets/1534210/22305110/8360f64e-e2f7-11e6-88f9-6c9c87a6d31d.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
