### PR TITLE
Fix stack buffer overflow in zxcvbn.

### DIFF
--- a/src/zxcvbn/zxcvbn.cpp
+++ b/src/zxcvbn/zxcvbn.cpp
@@ -496,7 +496,7 @@ typedef struct
     uint8_t LeetCnv[sizeof L33TCnv / LEET_NORM_MAP_SIZE + 1];
  /*   uint8_t LeetChr[3]; */
     uint8_t First;
-    uint8_t PossChars[48];
+    uint8_t PossChars[49];
 } DictWork_t;
 
 /**********************************************************************************


### PR DESCRIPTION
The array PossChars is filled with a 48 byte string plus a trailing zero
byte. Therefore it needs to be 49 bytes long.

This fixes a buffer overflow in the zxcvbn code. The code comes from the zxvcbn-c project, where I have also submitted a pull request:
https://github.com/tsyrogit/zxcvbn-c/pull/11

Apart from the bug itself I find it worrying that a security tool contains such a bug. Such bug classes can be trivially found with address sanitizer, a compiler feature in gcc/clang (just do something like "CFLAGS="-fsanitize=address -g" CXXFLAGS="-fsanitize=address -g" cmake .; make" and try to run keepassxc). Given that this bug is present means apparently that nobody ever tested the keepassxc code with address sanitizer. I'd consider that very basic quality assurance that especially security-related projects should do by default.