### PR TITLE
Highlight reference field in Database view

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -254,6 +254,17 @@ bool Entry::isExpired() const
     return m_data.timeInfo.expires() && m_data.timeInfo.expiryTime() < QDateTime::currentDateTimeUtc();
 }
 
+bool Entry::hasReferences() const
+{
+    const QList<QString> keyList = EntryAttributes::DefaultAttributes;
+    for (const QString& key : keyList) {
+        if (m_attributes->isReference(key)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 EntryAttributes* Entry::attributes()
 {
     return m_attributes;

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -690,20 +690,20 @@ QString Entry::resolvePlaceholder(const QString& str) const
     // using format from http://keepass.info/help/base/fieldrefs.html at the time of writing,
     // but supporting lookups of standard fields and references by UUID only
 
-    QRegExp tmpRegExp = m_attributes->referenceRegExp();
-    if (tmpRegExp.indexIn(result) != -1) {
+    QRegExp* tmpRegExp = m_attributes->referenceRegExp();
+    if (tmpRegExp->indexIn(result) != -1) {
         // cap(0) contains the whole reference
         // cap(1) contains which field is wanted
         // cap(2) contains the uuid of the referenced entry
-        Entry* tmpRefEntry = m_group->database()->resolveEntry(Uuid(QByteArray::fromHex(tmpRegExp.cap(2).toLatin1())));
+        Entry* tmpRefEntry = m_group->database()->resolveEntry(Uuid(QByteArray::fromHex(tmpRegExp->cap(2).toLatin1())));
         if (tmpRefEntry) {
             // entry found, get the relevant field
-            QString tmpRefField = tmpRegExp.cap(1).toLower();
-            if (tmpRefField == "t") result.replace(tmpRegExp.cap(0), tmpRefEntry->title(), Qt::CaseInsensitive);
-            else if (tmpRefField == "u") result.replace(tmpRegExp.cap(0), tmpRefEntry->username(), Qt::CaseInsensitive);
-            else if (tmpRefField == "p") result.replace(tmpRegExp.cap(0), tmpRefEntry->password(), Qt::CaseInsensitive);
-            else if (tmpRefField == "a") result.replace(tmpRegExp.cap(0), tmpRefEntry->url(), Qt::CaseInsensitive);
-            else if (tmpRefField == "n") result.replace(tmpRegExp.cap(0), tmpRefEntry->notes(), Qt::CaseInsensitive);
+            QString tmpRefField = tmpRegExp->cap(1).toLower();
+            if (tmpRefField == "t") result.replace(tmpRegExp->cap(0), tmpRefEntry->title(), Qt::CaseInsensitive);
+            else if (tmpRefField == "u") result.replace(tmpRegExp->cap(0), tmpRefEntry->username(), Qt::CaseInsensitive);
+            else if (tmpRefField == "p") result.replace(tmpRegExp->cap(0), tmpRefEntry->password(), Qt::CaseInsensitive);
+            else if (tmpRefField == "a") result.replace(tmpRegExp->cap(0), tmpRefEntry->url(), Qt::CaseInsensitive);
+            else if (tmpRefField == "n") result.replace(tmpRegExp->cap(0), tmpRefEntry->notes(), Qt::CaseInsensitive);
         }
     }
 

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -690,7 +690,7 @@ QString Entry::resolvePlaceholder(const QString& str) const
     // using format from http://keepass.info/help/base/fieldrefs.html at the time of writing,
     // but supporting lookups of standard fields and references by UUID only
 
-    QRegExp tmpRegExp("\\{REF:([TUPAN])@I:([^}]+)\\}", Qt::CaseInsensitive, QRegExp::RegExp2);
+    QRegExp tmpRegExp = m_attributes->referenceRegExp();
     if (tmpRegExp.indexIn(result) != -1) {
         // cap(0) contains the whole reference
         // cap(1) contains which field is wanted

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -79,6 +79,7 @@ public:
     QString password() const;
     QString notes() const;
     bool isExpired() const;
+    bool hasReferences() const;
     EntryAttributes* attributes();
     const EntryAttributes* attributes() const;
     EntryAttachments* attachments();

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -69,6 +69,21 @@ bool EntryAttributes::isProtected(const QString& key) const
     return m_protectedAttributes.contains(key);
 }
 
+bool EntryAttributes::isReference(const QString& key) const
+{
+    if (!m_attributes.contains(key)) {
+        Q_ASSERT(false);
+        return false;
+    }
+
+    QString data = value(key);
+    QRegExp referenceRegExp("\\{REF:([TUPAN])@I:([^}]+)\\}", Qt::CaseInsensitive, QRegExp::RegExp2);
+    if (referenceRegExp.indexIn(data) != -1) {
+        return true;
+    }
+    return false;
+}
+
 void EntryAttributes::set(const QString& key, const QString& value, bool protect)
 {
     bool emitModified = false;

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -28,6 +28,7 @@ const QString EntryAttributes::RememberCmdExecAttr = "_EXEC_CMD";
 
 EntryAttributes::EntryAttributes(QObject* parent)
     : QObject(parent)
+    , m_referenceRegExp("\\{REF:([TUPAN])@I:([^}]+)\\}", Qt::CaseInsensitive, QRegExp::RegExp2)
 {
     clear();
 }
@@ -77,11 +78,15 @@ bool EntryAttributes::isReference(const QString& key) const
     }
 
     QString data = value(key);
-    QRegExp referenceRegExp("\\{REF:([TUPAN])@I:([^}]+)\\}", Qt::CaseInsensitive, QRegExp::RegExp2);
-    if (referenceRegExp.indexIn(data) != -1) {
+    if (m_referenceRegExp.indexIn(data) != -1) {
         return true;
     }
     return false;
+}
+
+QRegExp EntryAttributes::referenceRegExp() const
+{
+    return m_referenceRegExp;
 }
 
 void EntryAttributes::set(const QString& key, const QString& value, bool protect)

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -84,9 +84,9 @@ bool EntryAttributes::isReference(const QString& key) const
     return false;
 }
 
-QRegExp EntryAttributes::referenceRegExp() const
+QRegExp* EntryAttributes::referenceRegExp()
 {
-    return m_referenceRegExp;
+    return &m_referenceRegExp;
 }
 
 void EntryAttributes::set(const QString& key, const QString& value, bool protect)

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -36,7 +36,7 @@ public:
     bool contains(const QString& key) const;
     bool isProtected(const QString& key) const;
     bool isReference(const QString& key) const;
-    QRegExp referenceRegExp() const;
+    QRegExp* referenceRegExp();
     void set(const QString& key, const QString& value, bool protect = false);
     void remove(const QString& key);
     void rename(const QString& oldKey, const QString& newKey);

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -35,6 +35,7 @@ public:
     QString value(const QString& key) const;
     bool contains(const QString& key) const;
     bool isProtected(const QString& key) const;
+    bool isReference(const QString& key) const;
     void set(const QString& key, const QString& value, bool protect = false);
     void remove(const QString& key);
     void rename(const QString& oldKey, const QString& newKey);

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -36,6 +36,7 @@ public:
     bool contains(const QString& key) const;
     bool isProtected(const QString& key) const;
     bool isReference(const QString& key) const;
+    QRegExp referenceRegExp() const;
     void set(const QString& key, const QString& value, bool protect = false);
     void remove(const QString& key);
     void rename(const QString& oldKey, const QString& newKey);
@@ -72,6 +73,7 @@ Q_SIGNALS:
 private:
     QMap<QString, QString> m_attributes;
     QSet<QString> m_protectedAttributes;
+    QRegExp m_referenceRegExp;
 };
 
 #endif // KEEPASSX_ENTRYATTRIBUTES_H

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -19,6 +19,7 @@
 
 #include <QFont>
 #include <QMimeData>
+#include <QPalette>
 
 #include "core/DatabaseIcons.h"
 #include "core/Entry.h"
@@ -127,8 +128,10 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
     }
 
     Entry* entry = entryFromIndex(index);
+    EntryAttributes* attr = entry->attributes();
 
     if (role == Qt::DisplayRole) {
+        QString result;
         switch (index.column()) {
         case ParentGroup:
             if (entry->group()) {
@@ -136,11 +139,23 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             }
             break;
         case Title:
-            return entry->title();
+            result = entry->resolvePlaceholder(entry->title());
+            if (attr->isReference(EntryAttributes::TitleKey)) {
+                result.prepend(tr("Ref: ","Reference abbreviation"));
+            }
+            return result;
         case Username:
-            return entry->username();
+            result = entry->resolvePlaceholder(entry->username());
+            if (attr->isReference(EntryAttributes::UserNameKey)) {
+                result.prepend(tr("Ref: ","Reference abbreviation"));
+            }
+            return result;
         case Url:
-            return entry->url();
+            result = entry->resolvePlaceholder(entry->url());
+            if (attr->isReference(EntryAttributes::URLKey)) {
+                result.prepend(tr("Ref: ","Reference abbreviation"));
+            }
+            return result;
         }
     }
     else if (role == Qt::DecorationRole) {
@@ -165,6 +180,12 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             font.setStrikeOut(true);
         }
         return font;
+    }
+    else if (role == Qt::TextColorRole) {
+        if (entry->hasReferences()) {
+            QPalette p;
+            return QVariant(p.color(QPalette::Active, QPalette::Mid));
+        }
     }
 
     return QVariant();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Highlight reference field in Database view instead of printing the full reference string

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Printing the full reference field (`{REF:U@I:<UUID>`) in the database view it's not very user friendly.
Searching also will show reference string instead of the searched content.
This PR shows reference field clearly without hiding the referenced content. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Screenshots (if appropriate):
![https://i.imgur.com/6XxwKS3.png](https://i.imgur.com/6XxwKS3.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

