### PR TITLE
Prompt the user before executing a command in a cmd:// URL

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -497,7 +497,16 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
 
     if (urlString.startsWith("cmd://")) {
         if (urlString.length() > 6) {
-            QProcess::startDetached(urlString.mid(6));
+            QMessageBox::StandardButton result;
+            result = MessageBox::question(
+                this, tr("Execute command?"),
+                tr("Do you really want to execute the following command?<br><br>%1")
+                .arg(urlString.left(200).toHtmlEscaped()),
+                QMessageBox::Yes | QMessageBox::No);
+
+            if (result == QMessageBox::Yes) {
+                QProcess::startDetached(urlString.mid(6));
+            }
         }
     }
     else {


### PR DESCRIPTION
## Description
When the user selects to open a `cmd://` URL, prompt them to ask, "Do you really want to execute the following command?"
(Does not have a "don't ask me anymore" option.)

## Motivation and Context
Fixes #51.

Not having worked with Qt (ever) or C++ (much) in the past, I copied the code from the `DatabaseWidget::deleteEntries` method to prompt the user and adjusted it appropriately. Looking at an example on the Qt website, I realized you could insert HTML into the text for message boxes. I wasn't sure whether to use `<br><br>`, `<br /><br />`, or `<p>` to produce the linebreak effect, or whether I should just not attempt that at all and instead should embed it into the question (e.g. `"Are you sure you want to run the command '%1'?"`). I couldn't see any other instances of `<br/?>` or `<p>` in the code.

## How Has This Been Tested?
I created two entries in a database – one with `http://example.com` as a URL and one instead with `cmd://echo this could be a malicious command`. Pressing the "Open URL" button in the context menu for the former opens the URL with no prompt, and with the latter produces the aforementioned message box. Clicking 'No' on the message box produces no output, and clicking 'Yes' produces 'this could be a malicious command' in the terminal.

Running the tests (`DWITH_TESTS=ON` and `make test`) produced no failures.

## Screenshots (if appropriate):
[https://i.gyazo.com/4fe418a1998c89a8fc901a936256643d.png](https://i.gyazo.com/4fe418a1998c89a8fc901a936256643d.png)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
