### PR TITLE
Disable reload prompt when db is locked

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -825,7 +825,7 @@ void DatabaseWidget::unlockDatabase(bool accepted)
         return;
     }
 
-    Database *db = Q_NULLPTR;
+    Database* db = Q_NULLPTR;
     if (sender() == m_unlockDatabaseDialog) {
         db = m_unlockDatabaseDialog->database();
     } else if (sender() == m_unlockDatabaseWidget) {
@@ -1125,8 +1125,13 @@ void DatabaseWidget::onWatchedFileChanged()
 
 void DatabaseWidget::reloadDatabaseFile()
 {
-    if (m_db == nullptr)
+    if (m_db == nullptr) {
         return;
+    }
+
+    if (currentMode() == DatabaseWidget::LockedMode) {
+        return;
+    }
 
     if (! config()->get("AutoReloadOnChange").toBool()) {
         // Ask if we want to reload the db

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -825,7 +825,7 @@ void DatabaseWidget::unlockDatabase(bool accepted)
         return;
     }
 
-    Database* db = Q_NULLPTR;
+    Database* db = nullptr;
     if (sender() == m_unlockDatabaseDialog) {
         db = m_unlockDatabaseDialog->database();
     } else if (sender() == m_unlockDatabaseWidget) {

--- a/src/gui/UnlockDatabaseDialog.h
+++ b/src/gui/UnlockDatabaseDialog.h
@@ -31,7 +31,7 @@ class UnlockDatabaseDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit UnlockDatabaseDialog(QWidget* parent = Q_NULLPTR);
+    explicit UnlockDatabaseDialog(QWidget* parent = nullptr);
     void setDBFilename(const QString& filename);
     void clearForms();
     Database* database();


### PR DESCRIPTION
Disable reload prompt when db is locked

## Description
This problem was raised in #1113 (but does not fix this particular issue)

## Motivation and context
We should not try reloading the database file when it is locked, as it will be reloaded anyway when the database will be unlocked.

## How has this been tested?
Locally by reproducing the steps in the issue, with `touch path/to/db.kdbx` while it is locked.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
