### PR TITLE
Fixed old-style-cast warning in custom icon hasher

### DIFF
--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -454,7 +454,7 @@ void Metadata::copyCustomIcons(const QSet<Uuid>& iconList, const Metadata* other
 
 QByteArray Metadata::hashImage(const QImage& image)
 {
-    auto data = QByteArray((char*)image.bits(), image.byteCount());
+    auto data = QByteArray(reinterpret_cast<const char*>(image.bits()), image.byteCount());
     return QCryptographicHash::hash(data, QCryptographicHash::Md5);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
QByteArray only accepts char* and QImage::bits only outputs uchar*.... 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Warnings can lead to silent issues.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
