### PR TITLE
Ignore group expansion and other minor changes when marking database as dirty

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -113,6 +113,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("UseGroupIconOnEntryCreation", false);
     m_defaults.insert("AutoTypeEntryTitleMatch", true);
     m_defaults.insert("UseGroupIconOnEntryCreation", true);
+    m_defaults.insert("IgnoreGroupExpansion", false);
     m_defaults.insert("security/clearclipboard", true);
     m_defaults.insert("security/clearclipboardtimeout", 10);
     m_defaults.insert("security/lockdatabaseidle", false);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -296,6 +296,9 @@ void Group::setExpanded(bool expanded)
     if (m_data.isExpanded != expanded) {
         m_data.isExpanded = expanded;
         updateTimeinfo();
+        if (config()->get("IgnoreGroupExpansion").toBool()) {
+            return;
+        }
         emit modified();
     }
 }

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -115,6 +115,7 @@ void SettingsWidget::loadSettings()
     m_generalUi->minimizeOnCopyCheckBox->setChecked(config()->get("MinimizeOnCopy").toBool());
     m_generalUi->useGroupIconOnEntryCreationCheckBox->setChecked(config()->get("UseGroupIconOnEntryCreation").toBool());
     m_generalUi->autoTypeEntryTitleMatchCheckBox->setChecked(config()->get("AutoTypeEntryTitleMatch").toBool());
+    m_generalUi->ignoreGroupExpansionCheckBox->setChecked(config()->get("IgnoreGroupExpansion").toBool());
 
     m_generalUi->languageComboBox->clear();
     QList<QPair<QString, QString> > languages = Translator::availableLanguages();
@@ -180,6 +181,8 @@ void SettingsWidget::saveSettings()
     config()->set("MinimizeOnCopy", m_generalUi->minimizeOnCopyCheckBox->isChecked());
     config()->set("UseGroupIconOnEntryCreation",
                   m_generalUi->useGroupIconOnEntryCreationCheckBox->isChecked());
+    config()->set("IgnoreGroupExpansion",
+                  m_generalUi->ignoreGroupExpansionCheckBox->isChecked());
     config()->set("AutoTypeEntryTitleMatch",
                   m_generalUi->autoTypeEntryTitleMatchCheckBox->isChecked());
     int currentLangIndex = m_generalUi->languageComboBox->currentIndex();

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -108,7 +108,7 @@
        <item>
         <widget class="QCheckBox" name="ignoreGroupExpansionCheckBox">
          <property name="text">
-          <string>Do not mark a database as modified when groups are expanded</string>
+          <string>Don't mark database as modified for non-data changes (e.g., expanding groups)</string>
          </property>
         </widget>
        </item>

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -106,6 +106,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="ignoreGroupExpansionCheckBox">
+         <property name="text">
+          <string>Dot not mark a database as modified when groups are expanded</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QWidget" name="systraySettings" native="true">
          <layout class="QVBoxLayout" name="systrayLayout">
           <property name="leftMargin">

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -108,7 +108,7 @@
        <item>
         <widget class="QCheckBox" name="ignoreGroupExpansionCheckBox">
          <property name="text">
-          <string>Dot not mark a database as modified when groups are expanded</string>
+          <string>Do not mark a database as modified when groups are expanded</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Allow user to ignore group expansion.

## Motivation and context
https://github.com/keepassxreboot/keepassxc/issues/446

## How has this been tested?
Locally + unit tests.


## Types of changes
- ✅ New feature

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed.