### PR TITLE
Update text in HTTP settings and a hard-to-translate command line hint

### DIFF
--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -1298,21 +1298,12 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Return only best matching entries for an URL instead
-of all entries for the whole domain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Match URL schemes
 Only entries with the same scheme (http://, https://, ftp://, ...) are returned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sort matching entries by &amp;username</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>R&amp;emove all shared encryption-keys from active database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1325,10 +1316,6 @@ Only entries with the same scheme (http://, https://, ftp://, ...) are returned<
     </message>
     <message>
         <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Activate the following only, if you know what you are doing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1345,14 +1332,6 @@ Only entries with the same scheme (http://, https://, ftp://, ...) are returned<
     </message>
     <message>
         <source>Only the selected database has to be connected with a client!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Return also advanced string fields which start with &quot;KPH: &quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Automatic creates or updates are not supported for string fields!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1387,6 +1366,27 @@ This is required for accessing your databases from ChromeIPass or PassIFox</sour
     <message>
         <source>Cannot bind to privileged ports below 1024!
 Using default port 19455.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Return only best matching entries for a URL instead
+of all entries for the whole domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R&amp;emove all shared encryption keys from active database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The following options can be dangerous. Change them only if you know what you are doing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Return advanced string fields which start with &quot;KPH: &quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatically creating or updating string fields is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1762,15 +1762,15 @@ give it a unique name to identify and accept it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>filename(s) of the password database(s) to open (*.kdbx)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>KeePassXC - cross-platform password manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>read password of the database from stdin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>filenames of the password databases to open (*.kdbx)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/http/OptionDialog.ui
+++ b/src/http/OptionDialog.ui
@@ -45,7 +45,7 @@ This is required for accessing your databases from ChromeIPass or PassIFox</stri
        <item>
         <widget class="QCheckBox" name="bestMatchOnly">
          <property name="text">
-          <string>&amp;Return only best matching entries for an URL instead
+          <string>&amp;Return only best matching entries for a URL instead
 of all entries for the whole domain</string>
          </property>
         </widget>
@@ -82,7 +82,7 @@ Only entries with the same scheme (http://, https://, ftp://, ...) are returned<
        <item>
         <widget class="QPushButton" name="removeSharedEncryptionKeys">
          <property name="text">
-          <string>R&amp;emove all shared encryption-keys from active database</string>
+          <string>R&amp;emove all shared encryption keys from active database</string>
          </property>
         </widget>
        </item>
@@ -148,7 +148,7 @@ Only entries with the same scheme (http://, https://, ftp://, ...) are returned<
           <string notr="true">color: rgb(255, 0, 0);</string>
          </property>
          <property name="text">
-          <string>Activate the following only, if you know what you are doing!</string>
+          <string>The following options can be dangerous. Change them only if you know what you are doing.</string>
          </property>
         </widget>
        </item>
@@ -186,14 +186,14 @@ Only entries with the same scheme (http://, https://, ftp://, ...) are returned<
        <item>
         <widget class="QCheckBox" name="supportKphFields">
          <property name="text">
-          <string>&amp;Return also advanced string fields which start with &quot;KPH: &quot;</string>
+          <string>&amp;Return advanced string fields which start with &quot;KPH: &quot;</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Automatic creates or updates are not supported for string fields!</string>
+          <string>Automatically creating or updating string fields is not supported.</string>
          </property>
          <property name="indent">
           <number>30</number>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char** argv)
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QCoreApplication::translate("main", "KeePassXC - cross-platform password manager"));
-    parser.addPositionalArgument("filename", QCoreApplication::translate("main", "filename(s) of the password database(s) to open (*.kdbx)"), "[filename(s)]");
+    parser.addPositionalArgument("filename", QCoreApplication::translate("main", "filenames of the password databases to open (*.kdbx)"), "[filename(s)]");
 
     QCommandLineOption configOption("config",
                                     QCoreApplication::translate("main", "path to a custom config file"),


### PR DESCRIPTION
Improve the clarity of various strings in the HTTP menu and a command-line parameter.

## Description
This modifies the text in various strings in the HTTP settings dialog, for the purposes of clarity (and grammar), and also in one of the command-line positional arguments.

## Motivation and Context
As discussed in IRC, "filename(s)" and "database(s)" means Transifex requires a certain number of parentheses in any translations, which makes it hard to translate for Italian where (I think) "database" and "databases" are the same word. In addition there was a typo in one of the HTTP setting strings ("only, if you know") which led me to go check the clarity of a bunch of strings in that dialog (and rewrite them).

## How Has This Been Tested?
I built the executable with the updated translations (after running the commands from the `share/translations/update.sh` script that I have the ability to, i.e. the `lupdate-qt5` commands), and the appropriate strings have been updated.

`./src/keepassxc --help`  produces the appropriate:
```
Arguments:
  filename             filenames of the password databases to open (*.kdbx)
```
(following the previous options as before)

Tests (including GUI tests) pass on my system.

## Screenshots (if appropriate):

![](https://puu.sh/udFyZ/93aeb75d9c.png)
![](https://puu.sh/udFsO/541cf8295c.png)

(I apologize for how these are cropped – my screenshot tool is acting up.)


## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
