### PR TITLE
Clearing deleted entries on applying.

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -429,6 +429,7 @@ void EditEntryWidget::saveEntry()
     // must stand before beginUpdate()
     // we don't want to create a new history item, if only the history has changed
     m_entry->removeHistoryItems(m_historyModel->deletedEntries());
+    m_historyModel->clearDeletedEntries();
 
     m_autoTypeAssoc->removeEmpty();
 
@@ -912,8 +913,7 @@ void EditEntryWidget::deleteHistoryEntry()
         m_historyModel->deleteIndex(index);
         if (m_historyModel->rowCount() > 0) {
             m_historyUi->deleteAllButton->setEnabled(true);
-        }
-        else {
+        } else {
             m_historyUi->deleteAllButton->setEnabled(false);
         }
     }

--- a/src/gui/entry/EntryHistoryModel.cpp
+++ b/src/gui/entry/EntryHistoryModel.cpp
@@ -115,6 +115,11 @@ void EntryHistoryModel::clear()
     endResetModel();
 }
 
+void EntryHistoryModel::clearDeletedEntries()
+{
+    m_deletedHistoryEntries.clear();
+}
+
 QList<Entry*> EntryHistoryModel::deletedEntries()
 {
     return m_deletedHistoryEntries;

--- a/src/gui/entry/EntryHistoryModel.h
+++ b/src/gui/entry/EntryHistoryModel.h
@@ -37,6 +37,7 @@ public:
 
     void setEntries(const QList<Entry*>& entries);
     void clear();
+    void clearDeletedEntries();
     QList<Entry*> deletedEntries();
     void deleteIndex(QModelIndex index);
     void deleteAll();


### PR DESCRIPTION
Fixes #812

We were trying to delete the same history items multiple times. The bug would also occur when deleting an history item an hitting multiple times the `apply` button.

## How has this been tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
