### PR TITLE
Fix double warning display for database open

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -140,6 +140,9 @@ void DatabaseOpenWidget::openDatabase()
 {
     KeePass2Reader reader;
     CompositeKey masterKey = databaseKey();
+    if (masterKey.isEmpty()) {
+        return;
+    }
 
     QFile file(m_filename);
     if (!file.open(QIODevice::ReadOnly)) {

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -140,7 +140,7 @@ void DatabaseOpenWidget::openDatabase()
 {
     KeePass2Reader reader;
     CompositeKey masterKey = databaseKey();
-    if (masterKey.isEmpty()) {
+    if (!masterKey.isValid()) {
         return;
     }
 
@@ -188,7 +188,7 @@ CompositeKey DatabaseOpenWidget::databaseKey()
         if (!key.load(keyFilename, &errorMsg)) {
             m_ui->messageWidget->showMessage(tr("Can't open key file").append(":\n")
                                              .append(errorMsg), MessageWidget::Error);
-            return CompositeKey();
+            return CompositeKey(false);
         }
         masterKey.addKey(key);
         lastKeyFiles[m_filename] = keyFilename;

--- a/src/keys/CompositeKey.cpp
+++ b/src/keys/CompositeKey.cpp
@@ -34,6 +34,11 @@ CompositeKey::CompositeKey()
 {
 }
 
+CompositeKey::CompositeKey(bool valid)
+{
+    invalid = !valid;
+}
+
 CompositeKey::CompositeKey(const CompositeKey& key)
 {
     *this = key;
@@ -54,6 +59,11 @@ void CompositeKey::clear()
 bool CompositeKey::isEmpty() const
 {
     return m_keys.isEmpty() && m_challengeResponseKeys.isEmpty();
+}
+
+bool CompositeKey::isValid() const
+{
+    return !invalid;
 }
 
 CompositeKey* CompositeKey::clone() const

--- a/src/keys/CompositeKey.cpp
+++ b/src/keys/CompositeKey.cpp
@@ -32,11 +32,12 @@
 
 CompositeKey::CompositeKey()
 {
+    m_isValid = true;
 }
 
 CompositeKey::CompositeKey(bool valid)
 {
-    invalid = !valid;
+    m_isValid = valid;
 }
 
 CompositeKey::CompositeKey(const CompositeKey& key)
@@ -63,7 +64,7 @@ bool CompositeKey::isEmpty() const
 
 bool CompositeKey::isValid() const
 {
-    return !invalid;
+    return m_isValid;
 }
 
 CompositeKey* CompositeKey::clone() const

--- a/src/keys/CompositeKey.h
+++ b/src/keys/CompositeKey.h
@@ -30,10 +30,12 @@ class CompositeKey : public Key
 {
 public:
     CompositeKey();
+    CompositeKey(bool valid);
     CompositeKey(const CompositeKey& key);
     ~CompositeKey();
     void clear();
     bool isEmpty() const;
+    bool isValid() const;
     CompositeKey* clone() const;
     CompositeKey& operator=(const CompositeKey& key);
 
@@ -52,6 +54,7 @@ private:
     static QByteArray transformKeyRaw(const QByteArray& key, const QByteArray& seed,
                                       quint64 rounds, bool* ok, QString* errorString);
 
+    bool invalid;
     QList<Key*> m_keys;
     QList<QSharedPointer<ChallengeResponseKey>> m_challengeResponseKeys;
 };

--- a/src/keys/CompositeKey.h
+++ b/src/keys/CompositeKey.h
@@ -54,7 +54,7 @@ private:
     static QByteArray transformKeyRaw(const QByteArray& key, const QByteArray& seed,
                                       quint64 rounds, bool* ok, QString* errorString);
 
-    bool invalid;
+    bool m_isValid;
     QList<Key*> m_keys;
     QList<QSharedPointer<ChallengeResponseKey>> m_challengeResponseKeys;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This change fixes the rapid display and covering of the file not found warning dialogue described in #741.

## Description
<!--- Describe your changes in detail -->
gui/DatabaseOpenWidget.cpp looks like [`DatabaseOpenWidget::openDatabase` accepts](https://github.com/keepassxreboot/keepassxc/blob/7580c385da58329ef29e0d026b1ac0720cbcccf2/src/gui/DatabaseOpenWidget.cpp#L142-L149) the [invalid `CompositeKey` returned by `DatabaseWidget::databaseKey` on failure](https://github.com/keepassxreboot/keepassxc/blob/7580c385da58329ef29e0d026b1ac0720cbcccf2/src/gui/DatabaseOpenWidget.cpp#L188).

This change short circuits the call to `file.open` in the case that an empty `masterKey` has been returned to allows the user to see the reason for that failure.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #741.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been manually tested using the steps to reproduce at the issue.

1. Create a database with a password and key file.
2. Attempt to open the database with a bad path to the key file.

## Screenshots (if appropriate):

Before change:
![unhelpful-warning](https://user-images.githubusercontent.com/275221/27815456-76704576-60c3-11e7-89ad-314c0203bee5.png)

After change:
![correct-warning](https://user-images.githubusercontent.com/275221/27815323-701ccc5e-60c2-11e7-8b35-61bfe7b695b0.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

Note that `-DWITH_ASAN=ON` tests fail with

```
The following tests FAILED:
	  1 - testgroup (Failed)
	  5 - testkeepass2writer (Failed)
	  9 - testsymmetriccipher (Failed)
	 19 - testcsvparser (Failed)
Errors while running CTest
```

However this is identical to the behaviour seen with the current develop HEAD 7580c385da58329ef29e0d026b1ac0720cbcccf2.
