### PR TITLE
Refactoring : Command base class for CLI commands

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -16,6 +16,8 @@
 set(cli_SOURCES
     Clip.cpp
     Clip.h
+    Command.cpp
+    Command.h
     EntropyMeter.cpp
     EntropyMeter.h
     Extract.cpp

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include <QMap>
+
+#include "Command.h"
+
+#include "Clip.h"
+#include "EntropyMeter.h"
+#include "Extract.h"
+#include "List.h"
+#include "Merge.h"
+#include "Show.h"
+
+QMap<QString, Command*> commands;
+
+Command::~Command()
+{
+}
+
+int Command::execute(int, char**)
+{
+    return EXIT_FAILURE;
+}
+
+QString Command::getDescriptionLine()
+{
+
+    QString response = this->name;
+    QString space(" ");
+    QString spaces = space.repeated(15 - this->name.length());
+    response = response.append(spaces);
+    response = response.append(this->description);
+    response = response.append("\n");
+    return response;
+}
+
+void populateCommands()
+{
+    if (commands.isEmpty()) {
+        commands.insert(QString("clip"), new Clip());
+        commands.insert(QString("entropy-meter"), new EntropyMeter());
+        commands.insert(QString("extract"), new Extract());
+        commands.insert(QString("ls"), new List());
+        commands.insert(QString("merge"), new Merge());
+        commands.insert(QString("show"), new Show());
+    }
+}
+
+Command* Command::getCommand(QString commandName)
+{
+    populateCommands();
+    if (commands.contains(commandName)) {
+        return commands[commandName];
+    }
+    return nullptr;
+}
+
+QList<Command*> Command::getCommands()
+{
+    populateCommands();
+    return commands.values();
+}

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -15,18 +15,27 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSXC_CLIP_H
-#define KEEPASSXC_CLIP_H
+#ifndef KEEPASSXC_COMMAND_H
+#define KEEPASSXC_COMMAND_H
 
-#include "Command.h"
+#include <QList>
+#include <QObject>
+#include <QString>
+#include <QStringList>
 
-class Clip : public Command
+#include "core/Database.h"
+
+class Command
 {
 public:
-    Clip();
-    ~Clip();
-    int execute(int argc, char** argv);
-    int clipEntry(Database* database, QString entryPath);
+    virtual ~Command();
+    virtual int execute(int argc, char** argv);
+    QString name;
+    QString description;
+    QString getDescriptionLine();
+
+    static QList<Command*> getCommands();
+    static Command* getCommand(QString commandName);
 };
 
-#endif // KEEPASSXC_CLIP_H
+#endif // KEEPASSXC_COMMAND_H

--- a/src/cli/EntropyMeter.cpp
+++ b/src/cli/EntropyMeter.cpp
@@ -18,8 +18,8 @@
 #include "EntropyMeter.h"
 
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 #include <zxcvbn.h>
 
 /* For pre-compiled headers under windows */
@@ -28,6 +28,16 @@
 #include "stdafx.h"
 #endif
 #endif
+
+EntropyMeter::EntropyMeter()
+{
+    this->name = QString("entropy-meter");
+    this->description = QObject::tr("Calculate password entropy.");
+}
+
+EntropyMeter::~EntropyMeter()
+{
+}
 
 static void calculate(const char *pwd, int advanced)
 {

--- a/src/cli/EntropyMeter.h
+++ b/src/cli/EntropyMeter.h
@@ -18,10 +18,14 @@
 #ifndef KEEPASSXC_ENTROPYMETER_H
 #define KEEPASSXC_ENTROPYMETER_H
 
-class EntropyMeter
+#include "Command.h"
+
+class EntropyMeter : public Command
 {
 public:
-    static int execute(int argc, char** argv);
+    EntropyMeter();
+    ~EntropyMeter();
+    int execute(int argc, char** argv);
 };
 
 #endif // KEEPASSXC_ENTROPYMETER_H

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -26,25 +26,41 @@
 #include <QStringList>
 #include <QTextStream>
 
+#include "cli/PasswordInput.h"
 #include "core/Database.h"
 #include "format/KeePass2Reader.h"
 #include "keys/CompositeKey.h"
-#include "cli/PasswordInput.h"
+
+Extract::Extract()
+{
+    this->name = QString("extract");
+    this->description = QObject::tr("Extract and print the content of a database.");
+}
+
+Extract::~Extract()
+{
+}
 
 int Extract::execute(int argc, char** argv)
 {
+    QStringList arguments;
+    // Skipping the first argument (keepassxc).
+    for (int i = 1; i < argc; ++i) {
+        arguments << QString(argv[i]);
+    }
+
     QCoreApplication app(argc, argv);
     QTextStream out(stdout);
 
     QCommandLineParser parser;
-    parser.setApplicationDescription(
-        QCoreApplication::translate("main", "Extract and print the content of a database."));
-    parser.addPositionalArgument("database", QCoreApplication::translate("main", "Path of the database to extract."));
-    parser.process(app);
+    parser.setApplicationDescription(this->description);
+    parser.addPositionalArgument("database", QObject::tr("Path of the database to extract."));
+    parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 1) {
-        parser.showHelp(EXIT_FAILURE);
+        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli extract");
+        return EXIT_FAILURE;
     }
 
     out << "Insert the database password\n> ";

--- a/src/cli/Extract.h
+++ b/src/cli/Extract.h
@@ -18,10 +18,14 @@
 #ifndef KEEPASSXC_EXTRACT_H
 #define KEEPASSXC_EXTRACT_H
 
-class Extract
+#include "Command.h"
+
+class Extract : public Command
 {
 public:
-    static int execute(int argc, char** argv);
+    Extract();
+    ~Extract();
+    int execute(int argc, char** argv);
 };
 
 #endif // KEEPASSXC_EXTRACT_H

--- a/src/cli/List.h
+++ b/src/cli/List.h
@@ -18,10 +18,15 @@
 #ifndef KEEPASSXC_LIST_H
 #define KEEPASSXC_LIST_H
 
-class List
+#include "Command.h"
+
+class List : public Command
 {
 public:
-    static int execute(int argc, char** argv);
+    List();
+    ~List();
+    int execute(int argc, char** argv);
+    int listGroup(Database* database, QString groupPath = QString(""));
 };
 
 #endif // KEEPASSXC_LIST_H

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -28,31 +28,39 @@
 #include "core/Database.h"
 #include "gui/UnlockDatabaseDialog.h"
 
+Merge::Merge()
+{
+    this->name = QString("merge");
+    this->description = QObject::tr("Merge two databases.");
+}
+
+Merge::~Merge()
+{
+}
+
 int Merge::execute(int argc, char** argv)
 {
-
     QStringList arguments;
-    for (int i = 0; i < argc; ++i) {
+    // Skipping the first argument (keepassxc).
+    for (int i = 1; i < argc; ++i) {
         arguments << QString(argv[i]);
     }
+
     QTextStream out(stdout);
 
     QCommandLineParser parser;
-    parser.setApplicationDescription(QCoreApplication::translate("main", "Merge two databases."));
-    parser.addPositionalArgument("database1",
-                                 QCoreApplication::translate("main", "Path of the database to merge into."));
-    parser.addPositionalArgument("database2",
-                                 QCoreApplication::translate("main", "Path of the database to merge from."));
+    parser.setApplicationDescription(this->description);
+    parser.addPositionalArgument("database1", QObject::tr("Path of the database to merge into."));
+    parser.addPositionalArgument("database2", QObject::tr("Path of the database to merge from."));
 
     QCommandLineOption samePasswordOption(
         QStringList() << "s"
                       << "same-password",
-        QCoreApplication::translate("main", "Use the same password for both database files."));
+        QObject::tr("Use the same password for both database files."));
 
-    QCommandLineOption guiPrompt(
-        QStringList() << "g"
-                      << "gui-prompt",
-        QCoreApplication::translate("main", "Use a GUI prompt unlocking the database."));
+    QCommandLineOption guiPrompt(QStringList() << "g"
+                                               << "gui-prompt",
+                                 QObject::tr("Use a GUI prompt unlocking the database."));
     parser.addOption(guiPrompt);
 
     parser.addOption(samePasswordOption);
@@ -61,7 +69,8 @@ int Merge::execute(int argc, char** argv)
     const QStringList args = parser.positionalArguments();
     if (args.size() != 2) {
         QCoreApplication app(argc, argv);
-        parser.showHelp(EXIT_FAILURE);
+        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli merge");
+        return EXIT_FAILURE;
     }
 
     Database* db1;
@@ -100,5 +109,4 @@ int Merge::execute(int argc, char** argv)
 
     out << "Successfully merged the database files.\n";
     return EXIT_SUCCESS;
-
 }

--- a/src/cli/Merge.h
+++ b/src/cli/Merge.h
@@ -18,10 +18,14 @@
 #ifndef KEEPASSXC_MERGE_H
 #define KEEPASSXC_MERGE_H
 
-class Merge
+#include "Command.h"
+
+class Merge : public Command
 {
 public:
-    static int execute(int argc, char** argv);
+    Merge();
+    ~Merge();
+    int execute(int argc, char** argv);
 };
 
 #endif // KEEPASSXC_MERGE_H

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -18,10 +18,15 @@
 #ifndef KEEPASSXC_SHOW_H
 #define KEEPASSXC_SHOW_H
 
-class Show
+#include "Command.h"
+
+class Show : public Command
 {
 public:
-    static int execute(int argc, char** argv);
+    Show();
+    ~Show();
+    int execute(int argc, char** argv);
+    int showEntry(Database* database, QString entryPath);
 };
 
 #endif // KEEPASSXC_SHOW_H

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -22,12 +22,7 @@
 #include <QStringList>
 #include <QTextStream>
 
-#include <cli/Clip.h>
-#include <cli/EntropyMeter.h>
-#include <cli/Extract.h>
-#include <cli/List.h>
-#include <cli/Merge.h>
-#include <cli/Show.h>
+#include <cli/Command.h>
 
 #include "config-keepassx.h"
 #include "core/Tools.h"
@@ -48,6 +43,7 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    QTextStream out(stdout);
     QStringList arguments;
     for (int i = 0; i < argc; ++i) {
         arguments << QString(argv[i]);
@@ -55,16 +51,13 @@ int main(int argc, char** argv)
     QCommandLineParser parser;
 
     QString description("KeePassXC command line interface.");
-    description = description.append(QString("\n\nAvailable commands:"));
-    description = description.append(QString("\n  clip\t\tCopy a password to the clipboard."));
-    description = description.append(QString("\n  extract\tExtract and print the content of a database."));
-    description = description.append(QString("\n  entropy-meter\tCalculate password entropy."));
-    description = description.append(QString("\n  list\t\tList database entries."));
-    description = description.append(QString("\n  merge\t\tMerge two databases."));
-    description = description.append(QString("\n  show\t\tShow a password."));
-    parser.setApplicationDescription(QCoreApplication::translate("main", qPrintable(description)));
+    description = description.append(QObject::tr("\n\nAvailable commands:\n"));
+    for (Command* command : Command::getCommands()) {
+        description = description.append(command->getDescriptionLine());
+    }
+    parser.setApplicationDescription(description);
 
-    parser.addPositionalArgument("command", QCoreApplication::translate("main", "Name of the command to execute."));
+    parser.addPositionalArgument("command", QObject::tr("Name of the command to execute."));
 
     parser.addHelpOption();
     parser.addVersionOption();
@@ -78,50 +71,16 @@ int main(int argc, char** argv)
         app.setApplicationVersion(KEEPASSX_VERSION);
         if (parser.isSet("version")) {
             // Switch to parser.showVersion() when available (QT 5.4).
-            QTextStream out(stdout);
-            out << KEEPASSX_VERSION << "\n";
-            out.flush();
+            out << KEEPASSX_VERSION << endl;
             return EXIT_SUCCESS;
         }
         parser.showHelp();
     }
 
     QString commandName = parser.positionalArguments().at(0);
+    Command* command = Command::getCommand(commandName);
 
-    int exitCode = EXIT_FAILURE;
-
-    if (commandName == "clip") {
-        // Removing the first cli argument before dispatching.
-        ++argv;
-        --argc;
-        argv[0] = const_cast<char*>("keepassxc-cli clip");
-        exitCode = Clip::execute(argc, argv);
-    } else if (commandName == "entropy-meter") {
-        ++argv;
-        --argc;
-        argv[0] = const_cast<char*>("keepassxc-cli entropy-meter");
-        exitCode = EntropyMeter::execute(argc, argv);
-    } else if (commandName == "extract") {
-        ++argv;
-        --argc;
-        argv[0] = const_cast<char*>("keepassxc-cli extract");
-        exitCode = Extract::execute(argc, argv);
-    } else if (commandName == "list") {
-        ++argv;
-        --argc;
-        argv[0] = const_cast<char*>("keepassxc-cli list");
-        exitCode = List::execute(argc, argv);
-    } else if (commandName == "merge") {
-        ++argv;
-        --argc;
-        argv[0] = const_cast<char*>("keepassxc-cli merge");
-        exitCode = Merge::execute(argc, argv);
-    } else if (commandName == "show") {
-        ++argv;
-        --argc;
-        argv[0] = const_cast<char*>("keepassxc-cli show");
-        exitCode = Show::execute(argc, argv);
-    } else {
+    if (command == nullptr) {
         qCritical("Invalid command %s.", qPrintable(commandName));
         QCoreApplication app(argc, argv);
         app.setApplicationVersion(KEEPASSX_VERSION);
@@ -129,6 +88,8 @@ int main(int argc, char** argv)
         // exit code here.
         parser.showHelp(EXIT_FAILURE);
     }
+
+    int exitCode = command->execute(argc, argv);
 
 #if defined(WITH_ASAN) && defined(WITH_LSAN)
     // do leak check here to prevent massive tail of end-of-process leak errors from third-party libraries

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -578,7 +578,7 @@ Group* Group::findGroupByPath(QString groupPath, QString basePath)
 
 }
 
-QString Group::print(bool printUuids, QString baseName, int depth)
+QString Group::print(bool recursive, int depth)
 {
 
     QString response;
@@ -590,21 +590,14 @@ QString Group::print(bool printUuids, QString baseName, int depth)
     }
 
     for (Entry* entry : entries()) {
-        response += indentation + entry->title();
-        if (printUuids) {
-            response += " " + entry->uuid().toHex();
-        }
-        response += "\n";
+        response += indentation + entry->title() + "\n";
     }
 
     for (Group* innerGroup : children()) {
-        QString newBaseName = baseName + innerGroup->name() + "/";
-        response += indentation + newBaseName;
-        if (printUuids) {
-            response += " " + innerGroup->uuid().toHex();
+        response += indentation + innerGroup->name() + "/\n";
+        if (recursive) {
+            response += innerGroup->print(recursive, depth + 1);
         }
-        response += "\n";
-        response += innerGroup->print(printUuids, newBaseName, depth + 1);
     }
 
     return response;

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -125,7 +125,7 @@ public:
     Group* clone(Entry::CloneFlags entryFlags = Entry::CloneNewUuid | Entry::CloneResetTimeInfo) const;
     void copyDataFrom(const Group* other);
     void merge(const Group* other);
-    QString print(bool printUuids = false, QString baseName = QString(""), int depth = 0);
+    QString print(bool recursive = false, int depth = 0);
 
 signals:
     void dataChanged(Group* group);

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -728,10 +728,6 @@ void TestGroup::testPrint()
     output = db->rootGroup()->print();
     QCOMPARE(output, QString("entry1\n"));
 
-    output = db->rootGroup()->print(true);
-    QCOMPARE(output, QString("entry1 " + entry1->uuid().toHex() + "\n"));
-
-
     Group* group1 = new Group();
     group1->setName("group1");
 
@@ -746,11 +742,16 @@ void TestGroup::testPrint()
     output = db->rootGroup()->print();
     QVERIFY(output.contains(QString("entry1\n")));
     QVERIFY(output.contains(QString("group1/\n")));
-    QVERIFY(output.contains(QString("  entry2\n")));
+    QVERIFY(!output.contains(QString("  entry2\n")));
 
     output = db->rootGroup()->print(true);
-    QVERIFY(output.contains(QString("entry1 " + entry1->uuid().toHex() + "\n")));
-    QVERIFY(output.contains(QString("group1/ " + group1->uuid().toHex() + "\n")));
-    QVERIFY(output.contains(QString("  entry2 " + entry2->uuid().toHex() + "\n")));
+    QVERIFY(output.contains(QString("entry1\n")));
+    QVERIFY(output.contains(QString("group1/\n")));
+    QVERIFY(output.contains(QString("  entry2\n")));
+
+    output = group1->print();
+    QVERIFY(!output.contains(QString("group1/\n")));
+    QVERIFY(output.contains(QString("entry2\n")));
+
     delete db;
 }


### PR DESCRIPTION
This PR introduces a `Command` class, from which all the CLI commands inherit. This makes it easy to programmatically get the names of all the available commands, using the factory-like static functions in the `Command` class.

Also took this opportunity to add most of the information on an entry to the `show` command, and renamed the `list` command to `ls`, to fit the unix name.

## Motivation and context
This will make it easier to add new cli commands (there will be more in the future...)

## How has this been tested?
* unit tests are passing
* Tested manually that all the commands were still working.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change
- ✅ Refactoring

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
