### PR TITLE
Let Qt figure out geometry of the about window.  Closes: #780.

### DIFF
--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>AboutDialog</class>
  <widget class="QDialog" name="AboutDialog">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>652</width>
-    <height>516</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>About KeePassXC</string>
   </property>


### PR DESCRIPTION
## Description
The size of the about window should not be hard-coded in the .ui file since no pixel size can be correct for all resolutions.

## Motivation and context
Solves https://github.com/keepassxreboot/keepassxc/issues/780.

## How has this been tested?
Visually inspected the about window.

## Screenshots (if appropriate):
Before:
![keepass-about](https://user-images.githubusercontent.com/1244737/28487863-e14db75e-6e68-11e7-8e97-8843e6e137a3.png)

After:
![keepass-about-fixed](https://user-images.githubusercontent.com/1244737/28487865-eb91bcc4-6e68-11e7-9c29-ac1f75411d8c.png)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**