### PR TITLE
Menus

### DIFF
--- a/src/format/KeePass2Reader.cpp
+++ b/src/format/KeePass2Reader.cpp
@@ -73,7 +73,7 @@ Database* KeePass2Reader::readDatabase(QIODevice* device, const CompositeKey& ke
     quint32 signature2 = Endian::readUInt32(m_headerStream, KeePass2::BYTEORDER, &ok);
     if (ok && signature2 == KeePass1::SIGNATURE_2) {
         raiseError(tr("The selected file is an old KeePass 1 database (.kdb).\n\n"
-                      "You can import it by clicking on Database > 'Import KeePass 1 database'.\n"
+                      "You can import it by clicking on Database > 'Import KeePass 1 database...'.\n"
                       "This is a one-way migration. You won't be able to open the imported "
                       "database with the old KeePassX 0.4 version."));
         return nullptr;

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -309,7 +309,7 @@
   </action>
   <action name="actionDatabaseOpen">
    <property name="text">
-    <string>&amp;Open database</string>
+    <string>&amp;Open database...</string>
    </property>
   </action>
   <action name="actionDatabaseSave">
@@ -391,7 +391,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Sa&amp;ve database as</string>
+    <string>Sa&amp;ve database as...</string>
    </property>
   </action>
   <action name="actionChangeMasterKey">
@@ -399,7 +399,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Change &amp;master key</string>
+    <string>Change &amp;master key...</string>
    </property>
   </action>
   <action name="actionChangeDatabaseSettings">
@@ -517,22 +517,22 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>&amp;Export to CSV file</string>
+    <string>&amp;Export to CSV file...</string>
    </property>
   </action>
   <action name="actionImportKeePass1">
    <property name="text">
-    <string>Import KeePass 1 database</string>
+    <string>Import KeePass 1 database...</string>
    </property>
   </action>
   <action name="actionImportCsv">
    <property name="text">
-    <string>Import CSV file</string>
+    <string>Import CSV file...</string>
    </property>
   </action>
   <action name="actionRepairDatabase">
    <property name="text">
-    <string>Re&amp;pair database</string>
+    <string>Re&amp;pair database...</string>
    </property>
   </action>
   <action name="actionEntryTotp">
@@ -542,7 +542,7 @@
   </action>
   <action name="actionEntrySetupTotp">
    <property name="text">
-    <string>Set up TOTP</string>
+    <string>Set up TOTP...</string>
    </property>
   </action>
   <action name="actionEntryCopyTotp">


### PR DESCRIPTION
Improve menus (on Windows)

## Description
<!--- Describe your changes in detail -->
Many menus require user input in order to achieve the action of the menu. When that extra input is required, it should be indicated by ellipsis.

"Setup" is a noun
"Set up" is a verb phrase

A program is often called "setup", but the action it's taking is to "set up" the program.
The "Set up TOPT" action falls in the latter category.

## Motivation and context
UI consistency

## How has this been tested?
None

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**