### PR TITLE
Fixes #199 : Disable buttonGenerate when no classes.

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -132,8 +132,10 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
 
 void PasswordGeneratorWidget::generatePassword()
 {
-    QString password = m_generator->generatePassword();
-    m_ui->editNewPassword->setText(password);
+    if (m_generator->isValid()) {
+        QString password = m_generator->generatePassword();
+        m_ui->editNewPassword->setText(password);
+    }
 }
 
 void PasswordGeneratorWidget::applyPassword()
@@ -278,6 +280,13 @@ void PasswordGeneratorWidget::updateGenerator()
     m_generator->setLength(m_ui->spinBoxLength->value());
     m_generator->setCharClasses(classes);
     m_generator->setFlags(flags);
+
+    if (m_generator->isValid()) {
+        m_ui->buttonGenerate->setEnabled(true);
+    }
+    else {
+        m_ui->buttonGenerate->setEnabled(false);
+    }
 
     regeneratePassword();
 }

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -283,8 +283,7 @@ void PasswordGeneratorWidget::updateGenerator()
 
     if (m_generator->isValid()) {
         m_ui->buttonGenerate->setEnabled(true);
-    }
-    else {
+    } else {
         m_ui->buttonGenerate->setEnabled(false);
     }
 


### PR DESCRIPTION
## Description

The presence of at least 1 character class was not verified before generating a new password, resulting in the following line https://github.com/keepassxreboot/keepassxc/blob/develop/src/core/PasswordGenerator.cpp#L52 crashing the program.

Note that the validity was checked when calling `PasswordGeneratorWidget::regeneratePassword`, but was not checked when calling `PasswordGeneratorWidget::generatePassword`. The `Generate` button is now disabled if the generator is in an invalid state.

Even though now we should never call `PasswordGeneratorWidget::generatePassword` with an invalid password generator, I added the `isValid()` verification for robustness and for consistency with `regeneratePassword`.

## Motivation and Context
Fixes #199

## How Has This Been Tested?
Unit tests + manual tests (on MacOs).

## Screenshots (if appropriate):
Generate button is enabled when at least 1 character class : 
![screen shot 2017-01-26 at 6 32 31 pm](https://cloud.githubusercontent.com/assets/3301383/22355184/38634024-e3f7-11e6-8a5c-291715eba9f4.png)

Generate button is disabled when no class selected :
![screen shot 2017-01-26 at 6 32 52 pm](https://cloud.githubusercontent.com/assets/3301383/22355207/58a9a684-e3f7-11e6-97ee-2a8f0fcfbc0c.png)

At some point it could be useful to add an error message stating why the `Generate` button is disabled.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
