### PR TITLE
detect system zxcvbn library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,12 +27,12 @@ if (NOT GIT_HEAD OR NOT GIT_DESCRIBE)
     set(GIT_DESCRIBE "")
 endif()
 
-find_library(ZXCVBN_FOUND zxcvbn)
-if(NOT ZXCVBN_FOUND)
+find_library(ZXCVBN_LIBRARIES zxcvbn)
+if(NOT ZXCVBN_LIBRARIES)
   add_library(zxcvbn STATIC zxcvbn/zxcvbn.cpp)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/zxcvbn)
-  set(ZXCVBN_FOUND zxcvbn)
-endif(NOT ZXCVBN_FOUND)
+  set(ZXCVBN_LIBRARIES zxcvbn)
+endif(NOT ZXCVBN_LIBRARIES)
 
 configure_file(version.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/version.h @ONLY)
 
@@ -222,7 +222,7 @@ target_link_libraries(keepassx_core
                       ${keepasshttp_LIB}
                       ${autotype_LIB}
                       ${YUBIKEY_LIBRARIES}
-                      ${ZXCVBN_FOUND}
+                      ${ZXCVBN_LIBRARIES}
                       Qt5::Core
                       Qt5::Network
                       Qt5::Concurrent

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,13 @@ if (NOT GIT_HEAD OR NOT GIT_DESCRIBE)
     set(GIT_DESCRIBE "")
 endif()
 
+find_library(ZXCVBN_FOUND zxcvbn)
+if(NOT ZXCVBN_FOUND)
+  add_library(zxcvbn STATIC zxcvbn/zxcvbn.cpp)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/zxcvbn)
+  set(ZXCVBN_FOUND zxcvbn)
+endif(NOT ZXCVBN_FOUND)
+
 configure_file(version.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/version.h @ONLY)
 
 set(keepassx_SOURCES
@@ -203,9 +210,6 @@ else()
   list(APPEND keepassx_SOURCES keys/drivers/YubiKeyStub.cpp)
 endif()
 
-add_library(zxcvbn STATIC zxcvbn/zxcvbn.cpp)
-target_link_libraries(zxcvbn)
-
 add_library(autotype STATIC ${autotype_SOURCES})
 target_link_libraries(autotype Qt5::Core Qt5::Widgets)
 
@@ -218,7 +222,7 @@ target_link_libraries(keepassx_core
                       ${keepasshttp_LIB}
                       ${autotype_LIB}
                       ${YUBIKEY_LIBRARIES}
-                      zxcvbn
+                      ${ZXCVBN_FOUND}
                       Qt5::Core
                       Qt5::Network
                       Qt5::Concurrent

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(keepassxc-cli
                       ${GCRYPT_LIBRARIES}
                       ${GPGERROR_LIBRARIES}
                       ${ZLIB_LIBRARIES}
-                      zxcvbn)
+                      ${ZXCVBN_FOUND})
 
 install(TARGETS keepassxc-cli
         BUNDLE DESTINATION . COMPONENT Runtime

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(keepassxc-cli
                       ${GCRYPT_LIBRARIES}
                       ${GPGERROR_LIBRARIES}
                       ${ZLIB_LIBRARIES}
-                      ${ZXCVBN_FOUND})
+                      ${ZXCVBN_LIBRARIES})
 
 install(TARGETS keepassxc-cli
         BUNDLE DESTINATION . COMPONENT Runtime

--- a/src/cli/EntropyMeter.cpp
+++ b/src/cli/EntropyMeter.cpp
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include "zxcvbn/zxcvbn.h"
+#include <zxcvbn.h>
 
 /* For pre-compiled headers under windows */
 #ifdef _WIN32

--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -19,7 +19,7 @@
 #include "PasswordGenerator.h"
 
 #include "crypto/Random.h"
-#include "zxcvbn/zxcvbn.h"
+#include <zxcvbn.h>
 
 PasswordGenerator::PasswordGenerator()
     : m_length(0)


### PR DESCRIPTION
detect a system version in case it is available.

this approach should be retro-compatible and safe for Debian builds
(we don't like embedded libraries).

maybe you could also update zxcvbn to get rid of that useless file like debian zxcvbn-c did