### PR TITLE
Add 'Remember my choice' checkbox, resolves #51

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -353,6 +353,12 @@ void Entry::setTitle(const QString& title)
 
 void Entry::setUrl(const QString& url)
 {
+    bool remove = url != m_attributes->value(EntryAttributes::URLKey) &&
+                  (m_attributes->value(EntryAttributes::RememberCmdExecAttr) == "1" ||
+                   m_attributes->value(EntryAttributes::RememberCmdExecAttr) == "0");
+    if (remove) {
+        m_attributes->remove(EntryAttributes::RememberCmdExecAttr);
+    }
     m_attributes->set(EntryAttributes::URLKey, url, m_attributes->isProtected(EntryAttributes::URLKey));
 }
 

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -24,6 +24,7 @@ const QString EntryAttributes::URLKey = "URL";
 const QString EntryAttributes::NotesKey = "Notes";
 const QStringList EntryAttributes::DefaultAttributes(QStringList() << TitleKey << UserNameKey
                                                      << PasswordKey << URLKey << NotesKey);
+const QString EntryAttributes::RememberCmdExecAttr = "_EXEC_CMD";
 
 EntryAttributes::EntryAttributes(QObject* parent)
     : QObject(parent)

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -52,6 +52,7 @@ public:
     static const QString URLKey;
     static const QString NotesKey;
     static const QStringList DefaultAttributes;
+    static const QString RememberCmdExecAttr;
     static bool isDefaultAttribute(const QString& key);
 
 Q_SIGNALS:

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -19,6 +19,7 @@
 
 #include <QAction>
 #include <QDesktopServices>
+#include <QCheckBox>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QFile>
@@ -496,16 +497,45 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
     }
 
     if (urlString.startsWith("cmd://")) {
+        // check if decision to execute command was stored
+        if (entry->attributes()->hasKey(EntryAttributes::RememberCmdExecAttr)) {
+            if (entry->attributes()->value(EntryAttributes::RememberCmdExecAttr) == "1") {
+                QProcess::startDetached(urlString.mid(6));
+            }
+            return;
+        }
+        
+        // otherwise ask user
         if (urlString.length() > 6) {
-            QMessageBox::StandardButton result;
-            result = MessageBox::question(
-                this, tr("Execute command?"),
-                tr("Do you really want to execute the following command?<br><br>%1")
-                .arg(urlString.left(200).toHtmlEscaped()),
-                QMessageBox::Yes | QMessageBox::No);
-
+            QString cmdTruncated = urlString;
+            if (cmdTruncated.length() > 400)
+                cmdTruncated = cmdTruncated.left(400) + " […]";
+            QMessageBox msgbox(QMessageBox::Icon::Question,
+                               tr("Execute command?"),
+                               tr("Do you really want to execute the following command?<br><br>%1<br>")
+                                   .arg(cmdTruncated.toHtmlEscaped()),
+                               QMessageBox::Yes | QMessageBox::No,
+                               this
+            );
+            msgbox.setDefaultButton(QMessageBox::No);
+            
+            QCheckBox* checkbox = new QCheckBox(tr("Remember my choice"), &msgbox);
+            msgbox.setCheckBox(checkbox);
+            bool remember = false;
+            QObject::connect(checkbox, &QCheckBox::stateChanged, [&](int state) {
+                if (static_cast<Qt::CheckState>(state) == Qt::CheckState::Checked) {
+                   remember = true;
+               }
+            });
+            
+            int result = msgbox.exec();
             if (result == QMessageBox::Yes) {
                 QProcess::startDetached(urlString.mid(6));
+            }
+            
+            if (remember) {
+                entry->attributes()->set(EntryAttributes::RememberCmdExecAttr,
+                                         result == QMessageBox::Yes ? "1" : "0");
             }
         }
     }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -507,7 +507,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
         
         // otherwise ask user
         if (urlString.length() > 6) {
-            QString cmdTruncated = urlString;
+            QString cmdTruncated = urlString.mid(6);
             if (cmdTruncated.length() > 400)
                 cmdTruncated = cmdTruncated.left(400) + " […]";
             QMessageBox msgbox(QMessageBox::Icon::Question,

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -434,6 +434,9 @@ void EditEntryWidget::saveEntry()
 
 void EditEntryWidget::updateEntryData(Entry* entry) const
 {
+    entry->attributes()->copyCustomKeysFrom(m_entryAttributes);
+    entry->attachments()->copyDataFrom(m_entryAttachments);
+    
     entry->setTitle(m_mainUi->titleEdit->text());
     entry->setUsername(m_mainUi->usernameEdit->text());
     entry->setUrl(m_mainUi->urlEdit->text());
@@ -442,9 +445,6 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
     entry->setExpiryTime(m_mainUi->expireDatePicker->dateTime().toUTC());
 
     entry->setNotes(m_mainUi->notesEdit->toPlainText());
-
-    entry->attributes()->copyCustomKeysFrom(m_entryAttributes);
-    entry->attachments()->copyDataFrom(m_entryAttachments);
 
     IconStruct iconStruct = m_iconsWidget->state();
 


### PR DESCRIPTION
Allow user to store preference when asked whether to execute command, resolves #51.

<!--- Provide a general summary of your changes in the title above -->

## Description
This patch adds the missing checkbox to store the user's decision whether to execute a command or not.
The preference is stored in the form of an extended attribute. When the URL of an entry changes, the attribute gets removed, so the user will be asked again next time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I performed many manual runs in different configuration contexts: creating a new entry, editing an entry, storing yes editing the entry, storing no, editing again and so on.

## Screenshots (if appropriate):
![screenshot_20170128_142342](https://cloud.githubusercontent.com/assets/911270/22396962/68f97c5c-e565-11e6-95fd-1e29bc525c1c.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

## Additional notes
Considering that we have at least two areas now where we use extended attributes to save internal configurations (KeePassHTTP and this), it might be reasonable to define a protected namespace prefix in the future to prevent collisions with user-defined attributes. Users won't be able to create attributes starting with that prefix.