### PR TITLE
Reduce external dependencies and install YubiKey deps from EPEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,8 @@ RUN set -x \
         > /etc/yum.repos.d/bugzy-keepassxc-epel-7.repo
 
 RUN set -x \
-    && curl "https://copr.fedorainfracloud.org/coprs/sic/backports/repo/epel-7/sic-backports-epel-7.repo" \
-        > /etc/yum.repos.d/sic-backports-epel-7.repo
-
-RUN set -x \
     && yum clean -y all \
+    && yum install -y epel-release \
     && yum upgrade -y
 
 # build and runtime dependencies
@@ -34,7 +31,7 @@ RUN set -x \
         make \
         automake \
         gcc-c++ \
-        cmake \
+        cmake3 \
         libgcrypt16-devel \
         qt5-qtbase-devel \
         qt5-linguist \
@@ -43,7 +40,9 @@ RUN set -x \
         qt5-qtx11extras \
         qt5-qtx11extras-devel \
         libXi-devel \
-        libXtst-devel
+        libXtst-devel \
+        libyubikey-devel \
+        ykpers-devel
 
 # AppImage dependencies
 RUN set -x \
@@ -51,30 +50,8 @@ RUN set -x \
         wget \
         fuse-libs
 
-# build libyubikey
-ENV YUBIKEY_VERSION=1.13
-RUN set -x && yum install -y libusb-devel
 RUN set -x \
-    && wget "https://developers.yubico.com/yubico-c/Releases/libyubikey-${YUBIKEY_VERSION}.tar.gz" \
-    && tar xf libyubikey-${YUBIKEY_VERSION}.tar.gz \
-    && cd libyubikey-${YUBIKEY_VERSION} \
-    && ./configure --prefix=/usr --libdir=/usr/lib64 \
-    && make \
-    && make install \
-    && cd .. \
-    && rm -Rf libyubikey-${YUBIKEY_VERSION}*
-
-# build libykpers-1
-ENV YKPERS_VERSION=1.18.0
-RUN set -x \
-    && wget "https://developers.yubico.com/yubikey-personalization/Releases/ykpers-${YKPERS_VERSION}.tar.gz" \
-    && tar xf ykpers-${YKPERS_VERSION}.tar.gz \
-    && cd ykpers-${YKPERS_VERSION} \
-    && ./configure --prefix=/usr --libdir=/usr/lib64 \
-    && make \
-    && make install \
-    && cd .. \
-    && rm -Rf ykpers-${YKPERS_VERSION}*
+    && ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 VOLUME /keepassxc/src
 VOLUME /keepassxc/out


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Shorten Dockerfile and reduce number of Copr repositories.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our new CentOS 7 Dockerfile can be reduced even further by pulling cmake3, libyubikey and libykpers-1 from CentOS/Fedora EPEL. This reduces the number of required external repositories even further and we also don't need to build the YubiKey libs ourselves anymore.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
AppImage build still working, YubiKey also detected successfully at runtime.
## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**