### PR TITLE
Add support for extended ASCII in password generator

### DIFF
--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -198,11 +198,13 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
     if (m_classes & EASCII) {
         PasswordGroup group;
 
-        for (int i = 128; i <= 169; i++) {
+        // [U+0080, U+009F] are C1 control characters,
+        // U+00A0 is non-breaking space
+        for (int i = 161; i <= 172; i++) {
             group.append(i);
         }
-
-        for (int i = 171; i <= 254; i++) {
+        // U+00AD is soft hyphen (format character)
+        for (int i = 174; i <= 255; i++) {
             if ((m_flags & ExcludeLookAlike) && (i == 249)) { // "﹒"
                 continue;
             }

--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -231,6 +231,9 @@ int PasswordGenerator::numCharClasses() const
     if (m_classes & SpecialCharacters) {
         numClasses++;
     }
+    if (m_classes & EASCII) {
+        numClasses++;
+    }
 
     return numClasses;
 }

--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -195,6 +195,22 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
 
         passwordGroups.append(group);
     }
+    if (m_classes & EASCII) {
+        PasswordGroup group;
+
+        for (int i = 128; i <= 169; i++) {
+            group.append(i);
+        }
+
+        for (int i = 171; i <= 254; i++) {
+            if ((m_flags & ExcludeLookAlike) && (i == 249)) { // "﹒"
+                continue;
+            }
+            group.append(i);
+        }
+
+        passwordGroups.append(group);
+    }
 
     return passwordGroups;
 }

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -33,7 +33,7 @@ public:
         UpperLetters      = 0x2,
         Numbers           = 0x4,
         SpecialCharacters = 0x8,
-        EASCII            = 0x16
+        EASCII            = 0x10
     };
     Q_DECLARE_FLAGS(CharClasses, CharClass)
 

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -32,7 +32,8 @@ public:
         LowerLetters      = 0x1,
         UpperLetters      = 0x2,
         Numbers           = 0x4,
-        SpecialCharacters = 0x8
+        SpecialCharacters = 0x8,
+        EASCII            = 0x16
     };
     Q_DECLARE_FLAGS(CharClasses, CharClass)
 

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -92,6 +92,7 @@ void PasswordGeneratorWidget::loadSettings()
     m_ui->checkBoxUpper->setChecked(config()->get("generator/UpperCase", true).toBool());
     m_ui->checkBoxNumbers->setChecked(config()->get("generator/Numbers", true).toBool());
     m_ui->checkBoxSpecialChars->setChecked(config()->get("generator/SpecialChars", false).toBool());
+    m_ui->checkBoxExtASCII->setChecked(config()->get("generator/EASCII", false).toBool());
     m_ui->checkBoxExcludeAlike->setChecked(config()->get("generator/ExcludeAlike", true).toBool());
     m_ui->checkBoxEnsureEvery->setChecked(config()->get("generator/EnsureEvery", true).toBool());
     m_ui->spinBoxLength->setValue(config()->get("generator/Length", 16).toInt());
@@ -112,6 +113,7 @@ void PasswordGeneratorWidget::saveSettings()
     config()->set("generator/UpperCase", m_ui->checkBoxUpper->isChecked());
     config()->set("generator/Numbers", m_ui->checkBoxNumbers->isChecked());
     config()->set("generator/SpecialChars", m_ui->checkBoxSpecialChars->isChecked());
+    config()->set("generator/EASCII", m_ui->checkBoxExtASCII->isChecked());
     config()->set("generator/ExcludeAlike", m_ui->checkBoxExcludeAlike->isChecked());
     config()->set("generator/EnsureEvery", m_ui->checkBoxEnsureEvery->isChecked());
     config()->set("generator/Length", m_ui->spinBoxLength->value());
@@ -287,6 +289,10 @@ PasswordGenerator::CharClasses PasswordGeneratorWidget::charClasses()
         classes |= PasswordGenerator::SpecialCharacters;
     }
 
+    if (m_ui->checkBoxExtASCII->isChecked()) {
+        classes |= PasswordGenerator::EASCII;
+    }
+
     return classes;
 }
 
@@ -323,6 +329,9 @@ void PasswordGeneratorWidget::updateGenerator()
                 minLength++;
             }
             if (classes.testFlag(PasswordGenerator::SpecialCharacters)) {
+                minLength++;
+            }
+            if (classes.testFlag(PasswordGenerator::EASCII)) {
                 minLength++;
             }
         }

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -222,11 +222,11 @@ QProgressBar::chunk {
              </property>
              <layout class="QVBoxLayout" name="verticalLayout">
               <item>
-               <layout class="QHBoxLayout" name="alphabetLayout" stretch="0,0,0,0,1">
+               <layout class="QHBoxLayout" name="alphabetLayout" stretch="0,0,0,0,1,0">
                 <item>
                  <widget class="QToolButton" name="checkBoxUpper">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -257,7 +257,7 @@ QProgressBar::chunk {
                 <item>
                  <widget class="QToolButton" name="checkBoxLower">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -288,7 +288,7 @@ QProgressBar::chunk {
                 <item>
                  <widget class="QToolButton" name="checkBoxNumbers">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -319,7 +319,7 @@ QProgressBar::chunk {
                 <item>
                  <widget class="QToolButton" name="checkBoxSpecialChars">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -338,6 +338,43 @@ QProgressBar::chunk {
                   </property>
                   <property name="text">
                    <string notr="true">/*_&amp; ...</string>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <attribute name="buttonGroup">
+                   <string notr="true">optionButtons</string>
+                  </attribute>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QToolButton" name="checkBoxExtASCII">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>25</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::StrongFocus</enum>
+                  </property>
+                  <property name="toolTip">
+                   <string>Extended ASCII</string>
+                  </property>
+                  <property name="text">
+                   <string notr="true">Extended ASCII</string>
                   </property>
                   <property name="checkable">
                    <bool>true</bool>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Resolve #343 

## Description
<!--- Describe your changes in detail -->
This adds support for extended ASCII character in the password generator, like KeePass.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with Travis

## Screenshots (if appropriate):
![istantanea_2017-04-28_22-05-01](https://cloud.githubusercontent.com/assets/686894/25545367/ce5dd8aa-2c5e-11e7-96f1-4f77defe2189.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
