### PR TITLE
Reuse password generator icon.

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -89,6 +89,7 @@ void EditEntryWidget::setupMain()
     add(tr("Entry"), m_mainWidget);
 
     m_mainUi->togglePasswordButton->setIcon(filePath()->onOffIcon("actions", "password-show"));
+    m_mainUi->togglePasswordGeneratorButton->setIcon(filePath()->icon("actions", "password-generator", false));
     connect(m_mainUi->togglePasswordButton, SIGNAL(toggled(bool)), m_mainUi->passwordEdit, SLOT(setShowPassword(bool)));
     connect(m_mainUi->togglePasswordGeneratorButton, SIGNAL(toggled(bool)), SLOT(togglePasswordGeneratorButton(bool)));
     connect(m_mainUi->expireCheck, SIGNAL(toggled(bool)), m_mainUi->expireDatePicker, SLOT(setEnabled(bool)));

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -77,9 +77,6 @@
      </item>
      <item>
       <widget class="QToolButton" name="togglePasswordGeneratorButton">
-       <property name="text">
-        <string>Generate</string>
-       </property>
        <property name="checkable">
         <bool>true</bool>
        </property>


### PR DESCRIPTION
## Description

Small change to reuse the `password-generator` button in the edit view.

## How Has This Been Tested?
Unit tests + manual tests.

## Screenshots (if appropriate):
Before:
![screenshot from 2017-01-26 21 02 20](https://cloud.githubusercontent.com/assets/3301383/22358136/e2e57068-e40a-11e6-94ae-82415d0264c7.png)

After:
![screenshot from 2017-01-26 21 01 43](https://cloud.githubusercontent.com/assets/3301383/22358139/ead91658-e40a-11e6-841b-4c6fa5c494ff.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ UI improvement

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
