### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -84,6 +84,8 @@ bool Service::isDatabaseOpened() const
         case DatabaseWidget::ViewMode:
         case DatabaseWidget::EditMode:
             return true;
+        default:
+            break;
         }
     return false;
 }
@@ -101,6 +103,8 @@ bool Service::openDatabase()
         case DatabaseWidget::ViewMode:
         case DatabaseWidget::EditMode:
             return true;
+        default:
+            break;
         }
     }
     //if (HttpSettings::showNotification()


### PR DESCRIPTION
## Description
Fixed a couple of compiler warnings due to the lack of default statement on switch statements. 

```
keepassxreboot/keepassxc/src/http/Service.cpp:79:16: warning: 
      enumeration value 'ImportMode' not handled in switch [-Wswitch]
        switch(dbWidget->currentMode()) {
               ^

keepassxreboot/keepassxc/src/http/Service.cpp:96:16: warning: 
      enumeration value 'ImportMode' not handled in switch [-Wswitch]
        switch(dbWidget->currentMode()) {
               ^
```

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**