### PR TITLE
Re-register global D-Bus menu when restoring window from tray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,9 @@ find_package(Qt5Widgets       5.2 REQUIRED)
 find_package(Qt5Test          5.2 REQUIRED)
 find_package(Qt5LinguistTools 5.2 REQUIRED)
 find_package(Qt5Network       5.2 REQUIRED)
+if (UNIX AND NOT APPLE)
+    find_package(Qt5DBus 5.2 REQUIRED)
+endif()
 set(CMAKE_AUTOMOC ON)
 
 # Debian sets the the build type to None for package builds.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,7 +197,11 @@ target_link_libraries(zxcvbn)
 
 if(WITH_XC_HTTP)
   add_library(keepasshttp STATIC ${keepasshttp_SOURCES})
-  target_link_libraries(keepasshttp ${MHD_LIBRARIES} Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Network)
+  target_link_libraries(keepasshttp ${MHD_LIBRARIES}
+                        Qt5::Core
+                        Qt5::Concurrent
+                        Qt5::Widgets 
+                        Qt5::Network)
 endif()
 
 add_library(autotype STATIC ${autotype_SOURCES})
@@ -207,7 +211,14 @@ set(autotype_LIB autotype)
 
 add_library(keepassx_core STATIC ${keepassx_SOURCES})
 set_target_properties(keepassx_core PROPERTIES COMPILE_DEFINITIONS KEEPASSX_BUILDING_CORE)
-target_link_libraries(keepassx_core zxcvbn ${keepasshttp_LIB} ${autotype_LIB} Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Network)
+target_link_libraries(keepassx_core zxcvbn ${keepasshttp_LIB} ${autotype_LIB}
+                      Qt5::Core
+                      Qt5::Concurrent
+                      Qt5::Widgets
+                      Qt5::Network)
+if (UNIX AND NOT APPLE)
+    target_link_libraries(keepassx_core Qt5::DBus)
+endif()
 
 add_executable(${PROGNAME} WIN32 MACOSX_BUNDLE ${keepassx_SOURCES_MAINEXE})
 target_link_libraries(${PROGNAME}
@@ -220,6 +231,7 @@ target_link_libraries(${PROGNAME}
                       ${GCRYPT_LIBRARIES}
                       ${GPGERROR_LIBRARIES}
                       ${ZLIB_LIBRARIES})
+
 
 set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -554,7 +554,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     if (minimizeOnClose && !appExitCalled)
     {
         event->ignore();
-        hide();
+        toggleWindow();
 
         if (config()->get("security/lockdatabaseminimize").toBool()) {
             m_ui->tabWidget->lockDatabases();
@@ -722,6 +722,7 @@ void MainWindow::trayIconTriggered(QSystemTrayIcon::ActivationReason reason)
 void MainWindow::toggleWindow()
 {
     if ((QApplication::activeWindow() == this) && isVisible() && !isMinimized()) {
+        setWindowState(windowState() | Qt::WindowMinimized);
         hide();
 
         if (config()->get("security/lockdatabaseminimize").toBool()) {
@@ -730,8 +731,8 @@ void MainWindow::toggleWindow()
     }
     else {
         ensurePolished();
-        setWindowState(windowState() & ~Qt::WindowMinimized);
         show();
+        setWindowState(windowState() & ~Qt::WindowMinimized);
         raise();
         activateWindow();
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -741,7 +741,7 @@ void MainWindow::toggleWindow()
         raise();
         activateWindow();
         
-#if defined(Q_OS_LINUX) && ! defined(QT_NO_DBUS) && QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+#if defined(Q_OS_LINUX) && ! defined(QT_NO_DBUS)
         // re-register global D-Bus menu (needed on Ubuntu with Unity)
         // see https://github.com/keepassxreboot/keepassxc/issues/271
         // and https://bugreports.qt.io/browse/QTBUG-58723


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This resolves issue #271

## Description
<!--- Describe your changes in detail -->
Ubuntu Unity unregisters global menus when the connected window is hidden. This leaves KeePassXC without a working menu bar when the the window is restored from the system tray.
This patch manually sends a D-Bus call to re-register the window. Unfortunately, it adds D-Bus as a direct dependency on Linux, but I couldn't find another working solution except for disabling native menus altogether.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I compiled an AppImage with Qt 5.8 and tested it in an Ubuntu 16.04 virtual machine and on Arch with KDE Plasma 5.9. Plasma 5.9 has never had issues to begin with (because windows weren't automatically unregistered), but it also doesn't show duplicate menus or any other weird behavior after this patch.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**