### PR TITLE
:lock: Fix search information leak

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1064,6 +1064,7 @@ void DatabaseWidget::lock()
         m_entryBeforeLock = m_entryView->currentEntry()->uuid();
     }
 
+    endSearch();
     clearAllWidgets();
     m_unlockDatabaseWidget->load(m_filename);
     setCurrentWidget(m_unlockDatabaseWidget);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -219,9 +219,11 @@ MainWindow::MainWindow()
     m_actionMultiplexer.connect(SIGNAL(entryContextMenuRequested(QPoint)),
                                 this, SLOT(showEntryContextMenu(QPoint)));
 
-    // Notify search when the active database changes
+    // Notify search when the active database changes or gets locked
     connect(m_ui->tabWidget, SIGNAL(activateDatabaseChanged(DatabaseWidget*)),
             search, SLOT(databaseChanged(DatabaseWidget*)));
+    connect(m_ui->tabWidget, SIGNAL(databaseLocked(DatabaseWidget*)),
+            search, SLOT(databaseChanged()));
 
     connect(m_ui->tabWidget, SIGNAL(tabNameChanged()),
             SLOT(updateWindowTitle()));

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -51,7 +51,7 @@ signals:
     void enterPressed();
 
 public slots:
-    void databaseChanged(DatabaseWidget* dbWidget);
+    void databaseChanged(DatabaseWidget* dbWidget = 0);
 
 private slots:
     void startSearchTimer();


### PR DESCRIPTION
## Description
When databases are locked, end search mode if it was activated and clear the visible input field for search term.

The `DatabaseWidget::endSearch()` call on `DatabaseWidget::lock()` clears the search term from memory regardless if search mode was active or not.

Adding a default argument for `SearchWidget::databaseChanged()` allows using the existing method for lock signaling.

## Motivation and context
A user on IRC pointed out that the search field is not cleared when locking databases and it could be perceived as unintentional information leak.

@TheZ3ro said the maintainers are considering this but no issue was ever opened.

## How has this been tested?
Locking/unlocking databases multiple databases, switching databases.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
