### PR TITLE
Disable stdin echo when entering passwords on cli

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,8 @@ set(keepassx_SOURCES
     core/Tools.cpp
     core/Translator.cpp
     core/Uuid.cpp
+    cli/PasswordInput.cpp
+    cli/PasswordInput.h
     crypto/Crypto.cpp
     crypto/CryptoHash.cpp
     crypto/Random.cpp

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -29,6 +29,7 @@
 #include "core/Database.h"
 #include "format/KeePass2Reader.h"
 #include "keys/CompositeKey.h"
+#include "cli/PasswordInput.h"
 
 int Extract::execute(int argc, char** argv)
 {
@@ -50,8 +51,7 @@ int Extract::execute(int argc, char** argv)
     out << "Insert the database password\n> ";
     out.flush();
 
-    static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
-    QString line = inputTextStream.readLine();
+    QString line = PasswordInput::getPassword();
     CompositeKey key = CompositeKey::readFromLine(line);
 
     QString databaseFilename = args.at(0);

--- a/src/cli/PasswordInput.cpp
+++ b/src/cli/PasswordInput.cpp
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PasswordInput.h"
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#else
+#include <termios.h>
+#include <unistd.h>
+#endif
+
+#include <QTextStream>
+
+
+PasswordInput::PasswordInput()
+{
+}
+
+void PasswordInput::setStdinEcho(bool enable = true)
+{
+#ifdef Q_OS_WIN
+    HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD mode;
+    GetConsoleMode(hIn, &mode);
+
+    if (enable) {
+        mode |= ENABLE_ECHO_INPUT;
+    } else {
+        mode &= ~ENABLE_ECHO_INPUT;
+    }
+
+    SetConsoleMode(hIn, mode);
+
+#else
+    struct termios t;
+    tcgetattr(STDIN_FILENO, &t);
+
+    if (enable) {
+        t.c_lflag |= ECHO;
+    } else {
+        t.c_lflag &= ~ECHO;
+    }
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &t);
+#endif
+}
+
+QString PasswordInput::getPassword()
+{
+    static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
+
+    setStdinEcho(false);
+    QString line = inputTextStream.readLine();
+    setStdinEcho(true);
+
+    return line;
+}

--- a/src/cli/PasswordInput.h
+++ b/src/cli/PasswordInput.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_PASSWORDINPUT_H
+#define KEEPASSXC_PASSWORDINPUT_H
+
+#include <QtCore/qglobal.h>
+
+class PasswordInput
+{
+public:
+    PasswordInput();
+    static void setStdinEcho(bool enable);
+    static QString getPassword();
+};
+
+#endif // KEEPASSXC_PASSWORDINPUT_H

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -29,6 +29,7 @@
 #include "core/Entry.h"
 #include "core/Group.h"
 #include "keys/CompositeKey.h"
+#include "cli/PasswordInput.h"
 
 int Show::execute(int argc, char** argv)
 {
@@ -50,8 +51,7 @@ int Show::execute(int argc, char** argv)
     out << "Insert the database password\n> ";
     out.flush();
 
-    static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
-    QString line = inputTextStream.readLine();
+    QString line = PasswordInput::getPassword();
     CompositeKey key = CompositeKey::readFromLine(line);
 
     Database* db = Database::openDatabaseFile(args.at(0), key);

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -24,6 +24,7 @@
 #include <QTimer>
 #include <QXmlStreamReader>
 
+#include "cli/PasswordInput.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "crypto/Random.h"
@@ -398,13 +399,12 @@ Database* Database::openDatabaseFile(QString fileName, CompositeKey key)
 
 Database* Database::unlockFromStdin(QString databaseFilename)
 {
-    static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
     QTextStream outputTextStream(stdout);
 
     outputTextStream << QString("Insert password to unlock " + databaseFilename + "\n> ");
     outputTextStream.flush();
 
-    QString line = inputTextStream.readLine();
+    QString line = PasswordInput::getPassword();
     CompositeKey key = CompositeKey::readFromLine(line);
     return Database::openDatabaseFile(databaseFilename, key);
 }


### PR DESCRIPTION
## Description
Disable echoing the `stdin` input back to `stdout` on cli password prompts to avoid leaving the password visible at the terminal buffer during and after the program execution.

## Motivation and context
https://github.com/keepassxreboot/keepassxc/pull/652#issuecomment-309787721

## How has this been tested?
Tested on macOS, Linux and Windows (with cmd.exe and Power Shell).

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
