### PR TITLE
Adding warning messages when config access error.

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -35,6 +35,16 @@ QVariant Config::get(const QString& key, const QVariant& defaultValue)
     return m_settings->value(key, defaultValue);
 }
 
+bool Config::hasAccessError()
+{
+    return m_settings->status() & QSettings::AccessError;
+}
+
+QString Config::getFileName()
+{
+    return m_settings->fileName();
+}
+
 void Config::set(const QString& key, const QVariant& value)
 {
     m_settings->setValue(key, value);
@@ -91,6 +101,10 @@ Config::~Config()
 void Config::init(const QString& fileName)
 {
     m_settings.reset(new QSettings(fileName, QSettings::IniFormat));
+
+    if (hasAccessError()) {
+        qWarning("Access error with config file %s", qPrintable(fileName));
+    }
 
     m_defaults.insert("RememberLastDatabases", true);
     m_defaults.insert("RememberLastKeyFiles", true);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -102,10 +102,6 @@ void Config::init(const QString& fileName)
 {
     m_settings.reset(new QSettings(fileName, QSettings::IniFormat));
 
-    if (hasAccessError()) {
-        qWarning("Access error with config file %s", qPrintable(fileName));
-    }
-
     m_defaults.insert("RememberLastDatabases", true);
     m_defaults.insert("RememberLastKeyFiles", true);
     m_defaults.insert("OpenPreviousDatabasesOnStartup", true);

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -31,7 +31,9 @@ public:
     ~Config();
     QVariant get(const QString& key);
     QVariant get(const QString& key, const QVariant& defaultValue);
+    QString getFileName();
     void set(const QString& key, const QVariant& value);
+    bool hasAccessError();
 
     static Config* instance();
     static void createConfigFromFile(const QString& file);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -314,6 +314,12 @@ MainWindow::MainWindow()
     connect(m_ui->tabWidget, SIGNAL(messageDismissTab()), this, SLOT(hideTabMessage()));
 
     updateTrayIcon();
+
+    if (config()->hasAccessError()) {
+        m_ui->globalMessageWidget->showMessage(
+            tr("Access error for config file ") + config()->getFileName(), MessageWidget::Error);
+    }
+
 }
 
 MainWindow::~MainWindow()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -317,7 +317,7 @@ MainWindow::MainWindow()
 
     if (config()->hasAccessError()) {
         m_ui->globalMessageWidget->showMessage(
-            tr("Access error for config file ") + config()->getFileName(), MessageWidget::Error);
+            tr("Access error for config file %1").arg(config()->getFileName()), MessageWidget::Error);
     }
 
 }

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -99,6 +99,12 @@ void SettingsWidget::addSettingsPage(ISettingsPage* page)
 
 void SettingsWidget::loadSettings()
 {
+
+    if (config()->hasAccessError()) {
+        showMessage(
+            tr("Access error for config file ") + config()->getFileName(), MessageWidget::Error);
+    }
+
     m_generalUi->rememberLastDatabasesCheckBox->setChecked(config()->get("RememberLastDatabases").toBool());
     m_generalUi->rememberLastKeyFilesCheckBox->setChecked(config()->get("RememberLastKeyFiles").toBool());
     m_generalUi->openPreviousDatabasesOnStartupCheckBox->setChecked(
@@ -154,6 +160,15 @@ void SettingsWidget::loadSettings()
 
 void SettingsWidget::saveSettings()
 {
+
+    if (config()->hasAccessError()) {
+        showMessage(
+            tr("Access error for config file ") + config()->getFileName(), MessageWidget::Error);
+        // We prevent closing the settings page if we could not write to
+        // the config file.
+        return;
+    }
+
     config()->set("RememberLastDatabases", m_generalUi->rememberLastDatabasesCheckBox->isChecked());
     config()->set("RememberLastKeyFiles", m_generalUi->rememberLastKeyFilesCheckBox->isChecked());
     config()->set("OpenPreviousDatabasesOnStartup",

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -102,7 +102,7 @@ void SettingsWidget::loadSettings()
 
     if (config()->hasAccessError()) {
         showMessage(
-            tr("Access error for config file ") + config()->getFileName(), MessageWidget::Error);
+            tr("Access error for config file %1").arg(config()->getFileName()), MessageWidget::Error);
     }
 
     m_generalUi->rememberLastDatabasesCheckBox->setChecked(config()->get("RememberLastDatabases").toBool());
@@ -163,7 +163,7 @@ void SettingsWidget::saveSettings()
 
     if (config()->hasAccessError()) {
         showMessage(
-            tr("Access error for config file ") + config()->getFileName(), MessageWidget::Error);
+            tr("Access error for config file %1").arg(config()->getFileName()), MessageWidget::Error);
         // We prevent closing the settings page if we could not write to
         // the config file.
         return;

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -68,7 +68,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
 
 #ifdef Q_OS_MAC
     // systray not useful on OS X
-   m_generalUi->systraySettings->setVisible(false);
+    m_generalUi->systraySettings->setVisible(false);
 #endif
 
     connect(this, SIGNAL(accepted()), SLOT(saveSettings()));

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -62,6 +62,11 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     addPage(tr("General"), FilePath::instance()->icon("categories", "preferences-other"), m_generalWidget);
     addPage(tr("Security"), FilePath::instance()->icon("status", "security-high"), m_secWidget);
 
+    if (config()->hasAccessError()) {
+        m_generalUi->messageWidget->showMessage(
+            tr("Access error with config file ") + config()->getFileName(), MessageWidget::Error);
+    }
+
     if (!autoType()->isAvailable()) {
         m_generalUi->generalSettingsTabWidget->removeTab(1);
     }

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -62,6 +62,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     addPage(tr("General"), FilePath::instance()->icon("categories", "preferences-other"), m_generalWidget);
     addPage(tr("Security"), FilePath::instance()->icon("status", "security-high"), m_secWidget);
 
+    m_generalUi->messageWidget->setVisible(false);
     if (config()->hasAccessError()) {
         m_generalUi->messageWidget->showMessage(
             tr("Access error with config file ") + config()->getFileName(), MessageWidget::Error);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -62,12 +62,6 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     addPage(tr("General"), FilePath::instance()->icon("categories", "preferences-other"), m_generalWidget);
     addPage(tr("Security"), FilePath::instance()->icon("status", "security-high"), m_secWidget);
 
-    m_generalUi->messageWidget->setVisible(false);
-    if (config()->hasAccessError()) {
-        m_generalUi->messageWidget->showMessage(
-            tr("Access error with config file ") + config()->getFileName(), MessageWidget::Error);
-    }
-
     if (!autoType()->isAvailable()) {
         m_generalUi->generalSettingsTabWidget->removeTab(1);
     }

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -24,9 +24,6 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="MessageWidget" name="messageWidget" native="true"/>
-   </item>
-   <item>
     <widget class="QTabWidget" name="generalSettingsTabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -370,12 +367,6 @@
    <class>ShortcutWidget</class>
    <extends>QLineEdit</extends>
    <header>autotype/ShortcutWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>MessageWidget</class>
-   <extends>QWidget</extends>
-   <header>gui/MessageWidget.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -24,6 +24,9 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="MessageWidget" name="messageWidget" native="true"/>
+   </item>
+   <item>
     <widget class="QTabWidget" name="generalSettingsTabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -367,6 +370,12 @@
    <class>ShortcutWidget</class>
    <extends>QLineEdit</extends>
    <header>autotype/ShortcutWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MessageWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/MessageWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
This is related to https://github.com/keepassxreboot/keepassxc/issues/269, so that we are able to rule out config file permissions problems when troubleshooting settings issues.

## How Has This Been Tested?
Tested locally with a valid (sufficient permissions) and an invalid (insufficient permissions) default config file.

## Screenshots (if appropriate):

![screenshot from 2017-03-18 14 02 28](https://cloud.githubusercontent.com/assets/3301383/24074669/a1b95130-0be3-11e7-8d76-c1c0d31881b1.png)



## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed.
