### PR TITLE
Add proxy icon to title bar in OSX

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -552,6 +552,16 @@ bool DatabaseTabWidget::isModified(int index)
     return indexDatabaseManagerStruct(index).modified;
 }
 
+QString DatabaseTabWidget::databasePath(int index)
+{
+    if (index == -1) {
+        index = currentIndex();
+    }
+
+    return indexDatabaseManagerStruct(index).filePath;
+}
+
+
 void DatabaseTabWidget::updateTabName(Database* db)
 {
     int index = databaseIndex(db);

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -81,6 +81,7 @@ public slots:
     bool isModified(int index = -1);
     void performGlobalAutoType();
     void lockDatabases();
+    QString databasePath(int index = -1);
 
 signals:
     void tabNameChanged();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -530,6 +530,12 @@ void MainWindow::updateWindowTitle()
         windowTitle = QString("%1 - %2").arg(customWindowTitlePart, BaseWindowTitle);
     }
 
+    if (customWindowTitlePart.isEmpty() || stackedWidgetIndex == 1) {
+        setWindowFilePath("");
+    } else {
+        setWindowFilePath(m_ui->tabWidget->databasePath(tabWidgetIndex));
+    }
+
     setWindowModified(m_ui->tabWidget->isModified(tabWidgetIndex));
 
     setWindowTitle(windowTitle);


### PR DESCRIPTION
## Description
Add support for proxy icons in OSX, according to [OSX human interface guidelines](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/WindowAppearanceBehavior.html#//apple_ref/doc/uid/20000957-CH33-SW1).

## Screenshots:
![2017-03-21 23_29_05](https://cloud.githubusercontent.com/assets/107672/24179507/3ebf4050-0e8e-11e7-80c9-5f3486cbc9ac.gif)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
