### PR TITLE
Use [*] placeholder in window title to get rid of Qt warning

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -552,8 +552,14 @@ void MainWindow::updateWindowTitle()
     QString customWindowTitlePart;
     int stackedWidgetIndex = m_ui->stackedWidget->currentIndex();
     int tabWidgetIndex = m_ui->tabWidget->currentIndex();
+    bool isModified = m_ui->tabWidget->isModified(tabWidgetIndex);
+
     if (stackedWidgetIndex == DatabaseTabScreen && tabWidgetIndex != -1) {
         customWindowTitlePart = m_ui->tabWidget->tabText(tabWidgetIndex);
+        if (isModified) {
+            // remove asterisk '*' from title
+            customWindowTitlePart.remove(customWindowTitlePart.size() - 1, 1);
+        }
         if (m_ui->tabWidget->readOnly(tabWidgetIndex)) {
             customWindowTitlePart.append(QString(" [%1]").arg(tr("read-only")));
         }
@@ -565,7 +571,7 @@ void MainWindow::updateWindowTitle()
     if (customWindowTitlePart.isEmpty()) {
         windowTitle = BaseWindowTitle;
     } else {
-        windowTitle = QString("%1 - %2").arg(customWindowTitlePart, BaseWindowTitle);
+        windowTitle = QString("%1[*] - %2").arg(customWindowTitlePart, BaseWindowTitle);
     }
 
     if (customWindowTitlePart.isEmpty() || stackedWidgetIndex == 1) {
@@ -574,7 +580,7 @@ void MainWindow::updateWindowTitle()
         setWindowFilePath(m_ui->tabWidget->databasePath(tabWidgetIndex));
     }
 
-    setWindowModified(m_ui->tabWidget->isModified(tabWidgetIndex));
+    setWindowModified(isModified);
 
     setWindowTitle(windowTitle);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch correctly adds a "[*]" placeholder to the window title to indicate whether the database was modified as described in the QWidget documentation.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The placeholder ensures that the visible modification indicator adheres to the platform standards and it gets rid of the following Qt warning:

QWidget::setWindowModified: The window title does not contain a '[*]' placeholder

No visual difference to the previous implementation exists on Linux (and I suppose Windows).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Opened and modified databases. All existing unit tests pass.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**