### PR TITLE
Treat warning as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if(WITH_APP_BUNDLE)
 endif()
 
 add_gcc_compiler_flags("-fno-common")
-add_gcc_compiler_flags("-Wall -Wextra -Wundef -Wpointer-arith -Wno-long-long")
+add_gcc_compiler_flags("-Wall -Werror -Wextra -Wundef -Wpointer-arith -Wno-long-long")
 add_gcc_compiler_flags("-Wformat=2 -Wmissing-format-attribute")
 add_gcc_compiler_flags("-fvisibility=hidden")
 add_gcc_compiler_cxxflags("-fvisibility-inlines-hidden")

--- a/src/http/qhttp/http-parser/http_parser.c
+++ b/src/http/qhttp/http-parser/http_parser.c
@@ -1815,6 +1815,9 @@ reexecute:
 
             case 2:
               parser->upgrade = 1;
+#if __GNUC__ >= 7
+              __attribute__ ((fallthrough));
+#endif
 
             case 1:
               parser->flags |= F_SKIPBODY;
@@ -2374,6 +2377,9 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
       case s_req_server_with_at:
         found_at = 1;
+#if __GNUC__ >= 7
+        __attribute__ ((fallthrough));
+#endif
 
       /* FALLTROUGH */
       case s_req_server:

--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -95,7 +95,7 @@ bool SSHAgent::sendMessage(const QByteArray& in, QByteArray& out) const
         return false;
     }
 
-    if (in.length() > AGENT_MAX_MSGLEN - 4) {
+    if (static_cast<quint32>(in.length()) > AGENT_MAX_MSGLEN - 4) {
         return false;
     }
 

--- a/src/sshagent/SSHAgent.h
+++ b/src/sshagent/SSHAgent.h
@@ -63,7 +63,7 @@ private:
 #ifndef Q_OS_WIN
     QString m_socketPath;
 #else
-    const int AGENT_MAX_MSGLEN = 8192;
+    const quint32 AGENT_MAX_MSGLEN = 8192;
     const quint32 AGENT_COPYDATA_ID = 0x804e50ba;
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This PR sets the compiler flag `-Werror` to treat all warnings as errors.
In addition, four thrown warnings were fixed, two of them inside third-party code (http_parser.c).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is no reason why warnings should be tolerated. The code should compile without any warnings, but pull requests keep introducing them and sometimes they go unnoticed, because code is not compiled from scratch. This change will ensure that our CI system will catch any warnings and report an error.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code compiles fine on my machine and also on CI.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
