### PR TITLE
Editable Auto-Type default

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -621,7 +621,7 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
             sequence = "{USERNAME}{ENTER}";
         }
         else {
-            sequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}";
+            sequence = config()->get("AutoTypeSequence").toString();
         }
     }
 

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -613,16 +613,8 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
         group = group->parentGroup();
     } while (group && (!enableSet || sequence.isEmpty()));
 
-    if (sequence.isEmpty() && (!entry->resolvePlaceholder(entry->username()).isEmpty() || !entry->resolvePlaceholder(entry->password()).isEmpty())) {
-        if (entry->resolvePlaceholder(entry->username()).isEmpty()) {
-            sequence = "{PASSWORD}{ENTER}";
-        }
-        else if (entry->resolvePlaceholder(entry->password()).isEmpty()) {
-            sequence = "{USERNAME}{ENTER}";
-        }
-        else {
-            sequence = config()->get("AutoTypeSequence").toString();
-        }
+    if (sequence.isEmpty() && !entry->resolvePlaceholder(entry->username()).isEmpty() && !entry->resolvePlaceholder(entry->password()).isEmpty()) {
+        sequence = config()->get("AutoTypeSequence").toString();
     }
 
     return sequence;

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -121,6 +121,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("AutoTypeEntryTitleMatch", true);
     m_defaults.insert("AutoTypeEntryURLMatch", true);
     m_defaults.insert("AutoTypeDelay", 25);
+    m_defaults.insert("AutoTypeSequence", "{USERNAME}{TAB}{PASSWORD}{ENTER}");
     m_defaults.insert("UseGroupIconOnEntryCreation", true);
     m_defaults.insert("IgnoreGroupExpansion", false);
     m_defaults.insert("security/clearclipboard", true);

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -19,6 +19,7 @@
 
 #include "config-keepassx.h"
 
+#include "core/Config.h"
 #include "core/Database.h"
 #include "core/DatabaseIcons.h"
 #include "core/Group.h"
@@ -212,7 +213,7 @@ QString Entry::effectiveAutoTypeSequence() const
           sequence = "{USERNAME}{ENTER}";
         }
         else {
-            sequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}";
+            sequence = config()->get("AutoTypeSequence").toString();
         }
     }
 

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -205,16 +205,8 @@ QString Entry::effectiveAutoTypeSequence() const
       return QString();
     }
 
-    if (sequence.isEmpty() && (!username().isEmpty() || !password().isEmpty())) {
-        if (username().isEmpty()) {
-            sequence = "{PASSWORD}{ENTER}";
-        }
-       else if (password().isEmpty()) {
-          sequence = "{USERNAME}{ENTER}";
-        }
-        else {
-            sequence = config()->get("AutoTypeSequence").toString();
-        }
+    if (sequence.isEmpty() && !username().isEmpty() && !password().isEmpty()) {
+        sequence = config()->get("AutoTypeSequence").toString();
     }
 
     return sequence;

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -203,7 +203,7 @@ QString Group::effectiveAutoTypeSequence() const
     } while (group && sequence.isEmpty());
 
     if (sequence.isEmpty()) {
-        sequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}";
+        sequence = config()->get("AutoTypeSequence").toString();
     }
 
     return sequence;

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -147,6 +147,7 @@ void SettingsWidget::loadSettings()
             m_generalUi->autoTypeShortcutWidget->setShortcut(m_globalAutoTypeKey, m_globalAutoTypeModifiers);
         }
         m_generalUi->autoTypeDelaySpinBox->setValue(config()->get("AutoTypeDelay").toInt());
+        m_generalUi->autoTypeSequenceEdit->setText(config()->get("AutoTypeSequence").toString());
     }
 
 
@@ -215,6 +216,7 @@ void SettingsWidget::saveSettings()
         config()->set("GlobalAutoTypeModifiers",
                       static_cast<int>(m_generalUi->autoTypeShortcutWidget->modifiers()));
         config()->set("AutoTypeDelay", m_generalUi->autoTypeDelaySpinBox->value());
+        config()->set("AutoTypeSequence", m_generalUi->autoTypeSequenceEdit->text());
     }
     config()->set("security/clearclipboard", m_secUi->clearClipboardCheckBox->isChecked());
     config()->set("security/clearclipboardtimeout", m_secUi->clearClipboardSpinBox->value());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -339,14 +339,14 @@
          <property name="topMargin">
           <number>10</number>
          </property>
-         <item row="1" column="0">
+         <item row="2" column="0">
           <widget class="QLabel" name="autoTypeShortcutLabel_2">
            <property name="text">
             <string>Global Auto-Type shortcut</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="2" column="1">
           <widget class="ShortcutWidget" name="autoTypeShortcutWidget">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -356,14 +356,14 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="autoTypeDelayLabel_2">
            <property name="text">
             <string>Auto-Type delay</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="3" column="1">
           <widget class="QSpinBox" name="autoTypeDelaySpinBox">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -384,6 +384,16 @@
             <number>25</number>
            </property>
           </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="autoTypeSequenceLabel">
+           <property name="text">
+            <string>Auto-Type sequence</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="autoTypeSequenceEdit"/>
          </item>
         </layout>
        </item>


### PR DESCRIPTION
Allow user to configure the default Auto-Type sequence. Also the rather unexpected(?) hard coded sequences for only username or password were removed in the second commit.

## Motivation and context
Improved configurability.

## How has this been tested?
Group and per-entry defaults inherit from the global setting.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/106598/29493043-58cbad9c-8596-11e7-820f-68204c640e3f.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
