### PR TITLE
Add WMClass to the desktop file to have proper linking to the desktop file

### DIFF
--- a/share/linux/org.keepassxc.KeePassXC.desktop
+++ b/share/linux/org.keepassxc.KeePassXC.desktop
@@ -9,6 +9,7 @@ Comment=Community-driven port of the Windows application “KeePass Password Saf
 Exec=keepassxc %f
 TryExec=keepassxc
 Icon=keepassxc
+StartupWMClass=keepassxc
 Terminal=false
 Type=Application
 Version=1.0


### PR DESCRIPTION
## Description
As the .desktop file has no StartupWMClass, Gnome can't match the desktop file to the application running.

## Motivation and context
This causes for example to have a duplicate icon on the dash-to-doc taskbar.

## How has this been tested?
Edit the desktop file, add the line, and add the icon to favourites.
Then start KeepassXC, and you'll notice there is no more duplicate icon.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
