### PR TITLE
Add dark tray icon parameter to settings.

### DIFF
--- a/share/keepassxc.ini
+++ b/share/keepassxc.ini
@@ -16,6 +16,7 @@ LastOpenedDatabases=@Invalid()
 [GUI]
 Language=system
 ShowTrayIcon=false
+DarkTrayIcon=false
 MinimizeToTray=false
 MinimizeOnClose=false
 MinimizeOnStartup=false

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -135,6 +135,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/IconDownloadFallbackToGoogle", false);
     m_defaults.insert("GUI/Language", "system");
     m_defaults.insert("GUI/ShowTrayIcon", false);
+    m_defaults.insert("GUI/DarkTrayIcon", false);
     m_defaults.insert("GUI/MinimizeToTray", false);
     m_defaults.insert("GUI/MinimizeOnClose", false);
 }

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -116,9 +117,9 @@ QIcon FilePath::trayIconUnlocked()
     bool darkIcon = useDarkIcon();
 
 #ifdef KEEPASSXC_DIST_SNAP
-    return (darkIcon) ? icon("apps", "keepassxc-dark", false) : icon("apps", "keepassxc-unlocked", false);
+    return darkIcon ? icon("apps", "keepassxc-dark", false) : icon("apps", "keepassxc-unlocked", false);
 #else
-    return (darkIcon) ? icon("apps", "keepassxc-dark") : icon("apps", "keepassxc-unlocked");
+    return darkIcon ? icon("apps", "keepassxc-dark") : icon("apps", "keepassxc-unlocked");
 #endif
 }
 

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -98,6 +98,15 @@ QIcon FilePath::applicationIcon()
 #endif
 }
 
+QIcon FilePath::applicationIconDark()
+{
+#ifdef KEEPASSXC_DIST_SNAP
+    return icon("apps", "keepassxc-dark", false);
+#else
+    return icon("apps", "keepassxc-dark");
+#endif
+}
+
 QIcon FilePath::trayIconLocked()
 {
 #ifdef KEEPASSXC_DIST_SNAP
@@ -113,6 +122,15 @@ QIcon FilePath::trayIconUnlocked()
     return icon("apps", "keepassxc-unlocked", false);
 #else
     return icon("apps", "keepassxc-unlocked");
+#endif
+}
+
+QIcon FilePath::trayIconUnlockedDark()
+{
+#ifdef KEEPASSXC_DIST_SNAP
+    return icon("apps", "keepassxc-dark", false);
+#else
+    return icon("apps", "keepassxc-dark");
 #endif
 }
 

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -23,6 +23,7 @@
 
 #include "config-keepassx.h"
 #include "core/Global.h"
+#include "core/Config.h"
 
 FilePath* FilePath::m_instance(nullptr);
 
@@ -91,21 +92,15 @@ QString FilePath::pluginPath(const QString& name)
 
 QIcon FilePath::applicationIcon()
 {
+    bool darkIcon = useDarkIcon();
+
 #ifdef KEEPASSXC_DIST_SNAP
-    return icon("apps", "keepassxc", false);
+    return (darkIcon) ? icon("apps", "keepassxc-dark", false) : icon("apps", "keepassxc", false);
 #else
-    return icon("apps", "keepassxc");
+    return (darkIcon) ? icon("apps", "keepassxc-dark") : icon("apps", "keepassxc");
 #endif
 }
 
-QIcon FilePath::applicationIconDark()
-{
-#ifdef KEEPASSXC_DIST_SNAP
-    return icon("apps", "keepassxc-dark", false);
-#else
-    return icon("apps", "keepassxc-dark");
-#endif
-}
 
 QIcon FilePath::trayIconLocked()
 {
@@ -118,19 +113,12 @@ QIcon FilePath::trayIconLocked()
 
 QIcon FilePath::trayIconUnlocked()
 {
-#ifdef KEEPASSXC_DIST_SNAP
-    return icon("apps", "keepassxc-unlocked", false);
-#else
-    return icon("apps", "keepassxc-unlocked");
-#endif
-}
+    bool darkIcon = useDarkIcon();
 
-QIcon FilePath::trayIconUnlockedDark()
-{
 #ifdef KEEPASSXC_DIST_SNAP
-    return icon("apps", "keepassxc-dark", false);
+    return (darkIcon) ? icon("apps", "keepassxc-dark", false) : icon("apps", "keepassxc-unlocked", false);
 #else
-    return icon("apps", "keepassxc-dark");
+    return (darkIcon) ? icon("apps", "keepassxc-dark") : icon("apps", "keepassxc-unlocked");
 #endif
 }
 
@@ -262,6 +250,11 @@ bool FilePath::testSetDir(const QString& dir)
     else {
         return false;
     }
+}
+
+bool FilePath::useDarkIcon()
+{
+    return config()->get("GUI/DarkTrayIcon").toBool();
 }
 
 FilePath* FilePath::instance()

--- a/src/core/FilePath.h
+++ b/src/core/FilePath.h
@@ -28,10 +28,8 @@ public:
     QString dataPath(const QString& name);
     QString pluginPath(const QString& name);
     QIcon applicationIcon();
-    QIcon applicationIconDark();
     QIcon trayIconLocked();
     QIcon trayIconUnlocked();
-    QIcon trayIconUnlockedDark();
     QIcon icon(const QString& category, const QString& name, bool fromTheme = true);
     QIcon onOffIcon(const QString& category, const QString& name);
 
@@ -40,6 +38,7 @@ public:
 private:
     FilePath();
     bool testSetDir(const QString& dir);
+    bool useDarkIcon();
 
     static FilePath* m_instance;
 

--- a/src/core/FilePath.h
+++ b/src/core/FilePath.h
@@ -28,8 +28,10 @@ public:
     QString dataPath(const QString& name);
     QString pluginPath(const QString& name);
     QIcon applicationIcon();
+    QIcon applicationIconDark();
     QIcon trayIconLocked();
     QIcon trayIconUnlocked();
+    QIcon trayIconUnlockedDark();
     QIcon icon(const QString& category, const QString& name, bool fromTheme = true);
     QIcon onOffIcon(const QString& category, const QString& name);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -773,8 +773,6 @@ bool MainWindow::saveLastDatabases()
 void MainWindow::updateTrayIcon()
 {
     if (isTrayIconEnabled()) {
-        bool darkIcon = config()->get("GUI/DarkTrayIcon").toBool();
-        
         if (!m_trayIcon) {
             m_trayIcon = new QSystemTrayIcon(this);
             QMenu* menu = new QMenu(this);
@@ -797,20 +795,11 @@ void MainWindow::updateTrayIcon()
 
             m_trayIcon->setContextMenu(menu);
             
-            if(darkIcon){
-                m_trayIcon->setIcon(filePath()->applicationIconDark());
-            } else {
-                m_trayIcon->setIcon(filePath()->applicationIcon());
-            }
-
+            m_trayIcon->setIcon(filePath()->applicationIcon());
             m_trayIcon->show();
         }
         if (m_ui->tabWidget->hasLockableDatabases()) {
-            if(darkIcon){
-                m_trayIcon->setIcon(filePath()->trayIconUnlockedDark());
-            } else {
-                m_trayIcon->setIcon(filePath()->trayIconUnlocked());
-            }
+            m_trayIcon->setIcon(filePath()->trayIconUnlocked());
         }
         else {
             m_trayIcon->setIcon(filePath()->trayIconLocked());

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -773,9 +773,10 @@ bool MainWindow::saveLastDatabases()
 void MainWindow::updateTrayIcon()
 {
     if (isTrayIconEnabled()) {
+        bool darkIcon = config()->get("GUI/DarkTrayIcon").toBool();
+        
         if (!m_trayIcon) {
             m_trayIcon = new QSystemTrayIcon(this);
-
             QMenu* menu = new QMenu(this);
 
             QAction* actionToggle = new QAction(tr("Toggle window"), menu);
@@ -795,11 +796,21 @@ void MainWindow::updateTrayIcon()
             connect(actionToggle, SIGNAL(triggered()), SLOT(toggleWindow()));
 
             m_trayIcon->setContextMenu(menu);
-            m_trayIcon->setIcon(filePath()->applicationIcon());
+            
+            if(darkIcon){
+                m_trayIcon->setIcon(filePath()->applicationIconDark());
+            } else {
+                m_trayIcon->setIcon(filePath()->applicationIcon());
+            }
+
             m_trayIcon->show();
         }
         if (m_ui->tabWidget->hasLockableDatabases()) {
-            m_trayIcon->setIcon(filePath()->trayIconUnlocked());
+            if(darkIcon){
+                m_trayIcon->setIcon(filePath()->trayIconUnlockedDark());
+            } else {
+                m_trayIcon->setIcon(filePath()->trayIconUnlocked());
+            }
         }
         else {
             m_trayIcon->setIcon(filePath()->trayIconLocked());

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -136,6 +136,7 @@ void SettingsWidget::loadSettings()
 
     m_generalUi->detailsHideCheckBox->setChecked(config()->get("GUI/HideDetailsView").toBool());
     m_generalUi->systrayShowCheckBox->setChecked(config()->get("GUI/ShowTrayIcon").toBool());
+    m_generalUi->systrayDarkIconCheckBox->setChecked(config()->get("GUI/DarkTrayIcon").toBool());
     m_generalUi->systrayMinimizeToTrayCheckBox->setChecked(config()->get("GUI/MinimizeToTray").toBool());
     m_generalUi->systrayMinimizeOnCloseCheckBox->setChecked(config()->get("GUI/MinimizeOnClose").toBool());
     m_generalUi->systrayMinimizeOnStartup->setChecked(config()->get("GUI/MinimizeOnStartup").toBool());
@@ -208,6 +209,7 @@ void SettingsWidget::saveSettings()
 
     config()->set("GUI/HideDetailsView", m_generalUi->detailsHideCheckBox->isChecked());
     config()->set("GUI/ShowTrayIcon", m_generalUi->systrayShowCheckBox->isChecked());
+    config()->set("GUI/DarkTrayIcon", m_generalUi->systrayDarkIconCheckBox->isChecked());
     config()->set("GUI/MinimizeToTray", m_generalUi->systrayMinimizeToTrayCheckBox->isChecked());
     config()->set("GUI/MinimizeOnClose", m_generalUi->systrayMinimizeOnCloseCheckBox->isChecked());
     config()->set("GUI/MinimizeOnStartup", m_generalUi->systrayMinimizeOnStartup->isChecked());
@@ -265,6 +267,7 @@ void SettingsWidget::enableAutoSaveOnExit(bool checked)
 
 void SettingsWidget::enableSystray(bool checked)
 {
+    m_generalUi->systrayDarkIconCheckBox->setEnabled(checked);
     m_generalUi->systrayMinimizeToTrayCheckBox->setEnabled(checked);
     m_generalUi->systrayMinimizeOnCloseCheckBox->setEnabled(checked);
 }

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -245,6 +245,42 @@
             </item>
            </layout>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SetMaximumSize</enum>
+            </property>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="systrayDarkIconCheckBox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Dark system tray icon</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
## Description
- New option `DarkTrayIcon` added to `keepassxc.ini` file, `false` by default.
- File paths now have two additional fields: `applicationIconDark` and `trayIconUnlockedDark`, both refer to the bundled dark icon.
- 'Dark system tray icon' option added to Settings UI

## Motivation and context
Implements feature request #784.

## How has this been tested?
Tested manually on macOS 10.13 and Ubuntu 17.04.
macOS screenshots attached.

## Screenshots:
![dark](https://user-images.githubusercontent.com/659520/32172348-f08425ae-bd83-11e7-8e76-6eaaefdaee19.png)

![light](https://user-images.githubusercontent.com/659520/32172353-f781d6ee-bd83-11e7-86bf-ada4b820f760.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

