### PR TITLE
Extend the .gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ release*/
 
 \.vscode/
 *.swp
+
+.DS_Store


### PR DESCRIPTION
## Description
Adds a new item to the `.gitignore` list so that `.DS_Store` files are ignored.

## Motivation and context
Currently, an ignore item for `.DS_Store` files created by Finder in Mac OS is missing from the list.

## How has this been tested?
N/A.

## Screenshots (if appropriate):
N/A.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
N/A.
