### PR TITLE
CLI : basic entry manipulation commands.

### DIFF
--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -145,5 +145,6 @@ int Add::execute(QStringList arguments)
         return EXIT_FAILURE;
     }
 
+    outputTextStream << "Successfully added entry " << entry->title() << "." << endl;
     return EXIT_SUCCESS;
 }

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -1,0 +1,149 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include "Add.h"
+
+#include <QCommandLineParser>
+#include <QTextStream>
+
+#include "cli/Utils.h"
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "core/PasswordGenerator.h"
+
+Add::Add()
+{
+    this->name = QString("add");
+    this->description = QObject::tr("Add a new entry to a database.");
+}
+
+Add::~Add()
+{
+}
+
+int Add::execute(QStringList arguments)
+{
+
+    QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
+    QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(this->description);
+    parser.addPositionalArgument("database", QObject::tr("Path of the database."));
+
+    QCommandLineOption keyFile(QStringList() << "k"
+                                             << "key-file",
+                               QObject::tr("Key file of the database."),
+                               QObject::tr("path"));
+    parser.addOption(keyFile);
+
+    QCommandLineOption username(QStringList() << "u"
+                                              << "username",
+                                QObject::tr("Username for the entry."),
+                                QObject::tr("username"));
+    parser.addOption(username);
+
+    QCommandLineOption url(QStringList() << "url", QObject::tr("URL for the entry."), QObject::tr("URL"));
+    parser.addOption(url);
+
+    QCommandLineOption prompt(QStringList() << "p"
+                                            << "password-prompt",
+                              QObject::tr("Prompt for the entry's password."));
+    parser.addOption(prompt);
+
+    QCommandLineOption generate(QStringList() << "g"
+                                              << "generate",
+                                QObject::tr("Generate a password for the entry."));
+    parser.addOption(generate);
+
+    QCommandLineOption length(QStringList() << "l"
+                                            << "password-length",
+                              QObject::tr("Length for the generated password."),
+                              QObject::tr("length"));
+    parser.addOption(length);
+
+    parser.addPositionalArgument("entry", QObject::tr("Path of the entry to add."));
+    parser.process(arguments);
+
+    const QStringList args = parser.positionalArguments();
+    if (args.size() != 2) {
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli add");
+        return EXIT_FAILURE;
+    }
+
+    QString databasePath = args.at(0);
+    QString entryPath = args.at(1);
+
+    Database* db = Database::unlockFromStdin(databasePath, parser.value(keyFile));
+    if (db == nullptr) {
+        return EXIT_FAILURE;
+    }
+
+    // Validating the password length here, before we actually create
+    // the entry.
+    QString passwordLength = parser.value(length);
+    if (!passwordLength.isEmpty() && !passwordLength.toInt()) {
+        qCritical("Invalid value for password length %s.", qPrintable(passwordLength));
+        return EXIT_FAILURE;
+    }
+
+    Entry* entry = db->rootGroup()->addEntryWithPath(entryPath);
+    if (!entry) {
+        qCritical("Could not create entry with path %s.", qPrintable(entryPath));
+        return EXIT_FAILURE;
+    }
+
+    if (!parser.value("username").isEmpty()) {
+        entry->setUsername(parser.value("username"));
+    }
+
+    if (!parser.value("url").isEmpty()) {
+        entry->setUrl(parser.value("url"));
+    }
+
+    if (parser.isSet(prompt)) {
+        outputTextStream << "Enter password for new entry: ";
+        outputTextStream.flush();
+        QString password = Utils::getPassword();
+        entry->setPassword(password);
+    } else if (parser.isSet(generate)) {
+        PasswordGenerator passwordGenerator;
+
+        if (passwordLength.isEmpty()) {
+            passwordGenerator.setLength(PasswordGenerator::DefaultLength);
+        } else {
+            passwordGenerator.setLength(passwordLength.toInt());
+        }
+
+        passwordGenerator.setCharClasses(PasswordGenerator::LowerLetters | PasswordGenerator::UpperLetters |
+                                         PasswordGenerator::Numbers);
+        QString password = passwordGenerator.generatePassword();
+        entry->setPassword(password);
+    }
+
+    QString errorMessage = db->saveToFile(databasePath);
+    if (!errorMessage.isEmpty()) {
+        qCritical("Writing the database failed %s.", qPrintable(errorMessage));
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Add.h
+++ b/src/cli/Add.h
@@ -1,5 +1,4 @@
 /*
- *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -16,30 +15,17 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_TESTGROUP_H
-#define KEEPASSX_TESTGROUP_H
+#ifndef KEEPASSXC_ADD_H
+#define KEEPASSXC_ADD_H
 
-#include <QObject>
-#include "core/Database.h"
+#include "Command.h"
 
-class TestGroup : public QObject
+class Add : public Command
 {
-    Q_OBJECT
-
-private slots:
-    void initTestCase();
-    void testParenting();
-    void testSignals();
-    void testEntries();
-    void testDeleteSignals();
-    void testCopyCustomIcon();
-    void testClone();
-    void testCopyCustomIcons();
-    void testFindEntry();
-    void testFindGroupByPath();
-    void testPrint();
-    void testLocate();
-    void testAddEntryWithPath();
+public:
+    Add();
+    ~Add();
+    int execute(QStringList arguments);
 };
 
-#endif // KEEPASSX_TESTGROUP_H
+#endif // KEEPASSXC_ADD_H

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -14,10 +14,14 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set(cli_SOURCES
+    Add.cpp
+    Add.h
     Clip.cpp
     Clip.h
     Command.cpp
     Command.h
+    Edit.cpp
+    Edit.h
     EntropyMeter.cpp
     EntropyMeter.h
     Extract.cpp
@@ -28,6 +32,8 @@ set(cli_SOURCES
     Locate.h
     Merge.cpp
     Merge.h
+    Remove.cpp
+    Remove.h
     Show.cpp
     Show.h)
 

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -22,12 +22,15 @@
 
 #include "Command.h"
 
+#include "Add.h"
+#include "Edit.h"
 #include "Clip.h"
 #include "EntropyMeter.h"
 #include "Extract.h"
 #include "List.h"
 #include "Locate.h"
 #include "Merge.h"
+#include "Remove.h"
 #include "Show.h"
 
 QMap<QString, Command*> commands;
@@ -56,12 +59,15 @@ QString Command::getDescriptionLine()
 void populateCommands()
 {
     if (commands.isEmpty()) {
+        commands.insert(QString("add"), new Add());
         commands.insert(QString("clip"), new Clip());
+        commands.insert(QString("edit"), new Edit());
         commands.insert(QString("entropy-meter"), new EntropyMeter());
         commands.insert(QString("extract"), new Extract());
         commands.insert(QString("locate"), new Locate());
         commands.insert(QString("ls"), new List());
         commands.insert(QString("merge"), new Merge());
+        commands.insert(QString("rm"), new Remove());
         commands.insert(QString("show"), new Show());
     }
 }

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -163,5 +163,6 @@ int Edit::execute(QStringList arguments)
         return EXIT_FAILURE;
     }
 
+    outputTextStream << "Successfully edited entry " << entry->title() << "." << endl;
     return EXIT_SUCCESS;
 }

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include "Edit.h"
+
+#include <QCommandLineParser>
+#include <QTextStream>
+
+#include "cli/Utils.h"
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "core/PasswordGenerator.h"
+
+Edit::Edit()
+{
+    this->name = QString("edit");
+    this->description = QObject::tr("Edit an entry.");
+}
+
+Edit::~Edit()
+{
+}
+
+int Edit::execute(QStringList arguments)
+{
+
+    QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
+    QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(this->description);
+    parser.addPositionalArgument("database", QObject::tr("Path of the database."));
+
+    QCommandLineOption keyFile(QStringList() << "k"
+                                             << "key-file",
+                               QObject::tr("Key file of the database."),
+                               QObject::tr("path"));
+    parser.addOption(keyFile);
+
+    QCommandLineOption username(QStringList() << "u"
+                                              << "username",
+                                QObject::tr("Username for the entry."),
+                                QObject::tr("username"));
+    parser.addOption(username);
+
+    QCommandLineOption url(QStringList() << "url", QObject::tr("URL for the entry."), QObject::tr("URL"));
+    parser.addOption(url);
+
+    QCommandLineOption title(QStringList() << "t"
+                                           << "title",
+                             QObject::tr("Title for the entry."),
+                             QObject::tr("title"));
+    parser.addOption(title);
+
+    QCommandLineOption prompt(QStringList() << "p"
+                                            << "password-prompt",
+                              QObject::tr("Prompt for the entry's password."));
+    parser.addOption(prompt);
+
+    QCommandLineOption generate(QStringList() << "g"
+                                              << "generate",
+                                QObject::tr("Generate a password for the entry."));
+    parser.addOption(generate);
+
+    QCommandLineOption length(QStringList() << "l"
+                                            << "password-length",
+                              QObject::tr("Length for the generated password."),
+                              QObject::tr("length"));
+    parser.addOption(length);
+
+    parser.addPositionalArgument("entry", QObject::tr("Path of the entry to edit."));
+    parser.process(arguments);
+
+    const QStringList args = parser.positionalArguments();
+    if (args.size() != 2) {
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli edit");
+        return EXIT_FAILURE;
+    }
+
+    QString databasePath = args.at(0);
+    QString entryPath = args.at(1);
+
+    Database* db = Database::unlockFromStdin(databasePath, parser.value(keyFile));
+    if (db == nullptr) {
+        return EXIT_FAILURE;
+    }
+
+    QString passwordLength = parser.value(length);
+    if (!passwordLength.isEmpty() && !passwordLength.toInt()) {
+        qCritical("Invalid value for password length %s.", qPrintable(passwordLength));
+        return EXIT_FAILURE;
+    }
+
+    Entry* entry = db->rootGroup()->findEntryByPath(entryPath);
+    if (!entry) {
+        qCritical("Could not find entry with path %s.", qPrintable(entryPath));
+        return EXIT_FAILURE;
+    }
+
+    if (parser.value("username").isEmpty() && parser.value("url").isEmpty() && parser.value("title").isEmpty() &&
+        !parser.isSet(prompt) && !parser.isSet(generate)) {
+        qCritical("Not changing any field for entry %s.", qPrintable(entryPath));
+        return EXIT_FAILURE;
+    }
+
+    entry->beginUpdate();
+
+    if (!parser.value("title").isEmpty()) {
+        entry->setTitle(parser.value("title"));
+    }
+
+    if (!parser.value("username").isEmpty()) {
+        entry->setUsername(parser.value("username"));
+    }
+
+    if (!parser.value("url").isEmpty()) {
+        entry->setUrl(parser.value("url"));
+    }
+
+    if (parser.isSet(prompt)) {
+        outputTextStream << "Enter new password for entry: ";
+        outputTextStream.flush();
+        QString password = Utils::getPassword();
+        entry->setPassword(password);
+    } else if (parser.isSet(generate)) {
+        PasswordGenerator passwordGenerator;
+
+        if (passwordLength.isEmpty()) {
+            passwordGenerator.setLength(PasswordGenerator::DefaultLength);
+        } else {
+            passwordGenerator.setLength(passwordLength.toInt());
+        }
+
+        passwordGenerator.setCharClasses(PasswordGenerator::LowerLetters | PasswordGenerator::UpperLetters |
+                                         PasswordGenerator::Numbers);
+        QString password = passwordGenerator.generatePassword();
+        entry->setPassword(password);
+    }
+
+    entry->endUpdate();
+
+    QString errorMessage = db->saveToFile(databasePath);
+    if (!errorMessage.isEmpty()) {
+        qCritical("Writing the database failed %s.", qPrintable(errorMessage));
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Edit.h
+++ b/src/cli/Edit.h
@@ -1,5 +1,4 @@
 /*
- *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -16,30 +15,17 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_TESTGROUP_H
-#define KEEPASSX_TESTGROUP_H
+#ifndef KEEPASSXC_EDIT_H
+#define KEEPASSXC_EDIT_H
 
-#include <QObject>
-#include "core/Database.h"
+#include "Command.h"
 
-class TestGroup : public QObject
+class Edit : public Command
 {
-    Q_OBJECT
-
-private slots:
-    void initTestCase();
-    void testParenting();
-    void testSignals();
-    void testEntries();
-    void testDeleteSignals();
-    void testCopyCustomIcon();
-    void testClone();
-    void testCopyCustomIcons();
-    void testFindEntry();
-    void testFindGroupByPath();
-    void testPrint();
-    void testLocate();
-    void testAddEntryWithPath();
+public:
+    Edit();
+    ~Edit();
+    int execute(QStringList arguments);
 };
 
-#endif // KEEPASSX_TESTGROUP_H
+#endif // KEEPASSXC_EDIT_H

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include "Remove.h"
+
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QStringList>
+#include <QTextStream>
+
+#include "cli/Utils.h"
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "core/Metadata.h"
+#include "core/Tools.h"
+
+Remove::Remove()
+{
+    this->name = QString("rm");
+    this->description = QString("Remove an entry from the database.");
+}
+
+Remove::~Remove()
+{
+}
+
+int Remove::execute(QStringList arguments)
+{
+    QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(QCoreApplication::translate("main", "Remove an entry from the database."));
+    parser.addPositionalArgument("database", QCoreApplication::translate("main", "Path of the database."));
+    QCommandLineOption keyFile(QStringList() << "k"
+                                             << "key-file",
+                               QObject::tr("Key file of the database."),
+                               QObject::tr("path"));
+    parser.addOption(keyFile);
+    parser.addPositionalArgument("entry", QCoreApplication::translate("main", "Path of the entry to remove."));
+    parser.process(arguments);
+
+    const QStringList args = parser.positionalArguments();
+    if (args.size() != 2) {
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli rm");
+        return EXIT_FAILURE;
+    }
+
+    Database* db = Database::unlockFromStdin(args.at(0), parser.value(keyFile));
+    if (db == nullptr) {
+        return EXIT_FAILURE;
+    }
+
+    return this->removeEntry(db, args.at(0), args.at(1));
+}
+
+int Remove::removeEntry(Database* database, QString databasePath, QString entryPath)
+{
+
+    QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
+    Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
+    if (!entry) {
+        qCritical("Entry %s not found.", qPrintable(entryPath));
+        return EXIT_FAILURE;
+    }
+
+    QString entryTitle = entry->title();
+    bool recycled = true;
+    if (Tools::hasChild(database->metadata()->recycleBin(), entry) || !database->metadata()->recycleBinEnabled()) {
+        delete entry;
+        recycled = false;
+    } else {
+        database->recycleEntry(entry);
+    };
+
+    QString errorMessage = database->saveToFile(databasePath);
+    if (!errorMessage.isEmpty()) {
+        qCritical("Unable to save database to file : %s", qPrintable(errorMessage));
+        return EXIT_FAILURE;
+    }
+
+    if (recycled) {
+        outputTextStream << "Successfully recycled entry " << entryTitle << "." << endl;
+    } else {
+        outputTextStream << "Successfully deleted entry " << entryTitle << "." << endl;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Remove.h
+++ b/src/cli/Remove.h
@@ -1,5 +1,4 @@
 /*
- *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -16,30 +15,20 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_TESTGROUP_H
-#define KEEPASSX_TESTGROUP_H
+#ifndef KEEPASSXC_REMOVE_H
+#define KEEPASSXC_REMOVE_H
 
-#include <QObject>
+#include "Command.h"
+
 #include "core/Database.h"
 
-class TestGroup : public QObject
+class Remove : public Command
 {
-    Q_OBJECT
-
-private slots:
-    void initTestCase();
-    void testParenting();
-    void testSignals();
-    void testEntries();
-    void testDeleteSignals();
-    void testCopyCustomIcon();
-    void testClone();
-    void testCopyCustomIcons();
-    void testFindEntry();
-    void testFindGroupByPath();
-    void testPrint();
-    void testLocate();
-    void testAddEntryWithPath();
+public:
+    Remove();
+    ~Remove();
+    int execute(QStringList arguments);
+    int removeEntry(Database* database, QString databasePath, QString entryPath);
 };
 
-#endif // KEEPASSX_TESTGROUP_H
+#endif // KEEPASSXC_REMOVE_H

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -9,7 +9,7 @@ keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager
 .I command
 
 .SH DESCRIPTION
-\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePassXC database, directly from the command line.
+\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePass database, directly from the command line.
 
 .SH COMMANDS
 

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -9,12 +9,18 @@ keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager
 .I command
 
 .SH DESCRIPTION
-\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability of listing the entries of a database, displaying the contents of an entry and many more, directly from the command line.
+\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePassXC database, directly from the command line.
 
 .SH COMMANDS
 
+.IP "add [options] <database> <entry>"
+Adds a new entry to a database. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+
 .IP "clip [options] <database> <entry> [timeout]"
 Copies the password of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
+
+.IP "edit [options] <database> <entry>"
+Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
 .IP "entropy-meter [-a pwd1 pwd2 ...]"
 Calculates the entropy of a single, or multiple passwords specified using the \fI-a\fP option. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
@@ -31,25 +37,58 @@ Lists the contents of a group in a database. If no group is specified, it will d
 .IP "merge [options] <database1> <database2>"
 Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
 
+.IP "rm [options] <database> <entry>"
+Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
+
 .IP "show [options] <database> <entry>"
 Shows the title, username, password, URL and notes of a database entry. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
 
 .SH OPTIONS
 
+.SS "General options"
+
 .IP "-k, --key-file <path>"
 Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
-
-.IP "-f, --key-file-from <path>"
-Specifies a path to a key file for the second database in a merge operation.
-
-.IP "-s, --same-credentials"
-Tells the program to use the same credentials for unlocking both of the database files in a merge operation.
 
 .IP "-h, --help"
 Displays help information.
 
 .IP "-v, --version"
 Shows the program version.
+
+
+.SS "Merge options"
+
+.IP "-f, --key-file-from <path>"
+Path of the key file for the second database.
+
+.IP "-s, --same-credentials"
+Use the same credentials for unlocking both database.
+
+
+.SS "Add and edit options"
+
+.IP "-u, --username <username>"
+Specify the username of the entry.
+
+.IP "--url <url>"
+Specify the URL of the entry.
+
+.IP "-p, --password-prompt"
+Use a password prompt for the entry's password.
+
+.IP "-g, --generate"
+Generate a new password for the entry.
+
+.IP "-l, --password-length"
+Specify the length of the password to generate.
+
+
+.SS "Edit options"
+
+.IP "-t, --title <title>"
+Specify the title of the entry.
+
 
 .SH REPORTING BUGS
 Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -949,3 +949,32 @@ QStringList Group::locate(QString locateTerm, QString currentPath)
 
     return response;
 }
+
+Entry* Group::addEntryWithPath(QString entryPath)
+{
+    Q_ASSERT(!entryPath.isNull());
+    if (this->findEntryByPath(entryPath)) {
+        return nullptr;
+    }
+
+    QStringList groups = entryPath.split("/");
+    QString entryTitle = groups.takeLast();
+    QString groupPath = groups.join("/");
+    if (groupPath.isNull()) {
+        groupPath = QString("");
+    }
+
+    Q_ASSERT(!groupPath.isNull());
+    Group* group = this->findGroupByPath(groupPath);
+    if (!group) {
+        return nullptr;
+    }
+
+    Entry* entry = new Entry();
+    entry->setTitle(entryTitle);
+    entry->setUuid(Uuid::random());
+    entry->setGroup(group);
+
+    return entry;
+
+}

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -85,6 +85,7 @@ public:
     Entry* findEntryByPath(QString entryPath, QString basePath = QString(""));
     Group* findGroupByPath(QString groupPath, QString basePath = QString("/"));
     QStringList locate(QString locateTerm, QString currentPath = QString("/"));
+    Entry* addEntryWithPath(QString entryPath);
     void setUuid(const Uuid& uuid);
     void setName(const QString& name);
     void setNotes(const QString& notes);

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -58,6 +58,8 @@ public:
     QString generatePassword() const;
     int getbits() const;
 
+    static const int DefaultLength = 16;
+
 private:
     QVector<PasswordGroup> passwordGroups() const;
     int numCharClasses() const;

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -98,7 +98,7 @@ void PasswordGeneratorWidget::loadSettings()
     m_ui->checkBoxExtASCII->setChecked(config()->get("generator/EASCII", false).toBool());
     m_ui->checkBoxExcludeAlike->setChecked(config()->get("generator/ExcludeAlike", true).toBool());
     m_ui->checkBoxEnsureEvery->setChecked(config()->get("generator/EnsureEvery", true).toBool());
-    m_ui->spinBoxLength->setValue(config()->get("generator/Length", 16).toInt());
+    m_ui->spinBoxLength->setValue(config()->get("generator/Length", PasswordGenerator::DefaultLength).toInt());
 
     // Diceware config
     m_ui->spinBoxWordCount->setValue(config()->get("generator/WordCount", 6).toInt());

--- a/src/http/HttpPasswordGeneratorWidget.cpp
+++ b/src/http/HttpPasswordGeneratorWidget.cpp
@@ -56,7 +56,7 @@ void HttpPasswordGeneratorWidget::loadSettings()
     m_ui->checkBoxExcludeAlike->setChecked(config()->get("Http/generator/ExcludeAlike", true).toBool());
     m_ui->checkBoxEnsureEvery->setChecked(config()->get("Http/generator/EnsureEvery", true).toBool());
 
-    m_ui->spinBoxLength->setValue(config()->get("Http/generator/Length", 16).toInt());
+    m_ui->spinBoxLength->setValue(config()->get("Http/generator/Length", PasswordGenerator::DefaultLength).toInt());
 }
 
 void HttpPasswordGeneratorWidget::saveSettings()

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -698,3 +698,51 @@ void TestGroup::testLocate()
 
     delete db;
 }
+
+void TestGroup::testAddEntryWithPath()
+{
+    Database* db = new Database();
+
+    Group* group1 = new Group();
+    group1->setName("group1");
+    group1->setParent(db->rootGroup());
+
+    Group* group2 = new Group();
+    group2->setName("group2");
+    group2->setParent(group1);
+
+    Entry* entry = db->rootGroup()->addEntryWithPath("entry1");
+    QVERIFY(entry != nullptr);
+    QVERIFY(!entry->uuid().isNull());
+
+    entry = db->rootGroup()->addEntryWithPath("entry1");
+    QVERIFY(entry == nullptr);
+
+    entry = db->rootGroup()->addEntryWithPath("/entry1");
+    QVERIFY(entry == nullptr);
+
+    entry = db->rootGroup()->addEntryWithPath("entry2");
+    QVERIFY(entry != nullptr);
+    QVERIFY(entry->title() == "entry2");
+    QVERIFY(!entry->uuid().isNull());
+
+    entry = db->rootGroup()->addEntryWithPath("/entry3");
+    QVERIFY(entry != nullptr);
+    QVERIFY(entry->title() == "entry3");
+    QVERIFY(!entry->uuid().isNull());
+
+    entry = db->rootGroup()->addEntryWithPath("/group1/entry4");
+    QVERIFY(entry != nullptr);
+    QVERIFY(entry->title() == "entry4");
+    QVERIFY(!entry->uuid().isNull());
+
+    entry = db->rootGroup()->addEntryWithPath("/group1/group2/entry5");
+    QVERIFY(entry != nullptr);
+    QVERIFY(entry->title() == "entry5");
+    QVERIFY(!entry->uuid().isNull());
+
+    entry = db->rootGroup()->addEntryWithPath("/group1/invalid_group/entry6");
+    QVERIFY(entry == nullptr);
+
+    delete db;
+}


### PR DESCRIPTION
* adding basic entry manipulation commands for the CLI. (add, edit and remove).
* extracted a `DefaultLength` for the password generation since `16` was hardcoded at multiple places
* added sub-sections to the `OPTIONS` section of the man page, to avoid mixing command specific and general options

## Motivation and context
Adresses #681

## How has this been tested?
* Tested locally the new commands
* Added unit tests where possible

## Screenshots
```
$ ./src/cli/keepassxc-cli
Usage: ./src/cli/keepassxc-cli [options] command
KeePassXC command line interface.

Available commands:
add            Add a new entry to a database.
clip           Copy an entry's password to the clipboard.
edit           Edit an entry.
entropy-meter  Calculate password entropy.
extract        Extract and print the content of a database.
locate         Find entries quickly.
ls             List database entries.
merge          Merge two databases.
rm             Remove an entry from the database.
show           Show an entry's information.


Options:
  -h, --help     Displays this help.
  -v, --version  Displays version information.

Arguments:
  command        Name of the command to execute.

```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
