### PR TITLE
Add copy button to password generator (#595)

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -24,6 +24,7 @@
 #include "core/Config.h"
 #include "core/PasswordGenerator.h"
 #include "core/FilePath.h"
+#include "gui/Clipboard.h"
 
 PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     : QWidget(parent)
@@ -40,6 +41,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updatePasswordStrength(QString)));
     connect(m_ui->togglePasswordButton, SIGNAL(toggled(bool)), SLOT(togglePasswordShown(bool)));
     connect(m_ui->buttonApply, SIGNAL(clicked()), SLOT(applyPassword()));
+    connect(m_ui->buttonCopy, SIGNAL(clicked()), SLOT(copyPassword()));
     connect(m_ui->buttonGenerate, SIGNAL(clicked()), SLOT(regeneratePassword()));
 
     connect(m_ui->sliderLength, SIGNAL(valueChanged(int)), SLOT(passwordSliderMoved()));
@@ -191,6 +193,11 @@ void PasswordGeneratorWidget::applyPassword()
     saveSettings();
     emit appliedPassword(m_ui->editNewPassword->text());
     emit dialogTerminated();
+}
+
+void PasswordGeneratorWidget::copyPassword()
+{
+    clipboard()->setText(m_ui->editNewPassword->text());
 }
 
 void PasswordGeneratorWidget::passwordSliderMoved()

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -57,6 +57,7 @@ signals:
 
 private slots:
     void applyPassword();
+    void copyPassword();
     void updateApplyEnabled(const QString& password);
     void updatePasswordStrength(const QString& password);
     void togglePasswordShown(bool hidden);

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -613,6 +613,13 @@ QProgressBar::chunk {
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="buttonCopy">
+         <property name="text">
+          <string>Copy</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="buttonApply">
          <property name="enabled">
           <bool>false</bool>


### PR DESCRIPTION
## Description
Add copy button to password generator. Uses the standard KeePassXC clipboard functionality so it is also cleared after a timeout if configured to do so.

## Motivation and context
Issue #595

## How has this been tested?
Copied password from the generator directly and while editing an entry. Clipboard was also cleared after my configured timeout.

## Screenshots (if appropriate):

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
