### PR TITLE
Don't build qhttp unless it's used.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -178,8 +178,8 @@ add_feature_info(AutoType WITH_XC_AUTOTYPE "Automatic password typing")
 add_feature_info(KeePassHTTP WITH_XC_HTTP "Browser integration compatible with ChromeIPass and PassIFox")
 add_feature_info(YubiKey WITH_XC_YUBIKEY "YubiKey HMAC-SHA1 challenge-response")
 
-add_subdirectory(http)
 if(WITH_XC_HTTP)
+    add_subdirectory(http)
     set(keepasshttp_LIB keepasshttp qhttp Qt5::Network)
 endif()
 

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -1,19 +1,17 @@
 add_subdirectory(qhttp)
 
-if(WITH_XC_HTTP)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-    
-    set(keepasshttp_SOURCES
-        AccessControlDialog.cpp
-        EntryConfig.cpp
-        HttpPasswordGeneratorWidget.cpp
-        HttpSettings.cpp
-        OptionDialog.cpp
-        Protocol.cpp
-        Server.cpp
-        Service.cpp
-    )
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-    add_library(keepasshttp STATIC ${keepasshttp_SOURCES})
-    target_link_libraries(keepasshttp qhttp Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Network)
-endif()
+set(keepasshttp_SOURCES
+    AccessControlDialog.cpp
+    EntryConfig.cpp
+    HttpPasswordGeneratorWidget.cpp
+    HttpSettings.cpp
+    OptionDialog.cpp
+    Protocol.cpp
+    Server.cpp
+    Service.cpp
+)
+
+add_library(keepasshttp STATIC ${keepasshttp_SOURCES})
+target_link_libraries(keepasshttp qhttp Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Network)


### PR DESCRIPTION
Not building qhttp unless it's used helps to ensure that it's not accidentally linked into application unless the feature is enabled. And it also slightly improves build time.

## How has this been tested?
Compared build logs of local build with and without this change and with http features being disabled. Before change build logs contain over 400 mentions of qhttp, after change logs contain only 2 mentions: cmake command line and a message about disabled feature.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
