### PR TITLE
[WIP] Create new KeepassHTTP KeyAcceptDialog

### DIFF
--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -5,6 +5,7 @@ if(WITH_XC_HTTP)
     
     set(keepasshttp_SOURCES
         AccessControlDialog.cpp
+        KeyAcceptDialog.cpp
         EntryConfig.cpp
         HttpPasswordGeneratorWidget.cpp
         HttpSettings.cpp

--- a/src/http/KeyAcceptDialog.cpp
+++ b/src/http/KeyAcceptDialog.cpp
@@ -1,0 +1,94 @@
+/*
+*  Copyright (C) 2013 Francois Ferrand
+*  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 2 or (at your option)
+*  version 3 of the License.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "KeyAcceptDialog.h"
+#include "ui_KeyAcceptDialog.h"
+#include "core/Entry.h"
+#include <QStandardItemModel>
+#include <QStandardItem>
+#include <Qt>
+
+KeyAcceptDialog::KeyAcceptDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::KeyAcceptDialog())
+{
+    this->setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+
+    ui->setupUi(this);
+    connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(ui->buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+
+    QStandardItemModel* listViewModel = new QStandardItemModel(ui->databasesListView);
+    ui->databasesListView->setModel(listViewModel);
+}
+
+KeyAcceptDialog::~KeyAcceptDialog()
+{
+}
+
+void KeyAcceptDialog::setItems(const QList<QString> &items)
+{
+    QStandardItemModel* listViewModel = (QStandardItemModel*) ui->databasesListView->model();
+
+    for (QString item: items) {
+        QStandardItem* listItem = new QStandardItem(item);
+        listItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
+        listItem->setData(Qt::Unchecked, Qt::CheckStateRole);
+
+        listViewModel->appendRow(listItem);
+    }
+}
+
+void KeyAcceptDialog::setItemChecked(int itemIndex, bool checked)
+{
+    QStandardItemModel* listViewModel = (QStandardItemModel*) ui->databasesListView->model();
+
+    QStandardItem* item = listViewModel->item(itemIndex);
+
+    if (item) {
+        if (checked) {
+            item->setCheckState(Qt::Checked);
+        } else {
+            item->setCheckState(Qt::Unchecked);
+        }
+    }
+}
+
+QList<int>* KeyAcceptDialog::getCheckedItems()
+{
+    QStandardItemModel* listViewModel = (QStandardItemModel*) ui->databasesListView->model();
+
+    int numRows = listViewModel->rowCount();
+
+    //XXX Memory Leak
+    QList<int>* resultList = new QList<int>;
+
+    for (int row = 0; row < numRows; row++) {
+        QStandardItem* item = listViewModel->item(row);
+        if (item->checkState() == Qt::Checked) {
+            resultList->append(row);
+        }
+    }
+
+    return resultList;
+}
+
+QString KeyAcceptDialog::getKeyName()
+{
+    return ui->keyNameLineEdit->text();
+}

--- a/src/http/KeyAcceptDialog.cpp
+++ b/src/http/KeyAcceptDialog.cpp
@@ -127,11 +127,11 @@ void KeyAcceptDialog::checkAcceptable()
     //TODO: Make translateable
     if (getKeyName().isEmpty()) {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
-        ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("Make sure the key name is not empty!");
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip(tr("Make sure the key name is not empty!"));
     }
     else if (!hasChecked) {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
-        ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("Check at least one database");
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip(tr("Check at least one database"));
     } else {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
         ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("");

--- a/src/http/KeyAcceptDialog.cpp
+++ b/src/http/KeyAcceptDialog.cpp
@@ -43,7 +43,9 @@ KeyAcceptDialog::~KeyAcceptDialog()
 
 void KeyAcceptDialog::setItems(const QList<QString> &items)
 {
-    QStandardItemModel* listViewModel = (QStandardItemModel*) ui->databasesListView->model();
+    QStandardItemModel* listViewModel = qobject_cast<QStandardItemModel*>(ui->databasesListView->model());
+
+    listViewModel->clear();
 
     for (QString item: items) {
         QStandardItem* listItem = new QStandardItem(item);
@@ -54,9 +56,20 @@ void KeyAcceptDialog::setItems(const QList<QString> &items)
     }
 }
 
+void KeyAcceptDialog::setItemEnabled(int itemIndex, bool enabled)
+{
+    QStandardItemModel* listViewModel = qobject_cast<QStandardItemModel*>(ui->databasesListView->model());
+
+    QStandardItem* item = listViewModel->item(itemIndex);
+
+    if (item) {
+        item->setEnabled(enabled);
+    }
+}
+
 void KeyAcceptDialog::setItemChecked(int itemIndex, bool checked)
 {
-    QStandardItemModel* listViewModel = (QStandardItemModel*) ui->databasesListView->model();
+    QStandardItemModel* listViewModel = qobject_cast<QStandardItemModel*>(ui->databasesListView->model());
 
     QStandardItem* item = listViewModel->item(itemIndex);
 
@@ -69,19 +82,19 @@ void KeyAcceptDialog::setItemChecked(int itemIndex, bool checked)
     }
 }
 
-QList<int>* KeyAcceptDialog::getCheckedItems()
+QList<int> KeyAcceptDialog::getCheckedItems()
 {
-    QStandardItemModel* listViewModel = (QStandardItemModel*) ui->databasesListView->model();
+    QStandardItemModel* listViewModel = qobject_cast<QStandardItemModel*>(ui->databasesListView->model());
 
     int numRows = listViewModel->rowCount();
 
     //XXX Memory Leak
-    QList<int>* resultList = new QList<int>;
+    QList<int> resultList;
 
     for (int row = 0; row < numRows; row++) {
         QStandardItem* item = listViewModel->item(row);
         if (item->checkState() == Qt::Checked) {
-            resultList->append(row);
+            resultList << row;
         }
     }
 
@@ -92,3 +105,8 @@ QString KeyAcceptDialog::getKeyName()
 {
     return ui->keyNameLineEdit->text();
 }
+
+//TODO
+//void KeyAcceptDialog::databaseUnlocked(DatabaseWidget* dbWidget)
+//{
+//}

--- a/src/http/KeyAcceptDialog.cpp
+++ b/src/http/KeyAcceptDialog.cpp
@@ -22,6 +22,8 @@
 #include <QStandardItemModel>
 #include <QStandardItem>
 #include <Qt>
+#include <QDialogButtonBox>
+#include <QPushButton>
 
 KeyAcceptDialog::KeyAcceptDialog(QWidget *parent) :
     QDialog(parent),
@@ -32,6 +34,9 @@ KeyAcceptDialog::KeyAcceptDialog(QWidget *parent) :
     ui->setupUi(this);
     connect(ui->buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
     connect(ui->buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+
+    connect(ui->keyNameLineEdit, SIGNAL(textChanged(const QString)), this, SLOT(keyEditChanged(const QString)));
+    this->keyEditChanged("");
 
     QStandardItemModel* listViewModel = new QStandardItemModel(ui->databasesListView);
     ui->databasesListView->setModel(listViewModel);
@@ -104,6 +109,18 @@ QList<int> KeyAcceptDialog::getCheckedItems()
 QString KeyAcceptDialog::getKeyName()
 {
     return ui->keyNameLineEdit->text();
+}
+
+void KeyAcceptDialog::keyEditChanged(const QString &text)
+{
+    //TODO: Make translateable
+    if (text.isEmpty()) {
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("Make sure the key name is not empty!");
+    } else {
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("");
+    }
 }
 
 //TODO

--- a/src/http/KeyAcceptDialog.cpp
+++ b/src/http/KeyAcceptDialog.cpp
@@ -1,33 +1,33 @@
 /*
-*  Copyright (C) 2013 Francois Ferrand
-*  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
-*
-*  This program is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 2 or (at your option)
-*  version 3 of the License.
-*
-*  This program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2013 Francois Ferrand
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "KeyAcceptDialog.h"
-#include "ui_KeyAcceptDialog.h"
 #include "core/Entry.h"
-#include <QStandardItemModel>
-#include <QStandardItem>
-#include <Qt>
+#include "ui_KeyAcceptDialog.h"
 #include <QDialogButtonBox>
 #include <QPushButton>
+#include <QStandardItem>
+#include <QStandardItemModel>
+#include <Qt>
 
-KeyAcceptDialog::KeyAcceptDialog(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::KeyAcceptDialog())
+KeyAcceptDialog::KeyAcceptDialog(QWidget* parent)
+    : QDialog(parent)
+    , ui(new Ui::KeyAcceptDialog())
 {
     this->setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
 
@@ -46,13 +46,13 @@ KeyAcceptDialog::~KeyAcceptDialog()
 {
 }
 
-void KeyAcceptDialog::setItems(const QList<QString> &items)
+void KeyAcceptDialog::setItems(const QList<QString>& items)
 {
     QStandardItemModel* listViewModel = qobject_cast<QStandardItemModel*>(ui->databasesListView->model());
 
     listViewModel->clear();
 
-    for (QString item: items) {
+    for (QString item : items) {
         QStandardItem* listItem = new QStandardItem(item);
         listItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
         listItem->setData(Qt::Unchecked, Qt::CheckStateRole);
@@ -93,7 +93,7 @@ QList<int> KeyAcceptDialog::getCheckedItems()
 
     int numRows = listViewModel->rowCount();
 
-    //XXX Memory Leak
+    // XXX Memory Leak
     QList<int> resultList;
 
     for (int row = 0; row < numRows; row++) {
@@ -124,12 +124,11 @@ void KeyAcceptDialog::checkAcceptable()
         }
     }
 
-    //TODO: Make translateable
+    // TODO: Make translateable
     if (getKeyName().isEmpty()) {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
         ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip(tr("Make sure the key name is not empty!"));
-    }
-    else if (!hasChecked) {
+    } else if (!hasChecked) {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
         ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip(tr("Check at least one database"));
     } else {
@@ -138,14 +137,14 @@ void KeyAcceptDialog::checkAcceptable()
     }
 }
 
-void KeyAcceptDialog::keyEditChanged(const QString &text)
+void KeyAcceptDialog::keyEditChanged(const QString& text)
 {
     (void)text;
 
     checkAcceptable();
 }
 
-void KeyAcceptDialog::modelItemChanged(QStandardItem *item)
+void KeyAcceptDialog::modelItemChanged(QStandardItem* item)
 {
     (void)item;
 

--- a/src/http/KeyAcceptDialog.cpp
+++ b/src/http/KeyAcceptDialog.cpp
@@ -93,7 +93,6 @@ QList<int> KeyAcceptDialog::getCheckedItems()
 
     int numRows = listViewModel->rowCount();
 
-    // XXX Memory Leak
     QList<int> resultList;
 
     for (int row = 0; row < numRows; row++) {
@@ -124,7 +123,6 @@ void KeyAcceptDialog::checkAcceptable()
         }
     }
 
-    // TODO: Make translateable
     if (getKeyName().isEmpty()) {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
         ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip(tr("Make sure the key name is not empty!"));

--- a/src/http/KeyAcceptDialog.cpp
+++ b/src/http/KeyAcceptDialog.cpp
@@ -36,10 +36,10 @@ KeyAcceptDialog::KeyAcceptDialog(QWidget *parent) :
     connect(ui->buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
     connect(ui->keyNameLineEdit, SIGNAL(textChanged(const QString)), this, SLOT(keyEditChanged(const QString)));
-    this->keyEditChanged("");
 
     QStandardItemModel* listViewModel = new QStandardItemModel(ui->databasesListView);
     ui->databasesListView->setModel(listViewModel);
+    connect(listViewModel, SIGNAL(itemChanged(QStandardItem*)), this, SLOT(modelItemChanged(QStandardItem*)));
 }
 
 KeyAcceptDialog::~KeyAcceptDialog()
@@ -111,14 +111,43 @@ QString KeyAcceptDialog::getKeyName()
     return ui->keyNameLineEdit->text();
 }
 
-void KeyAcceptDialog::keyEditChanged(const QString &text)
+void KeyAcceptDialog::checkAcceptable()
 {
+    QStandardItemModel* listViewModel = qobject_cast<QStandardItemModel*>(ui->databasesListView->model());
+    int numRows = listViewModel->rowCount();
+    bool hasChecked = false;
+    for (int row = 0; row < numRows; row++) {
+        QStandardItem* item = listViewModel->item(row);
+        if (item->checkState() == Qt::Checked) {
+            hasChecked = true;
+            break;
+        }
+    }
+
     //TODO: Make translateable
-    if (text.isEmpty()) {
+    if (getKeyName().isEmpty()) {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
         ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("Make sure the key name is not empty!");
+    }
+    else if (!hasChecked) {
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("Check at least one database");
     } else {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
         ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("");
     }
+}
+
+void KeyAcceptDialog::keyEditChanged(const QString &text)
+{
+    (void)text;
+
+    checkAcceptable();
+}
+
+void KeyAcceptDialog::modelItemChanged(QStandardItem *item)
+{
+    (void)item;
+
+    checkAcceptable();
 }

--- a/src/http/KeyAcceptDialog.cpp
+++ b/src/http/KeyAcceptDialog.cpp
@@ -122,8 +122,3 @@ void KeyAcceptDialog::keyEditChanged(const QString &text)
         ui->buttonBox->button(QDialogButtonBox::Ok)->setToolTip("");
     }
 }
-
-//TODO
-//void KeyAcceptDialog::databaseUnlocked(DatabaseWidget* dbWidget)
-//{
-//}

--- a/src/http/KeyAcceptDialog.h
+++ b/src/http/KeyAcceptDialog.h
@@ -1,0 +1,48 @@
+/*
+*  Copyright (C) 2013 Francois Ferrand
+*  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 2 or (at your option)
+*  version 3 of the License.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef KEYACCEPTDIALOG_H
+#define KEYACCEPTDIALOG_H
+
+#include <QDialog>
+#include <QScopedPointer>
+
+namespace Ui {
+class KeyAcceptDialog;
+}
+
+class KeyAcceptDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit KeyAcceptDialog(QWidget *parent = nullptr);
+    ~KeyAcceptDialog();
+
+    void setItems(const QList<QString> & items);
+    void setItemChecked(int itemIndex, bool checked);
+    QList<int>* getCheckedItems();
+
+    QString getKeyName();
+
+private:
+    QScopedPointer<Ui::KeyAcceptDialog> ui;
+};
+
+#endif // KEYACCEPTDIALOG_H
+

--- a/src/http/KeyAcceptDialog.h
+++ b/src/http/KeyAcceptDialog.h
@@ -21,6 +21,7 @@
 
 #include <QDialog>
 #include <QScopedPointer>
+#include <QStandardItem>
 
 namespace Ui {
 class KeyAcceptDialog;
@@ -41,8 +42,11 @@ public:
 
     QString getKeyName();
 
-public slots:
+    void checkAcceptable();
+
+private slots:
     void keyEditChanged(const QString &text);
+    void modelItemChanged(QStandardItem *item);
 
 private:
     QScopedPointer<Ui::KeyAcceptDialog> ui;

--- a/src/http/KeyAcceptDialog.h
+++ b/src/http/KeyAcceptDialog.h
@@ -41,6 +41,9 @@ public:
 
     QString getKeyName();
 
+public slots:
+    void keyEditChanged(const QString &text);
+
 //TODO
 //public slots:
 //    void databaseUnlocked(DatabaseWidget* dbWidget);

--- a/src/http/KeyAcceptDialog.h
+++ b/src/http/KeyAcceptDialog.h
@@ -1,20 +1,20 @@
 /*
-*  Copyright (C) 2013 Francois Ferrand
-*  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
-*
-*  This program is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 2 or (at your option)
-*  version 3 of the License.
-*
-*  This program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2013 Francois Ferrand
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef KEYACCEPTDIALOG_H
 #define KEYACCEPTDIALOG_H
@@ -23,8 +23,9 @@
 #include <QScopedPointer>
 #include <QStandardItem>
 
-namespace Ui {
-class KeyAcceptDialog;
+namespace Ui
+{
+    class KeyAcceptDialog;
 }
 
 class KeyAcceptDialog : public QDialog
@@ -32,10 +33,10 @@ class KeyAcceptDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit KeyAcceptDialog(QWidget *parent = nullptr);
+    explicit KeyAcceptDialog(QWidget* parent = nullptr);
     ~KeyAcceptDialog();
 
-    void setItems(const QList<QString> & items);
+    void setItems(const QList<QString>& items);
     void setItemChecked(int itemIndex, bool checked);
     void setItemEnabled(int itemIndex, bool enabled);
     QList<int> getCheckedItems();
@@ -45,12 +46,11 @@ public:
     void checkAcceptable();
 
 private slots:
-    void keyEditChanged(const QString &text);
-    void modelItemChanged(QStandardItem *item);
+    void keyEditChanged(const QString& text);
+    void modelItemChanged(QStandardItem* item);
 
 private:
     QScopedPointer<Ui::KeyAcceptDialog> ui;
 };
 
 #endif // KEYACCEPTDIALOG_H
-

--- a/src/http/KeyAcceptDialog.h
+++ b/src/http/KeyAcceptDialog.h
@@ -36,9 +36,15 @@ public:
 
     void setItems(const QList<QString> & items);
     void setItemChecked(int itemIndex, bool checked);
-    QList<int>* getCheckedItems();
+    void setItemEnabled(int itemIndex, bool enabled);
+    QList<int> getCheckedItems();
 
     QString getKeyName();
+
+//TODO
+//public slots:
+//    void databaseUnlocked(DatabaseWidget* dbWidget);
+//    void databaseLocked(DatabaseWidget* dbWidget);
 
 private:
     QScopedPointer<Ui::KeyAcceptDialog> ui;

--- a/src/http/KeyAcceptDialog.h
+++ b/src/http/KeyAcceptDialog.h
@@ -44,11 +44,6 @@ public:
 public slots:
     void keyEditChanged(const QString &text);
 
-//TODO
-//public slots:
-//    void databaseUnlocked(DatabaseWidget* dbWidget);
-//    void databaseLocked(DatabaseWidget* dbWidget);
-
 private:
     QScopedPointer<Ui::KeyAcceptDialog> ui;
 };

--- a/src/http/KeyAcceptDialog.ui
+++ b/src/http/KeyAcceptDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>403</width>
-    <height>233</height>
+    <width>469</width>
+    <height>292</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,7 +39,10 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which databases should this key be valid for?&lt;br&gt;(The currently selected database is pre-selected)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which databases should this key be valid for?&lt;br&gt;(The currently selected database is pre-selected; grayed-out databases are not opened - open them to enable accepting key!)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/src/http/KeyAcceptDialog.ui
+++ b/src/http/KeyAcceptDialog.ui
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>KeyAcceptDialog</class>
+ <widget class="QDialog" name="KeyAcceptDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>403</width>
+    <height>233</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>KeePassXC: New key association request</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You have received an association request for the above key.&lt;br&gt;If you would like to allow it access to your KeePassXC database,&lt;br&gt;give it a unique name to identify and accept it.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="keyNameLineEdit"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which databases should this key be valid for?&lt;br&gt;(The currently selected database is pre-selected)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListView" name="databasesListView"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>KeyAcceptDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>KeyAcceptDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/http/Server.cpp
+++ b/src/http/Server.cpp
@@ -216,13 +216,6 @@ void Server::stop(void)
 
 void Server::onNewRequest(QHttpRequest* request, QHttpResponse* response)
 {
-    if (!isDatabaseOpened()) {
-        if (!openDatabase()) {
-            response->setStatusCode(qhttp::ESTATUS_SERVICE_UNAVAILABLE);
-            response->end();
-            return;
-        }
-    }
 
     request->collectData(1024);
 

--- a/src/http/Server.h
+++ b/src/http/Server.h
@@ -1,86 +1,100 @@
 /*
-*  Copyright (C) 2013 Francois Ferrand
-*  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
-*
-*  This program is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 2 or (at your option)
-*  version 3 of the License.
-*
-*  This program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2013 Francois Ferrand
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef SERVER_H
 #define SERVER_H
 
-#include <QtCore/QObject>
 #include <QtCore/QList>
+#include <QtCore/QObject>
 
 #include "gui/DatabaseTabWidget.h"
 
-namespace qhttp {
-    namespace server {
+namespace qhttp
+{
+    namespace server
+    {
         class QHttpServer;
         class QHttpRequest;
         class QHttpResponse;
     }
 }
 
-namespace KeepassHttpProtocol {
-
-using namespace qhttp::server;
-
-class Request;
-class Response;
-class Entry;
-
-class Server : public QObject
+namespace KeepassHttpProtocol
 {
-    Q_OBJECT
-public:
-    explicit Server(QObject *parent = 0);
 
-    virtual bool isDatabaseOpened(DatabaseWidget* dbWidget = NULL) const = 0;
-    virtual bool openDatabase() = 0;
-    virtual QString getDatabaseRootUuid() = 0;
-    virtual QString getDatabaseRecycleBinUuid() = 0;
-    virtual QString getKey(const QString &id) = 0;
-    virtual QString storeKey(const QString &key) = 0;
-    virtual QList<Entry> findMatchingEntries(const QString &id, const QString &url, const QString & submitUrl, const QString & realm) = 0;
-    virtual int countMatchingEntries(const QString &id, const QString &url, const QString & submitUrl, const QString & realm) = 0;
-    virtual QList<Entry> searchAllEntries(const QString &id) = 0;
-    virtual void addEntry(const QString &id, const QString &login, const QString &password, const QString &url, const QString &submitUrl, const QString &realm) = 0;
-    virtual void updateEntry(const QString &id, const QString &uuid, const QString &login, const QString &password, const QString &url) = 0;
-    virtual QString generatePassword() = 0;
+    using namespace qhttp::server;
 
-public slots:
-    void start();
-    void stop();
+    class Request;
+    class Response;
+    class Entry;
 
-private slots:
-    void onNewRequest(QHttpRequest* request, QHttpResponse* response);
-    void handleRequest(const QByteArray& data, QHttpResponse* response);
+    class Server : public QObject
+    {
+        Q_OBJECT
+    public:
+        explicit Server(QObject* parent = 0);
 
-private:
-    void testAssociate(const KeepassHttpProtocol::Request &r, KeepassHttpProtocol::Response *protocolResp);
-    void associate(const KeepassHttpProtocol::Request &r, KeepassHttpProtocol::Response *protocolResp);
-    void getLogins(const KeepassHttpProtocol::Request &r, KeepassHttpProtocol::Response *protocolResp);
-    void getLoginsCount(const KeepassHttpProtocol::Request &r, KeepassHttpProtocol::Response *protocolResp);
-    void getAllLogins(const KeepassHttpProtocol::Request &r, KeepassHttpProtocol::Response *protocolResp);
-    void setLogin(const KeepassHttpProtocol::Request &r, KeepassHttpProtocol::Response *protocolResp);
-    void generatePassword(const KeepassHttpProtocol::Request &r, KeepassHttpProtocol::Response *protocolResp);
+        virtual bool isDatabaseOpened(DatabaseWidget* dbWidget = nullptr) const = 0;
+        virtual bool openDatabase() = 0;
+        virtual QString getDatabaseRootUuid() = 0;
+        virtual QString getDatabaseRecycleBinUuid() = 0;
+        virtual QString getKey(const QString& id) = 0;
+        virtual QString storeKey(const QString& key) = 0;
+        virtual QList<Entry>
+        findMatchingEntries(const QString& id, const QString& url, const QString& submitUrl, const QString& realm) = 0;
+        virtual int
+        countMatchingEntries(const QString& id, const QString& url, const QString& submitUrl, const QString& realm) = 0;
+        virtual QList<Entry> searchAllEntries(const QString& id) = 0;
+        virtual void addEntry(const QString& id,
+                              const QString& login,
+                              const QString& password,
+                              const QString& url,
+                              const QString& submitUrl,
+                              const QString& realm) = 0;
+        virtual void updateEntry(const QString& id,
+                                 const QString& uuid,
+                                 const QString& login,
+                                 const QString& password,
+                                 const QString& url) = 0;
+        virtual QString generatePassword() = 0;
 
-    bool m_started;
+    public slots:
+        void start();
+        void stop();
 
-    QHttpServer* m_server;
-};
+    private slots:
+        void onNewRequest(QHttpRequest* request, QHttpResponse* response);
+        void handleRequest(const QByteArray& data, QHttpResponse* response);
 
-}   /*namespace KeepassHttpProtocol*/
+    private:
+        void testAssociate(const KeepassHttpProtocol::Request& r, KeepassHttpProtocol::Response* protocolResp);
+        void associate(const KeepassHttpProtocol::Request& r, KeepassHttpProtocol::Response* protocolResp);
+        void getLogins(const KeepassHttpProtocol::Request& r, KeepassHttpProtocol::Response* protocolResp);
+        void getLoginsCount(const KeepassHttpProtocol::Request& r, KeepassHttpProtocol::Response* protocolResp);
+        void getAllLogins(const KeepassHttpProtocol::Request& r, KeepassHttpProtocol::Response* protocolResp);
+        void setLogin(const KeepassHttpProtocol::Request& r, KeepassHttpProtocol::Response* protocolResp);
+        void generatePassword(const KeepassHttpProtocol::Request& r, KeepassHttpProtocol::Response* protocolResp);
+
+        bool m_started;
+
+        QHttpServer* m_server;
+    };
+
+} /*namespace KeepassHttpProtocol*/
 
 #endif // SERVER_H

--- a/src/http/Server.h
+++ b/src/http/Server.h
@@ -22,6 +22,8 @@
 #include <QtCore/QObject>
 #include <QtCore/QList>
 
+#include "gui/DatabaseTabWidget.h"
+
 namespace qhttp {
     namespace server {
         class QHttpServer;
@@ -44,7 +46,7 @@ class Server : public QObject
 public:
     explicit Server(QObject *parent = 0);
 
-    virtual bool isDatabaseOpened() const = 0;
+    virtual bool isDatabaseOpened(DatabaseWidget* dbWidget = NULL) const = 0;
     virtual bool openDatabase() = 0;
     virtual QString getDatabaseRootUuid() = 0;
     virtual QString getDatabaseRecycleBinUuid() = 0;

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -1,57 +1,56 @@
 /*
-*  Copyright (C) 2013 Francois Ferrand
-*  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
-*
-*  This program is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 2 or (at your option)
-*  version 3 of the License.
-*
-*  This program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2013 Francois Ferrand
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QProgressDialog>
 
-#include "Service.h"
-#include "Protocol.h"
-#include "EntryConfig.h"
 #include "AccessControlDialog.h"
-#include "KeyAcceptDialog.h"
+#include "EntryConfig.h"
 #include "HttpSettings.h"
+#include "KeyAcceptDialog.h"
+#include "Protocol.h"
+#include "Service.h"
 
 #include "core/Database.h"
 #include "core/Entry.h"
+#include "core/EntrySearcher.h"
 #include "core/Global.h"
 #include "core/Group.h"
-#include "core/EntrySearcher.h"
 #include "core/Metadata.h"
-#include "core/Uuid.h"
 #include "core/PasswordGenerator.h"
+#include "core/Uuid.h"
 
 #include <algorithm>
 
-static const unsigned char KEEPASSHTTP_UUID_DATA[] = {
-    0x34, 0x69, 0x7a, 0x40, 0x8a, 0x5b, 0x41, 0xc0,
-    0x9f, 0x36, 0x89, 0x7d, 0x62, 0x3e, 0xcb, 0x31
-};
-static const Uuid KEEPASSHTTP_UUID = Uuid(QByteArray::fromRawData(reinterpret_cast<const char *>(KEEPASSHTTP_UUID_DATA), sizeof(KEEPASSHTTP_UUID_DATA)));
+static const unsigned char KEEPASSHTTP_UUID_DATA[] =
+    {0x34, 0x69, 0x7a, 0x40, 0x8a, 0x5b, 0x41, 0xc0, 0x9f, 0x36, 0x89, 0x7d, 0x62, 0x3e, 0xcb, 0x31};
+static const Uuid KEEPASSHTTP_UUID =
+    Uuid(QByteArray::fromRawData(reinterpret_cast<const char*>(KEEPASSHTTP_UUID_DATA), sizeof(KEEPASSHTTP_UUID_DATA)));
 static const char KEEPASSHTTP_NAME[] = "KeePassHttp Settings";
 static const char ASSOCIATE_KEY_PREFIX[] = "AES Key: ";
-static const char KEEPASSHTTP_GROUP_NAME[] = "KeePassHttp Passwords";   //Group where new KeePassHttp password are stored
-static int        KEEPASSHTTP_DEFAULT_ICON = 1;
-//private const int DEFAULT_NOTIFICATION_TIME = 5000;
+static const char KEEPASSHTTP_GROUP_NAME[] = "KeePassHttp Passwords"; // Group where new KeePassHttp password are stored
+static int KEEPASSHTTP_DEFAULT_ICON = 1;
+// private const int DEFAULT_NOTIFICATION_TIME = 5000;
 
-Service::Service(DatabaseTabWidget* parent) :
-    KeepassHttpProtocol::Server(parent),
-    m_dbTabWidget(parent)
+Service::Service(DatabaseTabWidget* parent)
+    : KeepassHttpProtocol::Server(parent)
+    , m_dbTabWidget(parent)
 {
     if (HttpSettings::isEnabled())
         start();
@@ -59,8 +58,8 @@ Service::Service(DatabaseTabWidget* parent) :
 
 Entry* Service::getConfigEntry(bool create)
 {
-    if (DatabaseWidget * dbWidget = m_dbTabWidget->currentDatabaseWidget())
-        if (Database * db = dbWidget->database()) {
+    if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget())
+        if (Database* db = dbWidget->database()) {
             Entry* entry = db->resolveEntry(KEEPASSHTTP_UUID);
             if (!entry && create) {
                 entry = new Entry();
@@ -72,11 +71,11 @@ Entry* Service::getConfigEntry(bool create)
                 if (create)
                     entry->setGroup(db->rootGroup());
                 else
-                    entry = NULL;
+                    entry = nullptr;
             }
             return entry;
         }
-    return NULL;
+    return nullptr;
 }
 
 QList<Entry*> Service::getConfigEntries(bool create)
@@ -97,7 +96,7 @@ QList<Entry*> Service::getConfigEntries(bool create)
                     if (create)
                         entry->setGroup(db->rootGroup());
                     else
-                        entry = NULL;
+                        entry = nullptr;
                 }
                 entries << entry;
             }
@@ -109,7 +108,7 @@ bool Service::isDatabaseOpened(DatabaseWidget* dbWidget) const
     if (!dbWidget)
         dbWidget = m_dbTabWidget->currentDatabaseWidget();
     if (dbWidget)
-        switch(dbWidget->currentMode()) {
+        switch (dbWidget->currentMode()) {
         case DatabaseWidget::None:
         case DatabaseWidget::LockedMode:
             break;
@@ -127,8 +126,8 @@ bool Service::openDatabase()
 {
     if (!HttpSettings::unlockDatabase())
         return false;
-    if (DatabaseWidget * dbWidget = m_dbTabWidget->currentDatabaseWidget()) {
-        switch(dbWidget->currentMode()) {
+    if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget()) {
+        switch (dbWidget->currentMode()) {
         case DatabaseWidget::None:
         case DatabaseWidget::LockedMode:
             break;
@@ -140,12 +139,12 @@ bool Service::openDatabase()
             break;
         }
     }
-    //if (HttpSettings::showNotification()
+    // if (HttpSettings::showNotification()
     //    && !ShowNotification(QString("%0: %1 is requesting access, click to allow or deny")
     //                                 .arg(id).arg(submitHost.isEmpty() ? host : submithost));
     //    return false;
     m_dbTabWidget->activateWindow();
-    //Wait a bit for DB to be open... (w/ asynchronous reply?)
+    // Wait a bit for DB to be open... (w/ asynchronous reply?)
     return false;
 }
 
@@ -167,14 +166,14 @@ QString Service::getDatabaseRecycleBinUuid()
     return QString();
 }
 
-QString Service::getKey(const QString &id)
+QString Service::getKey(const QString& id)
 {
     if (Entry* config = getConfigEntry())
         return config->attributes()->value(QLatin1String(ASSOCIATE_KEY_PREFIX) + id);
     return QString();
 }
 
-QList<QString> Service::getKeys(const QString &id)
+QList<QString> Service::getKeys(const QString& id)
 {
     QList<QString> keys;
     QList<Entry*> entries = getConfigEntries();
@@ -184,15 +183,15 @@ QList<QString> Service::getKeys(const QString &id)
     return keys;
 }
 
-bool Service::attributeExists(QList<Entry*> entries, const QString &attribute)
+bool Service::attributeExists(QList<Entry*> entries, const QString& attribute)
 {
-    for (Entry* entry: entries)
+    for (Entry* entry : entries)
         if (entry->attributes()->contains(attribute))
             return true;
     return false;
 }
 
-QString Service::storeKey(const QString &key)
+QString Service::storeKey(const QString& key)
 {
     QString id;
     QList<DatabaseWidget*> dbWidgets;
@@ -211,7 +210,7 @@ QString Service::storeKey(const QString &key)
         QList<QString> dbNames;
 
         dlg.setItems(dbTexts);
-        for (int i=0; i<dbWidgets.count(); i++) {
+        for (int i = 0; i < dbWidgets.count(); i++) {
             if (!isDatabaseOpened(dbWidgets.at(i)))
                 dlg.setItemEnabled(i, false);
             else if (dbWidgets.at(i) == currDbWidget)
@@ -219,25 +218,28 @@ QString Service::storeKey(const QString &key)
         }
 
         do {
-            //Indicate who wants to associate, and request user to enter the 'name' of association key
+            // Indicate who wants to associate, and request user to enter the 'name' of association key
             int res = dlg.exec();
 
             if (res != QDialog::Accepted)
                 return QString();
 
-            //Warn if association key already exists
-        } while(attributeExists(configs, QLatin1String(ASSOCIATE_KEY_PREFIX) + id) &&
-                QMessageBox::warning(0, tr("KeePassXC: Overwrite existing key?"),
-                                     tr("A shared encryption-key with the name \"%1\" already exists.\nDo you want to overwrite it?").arg(id),
-                                     QMessageBox::Yes | QMessageBox::No) == QMessageBox::No);
+            // Warn if association key already exists
+        } while (attributeExists(configs, QLatin1String(ASSOCIATE_KEY_PREFIX) + id) &&
+                 QMessageBox::warning(
+                     0,
+                     tr("KeePassXC: Overwrite existing key?"),
+                     tr("A shared encryption-key with the name \"%1\" already exists.\nDo you want to overwrite it?")
+                         .arg(id),
+                     QMessageBox::Yes | QMessageBox::No) == QMessageBox::No);
         QList<int> selectedDatabases = dlg.getCheckedItems();
         id = dlg.getKeyName();
-//        for (int i=0; i<selectedDatabases.count(); i++) {
-//            int dbIdx = selectedDatabases.at(i);
-//            qWarning("adding key to db: %d", dbIdx);
-//            configs.at(dbIdx)->attributes()->set(QLatin1String(ASSOCIATE_KEY_PREFIX) + id, key, true);
-//        }
-        for (int dbIdx: selectedDatabases) {
+        //        for (int i=0; i<selectedDatabases.count(); i++) {
+        //            int dbIdx = selectedDatabases.at(i);
+        //            qWarning("adding key to db: %d", dbIdx);
+        //            configs.at(dbIdx)->attributes()->set(QLatin1String(ASSOCIATE_KEY_PREFIX) + id, key, true);
+        //        }
+        for (int dbIdx : selectedDatabases) {
             qWarning("adding key to db: %d", dbIdx);
             configs.at(dbIdx)->attributes()->set(QLatin1String(ASSOCIATE_KEY_PREFIX) + id, key, true);
         }
@@ -245,16 +247,14 @@ QString Service::storeKey(const QString &key)
     return id;
 }
 
-bool Service::matchUrlScheme(const QString & url)
+bool Service::matchUrlScheme(const QString& url)
 {
     QString str = url.left(8).toLower();
-    return str.startsWith("http://") ||
-           str.startsWith("https://") ||
-           str.startsWith("ftp://") ||
+    return str.startsWith("http://") || str.startsWith("https://") || str.startsWith("ftp://") ||
            str.startsWith("ftps://");
 }
 
-bool Service::removeFirstDomain(QString & hostname)
+bool Service::removeFirstDomain(QString& hostname)
 {
     int pos = hostname.indexOf(".");
     if (pos < 0)
@@ -268,15 +268,14 @@ QList<Entry*> Service::searchEntries(Database* db, const QString& hostname)
     QList<Entry*> entries;
     if (Group* rootGroup = db->rootGroup()) {
         const auto results = EntrySearcher().search(hostname, rootGroup, Qt::CaseInsensitive);
-        for (Entry* entry: results) {
+        for (Entry* entry : results) {
             QString title = entry->title();
             QString url = entry->webUrl();
 
-            //Filter to match hostname in Title and Url fields
-            if (   (!title.isEmpty() && hostname.contains(title))
-                || (!url.isEmpty() && hostname.contains(url))
-                || (matchUrlScheme(title) && hostname.endsWith(QUrl(title).host()))
-                || (matchUrlScheme(url) && hostname.endsWith(QUrl(url).host())) )
+            // Filter to match hostname in Title and Url fields
+            if ((!title.isEmpty() && hostname.contains(title)) || (!url.isEmpty() && hostname.contains(url)) ||
+                (matchUrlScheme(title) && hostname.endsWith(QUrl(title).host())) ||
+                (matchUrlScheme(url) && hostname.endsWith(QUrl(url).host())))
                 entries.append(entry);
         }
     }
@@ -285,43 +284,43 @@ QList<Entry*> Service::searchEntries(Database* db, const QString& hostname)
 
 QList<Entry*> Service::searchEntries(const QString& text)
 {
-    //Get the list of databases to search
+    // Get the list of databases to search
     QList<Database*> databases;
     if (HttpSettings::searchInAllDatabases()) {
         for (int i = 0; i < m_dbTabWidget->count(); i++)
             if (DatabaseWidget* dbWidget = qobject_cast<DatabaseWidget*>(m_dbTabWidget->widget(i)))
                 if (Database* db = dbWidget->database())
                     databases << db;
-    }
-    else if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget()) {
+    } else if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget()) {
         if (Database* db = dbWidget->database())
             databases << db;
     }
 
-    //Search entries matching the hostname
+    // Search entries matching the hostname
     QString hostname = QUrl(text).host();
     QList<Entry*> entries;
     do {
-        for (Database* db: asConst(databases)) {
+        for (Database* db : asConst(databases)) {
             entries << searchEntries(db, hostname);
         }
-    } while(entries.isEmpty() && removeFirstDomain(hostname));
+    } while (entries.isEmpty() && removeFirstDomain(hostname));
 
     return entries;
 }
 
-Service::Access Service::checkAccess(const Entry *entry, const QString & host, const QString & submitHost, const QString & realm)
+Service::Access
+Service::checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm)
 {
     EntryConfig config;
     if (!config.load(entry))
-        return Unknown;  //not configured
+        return Unknown; // not configured
     if ((config.isAllowed(host)) && (submitHost.isEmpty() || config.isAllowed(submitHost)))
-        return Allowed;  //allowed
+        return Allowed; // allowed
     if ((config.isDenied(host)) || (!submitHost.isEmpty() && config.isDenied(submitHost)))
-        return Denied;   //denied
+        return Denied; // denied
     if (!realm.isEmpty() && config.realm() != realm)
         return Denied;
-    return Unknown;      //not configured for this host
+    return Unknown; // not configured for this host
 }
 
 KeepassHttpProtocol::Entry Service::prepareEntry(const Entry* entry)
@@ -331,9 +330,9 @@ KeepassHttpProtocol::Entry Service::prepareEntry(const Entry* entry)
                                    entry->resolveMultiplePlaceholders(entry->password()),
                                    entry->uuid().toHex());
     if (HttpSettings::supportKphFields()) {
-        const EntryAttributes * attr = entry->attributes();
+        const EntryAttributes* attr = entry->attributes();
         const auto keys = attr->keys();
-        for (const QString& key: keys) {
+        for (const QString& key : keys) {
             if (key.startsWith(QLatin1String("KPH: "))) {
                 res.addStringField(key, entry->resolveMultiplePlaceholders(attr->value(key)));
             }
@@ -342,13 +341,17 @@ KeepassHttpProtocol::Entry Service::prepareEntry(const Entry* entry)
     return res;
 }
 
-int Service::sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const
+int Service::sortPriority(const Entry* entry,
+                          const QString& host,
+                          const QString& submitUrl,
+                          const QString& baseSubmitUrl) const
 {
     QUrl url(entry->url());
     if (url.scheme().isEmpty())
         url.setScheme("http");
     const QString entryURL = url.toString(QUrl::StripTrailingSlash);
-    const QString baseEntryURL = url.toString(QUrl::StripTrailingSlash | QUrl::RemovePath | QUrl::RemoveQuery | QUrl::RemoveFragment);
+    const QString baseEntryURL =
+        url.toString(QUrl::StripTrailingSlash | QUrl::RemovePath | QUrl::RemoveQuery | QUrl::RemoveFragment);
 
     if (submitUrl == entryURL)
         return 100;
@@ -378,15 +381,18 @@ int Service::sortPriority(const Entry* entry, const QString& host, const QString
 class Service::SortEntries
 {
 public:
-    SortEntries(const QHash<const Entry*, int>& priorities, const QString & field):
-        m_priorities(priorities), m_field(field)
-    {}
+    SortEntries(const QHash<const Entry*, int>& priorities, const QString& field)
+        : m_priorities(priorities)
+        , m_field(field)
+    {
+    }
 
     bool operator()(const Entry* left, const Entry* right) const
     {
         int res = m_priorities.value(left) - m_priorities.value(right);
         if (res == 0)
-            return QString::localeAwareCompare(left->attributes()->value(m_field), right->attributes()->value(m_field)) < 0;
+            return QString::localeAwareCompare(left->attributes()->value(m_field),
+                                               right->attributes()->value(m_field)) < 0;
         return res < 0;
     }
 
@@ -395,18 +401,19 @@ private:
     const QString m_field;
 };
 
-QList<KeepassHttpProtocol::Entry> Service::findMatchingEntries(const QString& /*id*/, const QString& url, const QString& submitUrl, const QString& realm)
+QList<KeepassHttpProtocol::Entry>
+Service::findMatchingEntries(const QString& /*id*/, const QString& url, const QString& submitUrl, const QString& realm)
 {
     const bool alwaysAllowAccess = HttpSettings::alwaysAllowAccess();
     const QString host = QUrl(url).host();
     const QString submitHost = QUrl(submitUrl).host();
 
-    //Check entries for authorization
+    // Check entries for authorization
     QList<Entry*> pwEntriesToConfirm;
     QList<Entry*> pwEntries;
     const auto entries = searchEntries(url);
-    for (Entry* entry: entries) {
-        switch(checkAccess(entry, host, submitHost, realm)) {
+    for (Entry* entry : entries) {
+        switch (checkAccess(entry, host, submitHost, realm)) {
         case Denied:
             continue;
 
@@ -423,8 +430,8 @@ QList<KeepassHttpProtocol::Entry> Service::findMatchingEntries(const QString& /*
         }
     }
 
-    //If unsure, ask user for confirmation
-    //if (!pwEntriesToConfirm.isEmpty()
+    // If unsure, ask user for confirmation
+    // if (!pwEntriesToConfirm.isEmpty()
     //    && HttpSettings::showNotification()
     //    && !ShowNotification(QString("%0: %1 is requesting access, click to allow or deny")
     //                                 .arg(id).arg(submitHost.isEmpty() ? host : submithost));
@@ -435,11 +442,11 @@ QList<KeepassHttpProtocol::Entry> Service::findMatchingEntries(const QString& /*
         AccessControlDialog dlg;
         dlg.setUrl(url);
         dlg.setItems(pwEntriesToConfirm);
-        //dlg.setRemember();        //TODO: setting!
+        // dlg.setRemember();        //TODO: setting!
 
         int res = dlg.exec();
         if (dlg.remember()) {
-            for (Entry* entry: asConst(pwEntriesToConfirm)) {
+            for (Entry* entry : asConst(pwEntriesToConfirm)) {
                 EntryConfig config;
                 config.load(entry);
                 if (res == QDialog::Accepted) {
@@ -460,51 +467,54 @@ QList<KeepassHttpProtocol::Entry> Service::findMatchingEntries(const QString& /*
             pwEntries.append(pwEntriesToConfirm);
     }
 
-    //Sort results
+    // Sort results
     const bool sortSelection = true;
     if (sortSelection) {
         QUrl url(submitUrl);
         if (url.scheme().isEmpty())
             url.setScheme("http");
         const QString submitUrl = url.toString(QUrl::StripTrailingSlash);
-        const QString baseSubmitURL = url.toString(QUrl::StripTrailingSlash | QUrl::RemovePath | QUrl::RemoveQuery | QUrl::RemoveFragment);
+        const QString baseSubmitURL =
+            url.toString(QUrl::StripTrailingSlash | QUrl::RemovePath | QUrl::RemoveQuery | QUrl::RemoveFragment);
 
-        //Cache priorities
+        // Cache priorities
         QHash<const Entry*, int> priorities;
         priorities.reserve(pwEntries.size());
-        for (const Entry* entry: asConst(pwEntries)) {
+        for (const Entry* entry : asConst(pwEntries)) {
             priorities.insert(entry, sortPriority(entry, host, submitUrl, baseSubmitURL));
         }
 
-        //Sort by priorities
-        std::sort(pwEntries.begin(), pwEntries.end(), SortEntries(priorities, HttpSettings::sortByTitle() ? "Title" : "UserName"));
+        // Sort by priorities
+        std::sort(pwEntries.begin(),
+                  pwEntries.end(),
+                  SortEntries(priorities, HttpSettings::sortByTitle() ? "Title" : "UserName"));
     }
 
-    //Fill the list
+    // Fill the list
     QList<KeepassHttpProtocol::Entry> result;
     result.reserve(pwEntries.count());
-    for (Entry* entry: asConst(pwEntries)) {
+    for (Entry* entry : asConst(pwEntries)) {
         result << prepareEntry(entry);
     }
     return result;
 }
 
-int Service::countMatchingEntries(const QString &, const QString &url, const QString &, const QString &)
+int Service::countMatchingEntries(const QString&, const QString& url, const QString&, const QString&)
 {
     return searchEntries(url).count();
 }
 
-QList<KeepassHttpProtocol::Entry> Service::searchAllEntries(const QString &)
+QList<KeepassHttpProtocol::Entry> Service::searchAllEntries(const QString&)
 {
     QList<KeepassHttpProtocol::Entry> result;
     if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget()) {
         if (Database* db = dbWidget->database()) {
             if (Group* rootGroup = db->rootGroup()) {
                 const auto entries = rootGroup->entriesRecursive();
-                for (Entry* entry: entries) {
+                for (Entry* entry : entries) {
                     if (!entry->url().isEmpty() || QUrl(entry->title()).isValid()) {
-                        result << KeepassHttpProtocol::Entry(entry->title(), entry->username(),
-                                                             QString(), entry->uuid().toHex());
+                        result << KeepassHttpProtocol::Entry(
+                            entry->title(), entry->username(), QString(), entry->uuid().toHex());
                     }
                 }
             }
@@ -513,22 +523,22 @@ QList<KeepassHttpProtocol::Entry> Service::searchAllEntries(const QString &)
     return result;
 }
 
-Group * Service::findCreateAddEntryGroup()
+Group* Service::findCreateAddEntryGroup()
 {
-    if (DatabaseWidget * dbWidget = m_dbTabWidget->currentDatabaseWidget())
-        if (Database * db = dbWidget->database())
-            if (Group * rootGroup = db->rootGroup()) {
-                //TODO: setting to decide where new keys are created
+    if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget())
+        if (Database* db = dbWidget->database())
+            if (Group* rootGroup = db->rootGroup()) {
+                // TODO: setting to decide where new keys are created
                 const QString groupName = QLatin1String(KEEPASSHTTP_GROUP_NAME);
 
                 const auto groups = rootGroup->groupsRecursive(true);
-                for (const Group * g: groups) {
+                for (const Group* g : groups) {
                     if (g->name() == groupName) {
                         return db->resolveGroup(g->uuid());
                     }
                 }
 
-                Group * group;
+                Group* group;
                 group = new Group();
                 group->setUuid(Uuid::random());
                 group->setName(groupName);
@@ -536,13 +546,18 @@ Group * Service::findCreateAddEntryGroup()
                 group->setParent(rootGroup);
                 return group;
             }
-    return NULL;
+    return nullptr;
 }
 
-void Service::addEntry(const QString &, const QString &login, const QString &password, const QString &url, const QString &submitUrl, const QString &realm)
+void Service::addEntry(const QString&,
+                       const QString& login,
+                       const QString& password,
+                       const QString& url,
+                       const QString& submitUrl,
+                       const QString& realm)
 {
-    if (Group * group = findCreateAddEntryGroup()) {
-        Entry * entry = new Entry();
+    if (Group* group = findCreateAddEntryGroup()) {
+        Entry* entry = new Entry();
         entry->setUuid(Uuid::random());
         entry->setTitle(QUrl(url).host());
         entry->setUrl(url);
@@ -563,19 +578,26 @@ void Service::addEntry(const QString &, const QString &login, const QString &pas
     }
 }
 
-void Service::updateEntry(const QString &, const QString &uuid, const QString &login, const QString &password, const QString &url)
+void Service::updateEntry(const QString&,
+                          const QString& uuid,
+                          const QString& login,
+                          const QString& password,
+                          const QString& url)
 {
-    if (DatabaseWidget * dbWidget = m_dbTabWidget->currentDatabaseWidget())
-        if (Database * db = dbWidget->database())
-            if (Entry * entry = db->resolveEntry(Uuid::fromHex(uuid))) {
+    if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget())
+        if (Database* db = dbWidget->database())
+            if (Entry* entry = db->resolveEntry(Uuid::fromHex(uuid))) {
                 QString u = entry->username();
                 if (u != login || entry->password() != password) {
-                    //ShowNotification(QString("%0: You have an entry change prompt waiting, click to activate").arg(requestId));
-                    if (   HttpSettings::alwaysAllowUpdate()
-                        || QMessageBox::warning(0, tr("KeePassXC: Update Entry"),
-                                                tr("Do you want to update the information in %1 - %2?")
-                                                .arg(QUrl(url).host().toHtmlEscaped()).arg(u.toHtmlEscaped()),
-                                                QMessageBox::Yes|QMessageBox::No) == QMessageBox::Yes ) {
+                    // ShowNotification(QString("%0: You have an entry change prompt waiting, click to
+                    // activate").arg(requestId));
+                    if (HttpSettings::alwaysAllowUpdate() ||
+                        QMessageBox::warning(0,
+                                             tr("KeePassXC: Update Entry"),
+                                             tr("Do you want to update the information in %1 - %2?")
+                                                 .arg(QUrl(url).host().toHtmlEscaped())
+                                                 .arg(u.toHtmlEscaped()),
+                                             QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
                         entry->beginUpdate();
                         entry->setUsername(login);
                         entry->setPassword(password);
@@ -592,38 +614,43 @@ QString Service::generatePassword()
 
 void Service::removeSharedEncryptionKeys()
 {
-    if (!isDatabaseOpened(NULL)) {
-        QMessageBox::critical(0, tr("KeePassXC: Database locked!"),
+    if (!isDatabaseOpened(nullptr)) {
+        QMessageBox::critical(0,
+                              tr("KeePassXC: Database locked!"),
                               tr("The active database is locked!\n"
                                  "Please unlock the selected database or choose another one which is unlocked."),
                               QMessageBox::Ok);
     } else if (Entry* entry = getConfigEntry()) {
         QStringList keysToRemove;
         const auto keys = entry->attributes()->keys();
-        for (const QString& key: keys) {
+        for (const QString& key : keys) {
             if (key.startsWith(ASSOCIATE_KEY_PREFIX)) {
                 keysToRemove << key;
             }
         }
 
-        if(keysToRemove.count()) {
+        if (keysToRemove.count()) {
             entry->beginUpdate();
-            for (const QString& key: asConst(keysToRemove)) {
+            for (const QString& key : asConst(keysToRemove)) {
                 entry->attributes()->remove(key);
             }
             entry->endUpdate();
 
             const int count = keysToRemove.count();
-            QMessageBox::information(0, tr("KeePassXC: Removed keys from database"),
-                                     tr("Successfully removed %n encryption-key(s) from KeePassX/Http Settings.", "", count),
-                                     QMessageBox::Ok);
+            QMessageBox::information(
+                0,
+                tr("KeePassXC: Removed keys from database"),
+                tr("Successfully removed %n encryption-key(s) from KeePassX/Http Settings.", "", count),
+                QMessageBox::Ok);
         } else {
-            QMessageBox::information(0, tr("KeePassXC: No keys found"),
+            QMessageBox::information(0,
+                                     tr("KeePassXC: No keys found"),
                                      tr("No shared encryption-keys found in KeePassHttp Settings."),
                                      QMessageBox::Ok);
         }
     } else {
-        QMessageBox::information(0, tr("KeePassXC: Settings not available!"),
+        QMessageBox::information(0,
+                                 tr("KeePassXC: Settings not available!"),
                                  tr("The active database does not contain an entry of KeePassHttp Settings."),
                                  QMessageBox::Ok);
     }
@@ -631,38 +658,41 @@ void Service::removeSharedEncryptionKeys()
 
 void Service::removeStoredPermissions()
 {
-    if (!isDatabaseOpened(NULL)) {
-        QMessageBox::critical(0, tr("KeePassXC: Database locked!"),
+    if (!isDatabaseOpened(nullptr)) {
+        QMessageBox::critical(0,
+                              tr("KeePassXC: Database locked!"),
                               tr("The active database is locked!\n"
                                  "Please unlock the selected database or choose another one which is unlocked."),
                               QMessageBox::Ok);
     } else {
-        Database * db = m_dbTabWidget->currentDatabaseWidget()->database();
+        Database* db = m_dbTabWidget->currentDatabaseWidget()->database();
         QList<Entry*> entries = db->rootGroup()->entriesRecursive();
 
         QProgressDialog progress(tr("Removing stored permissions..."), tr("Abort"), 0, entries.count());
         progress.setWindowModality(Qt::WindowModal);
 
         uint counter = 0;
-        for (Entry* entry: asConst(entries)) {
+        for (Entry* entry : asConst(entries)) {
             if (progress.wasCanceled())
                 return;
             if (entry->attributes()->contains(KEEPASSHTTP_NAME)) {
                 entry->beginUpdate();
                 entry->attributes()->remove(KEEPASSHTTP_NAME);
                 entry->endUpdate();
-                counter ++;
+                counter++;
             }
             progress.setValue(progress.value() + 1);
         }
         progress.reset();
 
         if (counter > 0) {
-            QMessageBox::information(0, tr("KeePassXC: Removed permissions"),
+            QMessageBox::information(0,
+                                     tr("KeePassXC: Removed permissions"),
                                      tr("Successfully removed permissions from %n entries.", "", counter),
                                      QMessageBox::Ok);
         } else {
-            QMessageBox::information(0, tr("KeePassXC: No entry with permissions found!"),
+            QMessageBox::information(0,
+                                     tr("KeePassXC: No entry with permissions found!"),
                                      tr("The active database does not contain an entry with permissions."),
                                      QMessageBox::Ok);
         }

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -214,7 +214,7 @@ QString Service::storeKey(const QString &key)
         for (int i=0; i<dbWidgets.count(); i++) {
             if (!isDatabaseOpened(dbWidgets.at(i)))
                 dlg.setItemEnabled(i, false);
-            if (dbWidgets.at(i) == currDbWidget)
+            else if (dbWidgets.at(i) == currDbWidget)
                 dlg.setItemChecked(i, true);
         }
 

--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -184,9 +184,7 @@ QList<QString> Service::getKeys(const QString &id)
     return keys;
 }
 
-//XXX
-//bool Service::attributeExists(QList<Entry*> entries, const QString &attribute)
-bool Service::attributeExists(QList<Entry*> entries, const QString attribute)
+bool Service::attributeExists(QList<Entry*> entries, const QString &attribute)
 {
     for (Entry* entry: entries)
         if (entry->attributes()->contains(attribute))
@@ -221,9 +219,7 @@ QString Service::storeKey(const QString &key)
         }
 
         do {
-            bool ok;
             //Indicate who wants to associate, and request user to enter the 'name' of association key
-
             int res = dlg.exec();
 
             if (res != QDialog::Accepted)

--- a/src/http/Service.h
+++ b/src/http/Service.h
@@ -52,7 +52,7 @@ private:
     enum Access { Denied, Unknown, Allowed};
     QList<Entry*> getConfigEntries(bool create = false);
     Entry* getConfigEntry(bool create = false);
-    bool attributeExists(QList<Entry*> entries, const QString attribute);
+    bool attributeExists(QList<Entry*> entries, const QString& attribute);
     bool matchUrlScheme(const QString& url);
     Access checkAccess(const Entry* entry, const QString&  host, const QString&  submitHost, const QString&  realm);
     bool removeFirstDomain(QString& hostname);

--- a/src/http/Service.h
+++ b/src/http/Service.h
@@ -1,27 +1,27 @@
 /*
-*  Copyright (C) 2013 Francois Ferrand
-*  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
-*
-*  This program is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 2 or (at your option)
-*  version 3 of the License.
-*
-*  This program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *  Copyright (C) 2013 Francois Ferrand
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef SERVICE_H
 #define SERVICE_H
 
-#include <QObject>
-#include "gui/DatabaseTabWidget.h"
 #include "Server.h"
+#include "gui/DatabaseTabWidget.h"
+#include <QObject>
 
 class Service : public KeepassHttpProtocol::Server
 {
@@ -37,11 +37,22 @@ public:
     virtual QString getKey(const QString& id);
     virtual QList<QString> getKeys(const QString& id);
     virtual QString storeKey(const QString& key);
-    virtual QList<KeepassHttpProtocol::Entry> findMatchingEntries(const QString& id, const QString& url, const QString&  submitUrl, const QString&  realm);
-    virtual int countMatchingEntries(const QString& id, const QString& url, const QString&  submitUrl, const QString&  realm);
+    virtual QList<KeepassHttpProtocol::Entry>
+    findMatchingEntries(const QString& id, const QString& url, const QString& submitUrl, const QString& realm);
+    virtual int
+    countMatchingEntries(const QString& id, const QString& url, const QString& submitUrl, const QString& realm);
     virtual QList<KeepassHttpProtocol::Entry> searchAllEntries(const QString& id);
-    virtual void addEntry(const QString& id, const QString& login, const QString& password, const QString& url, const QString& submitUrl, const QString& realm);
-    virtual void updateEntry(const QString& id, const QString& uuid, const QString& login, const QString& password, const QString& url);
+    virtual void addEntry(const QString& id,
+                          const QString& login,
+                          const QString& password,
+                          const QString& url,
+                          const QString& submitUrl,
+                          const QString& realm);
+    virtual void updateEntry(const QString& id,
+                             const QString& uuid,
+                             const QString& login,
+                             const QString& password,
+                             const QString& url);
     virtual QString generatePassword();
 
 public slots:
@@ -49,21 +60,27 @@ public slots:
     void removeStoredPermissions();
 
 private:
-    enum Access { Denied, Unknown, Allowed};
+    enum Access
+    {
+        Denied,
+        Unknown,
+        Allowed
+    };
     QList<Entry*> getConfigEntries(bool create = false);
     Entry* getConfigEntry(bool create = false);
     bool attributeExists(QList<Entry*> entries, const QString& attribute);
     bool matchUrlScheme(const QString& url);
-    Access checkAccess(const Entry* entry, const QString&  host, const QString&  submitHost, const QString&  realm);
+    Access checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm);
     bool removeFirstDomain(QString& hostname);
-    Group *findCreateAddEntryGroup();
+    Group* findCreateAddEntryGroup();
     class SortEntries;
-    int sortPriority(const Entry *entry, const QString &host, const QString &submitUrl, const QString &baseSubmitUrl) const;
+    int
+    sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
     KeepassHttpProtocol::Entry prepareEntry(const Entry* entry);
     QList<Entry*> searchEntries(Database* db, const QString& hostname);
     QList<Entry*> searchEntries(const QString& text);
 
-    DatabaseTabWidget * const m_dbTabWidget;
+    DatabaseTabWidget* const m_dbTabWidget;
 };
 
 #endif // SERVICE_H

--- a/src/http/Service.h
+++ b/src/http/Service.h
@@ -30,11 +30,12 @@ class Service : public KeepassHttpProtocol::Server
 public:
     explicit Service(DatabaseTabWidget* parent = 0);
 
-    virtual bool isDatabaseOpened() const;
+    virtual bool isDatabaseOpened(DatabaseWidget* dbWidget) const;
     virtual bool openDatabase();
     virtual QString getDatabaseRootUuid();
     virtual QString getDatabaseRecycleBinUuid();
     virtual QString getKey(const QString& id);
+    virtual QList<QString> getKeys(const QString& id);
     virtual QString storeKey(const QString& key);
     virtual QList<KeepassHttpProtocol::Entry> findMatchingEntries(const QString& id, const QString& url, const QString&  submitUrl, const QString&  realm);
     virtual int countMatchingEntries(const QString& id, const QString& url, const QString&  submitUrl, const QString&  realm);
@@ -49,7 +50,9 @@ public slots:
 
 private:
     enum Access { Denied, Unknown, Allowed};
+    QList<Entry*> getConfigEntries(bool create = false);
     Entry* getConfigEntry(bool create = false);
+    bool attributeExists(QList<Entry*> entries, const QString attribute);
     bool matchUrlScheme(const QString& url);
     Access checkAccess(const Entry* entry, const QString&  host, const QString&  submitHost, const QString&  realm);
     bool removeFirstDomain(QString& hostname);


### PR DESCRIPTION
WIP - Creates a new dialog widget for accepting keys - needed for #838

For #838, #530

This is a proof-of-concept for myself that I can make changes to KeePassXC and a first step towards making some big changes to the KeepassHTTP authorization key management in order to address #838 and #530 and my own usability / workflow itches as someone who generally works with multiple databases open at the same time.

Please give this change a quick look and tell me if this is a good direction to go in, as well as anything problematic in the code I've changed (as far as it isn't a temporary mock-up / stub)

## Description

Planned changes:
* Fix #530 
* Allow to select which database(s) to add a KeepassHTTP authorization key to. (#838)
* Figure out if more information about the source of the authorization request can be taken from the KeepassHTTP connection and display it

## Motivation and context
See #530, #838 

## How has this been tested?

* Not yet, WIP changes

## Screenshots (if appropriate):

![keepassnewkey](https://user-images.githubusercontent.com/611471/29000914-26f26c12-7abe-11e7-948b-da275d8a30d7.png)


## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ? My code follows the code style of this project. **[REQUIRED]**
- X All new and existing tests passed. **[REQUIRED]**
- X I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ? My change requires a change to the documentation and I have updated it accordingly.
- X I have added tests to cover my changes.
