### PR TITLE
Fix : systray option visible mac

### DIFF
--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -65,6 +65,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
 #ifdef Q_OS_MAC
     // systray not useful on OS X
     m_generalUi->systrayShowCheckBox->setVisible(false);
+    m_generalUi->systrayMinimizeOnCloseCheckBox->setVisible(false);
     m_generalUi->systrayMinimizeToTrayCheckBox->setVisible(false);
 #endif
 


### PR DESCRIPTION
Not all the systray settings were hidden on MacOs.

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
Before
![screen shot 2017-02-11 at 1 55 16 pm](https://cloud.githubusercontent.com/assets/3301383/22856566/d7f9b4e4-f061-11e6-82e2-997073fc3ab5.png)

After
![screen shot 2017-02-11 at 1 51 43 pm](https://cloud.githubusercontent.com/assets/3301383/22856568/e01c9614-f061-11e6-9fb8-e339fcb88be8.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed.
