### PR TITLE
Mask passwords in URL column in entry view table

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -727,6 +727,13 @@ const Database* Entry::database() const
     }
 }
 
+QString Entry::maskPasswordPlaceholders(const QString &str) const
+{
+    QString result = str;
+    result.replace(QRegExp("(\\{PASSWORD\\})", Qt::CaseInsensitive, QRegExp::RegExp2), "******");
+    return result;
+}
+
 QString Entry::resolveMultiplePlaceholders(const QString& str) const
 {
     QString result = str;

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -142,6 +142,7 @@ public:
      */
     Entry* clone(CloneFlags flags) const;
     void copyDataFrom(const Entry* other);
+    QString maskPasswordPlaceholders(const QString& str) const;
     QString resolveMultiplePlaceholders(const QString& str) const;
     QString resolvePlaceholder(const QString& str) const;
     QString resolveUrl(const QString& url) const;

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -151,7 +151,8 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             }
             return result;
         case Url:
-            result = entry->resolveMultiplePlaceholders(entry->url());
+            result = entry->maskPasswordPlaceholders(entry->url());
+            result = entry->resolveMultiplePlaceholders(result);
             if (attr->isReference(EntryAttributes::URLKey)) {
                 result.prepend(tr("Ref: ","Reference abbreviation"));
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #845. {PASSWORD} placeholders are turned into ***** before calling "resolve placeholders" to prevent spillage of passwords in the entry view table.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Maintains security of passwords.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Screenshots (if appropriate):
![kxc_mask_pw1](https://user-images.githubusercontent.com/2809491/31029586-4ad12fe2-a520-11e7-9035-921764955d9d.png)

![kxc_mask_pw2](https://user-images.githubusercontent.com/2809491/31029589-4cf493ea-a520-11e7-8139-4d36e91ae28c.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
