### PR TITLE
Compile auto-type by default and encapsulate all networking code using WITH_XC_HTTP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(WITH_GUI_TESTS "Enable building of GUI tests" OFF)
 option(WITH_DEV_BUILD "Use only for development. Disables/warns about deprecated methods." OFF)
 option(WITH_COVERAGE "Use to build with coverage tests. (GCC ONLY)." OFF)
 
-option(WITH_XC_AUTOTYPE "Include Autotype." OFF)
+option(WITH_XC_AUTOTYPE "Include Autotype." ON)
 option(WITH_XC_HTTP "Include KeePassHTTP." OFF)
 option(WITH_XC_YUBIKEY "Include Yubikey support." OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,8 @@ option(WITH_GUI_TESTS "Enable building of GUI tests" OFF)
 option(WITH_DEV_BUILD "Use only for development. Disables/warns about deprecated methods." OFF)
 option(WITH_COVERAGE "Use to build with coverage tests. (GCC ONLY)." OFF)
 
-option(WITH_XC_AUTOTYPE "Include Autotype." ON)
-option(WITH_XC_HTTP "Include KeePassHTTP." OFF)
+option(WITH_XC_AUTOTYPE "Include Auto-Type." ON)
+option(WITH_XC_HTTP "Include KeePassHTTP and Custom Icon Downloads." OFF)
 option(WITH_XC_YUBIKEY "Include Yubikey support." OFF)
 
 set(KEEPASSXC_VERSION "2.1.3")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,7 +155,7 @@ add_feature_info(Autotype WITH_XC_AUTOTYPE "Auto-type passwords in Input fields"
 
 add_subdirectory(http)
 if(WITH_XC_HTTP)
-    set(keepasshttp_LIB keepasshttp)
+    set(keepasshttp_LIB keepasshttp qhttp Qt5::Network)
 endif()
 
 add_subdirectory(autotype)
@@ -196,11 +196,9 @@ target_link_libraries(keepassx_core
                       ${keepasshttp_LIB}
                       ${autotype_LIB}
                       zxcvbn
-                      qhttp
                       Qt5::Core
                       Qt5::Concurrent
                       Qt5::Widgets
-                      Qt5::Network
                       ${GCRYPT_LIBRARIES}
                       ${GPGERROR_LIBRARIES}
                       ${ZLIB_LIBRARIES})

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -28,10 +28,12 @@
 #include "gui/IconModels.h"
 #include "gui/MessageBox.h"
 
+#ifdef WITH_XC_HTTP
 #include "http/qhttp/qhttpclient.hpp"
 #include "http/qhttp/qhttpclientresponse.hpp"
 
 using namespace qhttp::client;
+#endif
 
 IconStruct::IconStruct()
     : uuid(Uuid())
@@ -45,7 +47,9 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     , m_database(nullptr)
     , m_defaultIconModel(new DefaultIconModel(this))
     , m_customIconModel(new CustomIconModel(this))
+    #ifdef WITH_XC_HTTP
     , m_httpClient(nullptr)
+    #endif
 {
     m_ui->setupUi(this);
 
@@ -65,6 +69,9 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     connect(m_ui->faviconButton, SIGNAL(clicked()), SLOT(downloadFavicon()));
 
     m_ui->faviconButton->setVisible(false);
+
+    m_fallbackToGoogle = true;
+    m_redirectCount = 0;
 }
 
 EditWidgetIcons::~EditWidgetIcons()
@@ -138,18 +145,25 @@ void EditWidgetIcons::load(const Uuid& currentUuid, Database* database, const Ic
 
 void EditWidgetIcons::setUrl(const QString& url)
 {
+#ifdef WITH_XC_HTTP
     m_url = url;
     m_ui->faviconButton->setVisible(!url.isEmpty());
     resetFaviconDownload();
+#else
+    m_ui->faviconButton->setVisible(false);
+#endif
 }
 
 void EditWidgetIcons::downloadFavicon()
 {
+#ifdef WITH_XC_HTTP
     QUrl url = QUrl(m_url);
     url.setPath("/favicon.ico");
     fetchFavicon(url);
+#endif
 }
 
+#ifdef WITH_XC_HTTP
 void EditWidgetIcons::fetchFavicon(const QUrl& url)
 {
     if (nullptr == m_httpClient) {
@@ -241,6 +255,7 @@ void EditWidgetIcons::resetFaviconDownload(bool clearRedirect)
     m_fallbackToGoogle = true;
     m_ui->faviconButton->setDisabled(false);
 }
+#endif
 
 void EditWidgetIcons::addCustomIcon()
 {

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -49,6 +49,8 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     , m_customIconModel(new CustomIconModel(this))
     #ifdef WITH_XC_HTTP
     , m_httpClient(nullptr)
+    , m_fallbackToGoogle(true)
+    , m_redirectCount(0)
     #endif
 {
     m_ui->setupUi(this);
@@ -69,9 +71,6 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     connect(m_ui->faviconButton, SIGNAL(clicked()), SLOT(downloadFavicon()));
 
     m_ui->faviconButton->setVisible(false);
-
-    m_fallbackToGoogle = true;
-    m_redirectCount = 0;
 }
 
 EditWidgetIcons::~EditWidgetIcons()

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -22,6 +22,7 @@
 #include <QSet>
 #include <QUrl>
 
+#include "config-keepassx.h"
 #include "core/Global.h"
 #include "core/Uuid.h"
 #include "gui/MessageWidget.h"
@@ -30,11 +31,14 @@ class Database;
 class DefaultIconModel;
 class CustomIconModel;
 
+#ifdef WITH_XC_HTTP
 namespace qhttp {
     namespace client {
         class QHttpClient;
     }
 }
+#endif
+
 namespace Ui {
     class EditWidgetIcons;
 }
@@ -68,9 +72,11 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void downloadFavicon();
+#ifdef WITH_XC_HTTP
     void fetchFavicon(const QUrl& url);
     void fetchFaviconFromGoogle(const QString& domain);
     void resetFaviconDownload(bool clearRedirect = true);
+#endif
     void addCustomIcon();
     void removeCustomIcon();
     void updateWidgetsDefaultIcons(bool checked);
@@ -84,11 +90,13 @@ private:
     Uuid m_currentUuid;
     QString m_url;
     QUrl m_redirectUrl;
-    bool m_fallbackToGoogle = true;
-    unsigned short m_redirectCount = 0;
+    bool m_fallbackToGoogle;
+    unsigned short m_redirectCount;
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;
+#ifdef WITH_XC_HTTP
     qhttp::client::QHttpClient* m_httpClient;
+#endif
 
     Q_DISABLE_COPY(EditWidgetIcons)
 };

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -89,12 +89,12 @@ private:
     Database* m_database;
     Uuid m_currentUuid;
     QString m_url;
-    QUrl m_redirectUrl;
-    bool m_fallbackToGoogle;
-    unsigned short m_redirectCount;
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;
 #ifdef WITH_XC_HTTP
+    QUrl m_redirectUrl;
+    bool m_fallbackToGoogle;
+    unsigned short m_redirectCount;
     qhttp::client::QHttpClient* m_httpClient;
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
* WITH_XC_AUTOTYPE defaults to ON
* WITH_XC_HTTP now wraps custom icon download code
* No networking libraries are included when WITH_XC_HTTP=OFF

Documentation on the wiki will be updated once merged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows us to easily distribute an "OFFLINE" version of KeePassXC

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and running existing tests

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
