### PR TITLE
Save the geometry of main window only if the window is visible

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -727,7 +727,9 @@ void MainWindow::changeEvent(QEvent* event)
 
 void MainWindow::saveWindowInformation()
 {
-    config()->set("GUI/MainWindowGeometry", saveGeometry());
+    if (isVisible()) {
+        config()->set("GUI/MainWindowGeometry", saveGeometry());
+    }
 }
 
 bool MainWindow::saveLastDatabases()
@@ -858,6 +860,7 @@ void MainWindow::trayIconTriggered(QSystemTrayIcon::ActivationReason reason)
 
 void MainWindow::hideWindow()
 {
+    saveWindowInformation();
 #ifndef Q_OS_MAC
     setWindowState(windowState() | Qt::WindowMinimized);
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

I found one small bug. KeePassXC saves the geometry even when the main window is hidden. It creates a wrong behaviour on my DE (I use Mate). When the application starts (after the app was closed with an invisible main window), the main window opens in the upper left corner of the monitor. 

## Description
<!--- Describe your changes in detail -->



## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix wrong behaviour

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

**Steps to reproduce:**

- Run app
- Move window to center of monitor
- Go to Options
- Mark checkboxes "Show a system try icon" and "Hide window to system tray instead of app exit"
- Save changes
- Close main window (Alt+F4)
- Quit from app via system tray menu
- Run app
- The main window opens in the upper left corner of the monitor

**Expected Behavior:**
 
App appear at center of monitor

**Current Behavior:**
The main window opens in the upper left corner of the monitor

**Debug Info:**

Develop branch 
Libraries:
- Qt 5.8.0
- libgcrypt 1.7.6-beta

Operating system: Ubuntu 17.04 (Mate)
CPU architecture: x86_64
Kernel: linux 4.10.0-28-generic

Enabled extensions:
- KeePassHTTP
- Auto-Type

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
