### PR TITLE
Feature : --key-file option for CLI

### DIFF
--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -23,7 +23,6 @@
 #include "Clip.h"
 
 #include <QCommandLineParser>
-#include <QStringList>
 #include <QTextStream>
 
 #include "cli/Utils.h"
@@ -41,13 +40,8 @@ Clip::~Clip()
 {
 }
 
-int Clip::execute(int argc, char** argv)
+int Clip::execute(QStringList arguments)
 {
-    QStringList arguments;
-    // Skipping the first argument (keepassxc).
-    for (int i = 1; i < argc; ++i) {
-        arguments << QString(argv[i]);
-    }
 
     QTextStream out(stdout);
 

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -22,7 +22,6 @@
 
 #include "Clip.h"
 
-#include <QApplication>
 #include <QCommandLineParser>
 #include <QStringList>
 #include <QTextStream>
@@ -31,7 +30,6 @@
 #include "core/Database.h"
 #include "core/Entry.h"
 #include "core/Group.h"
-#include "gui/UnlockDatabaseDialog.h"
 
 Clip::Clip()
 {
@@ -52,15 +50,14 @@ int Clip::execute(int argc, char** argv)
     }
 
     QTextStream out(stdout);
-    QApplication app(argc, argv);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(this->description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
-    QCommandLineOption guiPrompt(QStringList() << "g"
-                                               << "gui-prompt",
-                                 QObject::tr("Use a GUI prompt unlocking the database."));
-    parser.addOption(guiPrompt);
+    QCommandLineOption keyFile(QStringList() << "k"
+                                               << "key-file",
+                                 QObject::tr("Key file of the database."));
+    parser.addOption(keyFile);
     parser.addPositionalArgument("entry", QObject::tr("Path of the entry to clip."));
     parser.addPositionalArgument(
         "timeout",
@@ -74,16 +71,11 @@ int Clip::execute(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    Database* db = nullptr;
-    if (parser.isSet("gui-prompt")) {
-        db = UnlockDatabaseDialog::openDatabasePrompt(args.at(0));
-    } else {
-        db = Database::unlockFromStdin(args.at(0));
-    }
-
+    Database* db = Database::unlockFromStdin(args.at(0), parser.value(keyFile));
     if (!db) {
         return EXIT_FAILURE;
     }
+
     return this->clipEntry(db, args.at(1), args.value(2));
 }
 

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -49,8 +49,9 @@ int Clip::execute(QStringList arguments)
     parser.setApplicationDescription(this->description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
     QCommandLineOption keyFile(QStringList() << "k"
-                                               << "key-file",
-                                 QObject::tr("Key file of the database."));
+                                             << "key-file",
+                               QObject::tr("Key file of the database."),
+                               QObject::tr("path"));
     parser.addOption(keyFile);
     parser.addPositionalArgument("entry", QObject::tr("Path of the entry to clip."));
     parser.addPositionalArgument(

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -25,7 +25,7 @@ class Clip : public Command
 public:
     Clip();
     ~Clip();
-    int execute(int argc, char** argv);
+    int execute(QStringList arguments);
     int clipEntry(Database* database, QString entryPath, QString timeout);
 };
 

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -35,7 +35,7 @@ Command::~Command()
 {
 }
 
-int Command::execute(int, char**)
+int Command::execute(QStringList)
 {
     return EXIT_FAILURE;
 }

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -29,7 +29,7 @@ class Command
 {
 public:
     virtual ~Command();
-    virtual int execute(int argc, char** argv);
+    virtual int execute(QStringList arguments);
     QString name;
     QString description;
     QString getDescriptionLine();

--- a/src/cli/EntropyMeter.cpp
+++ b/src/cli/EntropyMeter.cpp
@@ -101,12 +101,13 @@ int EntropyMeter::execute(QStringList arguments)
 {
     printf("KeePassXC Entropy Meter, based on zxcvbn-c.\nEnter your password below or pass it as argv\n");
     printf("  Usage: entropy-meter [-a] [pwd1 pwd2 ...]\n> ");
-    int i, advanced;
+    int i, advanced = 0;
     if (arguments.size() > 1 && arguments.at(1) == "-a")
     {
       advanced = 1;
+      arguments.removeAt(1);
     }
-    i = 2;
+    i = 1;
     if (i >= arguments.size())
     {
         /* No test passwords on command line, so get them from stdin */

--- a/src/cli/EntropyMeter.cpp
+++ b/src/cli/EntropyMeter.cpp
@@ -97,17 +97,17 @@ static void calculate(const char *pwd, int advanced)
     }
 }
 
-int EntropyMeter::execute(int argc, char **argv)
+int EntropyMeter::execute(QStringList arguments)
 {
     printf("KeePassXC Entropy Meter, based on zxcvbn-c.\nEnter your password below or pass it as argv\n");
     printf("  Usage: entropy-meter [-a] [pwd1 pwd2 ...]\n> ");
     int i, advanced;
-    if ((argc > 1) && (argv[1][0] == '-') && (!strcmp(argv[1], "-a")))
+    if (arguments.size() > 1 && arguments.at(1) == "-a")
     {
       advanced = 1;
     }
     i = 2;
-    if (i >= argc)
+    if (i >= arguments.size())
     {
         /* No test passwords on command line, so get them from stdin */
         char line[500];
@@ -131,9 +131,9 @@ int EntropyMeter::execute(int argc, char **argv)
     else
     {
         /* Do the test passwords on the command line */
-        for(; i < argc; ++i)
+        for(; i < arguments.size(); ++i)
         {
-            calculate(argv[i],advanced);
+            calculate(arguments.at(i).toLatin1(), advanced);
         }
     }
     return 0;

--- a/src/cli/EntropyMeter.h
+++ b/src/cli/EntropyMeter.h
@@ -25,7 +25,7 @@ class EntropyMeter : public Command
 public:
     EntropyMeter();
     ~EntropyMeter();
-    int execute(int argc, char** argv);
+    int execute(QStringList arguments);
 };
 
 #endif // KEEPASSXC_ENTROPYMETER_H

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -30,6 +30,7 @@
 #include "core/Database.h"
 #include "format/KeePass2Reader.h"
 #include "keys/CompositeKey.h"
+#include "keys/PasswordKey.h"
 
 Extract::Extract()
 {
@@ -66,8 +67,12 @@ int Extract::execute(int argc, char** argv)
     out << "Insert the database password\n> ";
     out.flush();
 
+    CompositeKey compositeKey;
+
     QString line = Utils::getPassword();
-    CompositeKey key = CompositeKey::readFromLine(line);
+    PasswordKey passwordKey;
+    passwordKey.setPassword(line);
+    compositeKey.addKey(passwordKey);
 
     QString databaseFilename = args.at(0);
     QFile dbFile(databaseFilename);
@@ -82,7 +87,7 @@ int Extract::execute(int argc, char** argv)
 
     KeePass2Reader reader;
     reader.setSaveXml(true);
-    Database* db = reader.readDatabase(&dbFile, key);
+    Database* db = reader.readDatabase(&dbFile, compositeKey);
     delete db;
 
     QByteArray xmlData = reader.xmlData();

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -22,7 +22,6 @@
 
 #include <QCommandLineParser>
 #include <QFile>
-#include <QStringList>
 #include <QTextStream>
 
 #include "cli/Utils.h"
@@ -41,14 +40,8 @@ Extract::~Extract()
 {
 }
 
-int Extract::execute(int argc, char** argv)
+int Extract::execute(QStringList arguments)
 {
-    QStringList arguments;
-    // Skipping the first argument (keepassxc).
-    for (int i = 1; i < argc; ++i) {
-        arguments << QString(argv[i]);
-    }
-
     QTextStream out(stdout);
 
     QCommandLineParser parser;

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -21,7 +21,6 @@
 #include "Extract.h"
 
 #include <QCommandLineParser>
-#include <QCoreApplication>
 #include <QFile>
 #include <QStringList>
 #include <QTextStream>
@@ -50,7 +49,6 @@ int Extract::execute(int argc, char** argv)
         arguments << QString(argv[i]);
     }
 
-    QCoreApplication app(argc, argv);
     QTextStream out(stdout);
 
     QCommandLineParser parser;

--- a/src/cli/Extract.h
+++ b/src/cli/Extract.h
@@ -25,7 +25,7 @@ class Extract : public Command
 public:
     Extract();
     ~Extract();
-    int execute(int argc, char** argv);
+    int execute(QStringList arguments);
 };
 
 #endif // KEEPASSXC_EXTRACT_H

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -20,9 +20,7 @@
 
 #include "List.h"
 
-#include <QApplication>
 #include <QCommandLineParser>
-#include <QStringList>
 #include <QTextStream>
 
 #include "core/Database.h"
@@ -39,14 +37,8 @@ List::~List()
 {
 }
 
-int List::execute(int argc, char** argv)
+int List::execute(QStringList arguments)
 {
-    QStringList arguments;
-    // Skipping the first argument (keepassxc).
-    for (int i = 1; i < argc; ++i) {
-        arguments << QString(argv[i]);
-    }
-
     QTextStream out(stdout);
 
     QCommandLineParser parser;

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -47,8 +47,9 @@ int List::execute(QStringList arguments)
     parser.addPositionalArgument(
         "group", QObject::tr("Path of the group to list. Default is /"), QString("[group]"));
     QCommandLineOption keyFile(QStringList() << "k"
-                                               << "key-file",
-                                 QObject::tr("Key file of the database."));
+                                             << "key-file",
+                               QObject::tr("Key file of the database."),
+                               QObject::tr("path"));
     parser.addOption(keyFile);
     parser.process(arguments);
 

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -22,14 +22,12 @@
 
 #include <QApplication>
 #include <QCommandLineParser>
-#include <QCoreApplication>
 #include <QStringList>
 #include <QTextStream>
 
 #include "core/Database.h"
 #include "core/Entry.h"
 #include "core/Group.h"
-#include "gui/UnlockDatabaseDialog.h"
 
 List::List()
 {
@@ -56,28 +54,19 @@ int List::execute(int argc, char** argv)
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
     parser.addPositionalArgument(
         "group", QObject::tr("Path of the group to list. Default is /"), QString("[group]"));
-    QCommandLineOption guiPrompt(QStringList() << "g"
-                                               << "gui-prompt",
-                                 QObject::tr("Use a GUI prompt unlocking the database."));
-    parser.addOption(guiPrompt);
+    QCommandLineOption keyFile(QStringList() << "k"
+                                               << "key-file",
+                                 QObject::tr("Key file of the database."));
+    parser.addOption(keyFile);
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 1 && args.size() != 2) {
-        QCoreApplication app(argc, argv);
         out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli ls");
         return EXIT_FAILURE;
     }
 
-    Database* db = nullptr;
-    if (parser.isSet("gui-prompt")) {
-        QApplication app(argc, argv);
-        db = UnlockDatabaseDialog::openDatabasePrompt(args.at(0));
-    } else {
-        QCoreApplication app(argc, argv);
-        db = Database::unlockFromStdin(args.at(0));
-    }
-
+    Database* db = Database::unlockFromStdin(args.at(0), parser.value(keyFile));
     if (db == nullptr) {
         return EXIT_FAILURE;
     }

--- a/src/cli/List.h
+++ b/src/cli/List.h
@@ -25,7 +25,7 @@ class List : public Command
 public:
     List();
     ~List();
-    int execute(int argc, char** argv);
+    int execute(QStringList arguments);
     int listGroup(Database* database, QString groupPath = QString(""));
 };
 

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -19,9 +19,7 @@
 
 #include "Merge.h"
 
-#include <QApplication>
 #include <QCommandLineParser>
-#include <QStringList>
 #include <QTextStream>
 
 #include "core/Database.h"
@@ -36,14 +34,8 @@ Merge::~Merge()
 {
 }
 
-int Merge::execute(int argc, char** argv)
+int Merge::execute(QStringList arguments)
 {
-    QStringList arguments;
-    // Skipping the first argument (keepassxc).
-    for (int i = 1; i < argc; ++i) {
-        arguments << QString(argv[i]);
-    }
-
     QTextStream out(stdout);
 
     QCommandLineParser parser;
@@ -53,8 +45,8 @@ int Merge::execute(int argc, char** argv)
 
     QCommandLineOption samePasswordOption(
         QStringList() << "s"
-                      << "same-password",
-        QObject::tr("Use the same password for both database files."));
+                      << "same-credentials",
+        QObject::tr("Use the same credentials for both database files."));
 
     QCommandLineOption keyFile(QStringList() << "k"
                                                << "key-file",

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -49,12 +49,14 @@ int Merge::execute(QStringList arguments)
         QObject::tr("Use the same credentials for both database files."));
 
     QCommandLineOption keyFile(QStringList() << "k"
-                                               << "key-file",
-                                 QObject::tr("Key file of the database."));
+                                             << "key-file",
+                               QObject::tr("Key file of the database."),
+                               QObject::tr("path"));
     parser.addOption(keyFile);
     QCommandLineOption keyFileFrom(QStringList() << "f"
-                                               << "key-file-from",
-                                 QObject::tr("Key file of the database to merge from."));
+                                                 << "key-file-from",
+                               QObject::tr("Key file of the database to merge from."),
+                               QObject::tr("path"));
     parser.addOption(keyFileFrom);
 
     parser.addOption(samePasswordOption);
@@ -73,7 +75,7 @@ int Merge::execute(QStringList arguments)
     }
 
     Database* db2;
-    if (!parser.isSet("same-password")) {
+    if (!parser.isSet("same-credentials")) {
         db2 = Database::unlockFromStdin(args.at(1), parser.value(keyFileFrom));
     } else {
         db2 = Database::openDatabaseFile(args.at(1), *(db1->key().clone()));

--- a/src/cli/Merge.h
+++ b/src/cli/Merge.h
@@ -25,7 +25,7 @@ class Merge : public Command
 public:
     Merge();
     ~Merge();
-    int execute(int argc, char** argv);
+    int execute(QStringList arguments);
 };
 
 #endif // KEEPASSXC_MERGE_H

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -21,7 +21,6 @@
 #include "Show.h"
 
 #include <QCommandLineParser>
-#include <QStringList>
 #include <QTextStream>
 
 #include "core/Database.h"
@@ -38,14 +37,8 @@ Show::~Show()
 {
 }
 
-int Show::execute(int argc, char** argv)
+int Show::execute(QStringList arguments)
 {
-    QStringList arguments;
-    // Skipping the first argument (keepassxc).
-    for (int i = 1; i < argc; ++i) {
-        arguments << QString(argv[i]);
-    }
-
     QTextStream out(stdout);
 
     QCommandLineParser parser;

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -21,7 +21,6 @@
 #include "Show.h"
 
 #include <QCommandLineParser>
-#include <QCoreApplication>
 #include <QStringList>
 #include <QTextStream>
 
@@ -47,12 +46,15 @@ int Show::execute(int argc, char** argv)
         arguments << QString(argv[i]);
     }
 
-    QCoreApplication app(argc, argv);
     QTextStream out(stdout);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(this->description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
+    QCommandLineOption keyFile(QStringList() << "k"
+                                               << "key-file",
+                                 QObject::tr("Key file of the database."));
+    parser.addOption(keyFile);
     parser.addPositionalArgument("entry", QObject::tr("Name of the entry to show."));
     parser.process(arguments);
 
@@ -62,7 +64,7 @@ int Show::execute(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    Database* db = Database::unlockFromStdin(args.at(0));
+    Database* db = Database::unlockFromStdin(args.at(0), parser.value(keyFile));
     if (db == nullptr) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -45,8 +45,9 @@ int Show::execute(QStringList arguments)
     parser.setApplicationDescription(this->description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
     QCommandLineOption keyFile(QStringList() << "k"
-                                               << "key-file",
-                                 QObject::tr("Key file of the database."));
+                                             << "key-file",
+                               QObject::tr("Key file of the database."),
+                               QObject::tr("path"));
     parser.addOption(keyFile);
     parser.addPositionalArgument("entry", QObject::tr("Name of the entry to show."));
     parser.process(arguments);

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -25,7 +25,7 @@ class Show : public Command
 public:
     Show();
     ~Show();
-    int execute(int argc, char** argv);
+    int execute(QStringList arguments);
     int showEntry(Database* database, QString entryPath);
 };
 

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -43,6 +43,8 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
+    QCoreApplication app(argc, argv);
+
     QTextStream out(stdout);
     QStringList arguments;
     for (int i = 0; i < argc; ++i) {
@@ -67,7 +69,6 @@ int main(int argc, char** argv)
     parser.parse(arguments);
 
     if (parser.positionalArguments().size() < 1) {
-        QCoreApplication app(argc, argv);
         app.setApplicationVersion(KEEPASSX_VERSION);
         if (parser.isSet("version")) {
             // Switch to parser.showVersion() when available (QT 5.4).
@@ -82,7 +83,6 @@ int main(int argc, char** argv)
 
     if (command == nullptr) {
         qCritical("Invalid command %s.", qPrintable(commandName));
-        QCoreApplication app(argc, argv);
         app.setApplicationVersion(KEEPASSX_VERSION);
         // showHelp exits the application immediately, so we need to set the
         // exit code here.

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -44,6 +44,7 @@ int main(int argc, char** argv)
     }
 
     QCoreApplication app(argc, argv);
+    app.setApplicationVersion(KEEPASSX_VERSION);
 
     QTextStream out(stdout);
     QStringList arguments;
@@ -69,7 +70,6 @@ int main(int argc, char** argv)
     parser.parse(arguments);
 
     if (parser.positionalArguments().size() < 1) {
-        app.setApplicationVersion(KEEPASSX_VERSION);
         if (parser.isSet("version")) {
             // Switch to parser.showVersion() when available (QT 5.4).
             out << KEEPASSX_VERSION << endl;
@@ -83,13 +83,14 @@ int main(int argc, char** argv)
 
     if (command == nullptr) {
         qCritical("Invalid command %s.", qPrintable(commandName));
-        app.setApplicationVersion(KEEPASSX_VERSION);
         // showHelp exits the application immediately, so we need to set the
         // exit code here.
         parser.showHelp(EXIT_FAILURE);
     }
 
-    int exitCode = command->execute(argc, argv);
+    // Removing the first argument (keepassxc).
+    arguments.removeFirst();
+    int exitCode = command->execute(arguments);
 
 #if defined(WITH_ASAN) && defined(WITH_LSAN)
     // do leak check here to prevent massive tail of end-of-process leak errors from third-party libraries

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -122,7 +122,7 @@ public:
 
     static Database* databaseByUuid(const Uuid& uuid);
     static Database* openDatabaseFile(QString fileName, CompositeKey key);
-    static Database* unlockFromStdin(QString databaseFilename);
+    static Database* unlockFromStdin(QString databaseFilename, QString keyFilename = QString(""));
 
 signals:
     void groupDataChanged(Group* group);

--- a/src/gui/UnlockDatabaseDialog.cpp
+++ b/src/gui/UnlockDatabaseDialog.cpp
@@ -54,20 +54,3 @@ void UnlockDatabaseDialog::complete(bool r)
         reject();
     }
 }
-
-Database* UnlockDatabaseDialog::openDatabasePrompt(QString databaseFilename)
-{
-
-    UnlockDatabaseDialog* unlockDatabaseDialog = new UnlockDatabaseDialog();
-    unlockDatabaseDialog->setObjectName("Open database");
-    unlockDatabaseDialog->setDBFilename(databaseFilename);
-    unlockDatabaseDialog->show();
-    unlockDatabaseDialog->exec();
-
-    Database* db = unlockDatabaseDialog->database();
-    if (!db) {
-        qWarning("Could not open database %s.", qPrintable(databaseFilename));
-    }
-    delete unlockDatabaseDialog;
-    return db;
-}

--- a/src/gui/UnlockDatabaseDialog.h
+++ b/src/gui/UnlockDatabaseDialog.h
@@ -35,7 +35,6 @@ public:
     void setDBFilename(const QString& filename);
     void clearForms();
     Database* database();
-    static Database* openDatabasePrompt(QString databaseFilename);
 
 signals:
     void unlockDone(bool);

--- a/src/keys/CompositeKey.cpp
+++ b/src/keys/CompositeKey.cpp
@@ -80,29 +80,6 @@ CompositeKey& CompositeKey::operator=(const CompositeKey& key)
     return *this;
 }
 
-/*
- * Read a key from a line of input.
- * If the line references a valid file
- * path, the key is loaded from file.
- */
-CompositeKey CompositeKey::readFromLine(QString line)
-{
-
-  CompositeKey key;
-  if (QFile::exists(line)) {
-      FileKey fileKey;
-      fileKey.load(line);
-      key.addKey(fileKey);
-  }
-  else {
-      PasswordKey password;
-      password.setPassword(line);
-      key.addKey(password);
-  }
-  return key;
-
-}
-
 QByteArray CompositeKey::rawKey() const
 {
     CryptoHash cryptoHash(CryptoHash::Sha256);

--- a/src/keys/CompositeKey.h
+++ b/src/keys/CompositeKey.h
@@ -46,7 +46,6 @@ public:
     void addChallengeResponseKey(QSharedPointer<ChallengeResponseKey> key);
 
     static int transformKeyBenchmark(int msec);
-    static CompositeKey readFromLine(QString line);
 
 private:
     static QByteArray transformKeyRaw(const QByteArray& key, const QByteArray& seed,

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -84,22 +84,6 @@ void TestKeys::testComposite()
     delete compositeKey4;
 }
 
-void TestKeys::testCompositeKeyReadFromLine()
-{
-
-    QString keyFilename = QString("%1/FileKeyXml.key").arg(QString(KEEPASSX_TEST_DATA_DIR));
-
-    CompositeKey compositeFileKey = CompositeKey::readFromLine(keyFilename);
-    FileKey fileKey;
-    fileKey.load(keyFilename);
-    QCOMPARE(compositeFileKey.rawKey().size(), fileKey.rawKey().size());
-
-    CompositeKey compositePasswordKey = CompositeKey::readFromLine(QString("password"));
-    PasswordKey passwordKey(QString("password"));
-    QCOMPARE(compositePasswordKey.rawKey().size(), passwordKey.rawKey().size());
-
-}
-
 void TestKeys::testFileKey()
 {
     QFETCH(QString, type);

--- a/tests/TestKeys.h
+++ b/tests/TestKeys.h
@@ -28,7 +28,6 @@ class TestKeys : public QObject
 private slots:
     void initTestCase();
     void testComposite();
-    void testCompositeKeyReadFromLine();
     void testFileKey();
     void testFileKey_data();
     void testCreateFileKey();


### PR DESCRIPTION
* Introduced the `--key-file` option for CLI commands
* Removed support for `--gui-prompt` and related code.
* Moved `QCoreApplication` instantiation to `keepassxc-cli.cpp`
* Removed `CompositeKey::readFromLine`, which was assuming a password entered at the password prompt was possibly a key file path. We do not need that anymore now that there's an option for that.

Overall, removing the use of a `QApplication` in the CLI. We only use a `QCoreApplication` now, which removes the need to branch on the application type, and allows to move some duplicated logic to `keepassxc-cli`.


## How has this been tested?
* Unit tests
* Tested all the commands with / without key files
* Tested the merge command with all `key-file`, `key-file-from` and `-s` combination.

## Screenshots (if appropriate):
New documentation for the `key-file` option:
```
$ ./src/cli/keepassxc-cli clip
Usage: ./src/cli/keepassxc-cli clip [options] database entry [timeout]
Copy an entry's password to the clipboard.

Options:
  -k, --key-file <path>  Key file of the database.

Arguments:
  database               Path of the database.
  entry                  Path of the entry to clip.
  timeout                Timeout in seconds before clearing the clipboard.
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature
- ✅ Breaking change
- ✅ Refactoring

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
