### PR TITLE
Remove empty context menu from toolbar

### DIFF
--- a/share/keepassxc.ini
+++ b/share/keepassxc.ini
@@ -1,5 +1,4 @@
 [General]
-ShowToolbar=true
 RememberLastDatabases=true
 RememberLastKeyFiles=true
 OpenPreviousDatabasesOnStartup=true

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -114,7 +114,6 @@ void Config::init(const QString& fileName)
     m_defaults.insert("AutoSaveAfterEveryChange", false);
     m_defaults.insert("AutoReloadOnChange", true);
     m_defaults.insert("AutoSaveOnExit", false);
-    m_defaults.insert("ShowToolbar", true);
     m_defaults.insert("SearchLimitGroup", false);
     m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("UseGroupIconOnEntryCreation", false);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -114,6 +114,8 @@ MainWindow::MainWindow()
 {
     m_ui->setupUi(this);
 
+    m_ui->toolBar->setContextMenuPolicy(Qt::PreventContextMenu);
+
     // Setup the search widget in the toolbar
     SearchWidget *search = new SearchWidget();
     search->connectSignals(m_actionMultiplexer);
@@ -820,11 +822,6 @@ void MainWindow::showEntryContextMenu(const QPoint& globalPos)
 void MainWindow::showGroupContextMenu(const QPoint& globalPos)
 {
     m_ui->menuGroups->popup(globalPos);
-}
-
-void MainWindow::saveToolbarState(bool value)
-{
-    config()->set("ShowToolbar", value);
 }
 
 void MainWindow::setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -87,7 +87,6 @@ private slots:
     void updateCopyAttributesMenu();
     void showEntryContextMenu(const QPoint& globalPos);
     void showGroupContextMenu(const QPoint& globalPos);
-    void saveToolbarState(bool value);
     void rememberOpenDatabases(const QString& filePath);
     void applySettingsChanges();
     void trayIconTriggered(QSystemTrayIcon::ActivationReason reason);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Remove the empty "show toolbar" item and the context menu from the toolbar since the option to toggle it was removed at #1116 and without the "View" menu the user can't show the toolbar again after hiding it using the context menu.

## Screenshots (if appropriate):
Before:
![screen shot 2017-11-26 at 9 20 13 pm](https://user-images.githubusercontent.com/107672/33246180-a7a26c62-d2f8-11e7-814f-7c6bd7a04019.png)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
