### PR TITLE
Only use relative path in DIGEST file

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -657,7 +657,9 @@ sign() {
         fi
         
         logInfo "Creating digest for file '${f}'..."
-        sha256sum "$f"  > "${f}.DIGEST"
+        local rp="$(realpath "$f")"
+        local bname="$(basename "$f")"
+        (cd "$(dirname "$rp")"; sha256sum "$bname"  > "${bname}.DIGEST")
     done
     
     logInfo "All done!"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This is a little fix to the release script to make sure the DIGEST file always contains only the file name of the hashed file, not any other path prefixes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DIGEST files are delivered together with the binary releases in the same directory. No path names should be added when `release-tool sign` was called from a parent directory.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
