### PR TITLE
:bug: Use correct ZLib include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,8 @@ find_package(Gcrypt 1.6.0 REQUIRED)
 
 find_package(ZLIB REQUIRED)
 
+set(CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIR})
+
 check_cxx_source_compiles("
   #include <zlib.h>
 


### PR DESCRIPTION
## Description

Fixes #801

## Motivation and context
If a non-default (ex: MacPorts' /opt/local/include) include path provides a new enough zlib and an old zlib.h resides in default include paths (ex: on OS X 10.9 Mavericks), the version check fails. 

## How has this been tested?
I don't actually have a Mavericks box, so I changed the bottomline of ZLIB_VERNUM to 0x1290. MacPorts provides zlib 1.2.11 (ZLIB_VERNUM = 0x12b0), and macOS Sierra provides 1.2.8 (ZLIB_VERNUM = 0x1280). With the newly added line, KeePassXC compiles fine.

The command I used is:
```
cmake .. -DCMAKE_SYSTEM_PREFIX_PATH="/opt/local;/usr"
```

## Screenshots (if appropriate):
N/A build fix only

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]** (N/A on macOS)
- My change requires a change to the documentation and I have updated it accordingly. (N/A)
- I have added tests to cover my changes. (N/A)
