### PR TITLE
Rename QTotp class name to Totp

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -42,8 +42,8 @@ Entry::Entry()
     m_data.iconNumber = DefaultIconNumber;
     m_data.autoTypeEnabled = true;
     m_data.autoTypeObfuscation = 0;
-    m_data.totpStep = QTotp::defaultStep;
-    m_data.totpDigits = QTotp::defaultDigits;
+    m_data.totpStep = Totp::defaultStep;
+    m_data.totpDigits = Totp::defaultDigits;
 
     connect(m_attributes, SIGNAL(modified()), this, SIGNAL(modified()));
     connect(m_attributes, SIGNAL(defaultKeyModified()), SLOT(emitDataChanged()));
@@ -317,7 +317,7 @@ QString Entry::totp() const
     if (hasTotp()) {
         QString seed = totpSeed();
         quint64 time = QDateTime::currentDateTime().toTime_t();
-        QString output = QTotp::generateTotp(seed.toLatin1(), time, m_data.totpDigits, m_data.totpStep);
+        QString output = Totp::generateTotp(seed.toLatin1(), time, m_data.totpDigits, m_data.totpStep);
 
         return QString(output);
     } else {
@@ -328,15 +328,15 @@ QString Entry::totp() const
 void Entry::setTotp(const QString& seed, quint8& step, quint8& digits)
 {
     if (step == 0) {
-        step = QTotp::defaultStep;
+        step = Totp::defaultStep;
     }
 
     if (digits == 0) {
-        digits = QTotp::defaultDigits;
+        digits = Totp::defaultDigits;
     }
     QString data;
 
-    const QTotp::Encoder & enc = QTotp::encoders.value(digits, QTotp::defaultEncoder);
+    const Totp::Encoder & enc = Totp::encoders.value(digits, Totp::defaultEncoder);
 
     if (m_attributes->hasKey("otp")) {
         data = QString("key=%1&step=%2&size=%3").arg(seed).arg(step).arg(enc.digits == 0 ? digits : enc.digits);
@@ -365,24 +365,24 @@ QString Entry::totpSeed() const
         secret = m_attributes->value("TOTP Seed");
     }
 
-    m_data.totpDigits = QTotp::defaultDigits;
-    m_data.totpStep = QTotp::defaultStep;
+    m_data.totpDigits = Totp::defaultDigits;
+    m_data.totpStep = Totp::defaultStep;
 
     if (m_attributes->hasKey("TOTP Settings")) {
-        // this regex must be kept in sync with the set of allowed short names QTotp::shortNameToEncoder
+        // this regex must be kept in sync with the set of allowed short names Totp::shortNameToEncoder
         QRegularExpression rx(QString("(\\d+);((?:\\d+)|S)"));
         QRegularExpressionMatch m = rx.match(m_attributes->value("TOTP Settings"));
         if (m.hasMatch()) {
             m_data.totpStep = m.captured(1).toUInt();
-            if (QTotp::shortNameToEncoder.contains(m.captured(2))) {
-                m_data.totpDigits = QTotp::shortNameToEncoder[m.captured(2)];
+            if (Totp::shortNameToEncoder.contains(m.captured(2))) {
+                m_data.totpDigits = Totp::shortNameToEncoder[m.captured(2)];
             } else {
                 m_data.totpDigits = m.captured(2).toUInt();
             }
         }
     }
 
-    return QTotp::parseOtpString(secret, m_data.totpDigits, m_data.totpStep);
+    return Totp::parseOtpString(secret, m_data.totpDigits, m_data.totpStep);
 }
 
 quint8 Entry::totpStep() const

--- a/src/gui/SetupTotpDialog.cpp
+++ b/src/gui/SetupTotpDialog.cpp
@@ -46,7 +46,7 @@ void SetupTotpDialog::setupTotp()
     quint8 digits;
 
     if (m_ui->radioSteam->isChecked()) {
-        digits = QTotp::ENCODER_STEAM;
+        digits = Totp::ENCODER_STEAM;
     } else if (m_ui->radio8Digits->isChecked()) {
         digits = 8;
     } else {
@@ -54,7 +54,7 @@ void SetupTotpDialog::setupTotp()
     }
 
     quint8 step = m_ui->stepSpinBox->value();
-    QString seed = QTotp::parseOtpString(m_ui->seedEdit->text(), digits, step);
+    QString seed = Totp::parseOtpString(m_ui->seedEdit->text(), digits, step);
     m_entry->setTotp(seed, step, digits);
     emit m_parent->entrySelectionChanged();
     close();
@@ -63,16 +63,16 @@ void SetupTotpDialog::setupTotp()
 void SetupTotpDialog::toggleDefault(bool status)
 {
     if (status) {
-        setStep(QTotp::defaultStep);
-        setDigits(QTotp::defaultDigits);
+        setStep(Totp::defaultStep);
+        setDigits(Totp::defaultDigits);
     }
 }
 
 void SetupTotpDialog::toggleSteam(bool status)
 {
     if (status) {
-        setStep(QTotp::defaultStep);
-        setDigits(QTotp::ENCODER_STEAM);
+        setStep(Totp::defaultStep);
+        setDigits(Totp::ENCODER_STEAM);
     }
 }
 
@@ -95,9 +95,9 @@ void SetupTotpDialog::setSeed(QString value)
 void SetupTotpDialog::setSettings(quint8 digits) {
     quint8 step = m_ui->stepSpinBox->value();
 
-    bool isDefault = ((step == QTotp::defaultStep) &&
-        (digits == QTotp::defaultDigits));
-    bool isSteam = (digits == QTotp::ENCODER_STEAM);
+    bool isDefault = ((step == Totp::defaultStep) &&
+        (digits == Totp::defaultDigits));
+    bool isSteam = (digits == Totp::ENCODER_STEAM);
 
     if (isSteam) {
         m_ui->radioSteam->setChecked(true);

--- a/src/totp/totp.cpp
+++ b/src/totp/totp.cpp
@@ -28,8 +28,8 @@
 #include <QtEndian>
 #include <cmath>
 
-const quint8 QTotp::defaultStep = 30;
-const quint8 QTotp::defaultDigits = 6;
+const quint8 Totp::defaultStep = 30;
+const quint8 Totp::defaultDigits = 6;
 
 /**
  * Custom encoder types. Each should be unique and >= 128 and < 255
@@ -38,11 +38,11 @@ const quint8 QTotp::defaultDigits = 6;
 /**
  * Encoder for Steam Guard TOTP
  */
-const quint8 QTotp::ENCODER_STEAM = 254;
+const quint8 Totp::ENCODER_STEAM = 254;
 
-const QTotp::Encoder QTotp::defaultEncoder = { "", "", "0123456789", 0, 0, false };
-const QMap<quint8, QTotp::Encoder> QTotp::encoders{
-    { QTotp::ENCODER_STEAM, { "steam", "S", "23456789BCDFGHJKMNPQRTVWXY", 5, 30, true } },
+const Totp::Encoder Totp::defaultEncoder = { "", "", "0123456789", 0, 0, false };
+const QMap<quint8, Totp::Encoder> Totp::encoders{
+    { Totp::ENCODER_STEAM, { "steam", "S", "23456789BCDFGHJKMNPQRTVWXY", 5, 30, true } },
 };
 
 /**
@@ -52,23 +52,23 @@ const QMap<quint8, QTotp::Encoder> QTotp::encoders{
  * NOTE: when updating this map, a corresponding edit to the settings regex must be made
  *       in Entry::totpSeed()
  */
-const QMap<QString, quint8> QTotp::shortNameToEncoder{
-    { "S", QTotp::ENCODER_STEAM },
+const QMap<QString, quint8> Totp::shortNameToEncoder{
+    { "S", Totp::ENCODER_STEAM },
 };
 /**
  * These map the "encoder=" URL parameter of the "otp" field to our internal encoder number
  * that overloads the digits field. Make sure that the key matches the name value
  * in the corresponding Encoder
  */
-const QMap<QString, quint8> QTotp::nameToEncoder{
-    { "steam", QTotp::ENCODER_STEAM },
+const QMap<QString, quint8> Totp::nameToEncoder{
+    { "steam", Totp::ENCODER_STEAM },
 };
 
-QTotp::QTotp()
+Totp::Totp()
 {
 }
 
-QString QTotp::parseOtpString(QString key, quint8& digits, quint8& step)
+QString Totp::parseOtpString(QString key, quint8& digits, quint8& step)
 {
     QUrl url(key);
 
@@ -128,7 +128,7 @@ QString QTotp::parseOtpString(QString key, quint8& digits, quint8& step)
     return seed;
 }
 
-QString QTotp::generateTotp(const QByteArray key,
+QString Totp::generateTotp(const QByteArray key,
                             quint64 time,
                             const quint8 numDigits = defaultDigits,
                             const quint8 step = defaultStep)
@@ -176,7 +176,7 @@ QString QTotp::generateTotp(const QByteArray key,
 }
 
 // See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format
-QUrl QTotp::generateOtpString(const QString& secret,
+QUrl Totp::generateOtpString(const QString& secret,
                               const QString& type,
                               const QString& issuer,
                               const QString& username,

--- a/src/totp/totp.h
+++ b/src/totp/totp.h
@@ -25,10 +25,10 @@
 
 class QUrl;
 
-class QTotp
+class Totp
 {
 public:
-    QTotp();
+    Totp();
     static QString parseOtpString(QString rawSecret, quint8& digits, quint8& step);
     static QString generateTotp(const QByteArray key, quint64 time, const quint8 numDigits, const quint8 step);
     static QUrl generateOtpString(const QString& secret,

--- a/tests/TestTotp.cpp
+++ b/tests/TestTotp.cpp
@@ -41,21 +41,21 @@ void TestTotp::testParseSecret()
     QString secret = "otpauth://totp/"
                      "ACME%20Co:john@example.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm="
                      "SHA1&digits=6&period=30";
-    QCOMPARE(QTotp::parseOtpString(secret, digits, step), QString("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
+    QCOMPARE(Totp::parseOtpString(secret, digits, step), QString("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
     QCOMPARE(digits, quint8(6));
     QCOMPARE(step, quint8(30));
 
-    digits = QTotp::defaultDigits;
-    step = QTotp::defaultStep;
+    digits = Totp::defaultDigits;
+    step = Totp::defaultStep;
     secret = "key=HXDMVJECJJWSRBY%3d&step=25&size=8";
-    QCOMPARE(QTotp::parseOtpString(secret, digits, step), QString("HXDMVJECJJWSRBY="));
+    QCOMPARE(Totp::parseOtpString(secret, digits, step), QString("HXDMVJECJJWSRBY="));
     QCOMPARE(digits, quint8(8));
     QCOMPARE(step, quint8(25));
 
     digits = 0;
     step = 0;
     secret = "gezdgnbvgy3tqojqgezdgnbvgy3tqojq";
-    QCOMPARE(QTotp::parseOtpString(secret, digits, step), QString("gezdgnbvgy3tqojqgezdgnbvgy3tqojq"));
+    QCOMPARE(Totp::parseOtpString(secret, digits, step), QString("gezdgnbvgy3tqojqgezdgnbvgy3tqojq"));
     QCOMPARE(digits, quint8(6));
     QCOMPARE(step, quint8(30));
 }
@@ -68,26 +68,26 @@ void TestTotp::testTotpCode()
     QByteArray seed = QString("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ").toLatin1();
 
     quint64 time = 1234567890;
-    QString output = QTotp::generateTotp(seed, time, 6, 30);
+    QString output = Totp::generateTotp(seed, time, 6, 30);
     QCOMPARE(output, QString("005924"));
 
     time = 1111111109;
-    output = QTotp::generateTotp(seed, time, 6, 30);
+    output = Totp::generateTotp(seed, time, 6, 30);
     QCOMPARE(output, QString("081804"));
 
     time = 1111111111;
-    output = QTotp::generateTotp(seed, time, 8, 30);
+    output = Totp::generateTotp(seed, time, 8, 30);
     QCOMPARE(output, QString("14050471"));
 
     time = 2000000000;
-    output = QTotp::generateTotp(seed, time, 8, 30);
+    output = Totp::generateTotp(seed, time, 8, 30);
     QCOMPARE(output, QString("69279037"));
 }
 
 void TestTotp::testEncoderData()
 {
-    for (quint8 key: QTotp::encoders.keys()) {
-        const QTotp::Encoder& enc = QTotp::encoders.value(key);
+    for (quint8 key: Totp::encoders.keys()) {
+        const Totp::Encoder& enc = Totp::encoders.value(key);
         QVERIFY2(enc.digits != 0,
             qPrintable(QString("Custom encoders cannot have zero-value for digits field: %1(%2)")
                                .arg(enc.name)
@@ -100,47 +100,47 @@ void TestTotp::testEncoderData()
             qPrintable(QString("Custom encoders must have a shortName: %1(%2)")
                                .arg(enc.name)
                                .arg(key)));
-        QVERIFY2(QTotp::shortNameToEncoder.contains(enc.shortName),
+        QVERIFY2(Totp::shortNameToEncoder.contains(enc.shortName),
             qPrintable(QString("No shortNameToEncoder entry found for custom encoder: %1(%2) %3")
                                .arg(enc.name)
                                .arg(key)
                                .arg(enc.shortName)));
-        QVERIFY2(QTotp::shortNameToEncoder[enc.shortName] == key,
+        QVERIFY2(Totp::shortNameToEncoder[enc.shortName] == key,
             qPrintable(QString("shortNameToEncoder doesn't reference this custome encoder: %1(%2) %3")
                                .arg(enc.name)
                                .arg(key)
                                .arg(enc.shortName)));
-        QVERIFY2(QTotp::nameToEncoder.contains(enc.name),
+        QVERIFY2(Totp::nameToEncoder.contains(enc.name),
             qPrintable(QString("No nameToEncoder entry found for custom encoder: %1(%2) %3")
                                .arg(enc.name)
                                .arg(key)
                                .arg(enc.shortName)));
-        QVERIFY2(QTotp::nameToEncoder[enc.name] == key,
+        QVERIFY2(Totp::nameToEncoder[enc.name] == key,
             qPrintable(QString("nameToEncoder doesn't reference this custome encoder: %1(%2) %3")
                                .arg(enc.name)
                                .arg(key)
                                .arg(enc.shortName)));
     }
 
-    for (const QString & key: QTotp::nameToEncoder.keys()) {
-        quint8 value = QTotp::nameToEncoder.value(key);
-        QVERIFY2(QTotp::encoders.contains(value),
+    for (const QString & key: Totp::nameToEncoder.keys()) {
+        quint8 value = Totp::nameToEncoder.value(key);
+        QVERIFY2(Totp::encoders.contains(value),
                 qPrintable(QString("No custom encoder found for encoder named %1(%2)")
                                    .arg(value)
                                    .arg(key)));
-        QVERIFY2(QTotp::encoders[value].name == key,
+        QVERIFY2(Totp::encoders[value].name == key,
                 qPrintable(QString("nameToEncoder doesn't reference the right custom encoder: %1(%2)")
                                    .arg(value)
                                    .arg(key)));
     }
 
-    for (const QString & key: QTotp::shortNameToEncoder.keys()) {
-        quint8 value = QTotp::shortNameToEncoder.value(key);
-        QVERIFY2(QTotp::encoders.contains(value),
+    for (const QString & key: Totp::shortNameToEncoder.keys()) {
+        quint8 value = Totp::shortNameToEncoder.value(key);
+        QVERIFY2(Totp::encoders.contains(value),
                 qPrintable(QString("No custom encoder found for short-name encoder %1(%2)")
                                    .arg(value)
                                    .arg(key)));
-        QVERIFY2(QTotp::encoders[value].shortName == key,
+        QVERIFY2(Totp::encoders[value].shortName == key,
                 qPrintable(QString("shortNameToEncoder doesn't reference the right custom encoder: %1(%2)")
                                    .arg(value)
                                    .arg(key)));
@@ -154,8 +154,8 @@ void TestTotp::testSteamTotp()
     QString secret = "otpauth://totp/"
                      "test:test@example.com?secret=63BEDWCQZKTQWPESARIERL5DTTQFCJTK&issuer=Valve&algorithm="
                      "SHA1&digits=5&period=30&encoder=steam";
-    QCOMPARE(QTotp::parseOtpString(secret, digits, step), QString("63BEDWCQZKTQWPESARIERL5DTTQFCJTK"));
-    QCOMPARE(digits, quint8(QTotp::ENCODER_STEAM));
+    QCOMPARE(Totp::parseOtpString(secret, digits, step), QString("63BEDWCQZKTQWPESARIERL5DTTQFCJTK"));
+    QCOMPARE(digits, quint8(Totp::ENCODER_STEAM));
     QCOMPARE(step, quint8(30));
 
 
@@ -165,7 +165,7 @@ void TestTotp::testSteamTotp()
     // Steam mobile app with a throw-away steam account. The above secret was extracted
     // from the Steam app's data for use in testing here.
     quint64 time = 1511200518;
-    QCOMPARE(QTotp::generateTotp(seed, time, QTotp::ENCODER_STEAM, 30), QString("FR8RV"));
+    QCOMPARE(Totp::generateTotp(seed, time, Totp::ENCODER_STEAM, 30), QString("FR8RV"));
     time = 1511200714;
-    QCOMPARE(QTotp::generateTotp(seed, time, QTotp::ENCODER_STEAM, 30), QString("9P3VP"));
+    QCOMPARE(Totp::generateTotp(seed, time, Totp::ENCODER_STEAM, 30), QString("9P3VP"));
 }


### PR DESCRIPTION
## Description
Rename QTotp class name to Totp, as it has nothing to do with Qt.

Related: https://github.com/keepassxreboot/keepassxc/pull/1206#issuecomment-345872501

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**