### PR TITLE
Prioritize explicitly specified databases.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,15 @@ int main(int argc, char** argv)
         mainWindow.show();
     }
     
+    if (config()->get("OpenPreviousDatabasesOnStartup").toBool()) {
+        const QStringList filenames = config()->get("LastOpenedDatabases").toStringList();
+        for (const QString& filename : filenames) {
+            if (!filename.isEmpty() && QFile::exists(filename)) {
+                mainWindow.openDatabase(filename, QString(), QString());
+            }
+        }
+    }
+
     for (int ii=0; ii < args.length(); ii++) {
         QString filename = args[ii];
         if (!filename.isEmpty() && QFile::exists(filename)) {
@@ -124,15 +133,6 @@ int main(int argc, char** argv)
                 password = in.readLine();
             }
             mainWindow.openDatabase(filename, password, parser.value(keyfileOption));
-        }
-    }
-
-    if (config()->get("OpenPreviousDatabasesOnStartup").toBool()) {
-        const QStringList filenames = config()->get("LastOpenedDatabases").toStringList();
-        for (const QString& filename : filenames) {
-            if (!filename.isEmpty() && QFile::exists(filename)) {
-                mainWindow.openDatabase(filename, QString(), QString());
-            }
         }
     }
 


### PR DESCRIPTION
## Motivation and context
Fixes #468 

## How has this been tested?
Tested with the "Load previous databases" option enabled and with/without databases passed as argument to `keepassxc`.

The issue when opening directly a `.kdbx` was not reproducible on Mac, since that use case is handled by the `QFileOpenEvent` at https://github.com/keepassxreboot/keepassxc/blob/develop/src/gui/Application.cpp#L104.


## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed.