### PR TITLE
Add signtool function (Windows Only) to release-tool script

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -119,9 +119,11 @@ EOF
 Sign previously compiled release packages
 
 Options:
-  -f, --files       Files to sign (required)
-  -g, --gpg-key     GPG key used to sign the files (default: '${GPG_KEY}')
-  -h, --help        Show this help
+  -f, --files        Files to sign (required)
+  -g, --gpg-key      GPG key used to sign the files (default: '${GPG_KEY}')
+      --signtool     Specify the signtool executable (default: 'signtool')
+      --signtool-key Provide a key to be used with signtool (for Windows EXE)
+  -h, --help         Show this help
 EOF
     fi
 }
@@ -528,10 +530,10 @@ build() {
     checkWorkingTreeClean
 
     OUTPUT_DIR="$(realpath "$OUTPUT_DIR")"
-    
+
     logInfo "Checking out release tag '${TAG_NAME}'..."
     git checkout "$TAG_NAME"
-    
+
     logInfo "Creating output directory..."
     mkdir -p "$OUTPUT_DIR"
 
@@ -644,6 +646,8 @@ build() {
 # -----------------------------------------------------------------------
 sign() {
     SIGN_FILES=()
+    SIGNTOOL="signtool"
+    SIGNTOOL_KEY=""
     
     while [ $# -ge 1 ]; do
         local arg="$1"
@@ -656,6 +660,14 @@ sign() {
                 
             -g|--gpg-key)
                 GPG_KEY="$2"
+                shift ;;
+
+            --signtool)
+                SIGNTOOL="$2"
+                shift ;;
+
+            --signtool-key)
+                SIGNTOOL_KEY="$2"
                 shift ;;
             
             -h|--help)
@@ -675,13 +687,30 @@ sign() {
         printUsage "sign"
         exit 1
     fi
+
+    if [[ -n "$SIGNTOOL_KEY" && ! -f "$SIGNTOOL_KEY" ]]; then
+        exitError "Signtool Key was not found!"
+    elif [[ -f "$SIGNTOOL_KEY" && ! -x $(command -v "${SIGNTOOL}") ]]; then
+        exitError "signtool program not found on PATH!"
+    fi
     
     for f in "${SIGN_FILES[@]}"; do
         if [ ! -f "$f" ]; then
             exitError "File '${f}' does not exist!"
         fi
+
+        if [[ -n "$SIGNTOOL_KEY" && ${f: -4} == '.exe' ]]; then
+            logInfo "Signing file '${f}' using signtool...\n"
+            read -s -p "Signtool Key Password: " password
+            echo
+            "${SIGNTOOL}" sign -f "${SIGNTOOL_KEY}" -p ${password} -v -t http://timestamp.comodoca.com/authenticode ${f}
+
+            if [ 0 -ne $? ]; then
+                exitError "Signing failed!"
+            fi
+        fi
         
-        logInfo "Signing file '${f}'..."
+        logInfo "Signing file '${f}' using release key..."
         gpg --output "${f}.sig" --armor --local-user "$GPG_KEY" --detach-sig "$f"
         
         if [ 0 -ne $? ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Adds ability to use signtool program to sign windows binaries. Also added --ignore-repo option to the build function to allow building without being on a clean slate.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Full service signing on Windows.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
