### PR TITLE
Use Consolas on Windows for PasswordEdit

### DIFF
--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -31,9 +31,18 @@ PasswordEdit::PasswordEdit(QWidget* parent)
 {
     setEchoMode(QLineEdit::Password);
     updateStylesheet();
-    
-    // set font to system monospace font and increase letter spacing
+
+    // use a monospace font for the password field
     QFont passwordFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+#ifdef Q_OS_WIN
+    // try to use Consolas on Windows, because the default Courier New has too many similar characters
+    QFont consolasFont = QFontDatabase().font("Consolas", passwordFont.styleName(), passwordFont.pointSize());
+    const QFont defaultFont;
+    if (passwordFont != defaultFont) {
+        passwordFont = consolasFont;
+    }
+#endif
+
     passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
     setFont(passwordFont);
 }


### PR DESCRIPTION
Resolves #1226 

<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
The default monospace font on Windows is Courier New, which has a few very similar characters. This PR tries to use Consolas instead when KeePassXC is compiled for Windows. Other platforms are unchanged.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Courier New has very similar characters, e.g. I (lowercase L) and 1, which was a problem for the PasswordEdit field.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled on Windows, correct Consolars font is shown.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**