### PR TITLE
Fix quit submenu on macOS tray icon

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -747,10 +747,17 @@ void MainWindow::updateTrayIcon()
             QAction* actionToggle = new QAction(tr("Toggle window"), menu);
             menu->addAction(actionToggle);
 
+#ifdef Q_OS_MAC
+            QAction* actionQuit = new QAction(tr("Quit KeePassXC"), menu);
+            menu->addAction(actionQuit);
+
+            connect(actionQuit, SIGNAL(triggered()), SLOT(appExit()));
+#else
             menu->addAction(m_ui->actionQuit);
 
             connect(m_trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
                     SLOT(trayIconTriggered(QSystemTrayIcon::ActivationReason)));
+#endif
             connect(actionToggle, SIGNAL(triggered()), SLOT(toggleWindow()));
 
             m_trayIcon->setContextMenu(menu);


### PR DESCRIPTION
## Description
Add the quit submenu to macOS tray icon and disable redundant toggle window action when clicking on the icon.

## How has this been tested?
Local tests

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
