### PR TITLE
Hotfix #306: wifi network polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 CMakeLists.txt.*
 build*/
+release*/
+.idea/
+*.iml
+*.kdev4

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -28,6 +28,11 @@
 #include "gui/IconModels.h"
 #include "gui/MessageBox.h"
 
+#include "http/qhttp/qhttpclient.hpp"
+#include "http/qhttp/qhttpclientresponse.hpp"
+
+using namespace qhttp::client;
+
 IconStruct::IconStruct()
     : uuid(Uuid())
     , number(0)
@@ -40,8 +45,7 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     , m_database(nullptr)
     , m_defaultIconModel(new DefaultIconModel(this))
     , m_customIconModel(new CustomIconModel(this))
-    , m_networkAccessMngr(new QNetworkAccessManager(this))
-    , m_networkOperation(nullptr)
+    , m_httpClient(nullptr)
 {
     m_ui->setupUi(this);
 
@@ -59,8 +63,6 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     connect(m_ui->addButton, SIGNAL(clicked()), SLOT(addCustomIcon()));
     connect(m_ui->deleteButton, SIGNAL(clicked()), SLOT(removeCustomIcon()));
     connect(m_ui->faviconButton, SIGNAL(clicked()), SLOT(downloadFavicon()));
-    connect(m_networkAccessMngr, SIGNAL(finished(QNetworkReply*)),
-            this, SLOT(onRequestFinished(QNetworkReply*)) );
 
     m_ui->faviconButton->setVisible(false);
 }
@@ -93,7 +95,7 @@ IconStruct EditWidgetIcons::state()
             iconStruct.number = -1;
         }
     }
-    
+
     return iconStruct;
 }
 
@@ -103,7 +105,7 @@ void EditWidgetIcons::reset()
     m_currentUuid = Uuid();
 }
 
-void EditWidgetIcons::load(Uuid currentUuid, Database* database, IconStruct iconStruct, const QString &url)
+void EditWidgetIcons::load(const Uuid& currentUuid, Database* database, const IconStruct& iconStruct, const QString& url)
 {
     Q_ASSERT(database);
     Q_ASSERT(!currentUuid.isNull());
@@ -134,11 +136,11 @@ void EditWidgetIcons::load(Uuid currentUuid, Database* database, IconStruct icon
     }
 }
 
-void EditWidgetIcons::setUrl(const QString &url)
+void EditWidgetIcons::setUrl(const QString& url)
 {
     m_url = url;
     m_ui->faviconButton->setVisible(!url.isEmpty());
-    abortFaviconDownload();
+    resetFaviconDownload();
 }
 
 void EditWidgetIcons::downloadFavicon()
@@ -148,85 +150,97 @@ void EditWidgetIcons::downloadFavicon()
     fetchFavicon(url);
 }
 
-void EditWidgetIcons::fetchFavicon(QUrl url)
+void EditWidgetIcons::fetchFavicon(const QUrl& url)
 {
-    if (m_networkOperation == nullptr) {
-        m_networkOperation = m_networkAccessMngr->get(QNetworkRequest(url));
-        m_ui->faviconButton->setDisabled(true);
+    if (nullptr == m_httpClient) {
+        m_httpClient = new QHttpClient(this);
     }
+
+    bool requestMade = m_httpClient->request(qhttp::EHTTP_GET, url, [this, url](QHttpResponse* response) {
+        if (m_database == nullptr) {
+            return;
+        }
+
+        response->collectData();
+        response->onEnd([this, response, &url]() {
+            int status = response->status();
+            if (200 == status) {
+                QImage image;
+                image.loadFromData(response->collectedData());
+
+                if (!image.isNull()) {
+                    //Set the image
+                    Uuid uuid = Uuid::random();
+                    m_database->metadata()->addCustomIcon(uuid, image.scaled(16, 16));
+                    m_customIconModel->setIcons(m_database->metadata()->customIconsScaledPixmaps(),
+                                                m_database->metadata()->customIconsOrder());
+                    QModelIndex index = m_customIconModel->indexFromUuid(uuid);
+                    m_ui->customIconsView->setCurrentIndex(index);
+                    m_ui->customIconsRadio->setChecked(true);
+
+                    resetFaviconDownload();
+                } else {
+                    fetchFaviconFromGoogle(url.host());
+                }
+            } else if (301 == status || 302 == status) {
+                // Check if server has sent a redirect
+                QUrl possibleRedirectUrl(response->headers().value("location", ""));
+                if (!possibleRedirectUrl.isEmpty() && possibleRedirectUrl != m_redirectUrl && m_redirectCount < 3) {
+                    resetFaviconDownload(false);
+                    m_redirectUrl = possibleRedirectUrl;
+                    ++m_redirectCount;
+                    fetchFavicon(m_redirectUrl);
+                } else {
+                    // website is trying to redirect to itself or
+                    // maximum number of redirects has been reached, fall back to Google
+                    fetchFaviconFromGoogle(url.host());
+                }
+            } else {
+                fetchFaviconFromGoogle(url.host());
+            }
+        });
+    });
+
+    if (!requestMade) {
+        resetFaviconDownload();
+        return;
+    }
+
+    m_httpClient->setConnectingTimeOut(5000, [this]() {
+        resetFaviconDownload();
+        MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
+    });
+
+    m_ui->faviconButton->setDisabled(true);
 }
 
-void EditWidgetIcons::fetchFaviconFromGoogle(QString domain)
+void EditWidgetIcons::fetchFaviconFromGoogle(const QString& domain)
 {
      if (m_fallbackToGoogle) {
-        abortFaviconDownload();
+        resetFaviconDownload();
         m_fallbackToGoogle = false;
         fetchFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + domain));
     }
     else {
-        abortFaviconDownload();
+        resetFaviconDownload();
         MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
     }
 }
 
-void EditWidgetIcons::abortFaviconDownload(bool clearRedirect)
+void EditWidgetIcons::resetFaviconDownload(bool clearRedirect)
 {
-    if (m_networkOperation != nullptr) {
-        m_networkOperation->abort();
-        m_networkOperation->deleteLater();
-        m_networkOperation = nullptr;
-    }
-    
     if (clearRedirect) {
-        if (!m_redirectUrl.isEmpty()) {
-            m_redirectUrl.clear();
-        }
+        m_redirectUrl.clear();
         m_redirectCount = 0;
     }
-    
+
+    if (nullptr != m_httpClient) {
+        m_httpClient->deleteLater();
+        m_httpClient = nullptr;
+    }
+
     m_fallbackToGoogle = true;
     m_ui->faviconButton->setDisabled(false);
-}
-
-void EditWidgetIcons::onRequestFinished(QNetworkReply *reply)
-{
-    if (m_database == nullptr) {
-        return;
-    }
-
-    if (!reply->error()) {    
-        QImage image;
-        image.loadFromData(reply->readAll());
-
-        if (!image.isNull()) {
-            //Set the image
-            Uuid uuid = Uuid::random();
-            m_database->metadata()->addCustomIcon(uuid, image.scaled(16, 16));
-            m_customIconModel->setIcons(m_database->metadata()->customIconsScaledPixmaps(),
-                                        m_database->metadata()->customIconsOrder());
-            QModelIndex index = m_customIconModel->indexFromUuid(uuid);
-            m_ui->customIconsView->setCurrentIndex(index);
-            m_ui->customIconsRadio->setChecked(true);
-            
-            abortFaviconDownload();
-        }
-        else {
-            // Check if server has sent a redirect
-            QUrl possibleRedirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
-            if (!possibleRedirectUrl.isEmpty() && possibleRedirectUrl != m_redirectUrl && m_redirectCount < 3) {
-                abortFaviconDownload(false);
-                m_redirectUrl = possibleRedirectUrl;
-                ++m_redirectCount;
-                fetchFavicon(m_redirectUrl);
-            }
-            else { // Webpage is trying to redirect back to itself or the maximum number of redirects has been reached, fallback to Google
-                fetchFaviconFromGoogle(reply->url().host());
-            }
-        }
-    }
-    else { // Request Error e.g. 404, fallback to Google
-        fetchFaviconFromGoogle(reply->url().host());
-    }
 }
 
 void EditWidgetIcons::addCustomIcon()

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -20,9 +20,7 @@
 
 #include <QWidget>
 #include <QSet>
-
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
+#include <QUrl>
 
 #include "core/Global.h"
 #include "core/Uuid.h"
@@ -31,6 +29,11 @@ class Database;
 class DefaultIconModel;
 class CustomIconModel;
 
+namespace qhttp {
+    namespace client {
+        class QHttpClient;
+    }
+}
 namespace Ui {
     class EditWidgetIcons;
 }
@@ -53,17 +56,16 @@ public:
 
     IconStruct state();
     void reset();
-    void load(Uuid currentUuid, Database* database, IconStruct iconStruct, const QString &url = QString());
+    void load(const Uuid& currentUuid, Database* database, const IconStruct& iconStruct, const QString& url = "");
 
 public Q_SLOTS:
-    void setUrl(const QString &url);
+    void setUrl(const QString& url);
 
 private Q_SLOTS:
     void downloadFavicon();
-    void fetchFavicon(QUrl url);
-    void fetchFaviconFromGoogle(QString domain);
-    void abortFaviconDownload(bool clearRedirect = true);
-    void onRequestFinished(QNetworkReply *reply);
+    void fetchFavicon(const QUrl& url);
+    void fetchFaviconFromGoogle(const QString& domain);
+    void resetFaviconDownload(bool clearRedirect = true);
     void addCustomIcon();
     void removeCustomIcon();
     void updateWidgetsDefaultIcons(bool checked);
@@ -81,8 +83,7 @@ private:
     unsigned short m_redirectCount = 0;
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;
-    QNetworkAccessManager* const m_networkAccessMngr;
-    QNetworkReply* m_networkOperation;
+    qhttp::client::QHttpClient* m_httpClient;
 
     Q_DISABLE_COPY(EditWidgetIcons)
 };

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -14,7 +14,6 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QProgressDialog>
-#include <QDebug>
 
 #include "Service.h"
 #include "Protocol.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR resolves #306.

## Description
<!--- Describe your changes in detail -->
I replaced the former favicon download code with a new implementation based on our patched version of the QHttp library (see #317).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
QNetworkAccessManager causes unnecessary Wifi network scans every 10 seconds (see https://bugreports.qt.io/browse/QTBUG-40332). This results in very poor network performance (and probably also increased battery drain) on some platforms (e.g. OS X) when using a PC or laptop with a Wifi connection.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the changes myself manually to make sure favicons can still be downloaded
- over plain HTTP
- over HTTPS
- with up to 3 redirects
- from Google as fallback if no favicon.ico file could be found (e.g. when there is a favicon.png like on keepassxc.org)

If the server cannot be found, the download button is re-enabled after a timeout of 5 seconds and an error message is shown.

I also let the original reporters of this issue test the changes to make sure no Wifi polling occurs anymore.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
