### PR TITLE
Fix about dialog report bugs link functionality

### DIFF
--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -96,6 +96,9 @@
          <property name="text">
           <string>&lt;p&gt;Report bugs at: &lt;a href=&quot;https://github.com/keepassxreboot/keepassxc/issues&quot;&gt;https://github.com/&lt;/a&gt;&lt;/p&gt;</string>
          </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
About dialog "Report bugs at" link to GitHub did not have "openExternalLinks" property in the ui definition and the link did not work.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
