### PR TITLE
Fix CLI help and version options.

### DIFF
--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv)
         if (parser.isSet("version")) {
             parser.showVersion();
         }
-        parser.showHelp(EXIT_FAILURE);
+        parser.showHelp();
     }
 
     QString commandName = parser.positionalArguments().at(0);

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -67,8 +67,8 @@ int main(int argc, char** argv)
 
     parser.addHelpOption();
     parser.addVersionOption();
-    // TODO : use process once the setOptionsAfterPositionalArgumentsMode (Qt 5.6)
-    // is available. Until then, options passed to sub-commands won't be
+    // TODO : use the setOptionsAfterPositionalArgumentsMode (Qt 5.6) function
+    // when available. Until then, options passed to sub-commands won't be
     // recognized by this parser.
     parser.parse(arguments);
 
@@ -83,29 +83,37 @@ int main(int argc, char** argv)
 
     QString commandName = parser.positionalArguments().at(0);
 
-
-    // Removing the first cli argument before dispatching.
-    ++argv;
-    --argc;
-
     int exitCode = EXIT_FAILURE;
 
     if (commandName == "clip") {
+        // Removing the first cli argument before dispatching.
+        ++argv;
+        --argc;
         argv[0] = const_cast<char*>("keepassxc-cli clip");
         exitCode = Clip::execute(argc, argv);
     } else if (commandName == "entropy-meter") {
+        ++argv;
+        --argc;
         argv[0] = const_cast<char*>("keepassxc-cli entropy-meter");
         exitCode = EntropyMeter::execute(argc, argv);
     } else if (commandName == "extract") {
+        ++argv;
+        --argc;
         argv[0] = const_cast<char*>("keepassxc-cli extract");
         exitCode = Extract::execute(argc, argv);
     } else if (commandName == "list") {
+        ++argv;
+        --argc;
         argv[0] = const_cast<char*>("keepassxc-cli list");
         exitCode = List::execute(argc, argv);
     } else if (commandName == "merge") {
+        ++argv;
+        --argc;
         argv[0] = const_cast<char*>("keepassxc-cli merge");
         exitCode = Merge::execute(argc, argv);
     } else if (commandName == "show") {
+        ++argv;
+        --argc;
         argv[0] = const_cast<char*>("keepassxc-cli show");
         exitCode = Show::execute(argc, argv);
     } else {

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -47,6 +47,10 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    QStringList arguments;
+    for (int i = 0; i < argc; ++i) {
+        arguments << QString(argv[i]);
+    }
     QCommandLineParser parser;
 
     QString description("KeePassXC command line interface.");
@@ -63,10 +67,6 @@ int main(int argc, char** argv)
 
     parser.addHelpOption();
     parser.addVersionOption();
-    QStringList arguments;
-    for (int i = 0; i < argc; ++i) {
-        arguments << QString(argv[i]);
-    }
     // TODO : use process once the setOptionsAfterPositionalArgumentsMode (Qt 5.6)
     // is available. Until then, options passed to sub-commands won't be
     // recognized by this parser.

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -20,6 +20,7 @@
 #include <QCommandLineParser>
 #include <QCoreApplication>
 #include <QStringList>
+#include <QTextStream>
 
 #include <cli/Clip.h>
 #include <cli/EntropyMeter.h>
@@ -76,7 +77,11 @@ int main(int argc, char** argv)
         QCoreApplication app(argc, argv);
         app.setApplicationVersion(KEEPASSX_VERSION);
         if (parser.isSet("version")) {
-            parser.showVersion();
+            // Switch to parser.showVersion() when available (QT 5.4).
+            QTextStream out(stdout);
+            out << KEEPASSX_VERSION << "\n";
+            out.flush();
+            return EXIT_SUCCESS;
         }
         parser.showHelp();
     }

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -63,19 +63,26 @@ int main(int argc, char** argv)
 
     parser.addHelpOption();
     parser.addVersionOption();
+    QStringList arguments;
+    for (int i = 0; i < argc; ++i) {
+        arguments << QString(argv[i]);
+    }
     // TODO : use process once the setOptionsAfterPositionalArgumentsMode (Qt 5.6)
     // is available. Until then, options passed to sub-commands won't be
     // recognized by this parser.
-    // parser.process(app);
+    parser.parse(arguments);
 
-    if (argc < 2) {
+    if (parser.positionalArguments().size() < 1) {
         QCoreApplication app(argc, argv);
         app.setApplicationVersion(KEEPASSX_VERSION);
-        parser.showHelp();
-        return EXIT_FAILURE;
+        if (parser.isSet("version")) {
+            parser.showVersion();
+        }
+        parser.showHelp(EXIT_FAILURE);
     }
 
-    QString commandName = argv[1];
+    QString commandName = parser.positionalArguments().at(0);
+
 
     // Removing the first cli argument before dispatching.
     ++argv;
@@ -105,8 +112,9 @@ int main(int argc, char** argv)
         qCritical("Invalid command %s.", qPrintable(commandName));
         QCoreApplication app(argc, argv);
         app.setApplicationVersion(KEEPASSX_VERSION);
-        parser.showHelp();
-        exitCode = EXIT_FAILURE;
+        // showHelp exits the application immediately, so we need to set the
+        // exit code here.
+        parser.showHelp(EXIT_FAILURE);
     }
 
 #if defined(WITH_ASAN) && defined(WITH_LSAN)


### PR DESCRIPTION
## Description

Fixes #649 

As mentioned in the issue, the `showHelp` exits the application right after printing the help message. I wasn't aware of that before, and thought using the `exitCode` was fine.

Also, the `argv` is only modified once the `commandName` is known to be valid, otherwise the invalid command message will display an incorrect application name.

I'd like at some point to convert the `argv` to a `QStringList` once, and then only use a `QStringList` in the different commands, but for some reason there's no way to instantiate a `QApplication` without passing the `argv` and `argc` (unless maybe we hardcode some values for it).


## How has this been tested?

```
$ ./src/cli/keepassxc-cli
Usage: ./src/cli/keepassxc-cli [options] command
KeePassXC command line interface.

Available commands:
  clip		Copy a password to the clipboard.
  extract	Extract and print the content of a database.
  entropy-meter	Calculate password entropy.
  list		List database entries.
  merge		Merge two databases.
  show		Show a password.

Options:
  -h, --help     Displays this help.
  -v, --version  Displays version information.

Arguments:
  command        Name of the command to execute.
$ echo $?
0
$ ./src/cli/keepassxc-cli --help
Usage: ./src/cli/keepassxc-cli [options] command
KeePassXC command line interface.

Available commands:
  clip		Copy a password to the clipboard.
  extract	Extract and print the content of a database.
  entropy-meter	Calculate password entropy.
  list		List database entries.
  merge		Merge two databases.
  show		Show a password.

Options:
  -h, --help     Displays this help.
  -v, --version  Displays version information.

Arguments:
  command        Name of the command to execute.
$ echo $?
0
$ ./src/cli/keepassxc-cli --version
keepassxc-cli 2.1.4
$ echo $?
0
$ ./src/cli/keepassxc-cli not_a_command
Invalid command not_a_command.
Usage: ./src/cli/keepassxc-cli [options] command
KeePassXC command line interface.

Available commands:
  clip		Copy a password to the clipboard.
  extract	Extract and print the content of a database.
  entropy-meter	Calculate password entropy.
  list		List database entries.
  merge		Merge two databases.
  show		Show a password.

Options:
  -h, --help     Displays this help.
  -v, --version  Displays version information.

Arguments:
  command        Name of the command to execute.
$ echo $?
1

```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
