### PR TITLE
Clone an entry when in search mode

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -508,7 +508,8 @@ Entry* Entry::clone(CloneFlags flags) const
         entry->m_data.timeInfo.setLocationChanged(now);
     }
 
-
+    if (flags & CloneRenameTitle)
+        entry->setTitle(entry->title() + tr(" - Clone"));
 
     return entry;
 }

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -115,7 +115,8 @@ public:
         CloneNoFlags        = 0,
         CloneNewUuid        = 1, // generate a random uuid for the clone
         CloneResetTimeInfo  = 2, // set all TimeInfo attributes to the current time
-        CloneIncludeHistory = 4  // clone the history items
+        CloneIncludeHistory = 4, // clone the history items
+        CloneRenameTitle    = 8  // add "-Clone" after the original title
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -312,8 +312,10 @@ void DatabaseWidget::cloneEntry()
         return;
     }
 
-    Entry* entry = currentEntry->clone(Entry::CloneNewUuid | Entry::CloneResetTimeInfo);
+    Entry* entry = currentEntry->clone(Entry::CloneNewUuid | Entry::CloneResetTimeInfo | Entry::CloneRenameTitle);
     entry->setGroup(currentEntry->group());
+    if (isInSearchMode())
+        search(m_lastSearchText);
     m_entryView->setFocus();
     m_entryView->setCurrentEntry(entry);
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -364,7 +364,7 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             bool groupSelected = dbWidget->isGroupSelected();
 
             m_ui->actionEntryNew->setEnabled(!inSearch);
-            m_ui->actionEntryClone->setEnabled(singleEntrySelected && !inSearch);
+            m_ui->actionEntryClone->setEnabled(singleEntrySelected);
             m_ui->actionEntryEdit->setEnabled(singleEntrySelected);
             m_ui->actionEntryDelete->setEnabled(entriesSelected);
             m_ui->actionEntryCopyTitle->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTitle());

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -566,7 +566,7 @@ void TestGui::testCloneEntry()
     QCOMPARE(entryView->model()->rowCount(), 2);
     Entry* entryClone = entryView->entryFromIndex(entryView->model()->index(1, 1));
     QVERIFY(entryOrg->uuid() != entryClone->uuid());
-    QCOMPARE(entryClone->title(), entryOrg->title());
+    QCOMPARE(entryClone->title(), entryOrg->title() + QString(" - Clone"));
 }
 
 void TestGui::testDragAndDropEntry()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
When in search mode you can now clone entries! This fixes #214. Thank you to @datamaan for the suggestion.

Cloned entries also now get " - Clone" appended to their title. This does not occur when cloning a group.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually and via unit tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
