### PR TITLE
Add missing crypto init to OpenSSHKey test

### DIFF
--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -16,10 +16,16 @@
  */
 
 #include "TestOpenSSHKey.h"
+#include "crypto/Crypto.h"
 #include "sshagent/OpenSSHKey.h"
 #include <QTest>
 
 QTEST_GUILESS_MAIN(TestOpenSSHKey)
+
+void TestOpenSSHKey::initTestCase()
+{
+    QVERIFY(Crypto::init());
+}
 
 void TestOpenSSHKey::testParse()
 {

--- a/tests/TestOpenSSHKey.h
+++ b/tests/TestOpenSSHKey.h
@@ -27,6 +27,7 @@ class TestOpenSSHKey : public QObject
     Q_OBJECT
 
 private slots:
+    void initTestCase();
     void testParse();
     void testDecryptAES256CBC();
     void testDecryptAES256CTR();


### PR DESCRIPTION
OpenSSHKey test did not init Crypto and apparently worked by luck. It fails for me now without the required initialization.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OpenSSHKeyTest works again.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
