### PR TITLE
Move build system back to Trusty (with fixes)

### DIFF
--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -85,8 +85,8 @@ else
 fi
 EOF
 chmod +x ./usr/bin/keepassxc_env
-sed -i 's/Exec=keepassxc/Exec=keepassxc_env/' org.keepassxc.desktop
-get_desktopintegration $LOWERAPP
+sed -i 's/Exec=keepassxc/Exec=keepassxc_env/' org.${LOWERAPP}.desktop
+get_desktopintegration "org.${LOWERAPP}"
 
 GLIBC_NEEDED=$(glibc_needed)
 

--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -66,10 +66,6 @@ get_apprun
 copy_deps
 delete_blacklisted
 
-# remove dbus and systemd libs as they are not blacklisted
-find . -name libdbus-1.so.3 -exec rm {} \;
-find . -name libsystemd.so.0 -exec rm {} \;
-
 get_desktop
 get_icon
 cat << EOF > ./usr/bin/keepassxc_env

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,51 +14,54 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-FROM centos:7
+FROM ubuntu:14.04
+
+ENV QT5_VERSION=59
+ENV QT5_PPA_VERSION=${QT5_VERSION}2
 
 RUN set -x \
-    && curl "https://copr.fedorainfracloud.org/coprs/bugzy/keepassxc/repo/epel-7/bugzy-keepassxc-epel-7.repo" \
-        > /etc/yum.repos.d/bugzy-keepassxc-epel-7.repo
+    && apt-get update -y \
+    && apt-get -y install software-properties-common
 
 RUN set -x \
-    && curl "https://copr.fedorainfracloud.org/coprs/sic/backports/repo/epel-7/sic-backports-epel-7.repo" \
-        > /etc/yum.repos.d/sic-backports-epel-7.repo
+    && add-apt-repository ppa:beineri/opt-qt${QT5_PPA_VERSION}-trusty
 
 RUN set -x \
-    && yum clean -y all \
-    && yum upgrade -y
+    && apt-get update -y \
+    && apt-get upgrade -y
 
 # build and runtime dependencies
 RUN set -x \
-    && yum install -y \
-        make \
-        automake \
-        gcc-c++ \
-        cmake \
-        libgcrypt16-devel \
-        qt5-qtbase-devel \
-        qt5-linguist \
-        qt5-qttools \
-        zlib-devel \
-        qt5-qtx11extras \
-        qt5-qtx11extras-devel \
-        libXi-devel \
-        libXtst-devel
+    && apt-get install -y \
+        cmake3 \
+        g++ \
+        libgcrypt20-dev \
+        qt${QT5_VERSION}base \
+        qt${QT5_VERSION}tools \
+        qt${QT5_VERSION}x11extras \
+        zlib1g-dev \
+        libxi-dev \
+        libxtst-dev \
+        mesa-common-dev
+
+ENV CMAKE_PREFIX_PATH=/opt/qt${QT5_VERSION}/lib/cmake
+ENV LD_LIBRARY_PATH=/opt/qt${QT5_VERSION}/lib
+RUN set -x \
+    && echo /opt/qt${QT_VERSION}/lib > /etc/ld.so.conf.d/qt${QT5_VERSION}.conf
 
 # AppImage dependencies
 RUN set -x \
-    && yum install -y \
+    && apt-get install -y \
         wget \
-        fuse-libs
+        libfuse2
 
 # build libyubikey
 ENV YUBIKEY_VERSION=1.13
-RUN set -x && yum install -y libusb-devel
 RUN set -x \
     && wget "https://developers.yubico.com/yubico-c/Releases/libyubikey-${YUBIKEY_VERSION}.tar.gz" \
     && tar xf libyubikey-${YUBIKEY_VERSION}.tar.gz \
     && cd libyubikey-${YUBIKEY_VERSION} \
-    && ./configure --prefix=/usr --libdir=/usr/lib64 \
+    && ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu \
     && make \
     && make install \
     && cd .. \
@@ -67,10 +70,12 @@ RUN set -x \
 # build libykpers-1
 ENV YKPERS_VERSION=1.18.0
 RUN set -x \
+    && apt-get install -y libusb-dev
+RUN set -x \
     && wget "https://developers.yubico.com/yubikey-personalization/Releases/ykpers-${YKPERS_VERSION}.tar.gz" \
     && tar xf ykpers-${YKPERS_VERSION}.tar.gz \
     && cd ykpers-${YKPERS_VERSION} \
-    && ./configure --prefix=/usr --libdir=/usr/lib64 \
+    && ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu \
     && make \
     && make install \
     && cd .. \

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -73,6 +73,7 @@ protected:
     QString m_filename;
 
 private:
+    bool m_yubiKeyBeingPolled = false;
     Q_DISABLE_COPY(DatabaseOpenWidget)
 };
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -881,7 +881,7 @@ void MainWindow::toggleWindow()
         raise();
         activateWindow();
 
-#if defined(Q_OS_LINUX) && ! defined(QT_NO_DBUS)
+#if defined(Q_OS_LINUX) && ! defined(QT_NO_DBUS) && (QT_VERSION < QT_VERSION_CHECK(5, 9, 0))
         // re-register global D-Bus menu (needed on Ubuntu with Unity)
         // see https://github.com/keepassxreboot/keepassxc/issues/271
         // and https://bugreports.qt.io/browse/QTBUG-58723


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch resolves #1114 by reverting our AppImage build system back to Ubuntu 14.04, but with custom builds for libyubikey and libykpers-1. It also ships a required code fix to prevent the YubiKey from appearing twice in the menu (only happens when building with 14.04, newer Ubuntu versions are not affected, but it may also be a problem of a specific Qt version).

Additionally, this patch resolves #691 by restricting our global menu workaround to Qt versions older than 5.9.0.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Moving to CentOS solved a few problems. It cleaned up our Dockerfile and didn't necessarily require a newer Qt version and YubiKeys worked out of the box. Unfortunately, AppImages built with CentOS don't integrate with Ubuntu's global menu (at least not with the standard Qt 5.6) and don't run on older Ubuntu-based systems (we expected that).
The loss of compatibility would be an okay trade, if there were no way to enable (bug-free) YubiKey support for Trusty-built AppImages. But with a bit more tinkering and a few additional code fixes, I managed to do exactly that, so there is no more reason to keep our CentOS build system.

I would also suggest to provide a new 2.2.2 build which was built with the fixed Ubuntu 14.04 system (but with the 2.2.2 code base, of course, accepting that YubiKeys are detected twice). We cannot replace already published binaries, but we can add an additional AppImage build to the release page and link that from the website instead of the previous CentOS-based AppImage. An upcoming 2.2.3 (or 2.3.0, whichever comes first) may then also ship the code fixes.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
AppImage runs fine on Ubuntu 16.10 and 14.04, YubiKey is detected successfully and only once.
Global menu is working in Unity.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
