### PR TITLE
Add warning on long Auto Type sequences

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -692,3 +692,43 @@ bool AutoType::windowMatchesUrl(const QString& windowTitle, const QString& resol
 
     return false;
 }
+
+bool AutoType::checkSynatx(const QString &string)
+{
+    //checks things like {word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring
+    QString allowRepetition = "(\\s[0-9]*){0,1}";
+    QString normalCommands = "[A-Z]*" + allowRepetition;
+    QString specialLiterals = "[\\^\\%\\(\\)~\\{\\}\\[\\]\\+-]" + allowRepetition;
+    QString functionKeys = "(F[1-9]" + allowRepetition + "|F1[0-2])" + allowRepetition;
+    QString numpad = "NUMPAD[0-9]" + allowRepetition;
+    QString delay = "DELAY=[0-9]+";
+    QString beep = "BEEP\\s[0-9]*\\s[0-9]*";
+    QString vkey = "VKEY(-[EN]X){0,1}" + allowRepetition;
+
+    //these arent in parenthesis
+    QString shortcutKeys = "[\\^\\%~\\+@]";
+    QString fixedStrings = "[^\\^\\%~\\+@\\{\\}]*";
+
+    QRegExp autoTypeSyntax
+        ("(" + shortcutKeys + "|" + fixedStrings + "|\\{(" + normalCommands + "|" + specialLiterals + "|"
+             + functionKeys
+             + "|" + numpad + "|" + delay + "|" + beep + "|" + vkey + ")\\})*");
+    autoTypeSyntax.setCaseSensitivity(Qt::CaseInsensitive);
+    autoTypeSyntax.setPatternSyntax(QRegExp::RegExp);
+    return autoTypeSyntax.exactMatch(string);
+}
+
+bool AutoType::checkHighDelay(const QString &string)
+{
+    QRegExp highDelay(".*\\{Delay\\s[0-9]{5,}\\}.*"); //the 3 means 3 digitnumbers are too much
+    highDelay.setCaseSensitivity(Qt::CaseInsensitive);
+    highDelay.setPatternSyntax(QRegExp::RegExp);
+    return highDelay.exactMatch(string);
+}
+
+bool AutoType::checkHighRepetition(const QString &string)
+{
+    QRegExp highRepetition(".*\\s[0-9]{3,}.*");
+    highRepetition.setPatternSyntax(QRegExp::RegExp);
+    return highRepetition.exactMatch(string);
+}

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -20,6 +20,7 @@
 
 #include <QApplication>
 #include <QPluginLoader>
+#include <iostream>
 
 #include "config-keepassx.h"
 
@@ -396,7 +397,7 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
                 QMessageBox::StandardButton reply;
                 reply = QMessageBox::question(0,
                                               "AutoType",
-                                              "This AutoType command contains a very long delay. Do you really want to execute it?");
+                                              tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
 
                 if (reply == QMessageBox::No) {
                     return list;
@@ -407,7 +408,7 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
             QMessageBox::StandardButton reply;
             reply = QMessageBox::question(0,
                                           "AutoType",
-                                          "This AutoType command contains arguments which are repeated very often. Do you really want to execute it?");
+                                          tr("This AutoType command contains arguments which are repeated very often. Do you really want to execute it?"));
 
             if (reply == QMessageBox::No) {
                 return list;

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -725,7 +725,7 @@ bool AutoType::checkSyntax(const QString &string)
 
 bool AutoType::checkHighDelay(const QString &string)
 {
-    QRegExp highDelay(".*\\{Delay\\s[0-9]{5,}\\}.*"); //the 3 means 3 digitnumbers are too much
+    QRegExp highDelay(".*\\{Delay\\s[0-9]{5,}\\}.*"); //5 digit numbers(10 seconds) are too much
     highDelay.setCaseSensitivity(Qt::CaseInsensitive);
     highDelay.setPatternSyntax(QRegExp::RegExp);
     return highDelay.exactMatch(string);
@@ -733,7 +733,7 @@ bool AutoType::checkHighDelay(const QString &string)
 
 bool AutoType::checkHighRepetition(const QString &string)
 {
-    QRegExp highRepetition(".*\\s[0-9]{3,}.*");
+    QRegExp highRepetition(".*\\s[0-9]{3,}.*");//3 digit numbers are too much
     highRepetition.setPatternSyntax(QRegExp::RegExp);
     return highRepetition.exactMatch(string);
 }

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -356,13 +356,16 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
     }
 
     for (const QChar &ch : sequence) {
+        if (inTmpl) {
             if (ch == '{') {
                 qWarning("Syntax error in auto-type sequence.");
                 return false;
             }
             else if (ch == '}') {
-                QList<AutoTypeAction*> autoType = createActionFromTemplate(tmpl, entry);
-                if (autoType.isEmpty()) return false;
+                QList<AutoTypeAction *> autoType = createActionFromTemplate(tmpl, entry);
+                if (autoType.isEmpty()) {
+                    return false;
+                }
                 actions.append(autoType);
                 inTmpl = false;
                 tmpl.clear();

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -581,8 +581,8 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
     //allows to insert usernames and passwords multiple times
     if (!list.isEmpty()) {
         for (int i = 1; i < num; i++) {
-            for (int i = 0; i < resolved.size(); i++) {
-                list.append(list.at(i)->clone());
+            for (int j = 0; j < resolved.size(); j++) {
+                list.append(list.at(j)->clone());
             }
         }
     }

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -252,7 +252,8 @@ void AutoType::performAutoTypeFromGlobal(Entry* entry, const QString& sequence)
     m_plugin->raiseWindow(m_windowFromGlobal);
 
     m_inAutoType = false;
-    performAutoType(entry, nullptr, sequence, m_windowFromGlobal);
+
+    performAutoTypeWithSyntaxCheckingDialog(entry, nullptr, sequence, m_windowFromGlobal);
 }
 
 void AutoType::resetInAutoType()
@@ -713,4 +714,39 @@ bool AutoType::checkHighRepetition(const QString &string)
     QRegExp highRepetition(".*\\s[0-9]{3,}.*");//3 digit numbers are too much
     highRepetition.setPatternSyntax(QRegExp::RegExp);
     return highRepetition.exactMatch(string);
+}
+
+void
+AutoType::performAutoTypeWithSyntaxCheckingDialog(const Entry *entry,
+                                                  QWidget *hideWindow,
+                                                  const QString &customSequence,
+                                                  WId window)
+{
+    if (!AutoType::checkSyntax(entry->effectiveAutoTypeSequence())) {
+        QMessageBox messageBox;
+        messageBox.critical(0, "AutoType", tr("The Syntax of your AutoType statement is incorrect!"));
+        return;
+    }
+    else if (AutoType::checkHighDelay(entry->effectiveAutoTypeSequence())) {
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::question(0,
+                                      "AutoType",
+                                      tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
+
+        if (reply == QMessageBox::No) {
+            return;
+        }
+    }
+    else if (AutoType::checkHighRepetition(entry->effectiveAutoTypeSequence())) {
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::question(0,
+                                      "AutoType",
+                                      tr("This AutoType command contains arguments which are repeated very often. Do you really want to execute it?"));
+
+        if (reply == QMessageBox::No) {
+            return;
+        }
+    }
+    performAutoType(entry, hideWindow, customSequence, window);
+
 }

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -679,7 +679,7 @@ bool AutoType::checkSyntax(const QString &string)
 {
     //checks things like {word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring
     QString allowRepetition = "(\\s[0-9]*){0,1}";
-    QString normalCommands = "[A-Z]*" + allowRepetition;
+    QString normalCommands = "[A-Z:]*" + allowRepetition; //the ":" allows custom commands
     QString specialLiterals = "[\\^\\%\\(\\)~\\{\\}\\[\\]\\+-]" + allowRepetition;
     QString functionKeys = "(F[1-9]" + allowRepetition + "|F1[0-2])" + allowRepetition;
     QString numpad = "NUMPAD[0-9]" + allowRepetition;

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -20,8 +20,8 @@
 
 #include <QApplication>
 #include <QPluginLoader>
-#include <iostream>
 #include <QtWidgets/QErrorMessage>
+#include <iostream>
 
 #include "config-keepassx.h"
 
@@ -56,8 +56,7 @@ AutoType::AutoType(QObject* parent, bool test)
     QString pluginName = "keepassx-autotype-";
     if (!test) {
         pluginName += QApplication::platformName();
-    }
-    else {
+    } else {
         pluginName += "test";
     }
 
@@ -93,8 +92,7 @@ void AutoType::loadPlugin(const QString& pluginPath)
             if (m_plugin->isAvailable()) {
                 m_executor = m_plugin->createExecutor();
                 connect(pluginInstance, SIGNAL(globalShortcutTriggered()), SIGNAL(globalShortcutTriggered()));
-            }
-            else {
+            } else {
                 unloadPlugin();
             }
         }
@@ -140,8 +138,7 @@ void AutoType::_performAutoType(const Entry* entry, QWidget* hideWindow, const Q
     QString sequence;
     if (customSequence.isEmpty()) {
         sequence = autoTypeSequence(entry);
-    }
-    else {
+    } else {
         sequence = customSequence;
     }
 
@@ -223,16 +220,14 @@ void AutoType::performGlobalAutoType(const QList<Database*>& dbList)
         message.append("\n\n");
         message.append(windowTitle);
         MessageBox::information(nullptr, tr("Auto-Type - KeePassXC"), message);
-    }
-    else if ((entryList.size() == 1) && !config()->get("security/autotypeask").toBool()) {
+    } else if ((entryList.size() == 1) && !config()->get("security/autotypeask").toBool()) {
         m_inAutoType = false;
         performAutoType(entryList.first(), nullptr, sequenceHash[entryList.first()]);
-    }
-    else {
+    } else {
         m_windowFromGlobal = m_plugin->activeWindow();
         AutoTypeSelectDialog* selectDialog = new AutoTypeSelectDialog();
-        connect(selectDialog, SIGNAL(entryActivated(Entry*,QString)),
-                SLOT(performAutoTypeFromGlobal(Entry*,QString)));
+        connect(
+            selectDialog, SIGNAL(entryActivated(Entry*, QString)), SLOT(performAutoTypeFromGlobal(Entry*, QString)));
         connect(selectDialog, SIGNAL(rejected()), SLOT(resetInAutoType()));
         selectDialog->setEntries(entryList, sequenceHash);
 #if defined(Q_OS_MAC)
@@ -301,12 +296,10 @@ bool AutoType::registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifie
             m_currentGlobalKey = key;
             m_currentGlobalModifiers = modifiers;
             return true;
-        }
-        else {
+        } else {
             return false;
         }
-    }
-    else {
+    } else {
         return true;
     }
 }
@@ -333,33 +326,28 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
     bool inTmpl = false;
     m_autoTypeDelay = config()->get("AutoTypeDelay").toInt();
 
-    for (const QChar &ch : sequence) {
+    for (const QChar& ch : sequence) {
         if (inTmpl) {
             if (ch == '{') {
                 qWarning("Syntax error in auto-type sequence.");
                 return false;
-            }
-            else if (ch == '}') {
-                QList<AutoTypeAction *> autoType = createActionFromTemplate(tmpl, entry);
+            } else if (ch == '}') {
+                QList<AutoTypeAction*> autoType = createActionFromTemplate(tmpl, entry);
                 if (autoType.isEmpty()) {
                     return false;
                 }
                 actions.append(autoType);
                 inTmpl = false;
                 tmpl.clear();
-            }
-            else {
+            } else {
                 tmpl += ch;
             }
-        }
-        else if (ch == '{') {
+        } else if (ch == '{') {
             inTmpl = true;
-        }
-        else if (ch == '}') {
+        } else if (ch == '}') {
             qWarning("Syntax error in auto-type sequence.");
             return false;
-        }
-        else {
+        } else {
             actions.append(new AutoTypeChar(ch));
         }
     }
@@ -402,104 +390,72 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
 
     if (tmplName.compare("tab", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Tab));
-    }
-    else if (tmplName.compare("enter", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("enter", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Enter));
-    }
-    else if (tmplName.compare("space", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("space", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Space));
-    }
-    else if (tmplName.compare("up", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("up", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Up));
-    }
-    else if (tmplName.compare("down", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("down", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Down));
-    }
-    else if (tmplName.compare("left", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("left", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Left));
-    }
-    else if (tmplName.compare("right", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("right", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Right));
-    }
-    else if (tmplName.compare("insert", Qt::CaseInsensitive) == 0 ||
-        tmplName.compare("ins", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("insert", Qt::CaseInsensitive) == 0 ||
+               tmplName.compare("ins", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Insert));
-    }
-    else if (tmplName.compare("delete", Qt::CaseInsensitive) == 0 ||
-        tmplName.compare("del", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("delete", Qt::CaseInsensitive) == 0 ||
+               tmplName.compare("del", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Delete));
-    }
-    else if (tmplName.compare("home", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("home", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Home));
-    }
-    else if (tmplName.compare("end", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("end", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_End));
-    }
-    else if (tmplName.compare("pgup", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("pgup", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_PageUp));
-    }
-    else if (tmplName.compare("pgdown", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("pgdown", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_PageDown));
-    }
-    else if (tmplName.compare("backspace", Qt::CaseInsensitive) == 0 ||
-        tmplName.compare("bs", Qt::CaseInsensitive) == 0 ||
-        tmplName.compare("bksp", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("backspace", Qt::CaseInsensitive) == 0 ||
+               tmplName.compare("bs", Qt::CaseInsensitive) == 0 || tmplName.compare("bksp", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Backspace));
-    }
-    else if (tmplName.compare("break", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("break", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Pause));
-    }
-    else if (tmplName.compare("capslock", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("capslock", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_CapsLock));
-    }
-    else if (tmplName.compare("esc", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("esc", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Escape));
-    }
-    else if (tmplName.compare("help", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("help", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Help));
-    }
-    else if (tmplName.compare("numlock", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("numlock", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_NumLock));
-    }
-    else if (tmplName.compare("ptrsc", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("ptrsc", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Print));
-    }
-    else if (tmplName.compare("scrolllock", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("scrolllock", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_ScrollLock));
     }
-        // Qt doesn't know about keypad keys so use the normal ones instead
-    else if (tmplName.compare("add", Qt::CaseInsensitive) == 0 ||
-        tmplName.compare("+", Qt::CaseInsensitive) == 0) {
+    // Qt doesn't know about keypad keys so use the normal ones instead
+    else if (tmplName.compare("add", Qt::CaseInsensitive) == 0 || tmplName.compare("+", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('+'));
-    }
-    else if (tmplName.compare("subtract", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("subtract", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('-'));
-    }
-    else if (tmplName.compare("multiply", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("multiply", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('*'));
-    }
-    else if (tmplName.compare("divide", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("divide", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('/'));
-    }
-    else if (tmplName.compare("^", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("^", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('^'));
-    }
-    else if (tmplName.compare("%", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("%", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('%'));
-    }
-    else if (tmplName.compare("~", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("~", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('~'));
-    }
-    else if (tmplName.compare("(", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("(", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('('));
-    }
-    else if (tmplName.compare(")", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare(")", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar(')'));
-    }
-    else if (tmplName.compare("leftbrace", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("leftbrace", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('{'));
-    }
-    else if (tmplName.compare("rightbrace", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("rightbrace", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('}'));
     }
 
@@ -520,14 +476,11 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
         return list;
     }
 
-
     if (tmplName.compare("delay", Qt::CaseInsensitive) == 0 && num > 0) {
         list.append(new AutoTypeDelay(num));
-    }
-    else if (tmplName.compare("clearfield", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("clearfield", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeClearField());
-    }
-    else if (tmplName.compare("totp", Qt::CaseInsensitive) == 0) {
+    } else if (tmplName.compare("totp", Qt::CaseInsensitive) == 0) {
         QString totp = entry->totp();
         if (!totp.isEmpty()) {
             for (const QChar& ch : totp) {
@@ -546,11 +499,9 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
         for (const QChar& ch : resolved) {
             if (ch == '\n') {
                 list.append(new AutoTypeKey(Qt::Key_Enter));
-            }
-            else if (ch == '\t') {
+            } else if (ch == '\t') {
                 list.append(new AutoTypeKey(Qt::Key_Tab));
-            }
-            else {
+            } else {
                 list.append(new AutoTypeChar(ch));
             }
         }
@@ -575,8 +526,7 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
             if (windowMatches(windowTitle, window)) {
                 if (!assoc.sequence.isEmpty()) {
                     sequence = assoc.sequence;
-                }
-                else {
+                } else {
                     sequence = entry->defaultAutoTypeSequence();
                 }
                 match = true;
@@ -584,14 +534,14 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
             }
         }
 
-        if (!match && config()->get("AutoTypeEntryTitleMatch").toBool() 
-                && windowMatchesTitle(windowTitle, entry->resolvePlaceholder(entry->title()))) {
+        if (!match && config()->get("AutoTypeEntryTitleMatch").toBool() &&
+            windowMatchesTitle(windowTitle, entry->resolvePlaceholder(entry->title()))) {
             sequence = entry->defaultAutoTypeSequence();
             match = true;
         }
 
-        if (!match && config()->get("AutoTypeEntryURLMatch").toBool()
-                && windowMatchesUrl(windowTitle, entry->resolvePlaceholder(entry->url()))) {
+        if (!match && config()->get("AutoTypeEntryURLMatch").toBool() &&
+            windowMatchesUrl(windowTitle, entry->resolvePlaceholder(entry->url()))) {
             sequence = entry->defaultAutoTypeSequence();
             match = true;
         }
@@ -599,18 +549,16 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
         if (!match) {
             return QString();
         }
-    }
-    else {
+    } else {
         sequence = entry->defaultAutoTypeSequence();
     }
 
-    const Group *group = entry->group();
+    const Group* group = entry->group();
     do {
         if (!enableSet) {
             if (group->autoTypeEnabled() == Group::Disable) {
                 return QString();
-            }
-            else if (group->autoTypeEnabled() == Group::Enable) {
+            } else if (group->autoTypeEnabled() == Group::Enable) {
                 enableSet = true;
             }
         }
@@ -622,15 +570,13 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
         group = group->parentGroup();
     } while (group && (!enableSet || sequence.isEmpty()));
 
-    if (sequence.isEmpty() && (!entry->resolvePlaceholder(entry->username()).isEmpty()
-        || !entry->resolvePlaceholder(entry->password()).isEmpty())) {
+    if (sequence.isEmpty() && (!entry->resolvePlaceholder(entry->username()).isEmpty() ||
+                               !entry->resolvePlaceholder(entry->password()).isEmpty())) {
         if (entry->resolvePlaceholder(entry->username()).isEmpty()) {
             sequence = "{PASSWORD}{ENTER}";
-        }
-        else if (entry->resolvePlaceholder(entry->password()).isEmpty()) {
+        } else if (entry->resolvePlaceholder(entry->password()).isEmpty()) {
             sequence = "{USERNAME}{ENTER}";
-        }
-        else {
+        } else {
             sequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}";
         }
     }
@@ -643,8 +589,7 @@ bool AutoType::windowMatches(const QString& windowTitle, const QString& windowPa
     if (windowPattern.startsWith("//") && windowPattern.endsWith("//") && windowPattern.size() >= 4) {
         QRegExp regExp(windowPattern.mid(2, windowPattern.size() - 4), Qt::CaseInsensitive, QRegExp::RegExp2);
         return (regExp.indexIn(windowTitle) != -1);
-    }
-    else {
+    } else {
         return WildcardMatcher(windowTitle).match(windowPattern);
     }
 }
@@ -668,11 +613,11 @@ bool AutoType::windowMatchesUrl(const QString& windowTitle, const QString& resol
     return false;
 }
 
-bool AutoType::checkSyntax(const QString &string)
+bool AutoType::checkSyntax(const QString& string)
 {
-    //checks things like {word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring
+    // checks things like {word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring
     QString allowRepetition = "(\\s\\d*){0,1}";
-    QString normalCommands = "[A-Z:]*" + allowRepetition; //the ":" allows custom commands
+    QString normalCommands = "[A-Z:]*" + allowRepetition; // the ":" allows custom commands
     QString specialLiterals = "[\\^\\%\\(\\)~\\{\\}\\[\\]\\+-]" + allowRepetition;
     QString functionKeys = "(F[1-9]" + allowRepetition + "|F1[0-2])" + allowRepetition;
     QString numpad = "NUMPAD\\d" + allowRepetition;
@@ -680,63 +625,57 @@ bool AutoType::checkSyntax(const QString &string)
     QString beep = "BEEP\\s\\d*\\s\\d*";
     QString vkey = "VKEY(-[EN]X){0,1}" + allowRepetition;
 
-    //these arent in parenthesis
+    // these arent in parenthesis
     QString shortcutKeys = "[\\^\\%~\\+@]";
     QString fixedStrings = "[^\\^\\%~\\+@\\{\\}]*";
 
-    QRegExp autoTypeSyntax
-        ("(" + shortcutKeys + "|" + fixedStrings + "|\\{(" + normalCommands + "|" + specialLiterals + "|"
-             + functionKeys
-             + "|" + numpad + "|" + delay + "|" + beep + "|" + vkey + ")\\})*");
+    QRegExp autoTypeSyntax("(" + shortcutKeys + "|" + fixedStrings + "|\\{(" + normalCommands + "|" + specialLiterals +
+                           "|" + functionKeys + "|" + numpad + "|" + delay + "|" + beep + "|" + vkey + ")\\})*");
     autoTypeSyntax.setCaseSensitivity(Qt::CaseInsensitive);
     autoTypeSyntax.setPatternSyntax(QRegExp::RegExp);
     return autoTypeSyntax.exactMatch(string);
 }
 
-bool AutoType::checkHighDelay(const QString &string)
+bool AutoType::checkHighDelay(const QString& string)
 {
-    QRegExp highDelay("\\{DELAY\\s\\d{5,}\\}"); //5 digit numbers(10 seconds) are too much
+    QRegExp highDelay("\\{DELAY\\s\\d{5,}\\}"); // 5 digit numbers(10 seconds) are too much
     highDelay.setCaseSensitivity(Qt::CaseInsensitive);
     highDelay.setPatternSyntax(QRegExp::RegExp);
     return highDelay.exactMatch(string);
 }
 
-bool AutoType::checkHighRepetition(const QString &string)
+bool AutoType::checkHighRepetition(const QString& string)
 {
-    QRegExp highRepetition("\\{(?!DELAY\\s)\\w*\\s\\d{3,}\\}"); //3 digit numbers are too much
+    QRegExp highRepetition("\\{(?!DELAY\\s)\\w*\\s\\d{3,}\\}"); // 3 digit numbers are too much
     highRepetition.setCaseSensitivity(Qt::CaseInsensitive);
     highRepetition.setPatternSyntax(QRegExp::RegExp);
     return highRepetition.exactMatch(string);
 }
 
-void
-AutoType::performAutoType(const Entry *entry, QWidget *hideWindow, const QString &customSequence, WId window)
+void AutoType::performAutoType(const Entry* entry, QWidget* hideWindow, const QString& customSequence, WId window)
 {
     if (!AutoType::checkSyntax(entry->effectiveAutoTypeSequence())) {
         QMessageBox messageBox;
-        messageBox.critical(0, "AutoType", tr("The Syntax of your AutoType statement is incorrect!"));
+        messageBox.critical(0, tr("AutoType"), tr("The Syntax of your AutoType statement is incorrect!"));
         return;
-    }
-    else if (AutoType::checkHighDelay(entry->effectiveAutoTypeSequence())) {
+    } else if (AutoType::checkHighDelay(entry->effectiveAutoTypeSequence())) {
         QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(0,
-                                      "AutoType",
-                                      tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
+        reply = QMessageBox::question(
+            0,
+            tr("AutoType"),
+            tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
 
         if (reply == QMessageBox::No) {
             return;
         }
-    }
-    else if (AutoType::checkHighRepetition(entry->effectiveAutoTypeSequence())) {
+    } else if (AutoType::checkHighRepetition(entry->effectiveAutoTypeSequence())) {
         QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(0,
-                                      "AutoType",
-                                      tr("This AutoType command contains arguments which are repeated very often. Do you really want to execute it?"));
+        reply = QMessageBox::question(0, tr("AutoType"), tr("This AutoType command contains arguments which are "
+                                                            "repeated very often. Do you really want to execute it?"));
 
         if (reply == QMessageBox::No) {
             return;
         }
     }
     _performAutoType(entry, hideWindow, customSequence, window);
-
 }

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -21,6 +21,7 @@
 #include <QApplication>
 #include <QPluginLoader>
 #include <iostream>
+#include <QtWidgets/QErrorMessage>
 
 #include "config-keepassx.h"
 
@@ -328,8 +329,33 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
     m_autoTypeDelay = config()->get("AutoTypeDelay").toInt();
 
 
-    for (const QChar& ch : sequence) {
-        if (inTmpl) {
+    if (!AutoType::checkSyntax(sequence)) {
+        QMessageBox messageBox;
+        messageBox.critical(0, "AutoType", tr("The Syntax of your AutoType statement is incorrect!"));
+        return false;
+    }
+    else if (AutoType::checkHighDelay(sequence)) {
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::question(0,
+                                      "AutoType",
+                                      tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
+
+        if (reply == QMessageBox::No) {
+            return false;
+        }
+    }
+    else if (AutoType::checkHighRepetition(sequence)) {
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::question(0,
+                                      "AutoType",
+                                      tr("This AutoType command contains arguments which are repeated very often. Do you really want to execute it?"));
+
+        if (reply == QMessageBox::No) {
+            return false;
+        }
+    }
+
+    for (const QChar &ch : sequence) {
             if (ch == '{') {
                 qWarning("Syntax error in auto-type sequence.");
                 return false;
@@ -390,30 +416,6 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
 
         if (num == 0) {
             return list;
-        }
-        // some safety checks
-        else if (tmplName.compare("delay",Qt::CaseInsensitive)==0) {
-            if (num > 10000) {
-                QMessageBox::StandardButton reply;
-                reply = QMessageBox::question(0,
-                                              "AutoType",
-                                              tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
-
-                if (reply == QMessageBox::No) {
-                    return list;
-                }
-            }
-        }
-        else if (num > 100) {
-            QMessageBox::StandardButton reply;
-            reply = QMessageBox::question(0,
-                                          "AutoType",
-                                          tr("This AutoType command contains arguments which are repeated very often. Do you really want to execute it?"));
-
-            if (reply == QMessageBox::No) {
-                return list;
-            }
-
         }
     }
 

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -145,6 +145,10 @@ void AutoType::performAutoType(const Entry* entry, QWidget* hideWindow, const QS
         sequence = customSequence;
     }
 
+    if (!checkSyntax(sequence)) {
+        return;
+    }
+
     sequence.replace("{{}", "{LEFTBRACE}");
     sequence.replace("{}}", "{RIGHTBRACE}");
 
@@ -327,33 +331,6 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
     QString tmpl;
     bool inTmpl = false;
     m_autoTypeDelay = config()->get("AutoTypeDelay").toInt();
-
-
-    if (!AutoType::checkSyntax(sequence)) {
-        QMessageBox messageBox;
-        messageBox.critical(0, "AutoType", tr("The Syntax of your AutoType statement is incorrect!"));
-        return false;
-    }
-    else if (AutoType::checkHighDelay(sequence)) {
-        QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(0,
-                                      "AutoType",
-                                      tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
-
-        if (reply == QMessageBox::No) {
-            return false;
-        }
-    }
-    else if (AutoType::checkHighRepetition(sequence)) {
-        QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(0,
-                                      "AutoType",
-                                      tr("This AutoType command contains arguments which are repeated very often. Do you really want to execute it?"));
-
-        if (reply == QMessageBox::No) {
-            return false;
-        }
-    }
 
     for (const QChar &ch : sequence) {
         if (inTmpl) {

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -128,7 +128,7 @@ QStringList AutoType::windowTitles()
     return m_plugin->windowTitles();
 }
 
-void AutoType::_performAutoType(const Entry* entry, QWidget* hideWindow, const QString& customSequence, WId window)
+void AutoType::executeAutoType(const Entry* entry, QWidget* hideWindow, const QString& customSequence, WId window)
 {
     if (m_inAutoType || !m_plugin) {
         return;
@@ -677,5 +677,5 @@ void AutoType::performAutoType(const Entry* entry, QWidget* hideWindow, const QS
             return;
         }
     }
-    _performAutoType(entry, hideWindow, customSequence, window);
+    executeAutoType(entry, hideWindow, customSequence, window);
 }

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -693,7 +693,7 @@ bool AutoType::windowMatchesUrl(const QString& windowTitle, const QString& resol
     return false;
 }
 
-bool AutoType::checkSynatx(const QString &string)
+bool AutoType::checkSyntax(const QString &string)
 {
     //checks things like {word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring
     QString allowRepetition = "(\\s[0-9]*){0,1}";

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -62,9 +62,9 @@ AutoType::AutoType(QObject* parent, bool test)
     QString pluginPath = filePath()->pluginPath(pluginName);
 
     if (!pluginPath.isEmpty()) {
-        #ifdef WITH_XC_AUTOTYPE
+#ifdef WITH_XC_AUTOTYPE
         loadPlugin(pluginPath);
-        #endif
+#endif
     }
 
     connect(qApp, SIGNAL(aboutToQuit()), SLOT(unloadPlugin()));
@@ -394,126 +394,128 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
         else if (tmplName.compare("delay",Qt::CaseInsensitive)==0) {
             if (num > 10000) {
                 QMessageBox::StandardButton reply;
-                reply = QMessageBox::question(0,"AutoType",
+                reply = QMessageBox::question(0,
+                                              "AutoType",
                                               "This AutoType command contains a very long delay. Do you really want to execute it?");
 
-                if (reply==QMessageBox::No) {
+                if (reply == QMessageBox::No) {
                     return list;
                 }
             }
         }
         else if (num > 100) {
             QMessageBox::StandardButton reply;
-            reply = QMessageBox::question(0,"AutoType",
+            reply = QMessageBox::question(0,
+                                          "AutoType",
                                           "This AutoType command contains arguments which are repeated very often. Do you really want to execute it?");
 
-            if (reply==QMessageBox::No) {
+            if (reply == QMessageBox::No) {
                 return list;
             }
 
         }
     }
 
-    if (tmplName.compare("tab",Qt::CaseInsensitive)==0) {
+    if (tmplName.compare("tab", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Tab));
     }
-    else if (tmplName.compare("enter",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("enter", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Enter));
     }
-    else if (tmplName.compare("space",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("space", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Space));
     }
-    else if (tmplName.compare("up",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("up", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Up));
     }
-    else if (tmplName.compare("down",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("down", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Down));
     }
-    else if (tmplName.compare("left",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("left", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Left));
     }
-    else if (tmplName.compare("right",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("right", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Right));
     }
-    else if (tmplName.compare("insert",Qt::CaseInsensitive)==0 ||
-             tmplName.compare("ins",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("insert", Qt::CaseInsensitive) == 0 ||
+        tmplName.compare("ins", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Insert));
     }
-    else if (tmplName.compare("delete",Qt::CaseInsensitive)==0 ||
-             tmplName.compare("del",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("delete", Qt::CaseInsensitive) == 0 ||
+        tmplName.compare("del", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Delete));
     }
-    else if (tmplName.compare("home",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("home", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Home));
     }
-    else if (tmplName.compare("end",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("end", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_End));
     }
-    else if (tmplName.compare("pgup",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("pgup", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_PageUp));
     }
-    else if (tmplName.compare("pgdown",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("pgdown", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_PageDown));
     }
-    else if (tmplName.compare("backspace",Qt::CaseInsensitive)==0 ||
-             tmplName.compare("bs",Qt::CaseInsensitive)==0 ||
-             tmplName.compare("bksp",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("backspace", Qt::CaseInsensitive) == 0 ||
+        tmplName.compare("bs", Qt::CaseInsensitive) == 0 ||
+        tmplName.compare("bksp", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Backspace));
     }
-    else if (tmplName.compare("break",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("break", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Pause));
     }
-    else if (tmplName.compare("capslock",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("capslock", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_CapsLock));
     }
-    else if (tmplName.compare("esc",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("esc", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Escape));
     }
-    else if (tmplName.compare("help",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("help", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Help));
     }
-    else if (tmplName.compare("numlock",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("numlock", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_NumLock));
     }
-    else if (tmplName.compare("ptrsc",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("ptrsc", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_Print));
     }
-    else if (tmplName.compare("scrolllock",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("scrolllock", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeKey(Qt::Key_ScrollLock));
     }
-    // Qt doesn't know about keypad keys so use the normal ones instead
-    else if (tmplName.compare("add",Qt::CaseInsensitive)==0 ||
-             tmplName.compare("+",Qt::CaseInsensitive)==0) {
+        // Qt doesn't know about keypad keys so use the normal ones instead
+    else if (tmplName.compare("add", Qt::CaseInsensitive) == 0 ||
+        tmplName.compare("+", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('+'));
     }
-    else if (tmplName.compare("subtract",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("subtract", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('-'));
     }
-    else if (tmplName.compare("multiply",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("multiply", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('*'));
     }
-    else if (tmplName.compare("divide",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("divide", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('/'));
     }
-    else if (tmplName.compare("^",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("^", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('^'));
     }
-    else if (tmplName.compare("%",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("%", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('%'));
     }
-    else if (tmplName.compare("~",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("~", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('~'));
     }
-    else if (tmplName.compare("(",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("(", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('('));
     }
-    else if (tmplName.compare(")",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare(")", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar(')'));
     }
-    else if (tmplName.compare("leftbrace",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("leftbrace", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('{'));
     }
-    else if (tmplName.compare("rightbrace",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("rightbrace", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeChar('}'));
     }
 
@@ -535,10 +537,10 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
     }
 
 
-    if (tmplName.compare("delay",Qt::CaseInsensitive)==0 && num > 0) {
+    if (tmplName.compare("delay", Qt::CaseInsensitive) == 0 && num > 0) {
         list.append(new AutoTypeDelay(num));
     }
-    else if (tmplName.compare("clearfield",Qt::CaseInsensitive)==0) {
+    else if (tmplName.compare("clearfield", Qt::CaseInsensitive) == 0) {
         list.append(new AutoTypeClearField());
     }
     else if (tmplName.compare("totp", Qt::CaseInsensitive) == 0) {
@@ -573,7 +575,7 @@ QList<AutoTypeAction*> AutoType::createActionFromTemplate(const QString& tmpl, c
     //allows to insert usernames and passwords multiple times
     if (!list.isEmpty()) {
         for (int i = 1; i < num; i++) {
-            for (int i = 0; i< resolved.size();i++) {
+            for (int i = 0; i < resolved.size(); i++) {
                 list.append(list.at(i)->clone());
             }
         }
@@ -626,7 +628,7 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
         sequence = entry->defaultAutoTypeSequence();
     }
 
-    const Group* group = entry->group();
+    const Group *group = entry->group();
     do {
         if (!enableSet) {
             if (group->autoTypeEnabled() == Group::Disable) {
@@ -644,7 +646,8 @@ QString AutoType::autoTypeSequence(const Entry* entry, const QString& windowTitl
         group = group->parentGroup();
     } while (group && (!enableSet || sequence.isEmpty()));
 
-    if (sequence.isEmpty() && (!entry->resolvePlaceholder(entry->username()).isEmpty() || !entry->resolvePlaceholder(entry->password()).isEmpty())) {
+    if (sequence.isEmpty() && (!entry->resolvePlaceholder(entry->username()).isEmpty()
+        || !entry->resolvePlaceholder(entry->password()).isEmpty())) {
         if (entry->resolvePlaceholder(entry->username()).isEmpty()) {
             sequence = "{PASSWORD}{ENTER}";
         }

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -616,7 +616,7 @@ bool AutoType::checkSyntax(const QString& string)
     // the ":" allows custom commands with syntax S:Field
     // exclude BEEP otherwise will be checked as valid
     QString normalCommands = "(?!BEEP\\s)[A-Z:]*" + allowRepetition; 
-    QString specialLiterals = "[\\^\\%\\(\\)~\\{\\}\\[\\]\\+-]" + allowRepetition;
+    QString specialLiterals = "[\\^\\%\\(\\)~\\{\\}\\[\\]\\+]" + allowRepetition;
     QString functionKeys = "(?:F[1-9]" + allowRepetition + "|F1[0-2])" + allowRepetition;
     QString numpad = "NUMPAD\\d" + allowRepetition;
     QString delay = "DELAY=\\d+";

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -42,7 +42,7 @@ public:
     bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers);
     void unregisterGlobalShortcut();
     int callEventFilter(void* event);
-    static bool checkSynatx(const QString &string);
+    static bool checkSyntax(const QString &string);
     static bool checkHighRepetition(const QString &string);
     static bool checkHighDelay(const QString &string);
 

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -34,6 +34,7 @@ class AutoType : public QObject
 {
     Q_OBJECT
 
+
 public:
     QStringList windowTitles();
     void performAutoType(const Entry* entry, QWidget* hideWindow = nullptr,
@@ -41,6 +42,9 @@ public:
     bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers);
     void unregisterGlobalShortcut();
     int callEventFilter(void* event);
+    static bool checkSynatx(const QString &string);
+    static bool checkHighRepetition(const QString &string);
+    static bool checkHighDelay(const QString &string);
 
     inline bool isAvailable() {
         return m_plugin;

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -45,6 +45,10 @@ public:
     static bool checkSyntax(const QString &string);
     static bool checkHighRepetition(const QString &string);
     static bool checkHighDelay(const QString &string);
+    void performAutoTypeWithSyntaxCheckingDialog(const Entry *entry,
+                                                 QWidget *hideWindow = nullptr,
+                                                 const QString &customSequence = QString(),
+                                                 WId window = 0);
 
     inline bool isAvailable() {
         return m_plugin;

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -37,7 +37,7 @@ class AutoType : public QObject
 
 public:
     QStringList windowTitles();
-    void performAutoType(const Entry* entry, QWidget* hideWindow = nullptr,
+    void _performAutoType(const Entry* entry, QWidget* hideWindow = nullptr,
                          const QString& customSequence = QString(), WId window = 0);
     bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers);
     void unregisterGlobalShortcut();
@@ -45,10 +45,8 @@ public:
     static bool checkSyntax(const QString &string);
     static bool checkHighRepetition(const QString &string);
     static bool checkHighDelay(const QString &string);
-    void performAutoTypeWithSyntaxCheckingDialog(const Entry *entry,
-                                                 QWidget *hideWindow = nullptr,
-                                                 const QString &customSequence = QString(),
-                                                 WId window = 0);
+    void performAutoType(const Entry *entry, QWidget *hideWindow = nullptr,
+                         const QString &customSequence = QString(), WId window = 0);
 
     inline bool isAvailable() {
         return m_plugin;

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -36,7 +36,7 @@ class AutoType : public QObject
 
 public:
     QStringList windowTitles();
-    void _performAutoType(const Entry* entry,
+    void executeAutoType(const Entry* entry,
                           QWidget* hideWindow = nullptr,
                           const QString& customSequence = QString(),
                           WId window = 0);

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -34,21 +34,25 @@ class AutoType : public QObject
 {
     Q_OBJECT
 
-
 public:
     QStringList windowTitles();
-    void _performAutoType(const Entry* entry, QWidget* hideWindow = nullptr,
-                         const QString& customSequence = QString(), WId window = 0);
+    void _performAutoType(const Entry* entry,
+                          QWidget* hideWindow = nullptr,
+                          const QString& customSequence = QString(),
+                          WId window = 0);
     bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers);
     void unregisterGlobalShortcut();
     int callEventFilter(void* event);
-    static bool checkSyntax(const QString &string);
-    static bool checkHighRepetition(const QString &string);
-    static bool checkHighDelay(const QString &string);
-    void performAutoType(const Entry *entry, QWidget *hideWindow = nullptr,
-                         const QString &customSequence = QString(), WId window = 0);
+    static bool checkSyntax(const QString& string);
+    static bool checkHighRepetition(const QString& string);
+    static bool checkHighDelay(const QString& string);
+    void performAutoType(const Entry* entry,
+                         QWidget* hideWindow = nullptr,
+                         const QString& customSequence = QString(),
+                         WId window = 0);
 
-    inline bool isAvailable() {
+    inline bool isAvailable()
+    {
         return m_plugin;
     }
 
@@ -91,7 +95,8 @@ private:
     Q_DISABLE_COPY(AutoType)
 };
 
-inline AutoType* autoType() {
+inline AutoType* autoType()
+{
     return AutoType::instance();
 }
 

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -36,7 +36,7 @@ class AutoType : public QObject
 
 public:
     QStringList windowTitles();
-    void executeAutoType(const Entry* entry,
+    void executeAutoTypeActions(const Entry* entry,
                           QWidget* hideWindow = nullptr,
                           const QString& customSequence = QString(),
                           WId window = 0);
@@ -45,7 +45,9 @@ public:
     int callEventFilter(void* event);
     static bool checkSyntax(const QString& string);
     static bool checkHighRepetition(const QString& string);
+    static bool checkSlowKeypress(const QString& string);
     static bool checkHighDelay(const QString& string);
+    static bool verifyAutoTypeSyntax(const QString& sequence);
     void performAutoType(const Entry* entry,
                          QWidget* hideWindow = nullptr,
                          const QString& customSequence = QString(),

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -584,6 +584,31 @@ void DatabaseWidget::performAutoType()
         return;
     }
 
+    if (!AutoType::checkSyntax(currentEntry->effectiveAutoTypeSequence())) {
+        QMessageBox messageBox;
+        messageBox.critical(0, "AutoType", tr("The Syntax of your AutoType statement is incorrect!"));
+        return;
+    }
+    else if (AutoType::checkHighDelay(currentEntry->effectiveAutoTypeSequence())) {
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::question(0,
+                                      "AutoType",
+                                      tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
+
+        if (reply == QMessageBox::No) {
+            return;
+        }
+    }
+    else if (AutoType::checkHighRepetition(currentEntry->effectiveAutoTypeSequence())) {
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::question(0,
+                                      "AutoType",
+                                      tr("This AutoType command contains arguments which are repeated very often. Do you really want to execute it?"));
+
+        if (reply == QMessageBox::No) {
+            return;
+        }
+    }
     autoType()->performAutoType(currentEntry, window());
 }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -584,32 +584,7 @@ void DatabaseWidget::performAutoType()
         return;
     }
 
-    if (!AutoType::checkSyntax(currentEntry->effectiveAutoTypeSequence())) {
-        QMessageBox messageBox;
-        messageBox.critical(0, "AutoType", tr("The Syntax of your AutoType statement is incorrect!"));
-        return;
-    }
-    else if (AutoType::checkHighDelay(currentEntry->effectiveAutoTypeSequence())) {
-        QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(0,
-                                      "AutoType",
-                                      tr("This AutoType command contains a very long delay. Do you really want to execute it?"));
-
-        if (reply == QMessageBox::No) {
-            return;
-        }
-    }
-    else if (AutoType::checkHighRepetition(currentEntry->effectiveAutoTypeSequence())) {
-        QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(0,
-                                      "AutoType",
-                                      tr("This AutoType command contains arguments which are repeated very often. Do you really want to execute it?"));
-
-        if (reply == QMessageBox::No) {
-            return;
-        }
-    }
-    autoType()->performAutoType(currentEntry, window());
+    autoType()->performAutoTypeWithSyntaxCheckingDialog(currentEntry, window());
 }
 
 void DatabaseWidget::openUrl()
@@ -638,7 +613,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
             }
             return;
         }
-        
+
         // otherwise ask user
         if (urlString.length() > 6) {
             QString cmdTruncated = urlString.mid(6);
@@ -652,7 +627,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
                                this
             );
             msgbox.setDefaultButton(QMessageBox::No);
-            
+
             QCheckBox* checkbox = new QCheckBox(tr("Remember my choice"), &msgbox);
             msgbox.setCheckBox(checkbox);
             bool remember = false;
@@ -661,12 +636,12 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
                    remember = true;
                }
             });
-            
+
             int result = msgbox.exec();
             if (result == QMessageBox::Yes) {
                 QProcess::startDetached(urlString.mid(6));
             }
-            
+
             if (remember) {
                 entry->attributes()->set(EntryAttributes::RememberCmdExecAttr,
                                          result == QMessageBox::Yes ? "1" : "0");

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -584,7 +584,7 @@ void DatabaseWidget::performAutoType()
         return;
     }
 
-    autoType()->performAutoTypeWithSyntaxCheckingDialog(currentEntry, window());
+    autoType()->performAutoType(currentEntry, window());
 }
 
 void DatabaseWidget::openUrl()

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -32,8 +32,8 @@
 #include <QMimeData>
 #include <QEvent>
 #include <iostream>
-#include <autotype/AutoType.h>
 
+#include "autotype/AutoType.h"
 #include "core/Config.h"
 #include "core/Database.h"
 #include "core/Entry.h"

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -766,40 +766,9 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
         entry->setDefaultAutoTypeSequence(QString());
     }
     else {
-        if (!AutoType::checkSyntax(m_autoTypeUi->sequenceEdit->text())) {
-            //handle wrong syntax
-            QMessageBox messageBox;
-            messageBox.critical(0,
-                                "AutoType",
-                                tr("The Syntax of your AutoType statement is incorrect! It won't be saved!"));
-
-        }
-        else if (AutoType::checkHighDelay(m_autoTypeUi->sequenceEdit->text())) {
-            //handle too long delay
-            QMessageBox::StandardButton reply;
-            reply = QMessageBox::question(0,
-                                          "AutoType",
-                                          tr("This AutoType command contains a very long delay. Do you really want to save it?"));
-
-            if (reply == QMessageBox::Yes) {
-                entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
-            }
-        }
-        else if (AutoType::checkHighRepetition(m_autoTypeUi->sequenceEdit->text())) {
-            //handle too much repetition
-            QMessageBox::StandardButton reply;
-            reply = QMessageBox::question(0,
-                                          "AutoType",
-                                          tr("This AutoType command contains arguments which are repeated very often. Do you really want to save it?"));
-
-            if (reply == QMessageBox::Yes) {
-                entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
-            }
-        }
-        else {
+        if (AutoType::verifyAutoTypeSyntax(m_autoTypeUi->sequenceEdit->text())) {
             entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
         }
-
     }
 
     entry->autoTypeAssociations()->copyDataFrom(m_autoTypeAssoc);

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -767,18 +767,39 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
     }
     else {
         if (!AutoType::checkSyntax(m_autoTypeUi->sequenceEdit->text())) {
-            //@TODO handle wrong syntax
-            std::cout << "wrong syntax\n";
+            //handle wrong syntax
+            QMessageBox messageBox;
+            messageBox.critical(0,
+                                "AutoType",
+                                tr("The Syntax of your AutoType statement is incorrect! It won't be saved!"));
+
         }
         else if (AutoType::checkHighDelay(m_autoTypeUi->sequenceEdit->text())) {
-            //@TODO handle too long delay
-            std::cout << "too long delay\n";
+            //handle too long delay
+            QMessageBox::StandardButton reply;
+            reply = QMessageBox::question(0,
+                                          "AutoType",
+                                          tr("This AutoType command contains a very long delay. Do you really want to save it?"));
+
+            if (reply == QMessageBox::Yes) {
+                entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
+            }
         }
         else if (AutoType::checkHighRepetition(m_autoTypeUi->sequenceEdit->text())) {
-            //@TODO handle too much repetition
-            std::cout << "too much repetition\n";
+            //handle too much repetition
+            QMessageBox::StandardButton reply;
+            reply = QMessageBox::question(0,
+                                          "AutoType",
+                                          tr("This AutoType command contains arguments which are repeated very often. Do you really want to save it?"));
+
+            if (reply == QMessageBox::Yes) {
+                entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
+            }
         }
-        entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
+        else {
+            entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
+        }
+
     }
 
     entry->autoTypeAssociations()->copyDataFrom(m_autoTypeAssoc);

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -770,43 +770,67 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
         QString allowRepetition = "(\\s[0-9]*){0,1}";
         QString normalCommands = "[A-Z]*" + allowRepetition;
         QString specialLiterals = "[\\^\\%\\(\\)~\\{\\}\\[\\]\\+-]" + allowRepetition;
-        QString functionKeys = "(F[1-9]" +allowRepetition + "|F1[0-2])" + allowRepetition;
+        QString functionKeys = "(F[1-9]" + allowRepetition + "|F1[0-2])" + allowRepetition;
         QString numpad = "NUMPAD[0-9]" + allowRepetition;
         QString delay = "DELAY=[0-9]+";
         QString beep = "BEEP\\s[0-9]*\\s[0-9]*";
-        QString vkey = "VKEY-[EN]X" + allowRepetition;
+        QString vkey = "VKEY(-[EN]X){0,1}" + allowRepetition;
 
         //these arent in parenthesis
         QString shortcutKeys = "[\\^\\%~\\+@]";
         QString fixedStrings = "[^\\^\\%~\\+@\\{\\}]*";
 
         QRegExp autoTypeSyntax
-            ("("+shortcutKeys + "|" + fixedStrings + "|\\{(" + normalCommands + "|" + specialLiterals + "|" + functionKeys
-                 + "|" + numpad + "|" + delay + "|" + beep + "|" + vkey+")\\})*");
+            ("(" + shortcutKeys + "|" + fixedStrings + "|\\{(" + normalCommands + "|" + specialLiterals + "|"
+                 + functionKeys
+                 + "|" + numpad + "|" + delay + "|" + beep + "|" + vkey + ")\\})*");
         autoTypeSyntax.setCaseSensitivity(Qt::CaseInsensitive);
         autoTypeSyntax.setPatternSyntax(QRegExp::RegExp);
 
+        QRegExp highDelay(".*\\{Delay\\s[0-9]{5,}\\}.*"); //the 3 means 3 digitnumbers are too much
+        highDelay.setCaseSensitivity(Qt::CaseInsensitive);
+        highDelay.setPatternSyntax(QRegExp::RegExp);
+
+        QRegExp highRepetition(".*\\s[0-9]{3,}.*");
+        highRepetition.setPatternSyntax(QRegExp::RegExp);
 
 
         //small test @TODO delete
-        if(autoTypeSyntax.exactMatch(QString("{word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds{Beep 23 32}{Vkey-NX 34}"))) {
+        if (autoTypeSyntax.exactMatch(QString(
+            "{word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds{Beep 23 32}{Vkey-NX 34}"))) {
             std::cout << "yes\n";
         }
-        if(autoTypeSyntax.exactMatch(QString("word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds"))) {
+        if (autoTypeSyntax
+            .exactMatch(QString("word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds"))) {
             std::cout << "no1\n";
         }
-        if(autoTypeSyntax.exactMatch(QString("{@}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds"))) {
+        if (autoTypeSyntax
+            .exactMatch(QString("{@}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds"))) {
             std::cout << "no2\n";
         }
+        if (highDelay.exactMatch("{asfd}{DELAY 10000}{dasf}")) {
+            std::cout << "yes1\n";
+        }
+        if (highDelay.exactMatch("{asfd}{DELAY 1000}{dasf}")) {
+            std::cout << "no3\n";
+        }
+        if (highRepetition.exactMatch("{asfd}{DELAY 100}{dasf}")) {
+            std::cout << "yes2\n";
+        }
+        if (highRepetition.exactMatch("{asfd}{DELAY 10}{dasf}")) {
+            std::cout << "no4\n";
+        }
 
-        //@TODO restrict repetition only on normal commands and delay
-        QRegExp highRepetition(".*[0-9]{3,}.*"); //the 3 means 3 digitnumbers are too much
-        highRepetition.setPatternSyntax(QRegExp::RegExp);
+
+
 
         if (!autoTypeSyntax.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
             //@TODO handle wrong syntax
         }
-        if (!highRepetition.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
+        else if (highDelay.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
+            //@TODO handle too long delay
+        }
+        else if (highRepetition.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
             //@TODO handle too much repetition
         }
         entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -766,7 +766,7 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
         entry->setDefaultAutoTypeSequence(QString());
     }
     else {
-        if (!AutoType::checkSynatx(m_autoTypeUi->sequenceEdit->text())) {
+        if (!AutoType::checkSyntax(m_autoTypeUi->sequenceEdit->text())) {
             //@TODO handle wrong syntax
             std::cout << "wrong syntax\n";
         }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -764,6 +764,20 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
         entry->setDefaultAutoTypeSequence(QString());
     }
     else {
+        QRegExp autoTypeSyntax("(\\{[A-Z]*(\\s[0-9]*){0,1}\\})*");
+        autoTypeSyntax.setCaseSensitivity(Qt::CaseInsensitive);
+        autoTypeSyntax.setPatternSyntax(QRegExp::RegExp);
+
+
+        QRegExp highRepetition(".*[0-9]{3,}.*"); //the 3 means 3 digitnumbers are too much
+        highRepetition.setPatternSyntax(QRegExp::RegExp);
+
+        if (!autoTypeSyntax.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
+            //@TODO handle wrong syntax
+        }
+        if (!highRepetition.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
+            //@TODO handle too much repetition
+        }
         entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
     }
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -31,7 +31,6 @@
 #include <QTemporaryFile>
 #include <QMimeData>
 #include <QEvent>
-#include <iostream>
 
 #include "autotype/AutoType.h"
 #include "core/Config.h"

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -32,6 +32,7 @@
 #include <QMimeData>
 #include <QEvent>
 #include <iostream>
+#include <autotype/AutoType.h>
 
 #include "core/Config.h"
 #include "core/Database.h"
@@ -765,73 +766,17 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
         entry->setDefaultAutoTypeSequence(QString());
     }
     else {
-        //checks things like {word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring
-
-        QString allowRepetition = "(\\s[0-9]*){0,1}";
-        QString normalCommands = "[A-Z]*" + allowRepetition;
-        QString specialLiterals = "[\\^\\%\\(\\)~\\{\\}\\[\\]\\+-]" + allowRepetition;
-        QString functionKeys = "(F[1-9]" + allowRepetition + "|F1[0-2])" + allowRepetition;
-        QString numpad = "NUMPAD[0-9]" + allowRepetition;
-        QString delay = "DELAY=[0-9]+";
-        QString beep = "BEEP\\s[0-9]*\\s[0-9]*";
-        QString vkey = "VKEY(-[EN]X){0,1}" + allowRepetition;
-
-        //these arent in parenthesis
-        QString shortcutKeys = "[\\^\\%~\\+@]";
-        QString fixedStrings = "[^\\^\\%~\\+@\\{\\}]*";
-
-        QRegExp autoTypeSyntax
-            ("(" + shortcutKeys + "|" + fixedStrings + "|\\{(" + normalCommands + "|" + specialLiterals + "|"
-                 + functionKeys
-                 + "|" + numpad + "|" + delay + "|" + beep + "|" + vkey + ")\\})*");
-        autoTypeSyntax.setCaseSensitivity(Qt::CaseInsensitive);
-        autoTypeSyntax.setPatternSyntax(QRegExp::RegExp);
-
-        QRegExp highDelay(".*\\{Delay\\s[0-9]{5,}\\}.*"); //the 3 means 3 digitnumbers are too much
-        highDelay.setCaseSensitivity(Qt::CaseInsensitive);
-        highDelay.setPatternSyntax(QRegExp::RegExp);
-
-        QRegExp highRepetition(".*\\s[0-9]{3,}.*");
-        highRepetition.setPatternSyntax(QRegExp::RegExp);
-
-
-        //small test @TODO delete
-        if (autoTypeSyntax.exactMatch(QString(
-            "{word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds{Beep 23 32}{Vkey-NX 34}"))) {
-            std::cout << "yes\n";
-        }
-        if (autoTypeSyntax
-            .exactMatch(QString("word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds"))) {
-            std::cout << "no1\n";
-        }
-        if (autoTypeSyntax
-            .exactMatch(QString("{@}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixeds"))) {
-            std::cout << "no2\n";
-        }
-        if (highDelay.exactMatch("{asfd}{DELAY 10000}{dasf}")) {
-            std::cout << "yes1\n";
-        }
-        if (highDelay.exactMatch("{asfd}{DELAY 1000}{dasf}")) {
-            std::cout << "no3\n";
-        }
-        if (highRepetition.exactMatch("{asfd}{DELAY 100}{dasf}")) {
-            std::cout << "yes2\n";
-        }
-        if (highRepetition.exactMatch("{asfd}{DELAY 10}{dasf}")) {
-            std::cout << "no4\n";
-        }
-
-
-
-
-        if (!autoTypeSyntax.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
+        if (!AutoType::checkSynatx(m_autoTypeUi->sequenceEdit->text())) {
             //@TODO handle wrong syntax
+            std::cout << "wrong syntax\n";
         }
-        else if (highDelay.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
+        else if (AutoType::checkHighDelay(m_autoTypeUi->sequenceEdit->text())) {
             //@TODO handle too long delay
+            std::cout << "too long delay\n";
         }
-        else if (highRepetition.exactMatch(m_autoTypeUi->sequenceEdit->text())) {
+        else if (AutoType::checkHighRepetition(m_autoTypeUi->sequenceEdit->text())) {
             //@TODO handle too much repetition
+            std::cout << "too much repetition\n";
         }
         entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
     }

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -282,3 +282,18 @@ void TestAutoType::testGlobalAutoTypeRegExp()
     QCOMPARE(m_test->actionChars(), QString("custom_attr_third"));
     m_test->clearActions();
 }
+
+void TestAutoType::testAutoTypeSyntaxChecks()
+{
+    // Huge sequence
+    QCOMPARE(true, AutoType::checkSyntax("{word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring"));
+    // Bad sequence
+    QCOMPARE(false, AutoType::checkSyntax("{{{}}{}{}}{{}}"));
+    // High DelAY / low delay
+    QCOMPARE(true, AutoType::checkHighDelay("{DelAY 50000}"));
+    QCOMPARE(false, AutoType::checkHighDelay("{delay 50}"));
+    // Many repetition / few repetition / delay not repetition
+    QCOMPARE(true, AutoType::checkHighRepetition("{LEFT 50000000}"));
+    QCOMPARE(false, AutoType::checkHighRepetition("{SPACE 10}{TAB 3}{RIGHT 50}"));
+    QCOMPARE(false, AutoType::checkHighRepetition("{delay 5000000000}"));
+}

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -287,11 +287,23 @@ void TestAutoType::testAutoTypeSyntaxChecks()
 {
     // Huge sequence
     QCOMPARE(true, AutoType::checkSyntax("{word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring"));
+
+    QCOMPARE(true, AutoType::checkSyntax("{NUMPAD1 3}"));
+
+    QCOMPARE(true, AutoType::checkSyntax("{BEEP 3 3}"));
+    QCOMPARE(false, AutoType::checkSyntax("{BEEP 3}"));
+
+    QCOMPARE(true, AutoType::checkSyntax("{VKEY 0x01}"));
+    QCOMPARE(true, AutoType::checkSyntax("{VKEY VK_LBUTTON}"));
+    QCOMPARE(true, AutoType::checkSyntax("{VKEY-EX 0x01}"));
     // Bad sequence
     QCOMPARE(false, AutoType::checkSyntax("{{{}}{}{}}{{}}"));
     // High DelAY / low delay
     QCOMPARE(true, AutoType::checkHighDelay("{DelAY 50000}"));
     QCOMPARE(false, AutoType::checkHighDelay("{delay 50}"));
+    // Slow typing
+    QCOMPARE(true, AutoType::checkSlowKeypress("{DelAY=50000}"));
+    QCOMPARE(false, AutoType::checkSlowKeypress("{delay=50}"));
     // Many repetition / few repetition / delay not repetition
     QCOMPARE(true, AutoType::checkHighRepetition("{LEFT 50000000}"));
     QCOMPARE(false, AutoType::checkHighRepetition("{SPACE 10}{TAB 3}{RIGHT 50}"));

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -286,7 +286,7 @@ void TestAutoType::testGlobalAutoTypeRegExp()
 void TestAutoType::testAutoTypeSyntaxChecks()
 {
     // Huge sequence
-    QCOMPARE(true, AutoType::checkSyntax("{word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{-}~+%@fixedstring"));
+    QCOMPARE(true, AutoType::checkSyntax("{word 23}{F1 23}{~ 23}{% 23}{^}{F12}{(}{) 23}{[}{[}{]}{Delay=23}{+}{SUBTRACT}~+%@fixedstring"));
 
     QCOMPARE(true, AutoType::checkSyntax("{NUMPAD1 3}"));
 
@@ -298,6 +298,10 @@ void TestAutoType::testAutoTypeSyntaxChecks()
     QCOMPARE(true, AutoType::checkSyntax("{VKEY-EX 0x01}"));
     // Bad sequence
     QCOMPARE(false, AutoType::checkSyntax("{{{}}{}{}}{{}}"));
+    // Good sequence
+    QCOMPARE(true, AutoType::checkSyntax("{{}{}}{}}{{}"));
+    QCOMPARE(true, AutoType::checkSyntax("{]}{[}{[}{]}"));
+    QCOMPARE(true, AutoType::checkSyntax("{)}{(}{(}{)}"));
     // High DelAY / low delay
     QCOMPARE(true, AutoType::checkHighDelay("{DelAY 50000}"));
     QCOMPARE(false, AutoType::checkHighDelay("{delay 50}"));

--- a/tests/TestAutoType.h
+++ b/tests/TestAutoType.h
@@ -47,6 +47,7 @@ private slots:
     void testGlobalAutoTypeUrlSubdomainMatch();
     void testGlobalAutoTypeTitleMatchDisabled();
     void testGlobalAutoTypeRegExp();
+    void testAutoTypeSyntaxChecks();
 
 private:
     AutoTypePlatformInterface* m_platform;


### PR DESCRIPTION
Replace #552 all credits to @marcbone

Auto Type now shows a warning when you try to  repeat something too often.
Also you can now repeat your password and username

<!--- Provide a general summary of your changes in the title above -->
I'm new to all this open source, transifex,qt and c++ stuff. So dont spare with criticism but be nice.
I didnt know how to get the message-strings away from the code and had some problems with the tests, so it would be better if somebody looks over it. Sorry for that.

## Description
<!--- Describe your changes in detail -->
Large delays and large repetitions arent ignored anymore, instead you get a Messagebox asking you if you want to continue or abort.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #216 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I changed autoType command to repeat it 101 times and executed the autotype command.


Problem is, if you have multiple commands which are repeated very often (ex. {Password 101} {Username 101}) you get multiple MessageBoxes. I could have changed that, but I didnt find a way to do so without bad code or bigger changes.

Tested on Ubuntu 16.04

## Screenshots (if appropriate):
![bildschirmfoto vom 2017-05-08 16-28-48](https://cloud.githubusercontent.com/assets/16033059/25809524/8b9e5966-340d-11e7-805b-587fb28c026e.png)
## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project. 
-  All new and existing tests passed. GUI-Test failed, bui it also failed without my changes so I guess its ok
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. (I have testesd coverage and directly the autotype features, diddnt get warnings on the console, but I really dont know what I should do there exactly