### PR TITLE
Fix macOS file dialog localization

### DIFF
--- a/share/macosx/Info.plist.cmake
+++ b/share/macosx/Info.plist.cmake
@@ -4,6 +4,8 @@
 <dict>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
+  <key>CFBundleAllowMixedLocalizations</key>
+  <true/>
   <key>CFBundleDevelopmentRegion</key>
   <string>English</string>
   <key>CFBundleDisplayName</key>
@@ -27,7 +29,7 @@
   <key>CFBundleVersion</key>
   <string>${KEEPASSXC_VERSION_NUM}</string>
   <key>NSHumanReadableCopyright</key>
-    <string>Copyright 2016 KeePassXC Development Team</string>
+    <string>Copyright 2016-2017 KeePassXC Development Team</string>
     <key>CFBundleDocumentTypes</key>
     <array>
       <dict>


### PR DESCRIPTION
## Description
Add the `CFBundleAllowMixedLocalizations` key to the embedded Info.plist to allow Cocoa to localize its strings in the open and save file dialogs.

closes #554 

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**