### PR TITLE
Fix clone dialog text

### DIFF
--- a/src/gui/CloneDialog.ui
+++ b/src/gui/CloneDialog.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QCheckBox" name="titleClone">
        <property name="text">
-        <string>Append ' - Copy' to title</string>
+        <string>Append ' - Clone' to title</string>
        </property>
        <property name="checked">
         <bool>true</bool>


### PR DESCRIPTION
## Description
The clone dialog in the ui says `Append ' - Copy' to title.'`
The actual code creates an entry with added '- Clone'.
Fixed the string in the CloneDialog.ui file and in the translation files.

## Motivation and context
Makes UI consistent with the actual behavior of the code.

## How has this been tested?
Have not built the application. It should be a simple string change. 

## Screenshots (if appropriate):
![screen shot 2017-07-20 at 13 12 03](https://user-images.githubusercontent.com/4920542/28414763-591fc08c-6d4d-11e7-9754-9c104dfd04a2.png)
Notice how the cloned entries have a '- Clone' suffix and not '- Copy'.

## Types of changes
Simple text string change

- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**

