### PR TITLE
Fixes #940 : segfault when searching after merging

### DIFF
--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -116,6 +116,7 @@ void TestMerge::testResolveConflictNewer()
 
     entry1 = dbDestination->rootGroup()->findEntry("entry1");
     QVERIFY(entry1 != nullptr);
+    QVERIFY(entry1->group() != nullptr);
     QCOMPARE(entry1->password(), QString("password"));
 
     // When updating an entry, it should not end up in the


### PR DESCRIPTION
Adding a unit test in `develop` for #941.

The bug is not in `develop` as we use `setGroup` already, but it's worth adding a unit test anyway.

This is going to cause conflicts when upporting 2.2.1 into develop, but I think the fix can't wait for 2.3.0.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
