### PR TITLE
Moved a hardcoded English menu string to the string resources

### DIFF
--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -1287,6 +1287,10 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <source>Password Generator</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Clear history</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OptionDialog</name>

--- a/share/translations/keepassx_ru.ts
+++ b/share/translations/keepassx_ru.ts
@@ -1291,6 +1291,10 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <source>Password Generator</source>
         <translation>Генератор паролей</translation>
     </message>
+    <message>
+        <source>Clear history</source>
+        <translation>Очистить историю</translation>
+    </message>
 </context>
 <context>
     <name>OptionDialog</name>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -130,7 +130,7 @@ MainWindow::MainWindow()
     m_ui->toolBar->setVisible(showToolbar);
     connect(m_ui->toolBar, SIGNAL(visibilityChanged(bool)), this, SLOT(saveToolbarState(bool)));
 
-    m_clearHistoryAction = new QAction("Clear history", m_ui->menuFile);
+    m_clearHistoryAction = new QAction(tr("Clear history"), m_ui->menuFile);
     m_lastDatabasesActions = new QActionGroup(m_ui->menuRecentDatabases);
     connect(m_clearHistoryAction, SIGNAL(triggered()), this, SLOT(clearLastDatabases()));
     connect(m_lastDatabasesActions, SIGNAL(triggered(QAction*)), this, SLOT(openRecentDatabase(QAction*)));


### PR DESCRIPTION
## Description
Using the Russian localization of KeepassXC I noticed that the menu item "Database > Recent databases > **Clear history**" is not translated to Russian. I couldn't find that string nontranslated on Transiflex, it was just missing. I took a look at the code and found out that the string was just hardcoded (there was no call to `tr(...)`). So I added the call and added the string to keepassx_en.ts and keepassx_ru.ts.

Note, a new string was required to be added to keepassx_en.ts, therefore I couldn't just translate it on Transiflex. I believe I don't have the permission to upload a new base file for translations on Transiflex and I don't see the option to create a new string in the Transiflex web interface. So please make the appropriate arrangements with Transiflex using the TS files updated by me.

## Motivation and context
I'm trying to use the Russian translation of KeepassXC (because I'm Russian) and I don't like the translation flaws and nonfinished translations, therefore I'm contributing this stuff.

## How has this been tested?
This was tested by building and running the program and ensuring that the menu string I've mentioned above looks Russian. Also I've built the thing with `-DWITH_TESTS=ON` and `-DWITH_GUI_TESTS=ON` and run `make test`. 24 of 25 tests have been OK. Number 18 is failing, but it is not related to my change.

## Screenshots (if appropriate):
Here is the screenshot of the current public version 2.1.4 in Russian where that menu item is English
![nonlocalized](https://cloud.githubusercontent.com/assets/11542782/25134906/7ab06054-2459-11e7-8869-5b6944d26f6b.png)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ 24 of 25 tests are passing except for 18. It has something to do with a CSV parser, but I haven't touched that parser, so I don't think it was me who introduced the problem **[REQUIRED]**
Here is the output from your testing utility
```
Running tests...
Test project D:/MyRepositories/keepassxc/build
      Start  1: testgroup
 1/25 Test  #1: testgroup ........................   Passed    0.12 sec
      Start  2: testkeepass2xmlreader
 2/25 Test  #2: testkeepass2xmlreader ............   Passed    0.22 sec
      Start  3: testkeys
 3/25 Test  #3: testkeys .........................   Passed    0.17 sec
      Start  4: testkeepass2reader
 4/25 Test  #4: testkeepass2reader ...............   Passed    0.13 sec
      Start  5: testkeepass2writer
 5/25 Test  #5: testkeepass2writer ...............   Passed    0.17 sec
      Start  6: testgroupmodel
 6/25 Test  #6: testgroupmodel ...................   Passed    0.12 sec
      Start  7: testentrymodel
 7/25 Test  #7: testentrymodel ...................   Passed    0.12 sec
      Start  8: testcryptohash
 8/25 Test  #8: testcryptohash ...................   Passed    0.03 sec
      Start  9: testsymmetriccipher
 9/25 Test  #9: testsymmetriccipher ..............   Passed    0.10 sec
      Start 10: testhashedblockstream
10/25 Test #10: testhashedblockstream ............   Passed    0.10 sec
      Start 11: testkeepass2randomstream
11/25 Test #11: testkeepass2randomstream .........   Passed    0.04 sec
      Start 12: testmodified
12/25 Test #12: testmodified .....................   Passed    0.15 sec
      Start 13: testdeletedobjects
13/25 Test #13: testdeletedobjects ...............   Passed    0.15 sec
      Start 14: testkeepass1reader
14/25 Test #14: testkeepass1reader ...............   Passed    0.23 sec
      Start 15: testwildcardmatcher
15/25 Test #15: testwildcardmatcher ..............   Passed    0.03 sec
      Start 16: testautotype
16/25 Test #16: testautotype .....................   Passed    0.14 sec
      Start 17: testentry
17/25 Test #17: testentry ........................   Passed    0.12 sec
      Start 18: testcsvparser
18/25 Test #18: testcsvparser ....................***Failed    0.18 sec
      Start 19: testrandom
19/25 Test #19: testrandom .......................   Passed    0.03 sec
      Start 20: testentrysearcher
20/25 Test #20: testentrysearcher ................   Passed    0.08 sec
      Start 21: testexporter
21/25 Test #21: testexporter .....................   Passed    0.12 sec
      Start 22: testcsvexporter
22/25 Test #22: testcsvexporter ..................   Passed    0.10 sec
      Start 23: testykchallengeresponsekey
23/25 Test #23: testykchallengeresponsekey .......   Passed    0.08 sec
      Start 24: testgui
24/25 Test #24: testgui ..........................   Passed   14.61 sec
      Start 25: testguipixmaps
25/25 Test #25: testguipixmaps ...................   Passed    0.25 sec

96% tests passed, 1 tests failed out of 25

Total Test time (real) =  17.62 sec

The following tests FAILED:
         18 - testcsvparser (Failed)
Errors while running CTest
make: *** [Makefile:150: test] Error 8
```
- ✅ I haven't compiled and verified my code with `-DWITH_ASAN=ON`, because your build script report that this thing is only supported on Linux. I'm contributing this being on Windows at the moment. **[REQUIRED]**
