### PR TITLE
Added proper plural processing in CSV importer (localization)

### DIFF
--- a/src/gui/csvImport/CsvParserModel.cpp
+++ b/src/gui/csvImport/CsvParserModel.cpp
@@ -31,9 +31,9 @@ void CsvParserModel::setFilename(const QString& filename) {
 }
 
 QString CsvParserModel::getFileInfo(){
-    QString a(QString::number(getFileSize()).append(tr(" byte, ")));
-    a.append(QString::number(getCsvRows())).append(tr(" rows, "));
-    a.append(QString::number(qMax(0, getCsvCols()-1))).append(tr(" columns"));
+    QString a(tr("%n byte(s), ", Q_NULLPTR, getFileSize()));
+    a.append(tr("%n row(s), ", Q_NULLPTR, getCsvRows()));
+    a.append(tr("%n column(s)", Q_NULLPTR, qMax(0, getCsvCols() - 1)));
     return a;
 }
 

--- a/src/gui/csvImport/CsvParserModel.cpp
+++ b/src/gui/csvImport/CsvParserModel.cpp
@@ -31,9 +31,9 @@ void CsvParserModel::setFilename(const QString& filename) {
 }
 
 QString CsvParserModel::getFileInfo(){
-    QString a(tr("%n byte(s), ", Q_NULLPTR, getFileSize()));
-    a.append(tr("%n row(s), ", Q_NULLPTR, getCsvRows()));
-    a.append(tr("%n column(s)", Q_NULLPTR, qMax(0, getCsvCols() - 1)));
+    QString a(tr("%n byte(s), ", nullptr, getFileSize()));
+    a.append(tr("%n row(s), ", nullptr, getCsvRows()));
+    a.append(tr("%n column(s)", nullptr, qMax(0, getCsvCols() - 1)));
     return a;
 }
 


### PR DESCRIPTION
## Description
During localization of the version 2.2.0 to Russian I've noticed that the file info published by the CSV Importer doesn't really follow the pluralization rules of Qt, described [here](http://doc.qt.io/qt-5/i18n-source-translation.html). Therefore even in English the info will not look good enough, for example it will say "1323 byte, 1 rows, 1 columns" instead of "1323 bytes, 1 row, 1 column".

## Motivation and context
This change just makes the stuff more human-friendly.

## How has this been tested?
Your standard tests.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
