### PR TITLE
Fix autotype custom-attribute placeholder

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -646,12 +646,17 @@ QString Entry::resolvePlaceholder(const QString& str) const
     const QList<QString> keyList = attributes()->keys();
     for (const QString& key : keyList) {
         Qt::CaseSensitivity cs = Qt::CaseInsensitive;
+        QString k = key;
+
         if (!EntryAttributes::isDefaultAttribute(key)) {
             cs = Qt::CaseSensitive;
+            k.prepend("{S:");
+        } else {
+            k.prepend("{");
         }
 
-        QString k = key;
-        k.prepend("{").append("}");
+        
+        k.append("}");
         if (result.compare(k,cs)==0) {
             result.replace(result,attributes()->value(key));
             break;

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -96,10 +96,10 @@ void TestAutoType::init()
     m_entry4->setPassword("custom_attr");
     m_entry4->attributes()->set("CUSTOM","Attribute",false);
     association.window = "//^CustomAttr1$//";
-    association.sequence = "{PASSWORD}:{CUSTOM}";
+    association.sequence = "{PASSWORD}:{S:CUSTOM}";
     m_entry4->autoTypeAssociations()->add(association);
     association.window = "//^CustomAttr2$//";
-    association.sequence = "{CuStOm}";
+    association.sequence = "{S:CuStOm}";
     m_entry4->autoTypeAssociations()->add(association);
     association.window = "//^CustomAttr3$//";
     association.sequence = "{PaSSworD}";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Edit `resolvePlaceholder` to load custom-attribute in the `{S:Custom}` format
Fix #218 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the autotype sequence you can call custom attribute with `{S:Custom}` like stated in the [KeePass](http://keepass.info/help/base/placeholders.html) interface. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new tests for Custom attribute autotype are 100% pass

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
