### PR TITLE
Fix major visual glitches

### DIFF
--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>455</width>
-    <height>238</height>
+    <height>266</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -53,7 +53,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string notr="true">&lt;a href=&quot;https://www.keepassxc.org/&quot;&gt;https://www.keepassxc.org/&lt;/a&gt;</string>
+      <string notr="true">&lt;a href=&quot;https://keepassxc.org/&quot;&gt;https://keepassxc.org/&lt;/a&gt;</string>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>
@@ -69,7 +69,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>KeePassXC is distributed under the term of the GNU General Public License (GPL) version 2 or (at your option) version 3.</string>
+      <string>KeePassXC is distributed under the terms of the GNU General Public License (GPL) version 2 or (at your option) version 3.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -82,7 +82,7 @@
       <string/>
      </property>
      <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
@@ -91,6 +91,9 @@
      <property name="text">
       <string>Using:</string>
      </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+     </property>
     </widget>
    </item>
    <item>
@@ -98,6 +101,9 @@
      <property name="text">
       <string>Extensions:
 </string>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>

--- a/src/gui/ChangeMasterKeyWidget.ui
+++ b/src/gui/ChangeMasterKeyWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>438</width>
-    <height>256</height>
+    <width>818</width>
+    <height>397</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -41,8 +41,8 @@
      <property name="checked">
       <bool>true</bool>
      </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" alignment="Qt::AlignRight">
        <widget class="QLabel" name="enterPasswordLabel">
         <property name="text">
          <string>Enter password:</string>
@@ -67,7 +67,7 @@
         </item>
        </layout>
       </item>
-      <item row="1" column="0">
+      <item row="1" column="0" alignment="Qt::AlignRight">
        <widget class="QLabel" name="repeatPasswordLabel">
         <property name="text">
          <string>Repeat password:</string>
@@ -87,7 +87,7 @@
    <item>
     <widget class="QGroupBox" name="keyFileGroup">
      <property name="title">
-      <string>Key file</string>
+      <string>&amp;Key file</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -52,6 +52,13 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
 
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(openDatabase()));
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(reject()));
+    
+#ifdef Q_OS_MACOS
+    // add random padding to layouts to align widgets properly
+    m_ui->dialogButtonsLayout->setContentsMargins(10, 0, 15, 0);
+    m_ui->gridLayout->setContentsMargins(10, 0, 0, 0);
+    m_ui->labelLayout->setContentsMargins(10, 0, 10, 0);
+#endif
 }
 
 DatabaseOpenWidget::~DatabaseOpenWidget()

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -10,7 +10,7 @@
     <height>250</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0,1,0,0,3">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1,0,0,3">
    <property name="spacing">
     <number>8</number>
    </property>
@@ -28,14 +28,24 @@
     </spacer>
    </item>
    <item>
-    <widget class="QLabel" name="labelHeadline">
-     <property name="text">
-      <string>Enter master key</string>
+    <layout class="QVBoxLayout" name="labelLayout">
+     <property name="leftMargin">
+      <number>5</number>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="labelFilename"/>
+     <property name="rightMargin">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="labelHeadline">
+       <property name="text">
+        <string>Enter master key</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelFilename"/>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer_3">
@@ -52,17 +62,20 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <property name="leftMargin">
+      <number>5</number>
+     </property>
      <property name="verticalSpacing">
       <number>8</number>
      </property>
-     <item row="1" column="0">
+     <item row="1" column="0" alignment="Qt::AlignVCenter">
       <widget class="QCheckBox" name="checkKeyFile">
        <property name="text">
         <string>Key File:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
+     <item row="0" column="0" alignment="Qt::AlignVCenter">
       <widget class="QCheckBox" name="checkPassword">
        <property name="text">
         <string>Password:</string>
@@ -70,9 +83,18 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <layout class="QHBoxLayout" name="keyFileLayout">
+       <property name="leftMargin">
+        <number>5</number>
+       </property>
+       <property name="rightMargin">
+        <number>5</number>
+       </property>
        <item>
         <widget class="QComboBox" name="comboKeyFile">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -94,7 +116,13 @@
       </layout>
      </item>
      <item row="0" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
+      <layout class="QHBoxLayout" name="passwordLayout">
+       <property name="leftMargin">
+        <number>5</number>
+       </property>
+       <property name="rightMargin">
+        <number>5</number>
+       </property>
        <item>
         <widget class="PasswordEdit" name="editPassword">
          <property name="echoMode">
@@ -114,14 +142,21 @@
     </layout>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <layout class="QHBoxLayout" name="dialogButtonsLayout">
+     <property name="leftMargin">
+      <number>5</number>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="rightMargin">
+      <number>5</number>
      </property>
-    </widget>
+     <item alignment="Qt::AlignRight">
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -152,7 +187,6 @@
   <tabstop>checkKeyFile</tabstop>
   <tabstop>comboKeyFile</tabstop>
   <tabstop>buttonBrowseFile</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/gui/DatabaseSettingsWidget.ui
+++ b/src/gui/DatabaseSettingsWidget.ui
@@ -68,6 +68,18 @@
           </item>
           <item>
            <widget class="QToolButton" name="transformBenchmarkButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>25</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="text">
              <string>Benchmark</string>
             </property>

--- a/src/gui/DatabaseSettingsWidget.ui
+++ b/src/gui/DatabaseSettingsWidget.ui
@@ -6,160 +6,192 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>399</height>
+    <width>600</width>
+    <height>340</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,2,5,1">
    <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>1</width>
-       <height>3</height>
+       <width>0</width>
+       <height>0</height>
       </size>
      </property>
     </spacer>
    </item>
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <item row="1" column="0">
-      <widget class="QLabel" name="dbNameLabel">
-       <property name="text">
-        <string>Database name:</string>
+    <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1,0">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QWidget" name="widget" native="true">
+       <property name="maximumSize">
+        <size>
+         <width>800</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="2" column="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QSpinBox" name="transformRoundsSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>1000000000</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="transformBenchmarkButton">
+            <property name="text">
+             <string>Benchmark</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="1" alignment="Qt::AlignRight">
+         <widget class="QLabel" name="dbNameLabel">
+          <property name="text">
+           <string>Database name:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QCheckBox" name="historyMaxSizeCheckBox">
+          <property name="text">
+           <string>Max. history size:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1" alignment="Qt::AlignRight">
+         <widget class="QLabel" name="transformRoundsLabel">
+          <property name="text">
+           <string>Transform rounds:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="historyMaxItemsCheckBox">
+          <property name="text">
+           <string>Max. history items:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLineEdit" name="dbNameEdit"/>
+        </item>
+        <item row="5" column="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QSpinBox" name="historyMaxItemsSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximum">
+             <number>2000000000</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="3" column="1" alignment="Qt::AlignRight">
+         <widget class="QLabel" name="defaultUsernameLabel">
+          <property name="text">
+           <string>Default username:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLineEdit" name="dbDescriptionEdit"/>
+        </item>
+        <item row="6" column="2">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QSpinBox" name="historyMaxSizeSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="suffix">
+             <string> MiB</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>2000000000</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="4" column="2">
+         <widget class="QCheckBox" name="recycleBinEnabledCheckBox">
+          <property name="text">
+           <string>Use recycle bin</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QLineEdit" name="defaultUsernameEdit">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1" alignment="Qt::AlignRight">
+         <widget class="QLabel" name="dbDescriptionLabel">
+          <property name="text">
+           <string>Database description:</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="dbNameEdit"/>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="dbDescriptionLabel">
-       <property name="text">
-        <string>Database description:</string>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="dbDescriptionEdit"/>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="transformRoundsLabel">
-       <property name="text">
-        <string>Transform rounds:</string>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
        </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="defaultUsernameLabel">
-       <property name="text">
-        <string>Default username:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLineEdit" name="defaultUsernameEdit">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Use recycle bin:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QSpinBox" name="historyMaxSizeSpinBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="suffix">
-          <string> MiB</string>
-         </property>
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>2000000000</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="6" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QSpinBox" name="historyMaxItemsSpinBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximum">
-          <number>2000000000</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="3" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="QSpinBox" name="transformRoundsSpinBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>1000000000</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="transformBenchmarkButton">
-         <property name="text">
-          <string>Benchmark</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="6" column="0">
-      <widget class="QCheckBox" name="historyMaxItemsCheckBox">
-       <property name="text">
-        <string>Max. history items:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QCheckBox" name="historyMaxSizeCheckBox">
-       <property name="text">
-        <string>Max. history size:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QCheckBox" name="recycleBinEnabledCheckBox"/>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/src/gui/EditWidget.ui
+++ b/src/gui/EditWidget.ui
@@ -49,11 +49,18 @@
     </layout>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="topMargin">
+      <number>5</number>
      </property>
-    </widget>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -66,7 +73,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>categoryList</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/gui/EditWidgetIcons.ui
+++ b/src/gui/EditWidgetIcons.ui
@@ -6,15 +6,27 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>437</width>
     <height>300</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QRadioButton" name="defaultIconsRadio">
      <property name="text">
-      <string>Use default icon</string>
+      <string>&amp;Use default icon</string>
      </property>
     </widget>
    </item>
@@ -46,7 +58,7 @@
    <item>
     <widget class="QRadioButton" name="customIconsRadio">
      <property name="text">
-      <string>Use custom icon</string>
+      <string>Use custo&amp;m icon</string>
      </property>
     </widget>
    </item>

--- a/src/gui/EditWidgetProperties.ui
+++ b/src/gui/EditWidgetProperties.ui
@@ -14,6 +14,15 @@
    <property name="fieldGrowthPolicy">
     <enum>QFormLayout::ExpandingFieldsGrow</enum>
    </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="1" column="1">
     <widget class="QLineEdit" name="createdEdit">
      <property name="sizePolicy">

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -247,9 +247,21 @@ QProgressBar::chunk {
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
-         <layout class="QHBoxLayout" name="alphabetLayout">
+         <layout class="QHBoxLayout" name="alphabetLayout" stretch="0,0,0,0,1">
           <item>
            <widget class="QToolButton" name="checkBoxUpper">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>25</height>
+             </size>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -269,6 +281,18 @@ QProgressBar::chunk {
           </item>
           <item>
            <widget class="QToolButton" name="checkBoxLower">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>25</height>
+             </size>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -288,6 +312,18 @@ QProgressBar::chunk {
           </item>
           <item>
            <widget class="QToolButton" name="checkBoxNumbers">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>25</height>
+             </size>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -307,6 +343,18 @@ QProgressBar::chunk {
           </item>
           <item>
            <widget class="QToolButton" name="checkBoxSpecialChars">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>25</height>
+             </size>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>278</height>
+    <width>575</width>
+    <height>284</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -16,10 +16,25 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>284</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string/>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
    <item>
     <layout class="QGridLayout" name="passwordFieldLayout">
      <property name="bottomMargin">
@@ -235,12 +250,6 @@ QProgressBar::chunk {
          <layout class="QHBoxLayout" name="alphabetLayout">
           <item>
            <widget class="QToolButton" name="checkBoxUpper">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>26</height>
-             </size>
-            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -260,12 +269,6 @@ QProgressBar::chunk {
           </item>
           <item>
            <widget class="QToolButton" name="checkBoxLower">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>26</height>
-             </size>
-            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -285,12 +288,6 @@ QProgressBar::chunk {
           </item>
           <item>
            <widget class="QToolButton" name="checkBoxNumbers">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>26</height>
-             </size>
-            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
@@ -310,12 +307,6 @@ QProgressBar::chunk {
           </item>
           <item>
            <widget class="QToolButton" name="checkBoxSpecialChars">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>26</height>
-             </size>
-            </property>
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -77,6 +77,8 @@ EditEntryWidget::EditEntryWidget(QWidget* parent)
 
     connect(this, SIGNAL(accepted()), SLOT(saveEntry()));
     connect(this, SIGNAL(rejected()), SLOT(cancel()));
+    
+    m_mainUi->passwordGenerator->layout()->setContentsMargins(0, 0, 0, 0);
 }
 
 EditEntryWidget::~EditEntryWidget()

--- a/src/gui/entry/EditEntryWidgetAdvanced.ui
+++ b/src/gui/entry/EditEntryWidgetAdvanced.ui
@@ -7,10 +7,22 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>315</height>
+    <height>366</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QGroupBox" name="attributesBox">
      <property name="title">

--- a/src/gui/entry/EditEntryWidgetAutoType.ui
+++ b/src/gui/entry/EditEntryWidgetAutoType.ui
@@ -110,15 +110,15 @@
             <bool>false</bool>
            </property>
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
-             <verstretch>1</verstretch>
+             <verstretch>0</verstretch>
             </sizepolicy>
            </property>
            <property name="minimumSize">
             <size>
-             <width>35</width>
-             <height>0</height>
+             <width>0</width>
+             <height>25</height>
             </size>
            </property>
            <property name="text">
@@ -132,10 +132,16 @@
             <bool>false</bool>
            </property>
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>25</height>
+            </size>
            </property>
            <property name="text">
             <string>-</string>

--- a/src/gui/entry/EditEntryWidgetAutoType.ui
+++ b/src/gui/entry/EditEntryWidgetAutoType.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>567</width>
-    <height>347</height>
+    <height>348</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -37,14 +37,14 @@
    <item>
     <widget class="QRadioButton" name="inheritSequenceButton">
      <property name="text">
-      <string>Inherit default Auto-Type sequence from the group</string>
+      <string>Inherit default Auto-Type sequence from the &amp;group</string>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QRadioButton" name="customSequenceButton">
      <property name="text">
-      <string>Use custom Auto-Type sequence:</string>
+      <string>&amp;Use custom Auto-Type sequence:</string>
      </property>
     </widget>
    </item>
@@ -90,39 +90,7 @@
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <widget class="QPushButton" name="assocAddButton">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>+</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="assocRemoveButton">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>-</string>
-           </property>
-          </widget>
-         </item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="2,1,1">
          <item>
           <spacer name="horizontalSpacer_3">
            <property name="orientation">
@@ -135,6 +103,44 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="assocAddButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>35</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>+</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="assocRemoveButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>-</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -171,14 +177,14 @@
        <item>
         <widget class="QRadioButton" name="defaultWindowSequenceButton">
          <property name="text">
-          <string>Use default sequence</string>
+          <string>Use default se&amp;quence</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QRadioButton" name="customWindowSequenceButton">
          <property name="text">
-          <string>Set custom sequence:</string>
+          <string>Set custo&amp;m sequence:</string>
          </property>
         </widget>
        </item>

--- a/src/gui/entry/EditEntryWidgetAutoType.ui
+++ b/src/gui/entry/EditEntryWidgetAutoType.ui
@@ -11,6 +11,18 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QCheckBox" name="enableButton">
      <property name="text">

--- a/src/gui/entry/EditEntryWidgetHistory.ui
+++ b/src/gui/entry/EditEntryWidgetHistory.ui
@@ -11,6 +11,18 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QTreeView" name="historyView">
      <property name="sortingEnabled">

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -17,6 +17,15 @@
    </sizepolicy>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="5" column="0" alignment="Qt::AlignRight">
     <widget class="QLabel" name="urlLabel">
      <property name="text">

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -166,7 +166,7 @@
    <item row="5" column="1">
     <widget class="QLineEdit" name="urlEdit"/>
    </item>
-   <item row="7" column="0">
+   <item row="7" column="0" alignment="Qt::AlignRight">
     <widget class="QCheckBox" name="expireCheck">
      <property name="text">
       <string>Expires</string>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -6,35 +6,41 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>372</width>
-    <height>364</height>
+    <width>692</width>
+    <height>323</height>
    </rect>
   </property>
-  <layout class="QFormLayout" name="formLayout">
-   <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::ExpandingFieldsGrow</enum>
-   </property>
-   <item row="0" column="0">
-    <widget class="QLabel" name="titleLabel">
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="5" column="0" alignment="Qt::AlignRight">
+    <widget class="QLabel" name="urlLabel">
      <property name="text">
-      <string>Title:</string>
+      <string>URL:</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="titleEdit"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="usernameLabel">
-     <property name="text">
-      <string>Username:</string>
+   <item row="4" column="1">
+    <widget class="PasswordGeneratorWidget" name="passwordGenerator" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="usernameEdit"/>
-   </item>
-   <item row="3" column="0">
+   <item row="2" column="0" alignment="Qt::AlignRight">
     <widget class="QLabel" name="passwordLabel">
      <property name="text">
       <string>Password:</string>
@@ -42,31 +48,6 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="PasswordEdit" name="passwordEdit">
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="togglePasswordButton">
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="passwordRepeatLabel">
-     <property name="text">
-      <string>Repeat:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="PasswordEdit" name="passwordRepeatEdit">
@@ -84,24 +65,46 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="urlLabel">
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="PasswordEdit" name="passwordEdit">
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="togglePasswordButton">
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0" alignment="Qt::AlignRight">
+    <widget class="QLabel" name="passwordRepeatLabel">
      <property name="text">
-      <string>URL:</string>
+      <string>Repeat:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" alignment="Qt::AlignRight">
+    <widget class="QLabel" name="titleLabel">
+     <property name="text">
+      <string>Title:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" alignment="Qt::AlignRight|Qt::AlignTop">
+    <widget class="QLabel" name="notesLabel">
+     <property name="text">
+      <string>Notes:</string>
      </property>
     </widget>
    </item>
    <item row="7" column="1">
-    <widget class="QLineEdit" name="urlEdit"/>
-   </item>
-   <item row="8" column="0">
-    <widget class="QCheckBox" name="expireCheck">
-     <property name="text">
-      <string>Expires</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QDateTimeEdit" name="expireDatePicker">
@@ -115,19 +118,18 @@
      </item>
      <item>
       <widget class="QPushButton" name="expirePresets">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Presets</string>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="notesLabel">
-     <property name="text">
-      <string>Notes:</string>
-     </property>
-    </widget>
    </item>
    <item row="9" column="1">
     <widget class="QPlainTextEdit" name="notesEdit">
@@ -139,8 +141,28 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="PasswordGeneratorWidget" name="passwordGenerator" native="true"/>
+   <item row="1" column="0" alignment="Qt::AlignRight">
+    <widget class="QLabel" name="usernameLabel">
+     <property name="text">
+      <string>Username:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="titleEdit"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="usernameEdit"/>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="urlEdit"/>
+   </item>
+   <item row="7" column="0">
+    <widget class="QCheckBox" name="expireCheck">
+     <property name="text">
+      <string>Expires</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -165,7 +187,6 @@
   <tabstop>togglePasswordButton</tabstop>
   <tabstop>togglePasswordGeneratorButton</tabstop>
   <tabstop>urlEdit</tabstop>
-  <tabstop>expireCheck</tabstop>
   <tabstop>expireDatePicker</tabstop>
   <tabstop>expirePresets</tabstop>
   <tabstop>notesEdit</tabstop>

--- a/src/http/OptionDialog.ui
+++ b/src/http/OptionDialog.ui
@@ -28,7 +28,7 @@ This is required for accessing your databases from ChromeIPass or PassIFox</stri
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">


### PR DESCRIPTION
## Description
This PR fixes major visual glitches, most of them occurring on OS X (but partly also on other platforms). It therefore fixes almost all issues described in #295. The error message bug, however, has not been fixed, because inline messages have not been merged into the current release branch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The KeePassXC interface contains many minor layout inaccuracies and some major visual bugs. Most of these issues appear on OS X, because Qt apparently cannot emulate native Mac widgets too well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All changes have been tested on Mac OS X 10.12 Sierra. Some of the fixes require adding arbitrary paddings to widgets and layouts. **It would therefore be good if someone could test this on other OS X versions before this patch gets merged.**

The changes were also verified on Arch Linux with KDE Plasma 5.9 (Breeze) and Windows 10 to ensure they didn't break anything or that an issue was fixed on those platforms as well if it wasn't a Mac-only problem.

The GUI tests were run on Arch Linux (KDE) and still pass.

## Screenshots:

### Unlock dialog
I aligned the keyfile combobox and "Browser" button left and right.

Before:
![unlock_before](https://cloud.githubusercontent.com/assets/911270/22867653/51500a7a-f18c-11e6-801d-c2ce5a33ff07.png)

After:
![unlock_after](https://cloud.githubusercontent.com/assets/911270/22867657/56c5738c-f18c-11e6-8d74-688eb765c166.png)

### Change master key dialog
I assigned the password fields a proper width. The checkboxes are still tiny, because they are not really checkboxes. They really are just group boxes with the "checkable" property set. Mac is the only platform that makes a visual problem of that and there is quite a bit of code wired to this, which is why I left it as is for now.

Before:
![changepw_before](https://cloud.githubusercontent.com/assets/911270/22867680/93e4ea7c-f18c-11e6-829d-18bc24bb3a98.png)

After:
![changepw_after](https://cloud.githubusercontent.com/assets/911270/22867681/9710f9ac-f18c-11e6-9aef-b6da7fd59930.png)

### Entry edit widget
The form layout of the edit entry widget was a real mess, resulting in the "Expires" checkbox being completely out of place (most noticeable on OS X, but also on other platforms). I reordered everything in a proper grid layout and adjusted label and field widths. On OS X, the "Expires" checkbox is still a little displaced towards the bottom, but it's a lot better now. It's perfect on Plasma 5.

Before:
![expires_before](https://cloud.githubusercontent.com/assets/911270/22867704/26caaff2-f18d-11e6-92d7-37a09afea31f.png)
After:
![expires_after](https://cloud.githubusercontent.com/assets/911270/22867705/287c1732-f18d-11e6-9abb-33ee62e5d10e.png)

In addition to these changes, I also adjusted the margins around the dynamic password generator widget inside the edit entry widget.

Before:
![passwordgen_before](https://cloud.githubusercontent.com/assets/911270/22867776/4b50600a-f18e-11e6-9725-ee414b9edc86.png)

After:
![passwordgen_after](https://cloud.githubusercontent.com/assets/911270/22867777/4fedc65c-f18e-11e6-85c5-416006087c70.png)

Furthermore, the "+" and "-" buttons for adding or removing window title rules in the auto-type settings of an entry had a very weird problem on OS X. Although they were identical QPushButtons, one of them looked completely different from the other. I morphed the QPushButtons into QToolButtons, adjusted their width and height and moved the spacer to the left.

Before:
![autotype_before](https://cloud.githubusercontent.com/assets/911270/22867749/023a7c98-f18e-11e6-89a0-e54bde582aa1.png)
After:
![autotype_after](https://cloud.githubusercontent.com/assets/911270/22867750/04d24f08-f18e-11e6-84bc-06d09979c72f.png)

### Database settings
The most dramatic changes were performed on the database settings widget. The form elements had basically no layout at all and the "Use recycle bin" checkbox had no proper text. It only a label to the left instead (which is the wrong side). I reorganized all form elements in a centered grid layout with a max width of 800. I also changed the "Benchmark" QPushButton to a QToolButton, because the QPushButton caused major layout shifts on OS X.

Before:
![dbsettings_before](https://cloud.githubusercontent.com/assets/911270/22867870/73283ab6-f18f-11e6-821d-ab9753f6f9e2.png)

After:
![dbsettings_after](https://cloud.githubusercontent.com/assets/911270/22867833/043f166a-f18f-11e6-84b6-3a71f4957a3e.png)

## Additional changes
### HTTP settings
I changed the default tab of the KeePassHTTP settings to "General" instead of "Advanced". This is the only thing I changed in the settings. A general settings rework is a task for 2.2.0.

### About dialog
I removed the `www.` from the URL and made the "Using:" and "Extensions:" labels selectable. 

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
