### PR TITLE
Open previously opened databases in correct order

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,7 +131,8 @@ int main(int argc, char** argv)
     
     if (config()->get("OpenPreviousDatabasesOnStartup").toBool()) {
         const QStringList filenames = config()->get("LastOpenedDatabases").toStringList();
-        for (const QString& filename : filenames) {
+        for (int ii = filenames.size()-1; ii >= 0; ii--) {
+            QString filename = filenames.at(ii);
             if (!filename.isEmpty() && QFile::exists(filename)) {
                 mainWindow.openDatabase(filename, QString(), QString());
             }


### PR DESCRIPTION
## Description
In LastOpenedDatabases, the most recently opened file is listed first and the
least recently opened one is listed last. If the databases are re-opened in this
order, LastOpenedDatabases is reversed afterwards. To avoid this, load the files
in reverse order, so LastOpenedDatabases is not modified.

## Motivation and context
Currently, with each start of KeePassXC, the order of the tabs which represent previously opened databases gets reversed. This can be easily reproduced:
1. Open at least two databases
2. Close and open KeePassXC repeatedly, observe order of tabs

## How has this been tested?
The change is rather minimal and easy to review. Testing was done in two ways:
* `make test` was run and 100% tests passed
* fix of the behavior described above was tested manually by repeatedly opening the application and looking at values stored in keepassxc.ini.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
