### PR TITLE
Hotfix #304: Compositing glitches when restoring from tray

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -77,14 +77,9 @@ DatabaseTabWidget::~DatabaseTabWidget()
 void DatabaseTabWidget::toggleTabbar()
 {
     if (count() > 1) {
-        if (!tabBar()->isVisible()) {
-            tabBar()->show();
-        }
-    }
-    else {
-        if (tabBar()->isVisible()) {
-            tabBar()->hide();
-        }
+        tabBar()->show();
+    } else {
+        tabBar()->hide();
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -745,7 +745,8 @@ void MainWindow::toggleWindow()
         // re-register global D-Bus menu (needed on Ubuntu with Unity)
         // see https://github.com/keepassxreboot/keepassxc/issues/271
         // and https://bugreports.qt.io/browse/QTBUG-58723
-        if (m_ui->menubar->isNativeMenuBar()) {
+        // check for !isVisible(), because isNativeMenuBar() does not work with appmenu-qt5
+        if (!m_ui->menubar->isVisible()) {
             QDBusMessage msg = QDBusMessage::createMethodCall(
                 "com.canonical.AppMenu.Registrar",
                 "/com/canonical/AppMenu/Registrar",

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -728,18 +728,19 @@ void MainWindow::toggleWindow()
 {
     if ((QApplication::activeWindow() == this) && isVisible() && !isMinimized()) {
         setWindowState(windowState() | Qt::WindowMinimized);
-        hide();
-
+        QTimer::singleShot(0, this, SLOT(hide()));
+        
         if (config()->get("security/lockdatabaseminimize").toBool()) {
             m_ui->tabWidget->lockDatabases();
         }
-    }
-    else {
+    } else {
         ensurePolished();
-        show();
         setWindowState(windowState() & ~Qt::WindowMinimized);
-        raise();
-        activateWindow();
+        QTimer::singleShot(0, this, [this]() {
+            show();
+            raise();
+            activateWindow();
+        });
         
 #if defined(Q_OS_LINUX) && ! defined(QT_NO_DBUS)
         // re-register global D-Bus menu (needed on Ubuntu with Unity)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -736,11 +736,9 @@ void MainWindow::toggleWindow()
     } else {
         ensurePolished();
         setWindowState(windowState() & ~Qt::WindowMinimized);
-        QTimer::singleShot(0, this, [this]() {
-            show();
-            raise();
-            activateWindow();
-        });
+        show();
+        raise();
+        activateWindow();
         
 #if defined(Q_OS_LINUX) && ! defined(QT_NO_DBUS)
         // re-register global D-Bus menu (needed on Ubuntu with Unity)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,9 +101,12 @@ int main(int argc, char** argv)
     QObject::connect(&app, SIGNAL(openFile(QString)), &mainWindow, SLOT(openDatabase(QString)));
     
     // start minimized if configured
-    if (config()->get("GUI/MinimizeOnStartup").toBool()) {
+    bool minimizeOnStartup = config()->get("GUI/MinimizeOnStartup").toBool();
+    bool minimizeToTray    = config()->get("GUI/MinimizeToTray").toBool();
+    if (minimizeOnStartup) {
         mainWindow.setWindowState(Qt::WindowMinimized);
-    } else {
+    }
+    if (!(minimizeOnStartup && minimizeToTray)) {
         mainWindow.show();
     }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,13 +97,14 @@ int main(int argc, char** argv)
 
     MainWindow mainWindow;
     app.setMainWindow(&mainWindow);
-    mainWindow.show();
     
     QObject::connect(&app, SIGNAL(openFile(QString)), &mainWindow, SLOT(openDatabase(QString)));
     
     // start minimized if configured
     if (config()->get("GUI/MinimizeOnStartup").toBool()) {
         mainWindow.setWindowState(Qt::WindowMinimized);
+    } else {
+        mainWindow.show();
     }
     
     for (int ii=0; ii < args.length(); ii++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR resolves #304.

## Description
<!--- Describe your changes in detail -->
When _"Hide window to system tray when minimized"_ and _"Minimize window at application startup"_ are enabled, restoring the window from the tray causes compositing problems on Ubuntu Unity/Compiz.
Most of those glitches have already been solved as a result of #276 which properly sets the minimize flag on the window before hiding it, but that didn't apply at startup time.

With this fix, KeePassXC doesn't try to show the main window anymore, only to minimize it right after if both options are set. This not only gets rid of artifacts on Ubuntu, but also prevents the window from flashing up for a split second after starting KeePassXC.

I also smuggled another small fix into this PR which solves a timing issues which sometimes causes the window to not be shown properly when restoring it from the tray on Linux (at the cost of not having the window manager's restore animation anymore).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested on a physical Ubuntu 16.04 machine with Unity and the glitches are gone.

It was also tested on the following non-affected platforms to ensure no regressions were introduced:
 - Arch Linux with Plasma 5
 - Ubuntu 16.10 with Plasma 5
 - Ubuntu 16.04 with Unity inside a VirtualBox VM
 - Windows 10 (also a VirtualBox VM)

Mac was not tested because it doesn't have a tray.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
