### PR TITLE
Add support for placeholders on the KeePassHTTP custom fields (#1067)

### DIFF
--- a/src/http/Service.cpp
+++ b/src/http/Service.cpp
@@ -259,13 +259,16 @@ Service::Access Service::checkAccess(const Entry *entry, const QString & host, c
 
 KeepassHttpProtocol::Entry Service::prepareEntry(const Entry* entry)
 {
-    KeepassHttpProtocol::Entry res(entry->resolvePlaceholder(entry->title()), entry->resolvePlaceholder(entry->username()), entry->resolvePlaceholder(entry->password()), entry->uuid().toHex());
+    KeepassHttpProtocol::Entry res(entry->resolveMultiplePlaceholders(entry->title()),
+                                   entry->resolveMultiplePlaceholders(entry->username()),
+                                   entry->resolveMultiplePlaceholders(entry->password()),
+                                   entry->uuid().toHex());
     if (HttpSettings::supportKphFields()) {
         const EntryAttributes * attr = entry->attributes();
         const auto keys = attr->keys();
         for (const QString& key: keys) {
             if (key.startsWith(QLatin1String("KPH: "))) {
-                res.addStringField(key, attr->value(key));
+                res.addStringField(key, entry->resolveMultiplePlaceholders(attr->value(key)));
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Add support for placeholders on the KeePassHTTP custom fields (#1067)

## Description
<!--- Describe your changes in detail -->
Changes: 

- Function Entry::resolvePlaceholder recognize {TOTP} placeholder 
- KeepassHttpProtocol::Server::prepareEntry use Entry::resolveMultiplePlaceholders for resolving placeholders on custom fields 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fix opened issue #1067

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually via chromeIPass extension

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**