### PR TITLE
Enhance attribute entry

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -649,8 +649,12 @@ void EditEntryWidget::protectCurrentAttribute(bool state)
     QModelIndex index = m_advancedUi->attributesView->currentIndex();
     if (!m_history && index.isValid()) {
         QString key = m_attributesModel->keyByIndex(index);
-        // Set the protected state of the current attribute
-        m_entryAttributes->set(key, m_entryAttributes->value(key), state);
+        if (state)
+            // Save the current text and protect the attribute
+            m_entryAttributes->set(key, m_advancedUi->attributesEdit->toPlainText(), true);
+        else
+            // Unprotect the current attribute value (don't save text as it is obscured)
+            m_entryAttributes->set(key, m_entryAttributes->value(key), false);
 
         // Display the attribute
         displayAttribute(index, state);

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -353,6 +353,11 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
         m_advancedUi->attributesEdit->setEnabled(false);
     }
 
+    QList<int> sizes = m_advancedUi->attributesSplitter->sizes();
+    sizes.replace(0, m_advancedUi->attributesSplitter->width() * 0.3);
+    sizes.replace(1, m_advancedUi->attributesSplitter->width() * 0.7);
+    m_advancedUi->attributesSplitter->setSizes(sizes);
+
     IconStruct iconStruct;
     iconStruct.uuid = entry->iconUuid();
     iconStruct.number = entry->iconNumber();

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -654,12 +654,13 @@ void EditEntryWidget::protectCurrentAttribute(bool state)
     QModelIndex index = m_advancedUi->attributesView->currentIndex();
     if (!m_history && index.isValid()) {
         QString key = m_attributesModel->keyByIndex(index);
-        if (state)
+        if (state) {
             // Save the current text and protect the attribute
             m_entryAttributes->set(key, m_advancedUi->attributesEdit->toPlainText(), true);
-        else
+        } else {
             // Unprotect the current attribute value (don't save text as it is obscured)
             m_entryAttributes->set(key, m_entryAttributes->value(key), false);
+        }
 
         // Display the attribute
         displayAttribute(index, state);

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -76,6 +76,8 @@ private Q_SLOTS:
     void editCurrentAttribute();
     void removeCurrentAttribute();
     void updateCurrentAttribute();
+    void protectCurrentAttribute(bool state);
+    void revealCurrentAttribute();
     void insertAttachment();
     void saveCurrentAttachment();
     void openAttachment(const QModelIndex& index);
@@ -109,6 +111,8 @@ private:
     void setForms(const Entry* entry, bool restore = false);
     QMenu* createPresetsMenu();
     void updateEntryData(Entry* entry) const;
+
+    void displayAttribute(QModelIndex index, bool showProtected);
 
     Entry* m_entry;
     Database* m_database;

--- a/src/gui/entry/EditEntryWidgetAdvanced.ui
+++ b/src/gui/entry/EditEntryWidgetAdvanced.ui
@@ -30,9 +30,12 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
-       <widget class="QSplitter" name="splitter">
+       <widget class="QSplitter" name="attributesSplitter">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="childrenCollapsible">
+         <bool>false</bool>
         </property>
         <widget class="AttributesListView" name="attributesView">
          <property name="minimumSize">
@@ -40,6 +43,9 @@
            <width>0</width>
            <height>0</height>
           </size>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContents</enum>
          </property>
          <property name="resizeMode">
           <enum>QListView::Adjust</enum>
@@ -49,11 +55,23 @@
          <property name="enabled">
           <bool>false</bool>
          </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>170</width>
+           <height>0</height>
+          </size>
+         </property>
         </widget>
        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+       <layout class="QVBoxLayout" name="attributesButtonLayout">
         <item>
          <widget class="QPushButton" name="addAttributeButton">
           <property name="text">
@@ -145,7 +163,7 @@
        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <layout class="QVBoxLayout" name="attachmentsButtonLayout">
         <item>
          <widget class="QPushButton" name="addAttachmentButton">
           <property name="text">

--- a/src/gui/entry/EditEntryWidgetAdvanced.ui
+++ b/src/gui/entry/EditEntryWidgetAdvanced.ui
@@ -28,15 +28,28 @@
      <property name="title">
       <string>Additional attributes</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
-       <widget class="AttributesListView" name="attributesView"/>
-      </item>
-      <item>
-       <widget class="QPlainTextEdit" name="attributesEdit">
-        <property name="enabled">
-         <bool>false</bool>
+       <widget class="QSplitter" name="splitter">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
+        <widget class="AttributesListView" name="attributesView">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="resizeMode">
+          <enum>QListView::Adjust</enum>
+         </property>
+        </widget>
+        <widget class="QPlainTextEdit" name="attributesEdit">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
        </widget>
       </item>
       <item>
@@ -49,22 +62,22 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="editAttributeButton">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Edit</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QPushButton" name="removeAttributeButton">
           <property name="enabled">
            <bool>false</bool>
           </property>
           <property name="text">
            <string>Remove</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="editAttributeButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Edit Name</string>
           </property>
          </widget>
         </item>
@@ -80,6 +93,35 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="protectAttributeButton">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">margin-left:50%;margin-right:50%</string>
+          </property>
+          <property name="text">
+           <string>Protect</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="revealAttributeButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Reveal</string>
+          </property>
+          <property name="checkable">
+           <bool>false</bool>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -172,11 +214,12 @@
   <tabstop>attributesView</tabstop>
   <tabstop>attributesEdit</tabstop>
   <tabstop>addAttributeButton</tabstop>
-  <tabstop>editAttributeButton</tabstop>
   <tabstop>removeAttributeButton</tabstop>
+  <tabstop>editAttributeButton</tabstop>
   <tabstop>attachmentsView</tabstop>
   <tabstop>addAttachmentButton</tabstop>
   <tabstop>removeAttachmentButton</tabstop>
+  <tabstop>openAttachmentButton</tabstop>
   <tabstop>saveAttachmentButton</tabstop>
  </tabstops>
  <resources/>

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -181,6 +181,12 @@ void TestEntryModel::testAttributesModel()
     QCOMPARE(spyAboutToRemove.count(), 1);
     QCOMPARE(spyRemoved.count(), 1);
 
+    // test attribute protection
+    QString value = entryAttributes->value("2nd");
+    entryAttributes->set("2nd", value, true);
+    QVERIFY(entryAttributes->isProtected("2nd"));
+    QCOMPARE(entryAttributes->value("2nd"), value);
+
     QSignalSpy spyReset(model, SIGNAL(modelReset()));
     entryAttributes->clear();
     model->setEntryAttributes(0);

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -25,6 +25,7 @@
 #include <QMimeData>
 #include <QPushButton>
 #include <QSpinBox>
+#include <QPlainTextEdit>
 #include <QTemporaryFile>
 #include <QTest>
 #include <QToolBar>
@@ -241,6 +242,19 @@ void TestGui::testEditEntry()
     EditEntryWidget* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
     QLineEdit* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
     QTest::keyClicks(titleEdit, "_test");
+
+    // Test protected attributes
+    editEntryWidget->setCurrentPage(1);
+    QPlainTextEdit* attrTextEdit = editEntryWidget->findChild<QPlainTextEdit*>("attributesEdit");
+    QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("addAttributeButton"), Qt::LeftButton);
+    QString attrText = "TEST TEXT";
+    QTest::keyClicks(attrTextEdit, attrText);
+    QCOMPARE(attrTextEdit->toPlainText(), attrText);
+    QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("protectAttributeButton"), Qt::LeftButton);
+    QVERIFY(attrTextEdit->toPlainText().contains("PROTECTED"));
+    QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("revealAttributeButton"), Qt::LeftButton);
+    QCOMPARE(attrTextEdit->toPlainText(), attrText);
+    editEntryWidget->setCurrentPage(0);
 
     // Save the edit
     QDialogButtonBox* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Allow protected attributes to be hidden
* Entry area is resizable

Fixes #111 and fixes #45 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Attribute entry area was ugly and boring. It is now awesome (or at least slightly better)! The protected view is powered by the already existing protected attributes in the entry class.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing

## Screenshots (if appropriate):
![keepassxc_attributes](https://cloud.githubusercontent.com/assets/2809491/22318999/f30060ca-e34c-11e6-9853-794d1342efb1.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
