### PR TITLE
Split auto-type title and URL matching into separate options (fixes #638)

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -576,8 +576,13 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
         }
 
         if (!match && config()->get("AutoTypeEntryTitleMatch").toBool() 
-                && (windowMatchesTitle(windowTitle, entry->resolvePlaceholder(entry->title()))
-                || windowMatchesUrl(windowTitle, entry->resolvePlaceholder(entry->url())))) {
+                && windowMatchesTitle(windowTitle, entry->resolvePlaceholder(entry->title()))) {
+            sequence = entry->defaultAutoTypeSequence();
+            match = true;
+        }
+
+        if (!match && config()->get("AutoTypeEntryURLMatch").toBool()
+                && windowMatchesUrl(windowTitle, entry->resolvePlaceholder(entry->url()))) {
             sequence = entry->defaultAutoTypeSequence();
             match = true;
         }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -118,6 +118,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("UseGroupIconOnEntryCreation", false);
     m_defaults.insert("AutoTypeEntryTitleMatch", true);
+    m_defaults.insert("AutoTypeEntryURLMatch", true);
     m_defaults.insert("UseGroupIconOnEntryCreation", true);
     m_defaults.insert("IgnoreGroupExpansion", false);
     m_defaults.insert("security/clearclipboard", true);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -117,6 +117,7 @@ void SettingsWidget::loadSettings()
     m_generalUi->minimizeOnCopyCheckBox->setChecked(config()->get("MinimizeOnCopy").toBool());
     m_generalUi->useGroupIconOnEntryCreationCheckBox->setChecked(config()->get("UseGroupIconOnEntryCreation").toBool());
     m_generalUi->autoTypeEntryTitleMatchCheckBox->setChecked(config()->get("AutoTypeEntryTitleMatch").toBool());
+    m_generalUi->autoTypeEntryURLMatchCheckBox->setChecked(config()->get("AutoTypeEntryURLMatch").toBool());
     m_generalUi->ignoreGroupExpansionCheckBox->setChecked(config()->get("IgnoreGroupExpansion").toBool());
 
     m_generalUi->languageComboBox->clear();
@@ -190,6 +191,8 @@ void SettingsWidget::saveSettings()
                   m_generalUi->ignoreGroupExpansionCheckBox->isChecked());
     config()->set("AutoTypeEntryTitleMatch",
                   m_generalUi->autoTypeEntryTitleMatchCheckBox->isChecked());
+    config()->set("AutoTypeEntryURLMatch",
+                  m_generalUi->autoTypeEntryURLMatchCheckBox->isChecked());
     int currentLangIndex = m_generalUi->languageComboBox->currentIndex();
 
     config()->set("GUI/Language", m_generalUi->languageComboBox->itemData(currentLangIndex).toString());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -303,7 +303,14 @@
        <item>
         <widget class="QCheckBox" name="autoTypeEntryTitleMatchCheckBox">
          <property name="text">
-          <string>Use entry title and URL to match windows for global Auto-Type</string>
+          <string>Use entry title to match windows for global Auto-Type</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="autoTypeEntryURLMatchCheckBox">
+         <property name="text">
+          <string>Use entry URL to match windows for global Auto-Type</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
A user requested KeePassXC to have separate options to match the title and URL of an entry like in KeePass.

## Description
Created second checkbox for URL matching, new configuration option with default on, changed auto-type window matching logic to test them separately.

Release note: the new checkbox is checked by default like the old one was so if one has title matching disabled URL matching will become enabled anyway until unchecked.

## Motivation and context
Issue #638.

## How has this been tested?
Two entries where one has matching title only and one which has matching URL only.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/106598/27648688-feb7d042-5c37-11e7-8325-a3d1cd1c9f16.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**