### PR TITLE
Fix correct favicon downloading

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -795,22 +795,24 @@ QString Entry::resolvePlaceholder(const QString& str) const
 QString Entry::resolveUrl(const QString& url) const
 {
 #ifdef WITH_XC_HTTP
-    QString newurl = url;
+    QString newUrl = url;
     if (!url.contains("://")) {
         // URL doesn't have a protocol, add https by default
-        newurl.prepend("https://");
+        newUrl.prepend("https://");
     }
-    QUrl uurl = QUrl(newurl);
+    QUrl tempUrl = QUrl(newUrl);
 
-    if (uurl.scheme() == "cmd") {
-        // URL is a cmd, hopefully the second argument is an URL
-        QStringList cmd = newurl.split(" ");
-        if (cmd.size() > 1) {
-            return resolveUrl(cmd[1].remove("'").remove("\""));
+    if (tempUrl.isValid()) {
+        if (tempUrl.scheme() == "cmd") {
+            // URL is a cmd, hopefully the second argument is an URL
+            QStringList cmd = newUrl.split(" ");
+            if (cmd.size() > 1) {
+                return resolveUrl(cmd[1].remove("'").remove("\""));
+            }
+        } else if (tempUrl.scheme() == "http" || tempUrl.scheme() == "https") {
+            // URL is nice
+            return tempUrl.url();
         }
-    } else if (uurl.scheme() == "http" || uurl.scheme() == "https") {
-        // URL is nice
-        return uurl.url();
     }
 #else
     Q_UNUSED(url);

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -802,13 +802,13 @@ QString Entry::resolveUrl(const QString& url) const
     }
     QUrl uurl = QUrl(newurl);
 
-    if(uurl.scheme() == "cmd") {
-        // URL is a cmd, hopefully the second argument it's an URL
+    if (uurl.scheme() == "cmd") {
+        // URL is a cmd, hopefully the second argument is an URL
         QStringList cmd = newurl.split(" ");
         if (cmd.size() > 1) {
             return resolveUrl(cmd[1].remove("'").remove("\""));
         }
-    } else if(uurl.scheme() == "http" || uurl.scheme() == "https") {
+    } else if (uurl.scheme() == "http" || uurl.scheme() == "https") {
         // URL is nice
         return uurl.url();
     }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -237,6 +237,11 @@ QString Entry::url() const
     return m_attributes->value(EntryAttributes::URLKey);
 }
 
+QString Entry::webUrl() const
+{
+    return resolveUrl(m_attributes->value(EntryAttributes::URLKey));
+}
+
 QString Entry::username() const
 {
     return m_attributes->value(EntryAttributes::UserNameKey);
@@ -783,4 +788,24 @@ QString Entry::resolvePlaceholder(const QString& str) const
     }
 
     return result;
+}
+
+QString Entry::resolveUrl(const QString& url) const
+{
+    QString newurl = url;
+    if (!url.contains("://")) {
+        // URL doesn't have a protocol, add https by default
+        newurl.prepend("https://");
+    }
+    QUrl uurl = QUrl(newurl);
+
+    if(uurl.scheme() == "cmd") {
+        // URL is a cmd, hopefully the second argument it's an URL
+        QStringList cmd = newurl.split(" ");
+        return resolveUrl(cmd[1].remove("'").remove("\""));
+    } else if(uurl.scheme() != "http" && uurl.scheme() != "https") {
+        // URL isn't very nice
+        return QString("");
+    }
+    return uurl.url();
 }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -17,6 +17,8 @@
  */
 #include "Entry.h"
 
+#include "config-keepassx.h"
+
 #include "core/Database.h"
 #include "core/DatabaseIcons.h"
 #include "core/Group.h"
@@ -792,6 +794,7 @@ QString Entry::resolvePlaceholder(const QString& str) const
 
 QString Entry::resolveUrl(const QString& url) const
 {
+#ifdef WITH_XC_HTTP
     QString newurl = url;
     if (!url.contains("://")) {
         // URL doesn't have a protocol, add https by default
@@ -802,10 +805,15 @@ QString Entry::resolveUrl(const QString& url) const
     if(uurl.scheme() == "cmd") {
         // URL is a cmd, hopefully the second argument it's an URL
         QStringList cmd = newurl.split(" ");
-        return resolveUrl(cmd[1].remove("'").remove("\""));
-    } else if(uurl.scheme() != "http" && uurl.scheme() != "https") {
-        // URL isn't very nice
-        return QString("");
+        if (cmd.size() > 1) {
+            return resolveUrl(cmd[1].remove("'").remove("\""));
+        }
+    } else if(uurl.scheme() == "http" || uurl.scheme() == "https") {
+        // URL is nice
+        return uurl.url();
     }
-    return uurl.url();
+#else
+    Q_UNUSED(url);
+#endif
+    return QString("");
 }

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -78,6 +78,7 @@ public:
     const AutoTypeAssociations* autoTypeAssociations() const;
     QString title() const;
     QString url() const;
+    QString webUrl() const;
     QString username() const;
     QString password() const;
     QString notes() const;
@@ -143,6 +144,7 @@ public:
     void copyDataFrom(const Entry* other);
     QString resolveMultiplePlaceholders(const QString& str) const;
     QString resolvePlaceholder(const QString& str) const;
+    QString resolveUrl(const QString& url) const;
 
     /**
      * Call before and after set*() methods to create a history item

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -244,7 +244,7 @@ void EditWidgetIcons::fetchFaviconFromGoogle(const QString& domain)
         resetFaviconDownload();
         m_fallbackToGoogle = false;
         QUrl faviconUrl = QUrl("https://www.google.com/s2/favicons");
-        faviconUrl.setQuery("domain=" + domain);
+        faviconUrl.setQuery("domain=" + QUrl::toPercentEncoding(domain));
         fetchFavicon(faviconUrl);
     } else {
         resetFaviconDownload();

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -223,8 +223,15 @@ void EditWidgetIcons::fetchFavicon(const QUrl& url)
     }
 
     m_httpClient->setConnectingTimeOut(5000, [this]() {
-        resetFaviconDownload();
-        MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
+        QUrl tempurl = QUrl(m_url);
+        if (tempurl.scheme() == "http") {
+            resetFaviconDownload();
+            MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
+        } else {
+            tempurl.setScheme("http");
+            tempurl.setPath("/favicon.ico");
+            fetchFavicon(tempurl);
+        }
     });
 
     m_ui->faviconButton->setDisabled(true);

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -229,6 +229,7 @@ void EditWidgetIcons::fetchFavicon(const QUrl& url)
             MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
         } else {
             tempurl.setScheme("http");
+            m_url = tempurl.url();
             tempurl.setPath("/favicon.ico");
             fetchFavicon(tempurl);
         }

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -242,7 +242,7 @@ void EditWidgetIcons::fetchFaviconFromGoogle(const QString& domain)
     if (config()->get("security/IconDownloadFallbackToGoogle", false).toBool() && m_fallbackToGoogle) {
         resetFaviconDownload();
         m_fallbackToGoogle = false;
-        fetchFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + domain));
+        fetchFavicon(QUrl("https://www.google.com/s2/favicons?domain=" + domain));
     } else {
         resetFaviconDownload();
         MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -226,7 +226,7 @@ void EditWidgetIcons::fetchFavicon(const QUrl& url)
         QUrl tempurl = QUrl(m_url);
         if (tempurl.scheme() == "http") {
             resetFaviconDownload();
-            MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
+            MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon.") + "\n" + tr("Hint: You can enable Google as a fallback under Tools>Settings>Security"));
         } else {
             tempurl.setScheme("http");
             m_url = tempurl.url();
@@ -243,7 +243,9 @@ void EditWidgetIcons::fetchFaviconFromGoogle(const QString& domain)
     if (config()->get("security/IconDownloadFallbackToGoogle", false).toBool() && m_fallbackToGoogle) {
         resetFaviconDownload();
         m_fallbackToGoogle = false;
-        fetchFavicon(QUrl("https://www.google.com/s2/favicons?domain=" + domain));
+        QUrl faviconUrl = QUrl("https://www.google.com/s2/favicons");
+        faviconUrl.setQuery("domain=" + domain);
+        fetchFavicon(faviconUrl);
     } else {
         resetFaviconDownload();
         MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -363,7 +363,7 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
     IconStruct iconStruct;
     iconStruct.uuid = entry->iconUuid();
     iconStruct.number = entry->iconNumber();
-    m_iconsWidget->load(entry->uuid(), m_database, iconStruct, entry->url());
+    m_iconsWidget->load(entry->uuid(), m_database, iconStruct, entry->webUrl());
     connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), m_iconsWidget, SLOT(setUrl(QString)));
 
     m_autoTypeUi->enableButton->setChecked(entry->autoTypeEnabled());

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -203,7 +203,7 @@ QList<Entry*> Service::searchEntries(Database* db, const QString& hostname)
         const auto results = EntrySearcher().search(hostname, rootGroup, Qt::CaseInsensitive);
         for (Entry* entry: results) {
             QString title = entry->title();
-            QString url = entry->url();
+            QString url = entry->webUrl();
 
             //Filter to match hostname in Title and Url fields
             if (   (!title.isEmpty() && hostname.contains(title))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,7 +98,7 @@ set(TEST_LIBRARIES
 
 set(testsupport_SOURCES modeltest.cpp FailDevice.cpp)
 add_library(testsupport STATIC ${testsupport_SOURCES})
-target_link_libraries(testsupport ${MHD_LIBRARIES} Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Test)
+target_link_libraries(testsupport Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Test)
 
 if(YUBIKEY_FOUND)
   set(TEST_LIBRARIES ${TEST_LIBRARIES} ${YUBIKEY_LIBRARIES})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
The user provided URL field can contain various protocol URL other than `http` and `https` (like `cmd`, `ftp`, `sftp`, etc)
This PR adds an entry method called `webUrl` that takes the url field, checks if it's web-friendly (check if the protocol is `http` or `https`, adds `https` by default if the protocol is missing, tries to extract the url from `cmd` protocol, ...)
The `webUrl` is then used for downloadingFavicon and for the KeePassHTTP protocol.

If the website don't support `https`, the request will timeout so we need to retry under `http`

This fixes #238 and #240 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Writing tests for this is pretty painful.
I've tested this manually with the following url:
- `www.google.com` *url without protocol* -> fetch icon for `https://www.google.com`
- `www.stealmylogin.com` *url without protocol, website without https* -> checks the `https` favicon but fails for timeout and then fetch icon for the `http` version
- `cmd://firefox www.google.com` *cmd with url as first command argument* -> fetch icon for `https://www.google.com`
- `cmd://firefox "http://no-favicon.com/"` *cmd with url inside quote, unavailable website* -> report `Unable to fetch favicon`
- `ftp://8.8.8.8` *ftp protocol* -> favicon download button is hidden.

If someone wants to try to write tests for this, I would be very happy :smile: 

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

