### PR TITLE
Adding a GUI prompt for password.

### DIFF
--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -26,37 +26,47 @@
 #include <QStringList>
 #include <QTextStream>
 
+#include "gui/UnlockDatabaseDialog.h"
 #include "core/Database.h"
 #include "core/Entry.h"
 #include "core/Group.h"
 #include "gui/Clipboard.h"
-#include "keys/CompositeKey.h"
 
 int Clip::execute(int argc, char** argv)
 {
-    QApplication app(argc, argv);
+
+    QStringList arguments;
+    for (int i = 0; i < argc; ++i) {
+        arguments << QString(argv[i]);
+    }
     QTextStream out(stdout);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QCoreApplication::translate("main", "Copy a password to the clipboard"));
     parser.addPositionalArgument("database", QCoreApplication::translate("main", "Path of the database."));
+    QCommandLineOption guiPrompt(
+        QStringList() << "g"
+                      << "gui-prompt",
+        QCoreApplication::translate("main", "Use a GUI prompt unlocking the database."));
+    parser.addOption(guiPrompt);
     parser.addPositionalArgument("entry", QCoreApplication::translate("main", "Name of the entry to clip."));
-    parser.process(app);
+    parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 2) {
+        QCoreApplication app(argc, argv);
         parser.showHelp();
         return EXIT_FAILURE;
     }
 
-    out << "Insert the database password\n> ";
-    out.flush();
+    Database* db = nullptr;
+    QApplication app(argc, argv);
+    if (parser.isSet("gui-prompt")) {
+        db = UnlockDatabaseDialog::openDatabasePrompt(args.at(0));
+    } else {
+        db = Database::unlockFromStdin(args.at(0));
+    }
 
-    static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
-    QString line = inputTextStream.readLine();
-    CompositeKey key = CompositeKey::readFromLine(line);
-
-    Database* db = Database::openDatabaseFile(args.at(0), key);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -47,9 +47,6 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    QCoreApplication app(argc, argv);
-    app.setApplicationVersion(KEEPASSX_VERSION);
-
     QCommandLineParser parser;
 
     QString description("KeePassXC command line interface.");
@@ -72,6 +69,8 @@ int main(int argc, char** argv)
     // parser.process(app);
 
     if (argc < 2) {
+        QCoreApplication app(argc, argv);
+        app.setApplicationVersion(KEEPASSX_VERSION);
         parser.showHelp();
         return EXIT_FAILURE;
     }
@@ -104,6 +103,8 @@ int main(int argc, char** argv)
         exitCode = Show::execute(argc, argv);
     } else {
         qCritical("Invalid command %s.", qPrintable(commandName));
+        QCoreApplication app(argc, argv);
+        app.setApplicationVersion(KEEPASSX_VERSION);
         parser.showHelp();
         exitCode = EXIT_FAILURE;
     }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -18,6 +18,7 @@
 #include "Database.h"
 
 #include <QFile>
+#include <QTextStream>
 #include <QTimer>
 #include <QXmlStreamReader>
 
@@ -394,5 +395,19 @@ Database* Database::openDatabaseFile(QString fileName, CompositeKey key)
     }
 
     return db;
+
+}
+
+Database* Database::unlockFromStdin(QString databaseFilename)
+{
+    static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
+    QTextStream outputTextStream(stdout);
+
+    outputTextStream << QString("Insert password to unlock " + databaseFilename + "\n>");
+    outputTextStream.flush();
+
+    QString line = inputTextStream.readLine();
+    CompositeKey key = CompositeKey::readFromLine(line);
+    return Database::openDatabaseFile(databaseFilename, key);
 
 }

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -90,7 +90,7 @@ public:
     QByteArray transformSeed() const;
     quint64 transformRounds() const;
     QByteArray transformedMasterKey() const;
-    const CompositeKey & key() const;
+    const CompositeKey& key() const;
     QByteArray challengeResponseKey() const;
     bool challengeMasterSeed(const QByteArray& masterSeed);
 
@@ -120,6 +120,7 @@ public:
 
     static Database* databaseByUuid(const Uuid& uuid);
     static Database* openDatabaseFile(QString fileName, CompositeKey key);
+    static Database* unlockFromStdin(QString databaseFilename);
 
 signals:
     void groupDataChanged(Group* group);

--- a/src/gui/UnlockDatabaseDialog.cpp
+++ b/src/gui/UnlockDatabaseDialog.cpp
@@ -19,18 +19,17 @@
 #include "UnlockDatabaseWidget.h"
 
 #include "autotype/AutoType.h"
-#include "gui/DragTabBar.h"
 #include "core/Database.h"
+#include "gui/DragTabBar.h"
 
-
-UnlockDatabaseDialog::UnlockDatabaseDialog(QWidget *parent)
+UnlockDatabaseDialog::UnlockDatabaseDialog(QWidget* parent)
     : QDialog(parent)
     , m_view(new UnlockDatabaseWidget(this))
 {
     connect(m_view, SIGNAL(editFinished(bool)), this, SLOT(complete(bool)));
 }
 
-void UnlockDatabaseDialog::setDBFilename(const QString &filename)
+void UnlockDatabaseDialog::setDBFilename(const QString& filename)
 {
     m_view->load(filename);
 }
@@ -40,7 +39,7 @@ void UnlockDatabaseDialog::clearForms()
     m_view->clearForms();
 }
 
-Database *UnlockDatabaseDialog::database()
+Database* UnlockDatabaseDialog::database()
 {
     return m_view->database();
 }
@@ -53,4 +52,21 @@ void UnlockDatabaseDialog::complete(bool r)
     } else {
         reject();
     }
+}
+
+Database* UnlockDatabaseDialog::openDatabasePrompt(QString databaseFilename)
+{
+
+    UnlockDatabaseDialog* unlockDatabaseDialog = new UnlockDatabaseDialog();
+    unlockDatabaseDialog->setObjectName("Open database");
+    unlockDatabaseDialog->setDBFilename(databaseFilename);
+    unlockDatabaseDialog->show();
+    unlockDatabaseDialog->exec();
+
+    Database* db = unlockDatabaseDialog->database();
+    if (!db) {
+        qWarning("Could not open database %s.", qPrintable(databaseFilename));
+    }
+    delete unlockDatabaseDialog;
+    return db;
 }

--- a/src/gui/UnlockDatabaseDialog.h
+++ b/src/gui/UnlockDatabaseDialog.h
@@ -31,10 +31,11 @@ class UnlockDatabaseDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit UnlockDatabaseDialog(QWidget *parent = Q_NULLPTR);
+    explicit UnlockDatabaseDialog(QWidget* parent = Q_NULLPTR);
     void setDBFilename(const QString& filename);
     void clearForms();
     Database* database();
+    static Database* openDatabasePrompt(QString databaseFilename);
 
 signals:
     void unlockDone(bool);


### PR DESCRIPTION
This PR adds a GUI password prompt for the CLI commands. Some logic is now needed to determine which type of QApplication to instantiate (QCoreApplication or QApplication), since we need a GUI type application to display the GUI prompt. Also, creating 2 QApplications will result in a seg fault when the program terminates, so the instantiation of the QApplication is done at the last moment.

I will add the option to use the GUI to the other commands at some point.

## How has this been tested?
Tested that the Clip command was still working.

## Screenshots (if appropriate):
![screenshot from 2017-05-20 21-47-53](https://cloud.githubusercontent.com/assets/3301383/26280581/afd0b038-3da7-11e7-90b3-c7031f31a7af.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. 
- ✅ My code follows the code style of this project. 
- ✅ All new and existing tests passed.
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. 
