### PR TITLE
Add support for displaying TOTP keys as QR codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ option(WITH_APP_BUNDLE "Enable Application Bundle for OS X" ON)
 option(WITH_XC_AUTOTYPE "Include Auto-Type." ON)
 option(WITH_XC_HTTP "Include KeePassHTTP and Custom Icon Downloads." OFF)
 option(WITH_XC_YUBIKEY "Include YubiKey support." OFF)
+option(WITH_XC_TOTPDISPLAYKEY "Enable displaying TOTP keys as QR codes." OFF)
 
 # Process ui files automatically from source files
 set(CMAKE_AUTOUIC ON)
@@ -157,6 +158,10 @@ add_gcc_compiler_cflags("-ansi")
 
 if(WITH_DEV_BUILD)
   add_definitions(-DQT_DEPRECATED_WARNINGS -DGCRYPT_NO_DEPRECATED)
+endif()
+
+if(WITH_XC_TOTPDISPLAYKEY)
+    add_definitions(-DWITH_XC_TOTPDISPLAYKEY)
 endif()
 
 if(MINGW)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cmake accepts the following options:
   -DWITH_XC_AUTOTYPE=[ON|OFF] Enable/Disable Auto-Type (default: ON)
   -DWITH_XC_HTTP=[ON|OFF] Enable/Disable KeePassHTTP and custom icon downloads (default: OFF)
   -DWITH_XC_YUBIKEY=[ON|OFF] Enable/Disable YubiKey HMAC-SHA1 authentication support (default: OFF)
+  -DWITH_XC_TOTPDISPLAYKEY=[ON|OFF] Enable/Disable Support for displaying TOTP keys as QR codes (default: OFF)
 
   -DWITH_TESTS=[ON|OFF] Enable/Disable building of unit tests (default: ON)
   -DWITH_GUI_TESTS=[ON|OFF] Enable/Disable building of GUI tests (default: OFF)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cmake accepts the following options:
   -DWITH_XC_AUTOTYPE=[ON|OFF] Enable/Disable Auto-Type (default: ON)
   -DWITH_XC_HTTP=[ON|OFF] Enable/Disable KeePassHTTP and custom icon downloads (default: OFF)
   -DWITH_XC_YUBIKEY=[ON|OFF] Enable/Disable YubiKey HMAC-SHA1 authentication support (default: OFF)
-  -DWITH_XC_TOTPDISPLAYKEY=[ON|OFF] Enable/Disable Support for displaying TOTP keys as QR codes (default: OFF)
+  -DWITH_XC_TOTPDISPLAYKEY=[ON|OFF] Enable/Disable support for displaying TOTP keys as QR codes (default: OFF)
 
   -DWITH_TESTS=[ON|OFF] Enable/Disable building of unit tests (default: ON)
   -DWITH_GUI_TESTS=[ON|OFF] Enable/Disable building of GUI tests (default: OFF)

--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -1483,6 +1483,10 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show TOTP key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Find</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,6 +177,7 @@ set(keepassx_SOURCES_MAINEXE
 add_feature_info(AutoType WITH_XC_AUTOTYPE "Automatic password typing")
 add_feature_info(KeePassHTTP WITH_XC_HTTP "Browser integration compatible with ChromeIPass and PassIFox")
 add_feature_info(YubiKey WITH_XC_YUBIKEY "YubiKey HMAC-SHA1 challenge-response")
+add_feature_info(TotpDisplayKey WITH_XC_TOTPDISPLAYKEY "Display TOTP keys as QR codes")
 
 add_subdirectory(http)
 if(WITH_XC_HTTP)
@@ -211,6 +212,18 @@ else()
   list(APPEND keepassx_SOURCES keys/drivers/YubiKeyStub.cpp)
 endif()
 
+if(WITH_XC_TOTPDISPLAYKEY)
+    find_path(QRENCODE_INCLUDE_DIR qrencode.h)
+    find_library(QRENCODE_LIBRARY qrencode)
+    set(keepassx_SOURCES ${keepassx_SOURCES}
+        gui/TotpKeyDisplayDialog.h
+        gui/TotpKeyDisplayDialog.cpp
+        core/QRCode.h
+        core/QRCode_p.h
+        core/QRCode.cpp
+        )
+endif()
+
 add_library(autotype STATIC ${autotype_SOURCES})
 target_link_libraries(autotype Qt5::Core Qt5::Widgets)
 
@@ -222,6 +235,7 @@ set_target_properties(keepassx_core PROPERTIES COMPILE_DEFINITIONS KEEPASSX_BUIL
 target_link_libraries(keepassx_core
                       ${keepasshttp_LIB}
                       ${autotype_LIB}
+                      ${QRENCODE_LIBRARY}
                       ${YUBIKEY_LIBRARIES}
                       ${ZXCVBN_LIBRARIES}
                       Qt5::Core

--- a/src/core/Base32.cpp
+++ b/src/core/Base32.cpp
@@ -15,7 +15,11 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Conforms to RFC 4648. For details, see: https://tools.ietf.org/html/rfc4648
+ /* Conforms to RFC 4648. For details, see: https://tools.ietf.org/html/rfc4648
+  * Use the functions Base32::addPadding/1, Base32::removePadding/1 or
+  * Base32::sanitizeInput/1 to fix input or output for a particular
+  * applications (e.g. to use with Google Authenticator).
+  */
 
 #include "Base32.h"
 
@@ -77,8 +81,8 @@ Optional<QByteArray> Base32::decode(const QByteArray& encodedData)
 
 
     Q_ASSERT(encodedData.size() > 0);
-    const int nQuantums = encodedData.size() / 8;
-    const int nBytes = (nQuantums - 1) * 5 + nSpecialBytes;
+    const int nQuanta = encodedData.size() / 8;
+    const int nBytes = (nQuanta - 1) * 5 + nSpecialBytes;
 
     QByteArray data(nBytes, Qt::Uninitialized);
 
@@ -96,7 +100,7 @@ Optional<QByteArray> Base32::decode(const QByteArray& encodedData)
                 if (ch >= ALPH_POS_2)
                     ch -= ASCII_a - ASCII_A;
             } else {
-                if (ch >= ASCII_2 && ch <= ASCII_7) {
+                if (ASCII_2 <= ch && ch <= ASCII_7) {
                     ch -= ASCII_2;
                     ch += ALPH_POS_2;
                 } else {
@@ -137,9 +141,9 @@ QByteArray Base32::encode(const QByteArray& data)
 
     const int nBits = data.size() * 8;
     const int rBits = nBits % 40; // in {0, 8, 16, 24, 32}
-    const int nQuantums = nBits / 40 + (rBits > 0 ? 1 : 0);
-    QByteArray encodedData(nQuantums * 8, Qt::Uninitialized);
-    
+    const int nQuanta = nBits / 40 + (rBits > 0 ? 1 : 0);
+    QByteArray encodedData(nQuanta * 8, Qt::Uninitialized);
+
     int i = 0;
     int o = 0;
     int n;
@@ -208,3 +212,66 @@ QByteArray Base32::encode(const QByteArray& data)
     return encodedData;
 }
 
+QByteArray Base32::addPadding(const QByteArray& encodedData)
+{
+    if (encodedData.size() <= 0 || encodedData.size() % 8 == 0)
+        return encodedData;
+
+    const int rBytes = encodedData.size() % 8;
+    // rBytes must be a member of {2, 4, 5, 7}
+    if (1 == rBytes || 3 == rBytes || 6 == rBytes)
+        return encodedData;
+
+    QByteArray newEncodedData(encodedData);
+    for(int nPads = 8 - rBytes; nPads > 0; --nPads) {
+        newEncodedData.append('=');
+    }
+
+    return newEncodedData;
+}
+
+QByteArray Base32::removePadding(const QByteArray& encodedData)
+{
+    if (encodedData.size() <= 0 || encodedData.size() % 8 != 0)
+        return encodedData; // return same bad input
+
+    int nPads = 0;
+    for (int i = -1; i > -7; --i) {
+        if ('=' == encodedData[encodedData.size() + i])
+            ++nPads;
+    }
+
+    QByteArray newEncodedData(encodedData);
+    newEncodedData.remove(encodedData.size() - nPads, nPads);
+    newEncodedData.resize(encodedData.size() - nPads);
+
+    return newEncodedData;
+}
+
+QByteArray Base32::sanitizeInput(const QByteArray& encodedData)
+{
+    if(encodedData.size() <= 0)
+        return encodedData;
+
+    QByteArray newEncodedData(encodedData.size(), Qt::Uninitialized);
+    int i = 0;
+    for (auto ch : encodedData) {
+        switch(ch) {
+        case '0':
+            newEncodedData[i++] = 'O';
+            break;
+        case '1':
+            newEncodedData[i++] = 'L';
+            break;
+        case '8':
+            newEncodedData[i++] = 'B';
+            break;
+        default:
+            if (('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z') || ('2' <= ch && ch <= '7'))
+                newEncodedData[i++] = ch;
+        }
+    }
+    newEncodedData.resize(i);
+
+    return addPadding(newEncodedData);
+}

--- a/src/core/Base32.cpp
+++ b/src/core/Base32.cpp
@@ -15,11 +15,11 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- /* Conforms to RFC 4648. For details, see: https://tools.ietf.org/html/rfc4648
-  * Use the functions Base32::addPadding/1, Base32::removePadding/1 or
-  * Base32::sanitizeInput/1 to fix input or output for a particular
-  * applications (e.g. to use with Google Authenticator).
-  */
+/* Conforms to RFC 4648. For details, see: https://tools.ietf.org/html/rfc4648
+ * Use the functions Base32::addPadding/1, Base32::removePadding/1 or
+ * Base32::sanitizeInput/1 to fix input or output for a particular
+ * applications (e.g. to use with Google Authenticator).
+ */
 
 #include "Base32.h"
 
@@ -42,15 +42,17 @@ constexpr quint8 ASCII_EQ = static_cast<quint8>('=');
 
 Optional<QByteArray> Base32::decode(const QByteArray& encodedData)
 {
-    if (encodedData.size() <= 0)
+    if (encodedData.size() <= 0) {
         return Optional<QByteArray>("");
+    }
 
-    if (encodedData.size() % 8 != 0)
+    if (encodedData.size() % 8 != 0) {
         return Optional<QByteArray>();
+    }
 
     int nPads = 0;
     for (int i = -1; i > -7; --i) {
-        if ('=' == encodedData[encodedData.size()+i])
+        if ('=' == encodedData[encodedData.size() + i])
             ++nPads;
     }
 
@@ -79,7 +81,6 @@ Optional<QByteArray> Base32::decode(const QByteArray& encodedData)
         specialOffset = 0;
     }
 
-
     Q_ASSERT(encodedData.size() > 0);
     const int nQuanta = encodedData.size() / 8;
     const int nBytes = (nQuanta - 1) * 5 + nSpecialBytes;
@@ -105,7 +106,7 @@ Optional<QByteArray> Base32::decode(const QByteArray& encodedData)
                     ch += ALPH_POS_2;
                 } else {
                     if (ASCII_EQ == ch) {
-                        if(i == encodedData.size()) {
+                        if (i == encodedData.size()) {
                             // finished with special quantum
                             quantum >>= specialOffset;
                             nQuantumBytes = nSpecialBytes;
@@ -136,8 +137,9 @@ Optional<QByteArray> Base32::decode(const QByteArray& encodedData)
 
 QByteArray Base32::encode(const QByteArray& data)
 {
-    if (data.size() < 1)
+    if (data.size() < 1) {
         return QByteArray();
+    }
 
     const int nBits = data.size() * 8;
     const int rBits = nBits % 40; // in {0, 8, 16, 24, 32}
@@ -174,7 +176,7 @@ QByteArray Base32::encode(const QByteArray& data)
             quantum |= static_cast<quint64>(data[i++]) << n;
 
         switch (rBits) {
-        case 8:  // expand to 10 bits
+        case 8: // expand to 10 bits
             quantum <<= 2;
             mask = MASK_10BIT;
             n = 5;
@@ -214,16 +216,18 @@ QByteArray Base32::encode(const QByteArray& data)
 
 QByteArray Base32::addPadding(const QByteArray& encodedData)
 {
-    if (encodedData.size() <= 0 || encodedData.size() % 8 == 0)
+    if (encodedData.size() <= 0 || encodedData.size() % 8 == 0) {
         return encodedData;
+    }
 
     const int rBytes = encodedData.size() % 8;
     // rBytes must be a member of {2, 4, 5, 7}
-    if (1 == rBytes || 3 == rBytes || 6 == rBytes)
+    if (1 == rBytes || 3 == rBytes || 6 == rBytes) {
         return encodedData;
+    }
 
     QByteArray newEncodedData(encodedData);
-    for(int nPads = 8 - rBytes; nPads > 0; --nPads) {
+    for (int nPads = 8 - rBytes; nPads > 0; --nPads) {
         newEncodedData.append('=');
     }
 
@@ -232,13 +236,15 @@ QByteArray Base32::addPadding(const QByteArray& encodedData)
 
 QByteArray Base32::removePadding(const QByteArray& encodedData)
 {
-    if (encodedData.size() <= 0 || encodedData.size() % 8 != 0)
+    if (encodedData.size() <= 0 || encodedData.size() % 8 != 0) {
         return encodedData; // return same bad input
+    }
 
     int nPads = 0;
     for (int i = -1; i > -7; --i) {
-        if ('=' == encodedData[encodedData.size() + i])
+        if ('=' == encodedData[encodedData.size() + i]) {
             ++nPads;
+        }
     }
 
     QByteArray newEncodedData(encodedData);
@@ -250,13 +256,14 @@ QByteArray Base32::removePadding(const QByteArray& encodedData)
 
 QByteArray Base32::sanitizeInput(const QByteArray& encodedData)
 {
-    if(encodedData.size() <= 0)
+    if (encodedData.size() <= 0) {
         return encodedData;
+    }
 
     QByteArray newEncodedData(encodedData.size(), Qt::Uninitialized);
     int i = 0;
     for (auto ch : encodedData) {
-        switch(ch) {
+        switch (ch) {
         case '0':
             newEncodedData[i++] = 'O';
             break;
@@ -267,8 +274,9 @@ QByteArray Base32::sanitizeInput(const QByteArray& encodedData)
             newEncodedData[i++] = 'B';
             break;
         default:
-            if (('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z') || ('2' <= ch && ch <= '7'))
+            if (('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z') || ('2' <= ch && ch <= '7')) {
                 newEncodedData[i++] = ch;
+            }
         }
     }
     newEncodedData.resize(i);

--- a/src/core/Base32.h
+++ b/src/core/Base32.h
@@ -15,7 +15,11 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Conforms to RFC 4648. For details, see: https://tools.ietf.org/html/rfc4648
+ /* Conforms to RFC 4648. For details, see: https://tools.ietf.org/html/rfc4648
+  * Use the functions Base32::addPadding/1, Base32::removePadding/1 or
+  * Base32::sanitizeInput/1 to fix input or output for a particular
+  * applications (e.g. to use with Google Authenticator).
+  */
 
 #ifndef BASE32_H
 #define BASE32_H
@@ -30,7 +34,9 @@ public:
     Base32() =default;
     Q_REQUIRED_RESULT static Optional<QByteArray> decode(const QByteArray&);
     Q_REQUIRED_RESULT static QByteArray encode(const QByteArray&);
+    Q_REQUIRED_RESULT static QByteArray addPadding(const QByteArray&);
+    Q_REQUIRED_RESULT static QByteArray removePadding(const QByteArray&);
+    Q_REQUIRED_RESULT static QByteArray sanitizeInput(const QByteArray&);
 };
-
 
 #endif //BASE32_H

--- a/src/core/Base32.h
+++ b/src/core/Base32.h
@@ -15,23 +15,23 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- /* Conforms to RFC 4648. For details, see: https://tools.ietf.org/html/rfc4648
-  * Use the functions Base32::addPadding/1, Base32::removePadding/1 or
-  * Base32::sanitizeInput/1 to fix input or output for a particular
-  * applications (e.g. to use with Google Authenticator).
-  */
+/* Conforms to RFC 4648. For details, see: https://tools.ietf.org/html/rfc4648
+ * Use the functions Base32::addPadding/1, Base32::removePadding/1 or
+ * Base32::sanitizeInput/1 to fix input or output for a particular
+ * applications (e.g. to use with Google Authenticator).
+ */
 
 #ifndef BASE32_H
 #define BASE32_H
 
 #include "Optional.h"
-#include <QtCore/qglobal.h>
 #include <QByteArray>
+#include <QtCore/qglobal.h>
 
 class Base32
 {
 public:
-    Base32() =default;
+    Base32() = default;
     Q_REQUIRED_RESULT static Optional<QByteArray> decode(const QByteArray&);
     Q_REQUIRED_RESULT static QByteArray encode(const QByteArray&);
     Q_REQUIRED_RESULT static QByteArray addPadding(const QByteArray&);
@@ -39,4 +39,4 @@ public:
     Q_REQUIRED_RESULT static QByteArray sanitizeInput(const QByteArray&);
 };
 
-#endif //BASE32_H
+#endif // BASE32_H

--- a/src/core/Optional.h
+++ b/src/core/Optional.h
@@ -22,20 +22,20 @@
  * This utility class is for providing basic support for an option type.
  * It can be replaced by std::optional (C++17) or
  * std::experimental::optional (C++11) when they become fully supported
- * by all the compilers.
+ * by all the main compiler toolchains.
  */
 
 template <typename T>
 class Optional
 {
 public:
-   
+
     // None
     Optional() :
         m_hasValue(false),
         m_value()
-    { };   
- 
+    { };
+
     // Some T
     Optional(const T& value) :
         m_hasValue(true),
@@ -77,7 +77,7 @@ public:
     {
         return m_hasValue ? m_value : other;
     }
-    
+
     Optional static makeOptional(const T& value)
     {
         return Optional(value);

--- a/src/core/Optional.h
+++ b/src/core/Optional.h
@@ -25,28 +25,23 @@
  * by all the main compiler toolchains.
  */
 
-template <typename T>
-class Optional
+template <typename T> class Optional
 {
 public:
-
     // None
-    Optional() :
-        m_hasValue(false),
-        m_value()
-    { };
+    Optional()
+        : m_hasValue(false)
+        , m_value(){};
 
     // Some T
-    Optional(const T& value) :
-        m_hasValue(true),
-        m_value(value)
-    { };
+    Optional(const T& value)
+        : m_hasValue(true)
+        , m_value(value){};
 
     // Copy
-    Optional(const Optional& other) :
-        m_hasValue(other.m_hasValue),
-        m_value(other.m_value)
-    { };
+    Optional(const Optional& other)
+        : m_hasValue(other.m_hasValue)
+        , m_value(other.m_value){};
 
     const Optional& operator=(const Optional& other)
     {
@@ -57,7 +52,7 @@ public:
 
     bool operator==(const Optional& other) const
     {
-        if(m_hasValue)
+        if (m_hasValue)
             return other.m_hasValue && m_value == other.m_value;
         else
             return !other.m_hasValue;
@@ -83,9 +78,7 @@ public:
         return Optional(value);
     }
 
-
 private:
-
     bool m_hasValue;
     T m_value;
 };

--- a/src/core/QRCode.cpp
+++ b/src/core/QRCode.cpp
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "QRCode.h"
+#include "QRCode_p.h"
+
+#include <QImage>
+#include <QPainter>
+#include <QPen>
+#include <QBrush>
+#include <QString>
+#include <QByteArray>
+
+QRCodePrivate::QRCodePrivate() : m_qrcode(nullptr)
+{
+}
+
+QRCodePrivate::~QRCodePrivate()
+{
+    if (nullptr != m_qrcode)
+       QRcode_free(m_qrcode);
+}
+
+QRCode::QRCode() : d_ptr(new QRCodePrivate())
+{
+}
+
+QRCode::QRCode(const QString& data,
+    const Version version,
+    const ErrorCorrectionLevel ecl,
+    const bool caseSensitive)
+    : d_ptr(new QRCodePrivate())
+{
+    init(data, version, ecl, caseSensitive);
+}
+
+QRCode::QRCode(const QByteArray& data,
+    const Version version,
+    const ErrorCorrectionLevel ecl)
+    : d_ptr(new QRCodePrivate())
+{
+    init(data, version, ecl);
+}
+
+QRCode::~QRCode() =default;
+
+void QRCode::init(const QString& data,
+    const Version version,
+    const ErrorCorrectionLevel ecl,
+    bool caseSensitive)
+{
+    if (data.isEmpty())
+        return;
+
+    d_ptr->m_qrcode = QRcode_encodeString(
+        data.toLocal8Bit().data(),
+        static_cast<int>(version),
+        static_cast<QRecLevel>(ecl),
+        QR_MODE_8,
+        caseSensitive ? 1 : 0);
+}
+
+void QRCode::init(const QByteArray& data,
+  const Version version,
+  const ErrorCorrectionLevel ecl)
+{
+    if (data.isEmpty())
+        return;
+
+    d_ptr->m_qrcode = QRcode_encodeData(
+        data.size(),
+        reinterpret_cast<const unsigned char*>(data.data()),
+        static_cast<int>(version),
+        static_cast<QRecLevel>(ecl));
+}
+
+QImage QRCode::toQImage(const int size, const int margin) const
+{
+    if (size <= 0 || margin < 0 || nullptr == d_ptr->m_qrcode)
+        return QImage();
+
+    const int width = d_ptr->m_qrcode->width + margin * 2;
+    QImage img(QSize(width,width), QImage::Format_Mono);
+
+    QPainter painter;
+    painter.begin(&img);
+
+    // Background
+    painter.setClipRect(QRect(0, 0, width, width));
+    painter.fillRect(QRect(0, 0, width, width), Qt::white);
+
+    // Foreground
+    // "Dots" are stored in a quint8 x quint8 array using row-major order.
+    // A dot is black if the LSB of its corresponding quint8 is 1.
+    const QPen pen(Qt::black, 0.1, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
+    const QBrush brush(Qt::black);
+    painter.setPen(pen);
+    painter.setBrush(brush);
+
+    const int rowSize = d_ptr->m_qrcode->width;
+    unsigned char* dot = d_ptr->m_qrcode->data;
+    for (int y = 0; y < rowSize; ++y) {
+        for (int x = 0; x < rowSize; ++x) {
+            if (quint8(0x01) == (static_cast<quint8>(*dot++) & quint8(0x01)))
+                painter.drawRect(margin + x, margin + y, 1, 1);
+      }
+    }
+
+    painter.end();
+
+    return img.scaled(size, size);
+}

--- a/src/core/QRCode.cpp
+++ b/src/core/QRCode.cpp
@@ -18,83 +18,77 @@
 #include "QRCode.h"
 #include "QRCode_p.h"
 
+#include <QBrush>
+#include <QByteArray>
 #include <QImage>
 #include <QPainter>
 #include <QPen>
-#include <QBrush>
 #include <QString>
-#include <QByteArray>
 
-QRCodePrivate::QRCodePrivate() : m_qrcode(nullptr)
+QRCodePrivate::QRCodePrivate()
+    : m_qrcode(nullptr)
 {
 }
 
 QRCodePrivate::~QRCodePrivate()
 {
-    if (nullptr != m_qrcode)
-       QRcode_free(m_qrcode);
+    if (nullptr != m_qrcode) {
+        QRcode_free(m_qrcode);
+    }
 }
 
-QRCode::QRCode() : d_ptr(new QRCodePrivate())
+QRCode::QRCode()
+    : d_ptr(new QRCodePrivate())
 {
 }
 
-QRCode::QRCode(const QString& data,
-    const Version version,
-    const ErrorCorrectionLevel ecl,
-    const bool caseSensitive)
+QRCode::QRCode(const QString& data, const Version version, const ErrorCorrectionLevel ecl, const bool caseSensitive)
     : d_ptr(new QRCodePrivate())
 {
     init(data, version, ecl, caseSensitive);
 }
 
-QRCode::QRCode(const QByteArray& data,
-    const Version version,
-    const ErrorCorrectionLevel ecl)
+QRCode::QRCode(const QByteArray& data, const Version version, const ErrorCorrectionLevel ecl)
     : d_ptr(new QRCodePrivate())
 {
     init(data, version, ecl);
 }
 
-QRCode::~QRCode() =default;
+QRCode::~QRCode() = default;
 
-void QRCode::init(const QString& data,
-    const Version version,
-    const ErrorCorrectionLevel ecl,
-    bool caseSensitive)
+void QRCode::init(const QString& data, const Version version, const ErrorCorrectionLevel ecl, bool caseSensitive)
 {
-    if (data.isEmpty())
+    if (data.isEmpty()) {
         return;
+    }
 
-    d_ptr->m_qrcode = QRcode_encodeString(
-        data.toLocal8Bit().data(),
-        static_cast<int>(version),
-        static_cast<QRecLevel>(ecl),
-        QR_MODE_8,
-        caseSensitive ? 1 : 0);
+    d_ptr->m_qrcode = QRcode_encodeString(data.toLocal8Bit().data(),
+                                          static_cast<int>(version),
+                                          static_cast<QRecLevel>(ecl),
+                                          QR_MODE_8,
+                                          caseSensitive ? 1 : 0);
 }
 
-void QRCode::init(const QByteArray& data,
-  const Version version,
-  const ErrorCorrectionLevel ecl)
+void QRCode::init(const QByteArray& data, const Version version, const ErrorCorrectionLevel ecl)
 {
-    if (data.isEmpty())
+    if (data.isEmpty()) {
         return;
+    }
 
-    d_ptr->m_qrcode = QRcode_encodeData(
-        data.size(),
-        reinterpret_cast<const unsigned char*>(data.data()),
-        static_cast<int>(version),
-        static_cast<QRecLevel>(ecl));
+    d_ptr->m_qrcode = QRcode_encodeData(data.size(),
+                                        reinterpret_cast<const unsigned char*>(data.data()),
+                                        static_cast<int>(version),
+                                        static_cast<QRecLevel>(ecl));
 }
 
 QImage QRCode::toQImage(const int size, const int margin) const
 {
-    if (size <= 0 || margin < 0 || nullptr == d_ptr->m_qrcode)
+    if (size <= 0 || margin < 0 || nullptr == d_ptr->m_qrcode) {
         return QImage();
+    }
 
     const int width = d_ptr->m_qrcode->width + margin * 2;
-    QImage img(QSize(width,width), QImage::Format_Mono);
+    QImage img(QSize(width, width), QImage::Format_Mono);
 
     QPainter painter;
     painter.begin(&img);
@@ -115,9 +109,10 @@ QImage QRCode::toQImage(const int size, const int margin) const
     unsigned char* dot = d_ptr->m_qrcode->data;
     for (int y = 0; y < rowSize; ++y) {
         for (int x = 0; x < rowSize; ++x) {
-            if (quint8(0x01) == (static_cast<quint8>(*dot++) & quint8(0x01)))
+            if (quint8(0x01) == (static_cast<quint8>(*dot++) & quint8(0x01))) {
                 painter.drawRect(margin + x, margin + y, 1, 1);
-      }
+            }
+        }
     }
 
     painter.end();

--- a/src/core/QRCode.h
+++ b/src/core/QRCode.h
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_QRCODE_H
+#define KEEPASSX_QRCODE_H
+
+#include <QtCore/qglobal.h>
+#include <QScopedPointer>
+
+class QImage;
+class QString;
+class QByteArray;
+
+struct QRCodePrivate;
+
+class QRCode
+{
+
+public:
+    enum class ErrorCorrectionLevel : int {
+        LOW = 0,
+        MEDIUM,
+        QUARTILE,
+        HIGH
+    };
+
+    // See: http://www.qrcode.com/en/about/version.html
+    enum class Version : int {
+        AUTO = 0,
+        V1, V2, V3, V4, V5, V6, V7, V8, V9, V10,
+        V11, V12, V13, V14, V15, V16, V17, V18, V19, V20,
+        V21, V22, V23, V24, V25, V26, V27, V28, V29, V30,
+        V31, V32, V33, V34, V35, V36, V37, V38, V39, V40
+    };
+
+    // Uses QRcode_encodeString (can't contain NUL characters)
+    explicit QRCode(const QString& data,
+        const Version version=Version::AUTO,
+        const ErrorCorrectionLevel ecl=ErrorCorrectionLevel::MEDIUM,
+        const bool caseSensitive=true);
+
+    // Uses QRcode_encodeData (can contain NUL characters)
+    explicit QRCode(const QByteArray& data,
+        const Version version=Version::AUTO,
+        const ErrorCorrectionLevel ecl=ErrorCorrectionLevel::HIGH);
+
+    QRCode();
+    ~QRCode();
+
+    QImage toQImage(const int size, const int margin) const;
+
+private:
+    void init(const QString& data,
+        const Version version,
+        const ErrorCorrectionLevel ecl,
+        const bool caseSensitive);
+
+    void init(const QByteArray& data,
+        const Version version,
+        const ErrorCorrectionLevel ecl);
+
+    QScopedPointer<QRCodePrivate> d_ptr;
+};
+
+#endif // KEEPASSX_QRCODE_H

--- a/src/core/QRCode.h
+++ b/src/core/QRCode.h
@@ -18,8 +18,8 @@
 #ifndef KEEPASSX_QRCODE_H
 #define KEEPASSX_QRCODE_H
 
-#include <QtCore/qglobal.h>
 #include <QScopedPointer>
+#include <QtCore/qglobal.h>
 
 class QImage;
 class QString;
@@ -31,7 +31,8 @@ class QRCode
 {
 
 public:
-    enum class ErrorCorrectionLevel : int {
+    enum class ErrorCorrectionLevel : int
+    {
         LOW = 0,
         MEDIUM,
         QUARTILE,
@@ -39,24 +40,61 @@ public:
     };
 
     // See: http://www.qrcode.com/en/about/version.html
-    enum class Version : int {
+    enum class Version : int
+    {
         AUTO = 0,
-        V1, V2, V3, V4, V5, V6, V7, V8, V9, V10,
-        V11, V12, V13, V14, V15, V16, V17, V18, V19, V20,
-        V21, V22, V23, V24, V25, V26, V27, V28, V29, V30,
-        V31, V32, V33, V34, V35, V36, V37, V38, V39, V40
+        V1,
+        V2,
+        V3,
+        V4,
+        V5,
+        V6,
+        V7,
+        V8,
+        V9,
+        V10,
+        V11,
+        V12,
+        V13,
+        V14,
+        V15,
+        V16,
+        V17,
+        V18,
+        V19,
+        V20,
+        V21,
+        V22,
+        V23,
+        V24,
+        V25,
+        V26,
+        V27,
+        V28,
+        V29,
+        V30,
+        V31,
+        V32,
+        V33,
+        V34,
+        V35,
+        V36,
+        V37,
+        V38,
+        V39,
+        V40
     };
 
     // Uses QRcode_encodeString (can't contain NUL characters)
     explicit QRCode(const QString& data,
-        const Version version=Version::AUTO,
-        const ErrorCorrectionLevel ecl=ErrorCorrectionLevel::MEDIUM,
-        const bool caseSensitive=true);
+                    const Version version = Version::AUTO,
+                    const ErrorCorrectionLevel ecl = ErrorCorrectionLevel::HIGH,
+                    const bool caseSensitive = true);
 
     // Uses QRcode_encodeData (can contain NUL characters)
     explicit QRCode(const QByteArray& data,
-        const Version version=Version::AUTO,
-        const ErrorCorrectionLevel ecl=ErrorCorrectionLevel::HIGH);
+                    const Version version = Version::AUTO,
+                    const ErrorCorrectionLevel ecl = ErrorCorrectionLevel::HIGH);
 
     QRCode();
     ~QRCode();
@@ -64,14 +102,9 @@ public:
     QImage toQImage(const int size, const int margin) const;
 
 private:
-    void init(const QString& data,
-        const Version version,
-        const ErrorCorrectionLevel ecl,
-        const bool caseSensitive);
+    void init(const QString& data, const Version version, const ErrorCorrectionLevel ecl, const bool caseSensitive);
 
-    void init(const QByteArray& data,
-        const Version version,
-        const ErrorCorrectionLevel ecl);
+    void init(const QByteArray& data, const Version version, const ErrorCorrectionLevel ecl);
 
     QScopedPointer<QRCodePrivate> d_ptr;
 };

--- a/src/core/QRCode_p.h
+++ b/src/core/QRCode_p.h
@@ -1,5 +1,4 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -16,24 +15,19 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef QTOTP_H
-#define QTOTP_H
+/* This class exists to isolate <qrencode.h> from the rest of the code base. */
 
-#include <QtCore/qglobal.h>
+#ifndef KEEPASSX_QRCODEPRIVATE_H
+#define KEEPASSX_QRCODEPRIVATE_H
 
-class QUrl;
+#include <qrencode.h>
 
-class QTotp
+struct QRCodePrivate
 {
-public:
-    QTotp();
-    static QString parseOtpString(QString rawSecret, quint8 &digits, quint8 &step);
-    static QString generateTotp(const QByteArray key, quint64 time, const quint8 numDigits, const quint8 step);
-    static QUrl generateOtpString(const QString& secret, const QString& type,
-        const QString& issuer, const QString& username, const QString& algorithm,
-        const quint8& digits, const quint8& step);
-    static const quint8 defaultStep;
-    static const quint8 defaultDigits;
+  QRcode* m_qrcode;
+
+  QRCodePrivate();
+  ~QRCodePrivate();
 };
 
-#endif // QTOTP_H
+#endif // KEEPASSX_QRCODEPRIVATE_H

--- a/src/core/QRCode_p.h
+++ b/src/core/QRCode_p.h
@@ -24,10 +24,10 @@
 
 struct QRCodePrivate
 {
-  QRcode* m_qrcode;
+    QRcode* m_qrcode;
 
-  QRCodePrivate();
-  ~QRCodePrivate();
+    QRCodePrivate();
+    ~QRCodePrivate();
 };
 
 #endif // KEEPASSX_QRCODEPRIVATE_H

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -45,6 +45,11 @@
 #include "gui/CloneDialog.h"
 #include "gui/SetupTotpDialog.h"
 #include "gui/TotpDialog.h"
+
+#ifdef WITH_XC_TOTPDISPLAYKEY
+#include "gui/TotpKeyDisplayDialog.h"
+#endif
+
 #include "gui/DatabaseOpenWidget.h"
 #include "gui/DatabaseSettingsWidget.h"
 #include "gui/KeePass1OpenWidget.h"
@@ -350,6 +355,20 @@ void DatabaseWidget::showTotp()
     totpDialog->open();
 }
 
+#ifdef WITH_XC_TOTPDISPLAYKEY
+void DatabaseWidget::showTotpKeyQRCode()
+{
+    Entry* currentEntry = m_entryView->currentEntry();
+    if(!currentEntry) {
+        Q_ASSERT(false);
+        return;
+    }
+
+    TotpKeyDisplayDialog* totpKeyDisplayDialog = new TotpKeyDisplayDialog(this, currentEntry);
+    totpKeyDisplayDialog->open();
+}
+#endif
+
 void DatabaseWidget::copyTotp()
 {
     Entry* currentEntry = m_entryView->currentEntry();
@@ -564,7 +583,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
             }
             return;
         }
-        
+
         // otherwise ask user
         if (urlString.length() > 6) {
             QString cmdTruncated = urlString.mid(6);
@@ -578,7 +597,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
                                this
             );
             msgbox.setDefaultButton(QMessageBox::No);
-            
+
             QCheckBox* checkbox = new QCheckBox(tr("Remember my choice"), &msgbox);
             msgbox.setCheckBox(checkbox);
             bool remember = false;
@@ -587,12 +606,12 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
                    remember = true;
                }
             });
-            
+
             int result = msgbox.exec();
             if (result == QMessageBox::Yes) {
                 QProcess::startDetached(urlString.mid(6));
             }
-            
+
             if (remember) {
                 entry->attributes()->set(EntryAttributes::RememberCmdExecAttr,
                                          result == QMessageBox::Yes ? "1" : "0");
@@ -861,7 +880,7 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
 void DatabaseWidget::switchToEntryEdit()
 {
     Entry* entry = m_entryView->currentEntry();
-    
+
     if (!entry) {
         return;
     }
@@ -872,7 +891,7 @@ void DatabaseWidget::switchToEntryEdit()
 void DatabaseWidget::switchToGroupEdit()
 {
     Group* group = m_groupView->currentGroup();
-    
+
     if (!group) {
         return;
     }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -19,18 +19,17 @@
 #include "DatabaseWidget.h"
 
 #include <QAction>
-#include <QDesktopServices>
-#include <QCheckBox>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QFile>
-#include <QLineEdit>
-#include <QKeyEvent>
-#include <QSplitter>
-#include <QLabel>
-#include <QProcess>
-#include <QHeaderView>
 #include <QApplication>
+#include <QCheckBox>
+#include <QDesktopServices>
+#include <QFile>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QProcess>
+#include <QSplitter>
 
 #include "autotype/AutoType.h"
 #include "core/Config.h"
@@ -54,8 +53,8 @@
 #include "gui/DatabaseSettingsWidget.h"
 #include "gui/KeePass1OpenWidget.h"
 #include "gui/MessageBox.h"
-#include "gui/UnlockDatabaseWidget.h"
 #include "gui/UnlockDatabaseDialog.h"
+#include "gui/UnlockDatabaseWidget.h"
 #include "gui/entry/EditEntryWidget.h"
 #include "gui/entry/EntryView.h"
 #include "gui/group/EditGroupWidget.h"
@@ -85,15 +84,13 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     m_groupView = new GroupView(db, m_splitter);
     m_groupView->setObjectName("groupView");
     m_groupView->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(m_groupView, SIGNAL(customContextMenuRequested(QPoint)),
-            SLOT(emitGroupContextMenuRequested(QPoint)));
+    connect(m_groupView, SIGNAL(customContextMenuRequested(QPoint)), SLOT(emitGroupContextMenuRequested(QPoint)));
 
     m_entryView = new EntryView(rightHandSideWidget);
     m_entryView->setObjectName("entryView");
     m_entryView->setContextMenuPolicy(Qt::CustomContextMenu);
     m_entryView->setGroup(db->rootGroup());
-    connect(m_entryView, SIGNAL(customContextMenuRequested(QPoint)),
-            SLOT(emitEntryContextMenuRequested(QPoint)));
+    connect(m_entryView, SIGNAL(customContextMenuRequested(QPoint)), SLOT(emitEntryContextMenuRequested(QPoint)));
 
     // Add a notification for when we are searching
     m_searchingLabel = new QLabel();
@@ -161,11 +158,12 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     addWidget(m_keepass1OpenWidget);
     addWidget(m_unlockDatabaseWidget);
 
-    connect(m_splitter, SIGNAL(splitterMoved(int,int)), SIGNAL(splitterSizesChanged()));
-    connect(m_entryView->header(), SIGNAL(sectionResized(int,int,int)), SIGNAL(entryColumnSizesChanged()));
+    connect(m_splitter, SIGNAL(splitterMoved(int, int)), SIGNAL(splitterSizesChanged()));
+    connect(m_entryView->header(), SIGNAL(sectionResized(int, int, int)), SIGNAL(entryColumnSizesChanged()));
     connect(m_groupView, SIGNAL(groupChanged(Group*)), this, SLOT(onGroupChanged(Group*)));
     connect(m_groupView, SIGNAL(groupChanged(Group*)), SIGNAL(groupChanged()));
-    connect(m_entryView, SIGNAL(entryActivated(Entry*, EntryModel::ModelColumn)),
+    connect(m_entryView,
+            SIGNAL(entryActivated(Entry*, EntryModel::ModelColumn)),
             SLOT(entryActivationSignalReceived(Entry*, EntryModel::ModelColumn)));
     connect(m_entryView, SIGNAL(entrySelectionChanged()), SIGNAL(entrySelectionChanged()));
     connect(m_editEntryWidget, SIGNAL(editFinished(bool)), SLOT(switchToView(bool)));
@@ -179,7 +177,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
     connect(m_keepass1OpenWidget, SIGNAL(editFinished(bool)), SLOT(openDatabase(bool)));
     connect(m_csvImportWizard, SIGNAL(importFinished(bool)), SLOT(csvImportFinished(bool)));
     connect(m_unlockDatabaseWidget, SIGNAL(editFinished(bool)), SLOT(unlockDatabase(bool)));
-	connect(m_unlockDatabaseDialog, SIGNAL(unlockDone(bool)), SLOT(unlockDatabase(bool)));
+    connect(m_unlockDatabaseDialog, SIGNAL(unlockDone(bool)), SLOT(unlockDatabase(bool)));
     connect(&m_fileWatcher, SIGNAL(fileChanged(QString)), this, SLOT(onWatchedFileChanged()));
     connect(&m_fileWatchTimer, SIGNAL(timeout()), this, SLOT(reloadDatabaseFile()));
     connect(&m_fileWatchUnblockTimer, SIGNAL(timeout()), this, SLOT(unblockAutoReload()));
@@ -205,18 +203,13 @@ DatabaseWidget::Mode DatabaseWidget::currentMode() const
 {
     if (currentWidget() == nullptr) {
         return DatabaseWidget::None;
-    }
-    else if (currentWidget() == m_csvImportWizard) {
+    } else if (currentWidget() == m_csvImportWizard) {
         return DatabaseWidget::ImportMode;
-    }
-    else if (currentWidget() == m_mainWidget) {
+    } else if (currentWidget() == m_mainWidget) {
         return DatabaseWidget::ViewMode;
-    }
-    else if (currentWidget() == m_unlockDatabaseWidget ||
-             currentWidget() == m_databaseOpenWidget) {
+    } else if (currentWidget() == m_unlockDatabaseWidget || currentWidget() == m_databaseOpenWidget) {
         return DatabaseWidget::LockedMode;
-    }
-    else {
+    } else {
         return DatabaseWidget::EditMode;
     }
 }
@@ -230,8 +223,7 @@ bool DatabaseWidget::isEditWidgetModified() const
 {
     if (currentWidget() == m_editEntryWidget) {
         return m_editEntryWidget->hasBeenModified();
-    }
-    else {
+    } else {
         // other edit widget don't have a hasBeenModified() method yet
         // assume that they already have been modified
         return true;
@@ -315,8 +307,7 @@ void DatabaseWidget::setIconFromParent()
 
     if (m_newParent->iconUuid().isNull()) {
         m_newEntry->setIcon(m_newParent->iconNumber());
-    }
-    else {
+    } else {
         m_newEntry->setIcon(m_newParent->iconUuid());
     }
 }
@@ -359,7 +350,7 @@ void DatabaseWidget::showTotp()
 void DatabaseWidget::showTotpKeyQRCode()
 {
     Entry* currentEntry = m_entryView->currentEntry();
-    if(!currentEntry) {
+    if (!currentEntry) {
         Q_ASSERT(false);
         return;
     }
@@ -395,9 +386,7 @@ void DatabaseWidget::setupTotp()
     }
 
     setupTotpDialog->open();
-
 }
-
 
 void DatabaseWidget::deleteEntries()
 {
@@ -419,18 +408,16 @@ void DatabaseWidget::deleteEntries()
         QMessageBox::StandardButton result;
 
         if (selected.size() == 1) {
-            result = MessageBox::question(
-                this, tr("Delete entry?"),
-                tr("Do you really want to delete the entry \"%1\" for good?")
-                .arg(selectedEntries.first()->title().toHtmlEscaped()),
-                QMessageBox::Yes | QMessageBox::No);
-        }
-        else {
-            result = MessageBox::question(
-                this, tr("Delete entries?"),
-                tr("Do you really want to delete %1 entries for good?")
-                .arg(selected.size()),
-                QMessageBox::Yes | QMessageBox::No);
+            result = MessageBox::question(this,
+                                          tr("Delete entry?"),
+                                          tr("Do you really want to delete the entry \"%1\" for good?")
+                                              .arg(selectedEntries.first()->title().toHtmlEscaped()),
+                                          QMessageBox::Yes | QMessageBox::No);
+        } else {
+            result = MessageBox::question(this,
+                                          tr("Delete entries?"),
+                                          tr("Do you really want to delete %1 entries for good?").arg(selected.size()),
+                                          QMessageBox::Yes | QMessageBox::No);
         }
 
         if (result == QMessageBox::Yes) {
@@ -439,20 +426,19 @@ void DatabaseWidget::deleteEntries()
             }
             refreshSearch();
         }
-    }
-    else {
+    } else {
         QMessageBox::StandardButton result;
 
         if (selected.size() == 1) {
+            result = MessageBox::question(this,
+                                          tr("Move entry to recycle bin?"),
+                                          tr("Do you really want to move entry \"%1\" to the recycle bin?")
+                                              .arg(selectedEntries.first()->title().toHtmlEscaped()),
+                                          QMessageBox::Yes | QMessageBox::No);
+        } else {
             result = MessageBox::question(
-                this, tr("Move entry to recycle bin?"),
-                tr("Do you really want to move entry \"%1\" to the recycle bin?")
-                .arg(selectedEntries.first()->title().toHtmlEscaped()),
-                QMessageBox::Yes | QMessageBox::No);
-        }
-        else {
-            result = MessageBox::question(
-                this, tr("Move entries to recycle bin?"),
+                this,
+                tr("Move entries to recycle bin?"),
                 tr("Do you really want to move %n entry(s) to the recycle bin?", 0, selected.size()),
                 QMessageBox::Yes | QMessageBox::No);
         }
@@ -469,7 +455,7 @@ void DatabaseWidget::deleteEntries()
 
 void DatabaseWidget::setFocus()
 {
-	m_entryView->setFocus();
+    m_entryView->setFocus();
 }
 
 void DatabaseWidget::copyTitle()
@@ -535,7 +521,8 @@ void DatabaseWidget::copyAttribute(QAction* action)
         return;
     }
 
-    setClipboardTextAndMinimize(currentEntry->resolveMultiplePlaceholders(currentEntry->attributes()->value(action->text())));
+    setClipboardTextAndMinimize(
+        currentEntry->resolveMultiplePlaceholders(currentEntry->attributes()->value(action->text())));
 }
 
 void DatabaseWidget::setClipboardTextAndMinimize(const QString& text)
@@ -594,8 +581,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
                                tr("Do you really want to execute the following command?<br><br>%1<br>")
                                    .arg(cmdTruncated.toHtmlEscaped()),
                                QMessageBox::Yes | QMessageBox::No,
-                               this
-            );
+                               this);
             msgbox.setDefaultButton(QMessageBox::No);
 
             QCheckBox* checkbox = new QCheckBox(tr("Remember my choice"), &msgbox);
@@ -603,8 +589,8 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
             bool remember = false;
             QObject::connect(checkbox, &QCheckBox::stateChanged, [&](int state) {
                 if (static_cast<Qt::CheckState>(state) == Qt::CheckState::Checked) {
-                   remember = true;
-               }
+                    remember = true;
+                }
             });
 
             int result = msgbox.exec();
@@ -613,12 +599,10 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
             }
 
             if (remember) {
-                entry->attributes()->set(EntryAttributes::RememberCmdExecAttr,
-                                         result == QMessageBox::Yes ? "1" : "0");
+                entry->attributes()->set(EntryAttributes::RememberCmdExecAttr, result == QMessageBox::Yes ? "1" : "0");
             }
         }
-    }
-    else {
+    } else {
         QUrl url = QUrl::fromUserInput(urlString);
         QDesktopServices::openUrl(url);
     }
@@ -650,15 +634,14 @@ void DatabaseWidget::deleteGroup()
     bool isRecycleBinSubgroup = Tools::hasChild(currentGroup, m_db->metadata()->recycleBin());
     if (inRecycleBin || isRecycleBin || isRecycleBinSubgroup || !m_db->metadata()->recycleBinEnabled()) {
         QMessageBox::StandardButton result = MessageBox::question(
-            this, tr("Delete group?"),
-            tr("Do you really want to delete the group \"%1\" for good?")
-            .arg(currentGroup->name().toHtmlEscaped()),
+            this,
+            tr("Delete group?"),
+            tr("Do you really want to delete the group \"%1\" for good?").arg(currentGroup->name().toHtmlEscaped()),
             QMessageBox::Yes | QMessageBox::No);
         if (result == QMessageBox::Yes) {
             delete currentGroup;
         }
-    }
-    else {
+    } else {
         m_db->recycleGroup(currentGroup);
     }
 }
@@ -701,8 +684,7 @@ void DatabaseWidget::csvImportFinished(bool accepted)
 {
     if (!accepted) {
         emit closeRequest();
-    }
-    else {
+    } else {
         setCurrentWidget(m_mainWidget);
     }
 }
@@ -714,21 +696,18 @@ void DatabaseWidget::switchToView(bool accepted)
             m_newGroup->setParent(m_newParent);
             m_groupView->setCurrentGroup(m_newGroup);
             m_groupView->expandGroup(m_newParent);
-        }
-        else {
+        } else {
             delete m_newGroup;
         }
 
         m_newGroup = nullptr;
         m_newParent = nullptr;
-    }
-    else if (m_newEntry) {
+    } else if (m_newEntry) {
         if (accepted) {
             m_newEntry->setGroup(m_newParent);
             m_entryView->setFocus();
             m_entryView->setCurrentEntry(m_newEntry);
-        }
-        else {
+        } else {
             delete m_newEntry;
         }
 
@@ -781,8 +760,7 @@ void DatabaseWidget::updateMasterKey(bool accepted)
             m_messageWidget->showMessage(tr("Unable to calculate master key"), MessageWidget::Error);
             return;
         }
-    }
-    else if (!m_db->hasKey()) {
+    } else if (!m_db->hasKey()) {
         emit closeRequest();
         return;
     }
@@ -804,8 +782,7 @@ void DatabaseWidget::openDatabase(bool accepted)
         delete m_keepass1OpenWidget;
         m_keepass1OpenWidget = nullptr;
         m_fileWatcher.addPath(m_filename);
-    }
-    else {
+    } else {
         m_fileWatcher.removePath(m_filename);
         if (m_databaseOpenWidget->database()) {
             delete m_databaseOpenWidget->database();
@@ -843,7 +820,7 @@ void DatabaseWidget::unlockDatabase(bool accepted)
         return;
     }
 
-    Database *db = Q_NULLPTR;
+    Database* db = Q_NULLPTR;
     if (sender() == m_unlockDatabaseDialog) {
         db = m_unlockDatabaseDialog->database();
     } else if (sender() == m_unlockDatabaseWidget) {
@@ -871,8 +848,7 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
 {
     if (column == EntryModel::Url && !entry->url().isEmpty()) {
         openUrlForEntry(entry);
-    }
-    else {
+    } else {
         switchToEntryEdit(entry);
     }
 }
@@ -919,8 +895,7 @@ void DatabaseWidget::switchToOpenDatabase(const QString& fileName)
     setCurrentWidget(m_databaseOpenWidget);
 }
 
-void DatabaseWidget::switchToOpenDatabase(const QString& fileName, const QString& password,
-                                          const QString& keyFile)
+void DatabaseWidget::switchToOpenDatabase(const QString& fileName, const QString& password, const QString& keyFile)
 {
     updateFilename(fileName);
     switchToOpenDatabase(fileName);
@@ -941,9 +916,7 @@ void DatabaseWidget::switchToOpenMergeDatabase(const QString& fileName)
     setCurrentWidget(m_databaseOpenMergeWidget);
 }
 
-
-void DatabaseWidget::switchToOpenMergeDatabase(const QString& fileName, const QString& password,
-                                          const QString& keyFile)
+void DatabaseWidget::switchToOpenMergeDatabase(const QString& fileName, const QString& password, const QString& keyFile)
 {
     switchToOpenMergeDatabase(fileName);
     m_databaseOpenMergeWidget->enterKey(password, keyFile);
@@ -966,7 +939,8 @@ void DatabaseWidget::databaseSaved()
     m_databaseModified = false;
 }
 
-void DatabaseWidget::refreshSearch() {
+void DatabaseWidget::refreshSearch()
+{
     if (isInSearchMode()) {
         search(m_lastSearchText);
     }
@@ -974,8 +948,7 @@ void DatabaseWidget::refreshSearch() {
 
 void DatabaseWidget::search(const QString& searchtext)
 {
-    if (searchtext.isEmpty())
-    {
+    if (searchtext.isEmpty()) {
         endSearch();
         return;
     }
@@ -994,8 +967,7 @@ void DatabaseWidget::search(const QString& searchtext)
     // Display a label detailing our search results
     if (searchResult.size() > 0) {
         m_searchingLabel->setText(tr("Search Results (%1)").arg(searchResult.size()));
-    }
-    else {
+    } else {
         m_searchingLabel->setText(tr("No Results"));
     }
 
@@ -1032,8 +1004,7 @@ QString DatabaseWidget::getCurrentSearch()
 
 void DatabaseWidget::endSearch()
 {
-    if (isInSearchMode())
-    {
+    if (isInSearchMode()) {
         emit listModeAboutToActivate();
 
         // Show the normal entry view of the current group
@@ -1085,8 +1056,7 @@ void DatabaseWidget::lock()
 
     if (m_groupView->currentGroup()) {
         m_groupBeforeLock = m_groupView->currentGroup()->uuid();
-    }
-    else {
+    } else {
         m_groupBeforeLock = m_db->rootGroup()->uuid();
     }
 
@@ -1145,11 +1115,13 @@ void DatabaseWidget::reloadDatabaseFile()
     if (m_db == nullptr)
         return;
 
-    if (! config()->get("AutoReloadOnChange").toBool()) {
+    if (!config()->get("AutoReloadOnChange").toBool()) {
         // Ask if we want to reload the db
-        QMessageBox::StandardButton mb = MessageBox::question(this, tr("Autoreload Request"),
-                             tr("The database file has changed. Do you want to load the changes?"),
-                             QMessageBox::Yes | QMessageBox::No);
+        QMessageBox::StandardButton mb =
+            MessageBox::question(this,
+                                 tr("Autoreload Request"),
+                                 tr("The database file has changed. Do you want to load the changes?"),
+                                 QMessageBox::Yes | QMessageBox::No);
 
         if (mb == QMessageBox::No) {
             // Notify everyone the database does not match the file
@@ -1168,10 +1140,12 @@ void DatabaseWidget::reloadDatabaseFile()
         if (db != nullptr) {
             if (m_databaseModified) {
                 // Ask if we want to merge changes into new database
-                QMessageBox::StandardButton mb = MessageBox::question(this, tr("Merge Request"),
-                                     tr("The database file has changed and you have unsaved changes."
-                                        "Do you want to merge your changes?"),
-                                     QMessageBox::Yes | QMessageBox::No);
+                QMessageBox::StandardButton mb =
+                    MessageBox::question(this,
+                                         tr("Merge Request"),
+                                         tr("The database file has changed and you have unsaved changes."
+                                            "Do you want to merge your changes?"),
+                                         QMessageBox::Yes | QMessageBox::No);
 
                 if (mb == QMessageBox::Yes) {
                     // Merge the old database into the new one
@@ -1187,8 +1161,7 @@ void DatabaseWidget::reloadDatabaseFile()
             Uuid groupBeforeReload;
             if (m_groupView && m_groupView->currentGroup()) {
                 groupBeforeReload = m_groupView->currentGroup()->uuid();
-            }
-            else {
+            } else {
                 groupBeforeReload = m_db->rootGroup()->uuid();
             }
 
@@ -1199,7 +1172,6 @@ void DatabaseWidget::reloadDatabaseFile()
 
             replaceDatabase(db);
             restoreGroupEntryFocus(groupBeforeReload, entryBeforeReload);
-
         }
     } else {
         m_messageWidget->showMessage(
@@ -1242,17 +1214,16 @@ void DatabaseWidget::restoreGroupEntryFocus(Uuid groupUuid, Uuid entryUuid)
     }
 
     if (restoredGroup != nullptr) {
-      m_groupView->setCurrentGroup(restoredGroup);
+        m_groupView->setCurrentGroup(restoredGroup);
 
-      const QList<Entry*> entries = restoredGroup->entries();
-      for (Entry* entry : entries) {
-          if (entry->uuid() == entryUuid) {
-              m_entryView->setCurrentEntry(entry);
-              break;
-          }
-      }
+        const QList<Entry*> entries = restoredGroup->entries();
+        for (Entry* entry : entries) {
+            if (entry->uuid() == entryUuid) {
+                m_entryView->setCurrentEntry(entry);
+                break;
+            }
+        }
     }
-
 }
 
 bool DatabaseWidget::isGroupSelected() const
@@ -1300,7 +1271,6 @@ bool DatabaseWidget::currentEntryHasUrl()
     return !currentEntry->resolveMultiplePlaceholders(currentEntry->url()).isEmpty();
 }
 
-
 bool DatabaseWidget::currentEntryHasTotp()
 {
     Entry* currentEntry = m_entryView->currentEntry();
@@ -1321,11 +1291,13 @@ bool DatabaseWidget::currentEntryHasNotes()
     return !currentEntry->resolveMultiplePlaceholders(currentEntry->notes()).isEmpty();
 }
 
-GroupView* DatabaseWidget::groupView() {
+GroupView* DatabaseWidget::groupView()
+{
     return m_groupView;
 }
 
-EntryView* DatabaseWidget::entryView() {
+EntryView* DatabaseWidget::entryView()
+{
     return m_entryView;
 }
 
@@ -1361,14 +1333,15 @@ bool DatabaseWidget::isRecycleBinSelected() const
 
 void DatabaseWidget::emptyRecycleBin()
 {
-    if(!isRecycleBinSelected()) {
+    if (!isRecycleBinSelected()) {
         return;
     }
 
-    QMessageBox::StandardButton result = MessageBox::question(
-        this, tr("Empty recycle bin?"),
-        tr("Are you sure you want to permanently delete everything from your recycle bin?"),
-        QMessageBox::Yes | QMessageBox::No);
+    QMessageBox::StandardButton result =
+        MessageBox::question(this,
+                             tr("Empty recycle bin?"),
+                             tr("Are you sure you want to permanently delete everything from your recycle bin?"),
+                             QMessageBox::Yes | QMessageBox::No);
 
     if (result == QMessageBox::Yes) {
         m_db->emptyRecycleBin();

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -19,16 +19,16 @@
 #ifndef KEEPASSX_DATABASEWIDGET_H
 #define KEEPASSX_DATABASEWIDGET_H
 
+#include <QFileSystemWatcher>
 #include <QScopedPointer>
 #include <QStackedWidget>
-#include <QFileSystemWatcher>
 #include <QTimer>
 
 #include "core/Uuid.h"
 
-#include "gui/entry/EntryModel.h"
 #include "gui/MessageWidget.h"
 #include "gui/csvImport/CsvImportWizard.h"
+#include "gui/entry/EntryModel.h"
 
 class ChangeMasterKeyWidget;
 class DatabaseOpenWidget;
@@ -50,7 +50,8 @@ class MessageWidget;
 class UnlockDatabaseDialog;
 class QFileSystemWatcher;
 
-namespace Ui {
+namespace Ui
+{
     class SearchWidget;
 }
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -136,6 +136,11 @@ public slots:
     void copyNotes();
     void copyAttribute(QAction* action);
     void showTotp();
+
+#ifdef WITH_XC_TOTPDISPLAYKEY
+    void showTotpKeyQRCode();
+#endif
+
     void copyTotp();
     void setupTotp();
     void performAutoType();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -23,7 +23,7 @@
 #include <QShortcut>
 #include <QTimer>
 
-#if defined(Q_OS_LINUX) && ! defined(QT_NO_DBUS)
+#if defined(Q_OS_LINUX) && !defined(QT_NO_DBUS)
 #include <QList>
 #include <QtDBus/QtDBus>
 #endif
@@ -37,26 +37,26 @@
 #include "core/Metadata.h"
 #include "format/KeePass2Writer.h"
 #include "gui/AboutDialog.h"
-#include "gui/DatabaseWidget.h"
 #include "gui/DatabaseRepairWidget.h"
+#include "gui/DatabaseWidget.h"
 #include "gui/FileDialog.h"
 #include "gui/MessageBox.h"
 #include "gui/SearchWidget.h"
 
 #ifdef WITH_XC_HTTP
-#include "http/Service.h"
 #include "http/HttpSettings.h"
 #include "http/OptionDialog.h"
+#include "http/Service.h"
 #endif
 
-#include "gui/SettingsWidget.h"
 #include "gui/PasswordGeneratorWidget.h"
+#include "gui/SettingsWidget.h"
 
 #ifdef WITH_XC_HTTP
-class HttpPlugin: public ISettingsPage
+class HttpPlugin : public ISettingsPage
 {
 public:
-    HttpPlugin(DatabaseTabWidget * tabWidget)
+    HttpPlugin(DatabaseTabWidget* tabWidget)
     {
         m_service = new Service(tabWidget);
     }
@@ -73,20 +73,20 @@ public:
         return FilePath::instance()->icon("apps", "internet-web-browser");
     }
 
-    QWidget * createWidget() override
+    QWidget* createWidget() override
     {
-        OptionDialog * dlg = new OptionDialog();
+        OptionDialog* dlg = new OptionDialog();
         QObject::connect(dlg, SIGNAL(removeSharedEncryptionKeys()), m_service, SLOT(removeSharedEncryptionKeys()));
         QObject::connect(dlg, SIGNAL(removeStoredPermissions()), m_service, SLOT(removeStoredPermissions()));
         return dlg;
     }
 
-    void loadSettings(QWidget * widget) override
+    void loadSettings(QWidget* widget) override
     {
         qobject_cast<OptionDialog*>(widget)->loadSettings();
     }
 
-    void saveSettings(QWidget * widget) override
+    void saveSettings(QWidget* widget) override
     {
         qobject_cast<OptionDialog*>(widget)->saveSettings();
         if (HttpSettings::isEnabled())
@@ -94,8 +94,9 @@ public:
         else
             m_service->stop();
     }
+
 private:
-    Service *m_service;
+    Service* m_service;
 };
 #endif
 
@@ -110,7 +111,7 @@ MainWindow::MainWindow()
     m_ui->setupUi(this);
 
     // Setup the search widget in the toolbar
-    SearchWidget *search = new SearchWidget();
+    SearchWidget* search = new SearchWidget();
     search->connectSignals(m_actionMultiplexer);
     m_searchWidgetAction = m_ui->toolBar->addWidget(search);
     m_searchWidgetAction->setEnabled(false);
@@ -118,9 +119,9 @@ MainWindow::MainWindow()
     m_countDefaultAttributes = m_ui->menuEntryCopyAttribute->actions().size();
 
     restoreGeometry(config()->get("GUI/MainWindowGeometry").toByteArray());
-    #ifdef WITH_XC_HTTP
+#ifdef WITH_XC_HTTP
     m_ui->settingsWidget->addSettingsPage(new HttpPlugin(m_ui->tabWidget));
-    #endif
+#endif
 
     setWindowIcon(filePath()->applicationIcon());
     m_ui->globalMessageWidget->setHidden(true);
@@ -138,14 +139,13 @@ MainWindow::MainWindow()
     connect(m_ui->menuRecentDatabases, SIGNAL(aboutToShow()), this, SLOT(updateLastDatabasesMenu()));
 
     m_copyAdditionalAttributeActions = new QActionGroup(m_ui->menuEntryCopyAttribute);
-    m_actionMultiplexer.connect(m_copyAdditionalAttributeActions, SIGNAL(triggered(QAction*)),
-                                SLOT(copyAttribute(QAction*)));
-    connect(m_ui->menuEntryCopyAttribute, SIGNAL(aboutToShow()),
-            this, SLOT(updateCopyAttributesMenu()));
+    m_actionMultiplexer.connect(
+        m_copyAdditionalAttributeActions, SIGNAL(triggered(QAction*)), SLOT(copyAttribute(QAction*)));
+    connect(m_ui->menuEntryCopyAttribute, SIGNAL(aboutToShow()), this, SLOT(updateCopyAttributesMenu()));
 
     Qt::Key globalAutoTypeKey = static_cast<Qt::Key>(config()->get("GlobalAutoTypeKey").toInt());
-    Qt::KeyboardModifiers globalAutoTypeModifiers = static_cast<Qt::KeyboardModifiers>(
-                config()->get("GlobalAutoTypeModifiers").toInt());
+    Qt::KeyboardModifiers globalAutoTypeModifiers =
+        static_cast<Qt::KeyboardModifiers>(config()->get("GlobalAutoTypeModifiers").toInt());
     if (globalAutoTypeKey > 0 && globalAutoTypeModifiers > 0) {
         autoType()->registerGlobalShortcut(globalAutoTypeKey, globalAutoTypeModifiers);
     }
@@ -153,8 +153,7 @@ MainWindow::MainWindow()
     m_ui->actionEntryAutoType->setVisible(autoType()->isAvailable());
 
     m_inactivityTimer = new InactivityTimer(this);
-    connect(m_inactivityTimer, SIGNAL(inactivityDetected()),
-            this, SLOT(lockDatabasesAfterInactivity()));
+    connect(m_inactivityTimer, SIGNAL(inactivityDetected()), this, SLOT(lockDatabasesAfterInactivity()));
     applySettingsChanges();
 
     m_ui->actionDatabaseNew->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_N);
@@ -210,35 +209,26 @@ MainWindow::MainWindow()
     m_ui->actionAbout->setIcon(filePath()->icon("actions", "help-about"));
     m_ui->actionAbout->setMenuRole(QAction::AboutRole);
 
-    m_actionMultiplexer.connect(SIGNAL(currentModeChanged(DatabaseWidget::Mode)),
-                                this, SLOT(setMenuActionState(DatabaseWidget::Mode)));
-    m_actionMultiplexer.connect(SIGNAL(groupChanged()),
-                                this, SLOT(setMenuActionState()));
-    m_actionMultiplexer.connect(SIGNAL(entrySelectionChanged()),
-                                this, SLOT(setMenuActionState()));
-    m_actionMultiplexer.connect(SIGNAL(groupContextMenuRequested(QPoint)),
-                                this, SLOT(showGroupContextMenu(QPoint)));
-    m_actionMultiplexer.connect(SIGNAL(entryContextMenuRequested(QPoint)),
-                                this, SLOT(showEntryContextMenu(QPoint)));
+    m_actionMultiplexer.connect(
+        SIGNAL(currentModeChanged(DatabaseWidget::Mode)), this, SLOT(setMenuActionState(DatabaseWidget::Mode)));
+    m_actionMultiplexer.connect(SIGNAL(groupChanged()), this, SLOT(setMenuActionState()));
+    m_actionMultiplexer.connect(SIGNAL(entrySelectionChanged()), this, SLOT(setMenuActionState()));
+    m_actionMultiplexer.connect(SIGNAL(groupContextMenuRequested(QPoint)), this, SLOT(showGroupContextMenu(QPoint)));
+    m_actionMultiplexer.connect(SIGNAL(entryContextMenuRequested(QPoint)), this, SLOT(showEntryContextMenu(QPoint)));
 
     // Notify search when the active database changes or gets locked
-    connect(m_ui->tabWidget, SIGNAL(activateDatabaseChanged(DatabaseWidget*)),
-            search, SLOT(databaseChanged(DatabaseWidget*)));
-    connect(m_ui->tabWidget, SIGNAL(databaseLocked(DatabaseWidget*)),
-            search, SLOT(databaseChanged()));
+    connect(m_ui->tabWidget,
+            SIGNAL(activateDatabaseChanged(DatabaseWidget*)),
+            search,
+            SLOT(databaseChanged(DatabaseWidget*)));
+    connect(m_ui->tabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), search, SLOT(databaseChanged()));
 
-    connect(m_ui->tabWidget, SIGNAL(tabNameChanged()),
-            SLOT(updateWindowTitle()));
-    connect(m_ui->tabWidget, SIGNAL(currentChanged(int)),
-            SLOT(updateWindowTitle()));
-    connect(m_ui->tabWidget, SIGNAL(currentChanged(int)),
-            SLOT(databaseTabChanged(int)));
-    connect(m_ui->tabWidget, SIGNAL(currentChanged(int)),
-            SLOT(setMenuActionState()));
-    connect(m_ui->tabWidget, SIGNAL(databaseLocked(DatabaseWidget*)),
-            SLOT(databaseStatusChanged(DatabaseWidget*)));
-    connect(m_ui->tabWidget, SIGNAL(databaseUnlocked(DatabaseWidget*)),
-            SLOT(databaseStatusChanged(DatabaseWidget*)));
+    connect(m_ui->tabWidget, SIGNAL(tabNameChanged()), SLOT(updateWindowTitle()));
+    connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(updateWindowTitle()));
+    connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(databaseTabChanged(int)));
+    connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(setMenuActionState()));
+    connect(m_ui->tabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), SLOT(databaseStatusChanged(DatabaseWidget*)));
+    connect(m_ui->tabWidget, SIGNAL(databaseUnlocked(DatabaseWidget*)), SLOT(databaseStatusChanged(DatabaseWidget*)));
     connect(m_ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(setMenuActionState()));
     connect(m_ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(updateWindowTitle()));
     connect(m_ui->settingsWidget, SIGNAL(accepted()), SLOT(applySettingsChanges()));
@@ -246,79 +236,47 @@ MainWindow::MainWindow()
     connect(m_ui->settingsWidget, SIGNAL(accepted()), SLOT(switchToDatabases()));
     connect(m_ui->settingsWidget, SIGNAL(rejected()), SLOT(switchToDatabases()));
 
-    connect(m_ui->actionDatabaseNew, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(newDatabase()));
-    connect(m_ui->actionDatabaseOpen, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(openDatabase()));
-    connect(m_ui->actionDatabaseSave, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(saveDatabase()));
-    connect(m_ui->actionDatabaseSaveAs, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(saveDatabaseAs()));
-    connect(m_ui->actionDatabaseClose, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(closeDatabase()));
-    connect(m_ui->actionDatabaseMerge, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(mergeDatabase()));
-    connect(m_ui->actionChangeMasterKey, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(changeMasterKey()));
-    connect(m_ui->actionChangeDatabaseSettings, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(changeDatabaseSettings()));
-    connect(m_ui->actionImportCsv, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(importCsv()));
-    connect(m_ui->actionImportKeePass1, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(importKeePass1Database()));
-    connect(m_ui->actionRepairDatabase, SIGNAL(triggered()), this,
-            SLOT(repairDatabase()));
-    connect(m_ui->actionExportCsv, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(exportToCsv()));
-    connect(m_ui->actionLockDatabases, SIGNAL(triggered()), m_ui->tabWidget,
-            SLOT(lockDatabases()));
+    connect(m_ui->actionDatabaseNew, SIGNAL(triggered()), m_ui->tabWidget, SLOT(newDatabase()));
+    connect(m_ui->actionDatabaseOpen, SIGNAL(triggered()), m_ui->tabWidget, SLOT(openDatabase()));
+    connect(m_ui->actionDatabaseSave, SIGNAL(triggered()), m_ui->tabWidget, SLOT(saveDatabase()));
+    connect(m_ui->actionDatabaseSaveAs, SIGNAL(triggered()), m_ui->tabWidget, SLOT(saveDatabaseAs()));
+    connect(m_ui->actionDatabaseClose, SIGNAL(triggered()), m_ui->tabWidget, SLOT(closeDatabase()));
+    connect(m_ui->actionDatabaseMerge, SIGNAL(triggered()), m_ui->tabWidget, SLOT(mergeDatabase()));
+    connect(m_ui->actionChangeMasterKey, SIGNAL(triggered()), m_ui->tabWidget, SLOT(changeMasterKey()));
+    connect(m_ui->actionChangeDatabaseSettings, SIGNAL(triggered()), m_ui->tabWidget, SLOT(changeDatabaseSettings()));
+    connect(m_ui->actionImportCsv, SIGNAL(triggered()), m_ui->tabWidget, SLOT(importCsv()));
+    connect(m_ui->actionImportKeePass1, SIGNAL(triggered()), m_ui->tabWidget, SLOT(importKeePass1Database()));
+    connect(m_ui->actionRepairDatabase, SIGNAL(triggered()), this, SLOT(repairDatabase()));
+    connect(m_ui->actionExportCsv, SIGNAL(triggered()), m_ui->tabWidget, SLOT(exportToCsv()));
+    connect(m_ui->actionLockDatabases, SIGNAL(triggered()), m_ui->tabWidget, SLOT(lockDatabases()));
     connect(m_ui->actionQuit, SIGNAL(triggered()), SLOT(appExit()));
 
-    m_actionMultiplexer.connect(m_ui->actionEntryNew, SIGNAL(triggered()),
-            SLOT(createEntry()));
-    m_actionMultiplexer.connect(m_ui->actionEntryClone, SIGNAL(triggered()),
-            SLOT(cloneEntry()));
-    m_actionMultiplexer.connect(m_ui->actionEntryEdit, SIGNAL(triggered()),
-            SLOT(switchToEntryEdit()));
-    m_actionMultiplexer.connect(m_ui->actionEntryDelete, SIGNAL(triggered()),
-            SLOT(deleteEntries()));
+    m_actionMultiplexer.connect(m_ui->actionEntryNew, SIGNAL(triggered()), SLOT(createEntry()));
+    m_actionMultiplexer.connect(m_ui->actionEntryClone, SIGNAL(triggered()), SLOT(cloneEntry()));
+    m_actionMultiplexer.connect(m_ui->actionEntryEdit, SIGNAL(triggered()), SLOT(switchToEntryEdit()));
+    m_actionMultiplexer.connect(m_ui->actionEntryDelete, SIGNAL(triggered()), SLOT(deleteEntries()));
 
-    m_actionMultiplexer.connect(m_ui->actionEntryTotp, SIGNAL(triggered()),
-            SLOT(showTotp()));
-    m_actionMultiplexer.connect(m_ui->actionEntrySetupTotp, SIGNAL(triggered()),
-            SLOT(setupTotp()));
+    m_actionMultiplexer.connect(m_ui->actionEntryTotp, SIGNAL(triggered()), SLOT(showTotp()));
+    m_actionMultiplexer.connect(m_ui->actionEntrySetupTotp, SIGNAL(triggered()), SLOT(setupTotp()));
 
-    m_actionMultiplexer.connect(m_ui->actionEntryCopyTotp, SIGNAL(triggered()),
-            SLOT(copyTotp()));
+    m_actionMultiplexer.connect(m_ui->actionEntryCopyTotp, SIGNAL(triggered()), SLOT(copyTotp()));
 
 #ifdef WITH_XC_TOTPDISPLAYKEY
-    m_actionMultiplexer.connect(m_ui->actionEntryTotpDisplayKey, SIGNAL(triggered()),
-            SLOT(showTotpKeyQRCode()));
+    m_actionMultiplexer.connect(m_ui->actionEntryTotpDisplayKey, SIGNAL(triggered()), SLOT(showTotpKeyQRCode()));
 #endif
 
-    m_actionMultiplexer.connect(m_ui->actionEntryCopyTitle, SIGNAL(triggered()),
-            SLOT(copyTitle()));
-    m_actionMultiplexer.connect(m_ui->actionEntryCopyUsername, SIGNAL(triggered()),
-            SLOT(copyUsername()));
-    m_actionMultiplexer.connect(m_ui->actionEntryCopyPassword, SIGNAL(triggered()),
-            SLOT(copyPassword()));
-    m_actionMultiplexer.connect(m_ui->actionEntryCopyURL, SIGNAL(triggered()),
-            SLOT(copyURL()));
-    m_actionMultiplexer.connect(m_ui->actionEntryCopyNotes, SIGNAL(triggered()),
-            SLOT(copyNotes()));
-    m_actionMultiplexer.connect(m_ui->actionEntryAutoType, SIGNAL(triggered()),
-            SLOT(performAutoType()));
-    m_actionMultiplexer.connect(m_ui->actionEntryOpenUrl, SIGNAL(triggered()),
-            SLOT(openUrl()));
+    m_actionMultiplexer.connect(m_ui->actionEntryCopyTitle, SIGNAL(triggered()), SLOT(copyTitle()));
+    m_actionMultiplexer.connect(m_ui->actionEntryCopyUsername, SIGNAL(triggered()), SLOT(copyUsername()));
+    m_actionMultiplexer.connect(m_ui->actionEntryCopyPassword, SIGNAL(triggered()), SLOT(copyPassword()));
+    m_actionMultiplexer.connect(m_ui->actionEntryCopyURL, SIGNAL(triggered()), SLOT(copyURL()));
+    m_actionMultiplexer.connect(m_ui->actionEntryCopyNotes, SIGNAL(triggered()), SLOT(copyNotes()));
+    m_actionMultiplexer.connect(m_ui->actionEntryAutoType, SIGNAL(triggered()), SLOT(performAutoType()));
+    m_actionMultiplexer.connect(m_ui->actionEntryOpenUrl, SIGNAL(triggered()), SLOT(openUrl()));
 
-    m_actionMultiplexer.connect(m_ui->actionGroupNew, SIGNAL(triggered()),
-            SLOT(createGroup()));
-    m_actionMultiplexer.connect(m_ui->actionGroupEdit, SIGNAL(triggered()),
-            SLOT(switchToGroupEdit()));
-    m_actionMultiplexer.connect(m_ui->actionGroupDelete, SIGNAL(triggered()),
-            SLOT(deleteGroup()));
-    m_actionMultiplexer.connect(m_ui->actionGroupEmptyRecycleBin, SIGNAL(triggered()),
-            SLOT(emptyRecycleBin()));
+    m_actionMultiplexer.connect(m_ui->actionGroupNew, SIGNAL(triggered()), SLOT(createGroup()));
+    m_actionMultiplexer.connect(m_ui->actionGroupEdit, SIGNAL(triggered()), SLOT(switchToGroupEdit()));
+    m_actionMultiplexer.connect(m_ui->actionGroupDelete, SIGNAL(triggered()), SLOT(deleteGroup()));
+    m_actionMultiplexer.connect(m_ui->actionGroupEmptyRecycleBin, SIGNAL(triggered()), SLOT(emptyRecycleBin()));
 
     connect(m_ui->actionSettings, SIGNAL(triggered()), SLOT(switchToSettings()));
     connect(m_ui->actionPasswordGenerator, SIGNAL(toggled(bool)), SLOT(switchToPasswordGen(bool)));
@@ -336,9 +294,15 @@ MainWindow::MainWindow()
     setUnifiedTitleAndToolBarOnMac(true);
 #endif
 
-    connect(m_ui->tabWidget, SIGNAL(messageGlobal(QString,MessageWidget::MessageType)), this, SLOT(displayGlobalMessage(QString, MessageWidget::MessageType)));
+    connect(m_ui->tabWidget,
+            SIGNAL(messageGlobal(QString, MessageWidget::MessageType)),
+            this,
+            SLOT(displayGlobalMessage(QString, MessageWidget::MessageType)));
     connect(m_ui->tabWidget, SIGNAL(messageDismissGlobal()), this, SLOT(hideGlobalMessage()));
-    connect(m_ui->tabWidget, SIGNAL(messageTab(QString,MessageWidget::MessageType)), this, SLOT(displayTabMessage(QString, MessageWidget::MessageType)));
+    connect(m_ui->tabWidget,
+            SIGNAL(messageTab(QString, MessageWidget::MessageType)),
+            this,
+            SLOT(displayTabMessage(QString, MessageWidget::MessageType)));
     connect(m_ui->tabWidget, SIGNAL(messageDismissTab()), this, SLOT(hideTabMessage()));
 
     m_screenLockListener = new ScreenLockListener(this);
@@ -347,10 +311,9 @@ MainWindow::MainWindow()
     updateTrayIcon();
 
     if (config()->hasAccessError()) {
-        m_ui->globalMessageWidget->showMessage(
-            tr("Access error for config file %1").arg(config()->getFileName()), MessageWidget::Error);
+        m_ui->globalMessageWidget->showMessage(tr("Access error for config file %1").arg(config()->getFileName()),
+                                               MessageWidget::Error);
     }
-
 }
 
 MainWindow::~MainWindow()
@@ -515,8 +478,7 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             Q_ASSERT(false);
         }
         m_ui->actionDatabaseClose->setEnabled(true);
-    }
-    else {
+    } else {
         const QList<QAction*> entryActions = m_ui->menuEntries->actions();
         for (QAction* action : entryActions) {
             action->setEnabled(false);
@@ -610,8 +572,7 @@ void MainWindow::switchToDatabases()
 {
     if (m_ui->tabWidget->currentIndex() == -1) {
         m_ui->stackedWidget->setCurrentIndex(WelcomeScreen);
-    }
-    else {
+    } else {
         m_ui->stackedWidget->setCurrentIndex(DatabaseTabScreen);
     }
 }
@@ -625,13 +586,13 @@ void MainWindow::switchToSettings()
 void MainWindow::switchToPasswordGen(bool enabled)
 {
     if (enabled == true) {
-      m_ui->passwordGeneratorWidget->loadSettings();
-      m_ui->passwordGeneratorWidget->regeneratePassword();
-      m_ui->passwordGeneratorWidget->setStandaloneMode(true);
-      m_ui->stackedWidget->setCurrentIndex(PasswordGeneratorScreen);
+        m_ui->passwordGeneratorWidget->loadSettings();
+        m_ui->passwordGeneratorWidget->regeneratePassword();
+        m_ui->passwordGeneratorWidget->setStandaloneMode(true);
+        m_ui->stackedWidget->setCurrentIndex(PasswordGeneratorScreen);
     } else {
-      m_ui->passwordGeneratorWidget->saveSettings();
-      switchToDatabases();
+        m_ui->passwordGeneratorWidget->saveSettings();
+        switchToDatabases();
     }
 }
 
@@ -670,7 +631,7 @@ void MainWindow::switchToImportCsv()
     switchToDatabases();
 }
 
-void MainWindow::databaseStatusChanged(DatabaseWidget *)
+void MainWindow::databaseStatusChanged(DatabaseWidget*)
 {
     updateTrayIcon();
 }
@@ -679,8 +640,7 @@ void MainWindow::databaseTabChanged(int tabIndex)
 {
     if (tabIndex != -1 && m_ui->stackedWidget->currentIndex() == WelcomeScreen) {
         m_ui->stackedWidget->setCurrentIndex(DatabaseTabScreen);
-    }
-    else if (tabIndex == -1 && m_ui->stackedWidget->currentIndex() == DatabaseTabScreen) {
+    } else if (tabIndex == -1 && m_ui->stackedWidget->currentIndex() == DatabaseTabScreen) {
         m_ui->stackedWidget->setCurrentIndex(WelcomeScreen);
     }
 
@@ -695,10 +655,8 @@ void MainWindow::closeEvent(QCloseEvent* event)
         return;
     }
 
-    bool minimizeOnClose = isTrayIconEnabled() &&
-                           config()->get("GUI/MinimizeOnClose").toBool();
-    if (minimizeOnClose && !m_appExitCalled)
-    {
+    bool minimizeOnClose = isTrayIconEnabled() && config()->get("GUI/MinimizeOnClose").toBool();
+    if (minimizeOnClose && !m_appExitCalled) {
         event->ignore();
         hideWindow();
 
@@ -717,8 +675,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
 
         event->accept();
         QApplication::quit();
-    }
-    else {
+    } else {
         event->ignore();
     }
 }
@@ -726,9 +683,8 @@ void MainWindow::closeEvent(QCloseEvent* event)
 void MainWindow::changeEvent(QEvent* event)
 {
     if ((event->type() == QEvent::WindowStateChange) && isMinimized()) {
-        if (isTrayIconEnabled() && m_trayIcon && m_trayIcon->isVisible()
-                && config()->get("GUI/MinimizeToTray").toBool())
-        {
+        if (isTrayIconEnabled() && m_trayIcon && m_trayIcon->isVisible() &&
+            config()->get("GUI/MinimizeToTray").toBool()) {
             event->ignore();
             QTimer::singleShot(0, this, SLOT(hide()));
         }
@@ -736,8 +692,7 @@ void MainWindow::changeEvent(QEvent* event)
         if (config()->get("security/lockdatabaseminimize").toBool()) {
             m_ui->tabWidget->lockDatabases();
         }
-    }
-    else {
+    } else {
         QMainWindow::changeEvent(event);
     }
 }
@@ -754,20 +709,18 @@ bool MainWindow::saveLastDatabases()
     bool openPreviousDatabasesOnStartup = config()->get("OpenPreviousDatabasesOnStartup").toBool();
 
     if (openPreviousDatabasesOnStartup) {
-        connect(m_ui->tabWidget, SIGNAL(databaseWithFileClosed(QString)),
-                this, SLOT(rememberOpenDatabases(QString)));
+        connect(m_ui->tabWidget, SIGNAL(databaseWithFileClosed(QString)), this, SLOT(rememberOpenDatabases(QString)));
     }
 
     if (!m_ui->tabWidget->closeAllDatabases()) {
         accept = false;
-    }
-    else {
+    } else {
         accept = true;
     }
 
     if (openPreviousDatabasesOnStartup) {
-        disconnect(m_ui->tabWidget, SIGNAL(databaseWithFileClosed(QString)),
-                   this, SLOT(rememberOpenDatabases(QString)));
+        disconnect(
+            m_ui->tabWidget, SIGNAL(databaseWithFileClosed(QString)), this, SLOT(rememberOpenDatabases(QString)));
         config()->set("LastOpenedDatabases", m_openDatabases);
     }
 
@@ -793,7 +746,8 @@ void MainWindow::updateTrayIcon()
 #else
             menu->addAction(m_ui->actionQuit);
 
-            connect(m_trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
+            connect(m_trayIcon,
+                    SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
                     SLOT(trayIconTriggered(QSystemTrayIcon::ActivationReason)));
 #endif
             connect(actionToggle, SIGNAL(triggered()), SLOT(toggleWindow()));
@@ -804,12 +758,10 @@ void MainWindow::updateTrayIcon()
         }
         if (m_ui->tabWidget->hasLockableDatabases()) {
             m_trayIcon->setIcon(filePath()->trayIconUnlocked());
-        }
-        else {
+        } else {
             m_trayIcon->setIcon(filePath()->trayIconLocked());
         }
-    }
-    else {
+    } else {
         if (m_trayIcon) {
             m_trayIcon->hide();
             delete m_trayIcon;
@@ -837,8 +789,7 @@ void MainWindow::setShortcut(QAction* action, QKeySequence::StandardKey standard
 {
     if (!QKeySequence::keyBindings(standard).isEmpty()) {
         action->setShortcuts(standard);
-    }
-    else if (fallback != 0) {
+    } else if (fallback != 0) {
         action->setShortcut(QKeySequence(fallback));
     }
 }
@@ -858,8 +809,7 @@ void MainWindow::applySettingsChanges()
     m_inactivityTimer->setInactivityTimeout(timeout);
     if (config()->get("security/lockdatabaseidle").toBool()) {
         m_inactivityTimer->activate();
-    }
-    else {
+    } else {
         m_inactivityTimer->deactivate();
     }
 
@@ -896,17 +846,16 @@ void MainWindow::toggleWindow()
         raise();
         activateWindow();
 
-#if defined(Q_OS_LINUX) && ! defined(QT_NO_DBUS)
+#if defined(Q_OS_LINUX) && !defined(QT_NO_DBUS)
         // re-register global D-Bus menu (needed on Ubuntu with Unity)
         // see https://github.com/keepassxreboot/keepassxc/issues/271
         // and https://bugreports.qt.io/browse/QTBUG-58723
         // check for !isVisible(), because isNativeMenuBar() does not work with appmenu-qt5
         if (!m_ui->menubar->isVisible()) {
-            QDBusMessage msg = QDBusMessage::createMethodCall(
-                "com.canonical.AppMenu.Registrar",
-                "/com/canonical/AppMenu/Registrar",
-                "com.canonical.AppMenu.Registrar",
-                "RegisterWindow");
+            QDBusMessage msg = QDBusMessage::createMethodCall("com.canonical.AppMenu.Registrar",
+                                                              "/com/canonical/AppMenu/Registrar",
+                                                              "com.canonical.AppMenu.Registrar",
+                                                              "RegisterWindow");
             QList<QVariant> args;
             args << QVariant::fromValue(static_cast<uint32_t>(winId()))
                  << QVariant::fromValue(QDBusObjectPath("/MenuBar/1"));
@@ -930,8 +879,7 @@ void MainWindow::lockDatabasesAfterInactivity()
 void MainWindow::repairDatabase()
 {
     QString filter = QString("%1 (*.kdbx);;%2 (*)").arg(tr("KeePass 2 Database"), tr("All files"));
-    QString fileName = fileDialog()->getOpenFileName(this, tr("Open database"), QString(),
-                                                     filter);
+    QString fileName = fileDialog()->getOpenFileName(this, tr("Open database"), QString(), filter);
     if (fileName.isEmpty()) {
         return;
     }
@@ -942,17 +890,20 @@ void MainWindow::repairDatabase()
     connect(dbRepairWidget, SIGNAL(error()), dialog.data(), SLOT(reject()));
     dbRepairWidget->load(fileName);
     if (dialog->exec() == QDialog::Accepted && dbRepairWidget->database()) {
-        QString saveFileName = fileDialog()->getSaveFileName(this, tr("Save repaired database"), QString(),
+        QString saveFileName = fileDialog()->getSaveFileName(this,
+                                                             tr("Save repaired database"),
+                                                             QString(),
                                                              tr("KeePass 2 Database").append(" (*.kdbx)"),
-                                                             nullptr, 0, "kdbx");
+                                                             nullptr,
+                                                             0,
+                                                             "kdbx");
 
         if (!saveFileName.isEmpty()) {
             KeePass2Writer writer;
             writer.writeDatabase(saveFileName, dbRepairWidget->database());
             if (writer.hasError()) {
-                displayGlobalMessage(
-                    tr("Writing the database failed.").append("\n").append(writer.errorString()),
-                    MessageWidget::Error);
+                displayGlobalMessage(tr("Writing the database failed.").append("\n").append(writer.errorString()),
+                                     MessageWidget::Error);
             }
         }
     }
@@ -960,8 +911,7 @@ void MainWindow::repairDatabase()
 
 bool MainWindow::isTrayIconEnabled() const
 {
-    return config()->get("GUI/ShowTrayIcon").toBool()
-            && QSystemTrayIcon::isSystemTrayAvailable();
+    return config()->get("GUI/ShowTrayIcon").toBool() && QSystemTrayIcon::isSystemTrayAvailable();
 }
 
 void MainWindow::displayGlobalMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton)
@@ -1002,7 +952,7 @@ void MainWindow::hideYubiKeyPopup()
 
 void MainWindow::handleScreenLock()
 {
-    if (config()->get("security/lockdatabasescreenlock").toBool()){
+    if (config()->get("security/lockdatabasescreenlock").toBool()) {
         lockDatabasesAfterInactivity();
     }
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -290,6 +290,12 @@ MainWindow::MainWindow()
 
     m_actionMultiplexer.connect(m_ui->actionEntryCopyTotp, SIGNAL(triggered()),
             SLOT(copyTotp()));
+
+#ifdef WITH_XC_TOTPDISPLAYKEY
+    m_actionMultiplexer.connect(m_ui->actionEntryTotpDisplayKey, SIGNAL(triggered()),
+            SLOT(showTotpKeyQRCode()));
+#endif
+
     m_actionMultiplexer.connect(m_ui->actionEntryCopyTitle, SIGNAL(triggered()),
             SLOT(copyTitle()));
     m_actionMultiplexer.connect(m_ui->actionEntryCopyUsername, SIGNAL(triggered()),
@@ -452,6 +458,13 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->actionEntryTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
             m_ui->actionEntryCopyTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
             m_ui->actionEntrySetupTotp->setEnabled(singleEntrySelected);
+
+#ifdef WITH_XC_TOTPDISPLAYKEY
+            m_ui->actionEntryTotpDisplayKey->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
+#else
+            m_ui->actionEntryTotpDisplayKey->setVisible(false);
+#endif
+
             m_ui->actionGroupNew->setEnabled(groupSelected);
             m_ui->actionGroupEdit->setEnabled(groupSelected);
             m_ui->actionGroupDelete->setEnabled(groupSelected && dbWidget->canDeleteCurrentGroup());

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -229,6 +229,7 @@
      </property>
      <addaction name="actionEntryCopyTotp"/>
      <addaction name="actionEntryTotp"/>
+     <addaction name="actionEntryTotpDisplayKey"/>
      <addaction name="actionEntrySetupTotp"/>
     </widget>
     <addaction name="actionEntryCopyUsername"/>
@@ -538,6 +539,11 @@
   <action name="actionEntryTotp">
    <property name="text">
     <string>Show TOTP</string>
+   </property>
+  </action>
+  <action name="actionEntryTotpDisplayKey">
+   <property name="text">
+    <string>Show TOTP key</string>
    </property>
   </action>
   <action name="actionEntrySetupTotp">

--- a/src/gui/TotpKeyDisplayDialog.cpp
+++ b/src/gui/TotpKeyDisplayDialog.cpp
@@ -16,13 +16,13 @@
  */
 
 #include "TotpKeyDisplayDialog.h"
-#include "ui_TotpKeyDisplayDialog.h"
 #include "core/Config.h"
 #include "core/Entry.h"
 #include "core/QRCode.h"
-#include "totp/totp.h"
-#include "gui/DatabaseWidget.h"
 #include "gui/Clipboard.h"
+#include "gui/DatabaseWidget.h"
+#include "totp/totp.h"
+#include "ui_TotpKeyDisplayDialog.h"
 #include <QPushButton>
 
 TotpKeyDisplayDialog::TotpKeyDisplayDialog(DatabaseWidget* parent, Entry* entry)
@@ -57,15 +57,13 @@ void TotpKeyDisplayDialog::copyToClipboard()
 
 QUrl TotpKeyDisplayDialog::totpKeyUri(const Entry* entry) const
 {
-    return QTotp::generateOtpString(
-        entry->totpSeed(),
-        QString("totp"),
-        QString(entry->title()),
-        QString(entry->username()),
-        QString("SHA1"),
-        entry->totpDigits(),
-        entry->totpStep()
-    );
+    return QTotp::generateOtpString(entry->totpSeed(),
+                                    QString("totp"),
+                                    QString(entry->title()),
+                                    QString(entry->username()),
+                                    QString("SHA1"),
+                                    entry->totpDigits(),
+                                    entry->totpStep());
 }
 
 TotpKeyDisplayDialog::~TotpKeyDisplayDialog()

--- a/src/gui/TotpKeyDisplayDialog.cpp
+++ b/src/gui/TotpKeyDisplayDialog.cpp
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TotpKeyDisplayDialog.h"
+#include "ui_TotpKeyDisplayDialog.h"
+#include "core/Config.h"
+#include "core/Entry.h"
+#include "core/QRCode.h"
+#include "totp/totp.h"
+#include "gui/DatabaseWidget.h"
+#include "gui/Clipboard.h"
+#include <QPushButton>
+
+TotpKeyDisplayDialog::TotpKeyDisplayDialog(DatabaseWidget* parent, Entry* entry)
+    : QDialog(parent)
+    , m_ui(new Ui::TotpKeyDisplayDialog())
+{
+    m_entry = entry;
+    m_parent = parent;
+
+    m_ui->setupUi(this);
+
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    const QUrl keyUri = totpKeyUri(entry);
+    const QRCode qrcode(keyUri.toEncoded());
+    m_ui->totpKeyLabel->setPixmap(QPixmap::fromImage(qrcode.toQImage(200, 4)));
+
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Copy"));
+
+    connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(close()));
+    connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(copyToClipboard()));
+}
+
+void TotpKeyDisplayDialog::copyToClipboard()
+{
+    const QUrl keyUri = totpKeyUri(m_entry);
+    clipboard()->setText(keyUri.toEncoded().data());
+    if (config()->get("MinimizeOnCopy").toBool()) {
+        m_parent->window()->showMinimized();
+    }
+}
+
+QUrl TotpKeyDisplayDialog::totpKeyUri(const Entry* entry) const
+{
+    return QTotp::generateOtpString(
+        entry->totpSeed(),
+        QString("totp"),
+        QString(entry->title()),
+        QString(entry->username()),
+        QString("SHA1"),
+        entry->totpDigits(),
+        entry->totpStep()
+    );
+}
+
+TotpKeyDisplayDialog::~TotpKeyDisplayDialog()
+{
+}

--- a/src/gui/TotpKeyDisplayDialog.h
+++ b/src/gui/TotpKeyDisplayDialog.h
@@ -1,5 +1,4 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -16,24 +15,39 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef QTOTP_H
-#define QTOTP_H
+#ifndef KEEPASSX_TOTPKEYDISPLAYDIALOG_H
+#define KEEPASSX_TOTPKEYDISPLAYDIALOG_H
 
-#include <QtCore/qglobal.h>
+#include <QDialog>
+#include <QScopedPointer>
+#include <QUrl>
+#include "core/Entry.h"
+#include "core/Database.h"
+#include "gui/DatabaseWidget.h"
 
-class QUrl;
+namespace Ui {
+    class TotpKeyDisplayDialog;
+}
 
-class QTotp
+class TotpKeyDisplayDialog : public QDialog
 {
+    Q_OBJECT
+
 public:
-    QTotp();
-    static QString parseOtpString(QString rawSecret, quint8 &digits, quint8 &step);
-    static QString generateTotp(const QByteArray key, quint64 time, const quint8 numDigits, const quint8 step);
-    static QUrl generateOtpString(const QString& secret, const QString& type,
-        const QString& issuer, const QString& username, const QString& algorithm,
-        const quint8& digits, const quint8& step);
-    static const quint8 defaultStep;
-    static const quint8 defaultDigits;
+    explicit TotpKeyDisplayDialog(DatabaseWidget* parent = nullptr, Entry* entry = nullptr);
+    ~TotpKeyDisplayDialog();
+
+private:
+    QScopedPointer<Ui::TotpKeyDisplayDialog> m_ui;
+
+private Q_SLOTS:
+    void copyToClipboard();
+
+protected:
+    Entry* m_entry;
+    DatabaseWidget* m_parent;
+
+    QUrl totpKeyUri(const Entry* entry) const;
 };
 
-#endif // QTOTP_H
+#endif // KEEPASSX_TOTPKEYDISPLAYDIALOG_H

--- a/src/gui/TotpKeyDisplayDialog.h
+++ b/src/gui/TotpKeyDisplayDialog.h
@@ -18,14 +18,15 @@
 #ifndef KEEPASSX_TOTPKEYDISPLAYDIALOG_H
 #define KEEPASSX_TOTPKEYDISPLAYDIALOG_H
 
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "gui/DatabaseWidget.h"
 #include <QDialog>
 #include <QScopedPointer>
 #include <QUrl>
-#include "core/Entry.h"
-#include "core/Database.h"
-#include "gui/DatabaseWidget.h"
 
-namespace Ui {
+namespace Ui
+{
     class TotpKeyDisplayDialog;
 }
 

--- a/src/gui/TotpKeyDisplayDialog.ui
+++ b/src/gui/TotpKeyDisplayDialog.ui
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TotpKeyDisplayDialog</class>
+ <widget class="QWidget" name="TotpKeyDisplayDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>264</width>
+    <height>194</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Scan TOTP Key</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="totpKeyLabel">
+     <property name="font">
+      <font>
+       <pointsize>53</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>000000</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/totp/totp.cpp
+++ b/src/totp/totp.cpp
@@ -18,15 +18,14 @@
 
 #include "totp.h"
 #include "core/Base32.h"
-#include <cmath>
-#include <QtEndian>
-#include <QRegExp>
-#include <QDateTime>
 #include <QCryptographicHash>
+#include <QDateTime>
 #include <QMessageAuthenticationCode>
+#include <QRegExp>
 #include <QUrl>
 #include <QUrlQuery>
-
+#include <QtEndian>
+#include <cmath>
 
 const quint8 QTotp::defaultStep = 30;
 const quint8 QTotp::defaultDigits = 6;
@@ -35,7 +34,7 @@ QTotp::QTotp()
 {
 }
 
-QString QTotp::parseOtpString(QString key, quint8 &digits, quint8 &step)
+QString QTotp::parseOtpString(QString key, quint8& digits, quint8& step)
 {
     QUrl url(key);
 
@@ -57,7 +56,6 @@ QString QTotp::parseOtpString(QString key, quint8 &digits, quint8 &step)
         if (q_step > 0 && q_step <= 60) {
             step = q_step;
         }
-
 
     } else {
         // Compatibility with "KeeOtp" plugin string format
@@ -93,8 +91,10 @@ QString QTotp::parseOtpString(QString key, quint8 &digits, quint8 &step)
     return seed;
 }
 
-QString QTotp::generateTotp(const QByteArray key, quint64 time,
-                            const quint8 numDigits = defaultDigits, const quint8 step = defaultStep)
+QString QTotp::generateTotp(const QByteArray key,
+                            quint64 time,
+                            const quint8 numDigits = defaultDigits,
+                            const quint8 step = defaultStep)
 {
     quint64 current = qToBigEndian(time / step);
 
@@ -109,11 +109,8 @@ QString QTotp::generateTotp(const QByteArray key, quint64 time,
     QByteArray hmac = code.result();
 
     int offset = (hmac[hmac.length() - 1] & 0xf);
-    int binary =
-            ((hmac[offset] & 0x7f) << 24)
-            | ((hmac[offset + 1] & 0xff) << 16)
-            | ((hmac[offset + 2] & 0xff) << 8)
-            | (hmac[offset + 3] & 0xff);
+    int binary = ((hmac[offset] & 0x7f) << 24) | ((hmac[offset + 1] & 0xff) << 16) | ((hmac[offset + 2] & 0xff) << 8) |
+                 (hmac[offset + 3] & 0xff);
 
     quint32 digitsPower = pow(10, numDigits);
 
@@ -122,9 +119,13 @@ QString QTotp::generateTotp(const QByteArray key, quint64 time,
 }
 
 // See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format
-QUrl QTotp::generateOtpString(const QString& secret, const QString& type,
-    const QString& issuer, const QString& username, const QString& algorithm,
-    const quint8& digits, const quint8& step)
+QUrl QTotp::generateOtpString(const QString& secret,
+                              const QString& type,
+                              const QString& issuer,
+                              const QString& username,
+                              const QString& algorithm,
+                              const quint8& digits,
+                              const quint8& step)
 {
     QUrl keyUri;
     keyUri.setScheme("otpauth");

--- a/src/totp/totp.h
+++ b/src/totp/totp.h
@@ -27,11 +27,15 @@ class QTotp
 {
 public:
     QTotp();
-    static QString parseOtpString(QString rawSecret, quint8 &digits, quint8 &step);
+    static QString parseOtpString(QString rawSecret, quint8& digits, quint8& step);
     static QString generateTotp(const QByteArray key, quint64 time, const quint8 numDigits, const quint8 step);
-    static QUrl generateOtpString(const QString& secret, const QString& type,
-        const QString& issuer, const QString& username, const QString& algorithm,
-        const quint8& digits, const quint8& step);
+    static QUrl generateOtpString(const QString& secret,
+                                  const QString& type,
+                                  const QString& issuer,
+                                  const QString& username,
+                                  const QString& algorithm,
+                                  const quint8& digits,
+                                  const quint8& step);
     static const quint8 defaultStep;
     static const quint8 defaultDigits;
 };

--- a/tests/TestBase32.cpp
+++ b/tests/TestBase32.cpp
@@ -23,22 +23,22 @@ QTEST_GUILESS_MAIN(TestBase32)
 
 void TestBase32::testDecode()
 {
-    // 3 quantums, all upper case + padding
+    // 3 quanta, all upper case + padding
     QByteArray encodedData = "JBSWY3DPEB3W64TMMQXC4LQ=";
     auto data = Base32::decode(encodedData);
     QCOMPARE(QString::fromLatin1(data.valueOr("ERROR")), QString("Hello world..."));
 
-    // 4 quantums, all upper case
+    // 4 quanta, all upper case
     encodedData = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
     data = Base32::decode(encodedData);
     QCOMPARE(QString::fromLatin1(data.valueOr("ERROR")), QString("12345678901234567890"));
 
-    // 4 quantums, all lower case
+    // 4 quanta, all lower case
     encodedData = "gezdgnbvgy3tqojqgezdgnbvgy3tqojq";
     data = Base32::decode(encodedData);
     QCOMPARE(QString::fromLatin1(data.valueOr("ERROR")), QString("12345678901234567890"));
 
-    // 4 quantums, mixed upper and lower case
+    // 4 quanta, mixed upper and lower case
     encodedData = "Gezdgnbvgy3tQojqgezdGnbvgy3tQojQ";
     data = Base32::decode(encodedData);
     QCOMPARE(QString::fromLatin1(data.valueOr("ERROR")), QString("12345678901234567890"));
@@ -115,7 +115,7 @@ void TestBase32::testEncode()
 
     data = "12345678901234567890";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")); 
+    QCOMPARE(encodedData, QByteArray("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"));
 
     data = "012345678901234567890";
     encodedData = Base32::encode(data);
@@ -123,46 +123,156 @@ void TestBase32::testEncode()
 
     data = "test";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("ORSXG5A=")); 
+    QCOMPARE(encodedData, QByteArray("ORSXG5A="));
 
     data = "___";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("L5PV6===")); 
+    QCOMPARE(encodedData, QByteArray("L5PV6==="));
 
     data = "foo bar";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("MZXW6IDCMFZA====")); 
+    QCOMPARE(encodedData, QByteArray("MZXW6IDCMFZA===="));
 
     data = "@";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("IA======")); 
+    QCOMPARE(encodedData, QByteArray("IA======"));
 
     // RFC 4648 test vectors
     data = "";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("")); 
+    QCOMPARE(encodedData, QByteArray(""));
 
     data = "f";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("MY======")); 
+    QCOMPARE(encodedData, QByteArray("MY======"));
 
     data = "fo";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("MZXQ====")); 
+    QCOMPARE(encodedData, QByteArray("MZXQ===="));
 
     data = "foo";
     encodedData = Base32::encode(data);
     QCOMPARE(encodedData, QByteArray("MZXW6==="));
- 
+
     data = "foob";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("MZXW6YQ=")); 
+    QCOMPARE(encodedData, QByteArray("MZXW6YQ="));
 
     data = "fooba";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("MZXW6YTB")); 
+    QCOMPARE(encodedData, QByteArray("MZXW6YTB"));
 
     data = "foobar";
     encodedData = Base32::encode(data);
-    QCOMPARE(encodedData, QByteArray("MZXW6YTBOI======")); 
+    QCOMPARE(encodedData, QByteArray("MZXW6YTBOI======"));
+}
+
+void TestBase32::testAddPadding()
+{
+    // Empty. Invalid, returns input.
+    QByteArray data = "";
+    QByteArray paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, data);
+
+    // One byte of encoded data. Invalid, returns input.
+    data = "B";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, data);
+
+    // Two bytes of encoded data.
+    data = "BB";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, QByteArray("BB======"));
+
+    // Three bytes of encoded data. Invalid, returns input.
+    data = "BBB";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, data);
+
+    // Four bytes of encoded data.
+    data = "BBBB";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, QByteArray("BBBB===="));
+
+    // Five bytes of encoded data.
+    data = "BBBBB";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, QByteArray("BBBBB==="));
+
+    // Six bytes of encoded data. Invalid, returns input.
+    data = "BBBBBB";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, data);
+
+    // Seven bytes of encoded data.
+    data = "BBBBBBB";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, QByteArray("BBBBBBB="));
+
+    // Eight bytes of encoded data. Valid, but returns same as input.
+    data = "BBBBBBBB";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, data);
+
+    // More than eight bytes (8+5).
+    data = "AAAAAAAABBBBB";
+    paddedData = Base32::addPadding(data);
+    QCOMPARE(paddedData, QByteArray("AAAAAAAABBBBB==="));
+}
+
+void TestBase32::testRemovePadding()
+{
+    QByteArray data = "";
+    QByteArray unpaddedData = Base32::removePadding(data);
+    QCOMPARE(unpaddedData, data);
+
+    data = "AAAAAAAABB======";
+    unpaddedData = Base32::removePadding(data);
+    QCOMPARE(unpaddedData, QByteArray("AAAAAAAABB"));
+
+    data = "BBBB====";
+    unpaddedData = Base32::removePadding(data);
+    QCOMPARE(unpaddedData, QByteArray("BBBB"));
+
+    data = "AAAAAAAABBBBB===";
+    unpaddedData = Base32::removePadding(data);
+    QCOMPARE(unpaddedData, QByteArray("AAAAAAAABBBBB"));
+
+    data = "BBBBBBB=";
+    unpaddedData = Base32::removePadding(data);
+    QCOMPARE(unpaddedData, QByteArray("BBBBBBB"));
+
+    // Invalid: 7 bytes of data. Returns same as input.
+    data = "IIIIIII";
+    unpaddedData = Base32::removePadding(data);
+    QCOMPARE(unpaddedData, data);
+
+    // Invalid: more padding than necessary. Returns same as input.
+    data = "AAAAAAAABBBB=====";
+    unpaddedData = Base32::removePadding(data);
+    QCOMPARE(unpaddedData, data);
+}
+
+void TestBase32::testSanitizeInput()
+{
+    // sanitize input (white space + missing padding)
+    QByteArray encodedData = "JBSW Y3DP EB3W 64TM MQXC 4LQA";
+    auto data = Base32::decode(Base32::sanitizeInput(encodedData));
+    QCOMPARE(QString::fromLatin1(data.valueOr("ERRROR")), QString("Hello world..."));
+
+    // sanitize input (typo + missing padding)
+    encodedData = "J8SWY3DPE83W64TMMQXC4LQA";
+    data = Base32::decode(Base32::sanitizeInput(encodedData));
+    QCOMPARE(QString::fromLatin1(data.valueOr("ERRROR")), QString("Hello world..."));
+
+    // sanitize input (other illegal characters)
+    encodedData = "J8SWY3D[PE83W64TMMQ]XC!4LQA";
+    data = Base32::decode(Base32::sanitizeInput(encodedData));
+    QCOMPARE(QString::fromLatin1(data.valueOr("ERRROR")), QString("Hello world..."));
+
+    // sanitize input (NUL character)
+    encodedData = "J8SWY3DPE83W64TMMQXC4LQA";
+    encodedData.insert(3, '\0');
+    data = Base32::decode(Base32::sanitizeInput(encodedData));
+    QCOMPARE(QString::fromLatin1(data.valueOr("ERRROR")), QString("Hello world..."));
 }

--- a/tests/TestBase32.h
+++ b/tests/TestBase32.h
@@ -29,6 +29,9 @@ class TestBase32 : public QObject
 private slots:
     void testEncode();
     void testDecode();
+    void testAddPadding();
+    void testRemovePadding();
+    void testSanitizeInput();
 };
 
 #endif // KEEPASSX_TESTBASE32_H

--- a/tests/TestTotp.cpp
+++ b/tests/TestTotp.cpp
@@ -18,11 +18,11 @@
 
 #include "TestTotp.h"
 
-#include <QTest>
-#include <QTime>
 #include <QDateTime>
-#include <QtEndian>
+#include <QTest>
 #include <QTextCodec>
+#include <QTime>
+#include <QtEndian>
 
 #include "crypto/Crypto.h"
 #include "totp/totp.h"
@@ -34,12 +34,13 @@ void TestTotp::initTestCase()
     QVERIFY(Crypto::init());
 }
 
-
 void TestTotp::testParseSecret()
 {
     quint8 digits = 0;
     quint8 step = 0;
-    QString secret = "otpauth://totp/ACME%20Co:john@example.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA1&digits=6&period=30";
+    QString secret = "otpauth://totp/"
+                     "ACME%20Co:john@example.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm="
+                     "SHA1&digits=6&period=30";
     QCOMPARE(QTotp::parseOtpString(secret, digits, step), QString("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
     QCOMPARE(digits, quint8(6));
     QCOMPARE(step, quint8(30));


### PR DESCRIPTION
## Description

This PR is for adding the feature requested in #764. It replaces PR #964, as something strange happened with my tree of that branch and I decided to start a new one based on upstream/develop and cherry-pick the commit from the previous branch.

### Changes

- Instead of using `qtqrencode`, a new class, `QRCode` is placed in `src/core` for enabling support for QR code generation using `libqrencode`. Besides not having another dependency, we have the benefit of not linking against `Qt::QtSvg` --which `qtqrencode` requires.
- QR code size is selected automatically by `libqrencode` based on input data.
- QR code error correction level is set to its highest.

- Our local base32 implementation is compliant with RFC 4648. Three new methods were added for compatibility with Google Authenticator's "Key Uri Format" (which requires no padding characters):
  - **Base32::addPadding/1** This function adds padding to valid encoded data missing those characters. Otherwise, it returns the same input value.
  - **Base32::removePadding/1** This function removes padding from valid encoded data. Otherwise, it returns the same input value.
  - **Base32::sanitizeInput/1** This function sanitizes the encoded data so that it can then be decoded correctly. It also corrects "typos" (1 -> L, 8 -> B, 0 -> O).

## Motivation and context

This is best explained by #764.

## How has this been tested?

Currently, it is build for testing using Fedora 26 and the following nix environment:

```
with import <nixpkgs> {};
stdenv.mkDerivation rec {
    name="keepassxc-env";
    env = buildEnv { name = name; paths = buildInputs; };
    buildInputs = [
        cmake
        libgcrypt
        zlib
        qt5.qtbase
        qt5.qtsvg
        qt5.qttools
        libgpgerror
        glibcLocales
        libmicrohttpd
        xorg.libXtst
        libyubikey
        libqrencode
        clang-tools
    ];
}
```

You need to enable the option `WITH_CX_TOTPDISPLAYKEY`:
```bash
mkdir build
cd build
cmake -DWITH_ASAN=ON -DWITH_XC_TOTPDISPLAYKEY=ON -DCMAKE_BUILD_TYPE=Debug ..
```

### Test barcodes
- Generate test data using: https://freeotp.github.io/qrcode.html and load it into a test DB.
- Test:
  - Barcode reads correctly from authenticator app
  - Authenticator app generates same OTPs as KeePassXC
- Tested using:
  - Google Authenticator (iOS) ✅
  - FreeOTP (iOS) ✅
  - Microsoft Authenticator (iOS) ✅
  - Yandex Authenticator AKA Ya.Key (iOS) ✅
  - LastPass Authenticator (iOS) ✅

- Also, scan the QR code from the FreeOTP generator site using one of the authenticator apps and compare the TOTPs with those from KeePassXC.

## Screenshots (if appropriate):

Below are two images that illustrate the proposed interface for this feature.

![Screenshot 1](https://cdn.pbrd.co/images/GMguVtP.png)
![Screenshot 2](https://cdn.pbrd.co/images/GMgvgSf.png)
**Note:** you can actually read the barcode above! (Tested with the Ya.Key iOS app). 

## Types of changes

- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes. **[[ 📝  Except for the UI]].**