### PR TITLE
Enable High DPI scaling, resolves #221

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include <QCommandLineParser>
 #include <QFile>
 #include <QTextStream>
+#include <QtGlobal>
 
 #include "config-keepassx.h"
 #include "core/Config.h"
@@ -44,7 +45,10 @@ int main(int argc, char** argv)
     Tools::disableCoreDumps();
 #endif
     Tools::setupSearchPaths();
-
+    
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
     Application app(argc, argv);
     Application::setApplicationName("keepassxc");
     Application::setApplicationVersion(KEEPASSX_VERSION);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR resolves #221

## Description
<!--- Describe your changes in detail -->
This PR enables automatic HiDPI scaling when compiled with Qt >= 5.6.0. This fixes or at least mitigates #221. We couldn't find a perfect solution for Windows 10 yet, but this fix at least resolves the biggest problems. It also appears to fix HiDPI problems on Fedora.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I can't test it myself due to the lack of a HiDPI monitor, so I can only rely on reports by affected users.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**