### PR TITLE
Fix double warning display for database open

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -162,7 +162,10 @@ void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
 void DatabaseOpenWidget::openDatabase()
 {
     KeePass2Reader reader;
-    CompositeKey masterKey = databaseKey();
+    CompositeKey* masterKey = databaseKey();
+    if (masterKey == nullptr) {
+        return;
+    }
 
     QFile file(m_filename);
     if (!file.open(QIODevice::ReadOnly)) {
@@ -174,7 +177,7 @@ void DatabaseOpenWidget::openDatabase()
         delete m_db;
     }
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    m_db = reader.readDatabase(&file, masterKey);
+    m_db = reader.readDatabase(&file, *masterKey);
     QApplication::restoreOverrideCursor();
 
     if (m_db) {
@@ -182,20 +185,21 @@ void DatabaseOpenWidget::openDatabase()
             m_ui->messageWidget->animatedHide();
         }
         emit editFinished(true);
-    }
-    else {
-        m_ui->messageWidget->showMessage(tr("Unable to open the database.")
-                                         .append("\n").append(reader.errorString()), MessageWidget::Error);
+    } else {
+        m_ui->messageWidget->showMessage(tr("Unable to open the database.").append("\n").append(reader.errorString()),
+                                         MessageWidget::Error);
         m_ui->editPassword->clear();
     }
+
+    delete masterKey;
 }
 
-CompositeKey DatabaseOpenWidget::databaseKey()
+CompositeKey* DatabaseOpenWidget::databaseKey()
 {
-    CompositeKey masterKey;
+    CompositeKey* masterKey = new CompositeKey();
 
     if (m_ui->checkPassword->isChecked()) {
-        masterKey.addKey(PasswordKey(m_ui->editPassword->text()));
+        masterKey->addKey(PasswordKey(m_ui->editPassword->text()));
     }
 
     QHash<QString, QVariant> lastKeyFiles = config()->get("LastKeyFiles").toHash();
@@ -206,11 +210,12 @@ CompositeKey DatabaseOpenWidget::databaseKey()
         QString keyFilename = m_ui->comboKeyFile->currentText();
         QString errorMsg;
         if (!key.load(keyFilename, &errorMsg)) {
-            m_ui->messageWidget->showMessage(tr("Can't open key file").append(":\n")
-                                             .append(errorMsg), MessageWidget::Error);
-            return CompositeKey();
+            m_ui->messageWidget->showMessage(tr("Can't open key file").append(":\n").append(errorMsg),
+                                             MessageWidget::Error);
+            delete masterKey;
+            return nullptr;
         }
-        masterKey.addKey(key);
+        masterKey->addKey(key);
         lastKeyFiles[m_filename] = keyFilename;
     } else {
         lastKeyFiles.remove(m_filename);
@@ -237,9 +242,9 @@ CompositeKey DatabaseOpenWidget::databaseKey()
 
         // read blocking mode from LSB and slot index number from second LSB
         bool blocking = comboPayload & 1;
-        int slot      = comboPayload >> 1;
-        auto key      = QSharedPointer<YkChallengeResponseKey>(new YkChallengeResponseKey(slot, blocking));
-        masterKey.addChallengeResponseKey(key);
+        int slot = comboPayload >> 1;
+        auto key = QSharedPointer<YkChallengeResponseKey>(new YkChallengeResponseKey(slot, blocking));
+        masterKey->addChallengeResponseKey(key);
     }
 #endif
 

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -162,8 +162,8 @@ void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
 void DatabaseOpenWidget::openDatabase()
 {
     KeePass2Reader reader;
-    CompositeKey* masterKey = databaseKey();
-    if (masterKey == nullptr) {
+    QScopedPointer<CompositeKey> masterKey(databaseKey());
+    if (masterKey.isNull()) {
         return;
     }
 
@@ -190,8 +190,6 @@ void DatabaseOpenWidget::openDatabase()
                                          MessageWidget::Error);
         m_ui->editPassword->clear();
     }
-
-    delete masterKey;
 }
 
 CompositeKey* DatabaseOpenWidget::databaseKey()

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -162,7 +162,7 @@ void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
 void DatabaseOpenWidget::openDatabase()
 {
     KeePass2Reader reader;
-    QScopedPointer<CompositeKey> masterKey(databaseKey());
+    QSharedPointer<CompositeKey> masterKey = databaseKey();
     if (masterKey.isNull()) {
         return;
     }
@@ -192,9 +192,9 @@ void DatabaseOpenWidget::openDatabase()
     }
 }
 
-CompositeKey* DatabaseOpenWidget::databaseKey()
+QSharedPointer<CompositeKey> DatabaseOpenWidget::databaseKey()
 {
-    CompositeKey* masterKey = new CompositeKey();
+    auto masterKey = QSharedPointer<CompositeKey>::create();
 
     if (m_ui->checkPassword->isChecked()) {
         masterKey->addKey(PasswordKey(m_ui->editPassword->text()));
@@ -210,8 +210,7 @@ CompositeKey* DatabaseOpenWidget::databaseKey()
         if (!key.load(keyFilename, &errorMsg)) {
             m_ui->messageWidget->showMessage(tr("Can't open key file").append(":\n").append(errorMsg),
                                              MessageWidget::Error);
-            delete masterKey;
-            return nullptr;
+            return QSharedPointer<CompositeKey>();
         }
         masterKey->addKey(key);
         lastKeyFiles[m_filename] = keyFilename;

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -52,7 +52,7 @@ signals:
 protected:
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
-    CompositeKey databaseKey();
+    CompositeKey* databaseKey();
 
 protected slots:
     virtual void openDatabase();

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -52,7 +52,7 @@ signals:
 protected:
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
-    CompositeKey* databaseKey();
+    QSharedPointer<CompositeKey> databaseKey();
 
 protected slots:
     virtual void openDatabase();


### PR DESCRIPTION
Second attempt to fix #741, after https://github.com/keepassxreboot/keepassxc/pull/744
Rebased on `2.2.2`.

## How has this been tested?
Locally, by opening a database with a keyfile, and testing the error message when providing an invalid path.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
