### PR TITLE
Handle FileKey::load errors (--key-file)

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -402,23 +402,27 @@ Database* Database::openDatabaseFile(QString fileName, CompositeKey key)
 
 Database* Database::unlockFromStdin(QString databaseFilename, QString keyFilename)
 {
+    CompositeKey compositeKey;
+
+    if (!keyFilename.isEmpty()) {
+        FileKey fileKey;
+        QString errorMessage;
+        if (!fileKey.load(keyFilename, &errorMessage)) {
+            qCritical("Failed to load key file %s : %s", qPrintable(keyFilename), qPrintable(errorMessage));
+            return nullptr;
+        }
+        compositeKey.addKey(fileKey);
+    }
+
     QTextStream outputTextStream(stdout);
 
     outputTextStream << QString("Insert password to unlock " + databaseFilename + "\n> ");
     outputTextStream.flush();
 
-    CompositeKey compositeKey;
-
     QString line = Utils::getPassword();
     PasswordKey passwordKey;
     passwordKey.setPassword(line);
     compositeKey.addKey(passwordKey);
-
-    if (!keyFilename.isEmpty()) {
-        FileKey fileKey;
-        fileKey.load(keyFilename);
-        compositeKey.addKey(fileKey);
-    }
 
     return Database::openDatabaseFile(databaseFilename, compositeKey);
 }


### PR DESCRIPTION
While reviewing #824 , I realized we were not handling errors when loading the keyfile.


## How has this been tested?
Locally, with the clip command

## Screenshots (if appropriate):
```
$ ./src/cli/keepassxc-cli clip ~/test.kdbx --key-file fadsfdsaf entry1
Failed to load key file fadsfdsaf : No such file or directory
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
