### PR TITLE
Add TOTP support, resolves #80

### DIFF
--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -1236,6 +1236,10 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Timed one-time password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Find</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ set(keepassx_SOURCES
     gui/SettingsWidget.cpp
     gui/SearchWidget.cpp
     gui/SortFilterHideProxyModel.cpp
+    gui/TotpDialog.cpp
     gui/UnlockDatabaseWidget.cpp
     gui/UnlockDatabaseDialog.cpp
     gui/WelcomeWidget.cpp
@@ -129,6 +130,8 @@ set(keepassx_SOURCES
     streams/qtiocompressor.cpp
     streams/StoreDataStream.cpp
     streams/SymmetricCipherStream.cpp
+    totp/totp.h
+    totp/totp.cpp
 )
 
 set(keepassx_SOURCES_MAINEXE
@@ -140,6 +143,7 @@ set(keepassx_FORMS
     gui/ChangeMasterKeyWidget.ui
     gui/CloneDialog.ui
     gui/csvImport/CsvImportWidget.ui
+    gui/TotpDialog.ui
     gui/DatabaseOpenWidget.ui
     gui/DatabaseSettingsWidget.ui
     gui/CategoryListWidget.ui
@@ -151,6 +155,7 @@ set(keepassx_FORMS
     gui/SearchWidget.ui
     gui/SettingsWidgetGeneral.ui
     gui/SettingsWidgetSecurity.ui
+    gui/TotpDialog.ui
     gui/WelcomeWidget.ui
     gui/entry/EditEntryWidgetAdvanced.ui
     gui/entry/EditEntryWidgetAutoType.ui

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -78,6 +78,9 @@ public:
     QString username() const;
     QString password() const;
     QString notes() const;
+    QString totp() const;
+
+    bool hasTotp() const;
     bool isExpired() const;
     bool hasReferences() const;
     EntryAttributes* attributes();

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -42,6 +42,7 @@
 #include "gui/ChangeMasterKeyWidget.h"
 #include "gui/Clipboard.h"
 #include "gui/CloneDialog.h"
+#include "gui/TotpDialog.h"
 #include "gui/DatabaseOpenWidget.h"
 #include "gui/DatabaseSettingsWidget.h"
 #include "gui/KeePass1OpenWidget.h"
@@ -331,6 +332,18 @@ void DatabaseWidget::cloneEntry()
     CloneDialog* cloneDialog = new CloneDialog(this, m_db, currentEntry);
     cloneDialog->show();
     return;
+}
+
+void DatabaseWidget::getTotp()
+{
+    Entry* currentEntry = m_entryView->currentEntry();
+    if (!currentEntry) {
+        Q_ASSERT(false);
+        return;
+    }
+
+    TotpDialog* totpDialog = new TotpDialog(this, currentEntry);
+    totpDialog->open();
 }
 
 void DatabaseWidget::deleteEntries()
@@ -1223,6 +1236,17 @@ bool DatabaseWidget::currentEntryHasUrl()
         return false;
     }
     return !currentEntry->resolveMultiplePlaceholders(currentEntry->url()).isEmpty();
+}
+
+
+bool DatabaseWidget::currentEntryHasTotp()
+{
+    Entry* currentEntry = m_entryView->currentEntry();
+    if (!currentEntry) {
+        Q_ASSERT(false);
+        return false;
+    }
+    return currentEntry->hasTotp();
 }
 
 bool DatabaseWidget::currentEntryHasNotes()

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -96,6 +96,7 @@ public:
     bool currentEntryHasPassword();
     bool currentEntryHasUrl();
     bool currentEntryHasNotes();
+    bool currentEntryHasTotp();
     GroupView* groupView();
     EntryView* entryView();
     void showUnlockDialog();
@@ -132,6 +133,7 @@ public slots:
     void copyURL();
     void copyNotes();
     void copyAttribute(QAction* action);
+    void getTotp();
     void performAutoType();
     void openUrl();
     void openUrlForEntry(Entry* entry);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -167,6 +167,7 @@ MainWindow::MainWindow()
     m_ui->actionEntryEdit->setShortcut(Qt::CTRL + Qt::Key_E);
     m_ui->actionEntryDelete->setShortcut(Qt::CTRL + Qt::Key_D);
     m_ui->actionEntryClone->setShortcut(Qt::CTRL + Qt::Key_K);
+    m_ui->actionEntryTotp->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_T);
     m_ui->actionEntryCopyUsername->setShortcut(Qt::CTRL + Qt::Key_B);
     m_ui->actionEntryCopyPassword->setShortcut(Qt::CTRL + Qt::Key_C);
     setShortcut(m_ui->actionEntryAutoType, QKeySequence::Paste, Qt::CTRL + Qt::Key_V);
@@ -273,6 +274,9 @@ MainWindow::MainWindow()
             SLOT(switchToEntryEdit()));
     m_actionMultiplexer.connect(m_ui->actionEntryDelete, SIGNAL(triggered()),
             SLOT(deleteEntries()));
+
+    m_actionMultiplexer.connect(m_ui->actionEntryTotp, SIGNAL(triggered()),
+            SLOT(getTotp()));
 
     m_actionMultiplexer.connect(m_ui->actionEntryCopyTitle, SIGNAL(triggered()),
             SLOT(copyTitle()));
@@ -426,6 +430,7 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->menuEntryCopyAttribute->setEnabled(singleEntrySelected);
             m_ui->actionEntryAutoType->setEnabled(singleEntrySelected);
             m_ui->actionEntryOpenUrl->setEnabled(singleEntrySelected && dbWidget->currentEntryHasUrl());
+            m_ui->actionEntryTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
             m_ui->actionGroupNew->setEnabled(groupSelected);
             m_ui->actionGroupEdit->setEnabled(groupSelected);
             m_ui->actionGroupDelete->setEnabled(groupSelected && dbWidget->canDeleteCurrentGroup());

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -225,6 +225,7 @@
     <addaction name="menuEntryCopyAttribute"/>
     <addaction name="actionEntryAutoType"/>
     <addaction name="actionEntryOpenUrl"/>
+    <addaction name="actionEntryTotp"/>
     <addaction name="actionEntryEdit"/>
     <addaction name="actionEntryClone"/>
     <addaction name="actionEntryDelete"/>
@@ -519,6 +520,11 @@
   <action name="actionRepairDatabase">
    <property name="text">
     <string>Re&amp;pair database</string>
+   </property>
+  </action>
+  <action name="actionEntryTotp">
+   <property name="text">
+    <string>&amp;Timed one-time password</string>
    </property>
   </action>
  </widget>

--- a/src/gui/TotpDialog.cpp
+++ b/src/gui/TotpDialog.cpp
@@ -1,0 +1,83 @@
+#include "TotpDialog.h"
+#include "ui_TotpDialog.h"
+
+#include "core/Config.h"
+#include "core/Entry.h"
+#include "gui/DatabaseWidget.h"
+#include "gui/Clipboard.h"
+
+#include <QTimer>
+#include <QDateTime>
+#include <QPushButton>
+
+
+TotpDialog::TotpDialog(DatabaseWidget* parent, Entry* entry)
+    : QDialog(parent)
+    , m_ui(new Ui::TotpDialog())
+{
+    m_entry = entry;
+    m_parent = parent;
+
+    m_ui->setupUi(this);
+
+    updateProgressBar();
+
+    QTimer *timer = new QTimer(this);
+    connect(timer, SIGNAL(timeout()), this, SLOT(updateProgressBar()));
+    connect(timer, SIGNAL(timeout()), this, SLOT(updateSeconds()));
+    timer->start(300);
+
+    uCounter = resetCounter();
+
+    updateTotp();
+
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Copy"));
+
+    connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(close()));
+    connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(copyToClipboard()));
+}
+
+void TotpDialog::copyToClipboard()
+{
+    clipboard()->setText(m_entry->totp());
+    if (config()->get("MinimizeOnCopy").toBool()) {
+        m_parent->window()->showMinimized();
+    }
+}
+
+void TotpDialog::updateProgressBar()
+{
+    if (uCounter <= 100) {
+        m_ui->progressBar->setValue(100 - uCounter);
+        uCounter++;
+    } else {
+        updateTotp();
+        uCounter = resetCounter();
+    }
+}
+
+
+void TotpDialog::updateSeconds()
+{
+    m_ui->timerLabel->setText(tr("Expires in") + " <b>" + QString::number(30 - (uCounter * 30 / 100)) + "</b> " + tr("seconds")); 
+}
+
+void TotpDialog::updateTotp()
+{
+    m_ui->totpLabel->setText(m_entry->totp());
+}
+
+unsigned TotpDialog::resetCounter()
+{
+    double curSeconds = QDateTime::currentDateTime().toString("s").toInt();
+
+    if (curSeconds >= 30)
+        curSeconds = curSeconds - 30;
+    return curSeconds / 30 * 100;
+}
+
+TotpDialog::~TotpDialog()
+{
+}

--- a/src/gui/TotpDialog.h
+++ b/src/gui/TotpDialog.h
@@ -1,0 +1,38 @@
+#ifndef KEEPASSX_TOTPDIALOG_H
+#define KEEPASSX_TOTPDIALOG_H
+
+#include <QDialog>
+#include <QScopedPointer>
+#include "core/Entry.h"
+#include "core/Database.h"
+#include "gui/DatabaseWidget.h"
+
+namespace Ui {
+    class TotpDialog;
+}
+
+class TotpDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TotpDialog(DatabaseWidget* parent = nullptr, Entry* entry = nullptr);
+    ~TotpDialog();
+
+private:
+    unsigned uCounter;
+    QScopedPointer<Ui::TotpDialog> m_ui;
+
+private Q_SLOTS:
+    void updateTotp();
+    void updateProgressBar();
+    void updateSeconds();
+    void copyToClipboard();
+    unsigned resetCounter();
+
+protected:
+    Entry* m_entry;
+    DatabaseWidget* m_parent;
+};
+
+#endif // KEEPASSX_TOTPDIALOG_H

--- a/src/gui/TotpDialog.ui
+++ b/src/gui/TotpDialog.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TotpDialog</class>
+ <widget class="QWidget" name="TotpDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>264</width>
+    <height>194</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Timed Password</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="totpLabel">
+     <property name="font">
+      <font>
+       <pointsize>53</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>000000</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="timerLabel">
+     <property name="text">
+      <string></string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/totp/totp.cpp
+++ b/src/totp/totp.cpp
@@ -1,0 +1,105 @@
+#include "totp.h"
+#include <QtEndian>
+#include <QDateTime>
+#include <QCryptographicHash>
+#include <QMessageAuthenticationCode>
+
+
+QTotp::QTotp()
+{
+}
+
+/** 
+ * Base32 implementation
+ *
+ * Copyright 2010 Google Inc.
+ * Author: Markus Gutschke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+int QTotp::base32_decode(const quint8 *encoded, quint8 *result, int bufSize)
+{
+    int buffer = 0;
+    int bitsLeft = 0;
+    int count = 0;
+
+    for (const quint8 *ptr = encoded; count < bufSize && *ptr; ++ptr) {
+        quint8 ch = *ptr;
+
+        if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '-') {
+            continue;
+        }
+
+        buffer <<= 5;
+
+        // Deal with commonly mistyped characters
+        if (ch == '0') {
+            ch = 'O';
+        } else if (ch == '1') {
+            ch = 'L';
+        } else if (ch == '8') {
+            ch = 'B';
+        }
+
+        // Look up one base32 digit
+        if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
+            ch = (ch & 0x1F) - 1;
+        } else if (ch >= '2' && ch <= '7') {
+            ch -= '2' - 26;
+        } else {
+            return -1;
+        }
+
+        buffer |= ch;
+        bitsLeft += 5;
+
+        if (bitsLeft >= 8) {
+            result[count++] = buffer >> (bitsLeft - 8);
+            bitsLeft -= 8;
+        }
+    }
+
+    if (count < bufSize) {
+        result[count] = '\000';
+    }
+
+    return count;
+}
+
+
+QString QTotp::generateTotp(const QByteArray key)
+{
+    quint64 time = QDateTime::currentDateTime().toTime_t();
+    quint64 current = qToBigEndian(time / 30);
+    const unsigned numDigits = 6;
+
+    int secretLen = (key.length() + 7) / 8 * 5;
+    quint8 secret[secretLen];
+    int res = QTotp::base32_decode(reinterpret_cast<const quint8 *>(key.constData()), secret, secretLen);
+
+    QMessageAuthenticationCode code(QCryptographicHash::Sha1);
+    code.setKey(QByteArray(reinterpret_cast<const char *>(secret), res));
+    code.addData(QByteArray(reinterpret_cast<char*>(&current), sizeof(current)));
+    QByteArray hmac = code.result();
+
+    int offset = (hmac[hmac.length() - 1] & 0xf);
+    int binary =
+            ((hmac[offset] & 0x7f) << 24)
+            | ((hmac[offset + 1] & 0xff) << 16)
+            | ((hmac[offset + 2] & 0xff) << 8)
+            | (hmac[offset + 3] & 0xff);
+
+    int password = binary % 1000000;
+    return QString("%1").arg(password, numDigits, 10, QChar('0'));
+}

--- a/src/totp/totp.h
+++ b/src/totp/totp.h
@@ -1,0 +1,15 @@
+#ifndef QTOTP_H
+#define QTOTP_H
+
+#include <QtCore/qglobal.h>
+
+class QTotp
+{
+public:
+    QTotp();
+    static int base32_decode(const quint8 *encoded, quint8 *result, int bufSize);
+    static QByteArray hmacSha1(QByteArray key, QByteArray baseString);
+    static QString generateTotp(const QByteArray key);
+};
+
+#endif // QTOTP_H

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -48,6 +48,7 @@
 #include "gui/DatabaseTabWidget.h"
 #include "gui/DatabaseWidget.h"
 #include "gui/CloneDialog.h"
+#include "gui/TotpDialog.h"
 #include "gui/FileDialog.h"
 #include "gui/MainWindow.h"
 #include "gui/MessageBox.h"


### PR DESCRIPTION
## Description
This PR add basic support for TOTP code generation (as described by [rfc6238](https://tools.ietf.org/html/rfc6238)) using KeepassXC.

## How it Works
Right now it supports the format used by the 2 TOTP plugins listed on [Keepass plugins page](keepass.info/plugins.html): [KeeOtp](http://keepass.info/plugins.html#keeotp) and [Tray TOTP](http://keepass.info/plugins.html#traytotp).

The following formats are supported:

|           | Attribute name | Value   |
|-----------|----------------|----------------|
| **Tray TOTP** |      `TOTP Seed` | `XXXXXXXXXXXXXXXX`     |
| **KeeOtp**    |           `otp`| `key=XXXXXXXXXXXXXXXX` |

If your entry has one of those attributes, the "Timed One Time Password" context menu will be available.

## Motivation and Context
A lot of people avoid using 2FA with TOTP because having to get your phone and opening Google Authenticator app every time you need to login is a hassle. There's also the risk of losing access to your accounts if you lose your phone.

Most modern password managers have support for generating TOTP codes and even Keepass 2.x have a couple of plugins that add this feature so it would be very useful for people who use KeepassXC to have access to their TOTP codes right from Keepass interface.

resolves #80

## How Has This Been Tested?
I tested about 10 different sites which I had setup 2FA with TOTP. All of them worked fine with the generated codes.

## Screenshots (if appropriate):

![image](https://cloud.githubusercontent.com/assets/107672/23592358/5cfa7aec-01de-11e7-986b-32a000f61b63.png)

![image](https://cloud.githubusercontent.com/assets/107672/23592281/23997466-01dd-11e7-9906-2c3ce9ad5f4b.png)


![image](https://cloud.githubusercontent.com/assets/107672/23682410/6ef5ca90-0372-11e7-84d0-96e3ce1395b7.png)



## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed.
