### PR TITLE
Adding .clang-format file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,89 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      true
+  AfterFunction:   true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -25,7 +25,7 @@
 
 #include "core/FilePath.h"
 
-SearchWidget::SearchWidget(QWidget *parent)
+SearchWidget::SearchWidget(QWidget* parent)
     : QWidget(parent)
     , m_ui(new Ui::SearchWidget())
 {
@@ -40,11 +40,11 @@ SearchWidget::SearchWidget(QWidget *parent)
     connect(this, SIGNAL(escapePressed()), m_ui->searchEdit, SLOT(clear()));
 
     new QShortcut(Qt::CTRL + Qt::Key_F, this, SLOT(searchFocus()), nullptr, Qt::ApplicationShortcut);
-	new QShortcut(Qt::Key_Escape, m_ui->searchEdit, SLOT(clear()), nullptr, Qt::ApplicationShortcut);
+    new QShortcut(Qt::Key_Escape, m_ui->searchEdit, SLOT(clear()), nullptr, Qt::ApplicationShortcut);
 
     m_ui->searchEdit->installEventFilter(this);
 
-    QMenu *searchMenu = new QMenu();
+    QMenu* searchMenu = new QMenu();
     m_actionCaseSensitive = searchMenu->addAction(tr("Case Sensitive"), this, SLOT(updateCaseSensitive()));
     m_actionCaseSensitive->setObjectName("actionSearchCaseSensitive");
     m_actionCaseSensitive->setCheckable(true);
@@ -58,39 +58,35 @@ SearchWidget::SearchWidget(QWidget *parent)
     m_ui->searchEdit->addAction(m_ui->clearIcon, QLineEdit::TrailingPosition);
 
     // Fix initial visibility of actions (bug in Qt)
-    for (QToolButton * toolButton: m_ui->searchEdit->findChildren<QToolButton *>()) {
+    for (QToolButton* toolButton : m_ui->searchEdit->findChildren<QToolButton*>()) {
         toolButton->setVisible(toolButton->defaultAction()->isVisible());
     }
 }
 
 SearchWidget::~SearchWidget()
 {
-
 }
 
-bool SearchWidget::eventFilter(QObject *obj, QEvent *event)
+bool SearchWidget::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::KeyPress) {
-        QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
         if (keyEvent->key() == Qt::Key_Escape) {
             emit escapePressed();
             return true;
-        }
-        else if (keyEvent->matches(QKeySequence::Copy)) {
+        } else if (keyEvent->matches(QKeySequence::Copy)) {
             // If Control+C is pressed in the search edit when no text
             // is selected, copy the password of the current entry
             if (!m_ui->searchEdit->hasSelectedText()) {
                 emit copyPressed();
                 return true;
             }
-        }
-        else if (keyEvent->matches(QKeySequence::MoveToNextLine)) {
+        } else if (keyEvent->matches(QKeySequence::MoveToNextLine)) {
             if (m_ui->searchEdit->cursorPosition() == m_ui->searchEdit->text().length()) {
                 // If down is pressed at EOL, move the focus to the entry view
                 emit downPressed();
                 return true;
-            }
-            else {
+            } else {
                 // Otherwise move the cursor to EOL
                 m_ui->searchEdit->setCursorPosition(m_ui->searchEdit->text().length());
                 return true;
@@ -110,7 +106,7 @@ void SearchWidget::connectSignals(SignalMultiplexer& mx)
     mx.connect(m_ui->searchEdit, SIGNAL(returnPressed()), SLOT(switchToEntryEdit()));
 }
 
-void SearchWidget::databaseChanged(DatabaseWidget *dbWidget)
+void SearchWidget::databaseChanged(DatabaseWidget* dbWidget)
 {
     if (dbWidget != nullptr) {
         // Set current search text from this database

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -18,11 +18,11 @@
 #ifndef KEEPASSX_SEARCHWIDGET_H
 #define KEEPASSX_SEARCHWIDGET_H
 
-#include <QWidget>
 #include <QTimer>
+#include <QWidget>
 
-#include "gui/DatabaseWidget.h"
 #include "core/SignalMultiplexer.h"
+#include "gui/DatabaseWidget.h"
 
 namespace Ui {
     class SearchWidget;
@@ -33,17 +33,17 @@ class SearchWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit SearchWidget(QWidget *parent = 0);
+    explicit SearchWidget(QWidget* parent = 0);
     ~SearchWidget();
 
     void connectSignals(SignalMultiplexer& mx);
     void setCaseSensitive(bool state);
 
 protected:
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject* obj, QEvent* event);
 
 signals:
-    void search(const QString &text);
+    void search(const QString& text);
     void caseSensitiveChanged(bool state);
     void escapePressed();
     void copyPressed();
@@ -62,7 +62,7 @@ private slots:
 private:
     const QScopedPointer<Ui::SearchWidget> m_ui;
     QTimer* m_searchTimer;
-    QAction *m_actionCaseSensitive;
+    QAction* m_actionCaseSensitive;
 
     Q_DISABLE_COPY(SearchWidget)
 };


### PR DESCRIPTION
Adding a `clang-format` file corresponding to the coding style of the project. Right now it's not hooked to anything, but it could be at some point (I think it can be integrated with `cmake`).

I don't think it would be a good idea to format the whole codebase, as it might cause some problems, for example when porting some keepassx changes to keepassxc, or when browsing the git history, but the style used for new code could be easily enforced with `clang-format`

I ran it on 2 files to show an example of the coding style being enforced.
```
clang-format -i -style=file src/gui/SearchWidget.*
```

@TheZ3ro @droidmonkey what do you guys think?

## Motivation and context
I feel like this would allow reviewers to concentrate on the feature instead of reviewing the coding style of the new code.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project. :grin: 
- ✅ All new and existing tests passed.
