### PR TITLE
Fix sort order when searching

### DIFF
--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -140,15 +140,21 @@ Entry* EntryView::entryFromIndex(const QModelIndex& index)
 void EntryView::switchToEntryListMode()
 {
     m_sortModel->hideColumn(0, false);
-    sortByColumn(1, Qt::AscendingOrder); // TODO: should probably be improved
+
+    m_sortModel->sort(1, Qt::AscendingOrder);
+    m_sortModel->sort(0, Qt::AscendingOrder);
     sortByColumn(0, Qt::AscendingOrder);
+
     m_inEntryListMode = true;
 }
 
 void EntryView::switchToGroupMode()
 {
     m_sortModel->hideColumn(0, true);
-    sortByColumn(-1, Qt::AscendingOrder);
+
+    m_sortModel->sort(-1, Qt::AscendingOrder);
+    m_sortModel->sort(0, Qt::AscendingOrder);
     sortByColumn(0, Qt::AscendingOrder);
+
     m_inEntryListMode = false;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR resolves #319

## Description
<!--- Describe your changes in detail -->
When searching for entries, a QSortFilterProxyModel is used for showing and hiding the *Group* column. However, sorting was still done on the original model which resulted in arbitrary sort order. This patch sorts the proxy model instead of the data model and only does one extra sort on the data afterwards to update the column headers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested it on a large database with lots of passwords and groups. Sort order before, while and after searching is as intended now.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
