### PR TITLE
Check for mismatched passwords BEFORE saving to prevent data loss

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -446,6 +446,12 @@ void EditEntryWidget::saveEntry()
 
 void EditEntryWidget::acceptEntry()
 {
+    // Check if passwords are mismatched first to prevent saving
+    if (!passwordsEqual()) {
+        showMessage(tr("Different passwords supplied."), MessageWidget::Error);
+        return;
+    }
+
     saveEntry();
     clear();
     emit editFinished(true);

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -268,6 +268,17 @@ void TestGui::testEditEntry()
     QCOMPARE(attrTextEdit->toPlainText(), attrText);
     editEntryWidget->setCurrentPage(0);
 
+    // Test mismatch passwords
+    QLineEdit* passwordEdit = editEntryWidget->findChild<QLineEdit*>("passwordEdit");
+    QString originalPassword = passwordEdit->text();
+    passwordEdit->setText("newpass");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    MessageWidget* messageWiget = editEntryWidget->findChild<MessageWidget*>("messageWidget");
+    QTRY_VERIFY(messageWiget->isVisible());
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(passwordEdit->text(), QString("newpass"));
+    passwordEdit->setText(originalPassword);
+
     // Save the edit (press OK)
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #909. Password fields are checked prior to saving to prevent data loss.

_Note: Code is repeated due to the way the apply button works (directly calls the save function). This should be refactored in the future._

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and unit tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
