### PR TITLE
New feature: hexadecimal password generator

### DIFF
--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -141,6 +141,10 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
             }
 
             group.append(i);
+
+            if ((m_flags & Hexadecimal) && (i == 102)) { // 'f'
+                break;
+            }
         }
 
         passwordGroups.append(group);
@@ -154,6 +158,10 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
             }
 
             group.append(i);
+
+            if ((m_flags & Hexadecimal) && (i == 70)) { // 'F'
+                break;
+            }
         }
 
         passwordGroups.append(group);

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -41,7 +41,8 @@ public:
     enum GeneratorFlag
     {
         ExcludeLookAlike   = 0x1,
-        CharFromEveryGroup = 0x2
+        CharFromEveryGroup = 0x2,
+        Hexadecimal        = 0x4
     };
     Q_DECLARE_FLAGS(GeneratorFlags, GeneratorFlag)
 

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -258,8 +258,7 @@ void PasswordGeneratorWidget::updateHexadecimalState()
         if (m_ui->radioButtonUpper->isChecked()) {
             m_ui->checkBoxUpper->setChecked(true);
             m_ui->checkBoxLower->setChecked(false);
-        }
-        else {
+        } else {
             m_ui->checkBoxUpper->setChecked(false);
             m_ui->checkBoxLower->setChecked(true);
         }
@@ -268,8 +267,7 @@ void PasswordGeneratorWidget::updateHexadecimalState()
         m_ui->checkBoxExtASCII->setChecked(false);
         m_ui->checkBoxExcludeAlike->setChecked(false);
         m_ui->checkBoxEnsureEvery->setChecked(false);
-    }
-    else {
+    } else {
         m_ui->checkBoxExcludeAlike->setEnabled(true);
         m_ui->checkBoxEnsureEvery->setEnabled(true);
         m_ui->checkBoxUpper->setEnabled(true);

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -47,6 +47,9 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
 
     connect(m_ui->sliderLength, SIGNAL(valueChanged(int)), SLOT(passwordSliderMoved()));
     connect(m_ui->spinBoxLength, SIGNAL(valueChanged(int)), SLOT(passwordSpinBoxChanged()));
+    connect(m_ui->checkBoxHexadecimal, SIGNAL(stateChanged(int)), SLOT(updateHexadecimalState()));
+    connect(m_ui->radioButtonUpper, SIGNAL(toggled(bool)), SLOT(updateHexadecimalState()));
+    connect(m_ui->radioButtonLower, SIGNAL(toggled(bool)), SLOT(updateHexadecimalState()));
 
     connect(m_ui->sliderWordCount, SIGNAL(valueChanged(int)), SLOT(dicewareSliderMoved()));
     connect(m_ui->spinBoxWordCount, SIGNAL(valueChanged(int)), SLOT(dicewareSpinBoxChanged()));
@@ -98,6 +101,9 @@ void PasswordGeneratorWidget::loadSettings()
     m_ui->checkBoxExtASCII->setChecked(config()->get("generator/EASCII", false).toBool());
     m_ui->checkBoxExcludeAlike->setChecked(config()->get("generator/ExcludeAlike", true).toBool());
     m_ui->checkBoxEnsureEvery->setChecked(config()->get("generator/EnsureEvery", true).toBool());
+    m_ui->checkBoxHexadecimal->setChecked(config()->get("generator/Hexadecimal", false).toBool());
+    m_ui->radioButtonUpper->setChecked(config()->get("generator/UpperHex", true).toBool());
+    m_ui->radioButtonLower->setChecked(config()->get("generator/LowerHex", false).toBool());
     m_ui->spinBoxLength->setValue(config()->get("generator/Length", PasswordGenerator::DefaultLength).toInt());
 
     // Diceware config
@@ -119,6 +125,9 @@ void PasswordGeneratorWidget::saveSettings()
     config()->set("generator/EASCII", m_ui->checkBoxExtASCII->isChecked());
     config()->set("generator/ExcludeAlike", m_ui->checkBoxExcludeAlike->isChecked());
     config()->set("generator/EnsureEvery", m_ui->checkBoxEnsureEvery->isChecked());
+    config()->set("generator/Hexadecimal", m_ui->checkBoxHexadecimal->isChecked());
+    config()->set("generator/UpperHex", m_ui->radioButtonUpper->isChecked());
+    config()->set("generator/LowerHex", m_ui->radioButtonLower->isChecked());
     config()->set("generator/Length", m_ui->spinBoxLength->value());
 
     // Diceware config
@@ -135,6 +144,7 @@ void PasswordGeneratorWidget::reset()
     m_ui->editNewPassword->setText("");
     setStandaloneMode(false);
     togglePasswordShown(config()->get("security/passwordscleartext").toBool());
+    updateHexadecimalState();
     updateGenerator();
 }
 
@@ -232,6 +242,48 @@ void PasswordGeneratorWidget::passwordSpinBoxChanged()
     updateGenerator();
 }
 
+void PasswordGeneratorWidget::updateHexadecimalState()
+{
+    if (m_ui->checkBoxHexadecimal->isChecked()) {
+        m_ui->checkBoxExcludeAlike->setEnabled(false);
+        m_ui->checkBoxEnsureEvery->setEnabled(false);
+        m_ui->checkBoxUpper->setEnabled(false);
+        m_ui->checkBoxLower->setEnabled(false);
+        m_ui->checkBoxNumbers->setEnabled(false);
+        m_ui->checkBoxSpecialChars->setEnabled(false);
+        m_ui->checkBoxExtASCII->setEnabled(false);
+        m_ui->radioButtonUpper->setEnabled(true);
+        m_ui->radioButtonLower->setEnabled(true);
+
+        if (m_ui->radioButtonUpper->isChecked()) {
+            m_ui->checkBoxUpper->setChecked(true);
+            m_ui->checkBoxLower->setChecked(false);
+        }
+        else {
+            m_ui->checkBoxUpper->setChecked(false);
+            m_ui->checkBoxLower->setChecked(true);
+        }
+        m_ui->checkBoxNumbers->setChecked(true);
+        m_ui->checkBoxSpecialChars->setChecked(false);
+        m_ui->checkBoxExtASCII->setChecked(false);
+        m_ui->checkBoxExcludeAlike->setChecked(false);
+        m_ui->checkBoxEnsureEvery->setChecked(false);
+    }
+    else {
+        m_ui->checkBoxExcludeAlike->setEnabled(true);
+        m_ui->checkBoxEnsureEvery->setEnabled(true);
+        m_ui->checkBoxUpper->setEnabled(true);
+        m_ui->checkBoxLower->setEnabled(true);
+        m_ui->checkBoxNumbers->setEnabled(true);
+        m_ui->checkBoxSpecialChars->setEnabled(true);
+        m_ui->checkBoxExtASCII->setEnabled(true);
+        m_ui->radioButtonUpper->setEnabled(false);
+        m_ui->radioButtonLower->setEnabled(false);
+    }
+
+    updateGenerator();
+}
+
 void PasswordGeneratorWidget::dicewareSliderMoved()
 {
     m_ui->spinBoxWordCount->setValue(m_ui->sliderWordCount->value());
@@ -318,6 +370,10 @@ PasswordGenerator::GeneratorFlags PasswordGeneratorWidget::generatorFlags()
 
     if (m_ui->checkBoxEnsureEvery->isChecked()) {
         flags |= PasswordGenerator::CharFromEveryGroup;
+    }
+
+    if (m_ui->checkBoxHexadecimal->isChecked()) {
+        flags |= PasswordGenerator::Hexadecimal;
     }
 
     return flags;

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -65,6 +65,7 @@ private slots:
 
     void passwordSliderMoved();
     void passwordSpinBoxChanged();
+    void updateHexadecimalState();
     void dicewareSliderMoved();
     void dicewareSpinBoxChanged();
     void colorStrengthIndicator(double entropy);

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>PasswordGeneratorWidget</class>
  <widget class="QWidget" name="PasswordGeneratorWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>736</width>
+    <height>546</height>
+   </rect>
+  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
     <horstretch>0</horstretch>
@@ -17,10 +25,10 @@
    </property>
    <item>
     <layout class="QGridLayout" name="passwordFieldLayout">
-     <property name="bottomMargin">
+     <property name="verticalSpacing">
       <number>0</number>
      </property>
-     <property name="verticalSpacing">
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item row="1" column="1">
@@ -362,6 +370,43 @@ QProgressBar::chunk {
                  <string notr="true">optionButtons</string>
                 </attribute>
                </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_5">
+                <item>
+                 <widget class="QCheckBox" name="checkBoxHexadecimal">
+                  <property name="autoFillBackground">
+                   <bool>false</bool>
+                  </property>
+                  <property name="text">
+                   <string>Hexadecimal</string>
+                  </property>
+                  <property name="checked">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QRadioButton" name="radioButtonUpper">
+                  <property name="layoutDirection">
+                   <enum>Qt::RightToLeft</enum>
+                  </property>
+                  <property name="text">
+                   <string>Upper case</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QRadioButton" name="radioButtonLower">
+                  <property name="layoutDirection">
+                   <enum>Qt::LeftToRight</enum>
+                  </property>
+                  <property name="text">
+                   <string>Lower case</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
              </layout>
             </widget>

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -25,6 +25,9 @@
 #include <QLabel>
 #include <QMimeData>
 #include <QPushButton>
+#include <QCheckBox>
+#include <QRadioButton>
+#include <QWidget>
 #include <QSpinBox>
 #include <QPlainTextEdit>
 #include <QComboBox>
@@ -36,6 +39,7 @@
 #include <QSignalSpy>
 #include <QClipboard>
 #include <QDebug>
+#include <QRegularExpression>
 
 #include "config-keepassx-tests.h"
 #include "core/Config.h"
@@ -50,6 +54,7 @@
 #include "gui/DatabaseWidget.h"
 #include "gui/CloneDialog.h"
 #include "gui/PasswordEdit.h"
+#include "gui/PasswordGeneratorWidget.h"
 #include "gui/TotpDialog.h"
 #include "gui/SetupTotpDialog.h"
 #include "gui/FileDialog.h"
@@ -511,6 +516,115 @@ void TestGui::testDicewareEntryEntropy()
 
     QCOMPARE(entropyLabel->text(),  QString("Entropy: 77.55 bit"));
     QCOMPARE(strengthLabel->text(), QString("Password Quality: Good"));
+}
+
+void TestGui::testHexadecimalPasswords()
+{
+    QToolBar* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
+
+    // Find the new entry action
+    QAction* entryNewAction = m_mainWindow->findChild<QAction*>("actionEntryNew");
+    QVERIFY(entryNewAction->isEnabled());
+
+    // Find the button associated with the new entry action
+    QWidget* entryNewWidget = toolBar->widgetForAction(entryNewAction);
+    QVERIFY(entryNewWidget->isVisible());
+    QVERIFY(entryNewWidget->isEnabled());
+
+    // Click the new entry button, check that we enter edit mode
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+
+    // Find all character types buttons and checkboxes
+    EditEntryWidget* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
+    QToolButton* checkBoxUpper = editEntryWidget->findChild<QToolButton*>("checkBoxUpper");
+    QToolButton* checkBoxLower = editEntryWidget->findChild<QToolButton*>("checkBoxLower");
+    QToolButton* checkBoxNumbers = editEntryWidget->findChild<QToolButton*>("checkBoxNumbers");
+    QToolButton* checkBoxSpecialChars = editEntryWidget->findChild<QToolButton*>("checkBoxSpecialChars");
+    QToolButton* checkBoxExtASCII = editEntryWidget->findChild<QToolButton*>("checkBoxExtASCII");
+    QCheckBox* checkBoxExcludeAlike = editEntryWidget->findChild<QCheckBox*>("checkBoxExcludeAlike");
+    QCheckBox* checkBoxEnsureEvery = editEntryWidget->findChild<QCheckBox*>("checkBoxEnsureEvery");
+    QCheckBox* checkBoxHexadecimal = editEntryWidget->findChild<QCheckBox*>("checkBoxHexadecimal");
+    QRadioButton* radioButtonUpper = editEntryWidget->findChild<QRadioButton*>("radioButtonUpper");
+    QRadioButton* radioButtonLower = editEntryWidget->findChild<QRadioButton*>("radioButtonLower");
+
+    // Test uppercase hexadecimal mode
+    if (!checkBoxHexadecimal->isChecked()) { // Default value may change in the future
+        QTest::mouseClick(checkBoxHexadecimal, Qt::LeftButton);
+    }
+    QTest::mouseClick(radioButtonUpper, Qt::LeftButton);
+    QVERIFY(checkBoxHexadecimal->isChecked());
+
+    QVERIFY(checkBoxUpper->isChecked());
+    QVERIFY(!checkBoxLower->isChecked());
+    QVERIFY(checkBoxNumbers->isChecked());
+    QVERIFY(!checkBoxSpecialChars->isChecked());
+    QVERIFY(!checkBoxExtASCII->isChecked());
+    QVERIFY(!checkBoxExcludeAlike->isChecked());
+    QVERIFY(!checkBoxEnsureEvery->isChecked());
+    QVERIFY(radioButtonUpper->isChecked());
+    QVERIFY(!radioButtonLower->isChecked());
+
+    QVERIFY(!checkBoxUpper->isEnabled());
+    QVERIFY(!checkBoxLower->isEnabled());
+    QVERIFY(!checkBoxNumbers->isEnabled());
+    QVERIFY(!checkBoxSpecialChars->isEnabled());
+    QVERIFY(!checkBoxExtASCII->isEnabled());
+    QVERIFY(!checkBoxExcludeAlike->isEnabled());
+    QVERIFY(!checkBoxEnsureEvery->isEnabled());
+    QVERIFY(checkBoxHexadecimal->isEnabled());
+    QVERIFY(radioButtonUpper->isEnabled());
+    QVERIFY(radioButtonLower->isEnabled());
+
+    QString password = editEntryWidget->findChild<PasswordEdit*>("editNewPassword")->text();
+    QString length = QString::number(editEntryWidget->findChild<QSpinBox*>("spinBoxLength")->value());
+    QRegularExpression reUpper("^[\\dA-F]{" + length + "}$");
+    QVERIFY(reUpper.match(password).hasMatch());
+
+    // Test lowercase hexadecimal mode
+    QTest::mouseClick(radioButtonLower, Qt::LeftButton);
+    QVERIFY(checkBoxHexadecimal->isChecked());
+
+    QVERIFY(!checkBoxUpper->isChecked());
+    QVERIFY(checkBoxLower->isChecked());
+    QVERIFY(checkBoxNumbers->isChecked());
+    QVERIFY(!checkBoxSpecialChars->isChecked());
+    QVERIFY(!checkBoxExtASCII->isChecked());
+    QVERIFY(!checkBoxExcludeAlike->isChecked());
+    QVERIFY(!checkBoxEnsureEvery->isChecked());
+    QVERIFY(!radioButtonUpper->isChecked());
+    QVERIFY(radioButtonLower->isChecked());
+
+    QVERIFY(!checkBoxUpper->isEnabled());
+    QVERIFY(!checkBoxLower->isEnabled());
+    QVERIFY(!checkBoxNumbers->isEnabled());
+    QVERIFY(!checkBoxSpecialChars->isEnabled());
+    QVERIFY(!checkBoxExtASCII->isEnabled());
+    QVERIFY(!checkBoxExcludeAlike->isEnabled());
+    QVERIFY(!checkBoxEnsureEvery->isEnabled());
+    QVERIFY(checkBoxHexadecimal->isEnabled());
+    QVERIFY(radioButtonUpper->isEnabled());
+    QVERIFY(radioButtonLower->isEnabled());
+
+    password = editEntryWidget->findChild<PasswordEdit*>("editNewPassword")->text();
+    length = QString::number(editEntryWidget->findChild<QSpinBox*>("spinBoxLength")->value());
+    QRegularExpression reLower("^[\\da-f]{" + length + "}$");
+    QVERIFY(reLower.match(password).hasMatch());
+
+    // Test with hexadecimal mode disabled
+    QTest::mouseClick(checkBoxHexadecimal, Qt::LeftButton);
+    QVERIFY(!checkBoxHexadecimal->isChecked());
+
+    QVERIFY(checkBoxUpper->isEnabled());
+    QVERIFY(checkBoxLower->isEnabled());
+    QVERIFY(checkBoxNumbers->isEnabled());
+    QVERIFY(checkBoxSpecialChars->isEnabled());
+    QVERIFY(checkBoxExtASCII->isEnabled());
+    QVERIFY(checkBoxExcludeAlike->isEnabled());
+    QVERIFY(checkBoxEnsureEvery->isEnabled());
+    QVERIFY(checkBoxHexadecimal->isEnabled());
+    QVERIFY(!radioButtonUpper->isEnabled());
+    QVERIFY(!radioButtonLower->isEnabled());
 }
 
 void TestGui::testTotp()

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -48,6 +48,7 @@ private slots:
     void testAddEntry();
     void testPasswordEntryEntropy();
     void testDicewareEntryEntropy();
+    void testHexadecimalPasswords();
     void testTotp();
     void testSearch();
     void testDeleteEntry();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
This PR adds a button in the password generator to select only hexadecimal characters, upper- or lower-cased depending on the need of the user. 

## Motivation and context
This solves #789, which states that "There are some [ed.: absurd?] use cases where one is required to generate a password which only consists of HEX characters".
I tried to keep it as light as possible. Because in the generator each button represents a class of disjoints characters, I've chosen to add another checkbox instead of another button.

## How has this been tested?
There are GUI tests, checking that buttons and checkbox are properly greyed and checked when generating a hexadecimal password, and that the generated password contains only hexadecimal characters.
I've also tested it manually on Linux Mint 18.2.

## Screenshots (if appropriate):

![](https://user-images.githubusercontent.com/25458217/32845881-3028fa00-ca26-11e7-806d-317dbb34d22d.png)

![](https://user-images.githubusercontent.com/25458217/32845960-614220b2-ca26-11e7-986b-5cf6311aa30a.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.