### PR TITLE
Unset XDG_DATA_DIRS env as an alternative fix to #194

### DIFF
--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -74,6 +74,11 @@ cat << EOF > ./usr/bin/keepassxc_env
 #export QT_QPA_PLATFORMTHEME=gtk2
 export LD_LIBRARY_PATH="../opt/qt58/lib:\${LD_LIBRARY_PATH}"
 export QT_PLUGIN_PATH="..${QT_PLUGIN_PATH}"
+
+# unset XDG_DATA_DIRS to make tray icon work in Ubuntu Unity
+# see https://github.com/probonopd/AppImageKit/issues/351
+unset XDG_DATA_DIRS
+
 exec keepassxc "\$@"
 EOF
 chmod +x ./usr/bin/keepassxc_env

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -91,12 +91,12 @@ QString FilePath::pluginPath(const QString& name)
 
 QIcon FilePath::applicationIcon()
 {
-    return icon("apps", "keepassxc", false);
+    return icon("apps", "keepassxc");
 }
 
 QIcon FilePath::trayIconLocked()
 {
-    return icon("apps", "keepassxc-locked", false);
+    return icon("apps", "keepassxc-locked");
 }
 
 QIcon FilePath::trayIconUnlocked()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR provides an alternative fix to #194 and reverts the previous solution in #273.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After some more research, I found that unsetting the `XDG_DATA_DIRS` environment variable in our AppImage startup script also resolves the tray icon issue (see https://github.com/probonopd/AppImageKit/issues/351). This allows us to continue using relative icon paths within the application.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Arch Linux (KDE Plasma 5.9) and Ubuntu 16.04 (Unity). Works fine in both.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
