### PR TITLE
AutoType: resolve placeholders for title in window associations

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -563,7 +563,8 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
         bool match = false;
         const QList<AutoTypeAssociations::Association> assocList = entry->autoTypeAssociations()->getAll();
         for (const AutoTypeAssociations::Association& assoc : assocList) {
-            if (windowMatches(windowTitle, assoc.window)) {
+            const QString window = entry->resolveMultiplePlaceholders(assoc.window);
+            if (windowMatches(windowTitle, window)) {
                 if (!assoc.sequence.isEmpty()) {
                     sequence = assoc.sequence;
                 }

--- a/src/gui/entry/AutoTypeAssociationsModel.cpp
+++ b/src/gui/entry/AutoTypeAssociationsModel.cpp
@@ -17,9 +17,12 @@
 
 #include "AutoTypeAssociationsModel.h"
 
+#include "core/Entry.h"
+
 AutoTypeAssociationsModel::AutoTypeAssociationsModel(QObject* parent)
     : QAbstractListModel(parent)
     , m_autoTypeAssociations(nullptr)
+    , m_entry(nullptr)
 {
 }
 
@@ -44,6 +47,11 @@ void AutoTypeAssociationsModel::setAutoTypeAssociations(AutoTypeAssociations* au
     }
 
     endResetModel();
+}
+
+void AutoTypeAssociationsModel::setEntry(const Entry *entry)
+{
+    m_entry = entry;
 }
 
 int AutoTypeAssociationsModel::rowCount(const QModelIndex& parent) const
@@ -86,7 +94,12 @@ QVariant AutoTypeAssociationsModel::data(const QModelIndex& index, int role) con
 
     if (role == Qt::DisplayRole) {
         if (index.column() == 0) {
-            return m_autoTypeAssociations->get(index.row()).window;
+            QString window = m_autoTypeAssociations->get(index.row()).window;
+            if (m_entry) {
+                window = m_entry->maskPasswordPlaceholders(window);
+                window = m_entry->resolveMultiplePlaceholders(window);
+            }
+            return window;
         }
         else {
             QString sequence = m_autoTypeAssociations->get(index.row()).sequence;

--- a/src/gui/entry/AutoTypeAssociationsModel.h
+++ b/src/gui/entry/AutoTypeAssociationsModel.h
@@ -19,10 +19,11 @@
 #define KEEPASSX_AUTOTYPEASSOCIATIONSMODEL_H
 
 #include <QAbstractListModel>
+#include <QPointer>
 
 #include "core/AutoTypeAssociations.h"
 
-class EntryAttributes;
+class Entry;
 
 class AutoTypeAssociationsModel : public QAbstractListModel
 {
@@ -31,6 +32,7 @@ class AutoTypeAssociationsModel : public QAbstractListModel
 public:
     explicit AutoTypeAssociationsModel(QObject* parent = nullptr);
     void setAutoTypeAssociations(AutoTypeAssociations* autoTypeAssociations);
+    void setEntry(const Entry* entry);
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
@@ -47,6 +49,7 @@ public slots:
 
 private:
     AutoTypeAssociations* m_autoTypeAssociations;
+    QPointer<const Entry> m_entry;
 };
 
 #endif // KEEPASSX_AUTOTYPEASSOCIATIONSMODEL_H

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -378,6 +378,7 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
     m_autoTypeUi->defaultWindowSequenceButton->setChecked(true);
     m_autoTypeUi->windowSequenceEdit->setText("");
     m_autoTypeAssoc->copyDataFrom(entry->autoTypeAssociations());
+    m_autoTypeAssocModel->setEntry(entry);
     if (m_autoTypeAssoc->size() != 0) {
         m_autoTypeUi->assocView->setCurrentIndex(m_autoTypeAssocModel->index(0, 0));
     }

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -96,6 +96,9 @@ void TestAutoType::init()
     m_entry4->setGroup(m_group);
     m_entry4->setPassword("custom_attr");
     m_entry4->attributes()->set("CUSTOM","Attribute",false);
+    m_entry4->attributes()->set("CustomAttrFirst","AttrValueFirst",false);
+    m_entry4->attributes()->set("CustomAttrSecond","AttrValueSecond",false);
+    m_entry4->attributes()->set("CustomAttrThird","AttrValueThird",false);
     association.window = "//^CustomAttr1$//";
     association.sequence = "{PASSWORD}:{S:CUSTOM}";
     m_entry4->autoTypeAssociations()->add(association);
@@ -105,7 +108,16 @@ void TestAutoType::init()
     association.window = "//^CustomAttr3$//";
     association.sequence = "{PaSSworD}";
     m_entry4->autoTypeAssociations()->add(association);
-    
+    association.window = "//^{S:CustomAttrFirst}$//";
+    association.sequence = "custom_attr_first";
+    m_entry4->autoTypeAssociations()->add(association);
+    association.window = "//{S:CustomAttrFirst}And{S:CustomAttrSecond}//";
+    association.sequence = "custom_attr_first_and_second";
+    m_entry4->autoTypeAssociations()->add(association);
+    association.window = "//{S:CustomAttrThird}//";
+    association.sequence = "custom_attr_third";
+    m_entry4->autoTypeAssociations()->add(association);
+
     m_entry5 = new Entry();
     m_entry5->setGroup(m_group);
     m_entry5->setPassword("example5");
@@ -252,5 +264,21 @@ void TestAutoType::testGlobalAutoTypeRegExp()
     m_test->setActiveWindowTitle("CustomAttr3");
     m_autoType->performGlobalAutoType(m_dbList);
     QCOMPARE(m_test->actionChars(), QString("custom_attr"));
+    m_test->clearActions();
+
+    // with resolve placeholders in window association title
+    m_test->setActiveWindowTitle("AttrValueFirst");
+    m_autoType->performGlobalAutoType(m_dbList);
+    QCOMPARE(m_test->actionChars(), QString("custom_attr_first"));
+    m_test->clearActions();
+
+    m_test->setActiveWindowTitle("lorem AttrValueFirstAndAttrValueSecond ipsum");
+    m_autoType->performGlobalAutoType(m_dbList);
+    QCOMPARE(m_test->actionChars(), QString("custom_attr_first_and_second"));
+    m_test->clearActions();
+
+    m_test->setActiveWindowTitle("lorem AttrValueThird ipsum");
+    m_autoType->performGlobalAutoType(m_dbList);
+    QCOMPARE(m_test->actionChars(), QString("custom_attr_third"));
     m_test->clearActions();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Allow to use entry placeholders in window association title

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This feature useful when we need to match window by some specific data (which not convenient to use as the name or the url), for example ip-address or mac-address, etc.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually, with using windows that do not contain name or url but contain value from the entry attribute.

## Screenshot:

![image](https://user-images.githubusercontent.com/3104366/31250606-fd1947b8-aa23-11e7-823f-3130c175f8a1.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- My change may require a change to the documentation.
