### PR TITLE
Add support for portable config settings

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -60,39 +60,43 @@ Config::Config(const QString& fileName, QObject* parent)
 Config::Config(QObject* parent)
     : QObject(parent)
 {
-    QString userPath;
-    QString homePath = QDir::homePath();
+    // Check if portable config is present. If not, find it in user's directory
+    QString portablePath = QDir::currentPath() + "/keepassxc.ini";
+    if (QFile::exists(portablePath)) {
+        init(portablePath);
+    } else {
+        QString userPath;
+        QString homePath = QDir::homePath();
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-    // we can't use QStandardPaths on X11 as it uses XDG_DATA_HOME instead of XDG_CONFIG_HOME
-    QByteArray env = qgetenv("XDG_CONFIG_HOME");
-    if (env.isEmpty()) {
-        userPath = homePath;
-        userPath += "/.config";
+    #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+        // we can't use QStandardPaths on X11 as it uses XDG_DATA_HOME instead of XDG_CONFIG_HOME
+        QByteArray env = qgetenv("XDG_CONFIG_HOME");
+        if (env.isEmpty()) {
+            userPath = homePath;
+            userPath += "/.config";
+        } else if (env[0] == '/') {
+            userPath = QFile::decodeName(env);
+        } else {
+            userPath = homePath;
+            userPath += '/';
+            userPath += QFile::decodeName(env);
+        }
+
+        userPath += "/keepassxc/";
+    #else
+        userPath = QDir::fromNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
+        // storageLocation() appends the application name ("/keepassxc") to the end
+        userPath += "/";
+    #endif
+
+    #ifdef QT_DEBUG
+        userPath += "keepassxc_debug.ini";
+    #else
+        userPath += "keepassxc.ini";
+    #endif
+
+        init(userPath);
     }
-    else if (env[0] == '/') {
-        userPath = QFile::decodeName(env);
-    }
-    else {
-        userPath = homePath;
-        userPath += '/';
-        userPath += QFile::decodeName(env);
-    }
-
-    userPath += "/keepassxc/";
-#else
-    userPath = QDir::fromNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
-    // storageLocation() appends the application name ("/keepassxc") to the end
-    userPath += "/";
-#endif
-
-#ifdef QT_DEBUG
-    userPath += "keepassxc_debug.ini";
-#else
-    userPath += "keepassxc.ini";
-#endif
-
-    init(userPath);
 }
 
 Config::~Config()

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -61,7 +61,7 @@ Config::Config(QObject* parent)
     : QObject(parent)
 {
     // Check if portable config is present. If not, find it in user's directory
-    QString portablePath = QDir::currentPath() + "/keepassxc.ini";
+    QString portablePath = QCoreApplication::applicationDirPath() + "/keepassxc.ini";
     if (QFile::exists(portablePath)) {
         init(portablePath);
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Implements #231. Config class checks for presence of keepassxc.ini in the run directory prior to checking the user's folder. If no ini file was found, the app proceeds as before with the user's stored config.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When deploying keepassxc as a portable app (.zip or .tar.gz) we will pre-package a keepassxc.ini config such that one is never created in the user's directory on first run. All other distribution methods will use the original behavior prior to this PR.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
