### PR TITLE
Styling + CFNotificationName -> CFStringRef

### DIFF
--- a/src/core/ScreenLockListenerMac.cpp
+++ b/src/core/ScreenLockListenerMac.cpp
@@ -32,8 +32,9 @@ ScreenLockListenerMac* ScreenLockListenerMac::instance()
     return m_ptr;
 }
 
-void ScreenLockListenerMac::notificationCenterCallBack(CFNotificationCenterRef /*center*/, void */*observer*/,
-                                        CFNotificationName /*name*/, const void */*object*/, CFDictionaryRef /*userInfo*/)
+void ScreenLockListenerMac::notificationCenterCallBack(CFNotificationCenterRef, void*,
+                                                       CFStringRef, const void*,
+                                                       CFDictionaryRef)
 {
     instance()->onSignalReception();
 }
@@ -48,12 +49,12 @@ ScreenLockListenerMac::ScreenLockListenerMac(QWidget* parent)
         return;
     }
 
-    CFNotificationCenterAddObserver(
-                distCenter,
-                this, &ScreenLockListenerMac::notificationCenterCallBack,
-                screenIsLockedSignal,
-                nullptr,
-                CFNotificationSuspensionBehaviorDeliverImmediately);
+    CFNotificationCenterAddObserver(distCenter,
+                                    this,
+                                    &ScreenLockListenerMac::notificationCenterCallBack,
+                                    screenIsLockedSignal,
+                                    nullptr,
+                                    CFNotificationSuspensionBehaviorDeliverImmediately);
 }
 
 void ScreenLockListenerMac::onSignalReception()

--- a/src/core/ScreenLockListenerMac.h
+++ b/src/core/ScreenLockListenerMac.h
@@ -29,8 +29,9 @@ class ScreenLockListenerMac: public ScreenLockListenerPrivate {
 
 public:
     static ScreenLockListenerMac* instance();
-    static void notificationCenterCallBack(CFNotificationCenterRef /*center*/, void */*observer*/,
-                            CFNotificationName /*name*/, const void */*object*/, CFDictionaryRef /*userInfo*/);
+    static void notificationCenterCallBack(CFNotificationCenterRef center, void* observer,
+                                           CFStringRef name, const void* object,
+                                           CFDictionaryRef userInfo);
 
 private:
     ScreenLockListenerMac(QWidget* parent = nullptr);

--- a/src/core/ScreenLockListenerWin.cpp
+++ b/src/core/ScreenLockListenerWin.cpp
@@ -57,7 +57,7 @@ ScreenLockListenerWin::~ScreenLockListenerWin()
     }
 }
 
-bool ScreenLockListenerWin::nativeEventFilter(const QByteArray &eventType, void* message, long *)
+bool ScreenLockListenerWin::nativeEventFilter(const QByteArray& eventType, void* message, long*)
 {
     if (eventType == "windows_generic_MSG" || eventType == "windows_dispatcher_MSG") {
         MSG* m = static_cast<MSG*>(message);

--- a/src/core/ScreenLockListenerWin.h
+++ b/src/core/ScreenLockListenerWin.h
@@ -29,7 +29,7 @@ class ScreenLockListenerWin : public ScreenLockListenerPrivate, public QAbstract
 public:
     explicit ScreenLockListenerWin(QWidget* parent = 0);
     ~ScreenLockListenerWin();
-    virtual bool nativeEventFilter(const QByteArray &eventType, void* message, long *) override;
+    virtual bool nativeEventFilter(const QByteArray &eventType, void* message, long*) override;
 
 private:
     void* m_powerNotificationHandle ;


### PR DESCRIPTION
I was having a hard time compiling this on Mac. Looked at the doc and realized that the function's signature for `CFNotificationCenterAddObserver` was actually using `CFStringRef` instead of `CFNotificationName`. What I'm not  sure of is how others were able to compile this on Mac and not me...

This is the doc I used https://developer.apple.com/reference/corefoundation/1543316-cfnotificationcenteraddobserver?language=objc
