### PR TITLE
Use CMake's variable instead of hardcoded path to install man pages

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -55,6 +55,6 @@ install(TARGETS keepassxc-cli
         RUNTIME DESTINATION ${CLI_INSTALL_DIR} COMPONENT Runtime)
 
 if(APPLE OR UNIX)
-    install(FILES keepassxc-cli.1 DESTINATION /usr/local/share/man/man1/)
+    install(FILES keepassxc-cli.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)
     execute_process(COMMAND mandb -q)
 endif()


### PR DESCRIPTION
## Description
Installation of unofficial Arch Linux user (AUR) package ```keepassxc-git fails:
```
error: failed to commit transaction (conflicting files)
keepassxc-git: /usr/local/share/man exists in filesystem
Errors occurred, no packages were upgraded.
```

## Motivation and context
Hard-coded install path from #888 breaks things. Arch Linux discourages packages to install files to /usr/local.

## How has this been tested?
Apply the patch and rebuild the package. The man page is installed to /usr/share/man/man1/keepassxc-cli.1.gz if CMAKE_INSTALL_PREFIX is /usr.

## Screenshots (if appropriate):
N/A. Build fix only.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
-  All new and existing tests passed. **[REQUIRED]**
With ASAN, 5 tests fail as there are leaks:
```
The following tests FAILED:
          5 - testkeepass2writer (Failed)
          9 - testsymmetriccipher (Failed)
         20 - testcsvparser (Failed)
         27 - testgui (Failed)
         28 - testguipixmaps (Failed)
```
Both GCC 7.2.0 and clang 5.0.0 reports the same result.
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**