### PR TITLE
Solve issue #847: Keyboard autofocus on search field at startup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -464,6 +464,11 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->actionDatabaseMerge->setEnabled(m_ui->tabWidget->currentIndex() != -1);
 
             m_searchWidgetAction->setEnabled(true);
+
+            //if not already in search mode focus the search widget and select all its content
+            if (!inSearch) {
+                m_ui->toolBar->findChild<SearchWidget *>("SearchWidget")->searchFocus();
+            }
             break;
         }
         case DatabaseWidget::EditMode:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -465,10 +465,6 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
 
             m_searchWidgetAction->setEnabled(true);
 
-            //if not already in search mode focus the search widget and select all its content
-            if (!inSearch) {
-                m_ui->toolBar->findChild<SearchWidget *>("SearchWidget")->searchFocus();
-            }
             break;
         }
         case DatabaseWidget::EditMode:

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -119,7 +119,8 @@ void SearchWidget::databaseChanged(DatabaseWidget* dbWidget)
     if (dbWidget != nullptr) {
         // Set current search text from this database
         m_ui->searchEdit->setText(dbWidget->getCurrentSearch());
-
+        // Keyboard focus on search widget at database unlocking
+        connect(dbWidget, SIGNAL(unlockedDatabase()), this, SLOT(searchFocus()));
         // Enforce search policy
         emit caseSensitiveChanged(m_actionCaseSensitive->isChecked());
         emit limitGroupChanged(m_actionLimitGroup->isChecked());

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -55,13 +55,13 @@ signals:
 
 public slots:
     void databaseChanged(DatabaseWidget* dbWidget = 0);
+    void searchFocus();
 
 private slots:
     void startSearchTimer();
     void startSearch();
     void updateCaseSensitive();
     void updateLimitGroup();
-    void searchFocus();
 
 private:
     const QScopedPointer<Ui::SearchWidget> m_ui;

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -55,13 +55,13 @@ signals:
 
 public slots:
     void databaseChanged(DatabaseWidget* dbWidget = 0);
-    void searchFocus();
 
 private slots:
     void startSearchTimer();
     void startSearch();
     void updateCaseSensitive();
     void updateLimitGroup();
+    void searchFocus();
 
 private:
     const QScopedPointer<Ui::SearchWidget> m_ui;


### PR DESCRIPTION
Signed-off-by: Ettore Dreucci <ettore.dreucci@gmail.com>

<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
At startup and when the database is open and no action is being carried out the keyboard focus is automatically given to the search widget so that it's possible to search an entry without using the ctrl+f shortcut or clicking on the search field.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed issue #847 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested:
1. Created a new database
2. Added some random entries
3. Started typing to search


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
