### PR TITLE
Revert "Enable High DPI scaling", resolves #323

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,6 @@
 #include <QCommandLineParser>
 #include <QFile>
 #include <QTextStream>
-#include <QtGlobal>
 
 #include "config-keepassx.h"
 #include "core/Config.h"
@@ -45,10 +44,7 @@ int main(int argc, char** argv)
     Tools::disableCoreDumps();
 #endif
     Tools::setupSearchPaths();
-    
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
+
     Application app(argc, argv);
     Application::setApplicationName("keepassxc");
     Application::setApplicationVersion(KEEPASSX_VERSION);


### PR DESCRIPTION
This reverts commit 188cac34ce6366ec37fea4c5c0a138cd6bfb1215.
Resolves #323 

<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
HiDPI scaling remains an issue, but setting `Qt::AA_EnableHighDpiScaling` only fixes it on some platforms while creating new issues on others. It is therefore a non-fix. 

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
