### PR TITLE
Fix apply button not saving new entries

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -278,6 +278,7 @@ void EditEntryWidget::loadEntry(Entry* entry, bool create, bool history, const Q
     m_database = database;
     m_create = create;
     m_history = history;
+    m_saved = false;
 
     if (history) {
         setHeadline(QString("%1 > %2").arg(parentName, tr("Entry history")));
@@ -438,6 +439,7 @@ void EditEntryWidget::saveEntry()
     }
 
     updateEntryData(m_entry);
+    m_saved = true;
 
     if (!m_create) {
         m_entry->endUpdate();
@@ -510,7 +512,7 @@ void EditEntryWidget::cancel()
 
     clear();
 
-    emit editFinished(false);
+    emit editFinished(m_saved);
 }
 
 void EditEntryWidget::clear()

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -121,6 +121,7 @@ private:
 
     bool m_create;
     bool m_history;
+    bool m_saved;
     const QScopedPointer<Ui::EditEntryWidgetMain> m_mainUi;
     const QScopedPointer<Ui::EditEntryWidgetAdvanced> m_advancedUi;
     const QScopedPointer<Ui::EditEntryWidgetAutoType> m_autoTypeUi;

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -332,15 +332,27 @@ void TestGui::testAddEntry()
     QTest::keyClicks(passwordRepeatEdit, "something 2");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
 
-    // Add entry "something 3"
+    // Add entry "something 3" using the apply button then click ok
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
     QTest::keyClicks(titleEdit, "something 3");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Apply), Qt::LeftButton);
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+
+    // Add entry "something 4" using the apply button then click cancel
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QTest::keyClicks(titleEdit, "something 4");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Apply), Qt::LeftButton);
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Cancel), Qt::LeftButton);
+
+    // Add entry "something 5" but click cancel button (does NOT add entry)
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QTest::keyClicks(titleEdit, "something 5");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Cancel), Qt::LeftButton);
 
     QApplication::processEvents();
 
-    // Confirm that 4 entries now exist
-    QTRY_COMPARE(entryView->model()->rowCount(), 4);
+    // Confirm that 5 entries now exist
+    QTRY_COMPARE(entryView->model()->rowCount(), 5);
 }
 
 void TestGui::testPasswordEntryEntropy()
@@ -513,7 +525,7 @@ void TestGui::testTotp()
 void TestGui::testSearch()
 {
     // Add canned entries for consistent testing
-    testAddEntry();
+    Q_UNUSED(addCannedEntries());
 
     QToolBar* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
 
@@ -629,7 +641,7 @@ void TestGui::testSearch()
 void TestGui::testDeleteEntry()
 {
     // Add canned entries for consistent testing
-    testAddEntry();
+    Q_UNUSED(addCannedEntries());
 
     GroupView* groupView = m_dbWidget->findChild<GroupView*>("groupView");
     EntryView* entryView = m_dbWidget->findChild<EntryView*>("entryView");
@@ -903,6 +915,42 @@ void TestGui::testDatabaseLocking()
 void TestGui::cleanupTestCase()
 {
     delete m_mainWindow;
+}
+
+int TestGui::addCannedEntries()
+{
+    int entries_added = 0;
+
+    // Find buttons
+    QToolBar* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
+    QWidget* entryNewWidget = toolBar->widgetForAction(m_mainWindow->findChild<QAction*>("actionEntryNew"));
+    EditEntryWidget* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
+    QLineEdit* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
+    QLineEdit* passwordEdit = editEntryWidget->findChild<QLineEdit*>("passwordEdit");
+    QLineEdit* passwordRepeatEdit = editEntryWidget->findChild<QLineEdit*>("passwordRepeatEdit");
+
+    // Add entry "test" and confirm added
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QTest::keyClicks(titleEdit, "test");
+    QDialogButtonBox* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    ++entries_added;
+
+    // Add entry "something 2"
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QTest::keyClicks(titleEdit, "something 2");
+    QTest::keyClicks(passwordEdit, "something 2");
+    QTest::keyClicks(passwordRepeatEdit, "something 2");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    ++entries_added;
+
+    // Add entry "something 3"
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QTest::keyClicks(titleEdit, "something 3");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    ++entries_added;
+
+    return entries_added;
 }
 
 void TestGui::checkDatabase(QString dbFileName)

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -61,6 +61,7 @@ private slots:
     void testDatabaseLocking();
 
 private:
+    int addCannedEntries();
     void checkDatabase(QString dbFileName = "");
     void triggerAction(const QString& name);
     void dragAndDropGroup(const QModelIndex& sourceIndex, const QModelIndex& targetIndex, int row,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #1133 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Loss of data if user hits apply then cancel when editing a new entry.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with newly written test cases.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
