### PR TITLE
Added snapd-xdg-open to snap to enable URL loading

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,8 +40,9 @@ parts:
       - libyubikey-dev
       - libykpers-1-dev
     after: [desktop-qt5]
+
+  # Redefine desktop-qt5 stage packages to work with Ubuntu 17.04
   desktop-qt5:
-    # Redefine stage packages to work with Ubuntu 17.04
     stage-packages:
       - libxkbcommon0
       - ttf-ubuntu-font-family
@@ -52,3 +53,12 @@ parts:
       - libgdk-pixbuf2.0-0
       - libqt5svg5 # for loading icon themes which are svg
       - locales-all
+
+  # Overcome limitation in snapd to support URL loading (CTRL+U)
+  snapd-xdg-open:
+    source: https://github.com/ubuntu-core/snapd-xdg-open.git
+    plugin: dump
+    organize:
+      data/xdg-open: bin/xdg-open
+    stage-packages:
+      - dbus


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #905. Adds snapd-xdg-open program within the snap to allow for URL opening using the CTRL+U shortcut and right-click context menu entry.

I added a [wiki page to document the snap gotchas](https://github.com/keepassxreboot/keepassxc/wiki/Snap-Tips).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on Ubuntu 17.04

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
