### PR TITLE
Ask for save location when creating new database

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -94,8 +94,16 @@ void DatabaseTabWidget::newDatabase()
     Database* db = new Database();
     db->rootGroup()->setName(tr("Root"));
     dbStruct.dbWidget = new DatabaseWidget(db, this);
+    
+    CompositeKey emptyKey;
+    db->setKey(emptyKey);
 
     insertDatabase(db, dbStruct);
+    
+    if (!saveDatabaseAs(db)) {
+        closeDatabase(db);
+        return;
+    }
 
     dbStruct.dbWidget->switchToMasterKeyChange();
 }
@@ -353,80 +361,78 @@ bool DatabaseTabWidget::saveDatabase(Database* db)
 
 bool DatabaseTabWidget::saveDatabaseAs(Database* db)
 {
-    DatabaseManagerStruct& dbStruct = m_dbList[db];
-    QString oldFileName;
-    if (dbStruct.saveToFilename) {
-        oldFileName = dbStruct.filePath;
-    }
-    else {
-        oldFileName = tr("New database").append(".kdbx");
-    }
-    QString fileName = fileDialog()->getSaveFileName(this, tr("Save database as"),
-                                                     oldFileName, tr("KeePass 2 Database").append(" (*.kdbx)"),
-                                                     nullptr, 0, "kdbx");
-    if (!fileName.isEmpty()) {
-        QFileInfo fileInfo(fileName);
-        QString lockFilePath;
-        if (fileInfo.exists()) {
-            // returns empty string when file doesn't exist
-            lockFilePath = fileInfo.canonicalPath();
+    while (true) {
+        DatabaseManagerStruct& dbStruct = m_dbList[db];
+        QString oldFileName;
+        if (dbStruct.saveToFilename) {
+            oldFileName = dbStruct.filePath;
+        } else {
+            oldFileName = tr("Passwords").append(".kdbx");
         }
-        else {
-            lockFilePath = fileInfo.absolutePath();
-        }
-        QString lockFileName = QString("%1/.%2.lock").arg(lockFilePath, fileInfo.fileName());
-        QScopedPointer<QLockFile> lockFile(new QLockFile(lockFileName));
-        lockFile->setStaleLockTime(0);
-        if (!lockFile->tryLock()) {
-            // for now silently ignore if we can't create a lock file
-            // due to lack of permissions
-            if (lockFile->error() != QLockFile::PermissionError) {
-                QMessageBox::StandardButton result = MessageBox::question(this, tr("Save database as"),
-                    tr("The database you are trying to save as is locked by another instance of KeePassXC.\n"
-                       "Do you want to save it anyway?"),
-                    QMessageBox::Yes | QMessageBox::No);
+        QString fileName = fileDialog()->getSaveFileName(this, tr("Save database as"),
+                                                        oldFileName, tr("KeePass 2 Database").append(" (*.kdbx)"),
+                                                        nullptr, 0, "kdbx");
+        if (!fileName.isEmpty()) {
+            QFileInfo fileInfo(fileName);
+            QString lockFilePath;
+            if (fileInfo.exists()) {
+                // returns empty string when file doesn't exist
+                lockFilePath = fileInfo.canonicalPath();
+            } else {
+                lockFilePath = fileInfo.absolutePath();
+            }
+            QString lockFileName = QString("%1/.%2.lock").arg(lockFilePath, fileInfo.fileName());
+            QScopedPointer<QLockFile> lockFile(new QLockFile(lockFileName));
+            lockFile->setStaleLockTime(0);
+            if (!lockFile->tryLock()) {
+                // for now silently ignore if we can't create a lock file
+                // due to lack of permissions
+                if (lockFile->error() != QLockFile::PermissionError) {
+                    QMessageBox::StandardButton result = MessageBox::question(this, tr("Save database as"),
+                        tr("The database you are trying to save as is locked by another instance of KeePassXC.\n"
+                        "Do you want to save it anyway?"),
+                        QMessageBox::Yes | QMessageBox::No);
 
-                if (result == QMessageBox::No) {
-                    return false;
-                }
-                else {
-                    // take over the lock file if possible
-                    if (lockFile->removeStaleLockFile()) {
-                        lockFile->tryLock();
+                    if (result == QMessageBox::No) {
+                        return false;
+                    } else {
+                        // take over the lock file if possible
+                        if (lockFile->removeStaleLockFile()) {
+                            lockFile->tryLock();
+                        }
                     }
                 }
             }
-        }
 
-        // setup variables so saveDatabase succeeds
-        dbStruct.saveToFilename = true;
-        dbStruct.canonicalFilePath = fileName;
+            // setup variables so saveDatabase succeeds
+            dbStruct.saveToFilename = true;
+            dbStruct.canonicalFilePath = fileName;
 
-        if (!saveDatabase(db)) {
-            // failed to save, revert back
-            dbStruct.saveToFilename = false;
-            dbStruct.canonicalFilePath = oldFileName;
+            if (!saveDatabase(db)) {
+                // failed to save, revert back
+                dbStruct.saveToFilename = false;
+                dbStruct.canonicalFilePath = oldFileName;
+                continue;
+            }
+
+            // refresh fileinfo since the file didn't exist before
+            fileInfo.refresh();
+
+            dbStruct.modified = false;
+            dbStruct.saveToFilename = true;
+            dbStruct.readOnly = false;
+            dbStruct.filePath = fileInfo.absoluteFilePath();
+            dbStruct.canonicalFilePath = fileInfo.canonicalFilePath();
+            dbStruct.fileName = fileInfo.fileName();
+            dbStruct.dbWidget->updateFilename(dbStruct.filePath);
+            delete dbStruct.lockFile;
+            dbStruct.lockFile = lockFile.take();
+            updateTabName(db);
+            updateLastDatabases(dbStruct.filePath);
+            return true;
+        } else {
             return false;
         }
-
-        // refresh fileinfo since the file didn't exist before
-        fileInfo.refresh();
-
-        dbStruct.modified = false;
-        dbStruct.saveToFilename = true;
-        dbStruct.readOnly = false;
-        dbStruct.filePath = fileInfo.absoluteFilePath();
-        dbStruct.canonicalFilePath = fileInfo.canonicalFilePath();
-        dbStruct.fileName = fileInfo.fileName();
-        dbStruct.dbWidget->updateFilename(dbStruct.filePath);
-        delete dbStruct.lockFile;
-        dbStruct.lockFile = lockFile.take();
-        updateTabName(db);
-        updateLastDatabases(dbStruct.filePath);
-        return true;
-    }
-    else {
-        return false;
     }
 }
 


### PR DESCRIPTION
This PR resolves #285.

## Description
<!--- Describe your changes in detail -->
When the user clicks the button to create a new database, they are asked immediately where to save the database. This resolves issues with the autosave feature in combination with unnamed databases. It also avoids general confusion when users are not aware that their database exists solely in memory until they explicitly save it.

When saving to a location fails, the save dialog is shown again, so the user can choose a different location. When the user clicks the "Cancel" button, the whole database creation process is canceled.

I also changed the default database file name to "Passwords.kdbx" to make it easier to understand for novice users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested to save to multiple different locations (writable and non-writable) on Arch Linux.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
