### PR TITLE
Add option to limit search to current group

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -114,6 +114,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("AutoReloadOnChange", true);
     m_defaults.insert("AutoSaveOnExit", false);
     m_defaults.insert("ShowToolbar", true);
+    m_defaults.insert("SearchLimitGroup", false);
     m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("UseGroupIconOnEntryCreation", false);
     m_defaults.insert("AutoTypeEntryTitleMatch", true);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -186,6 +186,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     m_ignoreAutoReload = false;
 
     m_searchCaseSensitive = false;
+    m_searchLimitGroup = config()->get("SearchLimitGroup", false).toBool();
 
     setCurrentWidget(m_mainWidget);
 }
@@ -963,7 +964,9 @@ void DatabaseWidget::search(const QString& searchtext)
 
     Qt::CaseSensitivity caseSensitive = m_searchCaseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive;
 
-    QList<Entry*> searchResult = EntrySearcher().search(searchtext, currentGroup(), caseSensitive);
+    Group* searchGroup = m_searchLimitGroup ? currentGroup() : m_db->rootGroup();
+
+    QList<Entry*> searchResult = EntrySearcher().search(searchtext, searchGroup, caseSensitive);
 
     m_entryView->setEntryList(searchResult);
     m_lastSearchText = searchtext;
@@ -984,6 +987,12 @@ void DatabaseWidget::search(const QString& searchtext)
 void DatabaseWidget::setSearchCaseSensitive(bool state)
 {
     m_searchCaseSensitive = state;
+    refreshSearch();
+}
+
+void DatabaseWidget::setSearchLimitGroup(bool state)
+{
+    m_searchLimitGroup = state;
     refreshSearch();
 }
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -163,6 +163,7 @@ public slots:
     // Search related slots
     void search(const QString& searchtext);
     void setSearchCaseSensitive(bool state);
+    void setSearchLimitGroup(bool state);
     void endSearch();
 
     void showMessage(const QString& text, MessageWidget::MessageType type);
@@ -221,6 +222,7 @@ private:
     // Search state
     QString m_lastSearchText;
     bool m_searchCaseSensitive;
+    bool m_searchLimitGroup;
 
     // Autoreload
     QFileSystemWatcher m_fileWatcher;

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -24,6 +24,7 @@
 #include <QShortcut>
 #include <QToolButton>
 
+#include "core/Config.h"
 #include "core/FilePath.h"
 
 SearchWidget::SearchWidget(QWidget* parent)
@@ -49,6 +50,11 @@ SearchWidget::SearchWidget(QWidget* parent)
     m_actionCaseSensitive = searchMenu->addAction(tr("Case Sensitive"), this, SLOT(updateCaseSensitive()));
     m_actionCaseSensitive->setObjectName("actionSearchCaseSensitive");
     m_actionCaseSensitive->setCheckable(true);
+
+    m_actionLimitGroup = searchMenu->addAction(tr("Limit search to selected group"), this, SLOT(updateLimitGroup()));
+    m_actionLimitGroup->setObjectName("actionSearchLimitGroup");
+    m_actionLimitGroup->setCheckable(true);
+    m_actionLimitGroup->setChecked(config()->get("SearchLimitGroup", false).toBool());
 
     m_ui->searchIcon->setIcon(filePath()->icon("actions", "system-search"));
     m_ui->searchIcon->setMenu(searchMenu);
@@ -102,6 +108,7 @@ void SearchWidget::connectSignals(SignalMultiplexer& mx)
 {
     mx.connect(this, SIGNAL(search(QString)), SLOT(search(QString)));
     mx.connect(this, SIGNAL(caseSensitiveChanged(bool)), SLOT(setSearchCaseSensitive(bool)));
+    mx.connect(this, SIGNAL(limitGroupChanged(bool)), SLOT(setSearchLimitGroup(bool)));
     mx.connect(this, SIGNAL(copyPressed()), SLOT(copyPassword()));
     mx.connect(this, SIGNAL(downPressed()), SLOT(setFocus()));
     mx.connect(m_ui->searchEdit, SIGNAL(returnPressed()), SLOT(switchToEntryEdit()));
@@ -115,6 +122,7 @@ void SearchWidget::databaseChanged(DatabaseWidget* dbWidget)
 
         // Enforce search policy
         emit caseSensitiveChanged(m_actionCaseSensitive->isChecked());
+        emit limitGroupChanged(m_actionLimitGroup->isChecked());
     } else {
         m_ui->searchEdit->clear();
     }
@@ -150,6 +158,19 @@ void SearchWidget::setCaseSensitive(bool state)
     m_actionCaseSensitive->setChecked(state);
     updateCaseSensitive();
 }
+
+void SearchWidget::updateLimitGroup()
+{
+    config()->set("SearchLimitGroup", m_actionLimitGroup->isChecked());
+    emit limitGroupChanged(m_actionLimitGroup->isChecked());
+}
+
+void SearchWidget::setLimitGroup(bool state)
+{
+    m_actionLimitGroup->setChecked(state);
+    updateLimitGroup();
+}
+
 
 void SearchWidget::searchFocus()
 {

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -39,6 +39,7 @@ public:
 
     void connectSignals(SignalMultiplexer& mx);
     void setCaseSensitive(bool state);
+    void setLimitGroup(bool state);
 
 protected:
     bool eventFilter(QObject* obj, QEvent* event);
@@ -46,6 +47,7 @@ protected:
 signals:
     void search(const QString& text);
     void caseSensitiveChanged(bool state);
+    void limitGroupChanged(bool state);
     void escapePressed();
     void copyPressed();
     void downPressed();
@@ -58,12 +60,14 @@ private slots:
     void startSearchTimer();
     void startSearch();
     void updateCaseSensitive();
+    void updateLimitGroup();
     void searchFocus();
 
 private:
     const QScopedPointer<Ui::SearchWidget> m_ui;
     QTimer* m_searchTimer;
     QAction* m_actionCaseSensitive;
+    QAction* m_actionLimitGroup;
 
     Q_DISABLE_COPY(SearchWidget)
 };

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -577,7 +577,12 @@ void TestGui::testSearch()
     QModelIndex rootGroupIndex = groupView->model()->index(0, 0);
     clickIndex(groupView->model()->index(0, 0, rootGroupIndex), groupView, Qt::LeftButton);
     QCOMPARE(groupView->currentGroup()->name(), QString("General"));
+    
+    searchWidget->setLimitGroup(false);
+    QTRY_COMPARE(entryView->model()->rowCount(), 2);
+    searchWidget->setLimitGroup(true);
     QTRY_COMPARE(entryView->model()->rowCount(), 0);
+
     // reset
     clickIndex(rootGroupIndex, groupView, Qt::LeftButton);
     QCOMPARE(groupView->currentGroup(), m_db->rootGroup());


### PR DESCRIPTION
## Description
Partially revert #16 and add an option at the search field icon to limit the search to the current group, as suggested by @TheZ3ro in this comment with alternative n. 4: https://github.com/keepassxreboot/keepassxc/issues/296#issuecomment-288720610

This option is remembered and defaults to allow global search.

Closes #296

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/107672/27353158-70d70a72-55d9-11e7-9b9c-eb9b95507c0b.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
