### PR TITLE
Add menu shortcut for consistency

### DIFF
--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -557,7 +557,7 @@
   </action>
   <action name="actionGroupEmptyRecycleBin">
    <property name="text">
-    <string>Empty recycle bin</string>
+    <string>E&amp;mpty recycle bin</string>
    </property>
    <property name="visible">
     <bool>false</bool>


### PR DESCRIPTION
## Description
I added Alt+m shortcut (underlined letter in menu) for _Groups > Empty recycle bin_ menu which I implemented some time ago to be consistent with other menu items in the same group which all have underlined letters.

## Motivation and context
This is a small tweak for UI consistency.

## How has this been tested?
This has been tested by visually looking at the application after the change and by actually using Alt+G,m shortcut to ensure the menu is really invoked.

## Screenshots (if appropriate):
This is how it looks now
![groupmenu](https://user-images.githubusercontent.com/11542782/27976993-74bc378e-6371-11e7-9932-b41937d5aae0.png)


## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
