### PR TITLE
Implement configurable default auto-type delay (fixes #699)

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -317,7 +317,7 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
 {
     QString tmpl;
     bool inTmpl = false;
-    m_autoTypeDelay = 25;
+    m_autoTypeDelay = config()->get("AutoTypeDelay").toInt();
 
 
     for (const QChar& ch : sequence) {

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -317,7 +317,7 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
 {
     QString tmpl;
     bool inTmpl = false;
-    m_autoTypeDelay = 0;
+    m_autoTypeDelay = 25;
 
 
     for (const QChar& ch : sequence) {

--- a/src/autotype/mac/AutoTypeMac.cpp
+++ b/src/autotype/mac/AutoTypeMac.cpp
@@ -499,14 +499,12 @@ void AutoTypeExecutorMac::execChar(AutoTypeChar* action)
 {
     m_platform->sendChar(action->character, true);
     m_platform->sendChar(action->character, false);
-    usleep(25 * 1000);
 }
 
 void AutoTypeExecutorMac::execKey(AutoTypeKey* action)
 {
     m_platform->sendKey(action->key, true);
     m_platform->sendKey(action->key, false);
-    usleep(25 * 1000);
 }
 
 void AutoTypeExecutorMac::execClearField(AutoTypeClearField* action = nullptr)

--- a/src/autotype/windows/AutoTypeWindows.cpp
+++ b/src/autotype/windows/AutoTypeWindows.cpp
@@ -522,14 +522,12 @@ void AutoTypeExecutorWin::execChar(AutoTypeChar* action)
 {
     m_platform->sendChar(action->character, true);
     m_platform->sendChar(action->character, false);
-    ::Sleep(25);
 }
 
 void AutoTypeExecutorWin::execKey(AutoTypeKey* action)
 {
     m_platform->sendKey(action->key, true);
     m_platform->sendKey(action->key, false);
-    ::Sleep(25);
 }
 
 void AutoTypeExecutorWin::execClearField(AutoTypeClearField* action = nullptr)

--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -849,13 +849,11 @@ AutoTypeExecutorX11::AutoTypeExecutorX11(AutoTypePlatformX11* platform)
 void AutoTypeExecutorX11::execChar(AutoTypeChar* action)
 {
     m_platform->SendKeyPressedEvent(m_platform->charToKeySym(action->character));
-    Tools::wait(25);
 }
 
 void AutoTypeExecutorX11::execKey(AutoTypeKey* action)
 {
     m_platform->SendKeyPressedEvent(m_platform->keyToKeySym(action->key));
-    Tools::wait(25);
 }
 
 void AutoTypeExecutorX11::execClearField(AutoTypeClearField* action = nullptr)

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -118,6 +118,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("UseGroupIconOnEntryCreation", false);
     m_defaults.insert("AutoTypeEntryTitleMatch", true);
+    m_defaults.insert("AutoTypeDelay", 25);
     m_defaults.insert("UseGroupIconOnEntryCreation", true);
     m_defaults.insert("IgnoreGroupExpansion", false);
     m_defaults.insert("security/clearclipboard", true);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -141,6 +141,7 @@ void SettingsWidget::loadSettings()
         if (m_globalAutoTypeKey > 0 && m_globalAutoTypeModifiers > 0) {
             m_generalUi->autoTypeShortcutWidget->setShortcut(m_globalAutoTypeKey, m_globalAutoTypeModifiers);
         }
+        m_generalUi->autoTypeDelaySpinBox->setValue(config()->get("AutoTypeDelay").toInt());
     }
 
 
@@ -205,6 +206,7 @@ void SettingsWidget::saveSettings()
         config()->set("GlobalAutoTypeKey", m_generalUi->autoTypeShortcutWidget->key());
         config()->set("GlobalAutoTypeModifiers",
                       static_cast<int>(m_generalUi->autoTypeShortcutWidget->modifiers()));
+        config()->set("AutoTypeDelay", m_generalUi->autoTypeDelaySpinBox->value());
     }
     config()->set("security/clearclipboard", m_secUi->clearClipboardCheckBox->isChecked());
     config()->set("security/clearclipboardtimeout", m_secUi->clearClipboardSpinBox->value());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -318,21 +318,35 @@
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout">
-         <property name="horizontalSpacing">
-          <number>12</number>
+        <layout class="QFormLayout" name="formLayout_2">
+         <property name="topMargin">
+          <number>10</number>
          </property>
-         <property name="verticalSpacing">
-          <number>6</number>
-         </property>
-         <item row="1" column="0" alignment="Qt::AlignRight">
-          <widget class="QLabel" name="autoTypeDelayLabel">
+         <item row="1" column="0">
+          <widget class="QLabel" name="autoTypeShortcutLabel_2">
+           <property name="text">
+            <string>Global Auto-Type shortcut</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="ShortcutWidget" name="autoTypeShortcutWidget">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="autoTypeDelayLabel_2">
            <property name="text">
             <string>Auto-Type delay</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="1" alignment="Qt::AlignLeft">
+         <item row="2" column="1">
           <widget class="QSpinBox" name="autoTypeDelaySpinBox">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -351,32 +365,6 @@
            </property>
            <property name="value">
             <number>25</number>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0" alignment="Qt::AlignRight">
-          <widget class="QLabel" name="autoTypeShortcutLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Global Auto-Type shortcut</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="ShortcutWidget" name="autoTypeShortcutWidget">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
            </property>
           </widget>
          </item>

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -318,11 +318,43 @@
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="spacing">
-          <number>15</number>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="horizontalSpacing">
+          <number>12</number>
          </property>
-         <item alignment="Qt::AlignRight">
+         <property name="verticalSpacing">
+          <number>6</number>
+         </property>
+         <item row="1" column="0" alignment="Qt::AlignRight">
+          <widget class="QLabel" name="autoTypeDelayLabel">
+           <property name="text">
+            <string>Auto-Type delay</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" alignment="Qt::AlignLeft">
+          <widget class="QSpinBox" name="autoTypeDelaySpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="suffix">
+            <string> ms</string>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="maximum">
+            <number>999</number>
+           </property>
+           <property name="value">
+            <number>25</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" alignment="Qt::AlignRight">
           <widget class="QLabel" name="autoTypeShortcutLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -338,7 +370,7 @@
            </property>
           </widget>
          </item>
-         <item>
+         <item row="0" column="1">
           <widget class="ShortcutWidget" name="autoTypeShortcutWidget">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">


### PR DESCRIPTION
Adds both solutions presented in issue #699.

## Description
All platform dependant hardcoded auto-type delays were removed in favor of a configurable default. UI was added to configure the delay which defaults to 25ms as specified.

## Motivation and context
Issue #699.

## How has this been tested?
Only on Linux with three different auto-type entries:

1. Default, no custom delay (will use the configured default)
2. Sequence with {DELAY=0} -> will override the default
3. Sequence with {DELAY=200} -> will override the default

Tested the default at 0 ms, 25 ms and 500 ms. All work and are overridable by the sequence {DELAY=X} option.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/106598/27646980-d1d08254-5c32-11e7-8944-c80e60863085.png)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
