### PR TITLE
Load a different config when debug option enabled

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -75,7 +75,11 @@ Config::Config(QObject* parent)
     userPath += "/";
 #endif
 
+#ifdef QT_DEBUG
+    userPath += "keepassxc_debug.ini";
+#else
     userPath += "keepassxc.ini";
+#endif
 
     init(userPath);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This PR let KeePassXC load a different configuration file when loaded from a Debug build

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is useful if you need to change KeePassXC configuration for testing some feature when developing.
You don't want to mess up your own KeePassXC configuration or revert your configuration back after the tests.
When KeePassXC is compiled with Debug option it will load keepassxc_debug.ini configuration, if it's a Release instead it will load keepassxc.ini

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by opening 2 different KeePassXC build (one Release and one Debug) and setting 2 different configuration.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

