### PR TITLE
Feature : Clip command using native programs.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,8 +66,8 @@ set(keepassx_SOURCES
     core/Tools.cpp
     core/Translator.cpp
     core/Uuid.cpp
-    cli/PasswordInput.cpp
-    cli/PasswordInput.h
+    cli/Utils.cpp
+    cli/Utils.h
     crypto/Crypto.cpp
     crypto/CryptoHash.cpp
     crypto/Random.cpp

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -15,21 +15,24 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
 #include <cstdlib>
 #include <stdio.h>
+#include <thread>
 
 #include "Clip.h"
 
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QCoreApplication>
 #include <QStringList>
 #include <QTextStream>
 
-#include "gui/UnlockDatabaseDialog.h"
+#include "cli/Utils.h"
 #include "core/Database.h"
 #include "core/Entry.h"
 #include "core/Group.h"
-#include "gui/Clipboard.h"
+#include "gui/UnlockDatabaseDialog.h"
 
 Clip::Clip()
 {
@@ -59,31 +62,44 @@ int Clip::execute(int argc, char** argv)
                                  QObject::tr("Use a GUI prompt unlocking the database."));
     parser.addOption(guiPrompt);
     parser.addPositionalArgument("entry", QObject::tr("Path of the entry to clip."));
+    parser.addPositionalArgument(
+        "timeout",
+        QObject::tr("Timeout in seconds before clearing the clipboard."),
+        QString("[timeout]"));
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
-    if (args.size() != 2) {
+    if (args.size() != 2 && args.size() != 3) {
         QCoreApplication app(argc, argv);
         out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli clip");
         return EXIT_FAILURE;
     }
 
     Database* db = nullptr;
-    QApplication app(argc, argv);
     if (parser.isSet("gui-prompt")) {
+        QApplication app(argc, argv);
         db = UnlockDatabaseDialog::openDatabasePrompt(args.at(0));
     } else {
+        QCoreApplication app(argc, argv);
         db = Database::unlockFromStdin(args.at(0));
     }
 
     if (!db) {
         return EXIT_FAILURE;
     }
-    return this->clipEntry(db, args.at(1));
+    return this->clipEntry(db, args.at(1), args.value(2));
 }
 
-int Clip::clipEntry(Database* database, QString entryPath)
+int Clip::clipEntry(Database* database, QString entryPath, QString timeout)
 {
+
+    int timeoutSeconds = 0;
+    if (!timeout.isEmpty() && !timeout.toInt()) {
+        qCritical("Invalid timeout value %s.", qPrintable(timeout));
+        return EXIT_FAILURE;
+    } else if (!timeout.isEmpty()) {
+        timeoutSeconds = timeout.toInt();
+    }
 
     QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
     Entry* entry = database->rootGroup()->findEntry(entryPath);
@@ -92,7 +108,25 @@ int Clip::clipEntry(Database* database, QString entryPath)
         return EXIT_FAILURE;
     }
 
-    Clipboard::instance()->setText(entry->password());
-    return EXIT_SUCCESS;
+    int exitCode = Utils::clipText(entry->password());
+    if (exitCode != EXIT_SUCCESS) {
+        return exitCode;
+    }
 
+    outputTextStream << "Entry's password copied to the clipboard!" << endl;
+
+    if (!timeoutSeconds) {
+        return exitCode;
+    }
+
+    while (timeoutSeconds > 0) {
+        outputTextStream << "\rClearing the clipboard in " << timeoutSeconds << " seconds...";
+        outputTextStream.flush();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        timeoutSeconds--;
+    }
+    Utils::clipText("");
+    outputTextStream << "\nClipboard cleared!" << endl;
+
+    return EXIT_SUCCESS;
 }

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -24,7 +24,6 @@
 
 #include <QApplication>
 #include <QCommandLineParser>
-#include <QCoreApplication>
 #include <QStringList>
 #include <QTextStream>
 
@@ -53,6 +52,7 @@ int Clip::execute(int argc, char** argv)
     }
 
     QTextStream out(stdout);
+    QApplication app(argc, argv);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(this->description);
@@ -70,17 +70,14 @@ int Clip::execute(int argc, char** argv)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 2 && args.size() != 3) {
-        QCoreApplication app(argc, argv);
         out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli clip");
         return EXIT_FAILURE;
     }
 
     Database* db = nullptr;
     if (parser.isSet("gui-prompt")) {
-        QApplication app(argc, argv);
         db = UnlockDatabaseDialog::openDatabasePrompt(args.at(0));
     } else {
-        QCoreApplication app(argc, argv);
         db = Database::unlockFromStdin(args.at(0));
     }
 

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -26,7 +26,7 @@ public:
     Clip();
     ~Clip();
     int execute(int argc, char** argv);
-    int clipEntry(Database* database, QString entryPath);
+    int clipEntry(Database* database, QString entryPath, QString timeout);
 };
 
 #endif // KEEPASSXC_CLIP_H

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -26,7 +26,7 @@
 #include <QStringList>
 #include <QTextStream>
 
-#include "cli/PasswordInput.h"
+#include "cli/Utils.h"
 #include "core/Database.h"
 #include "format/KeePass2Reader.h"
 #include "keys/CompositeKey.h"
@@ -66,7 +66,7 @@ int Extract::execute(int argc, char** argv)
     out << "Insert the database password\n> ";
     out.flush();
 
-    QString line = PasswordInput::getPassword();
+    QString line = Utils::getPassword();
     CompositeKey key = CompositeKey::readFromLine(line);
 
     QString databaseFilename = args.at(0);

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -94,10 +94,6 @@ int Utils::clipText(QString text)
     programName = "pbcopy";
 #endif
 
-#ifdef Q_OS_WIN
-    programName = "clip";
-#endif
-
     if (programName.isEmpty()) {
         qCritical("No program defined for clipboard manipulation");
         return EXIT_FAILURE;

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -94,6 +94,10 @@ int Utils::clipText(QString text)
     programName = "pbcopy";
 #endif
 
+#ifdef Q_OS_WIN
+    programName = "clip";
+#endif
+
     if (programName.isEmpty()) {
         qCritical("No program defined for clipboard manipulation");
         return EXIT_FAILURE;
@@ -108,8 +112,9 @@ int Utils::clipText(QString text)
         return EXIT_FAILURE;
     }
 
-    const char* data = qPrintable(text);
-    clipProcess->write(data, strlen(data));
+    if (clipProcess->write(text.toLatin1()) == -1) {
+        qDebug("Unable to write to process : %s", qPrintable(clipProcess->errorString()));
+    }
     clipProcess->waitForBytesWritten();
     clipProcess->closeWriteChannel();
     clipProcess->waitForFinished();

--- a/src/cli/Utils.h
+++ b/src/cli/Utils.h
@@ -15,17 +15,17 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSXC_PASSWORDINPUT_H
-#define KEEPASSXC_PASSWORDINPUT_H
+#ifndef KEEPASSXC_UTILS_H
+#define KEEPASSXC_UTILS_H
 
 #include <QtCore/qglobal.h>
 
-class PasswordInput
+class Utils
 {
 public:
-    PasswordInput();
     static void setStdinEcho(bool enable);
     static QString getPassword();
+    static int clipText(QString text);
 };
 
-#endif // KEEPASSXC_PASSWORDINPUT_H
+#endif // KEEPASSXC_UTILS_H

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -24,7 +24,7 @@
 #include <QTimer>
 #include <QXmlStreamReader>
 
-#include "cli/PasswordInput.h"
+#include "cli/Utils.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "crypto/Random.h"
@@ -404,7 +404,7 @@ Database* Database::unlockFromStdin(QString databaseFilename)
     outputTextStream << QString("Insert password to unlock " + databaseFilename + "\n> ");
     outputTextStream.flush();
 
-    QString line = PasswordInput::getPassword();
+    QString line = Utils::getPassword();
     CompositeKey key = CompositeKey::readFromLine(line);
     return Database::openDatabaseFile(databaseFilename, key);
 }


### PR DESCRIPTION
Clip command using native programs.

## Description
Summary of changes:
* Using native programs for the `Clip` command.
* Adding a timeout option for clearing the clipboard
* Renamed PasswordInput -> Utils, since we now use it for other CLI functions.

## Motivation and context
Interacting with the `QClipboard` is not possible for a `QCoreApplication`, and instantiating a `QApplication` does not play nicely with the CLI. The goal is to remove usages of `QApplication` (GUI applications) in the CLI, so that we can instantiate 1 `QCoreApplication` in `keepassxc-cli.cpp`, and that's it. No more branching to know what type of application to instantiate.

The next step is to remove the GUI prompt in favor of a `--key-file` option, supported in all of the commands. 

## How has this been tested?
Unit tests + tested on Mac and Linux.
@droidmonkey could you test this on Windows? I use the `clip` command, which I think is installed by default, but I'm lacking a windows setup to test this.

## Screenshots (if appropriate):
When passing a `timeout` option, the command will countdown until the timeout is finished, and then clear the clipboard.

```
$ ./src/cli/keepassxc-cli clip
Usage: ./src/cli/keepassxc-cli clip [options] database entry [timeout]
Copy an entry's password to the clipboard.

Options:
  -g, --gui-prompt  Use a GUI prompt unlocking the database.

Arguments:
  database          Path of the database.
  entry             Path of the entry to clip.
  timeout           Timeout in seconds before clearing the clipboard.
$ ./src/cli/keepassxc-cli clip ~/test.kdbx entry1 5
Insert password to unlock /home/louib/test.kdbx
> 
Entry's password copied to the clipboard!
Clearing the clipboard in 5 seconds...
```

Then after 5 seconds
```
$ ./src/cli/keepassxc-cli clip ~/test.kdbx entry1 5
Insert password to unlock /home/louib/test.kdbx
> 
Entry's password copied to the clipboard!
Clearing the clipboard in 1 seconds...
Clipboard cleared!
$
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
