### PR TITLE
Add test for DB creation, re-use ChnageMasterKeyWidget instance in CsvImportWizard

### DIFF
--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -236,6 +236,9 @@ private:
     bool m_searchCaseSensitive;
     bool m_searchLimitGroup;
 
+    // CSV import state
+    bool m_importingCsv;
+
     // Autoreload
     QFileSystemWatcher m_fileWatcher;
     QTimer m_fileWatchTimer;

--- a/src/gui/csvImport/CsvImportWizard.cpp
+++ b/src/gui/csvImport/CsvImportWizard.cpp
@@ -28,19 +28,9 @@ CsvImportWizard::CsvImportWizard(QWidget *parent)
     : DialogyWidget(parent)
 {
     m_layout = new QGridLayout(this);
-    m_pages = new QStackedWidget(parent);
-    m_layout->addWidget(m_pages, 0, 0);
+    m_layout->addWidget(m_parse = new CsvImportWidget(this), 0, 0);
 
-    m_pages->addWidget(key = new ChangeMasterKeyWidget(m_pages));
-    m_pages->addWidget(parse = new CsvImportWidget(m_pages));
-    key->headlineLabel()->setText(tr("Import CSV file"));
-    QFont headLineFont = key->headlineLabel()->font();
-    headLineFont.setBold(true);
-    headLineFont.setPointSize(headLineFont.pointSize() + 2);
-    key->headlineLabel()->setFont(headLineFont);
-
-    connect(key, SIGNAL(editFinished(bool)), this, SLOT(keyFinished(bool)));
-    connect(parse, SIGNAL(editFinished(bool)), this, SLOT(parseFinished(bool)));
+    connect(m_parse, SIGNAL(editFinished(bool)), this, SLOT(parseFinished(bool)));
 }
 
 CsvImportWizard::~CsvImportWizard()
@@ -49,21 +39,18 @@ CsvImportWizard::~CsvImportWizard()
 void CsvImportWizard::load(const QString& filename, Database* database)
 {
     m_db = database;
-    parse->load(filename, database);
-    key->clearForms();
+    m_parse->load(filename, database);
 }
 
-void CsvImportWizard::keyFinished(bool accepted)
+void CsvImportWizard::keyFinished(bool accepted, CompositeKey key)
 {
     if (!accepted) {
         emit importFinished(false);
         return;
     }
 
-    m_pages->setCurrentIndex(m_pages->currentIndex()+1);
-
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    bool result = m_db->setKey(key->newMasterKey());
+    bool result = m_db->setKey(key);
     QApplication::restoreOverrideCursor();
 
     if (!result) {

--- a/src/gui/csvImport/CsvImportWizard.h
+++ b/src/gui/csvImport/CsvImportWizard.h
@@ -38,19 +38,17 @@ public:
     explicit CsvImportWizard(QWidget *parent = nullptr);
     ~CsvImportWizard();
     void load(const QString& filename, Database *database);
+    void keyFinished(bool accepted, CompositeKey key);
 
 signals:
     void importFinished(bool accepted);
 
 private slots:
-    void keyFinished(bool accepted);
     void parseFinished(bool accepted);
 
 private:
     Database* m_db;
-    CsvImportWidget* parse;
-    ChangeMasterKeyWidget* key;
-    QStackedWidget *m_pages;
+    CsvImportWidget* m_parse;
     QGridLayout *m_layout;
 };
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -122,7 +122,12 @@ void TestGui::cleanup()
 
 void TestGui::testCreateDatabase()
 {
-    fileDialog()->setNextFileName(QString(KEEPASSX_TEST_DATA_DIR).append("/NewTestDatabase.kdbx"));
+    QTemporaryFile tmpFile;
+    QVERIFY(tmpFile.open());
+    QString tmpFileName = tmpFile.fileName();
+    tmpFile.remove();
+
+    fileDialog()->setNextFileName(tmpFileName);
     triggerAction("actionDatabaseNew");
 
     DatabaseWidget* dbWidget = m_tabWidget->currentDatabaseWidget();
@@ -148,13 +153,10 @@ void TestGui::testCreateDatabase()
     // there is a new empty db
     QCOMPARE(m_db->rootGroup()->children().size(), 0);
 
-    // clean 
+    // close the new database
     MessageBox::setNextAnswer(QMessageBox::No);
     triggerAction("actionDatabaseClose");
     Tools::wait(100);
-
-    QFile dbfile(QString(KEEPASSX_TEST_DATA_DIR).append("/NewTestDatabase.kdbx"));
-    dbfile.remove();
 }
 
 void TestGui::testMergeDatabase()

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -49,6 +49,7 @@
 #include "gui/DatabaseTabWidget.h"
 #include "gui/DatabaseWidget.h"
 #include "gui/CloneDialog.h"
+#include "gui/PasswordEdit.h"
 #include "gui/TotpDialog.h"
 #include "gui/SetupTotpDialog.h"
 #include "gui/FileDialog.h"
@@ -117,6 +118,43 @@ void TestGui::cleanup()
 
     m_db = nullptr;
     m_dbWidget = nullptr;
+}
+
+void TestGui::testCreateDatabase()
+{
+    fileDialog()->setNextFileName(QString(KEEPASSX_TEST_DATA_DIR).append("/NewTestDatabase.kdbx"));
+    triggerAction("actionDatabaseNew");
+
+    DatabaseWidget* dbWidget = m_tabWidget->currentDatabaseWidget();
+
+    QWidget* databaseNewWidget = dbWidget->findChild<QWidget*>("changeMasterKeyWidget");
+    QList<QWidget*> databaseNewWidgets = dbWidget->findChildren<QWidget*>("changeMasterKeyWidget");
+    PasswordEdit* editPassword = databaseNewWidget->findChild<PasswordEdit*>("enterPasswordEdit");
+    QVERIFY(editPassword->isVisible());
+
+    QLineEdit* editPasswordRepeat = databaseNewWidget->findChild<QLineEdit*>("repeatPasswordEdit");
+    QVERIFY(editPasswordRepeat->isVisible());
+
+    m_tabWidget->currentDatabaseWidget()->setCurrentWidget(databaseNewWidget);
+
+    QTest::keyClicks(editPassword, "test");
+    QTest::keyClicks(editPasswordRepeat, "test");
+    QTest::keyClick(editPasswordRepeat, Qt::Key_Enter);
+
+    QTRY_VERIFY(m_tabWidget->tabText(m_tabWidget->currentIndex()).contains("*"));
+
+    m_db = m_tabWidget->currentDatabaseWidget()->database();
+
+    // there is a new empty db
+    QCOMPARE(m_db->rootGroup()->children().size(), 0);
+
+    // clean 
+    MessageBox::setNextAnswer(QMessageBox::No);
+    triggerAction("actionDatabaseClose");
+    Tools::wait(100);
+
+    QFile dbfile(QString(KEEPASSX_TEST_DATA_DIR).append("/NewTestDatabase.kdbx"));
+    dbfile.remove();
 }
 
 void TestGui::testMergeDatabase()

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -40,6 +40,7 @@ private slots:
     void cleanup();
     void cleanupTestCase();
 
+    void testCreateDatabase();
     void testMergeDatabase();
     void testAutoreloadDatabase();
     void testTabs();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This PR add a GUI test for DB creation
It also fix CsvImportWizard to re-use the already running ChnageMasterKeyWidget instance

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently we aren't testing the DB creation mechanism

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, with `make test` and Travis

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
