### PR TITLE
memory leaks fixes in non-gui tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ compiler:
   - gcc
 
 env:
-  - CONFIG=Release ASAN_OPTIONS=detect_odr_violation=1:leak_check_at_exit=0
-  - CONFIG=Debug ASAN_OPTIONS=detect_odr_violation=1:leak_check_at_exit=0
+  - CONFIG=Release ASAN_OPTIONS=detect_odr_violation=1
+  - CONFIG=Debug ASAN_OPTIONS=detect_odr_violation=1
 
 git:
   depth: 3
@@ -37,7 +37,7 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=${CONFIG} -DWITH_GUI_TESTS=ON -DWITH_ASAN=ON -DWITH_XC_HTTP=ON -DWITH_XC_AUTOTYPE=ON -DWITH_XC_YUBIKEY=ON $CMAKE_ARGS ..
   - make -j2
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then make test ARGS+="-E testgui --output-on-failure"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -a --server-args="-screen 0 800x600x24" make test ARGS+="-R testgui --output-on-failure"; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ASAN_OPTIONS=${ASAN_OPTIONS}:leak_check_at_exit=0 xvfb-run -a --server-args="-screen 0 800x600x24" make test ARGS+="-R testgui --output-on-failure"; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make test ARGS+="--output-on-failure"; fi
 
 # Generate snapcraft build when merging into master/develop branches

--- a/src/crypto/SymmetricCipherGcrypt.cpp
+++ b/src/crypto/SymmetricCipherGcrypt.cpp
@@ -86,6 +86,8 @@ bool SymmetricCipherGcrypt::init()
 
     gcry_error_t error;
 
+    if(m_ctx != nullptr)
+        gcry_cipher_close(m_ctx);
     error = gcry_cipher_open(&m_ctx, m_algo, m_mode, 0);
     if (error != 0) {
         setErrorString(error);

--- a/src/format/KeePass2Repair.h
+++ b/src/format/KeePass2Repair.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2016 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,6 +21,7 @@
 
 #include <QCoreApplication>
 #include <QIODevice>
+#include <QPair>
 
 #include "core/Database.h"
 #include "keys/CompositeKey.h"
@@ -36,14 +38,12 @@ public:
         RepairSuccess,
         RepairFailed
     };
+    using RepairOutcome = QPair<RepairResult, Database*>;
 
-    KeePass2Repair();
-    RepairResult repairDatabase(QIODevice* device, const CompositeKey& key);
-    Database* database() const;
+    RepairOutcome repairDatabase(QIODevice* device, const CompositeKey& key);
     QString errorString() const;
 
 private:
-    Database* m_db;
     QString m_errorStr;
 };
 

--- a/src/gui/DatabaseRepairWidget.cpp
+++ b/src/gui/DatabaseRepairWidget.cpp
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2016 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -69,7 +70,8 @@ void DatabaseRepairWidget::openDatabase()
         delete m_db;
     }
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    KeePass2Repair::RepairResult repairResult = repair.repairDatabase(&file, masterKey);
+    auto repairOutcome = repair.repairDatabase(&file, masterKey);
+    KeePass2Repair::RepairResult repairResult = repairOutcome.first;
     QApplication::restoreOverrideCursor();
 
     switch (repairResult) {
@@ -83,7 +85,7 @@ void DatabaseRepairWidget::openDatabase()
         emit editFinished(false);
         return;
     case KeePass2Repair::RepairSuccess:
-        m_db = repair.database();
+        m_db = repairOutcome.second;
         MessageBox::warning(this, tr("Success"), tr("The database has been successfully repaired\nYou can now save it."));
         emit editFinished(true);
         return;

--- a/tests/TestCsvParser.h
+++ b/tests/TestCsvParser.h
@@ -22,6 +22,7 @@
 #include <QObject>
 #include <QFile>
 #include <QTemporaryFile>
+#include <QScopedPointer>
 
 #include "core/CsvParser.h"
 
@@ -37,7 +38,6 @@ private slots:
     void init();
     void cleanup();
     void initTestCase();
-    void cleanupTestCase();
 
     void testUnicode();
     void testLF();
@@ -62,8 +62,8 @@ private slots:
     void testColumns();
 
 private:
-    QTemporaryFile* file;
-    CsvParser* parser;
+    QScopedPointer<QTemporaryFile> file;
+    QScopedPointer<CsvParser> parser;
     CsvTable t;
     void dumpRow(CsvTable table, int row);
 };

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -18,9 +18,10 @@
 
 #include "TestGroup.h"
 
-#include <QPointer>
-#include <QSignalSpy>
 #include <QDebug>
+#include <QPointer>
+#include <QScopedPointer>
+#include <QSignalSpy>
 #include <QTest>
 
 #include "core/Database.h"
@@ -76,6 +77,7 @@ void TestGroup::testParenting()
     QCOMPARE(g4->children().size(), 0);
 
     QVERIFY(rootGroup->children().at(0) == g1);
+    QVERIFY(rootGroup->children().at(0) == g1);
     QVERIFY(g1->children().at(0) == g2);
     QVERIFY(g1->children().at(1) == g3);
     QVERIFY(g3->children().contains(g4));
@@ -99,7 +101,6 @@ void TestGroup::testParenting()
     g3->setIcon(Uuid::random());
     g1->setIcon(2);
     QCOMPARE(spy.count(), 6);
-
     delete db;
 
     QVERIFY(rootGroup.isNull());
@@ -107,7 +108,6 @@ void TestGroup::testParenting()
     QVERIFY(g2.isNull());
     QVERIFY(g3.isNull());
     QVERIFY(g4.isNull());
-
     delete tmpRoot;
 }
 
@@ -117,18 +117,18 @@ void TestGroup::testSignals()
     Database* db2 = new Database();
     QPointer<Group> root = db->rootGroup();
 
-    QSignalSpy spyAboutToAdd(db, SIGNAL(groupAboutToAdd(Group*,int)));
+    QSignalSpy spyAboutToAdd(db, SIGNAL(groupAboutToAdd(Group*, int)));
     QSignalSpy spyAdded(db, SIGNAL(groupAdded()));
     QSignalSpy spyAboutToRemove(db, SIGNAL(groupAboutToRemove(Group*)));
     QSignalSpy spyRemoved(db, SIGNAL(groupRemoved()));
-    QSignalSpy spyAboutToMove(db, SIGNAL(groupAboutToMove(Group*,Group*,int)));
+    QSignalSpy spyAboutToMove(db, SIGNAL(groupAboutToMove(Group*, Group*, int)));
     QSignalSpy spyMoved(db, SIGNAL(groupMoved()));
 
-    QSignalSpy spyAboutToAdd2(db2, SIGNAL(groupAboutToAdd(Group*,int)));
+    QSignalSpy spyAboutToAdd2(db2, SIGNAL(groupAboutToAdd(Group*, int)));
     QSignalSpy spyAdded2(db2, SIGNAL(groupAdded()));
     QSignalSpy spyAboutToRemove2(db2, SIGNAL(groupAboutToRemove(Group*)));
     QSignalSpy spyRemoved2(db2, SIGNAL(groupRemoved()));
-    QSignalSpy spyAboutToMove2(db2, SIGNAL(groupAboutToMove(Group*,Group*,int)));
+    QSignalSpy spyAboutToMove2(db2, SIGNAL(groupAboutToMove(Group*, Group*, int)));
     QSignalSpy spyMoved2(db2, SIGNAL(groupMoved()));
 
     Group* g1 = new Group();
@@ -251,7 +251,7 @@ void TestGroup::testEntries()
 
 void TestGroup::testDeleteSignals()
 {
-    Database* db = new Database();
+    QScopedPointer<Database> db(new Database());
     Group* groupRoot = db->rootGroup();
     Group* groupChild = new Group();
     Group* groupChildChild = new Group();
@@ -260,15 +260,13 @@ void TestGroup::testDeleteSignals()
     groupChildChild->setObjectName("groupChildChild");
     groupChild->setParent(groupRoot);
     groupChildChild->setParent(groupChild);
-    QSignalSpy spyAboutToRemove(db, SIGNAL(groupAboutToRemove(Group*)));
-    QSignalSpy spyRemoved(db, SIGNAL(groupRemoved()));
+    QSignalSpy spyAboutToRemove(db.data(), SIGNAL(groupAboutToRemove(Group*)));
+    QSignalSpy spyRemoved(db.data(), SIGNAL(groupRemoved()));
 
     delete groupChild;
     QVERIFY(groupRoot->children().isEmpty());
     QCOMPARE(spyAboutToRemove.count(), 2);
     QCOMPARE(spyRemoved.count(), 2);
-    delete db;
-
 
     Group* group = new Group();
     Entry* entry = new Entry();
@@ -282,7 +280,7 @@ void TestGroup::testDeleteSignals()
     QCOMPARE(spyEntryRemoved.count(), 1);
     delete group;
 
-    Database* db2 = new Database();
+    QScopedPointer<Database> db2(new Database());
     Group* groupRoot2 = db2->rootGroup();
     Group* group2 = new Group();
     group2->setParent(groupRoot2);
@@ -294,12 +292,11 @@ void TestGroup::testDeleteSignals()
     delete group2;
     QCOMPARE(spyEntryAboutToRemove2.count(), 1);
     QCOMPARE(spyEntryRemoved2.count(), 1);
-    delete db2;
 }
 
 void TestGroup::testCopyCustomIcon()
 {
-    Database* dbSource = new Database();
+    QScopedPointer<Database> dbSource(new Database());
 
     Uuid groupIconUuid = Uuid::random();
     QImage groupIcon(16, 16, QImage::Format_RGB32);
@@ -321,7 +318,7 @@ void TestGroup::testCopyCustomIcon()
     entry->setIcon(entryIconUuid);
     QCOMPARE(entry->icon(), entryIcon);
 
-    Database* dbTarget = new Database();
+    QScopedPointer<Database> dbTarget(new Database());
 
     group->setParent(dbTarget->rootGroup());
     QVERIFY(dbTarget->metadata()->containsCustomIcon(groupIconUuid));
@@ -332,37 +329,34 @@ void TestGroup::testCopyCustomIcon()
     QVERIFY(dbTarget->metadata()->containsCustomIcon(entryIconUuid));
     QCOMPARE(dbTarget->metadata()->customIcon(entryIconUuid), entryIcon);
     QCOMPARE(entry->icon(), entryIcon);
-
-    delete dbSource;
-    delete dbTarget;
 }
 
 void TestGroup::testClone()
 {
-    Database* db = new Database();
+    QScopedPointer<Database> db(new Database());
 
-    Group* originalGroup = new Group();
+    QScopedPointer<Group> originalGroup(new Group());
     originalGroup->setParent(db->rootGroup());
     originalGroup->setName("Group");
     originalGroup->setIcon(42);
 
-    Entry* originalGroupEntry = new Entry();
-    originalGroupEntry->setGroup(originalGroup);
+    QScopedPointer<Entry> originalGroupEntry(new Entry());
+    originalGroupEntry->setGroup(originalGroup.data());
     originalGroupEntry->setTitle("GroupEntryOld");
     originalGroupEntry->setIcon(43);
     originalGroupEntry->beginUpdate();
     originalGroupEntry->setTitle("GroupEntry");
     originalGroupEntry->endUpdate();
 
-    Group* subGroup = new Group();
-    subGroup->setParent(originalGroup);
+    QScopedPointer<Group> subGroup(new Group());
+    subGroup->setParent(originalGroup.data());
     subGroup->setName("SubGroup");
 
-    Entry* subGroupEntry = new Entry();
-    subGroupEntry->setGroup(subGroup);
+    QScopedPointer<Entry> subGroupEntry(new Entry());
+    subGroupEntry->setGroup(subGroup.data());
     subGroupEntry->setTitle("SubGroupEntry");
 
-    Group* clonedGroup = originalGroup->clone();
+    QScopedPointer<Group> clonedGroup(originalGroup->clone());
     QVERIFY(!clonedGroup->parentGroup());
     QVERIFY(!clonedGroup->database());
     QVERIFY(clonedGroup->uuid() != originalGroup->uuid());
@@ -387,19 +381,15 @@ void TestGroup::testClone()
     QVERIFY(clonedSubGroupEntry->uuid() != subGroupEntry->uuid());
     QCOMPARE(clonedSubGroupEntry->title(), QString("SubGroupEntry"));
 
-    Group* clonedGroupKeepUuid = originalGroup->clone(Entry::CloneNoFlags);
+    QScopedPointer<Group> clonedGroupKeepUuid(originalGroup->clone(Entry::CloneNoFlags));
     QCOMPARE(clonedGroupKeepUuid->entries().at(0)->uuid(), originalGroupEntry->uuid());
     QCOMPARE(clonedGroupKeepUuid->children().at(0)->entries().at(0)->uuid(), subGroupEntry->uuid());
-
-    delete clonedGroup;
-    delete clonedGroupKeepUuid;
-    delete db;
 }
 
 void TestGroup::testCopyCustomIcons()
 {
-    Database* dbSource = new Database();
-    Database* dbTarget = new Database();
+    QScopedPointer<Database> dbSource(new Database());
+    QScopedPointer<Database> dbTarget(new Database());
 
     QImage iconImage1(1, 1, QImage::Format_RGB32);
     iconImage1.setPixel(0, 0, qRgb(1, 2, 3));
@@ -407,20 +397,20 @@ void TestGroup::testCopyCustomIcons()
     QImage iconImage2(1, 1, QImage::Format_RGB32);
     iconImage2.setPixel(0, 0, qRgb(4, 5, 6));
 
-    Group* group1 = new Group();
+    QScopedPointer<Group> group1(new Group());
     group1->setParent(dbSource->rootGroup());
     Uuid group1Icon = Uuid::random();
     dbSource->metadata()->addCustomIcon(group1Icon, iconImage1);
     group1->setIcon(group1Icon);
 
-    Group* group2 = new Group();
-    group2->setParent(group1);
+    QScopedPointer<Group> group2(new Group());
+    group2->setParent(group1.data());
     Uuid group2Icon = Uuid::random();
     dbSource->metadata()->addCustomIcon(group2Icon, iconImage1);
     group2->setIcon(group2Icon);
 
-    Entry* entry1 = new Entry();
-    entry1->setGroup(group2);
+    QScopedPointer<Entry> entry1(new Entry());
+    entry1->setGroup(group2.data());
     Uuid entry1IconOld = Uuid::random();
     dbSource->metadata()->addCustomIcon(entry1IconOld, iconImage1);
     entry1->setIcon(entry1IconOld);
@@ -447,27 +437,24 @@ void TestGroup::testCopyCustomIcons()
 
     QCOMPARE(metaTarget->customIcon(group1Icon).pixel(0, 0), qRgb(1, 2, 3));
     QCOMPARE(metaTarget->customIcon(group2Icon).pixel(0, 0), qRgb(4, 5, 6));
-
-    delete dbTarget;
-    delete dbSource;
 }
 
 void TestGroup::testMerge()
 {
-    Group* group1 = new Group();
+    QScopedPointer<Group> group1(new Group());
     group1->setName("group 1");
-    Group* group2 = new Group();
+    QScopedPointer<Group> group2(new Group());
     group2->setName("group 2");
 
-    Entry* entry1 = new Entry();
-    Entry* entry2 = new Entry();
+    QScopedPointer<Entry> entry1(new Entry());
+    QScopedPointer<Entry> entry2(new Entry());
 
-    entry1->setGroup(group1);
+    entry1->setGroup(group1.data());
     entry1->setUuid(Uuid::random());
-    entry2->setGroup(group1);
+    entry2->setGroup(group1.data());
     entry2->setUuid(Uuid::random());
 
-    group2->merge(group1);
+    group2->merge(group1.data());
 
     QCOMPARE(group1->entries().size(), 2);
     QCOMPARE(group2->entries().size(), 2);
@@ -475,25 +462,22 @@ void TestGroup::testMerge()
 
 void TestGroup::testMergeDatabase()
 {
-    Database* dbSource = createMergeTestDatabase();
-    Database* dbDest = new Database();
+    QScopedPointer<Database> dbSource(createMergeTestDatabase());
+    QScopedPointer<Database> dbDest(new Database());
 
-    dbDest->merge(dbSource);
+    dbDest->merge(dbSource.data());
 
     QCOMPARE(dbDest->rootGroup()->children().size(), 2);
     QCOMPARE(dbDest->rootGroup()->children().at(0)->entries().size(), 2);
-
-    delete dbDest;
-    delete dbSource;
 }
 
 void TestGroup::testMergeConflict()
 {
-    Database* dbSource = createMergeTestDatabase();
+    QScopedPointer<Database> dbSource(createMergeTestDatabase());
 
     // test merging updated entries
     // falls back to KeepBoth mode
-    Database* dbCopy = new Database();
+    QScopedPointer<Database> dbCopy(new Database());
     dbCopy->setRootGroup(dbSource->rootGroup()->clone(Entry::CloneNoFlags));
 
     // sanity check
@@ -505,22 +489,19 @@ void TestGroup::testMergeConflict()
     updatedTimeInfo.setLastModificationTime(updatedTimeInfo.lastModificationTime().addYears(1));
     updatedEntry->setTimeInfo(updatedTimeInfo);
 
-    dbCopy->merge(dbSource);
+    dbCopy->merge(dbSource.data());
 
     // one entry is duplicated because of mode
     QCOMPARE(dbCopy->rootGroup()->children().at(0)->entries().size(), 2);
-
-    delete dbSource;
-    delete dbCopy;
 }
 
 void TestGroup::testMergeConflictKeepBoth()
 {
-    Database* dbSource = createMergeTestDatabase();
+    QScopedPointer<Database> dbSource(createMergeTestDatabase());
 
     // test merging updated entries
     // falls back to KeepBoth mode
-    Database* dbCopy = new Database();
+    QScopedPointer<Database> dbCopy(new Database());
     dbCopy->setRootGroup(dbSource->rootGroup()->clone(Entry::CloneNoFlags));
 
     // sanity check
@@ -534,21 +515,18 @@ void TestGroup::testMergeConflictKeepBoth()
 
     dbCopy->rootGroup()->setMergeMode(Group::MergeMode::KeepBoth);
 
-    dbCopy->merge(dbSource);
+    dbCopy->merge(dbSource.data());
 
     // one entry is duplicated because of mode
     QCOMPARE(dbCopy->rootGroup()->children().at(0)->entries().size(), 3);
     // the older entry was merged from the other db as last in the group
     Entry* olderEntry = dbCopy->rootGroup()->children().at(0)->entries().at(2);
     QVERIFY2(olderEntry->attributes()->hasKey("merged"), "older entry is marked with an attribute \"merged\"");
-
-    delete dbSource;
-    delete dbCopy;
 }
 
 Database* TestGroup::createMergeTestDatabase()
 {
-    Database* db = new Database();
+    QScopedPointer<Database> db(new Database());
 
     Group* group1 = new Group();
     group1->setName("group 1");
@@ -566,12 +544,12 @@ Database* TestGroup::createMergeTestDatabase()
     group1->setParent(db->rootGroup());
     group2->setParent(db->rootGroup());
 
-    return db;
+    return db.take();
 }
 
 void TestGroup::testFindEntry()
 {
-    Database* db = new Database();
+    QScopedPointer<Database> db(new Database());
 
     Entry* entry1 = new Entry();
     entry1->setTitle(QString("entry1"));
@@ -642,13 +620,11 @@ void TestGroup::testFindEntry()
     // An invalid UUID.
     entry = db->rootGroup()->findEntry(QString("febfb01ebcdf9dbd90a3f1579dc"));
     QVERIFY(entry == nullptr);
-
-    delete db;
 }
 
 void TestGroup::testFindGroupByPath()
 {
-    Database* db = new Database();
+    QScopedPointer<Database> db(new Database());
 
     Group* group1 = new Group();
     group1->setName("group1");
@@ -706,13 +682,11 @@ void TestGroup::testFindGroupByPath()
 
     group = db->rootGroup()->findGroupByPath("invalid");
     QVERIFY(group == nullptr);
-
-    delete db;
 }
 
 void TestGroup::testPrint()
 {
-    Database* db = new Database();
+    QScopedPointer<Database> db(new Database());
 
     QString output = db->rootGroup()->print();
     QCOMPARE(output, QString("[empty]\n"));
@@ -730,7 +704,6 @@ void TestGroup::testPrint()
 
     output = db->rootGroup()->print(true);
     QCOMPARE(output, QString("entry1 " + entry1->uuid().toHex() + "\n"));
-
 
     Group* group1 = new Group();
     group1->setName("group1");
@@ -752,5 +725,4 @@ void TestGroup::testPrint()
     QVERIFY(output.contains(QString("entry1 " + entry1->uuid().toHex() + "\n")));
     QVERIFY(output.contains(QString("group1/ " + group1->uuid().toHex() + "\n")));
     QVERIFY(output.contains(QString("  entry2 " + entry2->uuid().toHex() + "\n")));
-    delete db;
 }

--- a/tests/TestKeePass2Writer.cpp
+++ b/tests/TestKeePass2Writer.cpp
@@ -148,13 +148,15 @@ void TestKeePass2Writer::testRepair()
     KeePass2Repair repair;
     QFile file(brokenDbFilename);
     file.open(QIODevice::ReadOnly);
-    QCOMPARE(repair.repairDatabase(&file, key), KeePass2Repair::RepairSuccess);
-    Database* dbRepaired = repair.database();
+    auto result = repair.repairDatabase(&file, key);
+    QCOMPARE(result.first, KeePass2Repair::RepairSuccess);
+    Database* dbRepaired = result.second;
     QVERIFY(dbRepaired);
 
     QCOMPARE(dbRepaired->rootGroup()->entries().size(), 1);
     QCOMPARE(dbRepaired->rootGroup()->entries().at(0)->username(), QString("testuser").append(QChar(0x20AC)));
     QCOMPARE(dbRepaired->rootGroup()->entries().at(0)->password(), QString("testpw"));
+    delete dbRepaired;
 }
 
 void TestKeePass2Writer::cleanupTestCase()

--- a/tests/TestSymmetricCipher.cpp
+++ b/tests/TestSymmetricCipher.cpp
@@ -162,7 +162,7 @@ void TestSymmetricCipher::testTwofish256CbcEncryption()
     bool ok;
     
     for (int i = 0; i < keys.size(); ++i) {
-        cipher.init(keys[i], ivs[i]);
+        QVERIFY(cipher.init(keys[i], ivs[i]));
         QByteArray ptNext = plainTexts[i];
         QByteArray ctPrev = ivs[i];
         QByteArray ctCur;


### PR DESCRIPTION
Fixed memory leaks non-gui tests
## Description
Fixed 2 memory leaks in production code and a few in testcases. As a result `leak_check_at_exit` ASAN option does not need to turned off for non-gui tests.
Smart pointers should be used elsewhere for consistency, but the sooner this fixes are delivered, the lesser memory leaks are introduced.

## Motivation and context
Memory leaks are bugs in short, so motivation is pretty straightforward :)

## How has this been tested?
No logic was altered, thus existing testcases are sufficient

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
