### PR TITLE
Use unified toolbar on OS X

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -281,6 +281,10 @@ MainWindow::MainWindow()
     connect(m_ui->passwordGeneratorWidget, SIGNAL(dialogTerminated()), SLOT(closePasswordGen()));
 
     connect(m_ui->actionAbout, SIGNAL(triggered()), SLOT(showAboutDialog()));
+    
+#ifdef Q_OS_MAC
+    setUnifiedTitleAndToolBarOnMac(true);
+#endif
 
     updateTrayIcon();
 }


### PR DESCRIPTION
This patch enables the unified toolbar on Mac OS X for better visual integration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run the patch on OS X 10.12 Sierra, looks good.

## Screenshots (if appropriate):
Before:
![before](https://cloud.githubusercontent.com/assets/911270/23482419/5123170e-fecf-11e6-9e75-0b6937a0f9d1.png)

After:
![after](https://cloud.githubusercontent.com/assets/911270/23482425/558de490-fecf-11e6-9000-c97b2cb37eb9.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**