### PR TITLE
Add custom icons when merging.

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -335,6 +335,7 @@ void Database::merge(const Database* other)
     for (Uuid customIconId : other->metadata()->customIcons().keys()) {
         QImage customIcon = other->metadata()->customIcon(customIconId);
         if (!this->metadata()->containsCustomIcon(customIconId)) {
+            qDebug("Adding custom icon %s to database.", qPrintable(customIconId.toHex()));
             this->metadata()->addCustomIcon(customIconId, customIcon);
         }
     }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -331,6 +331,14 @@ void Database::emptyRecycleBin()
 void Database::merge(const Database* other)
 {
     m_rootGroup->merge(other->rootGroup());
+
+    for (Uuid customIconId : other->metadata()->customIcons().keys()) {
+        QImage customIcon = other->metadata()->customIcon(customIconId);
+        if (!this->metadata()->containsCustomIcon(customIconId)) {
+            this->metadata()->addCustomIcon(customIconId, customIcon);
+        }
+    }
+
     emit modified();
 }
 

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -41,7 +41,6 @@ Metadata::Metadata(QObject* parent)
     m_data.protectPassword = true;
     m_data.protectUrl = false;
     m_data.protectNotes = false;
-    // m_data.autoEnableVisualHiding = false;
 
     QDateTime now = QDateTime::currentDateTimeUtc();
     m_data.nameChanged = now;
@@ -157,11 +156,6 @@ bool Metadata::protectNotes() const
 {
     return m_data.protectNotes;
 }
-
-/*bool Metadata::autoEnableVisualHiding() const
-{
-    return m_autoEnableVisualHiding;
-}*/
 
 QImage Metadata::customIcon(const Uuid& uuid) const
 {
@@ -375,11 +369,6 @@ void Metadata::setProtectNotes(bool value)
 {
     set(m_data.protectNotes, value);
 }
-
-/*void Metadata::setAutoEnableVisualHiding(bool value)
-{
-    set(m_autoEnableVisualHiding, value);
-}*/
 
 void Metadata::addCustomIcon(const Uuid& uuid, const QImage& icon)
 {

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -60,7 +60,6 @@ public:
         bool protectPassword;
         bool protectUrl;
         bool protectNotes;
-        // bool autoEnableVisualHiding;
     };
 
     QString generator() const;
@@ -77,7 +76,6 @@ public:
     bool protectPassword() const;
     bool protectUrl() const;
     bool protectNotes() const;
-    // bool autoEnableVisualHiding() const;
     QImage customIcon(const Uuid& uuid) const;
     QPixmap customIconPixmap(const Uuid& uuid) const;
     QPixmap customIconScaledPixmap(const Uuid& uuid) const;
@@ -117,7 +115,6 @@ public:
     void setProtectPassword(bool value);
     void setProtectUrl(bool value);
     void setProtectNotes(bool value);
-    // void setAutoEnableVisualHiding(bool value);
     void addCustomIcon(const Uuid& uuid, const QImage& icon);
     void addCustomIconScaled(const Uuid& uuid, const QImage& icon);
     void removeCustomIcon(const Uuid& uuid);

--- a/src/format/KeePass2XmlReader.cpp
+++ b/src/format/KeePass2XmlReader.cpp
@@ -323,9 +323,6 @@ void KeePass2XmlReader::parseMemoryProtection()
         else if (m_xml.name() == "ProtectNotes") {
             m_meta->setProtectNotes(readBool());
         }
-        /*else if (m_xml.name() == "AutoEnableVisualHiding") {
-            m_meta->setAutoEnableVisualHiding(readBool());
-        }*/
         else {
             skipCurrentElement();
         }

--- a/src/format/KeePass2XmlWriter.cpp
+++ b/src/format/KeePass2XmlWriter.cpp
@@ -141,7 +141,6 @@ void KeePass2XmlWriter::writeMemoryProtection()
     writeBool("ProtectPassword", m_meta->protectPassword());
     writeBool("ProtectURL", m_meta->protectUrl());
     writeBool("ProtectNotes", m_meta->protectNotes());
-    // writeBool("AutoEnableVisualHiding", m_meta->autoEnableVisualHiding());
 
     m_xml.writeEndElement();
 }

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -420,6 +420,29 @@ void TestMerge::testMergeAndSync()
     delete dbSource;
 }
 
+/**
+ * Custom icons should be brought over when merging.
+ */
+void TestMerge::testMergeCustomIcons()
+{
+    Database* dbDestination = new Database();
+    Database* dbSource = createTestDatabase();
+
+    Uuid customIconId = Uuid::random();
+    QImage customIcon;
+
+    dbSource->metadata()->addCustomIcon(customIconId, customIcon);
+    // Sanity check.
+    QVERIFY(dbSource->metadata()->containsCustomIcon(customIconId));
+
+    dbDestination->merge(dbSource);
+
+    QVERIFY(dbDestination->metadata()->containsCustomIcon(customIconId));
+
+    delete dbDestination;
+    delete dbSource;
+}
+
 Database* TestMerge::createTestDatabase()
 {
     Database* db = new Database();

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -38,6 +38,7 @@ private slots:
     void testCreateNewGroups();
     void testUpdateEntryDifferentLocation();
     void testMergeAndSync();
+    void testMergeCustomIcons();
 
 private:
     Database* createTestDatabase();


### PR DESCRIPTION
Custom icons were not carried over when merging.

Also removed code related to `autoEnableVisualHiding`, since it's not used.

@droidmonkey I'd wait for the changes made in `2.2.1` to be carried over in `develop` before merging this. Do we have an ETA for that?

## Motivation and context
Fixes #971 

## How has this been tested?
* Unit test
* Tested manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
