### PR TITLE
Fix password generator button's enable behavior

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -37,7 +37,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
 
     m_ui->togglePasswordButton->setIcon(filePath()->onOffIcon("actions", "password-show"));
 
-    connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updateApplyEnabled(QString)));
+    connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updateButtonsEnabled(QString)));
     connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updatePasswordStrength(QString)));
     connect(m_ui->togglePasswordButton, SIGNAL(toggled(bool)), SLOT(togglePasswordShown(bool)));
     connect(m_ui->buttonApply, SIGNAL(clicked()), SLOT(applyPassword()));
@@ -139,6 +139,7 @@ void PasswordGeneratorWidget::reset()
 
 void PasswordGeneratorWidget::setStandaloneMode(bool standalone)
 {
+    m_standalone = standalone;
     if (standalone) {
         m_ui->buttonApply->setText(tr("Close"));
         togglePasswordShown(true);
@@ -164,9 +165,12 @@ void PasswordGeneratorWidget::regeneratePassword()
     }
 }
 
-void PasswordGeneratorWidget::updateApplyEnabled(const QString& password)
+void PasswordGeneratorWidget::updateButtonsEnabled(const QString& password)
 {
-    m_ui->buttonApply->setEnabled(!password.isEmpty());
+    if (!m_standalone) {
+        m_ui->buttonApply->setEnabled(!password.isEmpty());
+    }
+    m_ui->buttonCopy->setEnabled(!password.isEmpty());
 }
 
 void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -58,7 +58,7 @@ signals:
 private slots:
     void applyPassword();
     void copyPassword();
-    void updateApplyEnabled(const QString& password);
+    void updateButtonsEnabled(const QString& password);
     void updatePasswordStrength(const QString& password);
     void togglePasswordShown(bool hidden);
 
@@ -72,6 +72,7 @@ private slots:
 
 private:
     bool m_updatingSpinBox;
+    bool m_standalone = false;
 
     PasswordGenerator::CharClasses charClasses();
     PasswordGenerator::GeneratorFlags generatorFlags();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
In the password generator:
If the password field is empty, disable the Copy button and the Apply button. 
The Close button should instead be always enabled 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
