### PR TITLE
Prevent memory dumps on windows.

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -256,6 +256,7 @@ bool createWindowsDACL()
 {
     bool bSuccess = false;
 
+#ifdef Q_OS_WIN
     // Access control list
     PACL pACL = nullptr;
     DWORD cbACL = 0;
@@ -341,6 +342,7 @@ Cleanup:
     if (pACL != nullptr) {
         HeapFree(GetProcessHeap(), 0, pACL);
     }
+#endif
 
     return bSuccess;
 }

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -41,6 +41,7 @@ void sleep(int ms);
 void wait(int ms);
 void disableCoreDumps();
 void setupSearchPaths();
+bool createWindowsDACL();
 
 template <typename RandomAccessIterator, typename T>
 RandomAccessIterator binaryFind(RandomAccessIterator begin, RandomAccessIterator end, const T& value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Use a discretionary access control list to deny PROCESS_QUERY_INFORMATION and PROCESS_VM_READ access rights without admin privileges.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent memory dumps on windows

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 7 and Process Explorer
**Needs more testing**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
