### PR TITLE
Feature/430 fix unclean shutdown

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -40,6 +40,7 @@ class MainWindow : public QMainWindow
 public:
     MainWindow();
     ~MainWindow();
+
     enum StackedWidgetIndex
     {
         DatabaseTabScreen = 0,
@@ -118,7 +119,8 @@ private:
 
     Q_DISABLE_COPY(MainWindow)
 
-    bool appExitCalled;
+    bool m_appExitCalled;
+    bool m_appExiting;
 };
 
 #define KEEPASSXC_MAIN_WINDOW (qobject_cast<Application*>(qApp) ? \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This is a partial fix for issue #430. It resolves shutdown problems on OS X when using the "Quit" action from the right-click menu on the dock.

It also contains an incomplete clean shutdown implementation for Windows. The signaling mechanism via CreateEvent() and SetEvent() works in general, but trapping the actual system events doesn't. The control handler registered by SetConsoleCtrlHandler() isn't called. Maybe someone more knowledgeable in Windows API internals can help me here. I suppose it may be that Windows doesn't treat KeePassXC as a console application or some other stupid reason.

**EDIT:** Windows implementation canceled, considered a non-issue (mostly).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran on macOS Sierra and Windows 10.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**