### PR TITLE
Fix macOS man path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ endif()
 
 if(APPLE AND WITH_APP_BUNDLE AND "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local")
   set(CMAKE_INSTALL_PREFIX "/Applications")
+  set(CMAKE_INSTALL_MANDIR "/usr/local/share/man")
 endif()
 
 if(MINGW)


### PR DESCRIPTION
## Description
Partially revert #981 on macOS when building with app bundle.

## Motivation and context
Cmake was trying to install the cli manpage at `/man1` because when `WITH_APP_BUNDLE` is set, `include(GNUInstallDirs)` isn't called to define the default manpage path.

## How has this been tested?
`man keepassxc-cli`

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**


