### PR TITLE
Fix AppImage not detecting YubiKey and add support for keepassxc-cli to AppImages

### DIFF
--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -74,7 +74,6 @@ get_desktop
 get_icon
 cat << EOF > ./usr/bin/keepassxc_env
 #!/usr/bin/env bash
-#export QT_QPA_PLATFORMTHEME=gtk2
 export LD_LIBRARY_PATH="..$(dirname ${QT_PLUGIN_PATH})/lib:\${LD_LIBRARY_PATH}"
 export QT_PLUGIN_PATH="..${QT_PLUGIN_PATH}:\${KPXC_QT_PLUGIN_PATH}"
 
@@ -85,7 +84,7 @@ unset XDG_DATA_DIRS
 exec keepassxc "\$@"
 EOF
 chmod +x ./usr/bin/keepassxc_env
-sed -i 's/Exec=keepassxc/Exec=keepassxc_env/' keepassxc.desktop
+sed -i 's/Exec=keepassxc/Exec=keepassxc_env/' org.keepassxc.desktop
 get_desktopintegration $LOWERAPP
 
 GLIBC_NEEDED=$(glibc_needed)
@@ -94,5 +93,5 @@ cd ..
 
 generate_type2_appimage
 
-mv ../out/*.AppImage ..
+mv ../out/*.AppImage ../KeePassXC-${VERSION}-${ARCH}.AppImage
 rmdir ../out > /dev/null 2>&1

--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -34,6 +34,7 @@ fi
 APP="$1"
 LOWERAPP="$(echo "$APP" | tr '[:upper:]' '[:lower:]')"
 VERSION="$2"
+export ARCH=x86_64
 
 mkdir -p $APP.AppDir
 wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
@@ -42,6 +43,8 @@ wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./func
 LIB_DIR=./usr/lib
 if [ -d ./usr/lib/x86_64-linux-gnu ]; then
     LIB_DIR=./usr/lib/x86_64-linux-gnu
+elif [ -d ./usr/lib64 ]; then
+    LIB_DIR=./usr/lib64
 fi
 
 cd $APP.AppDir
@@ -51,7 +54,7 @@ rm -R ./usr/local
 rmdir ./opt 2> /dev/null
 
 # bundle Qt platform plugins and themes
-QXCB_PLUGIN="$(find /usr/lib -name 'libqxcb.so' 2> /dev/null)"
+QXCB_PLUGIN="$(find /usr/lib* -name 'libqxcb.so' 2> /dev/null)"
 if [ "$QXCB_PLUGIN" == "" ]; then
     QXCB_PLUGIN="$(find /opt/qt*/plugins -name 'libqxcb.so' 2> /dev/null)"
 fi

--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -78,10 +78,15 @@ export LD_LIBRARY_PATH="..$(dirname ${QT_PLUGIN_PATH})/lib:\${LD_LIBRARY_PATH}"
 export QT_PLUGIN_PATH="..${QT_PLUGIN_PATH}:\${KPXC_QT_PLUGIN_PATH}"
 
 # unset XDG_DATA_DIRS to make tray icon work in Ubuntu Unity
-# see https://github.com/probonopd/AppImageKit/issues/351
+# see https://github.com/AppImage/AppImageKit/issues/351
 unset XDG_DATA_DIRS
 
-exec keepassxc "\$@"
+if [ "\${1}" == "cli" ]; then
+    shift
+    exec keepassxc-cli "\$@"
+else
+    exec keepassxc "\$@"
+fi
 EOF
 chmod +x ./usr/bin/keepassxc_env
 sed -i 's/Exec=keepassxc/Exec=keepassxc_env/' org.keepassxc.desktop

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,50 +14,68 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-FROM ubuntu:14.04
+FROM centos:7
 
 RUN set -x \
-    && apt-get update \
-    && apt-get install --yes software-properties-common
+    && curl "https://copr.fedorainfracloud.org/coprs/bugzy/keepassxc/repo/epel-7/bugzy-keepassxc-epel-7.repo" \
+        > /etc/yum.repos.d/bugzy-keepassxc-epel-7.repo
 
 RUN set -x \
-    && add-apt-repository ppa:george-edison55/cmake-3.x
-
-ENV QT_PPA=qt591
-ENV QT_VERSION=qt59
+    && curl "https://copr.fedorainfracloud.org/coprs/sic/backports/repo/epel-7/sic-backports-epel-7.repo" \
+        > /etc/yum.repos.d/sic-backports-epel-7.repo
 
 RUN set -x \
-    && add-apt-repository --yes ppa:beineri/opt-${QT_PPA}-trusty
+    && yum clean -y all \
+    && yum upgrade -y
 
-
+# build and runtime dependencies
 RUN set -x \
-    && apt-get update \
-    && apt-get install --yes \
-        g++ \
+    && yum install -y \
+        make \
+        automake \
+        gcc-c++ \
         cmake \
-        libgcrypt20-dev \
-        ${QT_VERSION}base \
-        ${QT_VERSION}tools \
-        ${QT_VERSION}x11extras \
-        libxi-dev \
-        libxtst-dev \
-        zlib1g-dev \
-        libyubikey-dev \
-        libykpers-1-dev \
-        xvfb \
-        wget \
-        file \
-        fuse \
-        python
+        libgcrypt16-devel \
+        qt5-qtbase-devel \
+        qt5-linguist \
+        qt5-qttools \
+        zlib-devel \
+        qt5-qtx11extras \
+        qt5-qtx11extras-devel \
+        libXi-devel \
+        libXtst-devel
 
+# AppImage dependencies
 RUN set -x \
-    && apt-get install --yes mesa-common-dev
-        
+    && yum install -y \
+        wget \
+        fuse-libs
+
+# build libyubikey
+ENV YUBIKEY_VERSION=1.13
+RUN set -x && yum install -y libusb-devel
+RUN set -x \
+    && wget "https://developers.yubico.com/yubico-c/Releases/libyubikey-${YUBIKEY_VERSION}.tar.gz" \
+    && tar xf libyubikey-${YUBIKEY_VERSION}.tar.gz \
+    && cd libyubikey-${YUBIKEY_VERSION} \
+    && ./configure --prefix=/usr --libdir=/usr/lib64 \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -Rf libyubikey-${YUBIKEY_VERSION}*
+
+# build libykpers-1
+ENV YKPERS_VERSION=1.18.0
+RUN set -x \
+    && wget "https://developers.yubico.com/yubikey-personalization/Releases/ykpers-${YKPERS_VERSION}.tar.gz" \
+    && tar xf ykpers-${YKPERS_VERSION}.tar.gz \
+    && cd ykpers-${YKPERS_VERSION} \
+    && ./configure --prefix=/usr --libdir=/usr/lib64 \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -Rf ykpers-${YKPERS_VERSION}*
+
 VOLUME /keepassxc/src
 VOLUME /keepassxc/out
 WORKDIR /keepassxc
-
-ENV CMAKE_PREFIX_PATH=/opt/${QT_VERSION}/lib/cmake
-ENV LD_LIBRARY_PATH=/opt/${QT_VERSION}/lib
-RUN set -x \
-    && echo /opt/${QT_VERSION}/lib > /etc/ld.so.conf.d/${QT_VERSION}.conf

--- a/share/linux/org.keepassxc.desktop
+++ b/share/linux/org.keepassxc.desktop
@@ -12,5 +12,5 @@ Icon=keepassxc
 Terminal=false
 Type=Application
 Version=1.0
-Categories=Utility;Security;Qt
+Categories=Utility;Security;Qt;
 MimeType=application/x-keepass2;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #1034.

This patch migrates our Docker build system from Ubuntu 14.04 to CentOS, uses custom builds of libyubikey and libykpers-1 and adds the ability to call keepassxc-cli inside an AppImage by using a "cli" argument.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previous AppImage releases were unable to detect a plugged-in YubiKey and were also unable to directly start keepassxc-cli.
In addition, Ubuntu 14.04 is EOL while CentOS 7, whose first release was also in 2014, is still supported until 2024. In addition to that, we needed a lot of PPAs, because many packages were quite outdated, including Qt itself. The new Dockerfile reduces the number of non-official dependencies (at least when this issue is closed: https://github.com/bugzy/keepassxc-rpm-spec/issues/6). With it comes a Qt downgrade to 5.6, but that is still newer than Trusty's 5.2.
I hope, we don't lose too much compatibility by using a slightly newer base system.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
AppImage runs and detects my YubiKey. With the "cli" argument, it starts keepassxc-cli instead of keepassxc.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
