### PR TITLE
Kyodev patch 2

### DIFF
--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -42,6 +42,8 @@ wget -q https://github.com/AppImage/AppImages/raw/master/functions.sh -O ./funct
 LIB_DIR=./usr/lib
 if [ -d ./usr/lib/x86_64-linux-gnu ]; then
     LIB_DIR=./usr/lib/x86_64-linux-gnu
+elif [ -d ./usr/lib/i386-linux-gnu ]; then
+    LIB_DIR=./usr/lib/i386-linux-gnu
 fi
 
 cd $APP.AppDir

--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -36,7 +36,7 @@ LOWERAPP="$(echo "$APP" | tr '[:upper:]' '[:lower:]')"
 VERSION="$2"
 
 mkdir -p $APP.AppDir
-wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+wget -q https://github.com/AppImage/AppImages/raw/master/functions.sh -O ./functions.sh
 . ./functions.sh
 
 LIB_DIR=./usr/lib


### PR DESCRIPTION
## Description

* the url for script functions.sh was changed, see [functions.sh](https://github.com/AppImage/AppImages/raw/master/functions.sh)
* add 32bits architecture  for release-tool

## Motivation and context

* for information, **bug** on appImage: functions.sh don't build on debian, see [pull request](https://github.com/AppImage/AppImages/pull/252) then release-tool don't work.   
  the PR was accepted, and it is **important** for debian platforms
* release-tool don't work on 32bits architecture

## How has this been tested?

* before PR 252 (on AppImage), I can't build with release-tool, on Stretch or Sid
after Pull Request, I can
* I make a build, with success and use the image builded

## Types of changes

* add /usr/lib/i386-linux-gnu in 
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project. 
- ? All new and existing tests passed. I dont think that the tests concern release-tool
- ✅ I have worked with release-tool and I use on KeePassXC 2.2.0 on debian 32bits & 64 bits
