### PR TITLE
Add support for working with multiple entry attachments at once

### DIFF
--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -17,6 +17,8 @@
 
 #include "EntryAttachments.h"
 
+#include <QStringList>
+
 EntryAttachments::EntryAttachments(QObject* parent)
     : QObject(parent)
 {
@@ -71,7 +73,8 @@ void EntryAttachments::set(const QString& key, const QByteArray& value)
 void EntryAttachments::remove(const QString& key)
 {
     if (!m_attachments.contains(key)) {
-        Q_ASSERT(false);
+        Q_ASSERT_X(false, "EntryAttachments::remove",
+                   qPrintable(QString("Can't find attachment for key %1").arg(key)));
         return;
     }
 
@@ -81,6 +84,31 @@ void EntryAttachments::remove(const QString& key)
 
     emit removed(key);
     emit modified();
+}
+
+void EntryAttachments::remove(const QStringList &keys)
+{
+    if (keys.isEmpty()) {
+        return;
+    }
+
+    bool isModified = false;
+    for (const QString &key: keys) {
+        if (!m_attachments.contains(key)) {
+            Q_ASSERT_X(false, "EntryAttachments::remove",
+                       qPrintable(QString("Can't find attachment for key %1").arg(key)));
+            continue;
+        }
+
+        isModified = true;
+        emit aboutToBeRemoved(key);
+        m_attachments.remove(key);
+        emit removed(key);
+    }
+
+    if (isModified) {
+        emit modified();
+    }
 }
 
 void EntryAttachments::clear()

--- a/src/core/EntryAttachments.h
+++ b/src/core/EntryAttachments.h
@@ -21,6 +21,8 @@
 #include <QMap>
 #include <QObject>
 
+class QStringList;
+
 class EntryAttachments : public QObject
 {
     Q_OBJECT
@@ -33,6 +35,7 @@ public:
     QByteArray value(const QString& key) const;
     void set(const QString& key, const QByteArray& value);
     void remove(const QString& key);
+    void remove(const QStringList& keys);
     void clear();
     void copyDataFrom(const EntryAttachments* other);
     bool operator==(const EntryAttachments& other) const;

--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -27,7 +27,7 @@ QString FileDialog::getOpenFileName(QWidget* parent, const QString& caption, QSt
 {
     if (!m_nextFileName.isEmpty()) {
         QString result = m_nextFileName;
-        m_nextFileName = "";
+        m_nextFileName.clear();
         return result;
     }
     else {
@@ -51,13 +51,43 @@ QString FileDialog::getOpenFileName(QWidget* parent, const QString& caption, QSt
     }
 }
 
+QStringList FileDialog::getOpenFileNames(QWidget *parent, const QString &caption, QString dir,
+                                     const QString &filter, QString *selectedFilter,
+                                     QFileDialog::Options options)
+{
+    if (!m_nextFileNames.isEmpty()) {
+        QStringList results = m_nextFileNames;
+        m_nextFileNames.clear();
+        return results;
+    }
+    else {
+        if (dir.isEmpty()) {
+            dir = config()->get("LastDir").toString();
+        }
+
+        QStringList results = QFileDialog::getOpenFileNames(parent, caption, dir, filter,
+                                                           selectedFilter, options);
+
+        // on Mac OS X the focus is lost after closing the native dialog
+        if (parent) {
+            parent->activateWindow();
+        }
+
+        if (!results.isEmpty()) {
+            config()->set("LastDir", QFileInfo(results[0]).absolutePath());
+        }
+
+        return results;
+    }
+}
+
 QString FileDialog::getSaveFileName(QWidget* parent, const QString& caption, QString dir,
                                     const QString& filter, QString* selectedFilter,
                                     QFileDialog::Options options, const QString& defaultExtension)
 {
     if (!m_nextFileName.isEmpty()) {
         QString result = m_nextFileName;
-        m_nextFileName = "";
+        m_nextFileName.clear();
         return result;
     }
     else {
@@ -103,9 +133,47 @@ QString FileDialog::getSaveFileName(QWidget* parent, const QString& caption, QSt
     }
 }
 
+QString FileDialog::getExistingDirectory(QWidget *parent, const QString &caption, QString dir,
+                                         QFileDialog::Options options)
+{
+    if (!m_nextDirName.isEmpty()) {
+        QString result = m_nextDirName;
+        m_nextDirName.clear();
+        return result;
+    }
+    else {
+        if (dir.isEmpty()) {
+            dir = config()->get("LastDir").toString();
+        }
+
+        dir = QFileDialog::getExistingDirectory(parent, caption, dir, options);
+
+        // on Mac OS X the focus is lost after closing the native dialog
+        if (parent) {
+            parent->activateWindow();
+        }
+
+        if (!dir.isEmpty()) {
+            config()->set("LastDir", QFileInfo(dir).absolutePath());
+        }
+
+        return dir;
+    }
+}
+
 void FileDialog::setNextFileName(const QString& fileName)
 {
     m_nextFileName = fileName;
+}
+
+void FileDialog::setNextFileNames(const QStringList &fileNames)
+{
+    m_nextFileNames = fileNames;
+}
+
+void FileDialog::setNextDirName(const QString &dirName)
+{
+    m_nextDirName = dirName;
 }
 
 FileDialog::FileDialog()

--- a/src/gui/FileDialog.h
+++ b/src/gui/FileDialog.h
@@ -26,22 +26,31 @@ public:
     QString getOpenFileName(QWidget* parent = nullptr, const QString& caption = QString(),
                             QString dir = QString(), const QString& filter = QString(),
                             QString* selectedFilter = nullptr, QFileDialog::Options options = 0);
+    QStringList getOpenFileNames(QWidget* parent = nullptr, const QString& caption = QString(),
+                                 QString dir = QString(), const QString& filter = QString(),
+                                 QString* selectedFilter = nullptr, QFileDialog::Options options = 0);
     QString getSaveFileName(QWidget* parent = nullptr, const QString& caption = QString(),
                             QString dir = QString(), const QString& filter = QString(),
                             QString* selectedFilter = nullptr, QFileDialog::Options options = 0,
                             const QString& defaultExtension = QString());
+    QString getExistingDirectory(QWidget* parent = nullptr, const QString& caption = QString(),
+                                 QString dir = QString(), QFileDialog::Options options = QFileDialog::ShowDirsOnly);
 
     /**
      * Sets the result of the next get* method call.
      * Use only for testing.
      */
     void setNextFileName(const QString& fileName);
+    void setNextFileNames(const QStringList& fileNames);
+    void setNextDirName(const QString& dirName);
 
     static FileDialog* instance();
 
 private:
     FileDialog();
     QString m_nextFileName;
+    QStringList m_nextFileNames;
+    QString m_nextDirName;
 
     static FileDialog* m_instance;
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -727,7 +727,9 @@ void EditEntryWidget::insertAttachment()
         return;
     }
 
-    m_entryAttachments->set(QFileInfo(filename).fileName(), data);
+    const QFileInfo fInfo(filename);
+    config()->set("LastAttachmentDir", fInfo.absolutePath());
+    m_entryAttachments->set(fInfo.fileName(), data);
 }
 
 void EditEntryWidget::saveCurrentAttachment()
@@ -757,6 +759,7 @@ void EditEntryWidget::saveCurrentAttachment()
             showMessage(tr("Unable to save the attachment:\n").append(file.errorString()), MessageWidget::Error);
             return;
         }
+        config()->set("LastAttachmentDir", QFileInfo(savePath).absolutePath());
     }
 }
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -122,13 +122,14 @@ void EditEntryWidget::setupAdvanced()
 
     m_attachmentsModel->setEntryAttachments(m_entryAttachments);
     m_advancedUi->attachmentsView->setModel(m_attachmentsModel);
+    m_advancedUi->attachmentsView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     connect(m_advancedUi->attachmentsView->selectionModel(), SIGNAL(currentChanged(QModelIndex,QModelIndex)),
             SLOT(updateAttachmentButtonsEnabled(QModelIndex)));
     connect(m_advancedUi->attachmentsView, SIGNAL(doubleClicked(QModelIndex)), SLOT(openAttachment(QModelIndex)));
-    connect(m_advancedUi->saveAttachmentButton, SIGNAL(clicked()), SLOT(saveCurrentAttachment()));
-    connect(m_advancedUi->openAttachmentButton, SIGNAL(clicked()), SLOT(openCurrentAttachment()));
-    connect(m_advancedUi->addAttachmentButton, SIGNAL(clicked()), SLOT(insertAttachment()));
-    connect(m_advancedUi->removeAttachmentButton, SIGNAL(clicked()), SLOT(removeCurrentAttachment()));
+    connect(m_advancedUi->saveAttachmentButton, SIGNAL(clicked()), SLOT(saveSelectedAttachments()));
+    connect(m_advancedUi->openAttachmentButton, SIGNAL(clicked()), SLOT(openSelectedAttachments()));
+    connect(m_advancedUi->addAttachmentButton, SIGNAL(clicked()), SLOT(insertAttachments()));
+    connect(m_advancedUi->removeAttachmentButton, SIGNAL(clicked()), SLOT(removeSelectedAttachments()));
 
     m_attributesModel->setEntryAttributes(m_entryAttributes);
     m_advancedUi->attributesView->setModel(m_attributesModel);
@@ -672,6 +673,32 @@ void EditEntryWidget::displayAttribute(QModelIndex index, bool showProtected)
     m_advancedUi->protectAttributeButton->blockSignals(false);
 }
 
+bool EditEntryWidget::openAttachment(const QModelIndex &index, QString *errorMessage)
+{
+    const QString filename = m_attachmentsModel->keyByIndex(index);
+    const QByteArray attachmentData = m_entryAttachments->value(filename);
+
+    // tmp file will be removed once the database (or the application) has been closed
+    const QString tmpFileTemplate = QDir::temp().absoluteFilePath(QString("XXXXXX.").append(filename));
+    QTemporaryFile* tmpFile = new QTemporaryFile(tmpFileTemplate, this);
+
+    const bool saveOk = tmpFile->open()
+                        && tmpFile->write(attachmentData) == attachmentData.size()
+                        && tmpFile->flush();
+    if (!saveOk) {
+        if (errorMessage) {
+            *errorMessage = tr("Unable to save the attachment:\n").append(tmpFile->errorString());
+        }
+        delete tmpFile;
+        return false;
+    }
+
+    tmpFile->close();
+    QDesktopServices::openUrl(QUrl::fromLocalFile(tmpFile->fileName()));
+
+    return true;
+}
+
 void EditEntryWidget::protectCurrentAttribute(bool state)
 {
     QModelIndex index = m_advancedUi->attributesView->currentIndex();
@@ -702,7 +729,7 @@ void EditEntryWidget::revealCurrentAttribute()
     }
 }
 
-void EditEntryWidget::insertAttachment()
+void EditEntryWidget::insertAttachments()
 {
     Q_ASSERT(!m_history);
 
@@ -710,56 +737,115 @@ void EditEntryWidget::insertAttachment()
     if (defaultDir.isEmpty() || !QDir(defaultDir).exists()) {
         defaultDir = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation).value(0);
     }
-    QString filename = fileDialog()->getOpenFileName(this, tr("Select file"), defaultDir);
-    if (filename.isEmpty() || !QFile::exists(filename)) {
+
+    const QStringList filenames = fileDialog()->getOpenFileNames(this, tr("Select files"), defaultDir);
+    if (filenames.isEmpty()) {
         return;
     }
 
-    QFile file(filename);
-    if (!file.open(QIODevice::ReadOnly)) {
-        showMessage(tr("Unable to open file").append(":\n").append(file.errorString()), MessageWidget::Error);
-        return;
+    config()->set("LastAttachmentDir", QFileInfo(filenames.first()).absolutePath());
+
+    QStringList errors;
+    for (const QString &filename: filenames) {
+        const QFileInfo fInfo(filename);
+        QFile file(filename);
+        QByteArray data;
+        const bool readOk = file.open(QIODevice::ReadOnly) && Tools::readAllFromDevice(&file, data);
+        if (!readOk) {
+            errors.append(QString("%1 - %2").arg(fInfo.fileName(), file.errorString()));
+            continue;
+        }
+
+        m_entryAttachments->set(fInfo.fileName(), data);
     }
 
-    QByteArray data;
-    if (!Tools::readAllFromDevice(&file, data)) {
-        showMessage(tr("Unable to open file").append(":\n").append(file.errorString()), MessageWidget::Error);
-        return;
+    if (!errors.isEmpty()) {
+        showMessage(tr("Unable to open files:\n%1").arg(errors.join('\n')), MessageWidget::Error);
     }
-
-    const QFileInfo fInfo(filename);
-    config()->set("LastAttachmentDir", fInfo.absolutePath());
-    m_entryAttachments->set(fInfo.fileName(), data);
 }
 
-void EditEntryWidget::saveCurrentAttachment()
+void EditEntryWidget::saveSelectedAttachment()
 {
-    QModelIndex index = m_advancedUi->attachmentsView->currentIndex();
+    const QModelIndex index = m_advancedUi->attachmentsView->currentIndex();
     if (!index.isValid()) {
         return;
     }
 
-    QString filename = m_attachmentsModel->keyByIndex(index);
+    const QString filename = m_attachmentsModel->keyByIndex(index);
     QString defaultDirName = config()->get("LastAttachmentDir").toString();
     if (defaultDirName.isEmpty() || !QDir(defaultDirName).exists()) {
         defaultDirName = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     }
-    QDir dir(defaultDirName);
-    QString savePath = fileDialog()->getSaveFileName(this, tr("Save attachment"),
-                                                       dir.filePath(filename));
+
+    const QString savePath = fileDialog()->getSaveFileName(this, tr("Save attachment"),
+                                                           QDir(defaultDirName).filePath(filename));
     if (!savePath.isEmpty()) {
-        QByteArray attachmentData = m_entryAttachments->value(filename);
+        config()->set("LastAttachmentDir", QFileInfo(savePath).absolutePath());
 
         QFile file(savePath);
-        if (!file.open(QIODevice::WriteOnly)) {
+        const QByteArray attachmentData = m_entryAttachments->value(filename);
+        const bool saveOk = file.open(QIODevice::WriteOnly) && file.write(attachmentData) == attachmentData.size();
+        if (!saveOk) {
             showMessage(tr("Unable to save the attachment:\n").append(file.errorString()), MessageWidget::Error);
+        }
+    }
+}
+
+void EditEntryWidget::saveSelectedAttachments()
+{
+    const QModelIndexList indexes = m_advancedUi->attachmentsView->selectionModel()->selectedIndexes();
+    if (indexes.isEmpty()) {
+        return;
+    } else if (indexes.count() == 1) {
+        saveSelectedAttachment();
+        return;
+    }
+
+    QString defaultDirName = config()->get("LastAttachmentDir").toString();
+    if (defaultDirName.isEmpty() || !QDir(defaultDirName).exists()) {
+        defaultDirName = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    }
+
+    const QString savePath = fileDialog()->getExistingDirectory(this, tr("Save attachments"), defaultDirName);
+    if (savePath.isEmpty()) {
+        return;
+    }
+
+    QDir saveDir(savePath);
+    if (!saveDir.exists()) {
+        if (saveDir.mkpath(saveDir.absolutePath())) {
+            showMessage(tr("Unable to create the directory:\n").append(saveDir.absolutePath()), MessageWidget::Error);
             return;
         }
-        if (file.write(attachmentData) != attachmentData.size()) {
-            showMessage(tr("Unable to save the attachment:\n").append(file.errorString()), MessageWidget::Error);
-            return;
+    }
+    config()->set("LastAttachmentDir", QFileInfo(saveDir.absolutePath()).absolutePath());
+
+    QStringList errors;
+    for (const QModelIndex &index: indexes) {
+        const QString filename = m_attachmentsModel->keyByIndex(index);
+        const QString attachmentPath = saveDir.absoluteFilePath(filename);
+
+        if (QFileInfo::exists(attachmentPath)) {
+            const QString question(tr("Are you sure you want to overwrite existing file \"%1\" with the attachment?"));
+            auto ans = MessageBox::question(this, tr("Confirm overwrite"), question.arg(filename),
+                                            QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+            if (ans == QMessageBox::No) {
+                continue;
+            } else if (ans == QMessageBox::Cancel) {
+                return;
+            }
         }
-        config()->set("LastAttachmentDir", QFileInfo(savePath).absolutePath());
+
+        QFile file(attachmentPath);
+        const QByteArray attachmentData = m_entryAttachments->value(filename);
+        const bool saveOk = file.open(QIODevice::WriteOnly) && file.write(attachmentData) == attachmentData.size();
+        if (!saveOk) {
+            errors.append(QString("%1 - %2").arg(filename, file.errorString()));
+        }
+    }
+
+    if (!errors.isEmpty()) {
+        showMessage(tr("Unable to save the attachments:\n").append(errors.join('\n')), MessageWidget::Error);
     }
 }
 
@@ -770,55 +856,51 @@ void EditEntryWidget::openAttachment(const QModelIndex& index)
         return;
     }
 
-    QString filename = m_attachmentsModel->keyByIndex(index);
-    QByteArray attachmentData = m_entryAttachments->value(filename);
-
-    // tmp file will be removed once the database (or the application) has been closed
-    QString tmpFileTemplate = QDir::temp().absoluteFilePath(QString("XXXXXX.").append(filename));
-    QTemporaryFile* file = new QTemporaryFile(tmpFileTemplate, this);
-
-    if (!file->open()) {
-        showMessage(tr("Unable to save the attachment:\n").append(file->errorString()), MessageWidget::Error);
-        return;
+    QString errorMessage;
+    if (!openAttachment(index, &errorMessage)) {
+        showMessage(errorMessage, MessageWidget::Error);
     }
-
-    if (file->write(attachmentData) != attachmentData.size()) {
-        showMessage(tr("Unable to save the attachment:\n").append(file->errorString()), MessageWidget::Error);
-        return;
-    }
-
-    if (!file->flush()) {
-        showMessage(tr("Unable to save the attachment:\n").append(file->errorString()), MessageWidget::Error);
-        return;
-    }
-
-    file->close();
-
-    QDesktopServices::openUrl(QUrl::fromLocalFile(file->fileName()));
 }
 
-void EditEntryWidget::openCurrentAttachment()
+void EditEntryWidget::openSelectedAttachments()
 {
-    QModelIndex index = m_advancedUi->attachmentsView->currentIndex();
+    const QModelIndexList indexes = m_advancedUi->attachmentsView->selectionModel()->selectedIndexes();
+    if (indexes.isEmpty()) {
+        return;
+    }
 
-    openAttachment(index);
+    QStringList errors;
+    for (const QModelIndex &index: indexes) {
+        QString errorMessage;
+        if (!openAttachment(index, &errorMessage)) {
+            const QString filename = m_attachmentsModel->keyByIndex(index);
+            errors.append(QString("%1 - %2").arg(filename, errorMessage));
+        };
+    }
+
+    if (!errors.isEmpty()) {
+        showMessage(tr("Unable to open the attachments:\n").append(errors.join('\n')), MessageWidget::Error);
+    }
 }
 
-void EditEntryWidget::removeCurrentAttachment()
+void EditEntryWidget::removeSelectedAttachments()
 {
     Q_ASSERT(!m_history);
 
-    QModelIndex index = m_advancedUi->attachmentsView->currentIndex();
-    if (!index.isValid()) {
+    const QModelIndexList indexes = m_advancedUi->attachmentsView->selectionModel()->selectedIndexes();
+    if (indexes.isEmpty()) {
         return;
     }
 
+    const QString question = tr("Are you sure you want to remove %n attachments?", "", indexes.count());
     QMessageBox::StandardButton ans = MessageBox::question(this, tr("Confirm Remove"),
-                                                           tr("Are you sure you want to remove this attachment?"),
-                                                           QMessageBox::Yes | QMessageBox::No);
+                                                           question, QMessageBox::Yes | QMessageBox::No);
     if (ans == QMessageBox::Yes) {
-        QString key = m_attachmentsModel->keyByIndex(index);
-        m_entryAttachments->remove(key);
+        QStringList keys;
+        for (const QModelIndex &index: indexes) {
+            keys.append(m_attachmentsModel->keyByIndex(index));
+        }
+        m_entryAttachments->remove(keys);
     }
 }
 

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -80,11 +80,12 @@ private slots:
     void updateCurrentAttribute();
     void protectCurrentAttribute(bool state);
     void revealCurrentAttribute();
-    void insertAttachment();
-    void saveCurrentAttachment();
+    void insertAttachments();
+    void saveSelectedAttachment();
+    void saveSelectedAttachments();
     void openAttachment(const QModelIndex& index);
-    void openCurrentAttachment();
-    void removeCurrentAttachment();
+    void openSelectedAttachments();
+    void removeSelectedAttachments();
     void updateAutoTypeEnabled();
     void insertAutoTypeAssoc();
     void removeAutoTypeAssoc();
@@ -116,6 +117,8 @@ private:
     void updateEntryData(Entry* entry) const;
 
     void displayAttribute(QModelIndex index, bool showProtected);
+
+    bool openAttachment(const QModelIndex& index, QString *errorMessage);
 
     Entry* m_entry;
     Database* m_database;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->

All errors show at once

Supported actions:
- Insert 
- Remove 
- Open 
- Save 


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To make working with attachments more user friendly

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually.

## Screenshots (if appropriate):

Window with opening errors:  

![image](https://user-images.githubusercontent.com/3104366/32124719-7d41661a-bb71-11e7-9888-33a1dceb386d.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**


