### PR TITLE
Fix double warning display for database open

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,7 +24,7 @@ BraceWrapping:
   AfterFunction:   true
   AfterControlStatement: false
   AfterEnum:       true
-  AfterNamespace:  true
+  AfterNamespace:  false
   AfterStruct:     true
   AfterUnion:      true
   BeforeCatch:     false

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -22,20 +22,19 @@
 #include "core/Config.h"
 #include "core/Database.h"
 #include "core/FilePath.h"
-#include "gui/MainWindow.h"
-#include "gui/FileDialog.h"
-#include "gui/MessageBox.h"
+#include "crypto/Random.h"
 #include "format/KeePass2Reader.h"
+#include "gui/FileDialog.h"
+#include "gui/MainWindow.h"
+#include "gui/MessageBox.h"
 #include "keys/FileKey.h"
 #include "keys/PasswordKey.h"
-#include "crypto/Random.h"
 #include "keys/YkChallengeResponseKey.h"
 
 #include "config-keepassx.h"
 
-#include <QtConcurrentRun>
 #include <QSharedPointer>
-
+#include <QtConcurrentRun>
 
 DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     : DialogyWidget(parent)
@@ -52,8 +51,7 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     m_ui->labelHeadline->setFont(font);
 
     m_ui->buttonTogglePassword->setIcon(filePath()->onOffIcon("actions", "password-show"));
-    connect(m_ui->buttonTogglePassword, SIGNAL(toggled(bool)),
-            m_ui->editPassword, SLOT(setShowPassword(bool)));
+    connect(m_ui->buttonTogglePassword, SIGNAL(toggled(bool)), m_ui->editPassword, SLOT(setShowPassword(bool)));
     connect(m_ui->buttonBrowseFile, SIGNAL(clicked()), SLOT(browseKeyFile()));
 
     connect(m_ui->editPassword, SIGNAL(textChanged(QString)), SLOT(activatePassword()));
@@ -71,7 +69,7 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     connect(m_ui->buttonRedetectYubikey, SIGNAL(clicked()), SLOT(pollYubikey()));
     connect(m_ui->comboChallengeResponse, SIGNAL(activated(int)), SLOT(activateChallengeResponse()));
 
-    connect(YubiKey::instance(), SIGNAL(detected(int,bool)), SLOT(yubikeyDetected(int,bool)), Qt::QueuedConnection);
+    connect(YubiKey::instance(), SIGNAL(detected(int, bool)), SLOT(yubikeyDetected(int, bool)), Qt::QueuedConnection);
     connect(YubiKey::instance(), SIGNAL(notFound()), SLOT(noYubikeyFound()), Qt::QueuedConnection);
 #else
     m_ui->checkChallengeResponse->setVisible(false);
@@ -158,8 +156,8 @@ void DatabaseOpenWidget::openDatabase()
 
     QFile file(m_filename);
     if (!file.open(QIODevice::ReadOnly)) {
-        m_ui->messageWidget->showMessage(
-            tr("Unable to open the database.").append("\n").append(file.errorString()), MessageWidget::Error);
+        m_ui->messageWidget->showMessage(tr("Unable to open the database.").append("\n").append(file.errorString()),
+                                         MessageWidget::Error);
         return;
     }
     if (m_db) {
@@ -175,8 +173,8 @@ void DatabaseOpenWidget::openDatabase()
         }
         emit editFinished(true);
     } else {
-        m_ui->messageWidget->showMessage(tr("Unable to open the database.")
-                                         .append("\n").append(reader.errorString()), MessageWidget::Error);
+        m_ui->messageWidget->showMessage(tr("Unable to open the database.").append("\n").append(reader.errorString()),
+                                         MessageWidget::Error);
         m_ui->editPassword->clear();
     }
 
@@ -199,8 +197,8 @@ CompositeKey* DatabaseOpenWidget::databaseKey()
         QString keyFilename = m_ui->comboKeyFile->currentText();
         QString errorMsg;
         if (!key.load(keyFilename, &errorMsg)) {
-            m_ui->messageWidget->showMessage(tr("Can't open key file").append(":\n")
-                                             .append(errorMsg), MessageWidget::Error);
+            m_ui->messageWidget->showMessage(tr("Can't open key file").append(":\n").append(errorMsg),
+                                             MessageWidget::Error);
             delete masterKey;
             return nullptr;
         }
@@ -231,8 +229,8 @@ CompositeKey* DatabaseOpenWidget::databaseKey()
 
         // read blocking mode from LSB and slot index number from second LSB
         bool blocking = comboPayload & 1;
-        int slot      = comboPayload >> 1;
-        auto key      = QSharedPointer<YkChallengeResponseKey>(new YkChallengeResponseKey(slot, blocking));
+        int slot = comboPayload >> 1;
+        auto key = QSharedPointer<YkChallengeResponseKey>(new YkChallengeResponseKey(slot, blocking));
         masterKey->addChallengeResponseKey(key);
     }
 #endif

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -51,7 +51,7 @@ signals:
 
 protected:
     void showEvent(QShowEvent* event) override;
-    CompositeKey databaseKey();
+    CompositeKey* databaseKey();
 
 protected slots:
     virtual void openDatabase();


### PR DESCRIPTION
Second attempt to fix #741, after https://github.com/keepassxreboot/keepassxc/pull/744

Also fixed the `clang-format`, as it seems we never break after a `namespace`.

## How has this been tested?
Locally, by opening a database with a keyfile, and testing the error message when providing an invalid path.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
