### PR TITLE
Detect session lock on Xfce/XUbuntu 16.04

### DIFF
--- a/src/core/ScreenLockListenerDBus.cpp
+++ b/src/core/ScreenLockListenerDBus.cpp
@@ -20,6 +20,7 @@
 #include <QDBusConnection>
 #include <QDBusInterface>
 #include <QDBusReply>
+#include <QProcessEnvironment>
 
 ScreenLockListenerDBus::ScreenLockListenerDBus(QWidget *parent):
     ScreenLockListenerPrivate(parent)
@@ -34,7 +35,7 @@ ScreenLockListenerDBus::ScreenLockListenerDBus(QWidget *parent):
                 "ActiveChanged", // signal name
                 this, //receiver
                 SLOT(freedesktopScreenSaver(bool)));
-    
+
     sessionBus.connect(
                 "org.gnome.SessionManager", // service
                 "/org/gnome/SessionManager/Presence", // path
@@ -50,6 +51,15 @@ ScreenLockListenerDBus::ScreenLockListenerDBus(QWidget *parent):
                 "PrepareForSleep", // signal name
                 this, //receiver
                 SLOT(logindPrepareForSleep(bool)));
+
+    QString sessionId = QProcessEnvironment::systemEnvironment().value("XDG_SESSION_ID");
+    systemBus.connect(
+                "", // service
+                QString("/org/freedesktop/login1/session/") + sessionId, // path
+                "org.freedesktop.login1.Session", // interface
+                "Lock", // signal name
+                this, //receiver
+                SLOT(unityLocked()));
 
     sessionBus.connect(
                 "com.canonical.Unity", // service


### PR DESCRIPTION
The current code does not work with XUbuntu 16.04, which uses
light-locker to lock the screen.

I am not using a screensaver, but I suspect the screensaver activation
may have been detected by the existing events, and using it could thus
mask the issue.