### PR TITLE
Use consistent button min-heights, resolves #192

### DIFF
--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -285,6 +285,12 @@ QProgressBar::chunk {
           </item>
           <item>
            <widget class="QToolButton" name="checkBoxNumbers">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>26</height>
+             </size>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -304,6 +310,12 @@ QProgressBar::chunk {
           </item>
           <item>
            <widget class="QToolButton" name="checkBoxSpecialChars">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>26</height>
+             </size>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Resolves issue #192.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On KDE, there was never a visible difference, but tested it on Windows and buttons have the same size now.

## Screenshots
Before:
![button_paddings_before](https://cloud.githubusercontent.com/assets/911270/22379407/89a7ab38-e4b9-11e6-9cc9-1c9d46e2a619.png)

After:
![button_paddings_after](https://cloud.githubusercontent.com/assets/911270/22379410/8eda1e42-e4b9-11e6-8ba6-4da6449f554e.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
