### PR TITLE
Prevent database corruption when locked

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -298,8 +298,7 @@ bool DatabaseTabWidget::closeDatabase(Database* db)
             if (!saveDatabase(db)) {
                 return false;
             }
-        }
-        else {
+        } else if (dbStruct.dbWidget->currentMode() != DatabaseWidget::LockedMode) {
             QMessageBox::StandardButton result =
                 MessageBox::question(
                 this, tr("Save changes?"),
@@ -307,10 +306,9 @@ bool DatabaseTabWidget::closeDatabase(Database* db)
                 QMessageBox::Yes | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Yes);
             if (result == QMessageBox::Yes) {
                 if (!saveDatabase(db)) {
-                        return false;
+                    return false;
                 }
-            }
-            else if (result == QMessageBox::Cancel) {
+            } else if (result == QMessageBox::Cancel) {
                 return false;
             }
         }
@@ -355,8 +353,13 @@ bool DatabaseTabWidget::saveDatabase(Database* db)
 {
     DatabaseManagerStruct& dbStruct = m_dbList[db];
 
-    if (dbStruct.saveToFilename) {
+    if (dbStruct.dbWidget->currentMode() == DatabaseWidget::LockedMode) {
+        // Never allow saving a locked database; it causes corruption
+        // We return true since a save is not required
+        return true;
+    }
 
+    if (dbStruct.saveToFilename) {
         dbStruct.dbWidget->blockAutoReload(true);
         QString errorMessage = db->saveToFile(dbStruct.canonicalFilePath);
         dbStruct.dbWidget->blockAutoReload(false);
@@ -375,7 +378,6 @@ bool DatabaseTabWidget::saveDatabase(Database* db)
                             MessageWidget::Error);
             return false;
         }
-
     } else {
         return saveDatabaseAs(db);
     }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1125,7 +1125,7 @@ void DatabaseWidget::onWatchedFileChanged()
 
 void DatabaseWidget::reloadDatabaseFile()
 {
-    if (m_db == nullptr)
+    if (m_db == nullptr || currentMode() == DatabaseWidget::LockedMode)
         return;
 
     if (! config()->get("AutoReloadOnChange").toBool()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #1113 

We may want to add test cases for this, but I would defer to the refactor moving saving into the database class.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Databases can be corrupted if autoreload is triggered when the database is locked, reload not accepted, and then saved on exit. These fixes prevent unnecessary dialogs from popping up when databases are locked and also adds an interlock in the save function to prevent corruption.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
