### PR TITLE
Treat empty booleans in XML as false

### DIFF
--- a/src/format/KeePass2XmlReader.cpp
+++ b/src/format/KeePass2XmlReader.cpp
@@ -1037,6 +1037,9 @@ bool KeePass2XmlReader::readBool()
     else if (str.compare("False", Qt::CaseInsensitive) == 0) {
         return false;
     }
+    else if (str.length() == 0) {
+        return false;
+    }
     else {
         raiseError("Invalid bool value");
         return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
When reading kdbx files generated by libkeepass-unicode, the `<Expires>` field for `<Entry><Times>...</Times></Entry>` can be short closed without a value as `<Expires/>`. This is properly treated as false on other implementations including original KeePass but KeePassX(C) only accepted the string values `True` and `False`.

## Description
Treat empty boolean strings as false in XML.

## Motivation and context
Not fail when encountering a simple XML formatting difference.

## How has this been tested?
Tested using offending .kdbx file provided on IRC.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
