### PR TITLE
Bring KeepassHTTP confirmation window to the front

### DIFF
--- a/src/http/AccessControlDialog.cpp
+++ b/src/http/AccessControlDialog.cpp
@@ -19,6 +19,8 @@ AccessControlDialog::AccessControlDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AccessControlDialog())
 {
+    this->setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+
     ui->setupUi(this);
     connect(ui->allowButton, SIGNAL(clicked()), this, SLOT(accept()));
     connect(ui->denyButton, SIGNAL(clicked()), this, SLOT(reject()));


### PR DESCRIPTION
closes #460 

## Description
Bring KeepassHTTP confirmation window to the foreground when the browser makes a request.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**