### PR TITLE
Implement recursive resolving for placeholders

### DIFF
--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -134,6 +134,21 @@ public:
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 
+    enum class UrlPlaceholderType {
+        NotUrl,
+        FullUrl,
+        WithoutScheme,
+        Scheme,
+        Host,
+        Port,
+        Path,
+        Query,
+        Fragment,
+        UserInfo,
+        UserName,
+        Password,
+    };
+
     /**
      * Creates a duplicate of this entry except that the returned entry isn't
      * part of any group.
@@ -145,6 +160,8 @@ public:
     QString maskPasswordPlaceholders(const QString& str) const;
     QString resolveMultiplePlaceholders(const QString& str) const;
     QString resolvePlaceholder(const QString& str) const;
+    QString resolveUrlPlaceholder(const QString& url, UrlPlaceholderType placeholderType) const;
+    UrlPlaceholderType urlPlaceholderType(const QString& placeholder) const;
     QString resolveUrl(const QString& url) const;
 
     /**

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -134,19 +134,27 @@ public:
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 
-    enum class UrlPlaceholderType {
-        NotUrl,
-        FullUrl,
-        WithoutScheme,
-        Scheme,
-        Host,
-        Port,
-        Path,
-        Query,
-        Fragment,
-        UserInfo,
+    enum class PlaceholderType {
+        NotPlaceholder,
+        Unknown,
+        Title,
         UserName,
         Password,
+        Notes,
+        Totp,
+        Url,
+        UrlWithoutScheme,
+        UrlScheme,
+        UrlHost,
+        UrlPort,
+        UrlPath,
+        UrlQuery,
+        UrlFragment,
+        UrlUserInfo,
+        UrlUserName,
+        UrlPassword,
+        Reference,
+        CustomAttribute
     };
 
     /**
@@ -160,8 +168,8 @@ public:
     QString maskPasswordPlaceholders(const QString& str) const;
     QString resolveMultiplePlaceholders(const QString& str) const;
     QString resolvePlaceholder(const QString& str) const;
-    QString resolveUrlPlaceholder(const QString& url, UrlPlaceholderType placeholderType) const;
-    UrlPlaceholderType urlPlaceholderType(const QString& placeholder) const;
+    QString resolveUrlPlaceholder(PlaceholderType placeholderType) const;
+    PlaceholderType placeholderType(const QString& placeholder) const;
     QString resolveUrl(const QString& url) const;
 
     /**

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -96,6 +96,7 @@ public:
     const EntryAttachments* attachments() const;
 
     static const int DefaultIconNumber;
+    static const int ResolveMaximumDepth;
 
     void setUuid(const Uuid& uuid);
     void setIcon(int iconNumber);
@@ -168,7 +169,7 @@ public:
     QString maskPasswordPlaceholders(const QString& str) const;
     QString resolveMultiplePlaceholders(const QString& str) const;
     QString resolvePlaceholder(const QString& str) const;
-    QString resolveUrlPlaceholder(PlaceholderType placeholderType) const;
+    QString resolveUrlPlaceholder(const QString &str, PlaceholderType placeholderType) const;
     PlaceholderType placeholderType(const QString& placeholder) const;
     QString resolveUrl(const QString& url) const;
 
@@ -199,6 +200,9 @@ private slots:
     void updateModifiedSinceBegin();
 
 private:
+    QString resolveMultiplePlaceholdersRecursive(const QString& str, int maxDepth) const;
+    QString resolvePlaceholderRecursive(const QString& placeholder, int maxDepth) const;
+
     const Database* database() const;
     template <class T> bool set(T& property, const T& value);
 

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -158,3 +158,35 @@ void TestEntry::testResolveUrl()
 
     delete entry;
 }
+
+void TestEntry::testResolveUrlPlaceholders()
+{
+    Entry* entry = new Entry();
+    entry->setUrl("https://user:pw@keepassxc.org:80/path/example.php?q=e&s=t+2#fragment");
+
+    QString rmvscm("//user:pw@keepassxc.org:80/path/example.php?q=e&s=t+2#fragment"); // Entry URL without scheme name.
+    QString scm("https"); // Scheme name of the entry URL.
+    QString host("keepassxc.org"); // Host component of the entry URL.
+    QString port("80"); // Port number of the entry URL.
+    QString path("/path/example.php"); // Path component of the entry URL.
+    QString query("q=e&s=t+2"); // Query information of the entry URL.
+    QString userinfo("user:pw"); // User information of the entry URL.
+    QString username("user"); // User name of the entry URL.
+    QString password("pw"); // Password of the entry URL.
+    QString fragment("fragment"); // Password of the entry URL.
+
+    QCOMPARE(entry->resolvePlaceholder("{URL:RMVSCM}"), rmvscm);
+    QCOMPARE(entry->resolvePlaceholder("{URL:WITHOUTSCHEME}"), rmvscm);
+    QCOMPARE(entry->resolvePlaceholder("{URL:SCM}"), scm);
+    QCOMPARE(entry->resolvePlaceholder("{URL:SCHEME}"), scm);
+    QCOMPARE(entry->resolvePlaceholder("{URL:HOST}"), host);
+    QCOMPARE(entry->resolvePlaceholder("{URL:PORT}"), port);
+    QCOMPARE(entry->resolvePlaceholder("{URL:PATH}"), path);
+    QCOMPARE(entry->resolvePlaceholder("{URL:QUERY}"), query);
+    QCOMPARE(entry->resolvePlaceholder("{URL:USERINFO}"), userinfo);
+    QCOMPARE(entry->resolvePlaceholder("{URL:USERNAME}"), username);
+    QCOMPARE(entry->resolvePlaceholder("{URL:PASSWORD}"), password);
+    QCOMPARE(entry->resolvePlaceholder("{URL:FRAGMENT}"), fragment);
+
+    delete entry;
+}

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -20,7 +20,9 @@
 
 #include <QTest>
 
+#include "core/Database.h"
 #include "core/Entry.h"
+#include "core/Group.h"
 #include "crypto/Crypto.h"
 
 QTEST_GUILESS_MAIN(TestEntry)
@@ -161,8 +163,8 @@ void TestEntry::testResolveUrl()
 
 void TestEntry::testResolveUrlPlaceholders()
 {
-    Entry* entry = new Entry();
-    entry->setUrl("https://user:pw@keepassxc.org:80/path/example.php?q=e&s=t+2#fragment");
+    Entry entry;
+    entry.setUrl("https://user:pw@keepassxc.org:80/path/example.php?q=e&s=t+2#fragment");
 
     QString rmvscm("//user:pw@keepassxc.org:80/path/example.php?q=e&s=t+2#fragment"); // Entry URL without scheme name.
     QString scm("https"); // Scheme name of the entry URL.
@@ -173,20 +175,90 @@ void TestEntry::testResolveUrlPlaceholders()
     QString userinfo("user:pw"); // User information of the entry URL.
     QString username("user"); // User name of the entry URL.
     QString password("pw"); // Password of the entry URL.
-    QString fragment("fragment"); // Password of the entry URL.
+    QString fragment("fragment"); // Fragment of the entry URL.
 
-    QCOMPARE(entry->resolvePlaceholder("{URL:RMVSCM}"), rmvscm);
-    QCOMPARE(entry->resolvePlaceholder("{URL:WITHOUTSCHEME}"), rmvscm);
-    QCOMPARE(entry->resolvePlaceholder("{URL:SCM}"), scm);
-    QCOMPARE(entry->resolvePlaceholder("{URL:SCHEME}"), scm);
-    QCOMPARE(entry->resolvePlaceholder("{URL:HOST}"), host);
-    QCOMPARE(entry->resolvePlaceholder("{URL:PORT}"), port);
-    QCOMPARE(entry->resolvePlaceholder("{URL:PATH}"), path);
-    QCOMPARE(entry->resolvePlaceholder("{URL:QUERY}"), query);
-    QCOMPARE(entry->resolvePlaceholder("{URL:USERINFO}"), userinfo);
-    QCOMPARE(entry->resolvePlaceholder("{URL:USERNAME}"), username);
-    QCOMPARE(entry->resolvePlaceholder("{URL:PASSWORD}"), password);
-    QCOMPARE(entry->resolvePlaceholder("{URL:FRAGMENT}"), fragment);
+    QCOMPARE(entry.resolvePlaceholder("{URL:RMVSCM}"), rmvscm);
+    QCOMPARE(entry.resolvePlaceholder("{URL:WITHOUTSCHEME}"), rmvscm);
+    QCOMPARE(entry.resolvePlaceholder("{URL:SCM}"), scm);
+    QCOMPARE(entry.resolvePlaceholder("{URL:SCHEME}"), scm);
+    QCOMPARE(entry.resolvePlaceholder("{URL:HOST}"), host);
+    QCOMPARE(entry.resolvePlaceholder("{URL:PORT}"), port);
+    QCOMPARE(entry.resolvePlaceholder("{URL:PATH}"), path);
+    QCOMPARE(entry.resolvePlaceholder("{URL:QUERY}"), query);
+    QCOMPARE(entry.resolvePlaceholder("{URL:USERINFO}"), userinfo);
+    QCOMPARE(entry.resolvePlaceholder("{URL:USERNAME}"), username);
+    QCOMPARE(entry.resolvePlaceholder("{URL:PASSWORD}"), password);
+    QCOMPARE(entry.resolvePlaceholder("{URL:FRAGMENT}"), fragment);
+}
 
-    delete entry;
+void TestEntry::testResolveRecursivePlaceholders()
+{
+    Database db;
+    Group* root = db.rootGroup();
+
+    Entry* entry1 = new Entry();
+    entry1->setGroup(root);
+    entry1->setUuid(Uuid::random());
+    entry1->setTitle("{USERNAME}");
+    entry1->setUsername("{PASSWORD}");
+    entry1->setPassword("{URL}");
+    entry1->setUrl("{S:CustomTitle}");
+    entry1->attributes()->set("CustomTitle", "RecursiveValue");
+    QCOMPARE(entry1->resolveMultiplePlaceholders(entry1->title()), QString("RecursiveValue"));
+
+    Entry* entry2 = new Entry();
+    entry2->setGroup(root);
+    entry2->setUuid(Uuid::random());
+    entry2->setTitle("Entry2Title");
+    entry2->setUsername("{S:CustomUserNameAttribute}");
+    entry2->setPassword(QString("{REF:P@I:%1}").arg(entry1->uuid().toHex()));
+    entry2->setUrl("http://{S:IpAddress}:{S:Port}/{S:Uri}");
+    entry2->attributes()->set("CustomUserNameAttribute", "CustomUserNameValue");
+    entry2->attributes()->set("IpAddress", "127.0.0.1");
+    entry2->attributes()->set("Port", "1234");
+    entry2->attributes()->set("Uri", "uri/path");
+
+    Entry* entry3 = new Entry();
+    entry3->setGroup(root);
+    entry3->setUuid(Uuid::random());
+    entry3->setTitle(QString("{REF:T@I:%1}").arg(entry2->uuid().toHex()));
+    entry3->setUsername(QString("{REF:U@I:%1}").arg(entry2->uuid().toHex()));
+    entry3->setPassword(QString("{REF:P@I:%1}").arg(entry2->uuid().toHex()));
+    entry3->setUrl(QString("{REF:A@I:%1}").arg(entry2->uuid().toHex()));
+
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->title()), QString("Entry2Title"));
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->username()), QString("CustomUserNameValue"));
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->password()), QString("RecursiveValue"));
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->url()), QString("http://127.0.0.1:1234/uri/path"));
+
+    Entry* entry4 = new Entry();
+    entry4->setGroup(root);
+    entry4->setUuid(Uuid::random());
+    entry4->setTitle(QString("{REF:T@I:%1}").arg(entry3->uuid().toHex()));
+    entry4->setUsername(QString("{REF:U@I:%1}").arg(entry3->uuid().toHex()));
+    entry4->setPassword(QString("{REF:P@I:%1}").arg(entry3->uuid().toHex()));
+    entry4->setUrl(QString("{REF:A@I:%1}").arg(entry3->uuid().toHex()));
+
+    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->title()), QString("Entry2Title"));
+    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->username()), QString("CustomUserNameValue"));
+    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->password()), QString("RecursiveValue"));
+    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->url()), QString("http://127.0.0.1:1234/uri/path"));
+
+    Entry* entry5 = new Entry();
+    entry5->setGroup(root);
+    entry5->setUuid(Uuid::random());
+    entry5->attributes()->set("Scheme", "http");
+    entry5->attributes()->set("Host", "host.org");
+    entry5->attributes()->set("Port", "2017");
+    entry5->attributes()->set("Path", "/some/path");
+    entry5->attributes()->set("UserName", "username");
+    entry5->attributes()->set("Password", "password");
+    entry5->attributes()->set("Query", "q=e&t=s");
+    entry5->attributes()->set("Fragment", "fragment");
+    entry5->setUrl("{S:Scheme}://{S:UserName}:{S:Password}@{S:Host}:{S:Port}{S:Path}?{S:Query}#{S:Fragment}");
+    entry5->setTitle("title+{URL:Path}+{URL:Fragment}+title");
+
+    const QString url("http://username:password@host.org:2017/some/path?q=e&t=s#fragment");
+    QCOMPARE(entry5->resolveMultiplePlaceholders(entry5->url()), url);
+    QCOMPARE(entry5->resolveMultiplePlaceholders(entry5->title()), QString("title+/some/path+fragment+title"));
 }

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -32,6 +32,7 @@ private slots:
     void testCopyDataFrom();
     void testClone();
     void testResolveUrl();
+    void testResolveUrlPlaceholders();
 };
 
 #endif // KEEPASSX_TESTENTRY_H

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -33,6 +33,7 @@ private slots:
     void testClone();
     void testResolveUrl();
     void testResolveUrlPlaceholders();
+    void testResolveRecursivePlaceholders();
 };
 
 #endif // KEEPASSX_TESTENTRY_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Implement recursive resolving for placeholders

## Description
<!--- Describe your changes in detail -->

### Recursive resolving for placeholders 

From keepass [help](https://keepass.info/help/base/fieldrefs.html): 

> Referencing fields of other entries only works with standard fields, not with custom user strings. If you want to reference a custom user string, you need to place a redirection in a standard field of the entry with the custom string, using {S:<Name>}, and reference the standard field.

Currently KeePassXC does not support the described behavior.

### Add support for {URL:Placeholders} 

URL placeholders: 

- {URL:RMVSCM}
- {URL:WITHOUTSCHEME} - analog for {URL:RMVSCM}
- {URL:SCM} 
- {URL:SCHEME}  - analog for {URL:SCM}
- {URL:HOST}
- {URL:PORT}
- {URL:PATH}
- {URL:QUERY}
- {URL:FRAGMENT} - new url placeholder
- {URL:USERINFO}
- {URL:USERNAME}
- {URL:PASSWORD}

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Implement behavior similar to keepass2

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With unit test, TestEntry class.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/3104366/31607286-73d059de-b274-11e7-8899-7dd6e0457301.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation.
- ✅ I have added tests to cover my changes.
