### PR TITLE
Assign role 'NoRole' instead of 'Accept' to not mess with button order

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -165,7 +165,7 @@ void DatabaseTabWidget::openDatabase(const QString& fileName, const QString& pw,
             msgBox.setIcon(QMessageBox::Question);
             msgBox.addButton(QMessageBox::Yes);
             msgBox.addButton(QMessageBox::No);
-            auto readOnlyButton = msgBox.addButton(tr("Open read-only"), QMessageBox::AcceptRole);
+            auto readOnlyButton = msgBox.addButton(tr("Open read-only"), QMessageBox::NoRole);
             msgBox.setDefaultButton(readOnlyButton);
             msgBox.setEscapeButton(QMessageBox::No);
             auto result = msgBox.exec();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Change role of "Open read-only" button so Qt doesn't place it between the "Yes" and "No" button.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On Windows and Linux/KDE, the "Open read-only" button is correctly placed to the right of the "Yes" and "No" buttons. On OS X, it's to the left.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
