### PR TITLE
Delete a custom icon with multiple entries using it

### DIFF
--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -281,10 +281,9 @@ void EditWidgetIcons::removeCustomIcon()
             for (Entry* entry : allEntries) {
                 if (iconUuid == entry->iconUuid()) {
                     // Check if this is a history entry (no assigned group)
-                    if (entry->group() == nullptr) {
+                    if (!entry->group()) {
                         historyEntriesWithSameIcon << entry;
-                    }
-                    else if (m_currentUuid != entry->uuid()){
+                    } else if (m_currentUuid != entry->uuid()) {
                         entriesWithSameIcon << entry;
                     }
                 }
@@ -309,8 +308,7 @@ void EditWidgetIcons::removeCustomIcon()
                 if (ans == QMessageBox::No) {
                     // Early out, nothing is changed
                     return;
-                }
-                else {
+                } else {
                     // Revert matched entries to the default entry icon
                     for (Entry* entry : asConst(entriesWithSameIcon)) {
                         entry->setIcon(Entry::DefaultIconNumber);
@@ -341,8 +339,7 @@ void EditWidgetIcons::removeCustomIcon()
 
             if (m_database->resolveEntry(m_currentUuid) != nullptr) {
                 m_ui->defaultIconsView->setCurrentIndex(m_defaultIconModel->index(Entry::DefaultIconNumber));
-            }
-            else {
+            } else {
                 m_ui->defaultIconsView->setCurrentIndex(m_defaultIconModel->index(Group::DefaultIconNumber));
             }
         }

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -273,50 +273,77 @@ void EditWidgetIcons::removeCustomIcon()
         QModelIndex index = m_ui->customIconsView->currentIndex();
         if (index.isValid()) {
             Uuid iconUuid = m_customIconModel->uuidFromIndex(index);
-            int iconUsedCount = 0;
 
             const QList<Entry*> allEntries = m_database->rootGroup()->entriesRecursive(true);
+            QList<Entry*> entriesWithSameIcon;
             QList<Entry*> historyEntriesWithSameIcon;
 
             for (Entry* entry : allEntries) {
-                bool isHistoryEntry = !entry->group();
                 if (iconUuid == entry->iconUuid()) {
-                    if (isHistoryEntry) {
+                    // Check if this is a history entry (no assigned group)
+                    if (entry->group() == nullptr) {
                         historyEntriesWithSameIcon << entry;
                     }
-                    else if (m_currentUuid != entry->uuid()) {
-                        iconUsedCount++;
+                    else if (m_currentUuid != entry->uuid()){
+                        entriesWithSameIcon << entry;
                     }
                 }
             }
 
             const QList<Group*> allGroups = m_database->rootGroup()->groupsRecursive(true);
-            for (const Group* group : allGroups) {
+            QList<Group*> groupsWithSameIcon;
+
+            for (Group* group : allGroups) {
                 if (iconUuid == group->iconUuid() && m_currentUuid != group->uuid()) {
-                    iconUsedCount++;
+                    groupsWithSameIcon << group;
                 }
             }
 
-            if (iconUsedCount == 0) {
-                for (Entry* entry : asConst(historyEntriesWithSameIcon)) {
-                    entry->setUpdateTimeinfo(false);
-                    entry->setIcon(0);
-                    entry->setUpdateTimeinfo(true);
-                }
+            int iconUseCount = entriesWithSameIcon.size() + groupsWithSameIcon.size();
+            if (iconUseCount > 0) {
+                QMessageBox::StandardButton ans = MessageBox::question(this, tr("Confirm Delete"),
+                                     tr("This icon is used by %1 entries, and will be replaced "
+                                        "by the default icon. Are you sure you want to delete it?")
+                                     .arg(iconUseCount), QMessageBox::Yes | QMessageBox::No);
 
-                m_database->metadata()->removeCustomIcon(iconUuid);
-                m_customIconModel->setIcons(m_database->metadata()->customIconsScaledPixmaps(),
-                                            m_database->metadata()->customIconsOrder());
-                if (m_customIconModel->rowCount() > 0) {
-                    m_ui->customIconsView->setCurrentIndex(m_customIconModel->index(0, 0));
+                if (ans == QMessageBox::No) {
+                    // Early out, nothing is changed
+                    return;
                 }
                 else {
-                    updateRadioButtonDefaultIcons();
+                    // Revert matched entries to the default entry icon
+                    for (Entry* entry : asConst(entriesWithSameIcon)) {
+                        entry->setIcon(Entry::DefaultIconNumber);
+                    }
+
+                    // Revert matched groups to the default group icon
+                    for (Group* group : asConst(groupsWithSameIcon)) {
+                        group->setIcon(Group::DefaultIconNumber);
+                    }
                 }
             }
+
+
+            // Remove the icon from history entries
+            for (Entry* entry : asConst(historyEntriesWithSameIcon)) {
+                entry->setUpdateTimeinfo(false);
+                entry->setIcon(0);
+                entry->setUpdateTimeinfo(true);
+            }
+
+            // Remove the icon from the database
+            m_database->metadata()->removeCustomIcon(iconUuid);
+            m_customIconModel->setIcons(m_database->metadata()->customIconsScaledPixmaps(),
+                                        m_database->metadata()->customIconsOrder());
+
+            // Reset the current icon view
+            updateRadioButtonDefaultIcons();
+
+            if (m_database->resolveEntry(m_currentUuid) != nullptr) {
+                m_ui->defaultIconsView->setCurrentIndex(m_defaultIconModel->index(Entry::DefaultIconNumber));
+            }
             else {
-                Q_EMIT messageEditEntry(
-                    tr("Can't delete icon. Still used by %1 items.").arg(iconUsedCount), MessageWidget::Error);
+                m_ui->defaultIconsView->setCurrentIndex(m_defaultIconModel->index(Group::DefaultIconNumber));
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fixes #356 

## Description
<!--- Describe your changes in detail -->
All entries using the deleted custom icon are reset to the default entry or group icon. Also fixes the case when only the current entry has the icon, the default icon is selected after deletion instead of the first custom icon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an annoying aspect of having many custom icons.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
