### PR TITLE
Correct latent single instance lock file preventing launch

### DIFF
--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -60,9 +60,9 @@ private:
     static void handleUnixSignal(int sig);
     static int unixSignalSocket[2];
 #endif
-    bool alreadyRunning;
-    QLockFile* lock;
-    QLocalServer server;
+    bool m_alreadyRunning;
+    QLockFile* m_lockFile;
+    QLocalServer m_lockServer;
 };
 
 #endif // KEEPASSX_APPLICATION_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
* Fixes #893, if connection to the listen server fails three times, the lock file is removed and a new listen server is started.

I also took the opportunity to bring this code into alignment with the coding standards for variable naming.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This issue has been reported 4 times since release of 2.2.0.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
