### PR TITLE
closeEvent() should always hide the window, never raise it.

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -72,6 +72,7 @@ private Q_SLOTS:
     void rememberOpenDatabases(const QString& filePath);
     void applySettingsChanges();
     void trayIconTriggered(QSystemTrayIcon::ActivationReason reason);
+    void hideWindow();
     void toggleWindow();
     void lockDatabasesAfterInactivity();
     void repairDatabase();


### PR DESCRIPTION
This fixes an issue on X11 where Alt-F4 would not close the window, due
to toggleWindow() believing the window is inactive and trying to raise
it.  Avoid the problem by closing the window unconditionally.