### PR TITLE
Add initial Steam TOTP support

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -417,6 +417,8 @@ void DatabaseWidget::setupTotp()
         setupTotpDialog->setSeed(currentEntry->totpSeed());
         setupTotpDialog->setStep(currentEntry->totpStep());
         setupTotpDialog->setDigits(currentEntry->totpDigits());
+        // now that all settings are set, decide whether it's default, steam or custom
+        setupTotpDialog->setSettings(currentEntry->totpDigits());
     }
 
     setupTotpDialog->open();

--- a/src/gui/DetailsWidget.cpp
+++ b/src/gui/DetailsWidget.cpp
@@ -270,7 +270,7 @@ void DetailsWidget::updateTotp()
     if (!m_locked) {
         QString totpCode = m_currentEntry->totp();
         QString firstHalf = totpCode.left(totpCode.size() / 2);
-        QString secondHalf = totpCode.right(totpCode.size() / 2);
+        QString secondHalf = totpCode.mid(totpCode.size() / 2);
         m_ui->totpLabel->setText(firstHalf + " " + secondHalf);
     } else if (nullptr != m_timer) {
         m_timer->stop();

--- a/src/gui/SetupTotpDialog.h
+++ b/src/gui/SetupTotpDialog.h
@@ -39,8 +39,11 @@ public:
     void setSeed(QString value);
     void setStep(quint8 step);
     void setDigits(quint8 digits);
+    void setSettings(quint8 digits);
 
 private Q_SLOTS:
+    void toggleDefault(bool status);
+    void toggleSteam(bool status);
     void toggleCustom(bool status);
     void setupTotp();
 

--- a/src/gui/SetupTotpDialog.ui
+++ b/src/gui/SetupTotpDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>282</width>
-    <height>257</height>
+    <height>364</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,11 +29,38 @@
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="customSettingsCheckBox">
-     <property name="text">
-      <string>Use custom settings</string>
-     </property>
-    </widget>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QRadioButton" name="radioDefault">
+       <property name="text">
+        <string>Default RFC 6238 token settings</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">settingsButtonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioSteam">
+       <property name="text">
+        <string>Steam token settings</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">settingsButtonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioCustom">
+       <property name="text">
+        <string>Use custom settings</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">settingsButtonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QLabel" name="label_4">
@@ -134,4 +161,7 @@
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="settingsButtonGroup"/>
+ </buttongroups>
 </ui>

--- a/src/gui/TotpDialog.cpp
+++ b/src/gui/TotpDialog.cpp
@@ -87,8 +87,8 @@ void TotpDialog::updateSeconds()
 void TotpDialog::updateTotp()
 {
     QString totpCode = m_entry->totp();
-    QString firstHalf = totpCode.left(totpCode.size()/2);
-    QString secondHalf = totpCode.right(totpCode.size()/2);
+    QString firstHalf = totpCode.left(totpCode.size() / 2);
+    QString secondHalf = totpCode.mid(totpCode.size() / 2);
     m_ui->totpLabel->setText(firstHalf + " " + secondHalf);
 }
 

--- a/src/totp/totp.cpp
+++ b/src/totp/totp.cpp
@@ -31,6 +31,39 @@
 const quint8 QTotp::defaultStep = 30;
 const quint8 QTotp::defaultDigits = 6;
 
+/**
+ * Custom encoder types. Each should be unique and >= 128 and < 255
+ * Values have no meaning outside of keepassxc
+ */
+/**
+ * Encoder for Steam Guard TOTP
+ */
+const quint8 QTotp::ENCODER_STEAM = 254;
+
+const QTotp::Encoder QTotp::defaultEncoder = { "", "", "0123456789", 0, 0, false };
+const QMap<quint8, QTotp::Encoder> QTotp::encoders{
+    { QTotp::ENCODER_STEAM, { "steam", "S", "23456789BCDFGHJKMNPQRTVWXY", 5, 30, true } },
+};
+
+/**
+ * These map the second field of the "TOTP Settings" field to our internal encoder number
+ * that overloads the digits field. Make sure that the key matches the shortName value
+ * in the corresponding Encoder
+ * NOTE: when updating this map, a corresponding edit to the settings regex must be made
+ *       in Entry::totpSeed()
+ */
+const QMap<QString, quint8> QTotp::shortNameToEncoder{
+    { "S", QTotp::ENCODER_STEAM },
+};
+/**
+ * These map the "encoder=" URL parameter of the "otp" field to our internal encoder number
+ * that overloads the digits field. Make sure that the key matches the name value
+ * in the corresponding Encoder
+ */
+const QMap<QString, quint8> QTotp::nameToEncoder{
+    { "steam", QTotp::ENCODER_STEAM },
+};
+
 QTotp::QTotp()
 {
 }
@@ -57,7 +90,10 @@ QString QTotp::parseOtpString(QString key, quint8& digits, quint8& step)
         if (q_step > 0 && q_step <= 60) {
             step = q_step;
         }
-
+        QString encName = query.queryItemValue("encoder");
+        if (!encName.isEmpty() && nameToEncoder.contains(encName)) {
+            digits = nameToEncoder[encName];
+        }
     } else {
         // Compatibility with "KeeOtp" plugin string format
         QRegExp rx("key=(.+)", Qt::CaseInsensitive, QRegExp::RegExp);
@@ -119,10 +155,24 @@ QString QTotp::generateTotp(const QByteArray key,
             | (hmac[offset + 3] & 0xff);
     // clang-format on
 
-    quint32 digitsPower = pow(10, numDigits);
+    const Encoder& encoder = encoders.value(numDigits, defaultEncoder);
+    // if encoder.digits is 0, we need to use the passed-in number of digits (default encoder)
+    quint8 digits = encoder.digits == 0 ? numDigits : encoder.digits;
+    int direction = -1;
+    int startpos = digits - 1;
+    if (encoder.reverse) {
+        direction = 1;
+        startpos = 0;
+    }
+    quint32 digitsPower = pow(encoder.alphabet.size(), digits);
 
     quint64 password = binary % digitsPower;
-    return QString("%1").arg(password, numDigits, 10, QChar('0'));
+    QString retval(int(digits), encoder.alphabet[0]);
+    for (quint8 pos = startpos; password > 0; pos += direction) {
+        retval[pos] = encoder.alphabet[int(password % encoder.alphabet.size())];
+        password /= encoder.alphabet.size();
+    }
+    return retval;
 }
 
 // See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format
@@ -131,8 +181,8 @@ QUrl QTotp::generateOtpString(const QString& secret,
                               const QString& issuer,
                               const QString& username,
                               const QString& algorithm,
-                              const quint8& digits,
-                              const quint8& step)
+                              quint8 digits,
+                              quint8 step)
 {
     QUrl keyUri;
     keyUri.setScheme("otpauth");

--- a/src/totp/totp.h
+++ b/src/totp/totp.h
@@ -20,6 +20,8 @@
 #define QTOTP_H
 
 #include <QtCore/qglobal.h>
+#include <QString>
+#include <QMap>
 
 class QUrl;
 
@@ -34,10 +36,25 @@ public:
                                   const QString& issuer,
                                   const QString& username,
                                   const QString& algorithm,
-                                  const quint8& digits,
-                                  const quint8& step);
+                                  quint8 digits,
+                                  quint8 step);
     static const quint8 defaultStep;
     static const quint8 defaultDigits;
+    struct Encoder
+    {
+        QString name;
+        QString shortName;
+        QString alphabet;
+        quint8 digits;
+        quint8 step;
+        bool reverse;
+    };
+    static const Encoder defaultEncoder;
+    // custom encoder values that overload the digits field
+    static const quint8 ENCODER_STEAM;
+    static const QMap<quint8, Encoder> encoders;
+    static const QMap<QString, quint8> shortNameToEncoder;
+    static const QMap<QString, quint8> nameToEncoder;
 };
 
 #endif // QTOTP_H

--- a/tests/TestTotp.h
+++ b/tests/TestTotp.h
@@ -31,6 +31,8 @@ private slots:
     void initTestCase();
     void testParseSecret();
     void testTotpCode();
+    void testEncoderData();
+    void testSteamTotp();
 };
 
 #endif // KEEPASSX_TESTTOTP_H


### PR DESCRIPTION
Add initial Steam TOTP support

* Add the concept of custom TOTP encoders, each with potential for custom
  code alphabet, length, step interval and code direction (i.e. reversed)
* Select custom encoder via overload of the digits field of a loaded entry
* Allow selection of custom encoders via the "TOTP Settings" field's
  size, as currently done by KeeTrayTOTP for Steam. Use "S" for the
  short name of the Steam custom encoder
* Allow selection of custom encoders via the "otp" field by appending
  a "&encoder=<name>" field to the URL query. For example,
  "&encoder=steam"
* Update TOTP set-up dialog to permit selection between (default,
  steam, custom) settings.


## Description
Adds the ability to generate Steam Guard TOTP codes using the secret
associated with a Steam account.

## Motivation and context

Fixes #594

## How has this been tested?
Unit tests added

Tested existing TOTP entries

Added new Steam TOTP entries and verified code output

## Screenshots (if appropriate):

![screenshot_20171120_112911](https://user-images.githubusercontent.com/329907/33034833-581222a8-cde6-11e7-8bf7-2ab4efcca290.png)

![screenshot_20171120_113540](https://user-images.githubusercontent.com/329907/33035014-f51c03c0-cde6-11e7-9262-cb44fe519f5e.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.