### PR TITLE
Follow-up to #302: Disable 'Cancel' button when setting initial database password

### DIFF
--- a/src/gui/ChangeMasterKeyWidget.cpp
+++ b/src/gui/ChangeMasterKeyWidget.cpp
@@ -136,3 +136,8 @@ void ChangeMasterKeyWidget::reject()
 {
     Q_EMIT editFinished(false);
 }
+
+void ChangeMasterKeyWidget::setCancelEnabled(bool enabled)
+{
+    m_ui->buttonBox->button(QDialogButtonBox::Cancel)->setEnabled(enabled);
+}

--- a/src/gui/ChangeMasterKeyWidget.h
+++ b/src/gui/ChangeMasterKeyWidget.h
@@ -38,6 +38,7 @@ public:
     void clearForms();
     CompositeKey newMasterKey();
     QLabel* headlineLabel();
+    void setCancelEnabled(bool enabled);
 
 Q_SIGNALS:
     void editFinished(bool accepted);

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -100,7 +100,7 @@ void DatabaseTabWidget::newDatabase()
         return;
     }
 
-    dbStruct.dbWidget->switchToMasterKeyChange();
+    dbStruct.dbWidget->switchToMasterKeyChange(true);
 }
 
 void DatabaseTabWidget::openDatabase()

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -810,9 +810,10 @@ void DatabaseWidget::switchToGroupEdit()
     switchToGroupEdit(group, false);
 }
 
-void DatabaseWidget::switchToMasterKeyChange()
+void DatabaseWidget::switchToMasterKeyChange(bool disableCancel)
 {
     m_changeMasterKeyWidget->clearForms();
+    m_changeMasterKeyWidget->setCancelEnabled(!disableCancel);
     setCurrentWidget(m_changeMasterKeyWidget);
 }
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -132,7 +132,7 @@ public Q_SLOTS:
     void switchToView(bool accepted);
     void switchToEntryEdit();
     void switchToGroupEdit();
-    void switchToMasterKeyChange();
+    void switchToMasterKeyChange(bool disableCancel = false);
     void switchToDatabaseSettings();
     void switchToOpenDatabase(const QString& fileName);
     void switchToOpenDatabase(const QString& fileName, const QString& password, const QString& keyFile);


### PR DESCRIPTION
This is a follow-up pull request to #302 in order to fix the last remaining point of criticism about that PR.

<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch disables the *Cancel* button on the ChangeMasterKeyWidget when setting an initial password on a new database.
## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
