### PR TITLE
Fix startup delay

### DIFF
--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -127,12 +127,6 @@
        <height>100</height>
       </size>
      </property>
-     <property name="font">
-      <font>
-       <family>Monospace</family>
-       <pointsize>10</pointsize>
-      </font>
-     </property>
     </widget>
    </item>
    <item row="9" column="1">


### PR DESCRIPTION
Revert 5bc000c to fix the startup slowdown introduced at that commit.

For some reason, setting the font was increasing the start time from about 1 second to almost 5 seconds. I'm reverting this change until someone finds a better way to set the note field font without this side effect.

Related: #974

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
