### PR TITLE
Substitute deprecated commands with feature_summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,6 @@ if(PRINT_SUMMARY)
   feature_summary(WHAT ALL)
 else()
   # This will only print ENABLED and DISABLED feature
-  print_enabled_features()
-  print_disabled_features()
+  feature_summary(WHAT ENABLED_FEATURES DESCRIPTION "Enabled features:")
+  feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "Disabled features:")
 endif()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
print_enabled_features() and print_disabled_features() are deprecated using last cmake (3.8.0)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR avoid the warning messages displayed when running cmake >= 3.8.0

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Clean build of entire project with different options seems fine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
