### PR TITLE
Fix memory leak in DatabaseTabWidget::openDatabase function

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -181,6 +181,7 @@ void DatabaseTabWidget::openDatabase(const QString& fileName, const QString& pw,
                     lockFile->tryLock();
                 }
             } else {
+                delete lockFile;
                 return;
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fix memory leak in DatabaseTabWidget::openDatabase function

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Open first instance of KeePassXC 
2. Open database /tmp/test.kdbx 
3. Open second instance of KeePassXC 
4. Try open database /tmp/test.kdbx 
5. Сhoose "No" in the dialogue that appeared 
6. Close second instance of KeePassXC 

ASAN detect leak:
```
DatabaseTabWidget::openDatabase(QString const&, QString const&, QString const&) /home/frostasm/dev/qt/keepassxc/src/gui/DatabaseTabWidget.cpp:155
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
