### PR TITLE
Both slots on Yubikey are now polled for challenge/response

### DIFF
--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -51,6 +51,7 @@ signals:
 
 protected:
     void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
     CompositeKey databaseKey();
 
 protected slots:
@@ -63,6 +64,7 @@ private slots:
     void activateChallengeResponse();
     void browseKeyFile();
     void yubikeyDetected(int slot, bool blocking);
+    void yubikeyDetectComplete();
     void noYubikeyFound();
 
 protected:

--- a/src/keys/drivers/YubiKey.h
+++ b/src/keys/drivers/YubiKey.h
@@ -88,6 +88,11 @@ signals:
     void detected(int slot, bool blocking);
 
     /**
+     * Emitted when detection is complete
+     */
+    void detectComplete();
+
+    /**
      * Emitted when the YubiKey was challenged and has returned a response.
      */
     void challenged();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #1045 

The previous implementation bailed after finding the first slot that was configured for challenge/response. In order to overcome some threading interchanges and Yubikey limitations the implementation was expanded to be far more robust.

Also, yubikey signals are disconnected from all the unlock widgets when they are hidden. The previous behavior caused all created unlock widgets (about 4-5 per open database) to be updated when the yubikey was polled.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually with Yubikey Neo

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
