### PR TITLE
Set up is used as a verb phrase not a noun

### DIFF
--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -542,7 +542,7 @@
   </action>
   <action name="actionEntrySetupTotp">
    <property name="text">
-    <string>Setup TOTP</string>
+    <string>Set up TOTP</string>
    </property>
   </action>
   <action name="actionEntryCopyTotp">


### PR DESCRIPTION
Correct "set up" from "setup" (split from #782)

## Description
<!--- Describe your changes in detail -->

"Setup" is a noun
"Set up" is a verb phrase

A program is often called "setup", but the action it's taking is to "set up" the program.
The "Set up TOPT" action falls in the latter category.

## Motivation and context
UI consistency

## How has this been tested?
None

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**