### PR TITLE
Clear database open dialog before and after merging a database

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -119,6 +119,18 @@ void DatabaseOpenWidget::load(const QString& filename)
     m_ui->editPassword->setFocus();
 }
 
+void DatabaseOpenWidget::clearForms()
+{
+    m_ui->editPassword->clear();
+    m_ui->comboKeyFile->clear();
+    m_ui->checkPassword->setChecked(false);
+    m_ui->checkKeyFile->setChecked(false);
+    m_ui->checkChallengeResponse->setChecked(false);
+    m_ui->buttonTogglePassword->setChecked(false);
+    m_db = nullptr;
+}
+
+
 Database* DatabaseOpenWidget::database()
 {
     return m_db;

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -39,6 +39,7 @@ public:
     explicit DatabaseOpenWidget(QWidget* parent = nullptr);
     ~DatabaseOpenWidget();
     void load(const QString& filename);
+    void clearForms();
     void enterKey(const QString& pw, const QString& keyFile);
     Database* database();
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -813,6 +813,7 @@ void DatabaseWidget::mergeDatabase(bool accepted)
         m_db->merge(srcDb);
     }
 
+    m_databaseOpenMergeWidget->clearForms();
     setCurrentWidget(m_mainWidget);
     emit databaseMerged(m_db);
 }
@@ -918,6 +919,7 @@ void DatabaseWidget::switchToImportCsv(const QString& fileName)
 
 void DatabaseWidget::switchToOpenMergeDatabase(const QString& fileName)
 {
+    m_databaseOpenMergeWidget->clearForms();
     m_databaseOpenMergeWidget->load(fileName);
     setCurrentWidget(m_databaseOpenMergeWidget);
 }

--- a/src/gui/UnlockDatabaseWidget.cpp
+++ b/src/gui/UnlockDatabaseWidget.cpp
@@ -26,14 +26,3 @@ UnlockDatabaseWidget::UnlockDatabaseWidget(QWidget* parent)
 {
     m_ui->labelHeadline->setText(tr("Unlock database"));
 }
-
-void UnlockDatabaseWidget::clearForms()
-{
-    m_ui->editPassword->clear();
-    m_ui->comboKeyFile->clear();
-    m_ui->checkPassword->setChecked(false);
-    m_ui->checkKeyFile->setChecked(false);
-    m_ui->checkChallengeResponse->setChecked(false);
-    m_ui->buttonTogglePassword->setChecked(false);
-    m_db = nullptr;
-}

--- a/src/gui/UnlockDatabaseWidget.h
+++ b/src/gui/UnlockDatabaseWidget.h
@@ -26,7 +26,6 @@ class UnlockDatabaseWidget : public DatabaseOpenWidget
 
 public:
     explicit UnlockDatabaseWidget(QWidget* parent = nullptr);
-    void clearForms();
 };
 
 #endif // KEEPASSX_UNLOCKDATABASEWIDGET_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #944. Resets master key entry prior to showing the unlock dialog for merging and then after the merge is completed.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Not clearing the form can result in leaking the master key.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and unit tests

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
