### PR TITLE
Prevent unnecessary memory allocations

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -418,7 +418,7 @@ Database* Database::unlockFromStdin(QString databaseFilename, QString keyFilenam
         FileKey fileKey;
         QString errorMessage;
         if (!fileKey.load(keyFilename, &errorMessage)) {
-            errorTextStream << QObject::tr("Failed to load key file %1 : %2").arg(keyFilename).arg(errorMessage);
+            errorTextStream << QObject::tr("Failed to load key file %1 : %2").arg(keyFilename, errorMessage);
             errorTextStream << endl;
             return nullptr;
         }

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -29,7 +29,7 @@ QList<QString> EntryAttachments::keys() const
 
 bool EntryAttachments::hasKey(const QString& key) const
 {
-    return m_attachments.keys().contains(key);
+    return m_attachments.contains(key);
 }
 
 QList<QByteArray> EntryAttachments::values() const

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -41,7 +41,7 @@ QList<QString> EntryAttributes::keys() const
 
 bool EntryAttributes::hasKey(const QString& key) const
 {
-    return m_attributes.keys().contains(key);
+    return m_attributes.contains(key);
 }
 
 QList<QString> EntryAttributes::customKeys()

--- a/src/format/KeePass2XmlWriter.cpp
+++ b/src/format/KeePass2XmlWriter.cpp
@@ -521,9 +521,9 @@ void KeePass2XmlWriter::writeColor(const QString& qualifiedName, const QColor& c
     QString colorStr;
 
     if (color.isValid()) {
-      colorStr = QString("#%1%2%3").arg(colorPartToString(color.red()))
-              .arg(colorPartToString(color.green()))
-              .arg(colorPartToString(color.blue()));
+      colorStr = QString("#%1%2%3").arg(colorPartToString(color.red()),
+                                        colorPartToString(color.green()),
+                                        colorPartToString(color.blue()));
     }
 
     writeString(qualifiedName, colorStr);

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -59,16 +59,16 @@ AboutDialog::AboutDialog(QWidget* parent)
     }
 
     debugInfo.append(QString("%1\n- Qt %2\n- %3\n\n")
-             .arg(tr("Libraries:"))
-             .arg(QString::fromLocal8Bit(qVersion()))
-             .arg(Crypto::backendVersion()));
+             .arg(tr("Libraries:"),
+                  QString::fromLocal8Bit(qVersion()),
+                  Crypto::backendVersion()));
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
     debugInfo.append(tr("Operating system: %1\nCPU architecture: %2\nKernel: %3 %4")
-             .arg(QSysInfo::prettyProductName())
-             .arg(QSysInfo::currentCpuArchitecture())
-             .arg(QSysInfo::kernelType())
-             .arg(QSysInfo::kernelVersion()));
+             .arg(QSysInfo::prettyProductName(),
+                  QSysInfo::currentCpuArchitecture(),
+                  QSysInfo::kernelType(),
+                  QSysInfo::kernelVersion()));
 
     debugInfo.append("\n\n");
 #endif


### PR DESCRIPTION
1. Use the multi-arg version of QString::arg()
2. Don't create temporary containers

## Description
The first change avoids creating temporary QStrings (leading to unnecessary heap allocations) when using chained QString::arg() calls by using the multi-arg overload. Rationale: [https://github.com/KDE/clazy/blob/master/src/checks/level0/README-qstring-arg.md](https://github.com/KDE/clazy/blob/master/src/checks/level0/README-qstring-arg.md)

The second change does a similar thing with temporary containers.

## Motivation and context
Optimization.

## How has this been tested?
Made a rebuild of the project, then run related tests and the keepassxc binary.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
