### PR TITLE
Bind delete key to delete entry

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -167,6 +167,7 @@ MainWindow::MainWindow()
     setShortcut(m_ui->actionEntryNew, QKeySequence::New, Qt::CTRL + Qt::Key_N);
     m_ui->actionEntryEdit->setShortcut(Qt::CTRL + Qt::Key_E);
     m_ui->actionEntryDelete->setShortcut(Qt::CTRL + Qt::Key_D);
+    m_ui->actionEntryDelete->setShortcut(Qt::Key_Delete);
     m_ui->actionEntryClone->setShortcut(Qt::CTRL + Qt::Key_K);
     m_ui->actionEntryTotp->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_T);
     m_ui->actionEntryCopyTotp->setShortcut(Qt::CTRL + Qt::Key_T);


### PR DESCRIPTION
Use the `delete` key to delete selected records, ontop of the original `CTRL+D` record. 

## Description
Add a key bind for delete key to delete an entry

## Motivation and context
Using the delete key to delete a record just makes sense, That's what the key is for 👍 

## How has this been tested?
Locally. Select record, see if delete dialog appears.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
