### PR TITLE
Add StartupWMClass field in .desktop file

### DIFF
--- a/share/linux/org.keepassxc.KeePassXC.desktop
+++ b/share/linux/org.keepassxc.KeePassXC.desktop
@@ -14,3 +14,4 @@ Type=Application
 Version=1.0
 Categories=Utility;Security;Qt;
 MimeType=application/x-keepass2;
+StartupWMClass=keepassxc


### PR DESCRIPTION
In the absence of this field, KeePassXC cannot be added as a favorite to
Gnome laucher.