### PR TITLE
Don't show error message when trying to reload a locked database

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1061,8 +1061,7 @@ void DatabaseWidget::reloadDatabaseFile()
                     // Merge the old database into the new one
                     m_db->setEmitModified(false);
                     db->merge(m_db);
-                }
-                else {
+                } else {
                     // Since we are accepting the new file as-is, internally mark as unmodified
                     // TODO: when saving is moved out of DatabaseTabWidget, this should be replaced
                     m_databaseModified = false;
@@ -1086,16 +1085,9 @@ void DatabaseWidget::reloadDatabaseFile()
             restoreGroupEntryFocus(groupBeforeReload, entryBeforeReload);
 
         }
-        else {
-            MessageBox::critical(this, tr("Autoreload Failed"),
-                                 tr("Could not parse or unlock the new database file while attempting"
-                                    " to autoreload this database."));
-        }
-    }
-    else {
+    } else {
         MessageBox::critical(this, tr("Autoreload Failed"),
-                             tr("Could not open the new database file while attempting to autoreload"
-                                " this database."));
+                             tr("Could not open the new database file while attempting to autoreload this database."));
     }
 
     // Rewatch the database file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch removes an unnecessary error message when trying to reload a locked database.
This was especially annoying when syncing a database across multiple machines, because every time the file was updated, this error popped up.

However, this fix is merely a band-aid as it only removes the error message. When we are refactoring the database open/tab widgets, we should avoid monitoring locked databases in the first place. There is no point in watching for changes in a locked database. However, that is out of scope for this fix. Implementing that with the current code base is a non-trivial task, since we don't have a well encapsulated and self-contained database object which keeps track of the current status of the database. Instead, responsibilities are scattered all over the placed making this band-aid fix the easiest solution for now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I opened the same file in two KeePassXC instances and unlocked one of them. When I save changes, the other instance doesn't generate an error message anymore.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**-
- ✅ All new and existing tests passed. **[REQUIRED]**

