### PR TITLE
Moving print group in Group class.

### DIFF
--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -30,30 +30,6 @@
 #include "core/Group.h"
 #include "keys/CompositeKey.h"
 
-void printGroup(Group* group, QString baseName, int depth)
-{
-
-    QTextStream out(stdout);
-
-    QString groupName = baseName + group->name() + "/";
-    QString indentation = QString("  ").repeated(depth);
-
-    out << indentation << groupName << " " << group->uuid().toHex() << "\n";
-    out.flush();
-
-    if (group->entries().isEmpty() && group->children().isEmpty()) {
-        out << indentation << "  [empty]\n";
-        return;
-    }
-
-    for (Entry* entry : group->entries()) {
-        out << indentation << "  " << entry->title() << " " << entry->uuid().toHex() << "\n";
-    }
-
-    for (Group* innerGroup : group->children()) {
-        printGroup(innerGroup, groupName, depth + 1);
-    }
-}
 
 int List::execute(int argc, char** argv)
 {
@@ -63,6 +39,11 @@ int List::execute(int argc, char** argv)
     QCommandLineParser parser;
     parser.setApplicationDescription(QCoreApplication::translate("main", "List database entries."));
     parser.addPositionalArgument("database", QCoreApplication::translate("main", "Path of the database."));
+    QCommandLineOption printUuidsOption(
+        QStringList() << "u"
+                      << "print-uuids",
+        QCoreApplication::translate("main", "Print the UUIDs of the entries and groups."));
+    parser.addOption(printUuidsOption);
     parser.process(app);
 
     const QStringList args = parser.positionalArguments();
@@ -83,6 +64,7 @@ int List::execute(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    printGroup(db->rootGroup(), QString(""), 0);
+    out << db->rootGroup()->print(parser.isSet("print-uuids"));
+    out.flush();
     return EXIT_SUCCESS;
 }

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -18,8 +18,8 @@
 #include "Group.h"
 
 #include "core/Config.h"
-#include "core/Global.h"
 #include "core/DatabaseIcons.h"
+#include "core/Global.h"
 #include "core/Metadata.h"
 
 const int Group::DefaultIconNumber = 48;
@@ -202,7 +202,7 @@ QString Group::effectiveAutoTypeSequence() const
     } while (group && sequence.isEmpty());
 
     if (sequence.isEmpty()) {
-      sequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}";
+        sequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}";
     }
 
     return sequence;
@@ -535,6 +535,38 @@ Entry* Group::findEntryByPath(QString entryPath, QString basePath)
     return nullptr;
 }
 
+QString Group::print(bool printUuids, QString baseName, int depth)
+{
+
+    QString response;
+    QString indentation = QString("  ").repeated(depth);
+
+    if (entries().isEmpty() && children().isEmpty()) {
+        response += indentation + "[empty]\n";
+        return response;
+    }
+
+    for (Entry* entry : entries()) {
+        response += indentation + entry->title();
+        if (printUuids) {
+            response += " " + entry->uuid().toHex();
+        }
+        response += "\n";
+    }
+
+    for (Group* innerGroup : children()) {
+        QString newBaseName = baseName + innerGroup->name() + "/";
+        response += indentation + newBaseName;
+        if (printUuids) {
+            response += " " + uuid().toHex();
+        }
+        response += "\n";
+        response += innerGroup->print(printUuids, newBaseName, depth + 1);
+    }
+
+    return response;
+}
+
 QList<const Group*> Group::groupsRecursive(bool includeSelf) const
 {
     QList<const Group*> groupList;
@@ -761,8 +793,7 @@ void Group::markOlderEntry(Entry* entry)
 {
     entry->attributes()->set(
         "merged",
-        QString("older entry merged from database \"%1\"").arg(entry->group()->database()->metadata()->name())
-    );
+        QString("older entry merged from database \"%1\"").arg(entry->group()->database()->metadata()->name()));
 }
 
 bool Group::resolveSearchingEnabled() const

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -558,7 +558,7 @@ QString Group::print(bool printUuids, QString baseName, int depth)
         QString newBaseName = baseName + innerGroup->name() + "/";
         response += indentation + newBaseName;
         if (printUuids) {
-            response += " " + uuid().toHex();
+            response += " " + innerGroup->uuid().toHex();
         }
         response += "\n";
         response += innerGroup->print(printUuids, newBaseName, depth + 1);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -793,7 +793,8 @@ void Group::markOlderEntry(Entry* entry)
 {
     entry->attributes()->set(
         "merged",
-        QString("older entry merged from database \"%1\"").arg(entry->group()->database()->metadata()->name()));
+        QString("older entry merged from database \"%1\"").arg(entry->group()->database()->metadata()->name())
+    );
 }
 
 bool Group::resolveSearchingEnabled() const

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -123,6 +123,7 @@ public:
     Group* clone(Entry::CloneFlags entryFlags = Entry::CloneNewUuid | Entry::CloneResetTimeInfo) const;
     void copyDataFrom(const Group* other);
     void merge(const Group* other);
+    QString print(bool printUuids = false, QString baseName = QString(""), int depth = 0);
 
 signals:
     void dataChanged(Group* group);

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -619,3 +619,44 @@ void TestGroup::testFindEntry()
 
     delete db;
 }
+
+void TestGroup::testPrint()
+{
+    Database* db = new Database();
+
+    QString output = db->rootGroup()->print();
+    QCOMPARE(output, QString("[empty]\n"));
+
+    output = db->rootGroup()->print(true);
+    QCOMPARE(output, QString("[empty]\n"));
+
+    Entry* entry1 = new Entry();
+    entry1->setTitle(QString("entry1"));
+    entry1->setGroup(db->rootGroup());
+    entry1->setUuid(Uuid::random());
+
+    output = db->rootGroup()->print();
+    QCOMPARE(output, QString("entry1\n"));
+
+    output = db->rootGroup()->print(true);
+    QCOMPARE(output, QString("entry1 " + entry1->uuid().toHex() + "\n"));
+
+
+    Group* group1 = new Group();
+    group1->setName("group1");
+
+    Entry* entry2 = new Entry();
+
+    entry2->setTitle(QString("entry2"));
+    entry2->setGroup(group1);
+    entry2->setUuid(Uuid::random());
+
+    group1->setParent(db->rootGroup());
+
+    output = db->rootGroup()->print();
+    QVERIFY(output.contains(QString("entry1\n")));
+    QVERIFY(output.contains(QString("group1/\n")));
+    QVERIFY(output.contains(QString("  entry2\n")));
+
+    delete db;
+}

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -658,5 +658,9 @@ void TestGroup::testPrint()
     QVERIFY(output.contains(QString("group1/\n")));
     QVERIFY(output.contains(QString("  entry2\n")));
 
+    output = db->rootGroup()->print(true);
+    QVERIFY(output.contains(QString("entry1 " + entry1->uuid().toHex() + "\n")));
+    QVERIFY(output.contains(QString("group1/ " + group1->uuid().toHex() + "\n")));
+    QVERIFY(output.contains(QString("  entry2 " + entry2->uuid().toHex() + "\n")));
     delete db;
 }

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -39,6 +39,7 @@ private slots:
     void testMergeDatabase();
     void testMergeConflictKeepBoth();
     void testFindEntry();
+    void testPrint();
 
 private:
     Database* createMergeTestDatabase();


### PR DESCRIPTION
Moved code from the List command to the Group class. Also removed the printing of the Root group, since it doesn't add any value to the listing.

## Motivation and context
It's easier to unit test this way.

## How has this been tested?
CLI interface + new unit tests

## Screenshots (if appropriate):
```
$ ./src/cli/keepassxc-cli list ~/1.kdbx
SubGroup1/
  [empty]
SubGroup2/
  entry4
  entry5
Recycle Bin/
  entry1
  entry2
```

```
$ ./src/cli/keepassxc-cli list ~/1.kdbx -u
SubGroup1/ e05b75cc7875a7b708f4aa38a247e42f
  [empty]
SubGroup2/ f8bbae53ddb5148864a10b5b498db1b3
  entry4 7cac7da624ede2a1294ce1808f204dcc
  entry5 3ec4a60fa4858c1b5bc4525f5c884463
Recycle Bin/ 0a06b7d21db94d7be916f5d6946ac313
  entry1 7b0fe7b1d0ce0cdd3ee90ba921fdc68b
  entry2 4b9520590aff6c11ccda4b9fe1ce48a6
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed. 
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`.
