### PR TITLE
Add github-linguist language hints.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@ src/version.h.cmake export-subst
 snapcraft.yaml export-ignore
 make_release.sh export-ignore
 AppImage-Recipe.sh export-ignore
+
+# github-linguist language hints
+*.h linguist-language=C++
+*.cpp linguist-language=C++


### PR DESCRIPTION
Adding github-linguist language hints so that the main language displayed is C++ instead of C.

Stats before
```
74.62%  C
23.69%  C++
1.12%   CMake
0.45%   Shell
0.05%   Objective-C++
0.05%   Python
0.02%   Objective-C
```

Stats now
```
98.33%  C++
1.12%   CMake
0.45%   Shell
0.05%   Objective-C++
0.05%   Python
```

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
