### PR TITLE
More compact search widget

### DIFF
--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -21,6 +21,7 @@
 #include <QKeyEvent>
 #include <QMenu>
 #include <QShortcut>
+#include <QToolButton>
 
 #include "core/FilePath.h"
 
@@ -34,9 +35,7 @@ SearchWidget::SearchWidget(QWidget *parent)
     m_searchTimer->setSingleShot(true);
 
     connect(m_ui->searchEdit, SIGNAL(textChanged(QString)), SLOT(startSearchTimer()));
-    connect(m_ui->searchIcon, SIGNAL(pressed()), m_ui->searchEdit, SLOT(setFocus()));
-    connect(m_ui->clearIcon, SIGNAL(pressed()), m_ui->searchEdit, SLOT(clear()));
-    connect(m_ui->clearIcon, SIGNAL(pressed()), m_ui->searchEdit, SLOT(setFocus()));
+    connect(m_ui->clearIcon, SIGNAL(triggered(bool)), m_ui->searchEdit, SLOT(clear()));
     connect(m_searchTimer, SIGNAL(timeout()), this, SLOT(startSearch()));
     connect(this, SIGNAL(escapePressed()), m_ui->searchEdit, SLOT(clear()));
 
@@ -52,10 +51,16 @@ SearchWidget::SearchWidget(QWidget *parent)
 
     m_ui->searchIcon->setIcon(filePath()->icon("actions", "system-search"));
     m_ui->searchIcon->setMenu(searchMenu);
-    m_ui->searchIcon->setPopupMode(QToolButton::MenuButtonPopup);
+    m_ui->searchEdit->addAction(m_ui->searchIcon, QLineEdit::LeadingPosition);
 
     m_ui->clearIcon->setIcon(filePath()->icon("actions", "edit-clear-locationbar-rtl"));
-    m_ui->clearIcon->setEnabled(false);
+    m_ui->clearIcon->setVisible(false);
+    m_ui->searchEdit->addAction(m_ui->clearIcon, QLineEdit::TrailingPosition);
+
+    // Fix initial visibility of actions (bug in Qt)
+    for (QToolButton * toolButton: m_ui->searchEdit->findChildren<QToolButton *>()) {
+        toolButton->setVisible(toolButton->defaultAction()->isVisible());
+    }
 }
 
 SearchWidget::~SearchWidget()
@@ -133,7 +138,7 @@ void SearchWidget::startSearch()
     }
 
     bool hasText = m_ui->searchEdit->text().length() > 0;
-    m_ui->clearIcon->setEnabled(hasText);
+    m_ui->clearIcon->setVisible(hasText);
 
     search(m_ui->searchEdit->text());
 }

--- a/src/gui/SearchWidget.ui
+++ b/src/gui/SearchWidget.ui
@@ -30,20 +30,17 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QToolButton" name="searchIcon">
-     <property name="focusPolicy">
-      <enum>Qt::ClickFocus</enum>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="text">
-      <string>Search</string>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
      </property>
-     <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonIconOnly</enum>
-     </property>
-     <property name="autoRaise">
-      <bool>true</bool>
-     </property>
-    </widget>
+    </spacer>
    </item>
    <item>
     <widget class="QLineEdit" name="searchEdit">
@@ -51,33 +48,26 @@
       <string notr="true">padding:3px</string>
      </property>
      <property name="placeholderText">
-      <string>Find</string>
+      <string>Search...</string>
      </property>
      <property name="clearButtonEnabled">
       <bool>false</bool>
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QToolButton" name="clearIcon">
-     <property name="focusPolicy">
-      <enum>Qt::ClickFocus</enum>
-     </property>
-     <property name="text">
-      <string>Clear</string>
-     </property>
-     <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonIconOnly</enum>
-     </property>
-     <property name="autoRaise">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
+  <action name="searchIcon">
+   <property name="text">
+    <string>Search</string>
+   </property>
+  </action>
+  <action name="clearIcon">
+   <property name="text">
+    <string>Clear</string>
+   </property>
+  </action>
  </widget>
  <tabstops>
-  <tabstop>searchIcon</tabstop>
   <tabstop>searchEdit</tabstop>
  </tabstops>
  <resources/>

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -393,19 +393,24 @@ void TestGui::testSearch()
     EntryView* entryView = m_dbWidget->findChild<EntryView*>("entryView");
     QVERIFY(entryView->isVisible());
 
+    QAction* clearButton = searchWidget->findChild<QAction*>("clearIcon");
+    QVERIFY(!clearButton->isVisible());
+
     // Enter search
     QTest::mouseClick(searchTextEdit, Qt::LeftButton);
     QTRY_VERIFY(searchTextEdit->hasFocus());
+    QTRY_VERIFY(!clearButton->isVisible());
     // Search for "ZZZ"
     QTest::keyClicks(searchTextEdit, "ZZZ");
     QTRY_COMPARE(searchTextEdit->text(), QString("ZZZ"));
+    QTRY_VERIFY(clearButton->isVisible());
     QTRY_VERIFY(m_dbWidget->isInSearchMode());
     QTRY_COMPARE(entryView->model()->rowCount(), 0);
     // Press the search clear button
-    QToolButton* clearButton = searchWidget->findChild<QToolButton*>("clearIcon");
-    QTest::mouseClick(clearButton, Qt::LeftButton);
+    clearButton->trigger();
     QTRY_VERIFY(searchTextEdit->text().isEmpty());
     QTRY_VERIFY(searchTextEdit->hasFocus());
+    QTRY_VERIFY(!clearButton->isVisible());
     // Escape clears searchedit and retains focus
     QTest::keyClicks(searchTextEdit, "ZZZ");
     QTest::keyClick(searchTextEdit, Qt::Key_Escape);


### PR DESCRIPTION
* Move the search icon (with popup menu) and clear icon inside the line edit
* Move the search widget to the right-side of toolbar

This makes the toolbar less clutered, and the search widget has a more usual look.

![screenshot_2017-04-05_11-10-11](https://cloud.githubusercontent.com/assets/3909027/24698312/771c8d82-19f0-11e7-97c9-af0ea2b219f2.png)
