### PR TITLE
Clean up code, replace Q_* macros with MOC keywords

### DIFF
--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -48,13 +48,13 @@ public:
     static AutoType* instance();
     static void createTestInstance();
 
-public Q_SLOTS:
+public slots:
     void performGlobalAutoType(const QList<Database*>& dbList);
 
-Q_SIGNALS:
+signals:
     void globalShortcutTriggered();
 
-private Q_SLOTS:
+private slots:
     void performAutoTypeFromGlobal(Entry* entry, const QString& sequence);
     void resetInAutoType();
     void unloadPlugin();

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -91,7 +91,7 @@ void AutoTypeSelectDialog::emitEntryActivated(const QModelIndex& index)
 
     Entry* entry = m_view->entryFromIndex(index);
     accept();
-    Q_EMIT entryActivated(entry, m_sequences[entry]);
+    emit entryActivated(entry, m_sequences[entry]);
 }
 
 void AutoTypeSelectDialog::entryRemoved()

--- a/src/autotype/AutoTypeSelectDialog.h
+++ b/src/autotype/AutoTypeSelectDialog.h
@@ -33,13 +33,13 @@ public:
     explicit AutoTypeSelectDialog(QWidget* parent = nullptr);
     void setEntries(const QList<Entry*>& entries, const QHash<Entry*, QString>& sequences);
 
-Q_SIGNALS:
+signals:
     void entryActivated(Entry* entry, const QString& sequence);
 
-public Q_SLOTS:
+public slots:
     void done(int r) override;
 
-private Q_SLOTS:
+private slots:
     void emitEntryActivated(const QModelIndex& index);
     void entryRemoved();
 

--- a/src/autotype/AutoTypeSelectView.h
+++ b/src/autotype/AutoTypeSelectView.h
@@ -32,7 +32,7 @@ public:
 protected:
     void mouseMoveEvent(QMouseEvent* event) override;
 
-private Q_SLOTS:
+private slots:
     void selectFirstEntry();
 };
 

--- a/src/autotype/mac/AutoTypeMac.cpp
+++ b/src/autotype/mac/AutoTypeMac.cpp
@@ -460,7 +460,7 @@ OSStatus AutoTypePlatformMac::hotkeyHandler(EventHandlerCallRef nextHandler, Eve
 
     if (::GetEventParameter(theEvent, kEventParamDirectObject, typeEventHotKeyID, nullptr, sizeof(hotkeyId), nullptr, &hotkeyId) == noErr
             && hotkeyId.id == HOTKEY_ID) {
-        Q_EMIT self->globalShortcutTriggered();
+        emit self->globalShortcutTriggered();
     }
 
     return noErr;

--- a/src/autotype/mac/AutoTypeMac.h
+++ b/src/autotype/mac/AutoTypeMac.h
@@ -51,7 +51,7 @@ public:
     void sendChar(const QChar& ch, bool isKeyDown);
     void sendKey(Qt::Key key, bool isKeyDown);
 
-Q_SIGNALS:
+signals:
     void globalShortcutTriggered();
 
 private:

--- a/src/autotype/test/AutoTypeTest.h
+++ b/src/autotype/test/AutoTypeTest.h
@@ -60,7 +60,7 @@ public:
     void addActionChar(AutoTypeChar* action);
     void addActionKey(AutoTypeKey* action);
 
-Q_SIGNALS:
+signals:
     void globalShortcutTriggered();
 
 private:

--- a/src/autotype/windows/AutoTypeWindows.cpp
+++ b/src/autotype/windows/AutoTypeWindows.cpp
@@ -96,7 +96,7 @@ int AutoTypePlatformWin::platformEventFilter(void* event)
     MSG *msg = static_cast<MSG *>(event);
 
     if (msg->message == WM_HOTKEY && msg->wParam == HOTKEY_ID) {
-        Q_EMIT globalShortcutTriggered();
+        emit globalShortcutTriggered();
         return 1;
     }
 

--- a/src/autotype/windows/AutoTypeWindows.h
+++ b/src/autotype/windows/AutoTypeWindows.h
@@ -45,7 +45,7 @@ public:
     void sendChar(const QChar& ch, bool isKeyDown);
     void sendKey(Qt::Key key, bool isKeyDown);
 
-Q_SIGNALS:
+signals:
     void globalShortcutTriggered();
 
 private:

--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -214,7 +214,7 @@ int AutoTypePlatformX11::platformEventFilter(void* event)
                 && (!QApplication::activeWindow() || QApplication::activeWindow()->isMinimized())
                 && m_loaded) {
             if (type == XCB_KEY_PRESS) {
-                Q_EMIT globalShortcutTriggered();
+                emit globalShortcutTriggered();
             }
 
             return 1;

--- a/src/autotype/xcb/AutoTypeXCB.h
+++ b/src/autotype/xcb/AutoTypeXCB.h
@@ -59,7 +59,7 @@ public:
 
     void SendKeyPressedEvent(KeySym keysym);
 
-Q_SIGNALS:
+signals:
     void globalShortcutTriggered();
 
 private:

--- a/src/core/AutoTypeAssociations.cpp
+++ b/src/core/AutoTypeAssociations.cpp
@@ -39,29 +39,29 @@ void AutoTypeAssociations::copyDataFrom(const AutoTypeAssociations* other)
         return;
     }
 
-    Q_EMIT aboutToReset();
+    emit aboutToReset();
     m_associations = other->m_associations;
-    Q_EMIT reset();
-    Q_EMIT modified();
+    emit reset();
+    emit modified();
 }
 
 void AutoTypeAssociations::add(const AutoTypeAssociations::Association& association)
 {
     int index = m_associations.size();
-    Q_EMIT aboutToAdd(index);
+    emit aboutToAdd(index);
     m_associations.append(association);
-    Q_EMIT added(index);
-    Q_EMIT modified();
+    emit added(index);
+    emit modified();
 }
 
 void AutoTypeAssociations::remove(int index)
 {
     Q_ASSERT(index >= 0 && index < m_associations.size());
 
-    Q_EMIT aboutToRemove(index);
+    emit aboutToRemove(index);
     m_associations.removeAt(index);
-    Q_EMIT removed(index);
-    Q_EMIT modified();
+    emit removed(index);
+    emit modified();
 }
 
 void AutoTypeAssociations::removeEmpty()
@@ -81,8 +81,8 @@ void AutoTypeAssociations::update(int index, const AutoTypeAssociations::Associa
 
     if (m_associations.at(index) != association) {
         m_associations[index] = association;
-        Q_EMIT dataChanged(index);
-        Q_EMIT modified();
+        emit dataChanged(index);
+        emit modified();
     }
 }
 

--- a/src/core/AutoTypeAssociations.h
+++ b/src/core/AutoTypeAssociations.h
@@ -48,7 +48,7 @@ public:
 private:
     QList<AutoTypeAssociations::Association> m_associations;
 
-Q_SIGNALS:
+signals:
     void modified();
     void dataChanged(int index);
     void aboutToAdd(int index);

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -227,7 +227,7 @@ bool Database::setKey(const CompositeKey& key, const QByteArray& transformSeed,
     if (updateChangedTime) {
         m_metadata->setMasterKeyChanged(QDateTime::currentDateTimeUtc());
     }
-    Q_EMIT modifiedImmediate();
+    emit modifiedImmediate();
 
     return true;
 }
@@ -285,7 +285,7 @@ void Database::recycleGroup(Group* group)
 void Database::merge(const Database* other)
 {
     m_rootGroup->merge(other->rootGroup());
-    Q_EMIT modified();
+    emit modified();
 }
 
 void Database::setEmitModified(bool value)

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -115,7 +115,7 @@ public:
 
     static Database* databaseByUuid(const Uuid& uuid);
 
-Q_SIGNALS:
+signals:
     void groupDataChanged(Group* group);
     void groupAboutToAdd(Group* group, int index);
     void groupAdded();
@@ -127,7 +127,7 @@ Q_SIGNALS:
     void modified();
     void modifiedImmediate();
 
-private Q_SLOTS:
+private slots:
     void startModifiedTimer();
 
 private:

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -62,7 +62,7 @@ template <class T> inline bool Entry::set(T& property, const T& value)
 {
     if (property != value) {
         property = value;
-        Q_EMIT modified();
+        emit modified();
         return true;
     }
     else {
@@ -299,7 +299,7 @@ void Entry::setIcon(int iconNumber)
         m_data.iconNumber = iconNumber;
         m_data.customIcon = Uuid();
 
-        Q_EMIT modified();
+        emit modified();
         emitDataChanged();
     }
 }
@@ -312,7 +312,7 @@ void Entry::setIcon(const Uuid& uuid)
         m_data.customIcon = uuid;
         m_data.iconNumber = 0;
 
-        Q_EMIT modified();
+        emit modified();
         emitDataChanged();
     }
 }
@@ -392,7 +392,7 @@ void Entry::setExpires(const bool& value)
 {
     if (m_data.timeInfo.expires() != value) {
         m_data.timeInfo.setExpires(value);
-        Q_EMIT modified();
+        emit modified();
     }
 }
 
@@ -400,7 +400,7 @@ void Entry::setExpiryTime(const QDateTime& dateTime)
 {
     if (m_data.timeInfo.expiryTime() != dateTime) {
         m_data.timeInfo.setExpiryTime(dateTime);
-        Q_EMIT modified();
+        emit modified();
     }
 }
 
@@ -419,7 +419,7 @@ void Entry::addHistoryItem(Entry* entry)
     Q_ASSERT(!entry->parent());
 
     m_history.append(entry);
-    Q_EMIT modified();
+    emit modified();
 }
 
 void Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
@@ -437,7 +437,7 @@ void Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
         delete entry;
     }
 
-    Q_EMIT modified();
+    emit modified();
 }
 
 void Entry::truncateHistory()
@@ -633,7 +633,7 @@ void Entry::setGroup(Group* group)
 
 void Entry::emitDataChanged()
 {
-    Q_EMIT dataChanged(this);
+    emit dataChanged(this);
 }
 
 const Database* Entry::database() const

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -147,7 +147,7 @@ public:
 
     void setUpdateTimeinfo(bool value);
 
-Q_SIGNALS:
+signals:
     /**
      * Emitted when a default attribute has been changed.
      */
@@ -155,7 +155,7 @@ Q_SIGNALS:
 
     void modified();
 
-private Q_SLOTS:
+private slots:
     void emitDataChanged();
     void updateTimeinfo();
     void updateModifiedSinceBegin();

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -48,7 +48,7 @@ void EntryAttachments::set(const QString& key, const QByteArray& value)
     bool addAttachment = !m_attachments.contains(key);
 
     if (addAttachment) {
-        Q_EMIT aboutToBeAdded(key);
+        emit aboutToBeAdded(key);
     }
 
     if (addAttachment || m_attachments.value(key) != value) {
@@ -57,14 +57,14 @@ void EntryAttachments::set(const QString& key, const QByteArray& value)
     }
 
     if (addAttachment) {
-        Q_EMIT added(key);
+        emit added(key);
     }
     else {
-        Q_EMIT keyModified(key);
+        emit keyModified(key);
     }
 
     if (emitModified) {
-        Q_EMIT modified();
+        emit modified();
     }
 }
 
@@ -75,12 +75,12 @@ void EntryAttachments::remove(const QString& key)
         return;
     }
 
-    Q_EMIT aboutToBeRemoved(key);
+    emit aboutToBeRemoved(key);
 
     m_attachments.remove(key);
 
-    Q_EMIT removed(key);
-    Q_EMIT modified();
+    emit removed(key);
+    emit modified();
 }
 
 void EntryAttachments::clear()
@@ -89,23 +89,23 @@ void EntryAttachments::clear()
         return;
     }
 
-    Q_EMIT aboutToBeReset();
+    emit aboutToBeReset();
 
     m_attachments.clear();
 
-    Q_EMIT reset();
-    Q_EMIT modified();
+    emit reset();
+    emit modified();
 }
 
 void EntryAttachments::copyDataFrom(const EntryAttachments* other)
 {
     if (*this != *other) {
-        Q_EMIT aboutToBeReset();
+        emit aboutToBeReset();
 
         m_attachments = other->m_attachments;
 
-        Q_EMIT reset();
-        Q_EMIT modified();
+        emit reset();
+        emit modified();
     }
 }
 

--- a/src/core/EntryAttachments.h
+++ b/src/core/EntryAttachments.h
@@ -38,7 +38,7 @@ public:
     bool operator==(const EntryAttachments& other) const;
     bool operator!=(const EntryAttachments& other) const;
 
-Q_SIGNALS:
+signals:
     void modified();
     void keyModified(const QString& key);
     void aboutToBeAdded(const QString& key);

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -98,7 +98,7 @@ void EntryAttributes::set(const QString& key, const QString& value, bool protect
     bool defaultAttribute = isDefaultAttribute(key);
 
     if (addAttribute && !defaultAttribute) {
-        Q_EMIT aboutToBeAdded(key);
+        emit aboutToBeAdded(key);
     }
 
     if (addAttribute || changeValue) {
@@ -117,17 +117,17 @@ void EntryAttributes::set(const QString& key, const QString& value, bool protect
     }
 
     if (emitModified) {
-        Q_EMIT modified();
+        emit modified();
     }
 
     if (defaultAttribute && changeValue) {
-        Q_EMIT defaultKeyModified();
+        emit defaultKeyModified();
     }
     else if (addAttribute) {
-        Q_EMIT added(key);
+        emit added(key);
     }
     else if (emitModified) {
-        Q_EMIT customKeyModified(key);
+        emit customKeyModified(key);
     }
 }
 
@@ -140,13 +140,13 @@ void EntryAttributes::remove(const QString& key)
         return;
     }
 
-    Q_EMIT aboutToBeRemoved(key);
+    emit aboutToBeRemoved(key);
 
     m_attributes.remove(key);
     m_protectedAttributes.remove(key);
 
-    Q_EMIT removed(key);
-    Q_EMIT modified();
+    emit removed(key);
+    emit modified();
 }
 
 void EntryAttributes::rename(const QString& oldKey, const QString& newKey)
@@ -167,7 +167,7 @@ void EntryAttributes::rename(const QString& oldKey, const QString& newKey)
     QString data = value(oldKey);
     bool protect = isProtected(oldKey);
 
-    Q_EMIT aboutToRename(oldKey, newKey);
+    emit aboutToRename(oldKey, newKey);
 
     m_attributes.remove(oldKey);
     m_attributes.insert(newKey, data);
@@ -176,8 +176,8 @@ void EntryAttributes::rename(const QString& oldKey, const QString& newKey)
         m_protectedAttributes.insert(newKey);
     }
 
-    Q_EMIT modified();
-    Q_EMIT renamed(oldKey, newKey);
+    emit modified();
+    emit renamed(oldKey, newKey);
 }
 
 void EntryAttributes::copyCustomKeysFrom(const EntryAttributes* other)
@@ -186,7 +186,7 @@ void EntryAttributes::copyCustomKeysFrom(const EntryAttributes* other)
         return;
     }
 
-    Q_EMIT aboutToBeReset();
+    emit aboutToBeReset();
 
     // remove all non-default keys
     const QList<QString> keyList = keys();
@@ -207,8 +207,8 @@ void EntryAttributes::copyCustomKeysFrom(const EntryAttributes* other)
         }
     }
 
-    Q_EMIT reset();
-    Q_EMIT modified();
+    emit reset();
+    emit modified();
 }
 
 bool EntryAttributes::areCustomKeysDifferent(const EntryAttributes* other)
@@ -235,13 +235,13 @@ bool EntryAttributes::areCustomKeysDifferent(const EntryAttributes* other)
 void EntryAttributes::copyDataFrom(const EntryAttributes* other)
 {
     if (*this != *other) {
-        Q_EMIT aboutToBeReset();
+        emit aboutToBeReset();
 
         m_attributes = other->m_attributes;
         m_protectedAttributes = other->m_protectedAttributes;
 
-        Q_EMIT reset();
-        Q_EMIT modified();
+        emit reset();
+        emit modified();
     }
 }
 
@@ -259,7 +259,7 @@ bool EntryAttributes::operator!=(const EntryAttributes& other) const
 
 void EntryAttributes::clear()
 {
-    Q_EMIT aboutToBeReset();
+    emit aboutToBeReset();
 
     m_attributes.clear();
     m_protectedAttributes.clear();
@@ -268,8 +268,8 @@ void EntryAttributes::clear()
         m_attributes.insert(key, "");
     }
 
-    Q_EMIT reset();
-    Q_EMIT modified();
+    emit reset();
+    emit modified();
 }
 
 int EntryAttributes::attributesSize()

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -57,7 +57,7 @@ public:
     static const QString RememberCmdExecAttr;
     static bool isDefaultAttribute(const QString& key);
 
-Q_SIGNALS:
+signals:
     void modified();
     void defaultKeyModified();
     void customKeyModified(const QString& key);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -74,7 +74,7 @@ template <class P, class V> inline bool Group::set(P& property, const V& value) 
     if (property != value) {
         property = value;
         updateTimeinfo();
-        Q_EMIT modified();
+        emit modified();
         return true;
     }
     else {
@@ -249,7 +249,7 @@ void Group::setUuid(const Uuid& uuid)
 void Group::setName(const QString& name)
 {
     if (set(m_data.name, name)) {
-        Q_EMIT dataChanged(this);
+        emit dataChanged(this);
     }
 }
 
@@ -267,8 +267,8 @@ void Group::setIcon(int iconNumber)
         m_data.customIcon = Uuid();
 
         updateTimeinfo();
-        Q_EMIT modified();
-        Q_EMIT dataChanged(this);
+        emit modified();
+        emit dataChanged(this);
     }
 }
 
@@ -281,8 +281,8 @@ void Group::setIcon(const Uuid& uuid)
         m_data.iconNumber = 0;
 
         updateTimeinfo();
-        Q_EMIT modified();
-        Q_EMIT dataChanged(this);
+        emit modified();
+        emit dataChanged(this);
     }
 }
 
@@ -296,7 +296,7 @@ void Group::setExpanded(bool expanded)
     if (m_data.isExpanded != expanded) {
         m_data.isExpanded = expanded;
         updateTimeinfo();
-        Q_EMIT modified();
+        emit modified();
     }
 }
 
@@ -325,7 +325,7 @@ void Group::setExpires(bool value)
     if (m_data.timeInfo.expires() != value) {
         m_data.timeInfo.setExpires(value);
         updateTimeinfo();
-        Q_EMIT modified();
+        emit modified();
     }
 }
 
@@ -334,7 +334,7 @@ void Group::setExpiryTime(const QDateTime& dateTime)
     if (m_data.timeInfo.expiryTime() != dateTime) {
         m_data.timeInfo.setExpiryTime(dateTime);
         updateTimeinfo();
-        Q_EMIT modified();
+        emit modified();
     }
 }
 
@@ -391,12 +391,12 @@ void Group::setParent(Group* parent, int index)
             recSetDatabase(parent->m_db);
         }
         QObject::setParent(parent);
-        Q_EMIT aboutToAdd(this, index);
+        emit aboutToAdd(this, index);
         Q_ASSERT(index <= parent->m_children.size());
         parent->m_children.insert(index, this);
     }
     else {
-        Q_EMIT aboutToMove(this, parent, index);
+        emit aboutToMove(this, parent, index);
         m_parent->m_children.removeAll(this);
         m_parent = parent;
         QObject::setParent(parent);
@@ -408,13 +408,13 @@ void Group::setParent(Group* parent, int index)
         m_data.timeInfo.setLocationChanged(QDateTime::currentDateTimeUtc());
     }
 
-    Q_EMIT modified();
+    emit modified();
 
     if (!moveWithinDatabase) {
-        Q_EMIT added();
+        emit added();
     }
     else {
-        Q_EMIT moved();
+        emit moved();
     }
 }
 
@@ -566,7 +566,7 @@ void Group::merge(const Group* other)
         }
     }
 
-    Q_EMIT modified();
+    emit modified();
 }
 
 Group* Group::findChildByName(const QString& name)
@@ -623,7 +623,7 @@ void Group::addEntry(Entry* entry)
     Q_ASSERT(entry);
     Q_ASSERT(!m_entries.contains(entry));
 
-    Q_EMIT entryAboutToAdd(entry);
+    emit entryAboutToAdd(entry);
 
     m_entries << entry;
     connect(entry, SIGNAL(dataChanged(Entry*)), SIGNAL(entryDataChanged(Entry*)));
@@ -631,23 +631,23 @@ void Group::addEntry(Entry* entry)
         connect(entry, SIGNAL(modified()), m_db, SIGNAL(modifiedImmediate()));
     }
 
-    Q_EMIT modified();
-    Q_EMIT entryAdded(entry);
+    emit modified();
+    emit entryAdded(entry);
 }
 
 void Group::removeEntry(Entry* entry)
 {
     Q_ASSERT(m_entries.contains(entry));
 
-    Q_EMIT entryAboutToRemove(entry);
+    emit entryAboutToRemove(entry);
 
     entry->disconnect(this);
     if (m_db) {
         entry->disconnect(m_db);
     }
     m_entries.removeAll(entry);
-    Q_EMIT modified();
-    Q_EMIT entryRemoved(entry);
+    emit modified();
+    emit entryRemoved(entry);
 }
 
 void Group::recSetDatabase(Database* db)
@@ -693,10 +693,10 @@ void Group::recSetDatabase(Database* db)
 void Group::cleanupParent()
 {
     if (m_parent) {
-        Q_EMIT aboutToRemove(this);
+        emit aboutToRemove(this);
         m_parent->m_children.removeAll(this);
-        Q_EMIT modified();
-        Q_EMIT removed();
+        emit modified();
+        emit removed();
     }
 }
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -122,7 +122,7 @@ public:
     void copyDataFrom(const Group* other);
     void merge(const Group* other);
 
-Q_SIGNALS:
+signals:
     void dataChanged(Group* group);
 
     void aboutToAdd(Group* group, int index);

--- a/src/core/InactivityTimer.cpp
+++ b/src/core/InactivityTimer.cpp
@@ -73,7 +73,7 @@ void InactivityTimer::timeout()
     }
 
     if (m_active && !m_timer->isActive()) {
-        Q_EMIT inactivityDetected();
+        emit inactivityDetected();
     }
 
     m_emitMutx.unlock();

--- a/src/core/InactivityTimer.h
+++ b/src/core/InactivityTimer.h
@@ -33,13 +33,13 @@ public:
     void activate();
     void deactivate();
 
-Q_SIGNALS:
+signals:
     void inactivityDetected();
 
 protected:
     bool eventFilter(QObject* watched, QEvent* event);
 
-private Q_SLOTS:
+private slots:
     void timeout();
 
 private:

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -55,7 +55,7 @@ template <class P, class V> bool Metadata::set(P& property, const V& value)
 {
     if (property != value) {
         property = value;
-        Q_EMIT modified();
+        emit modified();
         return true;
     }
     else {
@@ -69,7 +69,7 @@ template <class P, class V> bool Metadata::set(P& property, const V& value, QDat
         if (m_updateDatetime) {
             dateTime = QDateTime::currentDateTimeUtc();
         }
-        Q_EMIT modified();
+        emit modified();
         return true;
     }
     else {
@@ -308,7 +308,7 @@ void Metadata::setGenerator(const QString& value)
 void Metadata::setName(const QString& value)
 {
     if (set(m_data.name, value, m_data.nameChanged)) {
-        Q_EMIT nameTextChanged();
+        emit nameTextChanged();
     }
 }
 
@@ -391,7 +391,7 @@ void Metadata::addCustomIcon(const Uuid& uuid, const QImage& icon)
     m_customIconScaledCacheKeys[uuid] = QPixmapCache::Key();
     m_customIconsOrder.append(uuid);
     Q_ASSERT(m_customIcons.count() == m_customIconsOrder.count());
-    Q_EMIT modified();
+    emit modified();
 }
 
 void Metadata::addCustomIconScaled(const Uuid& uuid, const QImage& icon)
@@ -422,7 +422,7 @@ void Metadata::removeCustomIcon(const Uuid& uuid)
     m_customIconScaledCacheKeys.remove(uuid);
     m_customIconsOrder.removeAll(uuid);
     Q_ASSERT(m_customIcons.count() == m_customIconsOrder.count());
-    Q_EMIT modified();
+    emit modified();
 }
 
 void Metadata::copyCustomIcons(const QSet<Uuid>& iconList, const Metadata* otherMetadata)
@@ -504,7 +504,7 @@ void Metadata::addCustomField(const QString& key, const QString& value)
     Q_ASSERT(!m_customFields.contains(key));
 
     m_customFields.insert(key, value);
-    Q_EMIT modified();
+    emit modified();
 }
 
 void Metadata::removeCustomField(const QString& key)
@@ -512,5 +512,5 @@ void Metadata::removeCustomField(const QString& key)
     Q_ASSERT(m_customFields.contains(key));
 
     m_customFields.remove(key);
-    Q_EMIT modified();
+    emit modified();
 }

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -146,7 +146,7 @@ public:
      */
     void copyAttributesFrom(const Metadata* other);
 
-Q_SIGNALS:
+signals:
     void nameTextChanged();
     void modified();
 

--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -97,11 +97,11 @@ QString PasswordGenerator::generatePassword() const
 
 int PasswordGenerator::getbits() const
 {
-    QVector<PasswordGroup> groups = passwordGroups();
+    const QVector<PasswordGroup> groups = passwordGroups();
 
     int bits = 0;
     QVector<QChar> passwordChars;
-    Q_FOREACH (const PasswordGroup& group, groups) {
+    for (const PasswordGroup& group: groups) {
         bits += group.size();
     }
 

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -148,7 +148,7 @@ void Application::handleUnixSignal(int sig)
         case SIGTERM:
         {
             char buf = 0;
-            ::write(unixSignalSocket[0], &buf, sizeof(buf));
+            Q_UNUSED(::write(unixSignalSocket[0], &buf, sizeof(buf)));
             return;
         }
         case SIGHUP:
@@ -160,7 +160,7 @@ void Application::quitBySignal()
 {
     m_unixSignalNotifier->setEnabled(false);
     char buf;
-    ::read(unixSignalSocket[1], &buf, sizeof(buf));
+    Q_UNUSED(::read(unixSignalSocket[1], &buf, sizeof(buf)));
     
     if (nullptr != m_mainWindow)
         static_cast<MainWindow*>(m_mainWindow)->appExit();

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -96,7 +96,7 @@ bool Application::event(QEvent* event)
 {
     // Handle Apple QFileOpenEvent from finder (double click on .kdbx file)
     if (event->type() == QEvent::FileOpen) {
-        Q_EMIT openFile(static_cast<QFileOpenEvent*>(event)->file());
+        emit openFile(static_cast<QFileOpenEvent*>(event)->file());
         return true;
     }
 #ifdef Q_OS_MAC

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -33,10 +33,10 @@ public:
 
     bool event(QEvent* event) override;
 
-Q_SIGNALS:
+signals:
     void openFile(const QString& filename);
 
-private Q_SLOTS:
+private slots:
 #if defined(Q_OS_UNIX)
     void quitBySignal();
 #endif

--- a/src/gui/ChangeMasterKeyWidget.cpp
+++ b/src/gui/ChangeMasterKeyWidget.cpp
@@ -131,13 +131,13 @@ void ChangeMasterKeyWidget::generateKey()
     }
 
     m_ui->messageWidget->hideMessage();
-    Q_EMIT editFinished(true);
+    emit editFinished(true);
 }
 
 
 void ChangeMasterKeyWidget::reject()
 {
-    Q_EMIT editFinished(false);
+    emit editFinished(false);
 }
 
 void ChangeMasterKeyWidget::setCancelEnabled(bool enabled)

--- a/src/gui/ChangeMasterKeyWidget.h
+++ b/src/gui/ChangeMasterKeyWidget.h
@@ -40,10 +40,10 @@ public:
     QLabel* headlineLabel();
     void setCancelEnabled(bool enabled);
 
-Q_SIGNALS:
+signals:
     void editFinished(bool accepted);
 
-private Q_SLOTS:
+private slots:
     void generateKey();
     void reject();
     void createKeyFile();

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -31,10 +31,10 @@ public:
 
     static Clipboard* instance();
 
-public Q_SLOTS:
+public slots:
     void clearCopiedText();
 
-private Q_SLOTS:
+private slots:
     void clearClipboard();
 
 private:

--- a/src/gui/CloneDialog.h
+++ b/src/gui/CloneDialog.h
@@ -39,7 +39,7 @@ public:
 private:
     QScopedPointer<Ui::CloneDialog> m_ui;
 
-private Q_SLOTS:
+private slots:
     void cloneEntry();
 
 protected:

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -130,7 +130,7 @@ void DatabaseOpenWidget::openDatabase()
         if (m_ui->messageWidget->isVisible()) {
             m_ui->messageWidget->animatedHide();
         }
-        Q_EMIT editFinished(true);
+        emit editFinished(true);
     }
     else {
         m_ui->messageWidget->showMessage(tr("Unable to open the database.")
@@ -174,7 +174,7 @@ CompositeKey DatabaseOpenWidget::databaseKey()
 
 void DatabaseOpenWidget::reject()
 {
-    Q_EMIT editFinished(false);
+    emit editFinished(false);
 }
 
 void DatabaseOpenWidget::activatePassword()

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -41,18 +41,18 @@ public:
     void enterKey(const QString& pw, const QString& keyFile);
     Database* database();
 
-Q_SIGNALS:
+signals:
     void editFinished(bool accepted);
 
 protected:
     void showEvent(QShowEvent* event) override;
     CompositeKey databaseKey();
 
-protected Q_SLOTS:
+protected slots:
     virtual void openDatabase();
     void reject();
 
-private Q_SLOTS:
+private slots:
     void activatePassword();
     void activateKeyFile();
     void browseKeyFile();

--- a/src/gui/DatabaseRepairWidget.cpp
+++ b/src/gui/DatabaseRepairWidget.cpp
@@ -50,7 +50,7 @@ void DatabaseRepairWidget::openDatabase()
         QString errorMsg;
         if (!key.load(keyFilename, &errorMsg)) {
             MessageBox::warning(this, tr("Error"), tr("Can't open key file").append(":\n").append(errorMsg));
-            Q_EMIT editFinished(false);
+            emit editFinished(false);
             return;
         }
         masterKey.addKey(key);
@@ -62,7 +62,7 @@ void DatabaseRepairWidget::openDatabase()
     if (!file.open(QIODevice::ReadOnly)) {
         MessageBox::warning(this, tr("Error"), tr("Unable to open the database.").append("\n")
                             .append(file.errorString()));
-        Q_EMIT editFinished(false);
+        emit editFinished(false);
         return;
     }
     if (m_db) {
@@ -75,21 +75,21 @@ void DatabaseRepairWidget::openDatabase()
     switch (repairResult) {
     case KeePass2Repair::NothingTodo:
         MessageBox::information(this, tr("Error"), tr("Database opened fine. Nothing to do."));
-        Q_EMIT editFinished(false);
+        emit editFinished(false);
         return;
     case KeePass2Repair::UnableToOpen:
         MessageBox::warning(this, tr("Error"), tr("Unable to open the database.").append("\n")
                             .append(repair.errorString()));
-        Q_EMIT editFinished(false);
+        emit editFinished(false);
         return;
     case KeePass2Repair::RepairSuccess:
         m_db = repair.database();
         MessageBox::warning(this, tr("Success"), tr("The database has been successfully repaired\nYou can now save it."));
-        Q_EMIT editFinished(true);
+        emit editFinished(true);
         return;
     case KeePass2Repair::RepairFailed:
         MessageBox::warning(this, tr("Error"), tr("Unable to repair the database."));
-        Q_EMIT editFinished(false);
+        emit editFinished(false);
         return;
     }
 }
@@ -97,9 +97,9 @@ void DatabaseRepairWidget::openDatabase()
 void DatabaseRepairWidget::processEditFinished(bool result)
 {
     if (result) {
-        Q_EMIT success();
+        emit success();
     }
     else {
-        Q_EMIT error();
+        emit error();
     }
 }

--- a/src/gui/DatabaseRepairWidget.h
+++ b/src/gui/DatabaseRepairWidget.h
@@ -27,14 +27,14 @@ class DatabaseRepairWidget : public DatabaseOpenWidget
 public:
     explicit DatabaseRepairWidget(QWidget* parent = nullptr);
 
-Q_SIGNALS:
+signals:
     void success();
     void error();
 
 protected:
     void openDatabase() override;
 
-private Q_SLOTS:
+private slots:
     void processEditFinished(bool result);
 };
 

--- a/src/gui/DatabaseSettingsWidget.cpp
+++ b/src/gui/DatabaseSettingsWidget.cpp
@@ -124,12 +124,12 @@ void DatabaseSettingsWidget::save()
         truncateHistories();
     }
 
-    Q_EMIT editFinished(true);
+    emit editFinished(true);
 }
 
 void DatabaseSettingsWidget::reject()
 {
-    Q_EMIT editFinished(false);
+    emit editFinished(false);
 }
 
 void DatabaseSettingsWidget::transformRoundsBenchmark()

--- a/src/gui/DatabaseSettingsWidget.h
+++ b/src/gui/DatabaseSettingsWidget.h
@@ -38,10 +38,10 @@ public:
 
     void load(Database* db);
 
-Q_SIGNALS:
+signals:
     void editFinished(bool accepted);
 
-private Q_SLOTS:
+private slots:
     void save();
     void reject();
     void transformRoundsBenchmark();

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -120,7 +120,7 @@ void DatabaseTabWidget::openDatabase(const QString& fileName, const QString& pw,
     QFileInfo fileInfo(fileName);
     QString canonicalFilePath = fileInfo.canonicalFilePath();
     if (canonicalFilePath.isEmpty()) {
-        Q_EMIT messageGlobal(tr("File not found!"), MessageWidget::Error);
+        emit messageGlobal(tr("File not found!"), MessageWidget::Error);
         return;
     }
 
@@ -141,7 +141,7 @@ void DatabaseTabWidget::openDatabase(const QString& fileName, const QString& pw,
     if (!file.open(QIODevice::ReadWrite)) {
         if (!file.open(QIODevice::ReadOnly)) {
             // can't open
-            Q_EMIT messageGlobal(
+            emit messageGlobal(
                 tr("Unable to open the database.").append("\n").append(file.errorString()), MessageWidget::Error);
             return;
         }
@@ -198,7 +198,7 @@ void DatabaseTabWidget::openDatabase(const QString& fileName, const QString& pw,
     insertDatabase(db, dbStruct);
 
     if (dbStruct.readOnly) {
-        Q_EMIT messageTab(tr("File opened in read only mode."), MessageWidget::Warning);
+        emit messageTab(tr("File opened in read only mode."), MessageWidget::Warning);
     }
 
     updateLastDatabases(dbStruct.filePath);
@@ -209,7 +209,7 @@ void DatabaseTabWidget::openDatabase(const QString& fileName, const QString& pw,
     else {
         dbStruct.dbWidget->switchToOpenDatabase(dbStruct.filePath);
     }
-    Q_EMIT messageDismissGlobal();
+    emit messageDismissGlobal();
 }
 
 void DatabaseTabWidget::mergeDatabase()
@@ -314,7 +314,7 @@ void DatabaseTabWidget::deleteDatabase(Database* db)
     delete db;
 
     if (emitDatabaseWithFileClosed) {
-        Q_EMIT databaseWithFileClosed(filePath);
+        emit databaseWithFileClosed(filePath);
     }
 }
 
@@ -340,7 +340,7 @@ bool DatabaseTabWidget::saveDatabase(Database* db)
             // write the database to the file
             m_writer.writeDatabase(&saveFile, db);
             if (m_writer.hasError()) {
-                Q_EMIT messageTab(tr("Writing the database failed.").append("\n")
+                emit messageTab(tr("Writing the database failed.").append("\n")
                 .append(m_writer.errorString()), MessageWidget::Error);
                 return false;
             }
@@ -350,17 +350,17 @@ bool DatabaseTabWidget::saveDatabase(Database* db)
                 dbStruct.modified = false;
                 dbStruct.dbWidget->databaseSaved();
                 updateTabName(db);
-                Q_EMIT messageDismissTab();
+                emit messageDismissTab();
                 return true;
             }
             else {
-                Q_EMIT messageTab(tr("Writing the database failed.").append("\n")
+                emit messageTab(tr("Writing the database failed.").append("\n")
                     .append(saveFile.errorString()), MessageWidget::Error);
                 return false;
             }
         }
         else {
-            Q_EMIT messageTab(tr("Writing the database failed.").append("\n")
+            emit messageTab(tr("Writing the database failed.").append("\n")
             .append(saveFile.errorString()), MessageWidget::Error);
             return false;
         }
@@ -503,7 +503,7 @@ void DatabaseTabWidget::exportToCsv()
 
     CsvExporter csvExporter;
     if (!csvExporter.exportDatabase(fileName, db)) {
-        Q_EMIT messageGlobal(
+        emit messageGlobal(
             tr("Writing the CSV file failed.").append("\n")
             .append(csvExporter.errorString()), MessageWidget::Error);
     }
@@ -565,7 +565,7 @@ void DatabaseTabWidget::updateTabName(Database* db)
     }
 
     setTabText(index, tabName);
-    Q_EMIT tabNameChanged();
+    emit tabNameChanged();
 }
 
 void DatabaseTabWidget::updateTabNameFromDbSender()
@@ -745,7 +745,7 @@ void DatabaseTabWidget::lockDatabases()
         // database has changed so we can't use the db variable anymore
         updateTabName(dbWidget->database());
 
-        Q_EMIT databaseLocked(dbWidget);
+        emit databaseLocked(dbWidget);
     }
 }
 
@@ -803,12 +803,12 @@ void DatabaseTabWidget::changeDatabase(Database* newDb, bool unsavedChanges)
 
 void DatabaseTabWidget::emitActivateDatabaseChanged()
 {
-    Q_EMIT activateDatabaseChanged(currentDatabaseWidget());
+    emit activateDatabaseChanged(currentDatabaseWidget());
 }
 
 void DatabaseTabWidget::emitDatabaseUnlockedFromDbWidgetSender()
 {
-    Q_EMIT databaseUnlocked(static_cast<DatabaseWidget*>(sender()));
+    emit databaseUnlocked(static_cast<DatabaseWidget*>(sender()));
 }
 
 void DatabaseTabWidget::connectDatabase(Database* newDb, Database* oldDb)

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -63,7 +63,7 @@ public:
 
     static const int LastDatabasesCount;
 
-public Q_SLOTS:
+public slots:
     void newDatabase();
     void openDatabase();
     void mergeDatabase();
@@ -80,7 +80,7 @@ public Q_SLOTS:
     void performGlobalAutoType();
     void lockDatabases();
 
-Q_SIGNALS:
+signals:
     void tabNameChanged();
     void databaseWithFileClosed(QString filePath);
     void activateDatabaseChanged(DatabaseWidget* dbWidget);
@@ -91,7 +91,7 @@ Q_SIGNALS:
     void messageDismissGlobal();
     void messageDismissTab();
 
-private Q_SLOTS:
+private slots:
     void updateTabName(Database* db);
     void updateTabNameFromDbSender();
     void updateTabNameFromDbWidgetSender();

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -263,7 +263,7 @@ void DatabaseWidget::clearAllWidgets()
 
 void DatabaseWidget::emitCurrentModeChanged()
 {
-    Q_EMIT currentModeChanged(currentMode());
+    emit currentModeChanged(currentMode());
 }
 
 Database* DatabaseWidget::database()
@@ -309,7 +309,7 @@ void DatabaseWidget::replaceDatabase(Database* db)
     Database* oldDb = m_db;
     m_db = db;
     m_groupView->changeDatabase(m_db);
-    Q_EMIT databaseChanged(m_db, m_databaseModified);
+    emit databaseChanged(m_db, m_databaseModified);
     delete oldDb;
 }
 
@@ -700,7 +700,7 @@ void DatabaseWidget::updateMasterKey(bool accepted)
         }
     }
     else if (!m_db->hasKey()) {
-        Q_EMIT closeRequest();
+        emit closeRequest();
         return;
     }
 
@@ -712,7 +712,7 @@ void DatabaseWidget::openDatabase(bool accepted)
     if (accepted) {
         replaceDatabase(static_cast<DatabaseOpenWidget*>(sender())->database());
         setCurrentWidget(m_mainWidget);
-        Q_EMIT unlockedDatabase();
+        emit unlockedDatabase();
 
         // We won't need those anymore and KeePass1OpenWidget closes
         // the file in its dtor.
@@ -727,7 +727,7 @@ void DatabaseWidget::openDatabase(bool accepted)
         if (m_databaseOpenWidget->database()) {
             delete m_databaseOpenWidget->database();
         }
-        Q_EMIT closeRequest();
+        emit closeRequest();
     }
 }
 
@@ -750,13 +750,13 @@ void DatabaseWidget::mergeDatabase(bool accepted)
     }
 
     setCurrentWidget(m_mainWidget);
-    Q_EMIT databaseMerged(m_db);
+    emit databaseMerged(m_db);
 }
 
 void DatabaseWidget::unlockDatabase(bool accepted)
 {
     if (!accepted) {
-        Q_EMIT closeRequest();
+        emit closeRequest();
         return;
     }
 
@@ -775,7 +775,7 @@ void DatabaseWidget::unlockDatabase(bool accepted)
 
     setCurrentWidget(m_mainWidget);
     m_unlockDatabaseWidget->clearForms();
-    Q_EMIT unlockedDatabase();
+    emit unlockedDatabase();
 
     if (sender() == m_unlockDatabaseDialog) {
         QList<Database*> dbList;
@@ -888,7 +888,7 @@ void DatabaseWidget::search(const QString& searchtext)
         return;
     }
 
-    Q_EMIT searchModeAboutToActivate();
+    emit searchModeAboutToActivate();
 
     Qt::CaseSensitivity caseSensitive = m_searchCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive;
 
@@ -907,7 +907,7 @@ void DatabaseWidget::search(const QString& searchtext)
 
     m_searchingLabel->setVisible(true);
 
-    Q_EMIT searchModeActivated();
+    emit searchModeActivated();
 }
 
 void DatabaseWidget::setSearchCaseSensitive(bool state)
@@ -934,12 +934,12 @@ void DatabaseWidget::endSearch()
 {
     if (isInSearchMode())
     {
-        Q_EMIT listModeAboutToActivate();
+        emit listModeAboutToActivate();
 
         // Show the normal entry view of the current group
         m_entryView->setGroup(currentGroup());
 
-        Q_EMIT listModeActivated();
+        emit listModeActivated();
     }
 
     m_searchingLabel->setVisible(false);
@@ -950,12 +950,12 @@ void DatabaseWidget::endSearch()
 
 void DatabaseWidget::emitGroupContextMenuRequested(const QPoint& pos)
 {
-    Q_EMIT groupContextMenuRequested(m_groupView->viewport()->mapToGlobal(pos));
+    emit groupContextMenuRequested(m_groupView->viewport()->mapToGlobal(pos));
 }
 
 void DatabaseWidget::emitEntryContextMenuRequested(const QPoint& pos)
 {
-    Q_EMIT entryContextMenuRequested(m_entryView->viewport()->mapToGlobal(pos));
+    emit entryContextMenuRequested(m_entryView->viewport()->mapToGlobal(pos));
 }
 
 bool DatabaseWidget::dbHasKey() const

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -101,7 +101,7 @@ public:
     void ignoreNextAutoreload();
     void refreshSearch();
 
-Q_SIGNALS:
+signals:
     void closeRequest();
     void currentModeChanged(DatabaseWidget::Mode mode);
     void groupChanged();
@@ -119,7 +119,7 @@ Q_SIGNALS:
     void entryColumnSizesChanged();
     void updateSearch(QString text);
 
-public Q_SLOTS:
+public slots:
     void createEntry();
     void cloneEntry();
     void deleteEntries();
@@ -157,7 +157,7 @@ public Q_SLOTS:
     void showMessage(const QString& text, MessageWidget::MessageType type);
     void hideMessage();
 
-private Q_SLOTS:
+private slots:
     void entryActivationSignalReceived(Entry* entry, EntryModel::ModelColumn column);
     void switchBackToEntryEdit();
     void switchToHistoryView(Entry* entry);

--- a/src/gui/DatabaseWidgetStateSync.h
+++ b/src/gui/DatabaseWidgetStateSync.h
@@ -29,12 +29,12 @@ public:
     explicit DatabaseWidgetStateSync(QObject* parent = nullptr);
     ~DatabaseWidgetStateSync();
 
-public Q_SLOTS:
+public slots:
     void setActive(DatabaseWidget* dbWidget);
     void restoreListView();
     void restoreSearchView();
 
-private Q_SLOTS:
+private slots:
     void blockUpdates();
     void updateSplitterSizes();
     void updateColumnSizes();

--- a/src/gui/DragTabBar.h
+++ b/src/gui/DragTabBar.h
@@ -34,7 +34,7 @@ protected:
     void dropEvent(QDropEvent* event) override;
     void tabLayoutChange() override;
 
-private Q_SLOTS:
+private slots:
     void dragSwitchTab();
 
 private:

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -48,9 +48,9 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     , m_defaultIconModel(new DefaultIconModel(this))
     , m_customIconModel(new CustomIconModel(this))
     #ifdef WITH_XC_HTTP
-    , m_httpClient(nullptr)
     , m_fallbackToGoogle(true)
     , m_redirectCount(0)
+    , m_httpClient(nullptr)
     #endif
 {
     m_ui->setupUi(this);
@@ -149,6 +149,7 @@ void EditWidgetIcons::setUrl(const QString& url)
     m_ui->faviconButton->setVisible(!url.isEmpty());
     resetFaviconDownload();
 #else
+    Q_UNUSED(url);
     m_ui->faviconButton->setVisible(false);
 #endif
 }

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -276,7 +276,7 @@ void EditWidgetIcons::addCustomIcon()
                 m_ui->customIconsView->setCurrentIndex(index);
             }
             else {
-                Q_EMIT messageEditEntry(tr("Can't read icon"), MessageWidget::Error);
+                emit messageEditEntry(tr("Can't read icon"), MessageWidget::Error);
             }
         }
     }

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -63,14 +63,14 @@ public:
     void reset();
     void load(const Uuid& currentUuid, Database* database, const IconStruct& iconStruct, const QString& url = "");
 
-public Q_SLOTS:
+public slots:
     void setUrl(const QString& url);
 
-Q_SIGNALS:
+signals:
     void messageEditEntry(QString, MessageWidget::MessageType);
     void messageEditEntryDismiss();
 
-private Q_SLOTS:
+private slots:
     void downloadFavicon();
 #ifdef WITH_XC_HTTP
     void fetchFavicon(const QUrl& url);

--- a/src/gui/KMessageWidget.cpp
+++ b/src/gui/KMessageWidget.cpp
@@ -21,6 +21,7 @@
 #include "KMessageWidget.h"
 
 #include "core/FilePath.h"
+#include "core/Global.h"
 
 #include <QAction>
 #include <QEvent>
@@ -117,7 +118,8 @@ void KMessageWidgetPrivate::createLayout()
     qDeleteAll(buttons);
     buttons.clear();
     
-    Q_FOREACH (QAction *action, q->actions()) {
+    const auto actions = q->actions();
+    for (QAction *action: actions) {
         QToolButton *button = new QToolButton(content);
         button->setDefaultAction(action);
         button->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
@@ -137,7 +139,7 @@ void KMessageWidgetPrivate::createLayout()
         
         QHBoxLayout *buttonLayout = new QHBoxLayout;
         buttonLayout->addStretch();
-        Q_FOREACH (QToolButton *button, buttons) {
+        for (QToolButton* button: asConst(buttons)) {
             // For some reason, calling show() is necessary if wordwrap is true,
             // otherwise the buttons do not show up. It is not needed if
             // wordwrap is false.
@@ -151,7 +153,7 @@ void KMessageWidgetPrivate::createLayout()
         layout->addWidget(iconLabel);
         layout->addWidget(textLabel);
         
-        Q_FOREACH (QToolButton *button, buttons) {
+        for (QToolButton* button: asConst(buttons)) {
             layout->addWidget(button);
         }
         

--- a/src/gui/KMessageWidget.h
+++ b/src/gui/KMessageWidget.h
@@ -224,7 +224,7 @@ public:
      */
     bool isShowAnimationRunning() const;
     
-public Q_SLOTS:
+public slots:
     /**
      * Set the text of the message widget to @p text.
      * If the message widget is already visible, the text changes on the fly.
@@ -277,7 +277,7 @@ public Q_SLOTS:
      */
     void setIcon(const QIcon &icon);
     
-Q_SIGNALS:
+signals:
     /**
      * This signal is emitted when the user clicks a link in the text label.
      * The URL referred to by the href anchor is passed in contents.

--- a/src/gui/KeePass1OpenWidget.cpp
+++ b/src/gui/KeePass1OpenWidget.cpp
@@ -62,7 +62,7 @@ void KeePass1OpenWidget::openDatabase()
 
     if (m_db) {
         m_db->metadata()->setName(QFileInfo(m_filename).completeBaseName());
-        Q_EMIT editFinished(true);
+        emit editFinished(true);
     }
     else {
         m_ui->messageWidget->showMessage(tr("Unable to open the database.").append("\n")

--- a/src/gui/LineEdit.h
+++ b/src/gui/LineEdit.h
@@ -34,7 +34,7 @@ public:
 protected:
     void resizeEvent(QResizeEvent* event) override;
 
-private Q_SLOTS:
+private slots:
     void updateCloseButton(const QString& text);
 
 private:

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -39,7 +39,7 @@ public:
     MainWindow();
     ~MainWindow();
 
-public Q_SLOTS:
+public slots:
     void openDatabase(const QString& fileName, const QString& pw = QString(),
                       const QString& keyFile = QString());
     void appExit();
@@ -48,7 +48,7 @@ protected:
      void closeEvent(QCloseEvent* event) override;
      void changeEvent(QEvent* event) override;
 
-private Q_SLOTS:
+private slots:
     void setMenuActionState(DatabaseWidget::Mode mode = DatabaseWidget::None);
     void updateWindowTitle();
     void showAboutDialog();

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -123,9 +123,7 @@
            </spacer>
           </item>
           <item>
-           <widget class="WelcomeWidget" name="welcomeWidget" native="true">
-            <zorder>horizontalSpacer_2</zorder>
-           </widget>
+           <widget class="WelcomeWidget" name="welcomeWidget" native="true"/>
           </item>
           <item>
            <spacer name="horizontalSpacer_2">

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -27,7 +27,7 @@ class MessageWidget : public KMessageWidget
 public:
     explicit MessageWidget(QWidget* parent = 0);
 
-public Q_SLOTS:
+public slots:
     void showMessage(const QString& text, MessageWidget::MessageType type);
     void hideMessage();
 

--- a/src/gui/PasswordComboBox.h
+++ b/src/gui/PasswordComboBox.h
@@ -35,7 +35,7 @@ public:
     void setNumberAlternatives(int alternatives);
     void showPopup();
 
-public Q_SLOTS:
+public slots:
     void setEcho(bool echo);
 
 private:

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -69,7 +69,7 @@ void PasswordEdit::setShowPassword(bool show)
         }
     }
     updateStylesheet();
-    Q_EMIT showPasswordChanged(show);
+    emit showPasswordChanged(show);
 }
 
 bool PasswordEdit::passwordsEqual() const

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -31,13 +31,13 @@ public:
     explicit PasswordEdit(QWidget* parent = nullptr);
     void enableVerifyMode(PasswordEdit* baseEdit);
 
-public Q_SLOTS:
+public slots:
     void setShowPassword(bool show);
 
-Q_SIGNALS:
+signals:
     void showPasswordChanged(bool show);
 
-private Q_SLOTS:
+private slots:
     void updateStylesheet();
     void autocompletePassword(QString password);
 

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -145,8 +145,8 @@ void PasswordGeneratorWidget::generatePassword()
 void PasswordGeneratorWidget::applyPassword()
 {
     saveSettings();
-    Q_EMIT appliedPassword(m_ui->editNewPassword->text());
-    Q_EMIT dialogTerminated();
+    emit appliedPassword(m_ui->editNewPassword->text());
+    emit dialogTerminated();
 }
 
 void PasswordGeneratorWidget::sliderMoved()

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -43,11 +43,11 @@ public:
     void setStandaloneMode(bool standalone);
     void regeneratePassword();
     
-Q_SIGNALS:
+signals:
     void appliedPassword(const QString& password);
     void dialogTerminated();
 
-private Q_SLOTS:
+private slots:
     void applyPassword();
     void generatePassword();
     void updateApplyEnabled(const QString& password);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -196,7 +196,7 @@ void SettingsWidget::saveSettings()
         page.saveSettings();
     }
 
-    Q_EMIT editFinished(true);
+    emit editFinished(true);
 }
 
 void SettingsWidget::reject()
@@ -206,7 +206,7 @@ void SettingsWidget::reject()
         autoType()->registerGlobalShortcut(m_globalAutoTypeKey, m_globalAutoTypeModifiers);
     }
 
-    Q_EMIT editFinished(false);
+    emit editFinished(false);
 }
 
 void SettingsWidget::enableAutoSaveOnExit(bool checked)

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -23,6 +23,7 @@
 #include "core/Config.h"
 #include "core/Translator.h"
 #include "core/FilePath.h"
+#include "core/Global.h"
 
 class SettingsWidget::ExtraPage
 {
@@ -144,8 +145,9 @@ void SettingsWidget::loadSettings()
     m_secUi->passwordRepeatCheckBox->setChecked(config()->get("security/passwordsrepeat").toBool());
 
 
-    Q_FOREACH (const ExtraPage& page, m_extraPages)
+    for (const ExtraPage& page: asConst(m_extraPages)) {
         page.loadSettings();
+    }
 
     setCurrentPage(0);
 }
@@ -190,8 +192,9 @@ void SettingsWidget::saveSettings()
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
     config()->set("security/passwordsrepeat", m_secUi->passwordRepeatCheckBox->isChecked());
 
-    Q_FOREACH (const ExtraPage& page, m_extraPages)
+    for (const ExtraPage& page: asConst(m_extraPages)) {
         page.saveSettings();
+    }
 
     Q_EMIT editFinished(true);
 }

--- a/src/gui/SettingsWidget.h
+++ b/src/gui/SettingsWidget.h
@@ -45,10 +45,10 @@ public:
     void addSettingsPage(ISettingsPage * page);
     void loadSettings();
 
-Q_SIGNALS:
+signals:
     void editFinished(bool accepted);
 
-private Q_SLOTS:
+private slots:
     void saveSettings();
     void reject();
     void enableAutoSaveOnExit(bool checked);

--- a/src/gui/UnlockDatabaseDialog.cpp
+++ b/src/gui/UnlockDatabaseDialog.cpp
@@ -49,7 +49,7 @@ void UnlockDatabaseDialog::complete(bool r)
 {
     if (r) {
         accept();
-        Q_EMIT unlockDone(true);
+        emit unlockDone(true);
     } else {
         reject();
     }

--- a/src/gui/UnlockDatabaseDialog.h
+++ b/src/gui/UnlockDatabaseDialog.h
@@ -36,10 +36,10 @@ public:
     void clearForms();
     Database* database();
 
-Q_SIGNALS:
+signals:
     void unlockDone(bool);
 
-public Q_SLOTS:
+public slots:
     void complete(bool r);
 
 private:

--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -64,5 +64,5 @@ void WelcomeWidget::openDatabaseFromFile(QListWidgetItem* item)
 	if (item->text().isEmpty()) {
 		return;
 	}
-	Q_EMIT openDatabaseFile(item->text());
+	emit openDatabaseFile(item->text());
 }

--- a/src/gui/WelcomeWidget.h
+++ b/src/gui/WelcomeWidget.h
@@ -33,13 +33,13 @@ public:
     explicit WelcomeWidget(QWidget* parent = nullptr);
     ~WelcomeWidget();
 
-Q_SIGNALS:
+signals:
 	void newDatabase();
 	void openDatabase();
 	void openDatabaseFile(QString);
 	void importKeePass1Database();
 
-private Q_SLOTS:
+private slots:
 	void openDatabaseFromFile(QListWidgetItem* item);
 
 private:

--- a/src/gui/entry/AutoTypeAssociationsModel.cpp
+++ b/src/gui/entry/AutoTypeAssociationsModel.cpp
@@ -103,7 +103,7 @@ QVariant AutoTypeAssociationsModel::data(const QModelIndex& index, int role) con
 
 void AutoTypeAssociationsModel::associationChange(int i)
 {
-    Q_EMIT dataChanged(index(i, 0), index(i, columnCount() - 1));
+    emit dataChanged(index(i, 0), index(i, columnCount() - 1));
 }
 
 void AutoTypeAssociationsModel::associationAboutToAdd(int i)

--- a/src/gui/entry/AutoTypeAssociationsModel.h
+++ b/src/gui/entry/AutoTypeAssociationsModel.h
@@ -36,7 +36,7 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
-public Q_SLOTS:
+public slots:
     void associationChange(int i);
     void associationAboutToAdd(int i);
     void associationAdd();

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -212,7 +212,7 @@ void EditEntryWidget::emitHistoryEntryActivated(const QModelIndex& index)
     Q_ASSERT(!m_history);
 
     Entry* entry = m_historyModel->entryFromIndex(index);
-    Q_EMIT historyEntryActivated(entry);
+    emit historyEntryActivated(entry);
 }
 
 void EditEntryWidget::histEntryActivated(const QModelIndex& index)
@@ -407,7 +407,7 @@ void EditEntryWidget::saveEntry()
     if (m_history) {
         clear();
         hideMessage();
-        Q_EMIT editFinished(false);
+        emit editFinished(false);
         return;
     }
 
@@ -442,7 +442,7 @@ void EditEntryWidget::saveEntry()
 
     clear();
 
-    Q_EMIT editFinished(true);
+    emit editFinished(true);
 }
 
 void EditEntryWidget::updateEntryData(Entry* entry) const
@@ -487,7 +487,7 @@ void EditEntryWidget::cancel()
     if (m_history) {
         clear();
         hideMessage();
-        Q_EMIT editFinished(false);
+        emit editFinished(false);
         return;
     }
 
@@ -498,7 +498,7 @@ void EditEntryWidget::cancel()
 
     clear();
 
-    Q_EMIT editFinished(false);
+    emit editFinished(false);
 }
 
 void EditEntryWidget::clear()

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -63,11 +63,11 @@ public:
     void clear();
     bool hasBeenModified() const;
 
-Q_SIGNALS:
+signals:
     void editFinished(bool accepted);
     void historyEntryActivated(Entry* entry);
 
-private Q_SLOTS:
+private slots:
     void saveEntry();
     void cancel();
     void togglePasswordGeneratorButton(bool checked);

--- a/src/gui/entry/EditEntryWidgetAutoType.ui
+++ b/src/gui/entry/EditEntryWidgetAutoType.ui
@@ -259,11 +259,6 @@
        </layout>
       </item>
      </layout>
-     <zorder></zorder>
-     <zorder></zorder>
-     <zorder></zorder>
-     <zorder></zorder>
-     <zorder></zorder>
     </widget>
    </item>
   </layout>

--- a/src/gui/entry/EntryAttachmentsModel.cpp
+++ b/src/gui/entry/EntryAttachmentsModel.cpp
@@ -97,7 +97,7 @@ QString EntryAttachmentsModel::keyByIndex(const QModelIndex& index) const
 void EntryAttachmentsModel::attachmentChange(const QString& key)
 {
     int row = m_entryAttachments->keys().indexOf(key);
-    Q_EMIT dataChanged(index(row, 0), index(row, columnCount()-1));
+    emit dataChanged(index(row, 0), index(row, columnCount()-1));
 }
 
 void EntryAttachmentsModel::attachmentAboutToAdd(const QString& key)

--- a/src/gui/entry/EntryAttachmentsModel.h
+++ b/src/gui/entry/EntryAttachmentsModel.h
@@ -34,7 +34,7 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QString keyByIndex(const QModelIndex& index) const;
 
-private Q_SLOTS:
+private slots:
     void attachmentChange(const QString& key);
     void attachmentAboutToAdd(const QString& key);
     void attachmentAdd();

--- a/src/gui/entry/EntryAttributesModel.cpp
+++ b/src/gui/entry/EntryAttributesModel.cpp
@@ -147,7 +147,7 @@ void EntryAttributesModel::attributeChange(const QString& key)
 {
     int row = m_attributes.indexOf(key);
     Q_ASSERT(row != -1);
-    Q_EMIT dataChanged(index(row, 0), index(row, columnCount()-1));
+    emit dataChanged(index(row, 0), index(row, columnCount()-1));
 }
 
 void EntryAttributesModel::attributeAboutToAdd(const QString& key)
@@ -213,7 +213,7 @@ void EntryAttributesModel::attributeRename(const QString& oldKey, const QString&
         m_nextRenameDataChange = false;
 
         QModelIndex keyIndex = index(m_attributes.indexOf(newKey), 0);
-        Q_EMIT dataChanged(keyIndex, keyIndex);
+        emit dataChanged(keyIndex, keyIndex);
     }
 }
 

--- a/src/gui/entry/EntryAttributesModel.h
+++ b/src/gui/entry/EntryAttributesModel.h
@@ -38,7 +38,7 @@ public:
     QModelIndex indexByKey(const QString& key) const;
     QString keyByIndex(const QModelIndex& index) const;
 
-private Q_SLOTS:
+private slots:
     void attributeChange(const QString& key);
     void attributeAboutToAdd(const QString& key);
     void attributeAdd();

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -64,7 +64,7 @@ void EntryModel::setGroup(Group* group)
     makeConnections(group);
 
     endResetModel();
-    Q_EMIT switchedToGroupMode();
+    emit switchedToGroupMode();
 }
 
 void EntryModel::setEntryList(const QList<Entry*>& entries)
@@ -101,7 +101,7 @@ void EntryModel::setEntryList(const QList<Entry*>& entries)
     }
 
     endResetModel();
-    Q_EMIT switchedToEntryListMode();
+    emit switchedToEntryListMode();
 }
 
 int EntryModel::rowCount(const QModelIndex& parent) const
@@ -315,7 +315,7 @@ void EntryModel::entryRemoved()
 void EntryModel::entryDataChanged(Entry* entry)
 {
     int row = m_entries.indexOf(entry);
-    Q_EMIT dataChanged(index(row, 0), index(row, columnCount()-1));
+    emit dataChanged(index(row, 0), index(row, columnCount()-1));
 }
 
 void EntryModel::severConnections()

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -52,14 +52,14 @@ public:
 
     void setEntryList(const QList<Entry*>& entries);
 
-Q_SIGNALS:
+signals:
     void switchedToEntryListMode();
     void switchedToGroupMode();
 
-public Q_SLOTS:
+public slots:
     void setGroup(Group* group);
 
-private Q_SLOTS:
+private slots:
     void entryAboutToAdd(Entry* entry);
     void entryAdded(Entry* entry);
     void entryAboutToRemove(Entry* entry);

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -57,7 +57,7 @@ void EntryView::keyPressEvent(QKeyEvent* event)
         emitEntryActivated(currentIndex());
 #ifdef Q_OS_MAC
         // Pressing return does not emit the QTreeView::activated signal on mac os
-        Q_EMIT activated(currentIndex());
+        emit activated(currentIndex());
 #endif
     }
 
@@ -83,7 +83,7 @@ void EntryView::setFirstEntryActive()
         setCurrentEntry(m_model->entryFromIndex(index));
     }
     else {
-        Q_EMIT entrySelectionChanged();
+        emit entrySelectionChanged();
     }
 }
 
@@ -96,7 +96,7 @@ void EntryView::emitEntryActivated(const QModelIndex& index)
 {
     Entry* entry = entryFromIndex(index);
 
-    Q_EMIT entryActivated(entry, static_cast<EntryModel::ModelColumn>(m_sortModel->mapToSource(index).column()));
+    emit entryActivated(entry, static_cast<EntryModel::ModelColumn>(m_sortModel->mapToSource(index).column()));
 }
 
 void EntryView::setModel(QAbstractItemModel* model)

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -42,17 +42,17 @@ public:
     int numberOfSelectedEntries();
     void setFirstEntryActive();
 
-public Q_SLOTS:
+public slots:
     void setGroup(Group* group);
 
-Q_SIGNALS:
+signals:
     void entryActivated(Entry* entry, EntryModel::ModelColumn column);
     void entrySelectionChanged();
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
 
-private Q_SLOTS:
+private slots:
     void emitEntryActivated(const QModelIndex& index);
     void switchToEntryListMode();
     void switchToGroupMode();

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -130,7 +130,7 @@ void EditGroupWidget::save()
     }
 
     clear();
-    Q_EMIT editFinished(true);
+    emit editFinished(true);
 }
 
 void EditGroupWidget::cancel()
@@ -141,7 +141,7 @@ void EditGroupWidget::cancel()
     }
 
     clear();
-    Q_EMIT editFinished(false);
+    emit editFinished(false);
 }
 
 void EditGroupWidget::clear()

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -43,12 +43,12 @@ public:
     void loadGroup(Group* group, bool create, Database* database);
     void clear();
 
-Q_SIGNALS:
+signals:
     void editFinished(bool accepted);
     void messageEditEntry(QString, MessageWidget::MessageType);
     void messageEditEntryDismiss();
 
-private Q_SLOTS:
+private slots:
     void save();
     void cancel();
 

--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -365,7 +365,7 @@ QMimeData* GroupModel::mimeData(const QModelIndexList& indexes) const
 void GroupModel::groupDataChanged(Group* group)
 {
     QModelIndex ix = index(group);
-    Q_EMIT dataChanged(ix, ix);
+    emit dataChanged(ix, ix);
 }
 
 void GroupModel::groupAboutToRemove(Group* group)

--- a/src/gui/group/GroupModel.h
+++ b/src/gui/group/GroupModel.h
@@ -49,7 +49,7 @@ public:
 private:
     QModelIndex parent(Group* group) const;
 
-private Q_SLOTS:
+private slots:
     void groupDataChanged(Group* group);
     void groupAboutToRemove(Group* group);
     void groupRemoved();

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -112,7 +112,7 @@ void GroupView::expandGroup(Group* group, bool expand)
 
 void GroupView::emitGroupChanged(const QModelIndex& index)
 {
-    Q_EMIT groupChanged(m_model->groupFromIndex(index));
+    emit groupChanged(m_model->groupFromIndex(index));
 }
 
 void GroupView::setModel(QAbstractItemModel* model)
@@ -123,7 +123,7 @@ void GroupView::setModel(QAbstractItemModel* model)
 
 void GroupView::emitGroupChanged()
 {
-    Q_EMIT groupChanged(currentGroup());
+    emit groupChanged(currentGroup());
 }
 
 void GroupView::syncExpandedState(const QModelIndex& parent, int start, int end)

--- a/src/gui/group/GroupView.h
+++ b/src/gui/group/GroupView.h
@@ -36,10 +36,10 @@ public:
     void setCurrentGroup(Group* group);
     void expandGroup(Group* group, bool expand = true);
 
-Q_SIGNALS:
+signals:
     void groupChanged(Group* group);
 
-private Q_SLOTS:
+private slots:
     void expandedChanged(const QModelIndex& index);
     void emitGroupChanged(const QModelIndex& index);
     void emitGroupChanged();

--- a/src/http/AccessControlDialog.cpp
+++ b/src/http/AccessControlDialog.cpp
@@ -34,10 +34,11 @@ void AccessControlDialog::setUrl(const QString &url)
                                   "Please select whether you want to allow access.")).arg(QUrl(url).host()));
 }
 
-void AccessControlDialog::setItems(const QList<Entry *> &items)
+void AccessControlDialog::setItems(const QList<Entry*> &items)
 {
-    Q_FOREACH (Entry * entry, items)
+    for (Entry* entry: items) {
         ui->itemsList->addItem(entry->title() + " - " + entry->username());
+    }
 }
 
 bool AccessControlDialog::remember() const

--- a/src/http/HttpPasswordGeneratorWidget.h
+++ b/src/http/HttpPasswordGeneratorWidget.h
@@ -38,7 +38,7 @@ public:
     void saveSettings();
     void reset();
 
-private Q_SLOTS:
+private slots:
     void sliderMoved();
     void spinBoxChanged();
 

--- a/src/http/OptionDialog.h
+++ b/src/http/OptionDialog.h
@@ -29,11 +29,11 @@ public:
     explicit OptionDialog(QWidget *parent = nullptr);
     ~OptionDialog();
 
-public Q_SLOTS:
+public slots:
     void loadSettings();
     void saveSettings();
 
-Q_SIGNALS:
+signals:
     void removeSharedEncryptionKeys();
     void removeStoredPermissions();
 

--- a/src/http/Protocol.cpp
+++ b/src/http/Protocol.cpp
@@ -17,6 +17,7 @@
 #include "crypto/Random.h"
 #include "crypto/SymmetricCipher.h"
 #include "crypto/SymmetricCipherGcrypt.h"
+#include "core/Global.h"
 
 namespace KeepassHttpProtocol
 {
@@ -370,8 +371,9 @@ QVariant Response::getEntries() const
 
     QList<QVariant> res;
     res.reserve(m_entries.size());
-    Q_FOREACH (const Entry &entry, m_entries)
+    for (const Entry& entry: asConst(m_entries)) {
         res.append(qobject2qvariant(&entry));
+    }
     return res;
 }
 
@@ -383,14 +385,16 @@ void Response::setEntries(const QList<Entry> &entries)
 
     QList<Entry> encryptedEntries;
     encryptedEntries.reserve(m_count);
-    Q_FOREACH (const Entry &entry, entries) {
+    for (const Entry& entry: entries) {
         Entry encryptedEntry(encrypt(entry.name(), m_cipher),
                              encrypt(entry.login(), m_cipher),
                              entry.password().isNull() ? QString() : encrypt(entry.password(), m_cipher),
                              encrypt(entry.uuid(), m_cipher));
-        Q_FOREACH (const StringField & field, entry.stringFields())
+        const auto stringFields = entry.stringFields();
+        for (const StringField& field: stringFields) {
             encryptedEntry.addStringField(encrypt(field.key(), m_cipher),
                                           encrypt(field.value(), m_cipher));
+        }
         encryptedEntries << encryptedEntry;
     }
     m_entries = encryptedEntries;
@@ -508,8 +512,9 @@ QVariant Entry::getStringFields() const
 
     QList<QVariant> res;
     res.reserve(m_stringFields.size());
-    Q_FOREACH (const StringField &stringfield, m_stringFields)
+    for (const StringField& stringfield: asConst(m_stringFields)) {
         res.append(qobject2qvariant(&stringfield));
+    }
     return res;
 }
 

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -23,6 +23,7 @@
 
 #include "core/Database.h"
 #include "core/Entry.h"
+#include "core/Global.h"
 #include "core/Group.h"
 #include "core/EntrySearcher.h"
 #include "core/Metadata.h"
@@ -189,8 +190,9 @@ bool Service::removeFirstDomain(QString & hostname)
 QList<Entry*> Service::searchEntries(Database* db, const QString& hostname)
 {
     QList<Entry*> entries;
-    if (Group* rootGroup = db->rootGroup())
-        Q_FOREACH (Entry* entry, EntrySearcher().search(hostname, rootGroup, Qt::CaseInsensitive)) {
+    if (Group* rootGroup = db->rootGroup()) {
+        const auto results = EntrySearcher().search(hostname, rootGroup, Qt::CaseInsensitive);
+        for (Entry* entry: results) {
             QString title = entry->title();
             QString url = entry->url();
 
@@ -201,6 +203,7 @@ QList<Entry*> Service::searchEntries(Database* db, const QString& hostname)
                 || (matchUrlScheme(url) && hostname.endsWith(QUrl(url).host())) )
                 entries.append(entry);
         }
+    }
     return entries;
 }
 
@@ -223,8 +226,9 @@ QList<Entry*> Service::searchEntries(const QString& text)
     QString hostname = QUrl(text).host();
     QList<Entry*> entries;
     do {
-        Q_FOREACH (Database* db, databases)
+        for (Database* db: asConst(databases)) {
             entries << searchEntries(db, hostname);
+        }
     } while(entries.isEmpty() && removeFirstDomain(hostname));
 
     return entries;
@@ -249,9 +253,12 @@ KeepassHttpProtocol::Entry Service::prepareEntry(const Entry* entry)
     KeepassHttpProtocol::Entry res(entry->resolvePlaceholder(entry->title()), entry->resolvePlaceholder(entry->username()), entry->resolvePlaceholder(entry->password()), entry->uuid().toHex());
     if (HttpSettings::supportKphFields()) {
         const EntryAttributes * attr = entry->attributes();
-        Q_FOREACH (const QString& key, attr->keys())
-            if (key.startsWith(QLatin1String("KPH: ")))
+        const auto keys = attr->keys();
+        for (const QString& key: keys) {
+            if (key.startsWith(QLatin1String("KPH: "))) {
                 res.addStringField(key, attr->value(key));
+            }
+        }
     }
     return res;
 }
@@ -318,7 +325,8 @@ QList<KeepassHttpProtocol::Entry> Service::findMatchingEntries(const QString& /*
     //Check entries for authorization
     QList<Entry*> pwEntriesToConfirm;
     QList<Entry*> pwEntries;
-    Q_FOREACH (Entry * entry, searchEntries(url)) {
+    const auto entries = searchEntries(url);
+    for (Entry* entry: entries) {
         switch(checkAccess(entry, host, submitHost, realm)) {
         case Denied:
             continue;
@@ -352,7 +360,7 @@ QList<KeepassHttpProtocol::Entry> Service::findMatchingEntries(const QString& /*
 
         int res = dlg.exec();
         if (dlg.remember()) {
-            Q_FOREACH (Entry * entry, pwEntriesToConfirm) {
+            for (Entry* entry: asConst(pwEntriesToConfirm)) {
                 EntryConfig config;
                 config.load(entry);
                 if (res == QDialog::Accepted) {
@@ -383,28 +391,22 @@ QList<KeepassHttpProtocol::Entry> Service::findMatchingEntries(const QString& /*
         const QString baseSubmitURL = url.toString(QUrl::StripTrailingSlash | QUrl::RemovePath | QUrl::RemoveQuery | QUrl::RemoveFragment);
 
         //Cache priorities
-        QHash<const Entry *, int> priorities;
+        QHash<const Entry*, int> priorities;
         priorities.reserve(pwEntries.size());
-        Q_FOREACH (const Entry * entry, pwEntries)
+        for (const Entry* entry: asConst(pwEntries)) {
             priorities.insert(entry, sortPriority(entry, host, submitUrl, baseSubmitURL));
+        }
 
         //Sort by priorities
         std::sort(pwEntries.begin(), pwEntries.end(), SortEntries(priorities, HttpSettings::sortByTitle() ? "Title" : "UserName"));
     }
 
-    //if (pwEntries.count() > 0)
-    //{
-    //    var names = (from e in resp.Entries select e.Name).Distinct<string>();
-    //    var n = String.Join("\n    ", names.ToArray<string>());
-    //    if (HttpSettings::receiveCredentialNotification())
-    //        ShowNotification(QString("%0: %1 is receiving credentials for:\n%2").arg(Id).arg(host).arg(n)));
-    //}
-
     //Fill the list
     QList<KeepassHttpProtocol::Entry> result;
     result.reserve(pwEntries.count());
-    Q_FOREACH (Entry * entry, pwEntries)
+    for (Entry* entry: asConst(pwEntries)) {
         result << prepareEntry(entry);
+    }
     return result;
 }
 
@@ -416,12 +418,19 @@ int Service::countMatchingEntries(const QString &, const QString &url, const QSt
 QList<KeepassHttpProtocol::Entry> Service::searchAllEntries(const QString &)
 {
     QList<KeepassHttpProtocol::Entry> result;
-    if (DatabaseWidget * dbWidget = m_dbTabWidget->currentDatabaseWidget())
-        if (Database * db = dbWidget->database())
-            if (Group * rootGroup = db->rootGroup())
-                Q_FOREACH (Entry * entry, rootGroup->entriesRecursive())
-                    if (!entry->url().isEmpty() || QUrl(entry->title()).isValid())
-                        result << KeepassHttpProtocol::Entry(entry->title(), entry->username(), QString(), entry->uuid().toHex());
+    if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget()) {
+        if (Database* db = dbWidget->database()) {
+            if (Group* rootGroup = db->rootGroup()) {
+                const auto entries = rootGroup->entriesRecursive();
+                for (Entry* entry: entries) {
+                    if (!entry->url().isEmpty() || QUrl(entry->title()).isValid()) {
+                        result << KeepassHttpProtocol::Entry(entry->title(), entry->username(),
+                                                             QString(), entry->uuid().toHex());
+                    }
+                }
+            }
+        }
+    }
     return result;
 }
 
@@ -430,11 +439,15 @@ Group * Service::findCreateAddEntryGroup()
     if (DatabaseWidget * dbWidget = m_dbTabWidget->currentDatabaseWidget())
         if (Database * db = dbWidget->database())
             if (Group * rootGroup = db->rootGroup()) {
-                const QString groupName = QLatin1String(KEEPASSHTTP_GROUP_NAME);//TODO: setting to decide where new keys are created
+                //TODO: setting to decide where new keys are created
+                const QString groupName = QLatin1String(KEEPASSHTTP_GROUP_NAME);
 
-                Q_FOREACH (const Group * g, rootGroup->groupsRecursive(true))
-                    if (g->name() == groupName)
+                const auto groups = rootGroup->groupsRecursive(true);
+                for (const Group * g: groups) {
+                    if (g->name() == groupName) {
                         return db->resolveGroup(g->uuid());
+                    }
+                }
 
                 Group * group;
                 group = new Group();
@@ -507,14 +520,18 @@ void Service::removeSharedEncryptionKeys()
                               QMessageBox::Ok);
     } else if (Entry* entry = getConfigEntry()) {
         QStringList keysToRemove;
-        Q_FOREACH (const QString& key, entry->attributes()->keys())
-            if (key.startsWith(ASSOCIATE_KEY_PREFIX))
+        const auto keys = entry->attributes()->keys();
+        for (const QString& key: keys) {
+            if (key.startsWith(ASSOCIATE_KEY_PREFIX)) {
                 keysToRemove << key;
+            }
+        }
 
         if(keysToRemove.count()) {
             entry->beginUpdate();
-            Q_FOREACH (const QString& key, keysToRemove)
+            for (const QString& key: asConst(keysToRemove)) {
                 entry->attributes()->remove(key);
+            }
             entry->endUpdate();
 
             const int count = keysToRemove.count();
@@ -548,7 +565,7 @@ void Service::removeStoredPermissions()
         progress.setWindowModality(Qt::WindowModal);
 
         uint counter = 0;
-        Q_FOREACH (Entry* entry, entries) {
+        for (Entry* entry: asConst(entries)) {
             if (progress.wasCanceled())
                 return;
             if (entry->attributes()->contains(KEEPASSHTTP_NAME)) {

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -29,6 +29,8 @@
 #include "core/Uuid.h"
 #include "core/PasswordGenerator.h"
 
+#include <algorithm>
+
 static const unsigned char KEEPASSHTTP_UUID_DATA[] = {
     0x34, 0x69, 0x7a, 0x40, 0x8a, 0x5b, 0x41, 0xc0,
     0x9f, 0x36, 0x89, 0x7d, 0x62, 0x3e, 0xcb, 0x31
@@ -387,7 +389,7 @@ QList<KeepassHttpProtocol::Entry> Service::findMatchingEntries(const QString& /*
             priorities.insert(entry, sortPriority(entry, host, submitUrl, baseSubmitURL));
 
         //Sort by priorities
-        qSort(pwEntries.begin(), pwEntries.end(), SortEntries(priorities, HttpSettings::sortByTitle() ? "Title" : "UserName"));
+        std::sort(pwEntries.begin(), pwEntries.end(), SortEntries(priorities, HttpSettings::sortByTitle() ? "Title" : "UserName"));
     }
 
     //if (pwEntries.count() > 0)

--- a/src/http/Service.h
+++ b/src/http/Service.h
@@ -38,7 +38,7 @@ public:
     virtual void updateEntry(const QString& id, const QString& uuid, const QString& login, const QString& password, const QString& url);
     virtual QString generatePassword();
 
-public Q_SLOTS:
+public slots:
     void removeSharedEncryptionKeys();
     void removeStoredPermissions();
 

--- a/src/streams/LayeredStream.h
+++ b/src/streams/LayeredStream.h
@@ -37,7 +37,7 @@ protected:
 
     QIODevice* const m_baseDevice;
 
-private Q_SLOTS:
+private slots:
     void closeStream();
 };
 

--- a/src/zxcvbn/zxcvbn.cpp
+++ b/src/zxcvbn/zxcvbn.cpp
@@ -1,4 +1,4 @@
-﻿/**********************************************************************************
+/**********************************************************************************
  * C implementation of the zxcvbn password strength estimation method.
  * Copyright (c) 2015, Tony Evans
  * All rights reserved.

--- a/src/zxcvbn/zxcvbn.h
+++ b/src/zxcvbn/zxcvbn.h
@@ -1,4 +1,4 @@
-﻿#ifndef ZXCVBN_H_F98183CE2A01_INCLUDED
+#ifndef ZXCVBN_H_F98183CE2A01_INCLUDED
 #define ZXCVBN_H_F98183CE2A01_INCLUDED
 /**********************************************************************************
  * C implementation of the zxcvbn password strength estimation method.

--- a/tests/TestAutoType.h
+++ b/tests/TestAutoType.h
@@ -31,7 +31,7 @@ class TestAutoType : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void init();
     void cleanup();

--- a/tests/TestCryptoHash.h
+++ b/tests/TestCryptoHash.h
@@ -24,7 +24,7 @@ class TestCryptoHash : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void test();
 };

--- a/tests/TestCsvExporter.h
+++ b/tests/TestCsvExporter.h
@@ -31,7 +31,7 @@ class TestCsvExporter : public QObject
 public:
     static const QString ExpectedHeaderLine;
 
-private Q_SLOTS:
+private slots:
     void init();
     void initTestCase();
     void cleanup();

--- a/tests/TestDeletedObjects.h
+++ b/tests/TestDeletedObjects.h
@@ -29,7 +29,7 @@ class TestDeletedObjects : public QObject
 private:
     void createAndDelete(Database* db, int delObjectsSize);
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testDeletedObjectsFromFile();
     void testDeletedObjectsFromNewDb();

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -26,7 +26,7 @@ class TestEntry : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testHistoryItemDeletion();
     void testCopyDataFrom();

--- a/tests/TestEntryModel.h
+++ b/tests/TestEntryModel.h
@@ -24,7 +24,7 @@ class TestEntryModel : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void test();
     void testAttachmentsModel();

--- a/tests/TestEntrySearcher.h
+++ b/tests/TestEntrySearcher.h
@@ -28,7 +28,7 @@ class TestEntrySearcher : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void cleanupTestCase();
 

--- a/tests/TestExporter.h
+++ b/tests/TestExporter.h
@@ -25,7 +25,7 @@ class TestExporter : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testToDbExporter();
 };

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -25,7 +25,7 @@ class TestGroup : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testParenting();
     void testSignals();

--- a/tests/TestGroupModel.cpp
+++ b/tests/TestGroupModel.cpp
@@ -131,7 +131,7 @@ void TestGroupModel::test()
     QCOMPARE(spyMoved.count(), 3);
     QVERIFY(index12.isValid());
     QCOMPARE(model->data(index12).toString(), QString("group12"));
-    QCOMPARE(model->data(index12.child(0, 0)).toString(), QString("group121"));
+    QCOMPARE(model->data(index12.model()->index(0, 0, index12)).toString(), QString("group121"));
 
     delete group12;
     QCOMPARE(spyAboutToAdd.count(), 1);

--- a/tests/TestGroupModel.h
+++ b/tests/TestGroupModel.h
@@ -24,7 +24,7 @@ class TestGroupModel : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void test();
 };

--- a/tests/TestHashedBlockStream.h
+++ b/tests/TestHashedBlockStream.h
@@ -24,7 +24,7 @@ class TestHashedBlockStream : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testWriteRead();
     void testReset();

--- a/tests/TestKeePass1Reader.h
+++ b/tests/TestKeePass1Reader.h
@@ -27,7 +27,7 @@ class TestKeePass1Reader : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testBasic();
     void testMasterKey();

--- a/tests/TestKeePass2RandomStream.h
+++ b/tests/TestKeePass2RandomStream.h
@@ -24,7 +24,7 @@ class TestKeePass2RandomStream : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void test();
 };

--- a/tests/TestKeePass2Reader.h
+++ b/tests/TestKeePass2Reader.h
@@ -24,7 +24,7 @@ class TestKeePass2Reader : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testNonAscii();
     void testCompressed();

--- a/tests/TestKeePass2Writer.h
+++ b/tests/TestKeePass2Writer.h
@@ -26,7 +26,7 @@ class TestKeePass2Writer : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testBasic();
     void testProtectedAttributes();

--- a/tests/TestKeePass2XmlReader.h
+++ b/tests/TestKeePass2XmlReader.h
@@ -27,7 +27,7 @@ class TestKeePass2XmlReader : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testMetadata();
     void testCustomIcons();

--- a/tests/TestKeys.h
+++ b/tests/TestKeys.h
@@ -24,7 +24,7 @@ class TestKeys : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testComposite();
     void testCompositeKeyReadFromLine();

--- a/tests/TestModified.h
+++ b/tests/TestModified.h
@@ -24,7 +24,7 @@ class TestModified : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testSignals();
     void testGroupSets();

--- a/tests/TestRandom.h
+++ b/tests/TestRandom.h
@@ -38,7 +38,7 @@ class TestRandom : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testUInt();
     void testUIntRange();

--- a/tests/TestSymmetricCipher.h
+++ b/tests/TestSymmetricCipher.h
@@ -24,7 +24,7 @@ class TestSymmetricCipher : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testAes256CbcEncryption();
     void testAes256CbcDecryption();

--- a/tests/TestWildcardMatcher.h
+++ b/tests/TestWildcardMatcher.h
@@ -26,7 +26,7 @@ class TestWildcardMatcher : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void testMatcher();
     void testMatcher_data();
 

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -33,7 +33,7 @@ class TestGui : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void init();
     void cleanup();

--- a/tests/gui/TestGuiPixmaps.h
+++ b/tests/gui/TestGuiPixmaps.h
@@ -26,7 +26,7 @@ class TestGuiPixmaps : public QObject
 {
     Q_OBJECT
 
-private Q_SLOTS:
+private slots:
     void initTestCase();
     void testDatabaseIcons();
     void testEntryIcons();

--- a/tests/modeltest.h
+++ b/tests/modeltest.h
@@ -46,7 +46,7 @@ class ModelTest : public QObject
 public:
   ModelTest( QAbstractItemModel *model, QObject *parent = 0 );
 
-private Q_SLOTS:
+private slots:
   void nonDestructiveBasicTest();
   void rowCount();
   void columnCount();
@@ -55,7 +55,7 @@ private Q_SLOTS:
   void parent();
   void data();
 
-protected Q_SLOTS:
+protected slots:
   void runAllTests();
   void layoutAboutToBeChanged();
   void layoutChanged();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This PR…
- fixes a few (C++ and Qt UI) compiler warnings
- fixes two Qt deprecation warnings
- replaces any remaining Q_FOREACH macros with C++11 range-based for loops
- removes UTF-8 BOMs
- replaces any Q_EMIT, Q_SIGNALS and Q_SLOTS macros with their corresponding MOC keywords.

The Q_FOREACH and BOM patches are a clean re-implementation of #151, which is obsolete therefore.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled with both GCC and Clang and the -DWITH_DEV_BUILD CMake option (no warnings remain). Program continues to run fine without issues. All unit tests pass.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**