### PR TITLE
Make Salsa20 optional if building against older libgcrypt

### DIFF
--- a/src/crypto/Crypto.cpp
+++ b/src/crypto/Crypto.cpp
@@ -90,11 +90,13 @@ bool Crypto::checkAlgorithms()
         qWarning("Crypto::checkAlgorithms: %s", qPrintable(m_errorStr));
         return false;
     }
+#if GCRYPT_VERSION_NUMBER >= 0x010600
     if (gcry_cipher_algo_info(GCRY_CIPHER_SALSA20, GCRYCTL_TEST_ALGO, nullptr, nullptr) != 0) {
         m_errorStr = "GCRY_CIPHER_SALSA20 not found.";
         qWarning("Crypto::checkAlgorithms: %s", qPrintable(m_errorStr));
         return false;
     }
+#endif
     if (gcry_md_test_algo(GCRY_MD_SHA256) != 0) {
         m_errorStr = "GCRY_MD_SHA256 not found.";
         qWarning("Crypto::checkAlgorithms: %s", qPrintable(m_errorStr));

--- a/src/crypto/SymmetricCipherGcrypt.cpp
+++ b/src/crypto/SymmetricCipherGcrypt.cpp
@@ -44,8 +44,10 @@ int SymmetricCipherGcrypt::gcryptAlgo(SymmetricCipher::Algorithm algo)
     case SymmetricCipher::Twofish:
         return GCRY_CIPHER_TWOFISH;
 
+#if GCRYPT_VERSION_NUMBER >= 0x010600
     case SymmetricCipher::Salsa20:
         return GCRY_CIPHER_SALSA20;
+#endif
 
     default:
         Q_ASSERT(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Check libgcrypt version to build with Salsa20 only when it is 1.6.0 or higher.

I don't expect *this* PR to be accepted as-is. If locally patching out Salsa20 in the package spec file would be preferred and this change is deemed enough the PR can be closed.

## Motivation and Context
My second use case away from home is at work where I use CentOS 7 as a stable and trustworthy workstation. KeePassX started to require libgcrypt 1.6.0 lately to support Salsa20 cipher.

All other requirements are met to build and run KeePassXC on CentOS 7 without Salsa20 support.

## How Has This Been Tested?
No extensive testing has been done. It builds and runs without Salsa20 when it's not encountered.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**

