### PR TITLE
:bug: Fix building with Qt 5.9 (closes #528)

### DIFF
--- a/tests/modeltest.cpp
+++ b/tests/modeltest.cpp
@@ -448,7 +448,8 @@ void ModelTest::data()
     QVariant textAlignmentVariant = model->data ( model->index ( 0, 0 ), Qt::TextAlignmentRole );
     if ( textAlignmentVariant.isValid() ) {
         int alignment = textAlignmentVariant.toInt();
-        QCOMPARE( alignment, ( alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask ) ) );
+        QCOMPARE( alignment, static_cast<int>( alignment & ( Qt::AlignHorizontal_Mask
+                                                           | Qt::AlignVertical_Mask ) ) );
     }
 
     // General Purpose roles that should return a QColor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Qt's QCOMPARE() is never well-defined. In some Qt versions it requires RHS and LHS to have exactly the same type while some versions just ask for comparable types. In Qt 5.9, there's a new breakage here.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Homebrew has updated to Qt 5.9 (https://github.com/Homebrew/homebrew-core/pull/14109). Arch Linux is on the way (https://www.archlinux.org/todo/qt-59-rebuild/). Fixing this simplifies packaging.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Building KeepassXC with the following command on macOS:
```
$ cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_BUILD_TYPE=Debug -DWITH_GUI_TESTS=ON -DWITH_DEV_BUILD=ON -DWITH_XC_AUTOTYPE=ON -DWITH_XC_HTTP=ON -DWITH_XC_YUBIKEY=ON -DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake -DWITH_APP_BUNDLE=OFF ..
```
And then run ```make test```

* Smoke tests: open my database, use KeepassHTTP to automatically enter a password, and get a TOTP token.

## Screenshots (if appropriate):
Looks just the same as previous Qt versions :)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
-  New feature (non-breaking change which adds functionality)
-  Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- All new and existing tests passed. **[REQUIRED]**
There's an intermittent failure in TestGui. I believe it's not caused by this PR - will create a new issue for that.
- I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
Not applicable on non-Linux
- My change requires a change to the documentation and I have updated it accordingly.
- I have added tests to cover my changes.