### PR TITLE
Improve macOS pasteboard handling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,6 +155,8 @@ if(APPLE)
     set(keepassx_SOURCES ${keepassx_SOURCES}
         core/ScreenLockListenerMac.h
         core/ScreenLockListenerMac.cpp
+        core/MacPasteboard.h
+        core/MacPasteboard.cpp
         )
 endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/src/core/MacPasteboard.cpp
+++ b/src/core/MacPasteboard.cpp
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MacPasteboard.h"
+
+QString MacPasteboard::convertorName() { return QLatin1String("MacPasteboard"); }
+
+QString MacPasteboard::flavorFor(const QString& mimetype) {
+    if (mimetype == QLatin1String("text/plain")) {
+        return QLatin1String("public.utf8-plain-text");
+    } else if (mimetype == QLatin1String("application/x-nspasteboard-concealed-type")) {
+        return QLatin1String("org.nspasteboard.ConcealedType");
+    }
+
+    int i = mimetype.indexOf(QLatin1String("charset="));
+
+    if (i >= 0) {
+        QString cs(mimetype.mid(i + 8).toLower());
+        i = cs.indexOf(QLatin1Char(';'));
+
+        if (i >= 0) {
+            cs = cs.left(i);
+        }
+
+        if (cs == QLatin1String("system")) {
+            return QLatin1String("public.utf8-plain-text");
+        } else if (cs == QLatin1String("iso-10646-ucs-2") ||
+                   cs == QLatin1String("utf16")) {
+            return QLatin1String("public.utf16-plain-text");
+        }
+    }
+    return QString();
+}
+
+QString MacPasteboard::mimeFor(QString flavor) {
+    if (flavor == QLatin1String("public.utf8-plain-text"))
+        return QLatin1String("text/plain");
+    if (flavor == QLatin1String("org.nspasteboard.ConcealedType"))
+        return QLatin1String("application/x-nspasteboard-concealed-type");
+    if (flavor == QLatin1String("public.utf16-plain-text"))
+        return QLatin1String("text/plain;charset=utf16");
+    return QString();
+}
+
+bool MacPasteboard::canConvert(const QString& mimetype, QString flavor) {
+    Q_UNUSED(mimetype);
+    Q_UNUSED(flavor);
+    return true;
+}
+
+QVariant MacPasteboard::convertToMime(const QString& mimetype, QList<QByteArray> data, QString flavor) {
+    if (data.count() > 1)
+        qWarning("QMime::convertToMime: Cannot handle multiple member data");
+    const QByteArray& firstData = data.first();
+    QVariant ret;
+    if (flavor == QLatin1String("public.utf8-plain-text")) {
+        ret = QString::fromUtf8(firstData);
+    } else if (flavor == QLatin1String("org.nspasteboard.ConcealedType")) {
+        ret = QString::fromUtf8(firstData);
+    } else if (flavor == QLatin1String("public.utf16-plain-text")) {
+        ret = QTextCodec::codecForName("UTF-16")->toUnicode(firstData);
+    } else {
+        qWarning("QMime::convertToMime: unhandled mimetype: %s",
+                 qPrintable(mimetype));
+    }
+    return ret;
+}
+
+QList<QByteArray> MacPasteboard::convertFromMime(const QString&, QVariant data, QString flavor) {
+    QList<QByteArray> ret;
+    QString string = data.toString();
+    if (flavor == QLatin1String("public.utf8-plain-text"))
+        ret.append(string.toUtf8());
+    else if (flavor == QLatin1String("org.nspasteboard.ConcealedType"))
+        ret.append(string.toUtf8());
+    else if (flavor == QLatin1String("public.utf16-plain-text"))
+        ret.append(QTextCodec::codecForName("UTF-16")->fromUnicode(string));
+    return ret;
+}
+

--- a/src/core/MacPasteboard.h
+++ b/src/core/MacPasteboard.h
@@ -26,12 +26,12 @@ class MacPasteboard : public QMacPasteboardMime
 public:
     explicit MacPasteboard() : QMacPasteboardMime(MIME_ALL) {}
 
-    QString convertorName();
-    bool canConvert(const QString &mime, QString flav);
-    QString mimeFor(QString flav);
-    QString flavorFor(const QString &mime);
-    QVariant convertToMime(const QString &mime, QList<QByteArray> data, QString flav);
-    QList<QByteArray> convertFromMime(const QString &mime, QVariant data, QString flav);
+    QString convertorName() override;
+    bool canConvert(const QString &mime, QString flav) override;
+    QString mimeFor(QString flav) override;
+    QString flavorFor(const QString &mime) override;
+    QVariant convertToMime(const QString &mime, QList<QByteArray> data, QString flav) override;
+    QList<QByteArray> convertFromMime(const QString &mime, QVariant data, QString flav) override;
 };
 
 #endif // KEEPASSXC_MACPASTEBOARD_H

--- a/src/core/MacPasteboard.h
+++ b/src/core/MacPasteboard.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_MACPASTEBOARD_H
+#define KEEPASSXC_MACPASTEBOARD_H
+
+#include <QMacPasteboardMime>
+#include <QTextCodec>
+
+class MacPasteboard : public QMacPasteboardMime
+{
+public:
+    explicit MacPasteboard() : QMacPasteboardMime(MIME_ALL) {}
+
+    QString convertorName();
+    bool canConvert(const QString &mime, QString flav);
+    QString mimeFor(QString flav);
+    QString flavorFor(const QString &mime);
+    QVariant convertToMime(const QString &mime, QList<QByteArray> data, QString flav);
+    QList<QByteArray> convertFromMime(const QString &mime, QVariant data, QString flav);
+};
+
+#endif // KEEPASSXC_MACPASTEBOARD_H

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -28,23 +28,13 @@ Clipboard* Clipboard::m_instance(nullptr);
 Clipboard::Clipboard(QObject* parent)
     : QObject(parent)
     , m_timer(new QTimer(this))
+#ifdef Q_OS_MAC
+    , m_pasteboard(new MacPasteboard)
+#endif
 {
     m_timer->setSingleShot(true);
-#ifdef Q_OS_MAC
-    m_pasteboard = new MacPasteboard;
-#endif
-
     connect(m_timer, SIGNAL(timeout()), SLOT(clearClipboard()));
     connect(qApp, SIGNAL(aboutToQuit()), SLOT(clearCopiedText()));
-}
-
-Clipboard::~Clipboard()
-{
-#ifdef Q_OS_MAC
-    if (m_pasteboard) {
-        delete m_pasteboard;
-    }
-#endif
 }
 
 void Clipboard::setText(const QString& text)

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -22,6 +22,9 @@
 #include <QTimer>
 
 #include "core/Config.h"
+#ifdef Q_OS_MAC
+#include "core/MacPasteboard.h"
+#endif
 
 Clipboard* Clipboard::m_instance(nullptr);
 
@@ -38,10 +41,18 @@ void Clipboard::setText(const QString& text)
 {
     QClipboard* clipboard = QApplication::clipboard();
 
+#ifdef Q_OS_MAC
+    new MacPasteboard;
+    QMimeData* mime = new QMimeData;
+    mime->setText(text);
+    mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());
+    clipboard->setMimeData(mime, QClipboard::Clipboard);
+#else
     clipboard->setText(text, QClipboard::Clipboard);
     if (clipboard->supportsSelection()) {
         clipboard->setText(text, QClipboard::Selection);
     }
+#endif
 
     if (config()->get("security/clearclipboard").toBool()) {
         int timeout = config()->get("security/clearclipboardtimeout").toInt();

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -22,9 +22,6 @@
 #include <QTimer>
 
 #include "core/Config.h"
-#ifdef Q_OS_MAC
-#include "core/MacPasteboard.h"
-#endif
 
 Clipboard* Clipboard::m_instance(nullptr);
 
@@ -33,8 +30,21 @@ Clipboard::Clipboard(QObject* parent)
     , m_timer(new QTimer(this))
 {
     m_timer->setSingleShot(true);
+#ifdef Q_OS_MAC
+    m_pasteboard = new MacPasteboard;
+#endif
+
     connect(m_timer, SIGNAL(timeout()), SLOT(clearClipboard()));
     connect(qApp, SIGNAL(aboutToQuit()), SLOT(clearCopiedText()));
+}
+
+Clipboard::~Clipboard()
+{
+#ifdef Q_OS_MAC
+    if (m_pasteboard) {
+        delete m_pasteboard;
+    }
+#endif
 }
 
 void Clipboard::setText(const QString& text)
@@ -42,7 +52,6 @@ void Clipboard::setText(const QString& text)
     QClipboard* clipboard = QApplication::clipboard();
 
 #ifdef Q_OS_MAC
-    new MacPasteboard;
     QMimeData* mime = new QMimeData;
     mime->setText(text);
     mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -31,7 +31,6 @@ class Clipboard : public QObject
 
 public:
     void setText(const QString& text);
-    ~Clipboard();
 
     static Clipboard* instance();
 
@@ -48,7 +47,7 @@ private:
 
     QTimer* m_timer;
 #ifdef Q_OS_MAC
-    MacPasteboard* m_pasteboard;
+    QScopedPointer<MacPasteboard> m_pasteboard;
 #endif
     QString m_lastCopied;
 };

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -19,6 +19,9 @@
 #define KEEPASSX_CLIPBOARD_H
 
 #include <QObject>
+#ifdef Q_OS_MAC
+#include "core/MacPasteboard.h"
+#endif
 
 class QTimer;
 
@@ -28,6 +31,7 @@ class Clipboard : public QObject
 
 public:
     void setText(const QString& text);
+    ~Clipboard();
 
     static Clipboard* instance();
 
@@ -43,6 +47,9 @@ private:
     static Clipboard* m_instance;
 
     QTimer* m_timer;
+#ifdef Q_OS_MAC
+    MacPasteboard* m_pasteboard;
+#endif
     QString m_lastCopied;
 };
 


### PR DESCRIPTION
Close #1118, close #787, close #720, close #894

## Description
Remove unwanted UTF-8 BOM from clipboard strings and use the [org.nspasteboard.ConcealedType](http://nspasteboard.org/) pasteboard.

## How has this been tested?
Manual tests using Apple's [Clipboard Viewer](https://developer.apple.com/library/content/samplecode/ClipboardViewer/Introduction/Intro.html) and testing apps that had problems with the UTF-8 BOM added by Qt (mainly Steam).


## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

