### PR TITLE
Forget keyfile path by honoring settings

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -277,6 +277,9 @@ void DatabaseOpenWidget::activateChallengeResponse()
 void DatabaseOpenWidget::browseKeyFile()
 {
     QString filters = QString("%1 (*);;%2 (*.key)").arg(tr("All files"), tr("Key files"));
+    if (!config()->get("RememberLastKeyFiles").toBool()) {
+        fileDialog()->setNextForgetDialog();
+    }
     QString filename = fileDialog()->getOpenFileName(this, tr("Select key file"), QString(), filters);
 
     if (!filename.isEmpty()) {

--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -42,11 +42,11 @@ QString FileDialog::getOpenFileName(QWidget* parent, const QString& caption, QSt
         if (parent) {
             parent->activateWindow();
         }
-
-        if (!result.isEmpty()) {
+        if (!result.isEmpty() && m_nextSaveLastDir) {
             config()->set("LastDir", QFileInfo(result).absolutePath());
         }
 
+        m_nextSaveLastDir = true;
         return result;
     }
 }
@@ -73,10 +73,11 @@ QStringList FileDialog::getOpenFileNames(QWidget *parent, const QString &caption
             parent->activateWindow();
         }
 
-        if (!results.isEmpty()) {
+        if (!results.isEmpty() && m_nextSaveLastDir) {
             config()->set("LastDir", QFileInfo(results[0]).absolutePath());
         }
 
+        m_nextSaveLastDir = true;
         return results;
     }
 }
@@ -125,10 +126,11 @@ QString FileDialog::getSaveFileName(QWidget* parent, const QString& caption, QSt
             parent->activateWindow();
         }
 
-        if (!result.isEmpty()) {
+        if (!result.isEmpty() && m_nextSaveLastDir) {
             config()->set("LastDir", QFileInfo(result).absolutePath());
         }
 
+        m_nextSaveLastDir = true;
         return result;
     }
 }
@@ -153,10 +155,11 @@ QString FileDialog::getExistingDirectory(QWidget *parent, const QString &caption
             parent->activateWindow();
         }
 
-        if (!dir.isEmpty()) {
+        if (!dir.isEmpty() && m_nextSaveLastDir) {
             config()->set("LastDir", QFileInfo(dir).absolutePath());
         }
 
+        m_nextSaveLastDir = true;
         return dir;
     }
 }
@@ -174,6 +177,11 @@ void FileDialog::setNextFileNames(const QStringList &fileNames)
 void FileDialog::setNextDirName(const QString &dirName)
 {
     m_nextDirName = dirName;
+}
+
+void FileDialog::setNextForgetDialog()
+{
+    m_nextSaveLastDir = false;
 }
 
 FileDialog::FileDialog()

--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -42,11 +42,8 @@ QString FileDialog::getOpenFileName(QWidget* parent, const QString& caption, QSt
         if (parent) {
             parent->activateWindow();
         }
-        if (!result.isEmpty() && m_nextSaveLastDir) {
-            config()->set("LastDir", QFileInfo(result).absolutePath());
-        }
 
-        m_nextSaveLastDir = true;
+        saveLastDir(result);
         return result;
     }
 }
@@ -73,11 +70,9 @@ QStringList FileDialog::getOpenFileNames(QWidget *parent, const QString &caption
             parent->activateWindow();
         }
 
-        if (!results.isEmpty() && m_nextSaveLastDir) {
-            config()->set("LastDir", QFileInfo(results[0]).absolutePath());
+        if (!results.isEmpty()) {
+            saveLastDir(results[0]);
         }
-
-        m_nextSaveLastDir = true;
         return results;
     }
 }
@@ -126,11 +121,7 @@ QString FileDialog::getSaveFileName(QWidget* parent, const QString& caption, QSt
             parent->activateWindow();
         }
 
-        if (!result.isEmpty() && m_nextSaveLastDir) {
-            config()->set("LastDir", QFileInfo(result).absolutePath());
-        }
-
-        m_nextSaveLastDir = true;
+        saveLastDir(result);
         return result;
     }
 }
@@ -155,11 +146,7 @@ QString FileDialog::getExistingDirectory(QWidget *parent, const QString &caption
             parent->activateWindow();
         }
 
-        if (!dir.isEmpty() && m_nextSaveLastDir) {
-            config()->set("LastDir", QFileInfo(dir).absolutePath());
-        }
-
-        m_nextSaveLastDir = true;
+        saveLastDir(dir);
         return dir;
     }
 }
@@ -181,11 +168,19 @@ void FileDialog::setNextDirName(const QString &dirName)
 
 void FileDialog::setNextForgetDialog()
 {
-    m_nextSaveLastDir = false;
+    m_forgetLastDir = true;
 }
 
 FileDialog::FileDialog()
 {
+}
+
+void FileDialog::saveLastDir(QString dir) {
+    if (!dir.isEmpty() && !m_forgetLastDir) {
+        config()->set("LastDir", QFileInfo(dir).absolutePath());
+    }
+
+    m_forgetLastDir = false;
 }
 
 FileDialog* FileDialog::instance()

--- a/src/gui/FileDialog.h
+++ b/src/gui/FileDialog.h
@@ -36,6 +36,7 @@ public:
     QString getExistingDirectory(QWidget* parent = nullptr, const QString& caption = QString(),
                                  QString dir = QString(), QFileDialog::Options options = QFileDialog::ShowDirsOnly);
 
+    void setNextForgetDialog();
     /**
      * Sets the result of the next get* method call.
      * Use only for testing.
@@ -51,6 +52,7 @@ private:
     QString m_nextFileName;
     QStringList m_nextFileNames;
     QString m_nextDirName;
+    bool m_nextSaveLastDir = true;
 
     static FileDialog* m_instance;
 

--- a/src/gui/FileDialog.h
+++ b/src/gui/FileDialog.h
@@ -52,7 +52,9 @@ private:
     QString m_nextFileName;
     QStringList m_nextFileNames;
     QString m_nextDirName;
-    bool m_nextSaveLastDir = true;
+    bool m_forgetLastDir = false;
+
+    void saveLastDir(QString);
 
     static FileDialog* m_instance;
 

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -241,6 +241,7 @@ void SettingsWidget::saveSettings()
 
     if (!config()->get("RememberLastKeyFiles").toBool()) {
         config()->set("LastKeyFiles", QVariant());
+        config()->set("LastDir", "");
     }
 
     for (const ExtraPage& page: asConst(m_extraPages)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fix #1151 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Every successful open/save dialog in KeePassXC save the path in the `LastDir` configuration.
This is a useful feature if you have to open your DB or adding/saving attachment many times.
On the other hand, keeping the directory of the keyfile is not so nice if the user unset "Remember last keyfiles"

**Users should always make their keyfile unavailable to an attacker. 
Hiding the keyfile path is just security by obscurity**

---

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
