### PR TITLE
Bring unlock database dialog to the front

### DIFF
--- a/src/gui/UnlockDatabaseDialog.cpp
+++ b/src/gui/UnlockDatabaseDialog.cpp
@@ -26,6 +26,7 @@ UnlockDatabaseDialog::UnlockDatabaseDialog(QWidget* parent)
     : QDialog(parent)
     , m_view(new UnlockDatabaseWidget(this))
 {
+    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     connect(m_view, SIGNAL(editFinished(bool)), this, SLOT(complete(bool)));
 }
 


### PR DESCRIPTION
Closes #662 

## Description
Bring unlock database dialog to the foreground when trying use auto-type with a locked database.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**