### PR TITLE
Make notes hidden by default

### DIFF
--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -163,6 +163,7 @@ void SettingsWidget::loadSettings()
     m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
     m_secUi->passwordDetailsCleartextCheckBox->setChecked(config()->get("security/hidepassworddetails").toBool());
     m_secUi->passwordRepeatCheckBox->setChecked(config()->get("security/passwordsrepeat").toBool());
+    m_secUi->hideNotesCheckBox->setChecked(config()->get("security/hidenotes").toBool());
 
 
     for (const ExtraPage& page: asConst(m_extraPages)) {
@@ -231,6 +232,7 @@ void SettingsWidget::saveSettings()
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
     config()->set("security/hidepassworddetails", m_secUi->passwordDetailsCleartextCheckBox->isChecked());
     config()->set("security/passwordsrepeat", m_secUi->passwordRepeatCheckBox->isChecked());
+    config()->set("security/hidenotes", m_secUi->hideNotesCheckBox->isChecked());
 
     // Security: clear storage if related settings are disabled
     if (!config()->get("RememberLastDatabases").toBool()) {

--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -143,6 +143,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="hideNotesCheckBox">
+        <property name="text">
+         <string>Hide entry notes by default</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -99,7 +99,7 @@ void EditEntryWidget::setupMain()
     connect(m_mainUi->togglePasswordButton, SIGNAL(toggled(bool)), m_mainUi->passwordEdit, SLOT(setShowPassword(bool)));
     connect(m_mainUi->togglePasswordGeneratorButton, SIGNAL(toggled(bool)), SLOT(togglePasswordGeneratorButton(bool)));
     connect(m_mainUi->expireCheck, SIGNAL(toggled(bool)), m_mainUi->expireDatePicker, SLOT(setEnabled(bool)));
-    connect(m_mainUi->notesEnabled, SIGNAL(toggled(bool)), m_mainUi->notesEdit, SLOT(setVisible(bool)));
+    connect(m_mainUi->notesEnabled, SIGNAL(toggled(bool)), this, SLOT(toggleHideNotes(bool)));
     m_mainUi->passwordRepeatEdit->enableVerifyMode(m_mainUi->passwordEdit);
     connect(m_mainUi->passwordGenerator, SIGNAL(appliedPassword(QString)), SLOT(setGeneratedPassword(QString)));
 
@@ -262,6 +262,12 @@ void EditEntryWidget::updateAttachmentButtonsEnabled(const QModelIndex& current)
     m_advancedUi->removeAttachmentButton->setEnabled(enable && !m_history);
 }
 
+void EditEntryWidget::toggleHideNotes(bool visible)
+{
+    m_mainUi->notesEdit->setVisible(visible);
+    m_mainUi->notesHint->setVisible(!visible);
+}
+
 QString EditEntryWidget::entryTitle() const
 {
     if (m_entry) {
@@ -311,7 +317,7 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
     m_mainUi->expireDatePicker->setReadOnly(m_history);
     m_mainUi->notesEnabled->setChecked(true);
     m_mainUi->notesEdit->setReadOnly(m_history);
-    m_mainUi->notesEdit->setVisible(false);
+    m_mainUi->notesEdit->setVisible(true);
     m_mainUi->togglePasswordGeneratorButton->setChecked(false);
     m_mainUi->togglePasswordGeneratorButton->setDisabled(m_history);
     m_mainUi->passwordGenerator->reset();

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -309,7 +309,7 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
     m_mainUi->passwordRepeatEdit->setReadOnly(m_history);
     m_mainUi->expireCheck->setEnabled(!m_history);
     m_mainUi->expireDatePicker->setReadOnly(m_history);
-    m_mainUi->notesEnabled->setChecked(false);
+    m_mainUi->notesEnabled->setChecked(true);
     m_mainUi->notesEdit->setReadOnly(m_history);
     m_mainUi->notesEdit->setVisible(false);
     m_mainUi->togglePasswordGeneratorButton->setChecked(false);

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -99,6 +99,7 @@ void EditEntryWidget::setupMain()
     connect(m_mainUi->togglePasswordButton, SIGNAL(toggled(bool)), m_mainUi->passwordEdit, SLOT(setShowPassword(bool)));
     connect(m_mainUi->togglePasswordGeneratorButton, SIGNAL(toggled(bool)), SLOT(togglePasswordGeneratorButton(bool)));
     connect(m_mainUi->expireCheck, SIGNAL(toggled(bool)), m_mainUi->expireDatePicker, SLOT(setEnabled(bool)));
+    connect(m_mainUi->notesEnabled, SIGNAL(toggled(bool)), m_mainUi->notesEdit, SLOT(setVisible(bool)));
     m_mainUi->passwordRepeatEdit->enableVerifyMode(m_mainUi->passwordEdit);
     connect(m_mainUi->passwordGenerator, SIGNAL(appliedPassword(QString)), SLOT(setGeneratedPassword(QString)));
 
@@ -308,7 +309,9 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
     m_mainUi->passwordRepeatEdit->setReadOnly(m_history);
     m_mainUi->expireCheck->setEnabled(!m_history);
     m_mainUi->expireDatePicker->setReadOnly(m_history);
+    m_mainUi->notesEnabled->setChecked(false);
     m_mainUi->notesEdit->setReadOnly(m_history);
+    m_mainUi->notesEdit->setVisible(false);
     m_mainUi->togglePasswordGeneratorButton->setChecked(false);
     m_mainUi->togglePasswordGeneratorButton->setDisabled(m_history);
     m_mainUi->passwordGenerator->reset();

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -315,9 +315,10 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
     m_mainUi->passwordRepeatEdit->setReadOnly(m_history);
     m_mainUi->expireCheck->setEnabled(!m_history);
     m_mainUi->expireDatePicker->setReadOnly(m_history);
-    m_mainUi->notesEnabled->setChecked(true);
+    m_mainUi->notesEnabled->setChecked(!config()->get("security/hidenotes").toBool());
     m_mainUi->notesEdit->setReadOnly(m_history);
-    m_mainUi->notesEdit->setVisible(true);
+    m_mainUi->notesEdit->setVisible(!config()->get("security/hidenotes").toBool());
+    m_mainUi->notesHint->setVisible(config()->get("security/hidenotes").toBool());
     m_mainUi->togglePasswordGeneratorButton->setChecked(false);
     m_mainUi->togglePasswordGeneratorButton->setDisabled(m_history);
     m_mainUi->passwordGenerator->reset();

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -100,6 +100,7 @@ private slots:
     void updateHistoryButtons(const QModelIndex& current, const QModelIndex& previous);
     void useExpiryPreset(QAction* action);
     void updateAttachmentButtonsEnabled(const QModelIndex& current);
+    void toggleHideNotes(bool visible);
 
 private:
     void setupMain();

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -79,10 +79,10 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" alignment="Qt::AlignRight|Qt::AlignTop">
-    <widget class="QLabel" name="notesLabel">
+   <item row="9" column="0" alignment="Qt::AlignLeft|Qt::AlignTop">
+    <widget class="QCheckBox" name="notesEnabled">
      <property name="text">
-      <string>Notes:</string>
+      <string>Notes</string>
      </property>
     </widget>
    </item>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -127,6 +127,12 @@
        <height>100</height>
       </size>
      </property>
+     <property name="font">
+      <font>
+       <family>Monospace</family>
+       <pointsize>10</pointsize>
+      </font>
+     </property>
     </widget>
    </item>
    <item row="1" column="0" alignment="Qt::AlignRight">

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -135,6 +135,19 @@
      </property>
     </widget>
    </item>
+   <item row="9" column="1">
+    <widget class="QLabel" name="notesHint">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Toggle the checkbox to reveal the notes section.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0" alignment="Qt::AlignRight">
     <widget class="QLabel" name="usernameLabel">
      <property name="text">


### PR DESCRIPTION
Finalization of #541 
All credit to @grim210 

## Description
I prefer the notes section to be fixed width (#540).  When searching for an issue on the issue tracker, I found #342, which seems like it would be easy to fix while I was working on my own issue.  Overall, it was a simple fix for both.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Commit 636b3a0 fixes the issue that I created: #540.
Commit b9531a7 fixes issue #342.

## How has this been tested?
Tried on existing database (my personal one, a few years old), and on a fresh database that was created for the screenshots below.  Notes persisted through save.  Disabling the notes after writing them does not erase them.

Tested on Ubuntu MATE 16.04.2 amd64, with Qt 5.5.1.  All tests in the 'tests' directory were passed (except the YubiKey ones; I don't have one).  There were no apparent side effects during testing.

## Screenshots (if appropriate):
This is what the entry looks like by default:
![keepassxc_disabled_notes](https://cloud.githubusercontent.com/assets/3255083/25560839/57ea1032-2d24-11e7-8b98-09a735f8cbf2.png)

When the notes section has been enabled, it looks like this:
![keepassxc_monospace_notes](https://cloud.githubusercontent.com/assets/3255083/25560840/5ae06444-2d24-11e7-9188-7b22f76e91f4.png)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
