### PR TITLE
Don't make font size of password strength labels smaller than 8pt, resolves #228

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -45,11 +45,15 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
 
     connect(m_ui->optionButtons, SIGNAL(buttonClicked(int)), SLOT(updateGenerator()));
 
-    // set font size of password quality and entropy labels dynamically to 80% of the default font size
+    // set font size of password quality and entropy labels dynamically to 80% of
+    // the default font size, but make it no smaller than 8pt
     QFont defaultFont;
-    defaultFont.setPointSize(static_cast<int>(defaultFont.pointSize() * 0.8f));
-    m_ui->entropyLabel->setFont(defaultFont);
-    m_ui->strengthLabel->setFont(defaultFont);
+    int smallerSize = static_cast<int>(defaultFont.pointSize() * 0.8f);
+    if (smallerSize >= 8) {
+        defaultFont.setPointSize(smallerSize);
+        m_ui->entropyLabel->setFont(defaultFont);
+        m_ui->strengthLabel->setFont(defaultFont);
+    }
     
     loadSettings();
     reset();

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -104,11 +104,6 @@ QProgressBar::chunk {
            <height>30</height>
           </size>
          </property>
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
          <property name="text">
           <string>strength</string>
          </property>
@@ -143,11 +138,6 @@ QProgressBar::chunk {
            <width>70</width>
            <height>0</height>
           </size>
-         </property>
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
          </property>
          <property name="text">
           <string>entropy</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This resolves issue #228.

## Description
<!--- Describe your changes in detail -->
The password entropy and strength labels below the password generator field are sized dynamically to be 80% of the default font size. On some platforms this lead to illegibly small text. This patch limits the minimum font size to 8pt. If the resulting font size would be smaller, no font size changes are applied.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on KDE: no visible change.
Tested on Windows: labels have a readable font size now.

## Screenshots (if appropriate):
Before:
![screenshot_before](https://cloud.githubusercontent.com/assets/911270/22379708/b111c09a-e4ba-11e6-8a7e-44ab7af25f45.png)

After:
![screenshot_after](https://cloud.githubusercontent.com/assets/911270/22379713/b62b7814-e4ba-11e6-8996-9e24c605cdcc.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**