### PR TITLE
Adding saveToFile function to Database.

### DIFF
--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -22,12 +22,10 @@
 #include <QApplication>
 #include <QCommandLineParser>
 #include <QCoreApplication>
-#include <QSaveFile>
 #include <QStringList>
 #include <QTextStream>
 
 #include "core/Database.h"
-#include "format/KeePass2Writer.h"
 #include "gui/UnlockDatabaseDialog.h"
 
 int Merge::execute(int argc, char** argv)
@@ -95,26 +93,13 @@ int Merge::execute(int argc, char** argv)
     }
 
     db1->merge(db2);
-
-    QSaveFile saveFile(args.at(0));
-    if (!saveFile.open(QIODevice::WriteOnly)) {
-        qCritical("Unable to open file %s for writing.", qPrintable(args.at(0)));
-        return EXIT_FAILURE;
-    }
-
-    KeePass2Writer writer;
-    writer.writeDatabase(&saveFile, db1);
-
-    if (writer.hasError()) {
-        qCritical("Error while updating the database:\n%s\n", qPrintable(writer.errorString()));
-        return EXIT_FAILURE;
-    }
-
-    if (!saveFile.commit()) {
-        qCritical("Error while updating the database:\n%s\n", qPrintable(writer.errorString()));
+    QString errorMessage = db1->saveToFile(args.at(0));
+    if (!errorMessage.isEmpty()) {
+        qCritical("Unable to save database to file : %s", qPrintable(errorMessage));
         return EXIT_FAILURE;
     }
 
     out << "Successfully merged the database files.\n";
     return EXIT_SUCCESS;
+
 }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -224,14 +224,12 @@ bool Database::setTransformRounds(quint64 rounds)
     return true;
 }
 
-bool Database::setKey(const CompositeKey& key, const QByteArray& transformSeed,
-                      bool updateChangedTime)
+bool Database::setKey(const CompositeKey& key, const QByteArray& transformSeed, bool updateChangedTime)
 {
     bool ok;
     QString errorString;
 
-    QByteArray transformedMasterKey =
-            key.transform(transformSeed, transformRounds(), &ok, &errorString);
+    QByteArray transformedMasterKey = key.transform(transformSeed, transformRounds(), &ok, &errorString);
     if (!ok) {
         return false;
     }
@@ -293,23 +291,21 @@ void Database::recycleEntry(Entry* entry)
             createRecycleBin();
         }
         entry->setGroup(metadata()->recycleBin());
-    }
-    else {
+    } else {
         delete entry;
     }
 }
 
 void Database::recycleGroup(Group* group)
 {
-     if (m_metadata->recycleBinEnabled()) {
+    if (m_metadata->recycleBinEnabled()) {
         if (!m_metadata->recycleBin()) {
             createRecycleBin();
         }
         group->setParent(metadata()->recycleBin());
-    }
-    else {
+    } else {
         delete group;
-     }
+    }
 }
 
 void Database::emptyRecycleBin()
@@ -398,7 +394,6 @@ Database* Database::openDatabaseFile(QString fileName, CompositeKey key)
     }
 
     return db;
-
 }
 
 Database* Database::unlockFromStdin(QString databaseFilename)
@@ -412,7 +407,6 @@ Database* Database::unlockFromStdin(QString databaseFilename)
     QString line = inputTextStream.readLine();
     CompositeKey key = CompositeKey::readFromLine(line);
     return Database::openDatabaseFile(databaseFilename, key);
-
 }
 
 QString Database::saveToFile(QString filePath)
@@ -437,5 +431,4 @@ QString Database::saveToFile(QString filePath)
     } else {
         return saveFile.errorString();
     }
-
 }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -19,6 +19,7 @@
 #include "Database.h"
 
 #include <QFile>
+#include <QSaveFile>
 #include <QTextStream>
 #include <QTimer>
 #include <QXmlStreamReader>
@@ -28,6 +29,7 @@
 #include "crypto/Random.h"
 #include "format/KeePass2.h"
 #include "format/KeePass2Reader.h"
+#include "format/KeePass2Writer.h"
 
 QHash<Uuid, Database*> Database::m_uuidMap;
 
@@ -410,5 +412,30 @@ Database* Database::unlockFromStdin(QString databaseFilename)
     QString line = inputTextStream.readLine();
     CompositeKey key = CompositeKey::readFromLine(line);
     return Database::openDatabaseFile(databaseFilename, key);
+
+}
+
+QString Database::saveToFile(QString filePath)
+{
+    KeePass2Writer writer;
+    QSaveFile saveFile(filePath);
+    if (saveFile.open(QIODevice::WriteOnly)) {
+
+        // write the database to the file
+        writer.writeDatabase(&saveFile, this);
+
+        if (writer.hasError()) {
+            return writer.errorString();
+        }
+
+        if (saveFile.commit()) {
+            // successfully saved database file
+            return QString();
+        } else {
+            return saveFile.errorString();
+        }
+    } else {
+        return saveFile.errorString();
+    }
 
 }

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -113,6 +113,7 @@ public:
     void setEmitModified(bool value);
     void copyAttributesFrom(const Database* other);
     void merge(const Database* other);
+    QString saveToFile(QString filePath);
 
     /**
      * Returns a unique id that is only valid as long as the Database exists.

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -22,7 +22,6 @@
 #include <QHash>
 #include <QTabWidget>
 
-#include "format/KeePass2Writer.h"
 #include "gui/DatabaseWidget.h"
 #include "gui/MessageWidget.h"
 
@@ -118,7 +117,6 @@ private:
     void updateLastDatabases(const QString& filename);
     void connectDatabase(Database* newDb, Database* oldDb = nullptr);
 
-    KeePass2Writer m_writer;
     QHash<Database*, DatabaseManagerStruct> m_dbList;
     DatabaseWidgetStateSync* m_dbWidgetStateSync;
 };

--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -23,6 +23,7 @@
 #include <QFileInfo>
 #include <QSpacerItem>
 
+#include "format/KeePass2Writer.h"
 #include "gui/MessageBox.h"
 #include "gui/MessageWidget.h"
 

--- a/src/gui/csvImport/CsvImportWidget.h
+++ b/src/gui/csvImport/CsvImportWidget.h
@@ -28,7 +28,6 @@
 #include <QStackedWidget>
 
 #include "core/Metadata.h"
-#include "format/KeePass2Writer.h"
 #include "gui/csvImport/CsvParserModel.h"
 #include "keys/PasswordKey.h"
 
@@ -42,7 +41,7 @@ class CsvImportWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit CsvImportWidget(QWidget *parent = nullptr);
+    explicit CsvImportWidget(QWidget* parent = nullptr);
     ~CsvImportWidget();
     void load(const QString& filename, Database* const db);
 
@@ -65,9 +64,8 @@ private:
     QStringListModel* const m_comboModel;
     QSignalMapper* m_comboMapper;
     QList<QComboBox*> m_combos;
-    Database *m_db;
+    Database* m_db;
 
-    KeePass2Writer m_writer;
     static const QStringList m_columnHeader;
     void configParser();
     void updateTableview();


### PR DESCRIPTION
This adds a `saveToFile` function to the `Database` class, allowing for a better encapsulation of the saving code. The main reason I do this is that this code will be reused in the future CLI commands that will need to write the database to file (it's already the case in the `Merge` command, so I made the switch).

## How has this been tested?
* Unit tests
* Tested the merge command, with and without a writing error. The writing error was produced by removing the writing permission on the file for the current user. The error message is still correctly displayed.
* Tested saving the file through the UI also, with the same error as above.

Note that the auto reloading is disabled for the whole `saveToFile`, instead of just during the actual writing to disk. I don't think this has much of an impact, but if you have any concerns, please raise a flag.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Refactoring

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
