### PR TITLE
Merge : Synchronising groups.

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -26,6 +26,11 @@
 const int Group::DefaultIconNumber = 48;
 const int Group::RecycleBinIconNumber = 43;
 
+Group::CloneFlags Group::DefaultCloneFlags = static_cast<Group::CloneFlags>(
+    Group::CloneNewUuid | Group::CloneResetTimeInfo | Group::CloneIncludeEntries);
+Entry::CloneFlags Group::DefaultEntryCloneFlags = static_cast<Entry::CloneFlags>(
+    Entry::CloneNewUuid | Entry::CloneResetTimeInfo);
+
 Group::Group()
     : m_updateTimeinfo(true)
 {

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -681,12 +681,12 @@ void Group::merge(const Group* other)
 
         Entry* existingEntry = rootGroup->findEntryByUuid(entry->uuid());
 
-        // This entry does not exist at all. Create it.
         if (!existingEntry) {
+            // This entry does not exist at all. Create it.
             qDebug("New entry %s detected. Creating it.", qPrintable(entry->title()));
             entry->clone(Entry::CloneIncludeHistory)->setGroup(this);
-        // Entry is already present in the database. Update it.
         } else {
+            // Entry is already present in the database. Update it.
             bool locationChanged = existingEntry->timeInfo().locationChanged() < entry->timeInfo().locationChanged();
             if (locationChanged && existingEntry->group() != this) {
                 existingEntry->setGroup(this);
@@ -978,13 +978,16 @@ void Group::resolveGroupConflict(Group* existingGroup, Group* otherGroup)
     const QDateTime timeExisting = existingGroup->timeInfo().lastModificationTime();
     const QDateTime timeOther = otherGroup->timeInfo().lastModificationTime();
 
-    // only if the other group newer, update the existing one.
+    // only if the other group is newer, update the existing one.
     if (timeExisting < timeOther) {
         qDebug("Updating group %s.", qPrintable(existingGroup->name()));
         existingGroup->setName(otherGroup->name());
         existingGroup->setNotes(otherGroup->notes());
-        existingGroup->setIcon(otherGroup->iconNumber());
-        existingGroup->setIcon(otherGroup->iconUuid());
+        if (otherGroup->iconNumber() == 0) {
+          existingGroup->setIcon(otherGroup->iconUuid());
+        } else {
+          existingGroup->setIcon(otherGroup->iconNumber());
+        }
         existingGroup->setExpiryTime(otherGroup->timeInfo().expiryTime());
     }
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -134,8 +134,8 @@ public:
      * Note that you need to copy the custom icons manually when inserting the
      * new group into another database.
      */
-    Group* clone(
-        Entry::CloneFlags entryFlags = DefaultEntryCloneFlags, CloneFlags groupFlags = DefaultCloneFlags) const;
+    Group* clone(Entry::CloneFlags entryFlags = DefaultEntryCloneFlags,
+                 CloneFlags groupFlags = DefaultCloneFlags) const;
 
     void copyDataFrom(const Group* other);
     void merge(const Group* other);

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -37,6 +37,14 @@ public:
     enum TriState { Inherit, Enable, Disable };
     enum MergeMode { ModeInherit, KeepBoth, KeepNewer, KeepExisting };
 
+    enum CloneFlag {
+        CloneNoFlags        = 0,
+        CloneNewUuid        = 1,  // generate a random uuid for the clone
+        CloneResetTimeInfo  = 2,  // set all TimeInfo attributes to the current time
+        CloneIncludeEntries = 4,  // clone the group entries
+    };
+    Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
+
     struct GroupData
     {
         QString name;
@@ -80,6 +88,7 @@ public:
     static const int RecycleBinIconNumber;
 
     Group* findChildByName(const QString& name);
+    Group* findChildByUuid(const Uuid& uuid);
     Entry* findEntry(QString entryId);
     Entry* findEntryByUuid(const Uuid& uuid);
     Entry* findEntryByPath(QString entryPath, QString basePath = QString(""));
@@ -126,7 +135,8 @@ public:
      * new group into another database.
      */
     Group* clone(Entry::CloneFlags entryFlags = Entry::CloneNewUuid | Entry::CloneResetTimeInfo,
-                 bool shallow = false) const;
+                 CloneFlags groupFlags = static_cast<CloneFlags>(Group::CloneNewUuid | Group::CloneResetTimeInfo |
+                                                                 Group::CloneIncludeEntries)) const;
     void copyDataFrom(const Group* other);
     void merge(const Group* other);
     QString print(bool recursive = false, int depth = 0);
@@ -160,7 +170,8 @@ private:
     void removeEntry(Entry* entry);
     void setParent(Database* db);
     void markOlderEntry(Entry* entry);
-    void resolveConflict(Entry* existingEntry, Entry* otherEntry);
+    void resolveEntryConflict(Entry* existingEntry, Entry* otherEntry);
+    void resolveGroupConflict(Group* existingGroup, Group* otherGroup);
 
     void recSetDatabase(Database* db);
     void cleanupParent();
@@ -182,5 +193,7 @@ private:
     friend Entry::~Entry();
     friend void Entry::setGroup(Group* group);
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(Group::CloneFlags)
 
 #endif // KEEPASSX_GROUP_H

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -86,6 +86,8 @@ public:
 
     static const int DefaultIconNumber;
     static const int RecycleBinIconNumber;
+    static CloneFlags DefaultCloneFlags;
+    static Entry::CloneFlags DefaultEntryCloneFlags;
 
     Group* findChildByName(const QString& name);
     Group* findChildByUuid(const Uuid& uuid);
@@ -128,15 +130,13 @@ public:
     QList<Group*> groupsRecursive(bool includeSelf);
     QSet<Uuid> customIconsRecursive() const;
     /**
-     * Creates a duplicate of this group including all child entries and groups (if not shallow).
-     * The exceptions are that the returned group doesn't have a parent group
-     * and all TimeInfo attributes are set to the current time.
+     * Creates a duplicate of this group.
      * Note that you need to copy the custom icons manually when inserting the
      * new group into another database.
      */
-    Group* clone(Entry::CloneFlags entryFlags = Entry::CloneNewUuid | Entry::CloneResetTimeInfo,
-                 CloneFlags groupFlags = static_cast<CloneFlags>(Group::CloneNewUuid | Group::CloneResetTimeInfo |
-                                                                 Group::CloneIncludeEntries)) const;
+    Group* clone(
+        Entry::CloneFlags entryFlags = DefaultEntryCloneFlags, CloneFlags groupFlags = DefaultCloneFlags) const;
+
     void copyDataFrom(const Group* other);
     void merge(const Group* other);
     QString print(bool recursive = false, int depth = 0);

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -391,6 +391,22 @@ void TestGroup::testClone()
     QCOMPARE(clonedGroupKeepUuid->entries().at(0)->uuid(), originalGroupEntry->uuid());
     QCOMPARE(clonedGroupKeepUuid->children().at(0)->entries().at(0)->uuid(), subGroupEntry->uuid());
 
+    Group* clonedGroupNoFlags = originalGroup->clone(Entry::CloneNoFlags, Group::CloneNoFlags);
+    QCOMPARE(clonedGroupNoFlags->entries().size(), 0);
+    QVERIFY(clonedGroupNoFlags->uuid() == originalGroup->uuid());
+
+    Group* clonedGroupNewUuid = originalGroup->clone(Entry::CloneNoFlags, Group::CloneNewUuid);
+    QCOMPARE(clonedGroupNewUuid->entries().size(), 0);
+    QVERIFY(clonedGroupNewUuid->uuid() != originalGroup->uuid());
+
+    // Making sure the new modification date is not the same.
+    QTest::qSleep(1);
+
+    Group* clonedGroupResetTimeInfo = originalGroup->clone(Entry::CloneNoFlags, Group::CloneNewUuid | Group::CloneResetTimeInfo);
+    QCOMPARE(clonedGroupResetTimeInfo->entries().size(), 0);
+    QVERIFY(clonedGroupResetTimeInfo->uuid() != originalGroup->uuid());
+    QVERIFY(clonedGroupResetTimeInfo->timeInfo().lastModificationTime() != originalGroup->timeInfo().lastModificationTime());
+
     delete clonedGroup;
     delete clonedGroupKeepUuid;
     delete db;

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -64,7 +64,7 @@ void TestMerge::testMergeNoChanges()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
     QCOMPARE(dbDestination->rootGroup()->entriesRecursive().size(), 2);
     QCOMPARE(dbSource->rootGroup()->entriesRecursive().size(), 2);
@@ -92,7 +92,7 @@ void TestMerge::testResolveConflictNewer()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
     // sanity check
     Group* group1 = dbSource->rootGroup()->findChildByName("group1");
@@ -141,7 +141,7 @@ void TestMerge::testResolveConflictOlder()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
     // sanity check
     Group* group1 = dbSource->rootGroup()->findChildByName("group1");
@@ -197,7 +197,7 @@ void TestMerge::testResolveConflictKeepBoth()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneIncludeHistory));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneIncludeHistory, Group::CloneIncludeEntries));
 
     // sanity check
     QCOMPARE(dbDestination->rootGroup()->children().at(0)->entries().size(), 2);
@@ -236,7 +236,7 @@ void TestMerge::testMoveEntry()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
     Entry* entry1 = dbSource->rootGroup()->findEntry("entry1");
     QVERIFY(entry1 != nullptr);
@@ -270,7 +270,7 @@ void TestMerge::testMoveEntryPreserveChanges()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
     Entry* entry1 = dbSource->rootGroup()->findEntry("entry1");
     QVERIFY(entry1 != nullptr);
@@ -307,11 +307,12 @@ void TestMerge::testCreateNewGroups()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
     QTest::qSleep(1);
     Group* group3 = new Group();
     group3->setName("group3");
+    group3->setUuid(Uuid::random());
     group3->setParent(dbSource->rootGroup());
 
     dbDestination->merge(dbSource);
@@ -329,11 +330,12 @@ void TestMerge::testMoveEntryIntoNewGroup()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
     QTest::qSleep(1);
     Group* group3 = new Group();
     group3->setName("group3");
+    group3->setUuid(Uuid::random());
     group3->setParent(dbSource->rootGroup());
 
     Entry* entry1 = dbSource->rootGroup()->findEntry("entry1");
@@ -365,10 +367,11 @@ void TestMerge::testUpdateEntryDifferentLocation()
     Database* dbDestination = createTestDatabase();
 
     Database* dbSource = new Database();
-    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags));
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
     Group* group3 = new Group();
     group3->setName("group3");
+    group3->setUuid(Uuid::random());
     group3->setParent(dbDestination->rootGroup());
 
     Entry* entry1 = dbDestination->rootGroup()->findEntry("entry1");
@@ -394,6 +397,84 @@ void TestMerge::testUpdateEntryDifferentLocation()
     QCOMPARE(entry1->username(), QString("username"));
     QCOMPARE(entry1->group()->name(), QString("group3"));
     QCOMPARE(uuidBeforeSyncing, entry1->uuid());
+
+    delete dbDestination;
+    delete dbSource;
+}
+
+/**
+ * Groups should be updated using the uuids.
+ */
+void TestMerge::testUpdateGroup()
+{
+    Database* dbDestination = createTestDatabase();
+
+    Database* dbSource = new Database();
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
+
+    QTest::qSleep(1);
+
+    Group* group2 = dbSource->rootGroup()->findChildByName("group2");
+    group2->setName("group2 renamed");
+    group2->setNotes("updated notes");
+    Uuid customIconId = Uuid::random();
+    QImage customIcon;
+    dbSource->metadata()->addCustomIcon(customIconId, customIcon);
+    group2->setIcon(customIconId);
+
+    Entry* entry1 = dbSource->rootGroup()->findEntry("entry1");
+    QVERIFY(entry1 != nullptr);
+    entry1->setGroup(group2);
+    entry1->setTitle("entry1 renamed");
+    Uuid uuidBeforeSyncing = entry1->uuid();
+
+    dbDestination->merge(dbSource);
+
+    QCOMPARE(dbDestination->rootGroup()->entriesRecursive().size(), 2);
+
+    entry1 = dbDestination->rootGroup()->findEntry("entry1 renamed");
+    QVERIFY(entry1 != nullptr);
+    QVERIFY(entry1->group() != nullptr);
+    QCOMPARE(entry1->group()->name(), QString("group2 renamed"));
+    QCOMPARE(uuidBeforeSyncing, entry1->uuid());
+
+    group2 = dbDestination->rootGroup()->findChildByName("group2 renamed");
+    QCOMPARE(group2->notes(), QString("updated notes"));
+    QCOMPARE(group2->iconUuid(), customIconId);
+
+    delete dbDestination;
+    delete dbSource;
+}
+
+void TestMerge::testUpdateGroupLocation()
+{
+    Database* dbDestination = createTestDatabase();
+    Group* group3 = new Group();
+    Uuid group3Uuid = Uuid::random();
+    group3->setUuid(group3Uuid);
+    group3->setName("group3");
+    group3->setParent(dbDestination->rootGroup()->findChildByName("group1"));
+
+    Database* dbSource = new Database();
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
+
+    // Sanity check
+    group3 = dbSource->rootGroup()->findChildByUuid(group3Uuid);
+    QVERIFY(group3 != nullptr);
+
+    QTest::qSleep(1);
+
+    group3->setParent(dbSource->rootGroup()->findChildByName("group2"));
+
+    dbDestination->merge(dbSource);
+    group3 = dbDestination->rootGroup()->findChildByUuid(group3Uuid);
+    QVERIFY(group3 != nullptr);
+    QCOMPARE(group3->parent(), dbDestination->rootGroup()->findChildByName("group2"));
+
+    dbDestination->merge(dbSource);
+    group3 = dbDestination->rootGroup()->findChildByUuid(group3Uuid);
+    QVERIFY(group3 != nullptr);
+    QCOMPARE(group3->parent(), dbDestination->rootGroup()->findChildByName("group2"));
 
     delete dbDestination;
     delete dbSource;
@@ -447,14 +528,54 @@ void TestMerge::testMergeCustomIcons()
     delete dbSource;
 }
 
+/**
+ * If the group is updated in the source database, and the
+ * destination database after, the group should remain the
+ * same.
+ */
+void TestMerge::testResolveGroupConflictOlder()
+{
+    Database* dbDestination = createTestDatabase();
+
+    Database* dbSource = new Database();
+    dbSource->setRootGroup(dbDestination->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
+
+    // sanity check
+    Group* group1 = dbSource->rootGroup()->findChildByName("group1");
+    QVERIFY(group1 != nullptr);
+
+    // Make sure the two changes have a different timestamp.
+    QTest::qSleep(1);
+    group1->setName("group1 updated in source");
+
+    // Make sure the two changes have a different timestamp.
+    QTest::qSleep(1);
+
+    group1 = dbDestination->rootGroup()->findChildByName("group1");
+    group1->setName("group1 updated in destination");
+
+    dbDestination->merge(dbSource);
+
+    // sanity check
+    group1 = dbDestination->rootGroup()->findChildByName("group1 updated in destination");
+    QVERIFY(group1 != nullptr);
+
+    delete dbDestination;
+    delete dbSource;
+}
+
+
 Database* TestMerge::createTestDatabase()
 {
     Database* db = new Database();
 
     Group* group1 = new Group();
     group1->setName("group1");
+    group1->setUuid(Uuid::random());
+
     Group* group2 = new Group();
     group2->setName("group2");
+    group2->setUuid(Uuid::random());
 
     Entry* entry1 = new Entry();
     Entry* entry2 = new Entry();

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -31,12 +31,15 @@ private slots:
     void testMergeNoChanges();
     void testResolveConflictNewer();
     void testResolveConflictOlder();
+    void testResolveGroupConflictOlder();
     void testResolveConflictKeepBoth();
     void testMoveEntry();
     void testMoveEntryPreserveChanges();
     void testMoveEntryIntoNewGroup();
     void testCreateNewGroups();
     void testUpdateEntryDifferentLocation();
+    void testUpdateGroup();
+    void testUpdateGroupLocation();
     void testMergeAndSync();
     void testMergeCustomIcons();
 


### PR DESCRIPTION
This changes the merge function to match the groups using the UUIDs, the same way we match the entries. This allows us to do basic conflict resolution on the groups, so we can update the basic information such as the name and the location.

I also removed the `shallow` parameter to `Group::clone` in favor of `CloneFlags`, just like for `Entry::clone`.

I think the next step for the merge function would be to separate the change detection (new entries, new groups, entries or groups changed) and the actual modification of the destination database. This would allow us to fix a couple of issues with the merge function. For example, we could easily implement a dry-run functionality, and we could detect when the database was really modified by a merge operation. This would also allow us to do the conflict resolution interactively.

## How has this been tested?
Added new unit tests.
Tested locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
