### PR TITLE
Fixes crash when deleting in search mode.

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -322,8 +322,7 @@ void DatabaseWidget::cloneEntry()
 
     Entry* entry = currentEntry->clone(Entry::CloneNewUuid | Entry::CloneResetTimeInfo | Entry::CloneRenameTitle);
     entry->setGroup(currentEntry->group());
-    if (isInSearchMode())
-        search(m_lastSearchText);
+    refreshSearch();
     m_entryView->setFocus();
     m_entryView->setCurrentEntry(entry);
 }
@@ -366,6 +365,7 @@ void DatabaseWidget::deleteEntries()
             for (Entry* entry : asConst(selectedEntries)) {
                 delete entry;
             }
+            refreshSearch();
         }
     }
     else {
@@ -875,6 +875,12 @@ void DatabaseWidget::databaseSaved()
     m_databaseModified = false;
 }
 
+void DatabaseWidget::refreshSearch() {
+    if (isInSearchMode()) {
+        search(m_lastSearchText);
+    }
+}
+
 void DatabaseWidget::search(const QString& searchtext)
 {
     if (searchtext.isEmpty())
@@ -908,9 +914,7 @@ void DatabaseWidget::search(const QString& searchtext)
 void DatabaseWidget::setSearchCaseSensitive(bool state)
 {
     m_searchCaseSensitive = state;
-
-    if (isInSearchMode())
-        search(m_lastSearchText);
+    refreshSearch();
 }
 
 void DatabaseWidget::onGroupChanged(Group* group)

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -147,10 +147,12 @@ public Q_SLOTS:
     void switchToImportKeepass1(const QString& fileName);
     void databaseModified();
     void databaseSaved();
+
     // Search related slots
     void search(const QString& searchtext);
     void setSearchCaseSensitive(bool state);
     void endSearch();
+
     void showMessage(const QString& text, MessageWidget::MessageType type);
     void hideMessage();
 
@@ -177,6 +179,7 @@ private:
     void setClipboardTextAndMinimize(const QString& text);
     void setIconFromParent();
     void replaceDatabase(Database* db);
+    void refreshSearch();
 
     Database* m_db;
     QWidget* m_mainWidget;


### PR DESCRIPTION
Fixes crash when deleting in search mode.

## Description
The `EntryView` was trying to refresh itself after we deleted the entry from the recycle bin. The `EntryModel` was never removed from the `EntryView` used by the search. Now, after deleting an entry permanently, we refresh the `EntryView` used by the search so that it does not try to access the deallocated memory of a deleted database entry.

This also fixes a bug that we had where deleting an entry in search mode while the recycle bin was disabled would not update the `Search Results (x)` label of the search widget.

## Motivation and Context
Fixes #369

## How Has This Been Tested?
Manual tests + tested locally.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed. 
