### PR TITLE
Fix PasswordGeneratorWidget sizes and size policies

### DIFF
--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -2,31 +2,11 @@
 <ui version="4.0">
  <class>PasswordGeneratorWidget</class>
  <widget class="QWidget" name="PasswordGeneratorWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>575</width>
-    <height>305</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>284</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
-    <height>16777215</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string/>
@@ -188,16 +168,10 @@ QProgressBar::chunk {
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
        </property>
        <property name="tabPosition">
         <enum>QTabWidget::North</enum>
@@ -225,12 +199,6 @@ QProgressBar::chunk {
                <layout class="QHBoxLayout" name="alphabetLayout" stretch="0,0,0,0,1,0">
                 <item>
                  <widget class="QToolButton" name="checkBoxUpper">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
                   <property name="minimumSize">
                    <size>
                     <width>0</width>
@@ -256,12 +224,6 @@ QProgressBar::chunk {
                 </item>
                 <item>
                  <widget class="QToolButton" name="checkBoxLower">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
                   <property name="minimumSize">
                    <size>
                     <width>0</width>
@@ -287,12 +249,6 @@ QProgressBar::chunk {
                 </item>
                 <item>
                  <widget class="QToolButton" name="checkBoxNumbers">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
                   <property name="minimumSize">
                    <size>
                     <width>0</width>
@@ -318,12 +274,6 @@ QProgressBar::chunk {
                 </item>
                 <item>
                  <widget class="QToolButton" name="checkBoxSpecialChars">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
                   <property name="minimumSize">
                    <size>
                     <width>0</width>
@@ -349,12 +299,6 @@ QProgressBar::chunk {
                 </item>
                 <item>
                  <widget class="QToolButton" name="checkBoxExtASCII">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="MinimumExpanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
                   <property name="minimumSize">
                    <size>
                     <width>0</width>
@@ -578,7 +522,7 @@ QProgressBar::chunk {
              <item row="2" column="1">
               <widget class="QLineEdit" name="editWordSeparator">
                <property name="text">
-                <string> </string>
+                <string/>
                </property>
               </widget>
              </item>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -2,20 +2,6 @@
 <ui version="4.0">
  <class>EditEntryWidgetMain</class>
  <widget class="QWidget" name="EditEntryWidgetMain">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>692</width>
-    <height>323</height>
-   </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <property name="topMargin">
     <number>0</number>
@@ -34,20 +20,7 @@
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="PasswordGeneratorWidget" name="passwordGenerator" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
+    <widget class="PasswordGeneratorWidget" name="passwordGenerator" native="true"/>
    </item>
    <item row="2" column="0" alignment="Qt::AlignRight">
     <widget class="QLabel" name="passwordLabel">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch fixes minimum widget sizes and size policies for components of the PasswordGeneratorWidget.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With certain "large-padding" themes such as KDE Breeze, the alphabet selection buttons appeared squished inside the inline password generator.

Before:
![before](https://user-images.githubusercontent.com/911270/27989674-2ce41936-643e-11e7-9f14-9baca5580079.png)

After:
![after](https://user-images.githubusercontent.com/911270/27989685-5638c55c-643e-11e7-8279-685fa15b9b45.png)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visuals are fine now on KDE with Breeze.


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

