### PR TITLE
Fixes database modified after discard

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -716,6 +716,7 @@ void DatabaseTabWidget::lockDatabases()
             }
             else if (result == QMessageBox::Discard) {
                 m_dbList[db].modified = false;
+                m_dbList[db].dbWidget->databaseSaved();
             }
             else if (result == QMessageBox::Cancel) {
                 continue;


### PR DESCRIPTION
When choosing to lock the database after it was modified but before is was saved, the `*` would remain indicating that changes were still pending. Calling `databaseSaved` clears the asterisk.

## How Has This Been Tested?
Unit tests + manual testing.

## Types of changes
- ✅ Bug fix

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. 
- ✅ My code follows the code style of this project. 
- ✅ All new and existing tests passed.