### PR TITLE
Outputing newline after password prompt.

### DIFF
--- a/src/cli/PasswordInput.cpp
+++ b/src/cli/PasswordInput.cpp
@@ -63,10 +63,15 @@ void PasswordInput::setStdinEcho(bool enable = true)
 QString PasswordInput::getPassword()
 {
     static QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
+    static QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
 
     setStdinEcho(false);
     QString line = inputTextStream.readLine();
     setStdinEcho(true);
+
+    // The new line was also not echoed, but we do want to echo it.
+    outputTextStream << "\n";
+    outputTextStream.flush();
 
     return line;
 }


### PR DESCRIPTION
The next line would be displayed on the same line as the password prompt.

before
```
$ ./src/cli/keepassxc-cli list ~/test1.kdbx 
Insert password to unlock /Users/louib/test1.kdbx
> Group1/
  [empty]
Group2/
  Entry1
```

after
```
$ ./src/cli/keepassxc-cli list ~/test1.kdbx 
Insert password to unlock /Users/louib/test1.kdbx
> 
Group1/
  [empty]
Group2/
  Entry1
```

## How has this been tested?
- Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
