### PR TITLE
Don't try to use theme icons for the system tray, resolves #194

### DIFF
--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -49,8 +49,6 @@ cp -a ../../bin-release/* .
 cp -a ./usr/local/* ./usr
 rm -R ./usr/local
 rmdir ./opt 2> /dev/null
-patch_strings_in_file /usr/local ././
-patch_strings_in_file /usr ./
 
 # bundle Qt platform plugins and themes
 QXCB_PLUGIN="$(find /usr/lib -name 'libqxcb.so' 2> /dev/null)"

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -91,12 +91,12 @@ QString FilePath::pluginPath(const QString& name)
 
 QIcon FilePath::applicationIcon()
 {
-    return icon("apps", "keepassxc");
+    return icon("apps", "keepassxc", false);
 }
 
 QIcon FilePath::trayIconLocked()
 {
-    return icon("apps", "keepassxc-locked");
+    return icon("apps", "keepassxc-locked", false);
 }
 
 QIcon FilePath::trayIconUnlocked()


### PR DESCRIPTION
This PR resolves #194.

Qt also looks in the program's working directory for icons, but apparently, the Ubuntu Unity system tray doesn't, resulting in missing tray icons

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Ubuntu 16.04 with Unity, tray icon now shows up.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**