### PR TITLE
Fix builds in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,11 @@ RUN set -x \
 RUN set -x \
     && add-apt-repository ppa:george-edison55/cmake-3.x
 
+ENV QT_PPA=qt591
 ENV QT_VERSION=qt59
 
 RUN set -x \
-    && add-apt-repository --yes ppa:beineri/opt-${QT_VERSION}-trusty
+    && add-apt-repository --yes ppa:beineri/opt-${QT_PPA}-trusty
 
 
 RUN set -x \

--- a/release-tool
+++ b/release-tool
@@ -615,7 +615,7 @@ build() {
         logInfo "Launching Docker container to compile sources..."
         
         docker run --name "$DOCKER_CONTAINER_NAME" --rm \
-            --cap-add SYS_ADMIN --device /dev/fuse \
+            --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse \
             -e "CC=${CC}" -e "CXX=${CXX}" \
             -v "$(realpath "$SRC_DIR"):/keepassxc/src:ro" \
             -v "$(realpath "$OUTPUT_DIR"):/keepassxc/out:rw" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description

 - PPA qt59 no longer exists for 14.04, see https://launchpad.net/~beineri
 - On Ubuntu 16.04 host with docker 17.09.0-ce, I needed apparmor:unconfined to be able to use fuse - see https://github.com/moby/moby/issues/9448#issuecomment-289950103

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows Docker builds to work correctly (for me).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've tested this by creating my own appimage with `docker build -t keepassxc-build . && ./release-tool build --version 2.2.1 --no-source-tarball --plugins ''` (after commenting out the check for a clean git repo).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**

('REQUIRED' items talking about passing tests and ASAN were removed)