### PR TITLE
Add auto hide functionality to inline message widget (#1006)

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1325,9 +1325,10 @@ void DatabaseWidget::closeUnlockDialog()
     m_unlockDatabaseDialog->close();
 }
 
-void DatabaseWidget::showMessage(const QString& text, MessageWidget::MessageType type)
+void DatabaseWidget::showMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton, int autoHideTimeout)
 {
-    m_messageWidget->showMessage(text, type);
+    m_messageWidget->setCloseButtonVisible(showClosebutton);
+    m_messageWidget->showMessage(text, type, autoHideTimeout);
 }
 
 void DatabaseWidget::hideMessage()

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -166,7 +166,8 @@ public slots:
     void setSearchLimitGroup(bool state);
     void endSearch();
 
-    void showMessage(const QString& text, MessageWidget::MessageType type);
+    void showMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton = true,
+                     int autoHideTimeout = MessageWidget::DefaultAutoHideTimeout);
     void hideMessage();
 
 private slots:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -952,16 +952,17 @@ bool MainWindow::isTrayIconEnabled() const
             && QSystemTrayIcon::isSystemTrayAvailable();
 }
 
-void MainWindow::displayGlobalMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton)
+void MainWindow::displayGlobalMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton,
+                                      int autoHideTimeout)
 {
     m_ui->globalMessageWidget->setCloseButtonVisible(showClosebutton);
-    m_ui->globalMessageWidget->showMessage(text, type);
+    m_ui->globalMessageWidget->showMessage(text, type, autoHideTimeout);
 }
 
-void MainWindow::displayTabMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton)
+void MainWindow::displayTabMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton,
+                                   int autoHideTimeout)
 {
-    m_ui->globalMessageWidget->setCloseButtonVisible(showClosebutton);
-    m_ui->tabWidget->currentDatabaseWidget()->showMessage(text, type);
+    m_ui->tabWidget->currentDatabaseWidget()->showMessage(text, type, showClosebutton, autoHideTimeout);
 }
 
 void MainWindow::hideGlobalMessage()
@@ -978,7 +979,8 @@ void MainWindow::hideTabMessage()
 
 void MainWindow::showYubiKeyPopup()
 {
-    displayGlobalMessage(tr("Please touch the button on your YubiKey!"), MessageWidget::Information, false);
+    displayGlobalMessage(tr("Please touch the button on your YubiKey!"), MessageWidget::Information,
+                         false, MessageWidget::DisableAutoHide);
     setEnabled(false);
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -54,8 +54,10 @@ public slots:
     void openDatabase(const QString& fileName, const QString& pw = QString(),
                       const QString& keyFile = QString());
     void appExit();
-    void displayGlobalMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton = true);
-    void displayTabMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton = true);
+    void displayGlobalMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton = true,
+                              int autoHideTimeout = MessageWidget::DefaultAutoHideTimeout);
+    void displayTabMessage(const QString& text, MessageWidget::MessageType type, bool showClosebutton = true,
+                           int autoHideTimeout = MessageWidget::DefaultAutoHideTimeout);
     void hideGlobalMessage();
     void showYubiKeyPopup();
     void hideYubiKeyPopup();

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -18,20 +18,50 @@
 
 #include "MessageWidget.h"
 
-MessageWidget::MessageWidget(QWidget* parent)
-    :KMessageWidget(parent)
-{
+#include "QTimer"
 
+MessageWidget::MessageWidget(QWidget* parent)
+    : KMessageWidget(parent)
+    , m_autoHideTimer(new QTimer(this))
+    , m_autoHideTimeout(6000)
+{
+    m_autoHideTimer->setSingleShot(true);
+    connect(m_autoHideTimer, SIGNAL(timeout()), this, SLOT(animatedHide()));
+    connect(this, SIGNAL(hideAnimationFinished()), m_autoHideTimer, SLOT(stop()));
+}
+
+int MessageWidget::autoHideTimeout() const
+{
+    return m_autoHideTimeout;
 }
 
 void MessageWidget::showMessage(const QString& text, MessageWidget::MessageType type)
 {
+    showMessage(text, type, m_autoHideTimeout);
+}
+
+void MessageWidget::showMessage(const QString &text, KMessageWidget::MessageType type, int autoHideTimeout)
+{
     setMessageType(type);
     setText(text);
     animatedShow();
+    if (autoHideTimeout > 0) {
+        m_autoHideTimer->start(autoHideTimeout);
+    } else {
+        m_autoHideTimer->stop();
+    }
 }
 
 void MessageWidget::hideMessage()
 {
     animatedHide();
+    m_autoHideTimer->stop();
+}
+
+void MessageWidget::setAutoHideTimeout(int autoHideTimeout)
+{
+    m_autoHideTimeout = autoHideTimeout;
+    if (autoHideTimeout <= 0) {
+        m_autoHideTimer->stop();
+    }
 }

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -20,10 +20,13 @@
 
 #include "QTimer"
 
+const int MessageWidget::DefaultAutoHideTimeout = 6000;
+const int MessageWidget::DisableAutoHide = -1;
+
 MessageWidget::MessageWidget(QWidget* parent)
     : KMessageWidget(parent)
     , m_autoHideTimer(new QTimer(this))
-    , m_autoHideTimeout(6000)
+    , m_autoHideTimeout(DefaultAutoHideTimeout)
 {
     m_autoHideTimer->setSingleShot(true);
     connect(m_autoHideTimer, SIGNAL(timeout()), this, SLOT(animatedHide()));

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -21,6 +21,8 @@
 
 #include "gui/KMessageWidget.h"
 
+class QTimer;
+
 class MessageWidget : public KMessageWidget
 {
     Q_OBJECT
@@ -28,10 +30,17 @@ class MessageWidget : public KMessageWidget
 public:
     explicit MessageWidget(QWidget* parent = 0);
 
+    int autoHideTimeout() const;
+
 public slots:
     void showMessage(const QString& text, MessageWidget::MessageType type);
+    void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);
     void hideMessage();
+    void setAutoHideTimeout(int autoHideTimeout);
 
+private:
+    QTimer* m_autoHideTimer;
+    int m_autoHideTimeout;
 };
 
 #endif // MESSAGEWIDGET_H

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -32,6 +32,9 @@ public:
 
     int autoHideTimeout() const;
 
+    static const int DefaultAutoHideTimeout;
+    static const int DisableAutoHide;
+
 public slots:
     void showMessage(const QString& text, MessageWidget::MessageType type);
     void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);

--- a/src/http/OptionDialog.cpp
+++ b/src/http/OptionDialog.cpp
@@ -35,7 +35,7 @@ OptionDialog::OptionDialog(QWidget *parent) :
     m_ui->warningWidget->showMessage(tr("The following options can be dangerous!\nChange them only if you know what you are doing."), MessageWidget::Warning);
     m_ui->warningWidget->setIcon(FilePath::instance()->icon("status", "dialog-warning"));
     m_ui->warningWidget->setCloseButtonVisible(false);
-    m_ui->warningWidget->setAutoHideTimeout(-1);
+    m_ui->warningWidget->setAutoHideTimeout(MessageWidget::DisableAutoHide);
 
     m_ui->tabWidget->setEnabled(m_ui->enableHttpServer->isChecked());
     connect(m_ui->enableHttpServer, SIGNAL(toggled(bool)), m_ui->tabWidget, SLOT(setEnabled(bool)));

--- a/src/http/OptionDialog.cpp
+++ b/src/http/OptionDialog.cpp
@@ -35,6 +35,7 @@ OptionDialog::OptionDialog(QWidget *parent) :
     m_ui->warningWidget->showMessage(tr("The following options can be dangerous!\nChange them only if you know what you are doing."), MessageWidget::Warning);
     m_ui->warningWidget->setIcon(FilePath::instance()->icon("status", "dialog-warning"));
     m_ui->warningWidget->setCloseButtonVisible(false);
+    m_ui->warningWidget->setAutoHideTimeout(-1);
 
     m_ui->tabWidget->setEnabled(m_ui->enableHttpServer->isChecked());
     connect(m_ui->enableHttpServer, SIGNAL(toggled(bool)), m_ui->tabWidget, SLOT(setEnabled(bool)));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Add ability to hide inline message widget after a set period of time (#1006)

## Description
<!--- Describe your changes in detail -->
Done: 

- Add the auto hide functionality to the KMessageWidget class
- Add ability to change the auto-hide settings for inline messages via gui

Possible improvements:

- Display the time through which the message will be closed 
- Change the default setting (currently auto-hide disabled by default)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix opened issue #1006 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually

## Screenshots (if appropriate):

![add-auto-hide-functionality-to-inline-message-widget](https://user-images.githubusercontent.com/3104366/31438734-0d4caec8-ae92-11e7-9286-9ddd9d5932c3.gif)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
