### PR TITLE
Add "Apply" button to entry and group edit windows

### DIFF
--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -105,7 +105,7 @@ void EditWidget::setReadOnly(bool readOnly)
     else {
         m_ui->buttonBox->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Apply);
         // Find and connect the apply button
-        QPushButton *applyButton = m_ui->buttonBox->button(QDialogButtonBox::Apply);
+        QPushButton* applyButton = m_ui->buttonBox->button(QDialogButtonBox::Apply);
         connect(applyButton, SIGNAL(clicked()), SIGNAL(apply()));
     }
 }

--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -18,6 +18,7 @@
 #include "EditWidget.h"
 #include "ui_EditWidget.h"
 #include <QScrollArea>
+#include <QPushButton>
 
 #include "core/FilePath.h"
 
@@ -102,7 +103,10 @@ void EditWidget::setReadOnly(bool readOnly)
         m_ui->buttonBox->setStandardButtons(QDialogButtonBox::Close);
     }
     else {
-        m_ui->buttonBox->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+        m_ui->buttonBox->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Apply);
+        // Find and connect the apply button
+        QPushButton *applyButton = m_ui->buttonBox->button(QDialogButtonBox::Apply);
+        connect(applyButton, SIGNAL(clicked()), SIGNAL(apply()));
     }
 }
 

--- a/src/gui/EditWidget.h
+++ b/src/gui/EditWidget.h
@@ -48,6 +48,7 @@ public:
     bool readOnly() const;
 
 signals:
+    void apply();
     void accepted();
     void rejected();
 

--- a/src/gui/EditWidget.ui
+++ b/src/gui/EditWidget.ui
@@ -66,7 +66,7 @@
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -75,8 +75,9 @@ EditEntryWidget::EditEntryWidget(QWidget* parent)
     setupProperties();
     setupHistory();
 
-    connect(this, SIGNAL(accepted()), SLOT(saveEntry()));
+    connect(this, SIGNAL(accepted()), SLOT(acceptEntry()));
     connect(this, SIGNAL(rejected()), SLOT(cancel()));
+    connect(this, SIGNAL(apply()), SLOT(saveEntry()));
     connect(m_iconsWidget, SIGNAL(messageEditEntry(QString, MessageWidget::MessageType)), SLOT(showMessage(QString, MessageWidget::MessageType)));
     connect(m_iconsWidget, SIGNAL(messageEditEntryDismiss()), SLOT(hideMessage()));
     
@@ -439,9 +440,12 @@ void EditEntryWidget::saveEntry()
     if (!m_create) {
         m_entry->endUpdate();
     }
+}
 
+void EditEntryWidget::acceptEntry()
+{
+    saveEntry();
     clear();
-
     emit editFinished(true);
 }
 

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -68,6 +68,7 @@ signals:
     void historyEntryActivated(Entry* entry);
 
 private slots:
+    void acceptEntry();
     void saveEntry();
     void cancel();
     void togglePasswordGeneratorButton(bool checked);

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -42,6 +42,7 @@ EditGroupWidget::EditGroupWidget(QWidget* parent)
     connect(m_mainUi->autoTypeSequenceCustomRadio, SIGNAL(toggled(bool)),
             m_mainUi->autoTypeSequenceCustomEdit, SLOT(setEnabled(bool)));
 
+    connect(this, SIGNAL(apply()), SLOT(apply()));
     connect(this, SIGNAL(accepted()), SLOT(save()));
     connect(this, SIGNAL(rejected()), SLOT(cancel()));
 
@@ -102,6 +103,13 @@ void EditGroupWidget::loadGroup(Group* group, bool create, Database* database)
 
 void EditGroupWidget::save()
 {
+    apply();
+    clear();
+    emit editFinished(true);
+}
+
+void EditGroupWidget::apply()
+{
     m_group->setName(m_mainUi->editName->text());
     m_group->setNotes(m_mainUi->editNotes->toPlainText());
     m_group->setExpires(m_mainUi->expireCheck->isChecked());
@@ -128,9 +136,6 @@ void EditGroupWidget::save()
     else {
         m_group->setIcon(iconStruct.uuid);
     }
-
-    clear();
-    emit editFinished(true);
 }
 
 void EditGroupWidget::cancel()

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -49,6 +49,7 @@ signals:
     void messageEditEntryDismiss();
 
 private slots:
+    void apply();
     void save();
     void cancel();
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -230,6 +230,7 @@ void TestGui::testEditEntry()
     // Select the first entry in the database
     EntryView* entryView = m_dbWidget->findChild<EntryView*>("entryView");
     QModelIndex entryItem = entryView->model()->index(0, 1);
+    Entry* entry = entryView->entryFromIndex(entryItem);
     clickIndex(entryItem, entryView, Qt::LeftButton);
 
     // Confirm the edit action button is enabled
@@ -246,6 +247,13 @@ void TestGui::testEditEntry()
     QLineEdit* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
     QTest::keyClicks(titleEdit, "_test");
 
+    // Apply the edit
+    QDialogButtonBox* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Apply), Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(entry->title(), QString("Sample Entry_test"));
+    QCOMPARE(entry->historyItems().size(), 1);
+
     // Test protected attributes
     editEntryWidget->setCurrentPage(1);
     QPlainTextEdit* attrTextEdit = editEntryWidget->findChild<QPlainTextEdit*>("attributesEdit");
@@ -259,15 +267,13 @@ void TestGui::testEditEntry()
     QCOMPARE(attrTextEdit->toPlainText(), attrText);
     editEntryWidget->setCurrentPage(0);
 
-    // Save the edit
-    QDialogButtonBox* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
+    // Save the edit (press OK)
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
 
     // Confirm edit was made
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
-    Entry* entry = entryView->entryFromIndex(entryItem);
     QCOMPARE(entry->title(), QString("Sample Entry_test"));
-    QCOMPARE(entry->historyItems().size(), 1);
+    QCOMPARE(entry->historyItems().size(), 2);
 
     // Confirm modified indicator is showing
     QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QString("%1*").arg(m_dbFileName));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Add's an "Apply" buttons to both the entry and group edit windows. Implements #509.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Often times you want to save your changes without exiting the edit windows.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with updated GUI tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
