### PR TITLE
Properly HTML-escape strings with user-defined contents in message boxes

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -246,7 +246,7 @@ bool DatabaseTabWidget::closeDatabase(Database* db)
         QMessageBox::StandardButton result =
             MessageBox::question(
             this, tr("Close?"),
-            tr("\"%1\" is in edit mode.\nDiscard changes and close anyway?").arg(dbName),
+            tr("\"%1\" is in edit mode.\nDiscard changes and close anyway?").arg(dbName.toHtmlEscaped()),
             QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Cancel);
         if (result == QMessageBox::Cancel) {
             return false;
@@ -262,7 +262,7 @@ bool DatabaseTabWidget::closeDatabase(Database* db)
             QMessageBox::StandardButton result =
                 MessageBox::question(
                 this, tr("Save changes?"),
-                tr("\"%1\" was modified.\nSave changes?").arg(dbName),
+                tr("\"%1\" was modified.\nSave changes?").arg(dbName.toHtmlEscaped()),
                 QMessageBox::Yes | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Yes);
             if (result == QMessageBox::Yes) {
                 if (!saveDatabase(db)) {

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -341,7 +341,7 @@ void DatabaseWidget::deleteEntries()
             result = MessageBox::question(
                 this, tr("Delete entry?"),
                 tr("Do you really want to delete the entry \"%1\" for good?")
-                .arg(selectedEntries.first()->title()),
+                .arg(selectedEntries.first()->title().toHtmlEscaped()),
                 QMessageBox::Yes | QMessageBox::No);
         }
         else {
@@ -365,7 +365,7 @@ void DatabaseWidget::deleteEntries()
             result = MessageBox::question(
                 this, tr("Move entry to recycle bin?"),
                 tr("Do you really want to move entry \"%1\" to the recycle bin?")
-                .arg(selectedEntries.first()->title()),
+                .arg(selectedEntries.first()->title().toHtmlEscaped()),
                 QMessageBox::Yes | QMessageBox::No);
         }
         else {
@@ -532,7 +532,7 @@ void DatabaseWidget::deleteGroup()
         QMessageBox::StandardButton result = MessageBox::question(
             this, tr("Delete group?"),
             tr("Do you really want to delete the group \"%1\" for good?")
-            .arg(currentGroup->name()),
+            .arg(currentGroup->name().toHtmlEscaped()),
             QMessageBox::Yes | QMessageBox::No);
         if (result == QMessageBox::Yes) {
             delete currentGroup;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -271,14 +271,15 @@ void EditEntryWidget::loadEntry(Entry* entry, bool create, bool history, const Q
     m_history = history;
 
     if (history) {
-        setHeadline(QString("%1 > %2").arg(parentName, tr("Entry history")));
+        setHeadline(QString("%1 > %2").arg(parentName.toHtmlEscaped(), tr("Entry history")));
     }
     else {
         if (create) {
-            setHeadline(QString("%1 > %2").arg(parentName, tr("Add entry")));
+            setHeadline(QString("%1 > %2").arg(parentName.toHtmlEscaped(), tr("Add entry")));
         }
         else {
-            setHeadline(QString("%1 > %2 > %3").arg(parentName, entry->title(), tr("Edit entry")));
+            setHeadline(QString("%1 > %2 > %3").arg(parentName.toHtmlEscaped(),
+                                                    entry->title().toHtmlEscaped(), tr("Edit entry")));
         }
     }
 

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -480,7 +480,8 @@ void Service::updateEntry(const QString &, const QString &uuid, const QString &l
                     //ShowNotification(QString("%0: You have an entry change prompt waiting, click to activate").arg(requestId));
                     if (   HttpSettings::alwaysAllowUpdate()
                         || QMessageBox::warning(0, tr("KeePassXC: Update Entry"),
-                                                tr("Do you want to update the information in %1 - %2?").arg(QUrl(url).host()).arg(u),
+                                                tr("Do you want to update the information in %1 - %2?")
+                                                .arg(QUrl(url).host().toHtmlEscaped()).arg(u.toHtmlEscaped()),
                                                 QMessageBox::Yes|QMessageBox::No) == QMessageBox::Yes ) {
                         entry->beginUpdate();
                         entry->setUsername(login);


### PR DESCRIPTION
This PR resolves #236

<!--- Provide a general summary of your changes in the title above -->
Although not a security issue, unescaped HTML contents in user-defined strings can have funny effects when displayed inside a MessageBox. This PR properly escapes HTML where necessary.

## Description
<!--- Describe your changes in detail -->
.toHtmlEscaped() was added to all user-defined strings which are shown in MessageBoxes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested to move groups and entries with HTML inside the title to the trash and then delete them "for good". As intended, HTML tags are now displayed as raw text and not interpreted anymore.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**