### PR TITLE
Rename EntropyMeter -> Estimate

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -22,8 +22,8 @@ set(cli_SOURCES
     Command.h
     Edit.cpp
     Edit.h
-    EntropyMeter.cpp
-    EntropyMeter.h
+    Estimate.cpp
+    Estimate.h
     Extract.cpp
     Extract.h
     List.cpp

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -55,9 +55,7 @@ int Clip::execute(QStringList arguments)
     parser.addOption(keyFile);
     parser.addPositionalArgument("entry", QObject::tr("Path of the entry to clip."));
     parser.addPositionalArgument(
-        "timeout",
-        QObject::tr("Timeout in seconds before clearing the clipboard."),
-        QString("[timeout]"));
+        "timeout", QObject::tr("Timeout in seconds before clearing the clipboard."), QString("[timeout]"));
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -25,7 +25,7 @@
 #include "Add.h"
 #include "Edit.h"
 #include "Clip.h"
-#include "EntropyMeter.h"
+#include "Estimate.h"
 #include "Extract.h"
 #include "List.h"
 #include "Locate.h"
@@ -62,7 +62,7 @@ void populateCommands()
         commands.insert(QString("add"), new Add());
         commands.insert(QString("clip"), new Clip());
         commands.insert(QString("edit"), new Edit());
-        commands.insert(QString("entropy-meter"), new EntropyMeter());
+        commands.insert(QString("estimate"), new Estimate());
         commands.insert(QString("extract"), new Extract());
         commands.insert(QString("locate"), new Locate());
         commands.insert(QString("ls"), new List());

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -23,8 +23,8 @@
 #include "Command.h"
 
 #include "Add.h"
-#include "Edit.h"
 #include "Clip.h"
+#include "Edit.h"
 #include "Estimate.h"
 #include "Extract.h"
 #include "List.h"

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "EntropyMeter.h"
+#include "Estimate.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,13 +29,13 @@
 #endif
 #endif
 
-EntropyMeter::EntropyMeter()
+Estimate::Estimate()
 {
-    this->name = QString("entropy-meter");
-    this->description = QObject::tr("Calculate password entropy.");
+    this->name = QString("estimate");
+    this->description = QObject::tr("Estimate the entropy of a password.");
 }
 
-EntropyMeter::~EntropyMeter()
+Estimate::~Estimate()
 {
 }
 
@@ -97,7 +97,7 @@ static void calculate(const char *pwd, int advanced)
     }
 }
 
-int EntropyMeter::execute(QStringList arguments)
+int Estimate::execute(QStringList arguments)
 {
     printf("KeePassXC Entropy Meter, based on zxcvbn-c.\nEnter your password below or pass it as argv\n");
     printf("  Usage: entropy-meter [-a] [pwd1 pwd2 ...]\n> ");

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -152,7 +152,7 @@ int Estimate::execute(QStringList arguments)
     parser.addPositionalArgument("password", QObject::tr("Password for which to estimate the entropy."), "[password]");
     QCommandLineOption advancedOption(QStringList() << "a"
                                                     << "advanced",
-                                      QObject::tr("Perform advanced analysis for the password."));
+                                      QObject::tr("Perform advanced analysis on the password."));
     parser.addOption(advancedOption);
     parser.process(arguments);
 

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -42,61 +42,103 @@ Estimate::~Estimate()
 {
 }
 
-static void calculate(const char *pwd, bool advanced)
+static void calculate(const char* pwd, bool advanced)
 {
     double e;
     int len = strlen(pwd);
-    if (!advanced){
-      e = ZxcvbnMatch(pwd, 0, 0);
-      printf("Pass '%s' \tLength %d\tEntropy %.3f\tLog10 %.3f\n", pwd, len, e, e * 0.301029996);
+    if (!advanced) {
+        e = ZxcvbnMatch(pwd, 0, 0);
+        printf("Pass '%s' \tLength %d\tEntropy %.3f\tLog10 %.3f\n", pwd, len, e, e * 0.301029996);
     } else {
-      int ChkLen;
-      ZxcMatch_t *info, *p;
-      double m = 0.0;
-      e = ZxcvbnMatch(pwd, 0, &info);
-      for(p = info; p; p = p->Next) {
-          m += p->Entrpy;
-      }
-      m = e - m;
-      printf("Pass '%s' \tLength %d\tEntropy %.3f\tLog10 %.3f\n  Multi-word extra bits %.1f\n", pwd, len, e, e * 0.301029996, m);
-      p = info;
-      ChkLen = 0;
-      while(p) {
-        int n;
-        switch(static_cast<int>(p->Type))
-        {
-            case BRUTE_MATCH:                     printf("  Type: Bruteforce     ");   break;
-            case DICTIONARY_MATCH:                printf("  Type: Dictionary     ");   break;
-            case DICT_LEET_MATCH:                 printf("  Type: Dict+Leet      ");   break;
-            case USER_MATCH:                      printf("  Type: User Words     ");   break;
-            case USER_LEET_MATCH:                 printf("  Type: User+Leet      ");   break;
-            case REPEATS_MATCH:                   printf("  Type: Repeated       ");   break;
-            case SEQUENCE_MATCH:                  printf("  Type: Sequence       ");   break;
-            case SPATIAL_MATCH:                   printf("  Type: Spatial        ");   break;
-            case DATE_MATCH:                      printf("  Type: Date           ");   break;
-            case BRUTE_MATCH+MULTIPLE_MATCH:      printf("  Type: Bruteforce(Rep)");   break;
-            case DICTIONARY_MATCH+MULTIPLE_MATCH: printf("  Type: Dictionary(Rep)");   break;
-            case DICT_LEET_MATCH+MULTIPLE_MATCH:  printf("  Type: Dict+Leet(Rep) ");   break;
-            case USER_MATCH+MULTIPLE_MATCH:       printf("  Type: User Words(Rep)");   break;
-            case USER_LEET_MATCH+MULTIPLE_MATCH:  printf("  Type: User+Leet(Rep) ");   break;
-            case REPEATS_MATCH+MULTIPLE_MATCH:    printf("  Type: Repeated(Rep)  ");   break;
-            case SEQUENCE_MATCH+MULTIPLE_MATCH:   printf("  Type: Sequence(Rep)  ");   break;
-            case SPATIAL_MATCH+MULTIPLE_MATCH:    printf("  Type: Spatial(Rep)   ");   break;
-            case DATE_MATCH+MULTIPLE_MATCH:       printf("  Type: Date(Rep)      ");   break;
+        int ChkLen;
+        ZxcMatch_t *info, *p;
+        double m = 0.0;
+        e = ZxcvbnMatch(pwd, 0, &info);
+        for (p = info; p; p = p->Next) {
+            m += p->Entrpy;
+        }
+        m = e - m;
+        printf("Pass '%s' \tLength %d\tEntropy %.3f\tLog10 %.3f\n  Multi-word extra bits %.1f\n",
+               pwd,
+               len,
+               e,
+               e * 0.301029996,
+               m);
+        p = info;
+        ChkLen = 0;
+        while (p) {
+            int n;
+            switch (static_cast<int>(p->Type)) {
+            case BRUTE_MATCH:
+                printf("  Type: Bruteforce     ");
+                break;
+            case DICTIONARY_MATCH:
+                printf("  Type: Dictionary     ");
+                break;
+            case DICT_LEET_MATCH:
+                printf("  Type: Dict+Leet      ");
+                break;
+            case USER_MATCH:
+                printf("  Type: User Words     ");
+                break;
+            case USER_LEET_MATCH:
+                printf("  Type: User+Leet      ");
+                break;
+            case REPEATS_MATCH:
+                printf("  Type: Repeated       ");
+                break;
+            case SEQUENCE_MATCH:
+                printf("  Type: Sequence       ");
+                break;
+            case SPATIAL_MATCH:
+                printf("  Type: Spatial        ");
+                break;
+            case DATE_MATCH:
+                printf("  Type: Date           ");
+                break;
+            case BRUTE_MATCH + MULTIPLE_MATCH:
+                printf("  Type: Bruteforce(Rep)");
+                break;
+            case DICTIONARY_MATCH + MULTIPLE_MATCH:
+                printf("  Type: Dictionary(Rep)");
+                break;
+            case DICT_LEET_MATCH + MULTIPLE_MATCH:
+                printf("  Type: Dict+Leet(Rep) ");
+                break;
+            case USER_MATCH + MULTIPLE_MATCH:
+                printf("  Type: User Words(Rep)");
+                break;
+            case USER_LEET_MATCH + MULTIPLE_MATCH:
+                printf("  Type: User+Leet(Rep) ");
+                break;
+            case REPEATS_MATCH + MULTIPLE_MATCH:
+                printf("  Type: Repeated(Rep)  ");
+                break;
+            case SEQUENCE_MATCH + MULTIPLE_MATCH:
+                printf("  Type: Sequence(Rep)  ");
+                break;
+            case SPATIAL_MATCH + MULTIPLE_MATCH:
+                printf("  Type: Spatial(Rep)   ");
+                break;
+            case DATE_MATCH + MULTIPLE_MATCH:
+                printf("  Type: Date(Rep)      ");
+                break;
 
-            default:                printf("  Type: Unknown%d ", p->Type);   break;
+            default:
+                printf("  Type: Unknown%d ", p->Type);
+                break;
+            }
+            ChkLen += p->Length;
+            printf("  Length %d  Entropy %6.3f (%.2f) ", p->Length, p->Entrpy, p->Entrpy * 0.301029996);
+            for (n = 0; n < p->Length; ++n, ++pwd) {
+                printf("%c", *pwd);
+            }
+            printf("\n");
+            p = p->Next;
         }
-        ChkLen += p->Length;
-        printf("  Length %d  Entropy %6.3f (%.2f) ", p->Length, p->Entrpy, p->Entrpy * 0.301029996);
-        for(n = 0; n < p->Length; ++n, ++pwd) {
-          printf("%c", *pwd);
-        }
-        printf("\n");
-        p = p->Next;
-      }
-      ZxcvbnFreeInfo(info);
-      if (ChkLen != len)
-          printf("*** Password length (%d) != sum of length of parts (%d) ***\n", len, ChkLen);
+        ZxcvbnFreeInfo(info);
+        if (ChkLen != len)
+            printf("*** Password length (%d) != sum of length of parts (%d) ***\n", len, ChkLen);
     }
 }
 
@@ -122,9 +164,9 @@ int Estimate::execute(QStringList arguments)
 
     QString password;
     if (args.size() == 1) {
-      password = args.at(0);
+        password = args.at(0);
     } else {
-      password = inputTextStream.readLine();
+        password = inputTextStream.readLine();
     }
 
     calculate(password.toLatin1(), parser.isSet(advancedOption));

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -137,8 +137,9 @@ static void calculate(const char* pwd, bool advanced)
             p = p->Next;
         }
         ZxcvbnFreeInfo(info);
-        if (ChkLen != len)
+        if (ChkLen != len) {
             printf("*** Password length (%d) != sum of length of parts (%d) ***\n", len, ChkLen);
+        }
     }
 }
 
@@ -157,7 +158,7 @@ int Estimate::execute(QStringList arguments)
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
-    if (args.size() != 1 && args.size() != 0) {
+    if (args.size() > 1) {
         outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli estimate");
         return EXIT_FAILURE;
     }

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -110,7 +110,7 @@ int Estimate::execute(QStringList arguments)
     parser.addPositionalArgument("password", QObject::tr("Password for which to estimate the entropy."), "[password]");
     QCommandLineOption advancedOption(QStringList() << "a"
                                                     << "advanced",
-                                      QObject::tr("Perform advanced estimation."));
+                                      QObject::tr("Perform advanced analysis for the password."));
     parser.addOption(advancedOption);
     parser.process(arguments);
 

--- a/src/cli/Estimate.h
+++ b/src/cli/Estimate.h
@@ -15,17 +15,17 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSXC_ENTROPYMETER_H
-#define KEEPASSXC_ENTROPYMETER_H
+#ifndef KEEPASSXC_ESTIMATE_H
+#define KEEPASSXC_ESTIMATE_H
 
 #include "Command.h"
 
-class EntropyMeter : public Command
+class Estimate : public Command
 {
 public:
-    EntropyMeter();
-    ~EntropyMeter();
+    Estimate();
+    ~Estimate();
     int execute(QStringList arguments);
 };
 
-#endif // KEEPASSXC_ENTROPYMETER_H
+#endif // KEEPASSXC_ESTIMATE_H

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -85,7 +85,6 @@ int Extract::execute(QStringList arguments)
         compositeKey.addKey(fileKey);
     }
 
-
     QString databaseFilename = args.at(0);
     QFile dbFile(databaseFilename);
     if (!dbFile.exists()) {

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -44,8 +44,7 @@ int List::execute(QStringList arguments)
     QCommandLineParser parser;
     parser.setApplicationDescription(this->description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
-    parser.addPositionalArgument(
-        "group", QObject::tr("Path of the group to list. Default is /"), QString("[group]"));
+    parser.addPositionalArgument("group", QObject::tr("Path of the group to list. Default is /"), QString("[group]"));
     QCommandLineOption keyFile(QStringList() << "k"
                                              << "key-file",
                                QObject::tr("Key file of the database."),

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -83,5 +83,4 @@ int Locate::locateEntry(Database* database, QString searchTerm)
         outputTextStream << result << endl;
     }
     return EXIT_SUCCESS;
-
 }

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -43,10 +43,9 @@ int Merge::execute(QStringList arguments)
     parser.addPositionalArgument("database1", QObject::tr("Path of the database to merge into."));
     parser.addPositionalArgument("database2", QObject::tr("Path of the database to merge from."));
 
-    QCommandLineOption samePasswordOption(
-        QStringList() << "s"
-                      << "same-credentials",
-        QObject::tr("Use the same credentials for both database files."));
+    QCommandLineOption samePasswordOption(QStringList() << "s"
+                                                        << "same-credentials",
+                                          QObject::tr("Use the same credentials for both database files."));
 
     QCommandLineOption keyFile(QStringList() << "k"
                                              << "key-file",
@@ -55,8 +54,8 @@ int Merge::execute(QStringList arguments)
     parser.addOption(keyFile);
     QCommandLineOption keyFileFrom(QStringList() << "f"
                                                  << "key-file-from",
-                               QObject::tr("Key file of the database to merge from."),
-                               QObject::tr("path"));
+                                   QObject::tr("Key file of the database to merge from."),
+                                   QObject::tr("path"));
     parser.addOption(keyFileFrom);
 
     parser.addOption(samePasswordOption);
@@ -67,7 +66,6 @@ int Merge::execute(QStringList arguments)
         out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli merge");
         return EXIT_FAILURE;
     }
-
 
     Database* db1 = Database::unlockFromStdin(args.at(0), parser.value(keyFile));
     if (db1 == nullptr) {

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -27,7 +27,6 @@
 #include <QProcess>
 #include <QTextStream>
 
-
 void Utils::setStdinEcho(bool enable = true)
 {
 #ifdef Q_OS_WIN

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -93,7 +93,7 @@ Specify the title of the entry.
 .SS "Estimate options"
 
 .IP "-a, --advanced"
-Perform advanced analysis for the password.
+Perform advanced analysis on the password.
 
 
 .SH REPORTING BUGS

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -22,8 +22,8 @@ Copies the password of a database entry to the clipboard. If multiple entries wi
 .IP "edit [options] <database> <entry>"
 Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
-.IP "entropy-meter [-a pwd1 pwd2 ...]"
-Calculates the entropy of a single, or multiple passwords specified using the \fI-a\fP option. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
+.IP "estimate [-a pwd1 pwd2 ...]"
+Estimates the entropy of a password. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
 
 .IP "extract [options] <database>"
 Extracts and prints the contents of a database to standard output in XML format.

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -22,8 +22,8 @@ Copies the password of a database entry to the clipboard. If multiple entries wi
 .IP "edit [options] <database> <entry>"
 Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
-.IP "estimate [-a pwd1 pwd2 ...]"
-Estimates the entropy of a password. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
+.IP "estimate [options] [password]"
+Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
 
 .IP "extract [options] <database>"
 Extracts and prints the contents of a database to standard output in XML format.
@@ -88,6 +88,12 @@ Specify the length of the password to generate.
 
 .IP "-t, --title <title>"
 Specify the title of the entry.
+
+
+.SS "Estimate options"
+
+.IP "-a, --advanced"
+Perform advanced analysis for the password.
 
 
 .SH REPORTING BUGS


### PR DESCRIPTION
The `entropy-meter` CLI command was lagging behind the other commands in terms of style, interface and documentation.

## Description
* renamed `entropy-meter` to `estimate`, since all the other commands are verbs
* Used QCommandLineParser for the arguments
* Only allow 1 password (via stdin or CLI arg)
* `clang-format` the whole `cli` directory
* Updated the man page.


## How has this been tested?
Locally

## Screenshots (if appropriate):
```
$ keepassxc-cli estimate
password
Pass 'password' 	Length 8	Entropy 1.000	Log10 0.301
$ keepassxc-cli estimate password
Pass 'password' 	Length 8	Entropy 1.000	Log10 0.301
$ keepassxc-cli estimate password -a
Pass 'password' 	Length 8	Entropy 1.000	Log10 0.301
  Multi-word extra bits 0.0
  Type: Dictionary       Length 8  Entropy  1.000 (0.30) password
$ keepassxc-cli estimate -a
password
Pass 'password' 	Length 8	Entropy 1.000	Log10 0.301
  Multi-word extra bits 0.0
  Type: Dictionary       Length 8  Entropy  1.000 (0.30) password
$ keepassxc-cli estimate invalid number of args
Usage: ./src/cli/keepassxc-cli estimate [options] [password]
Estimate the entropy of a password.

Options:
  -a, --advanced  Perform advanced analysis on the password.

Arguments:
  password        Password for which to estimate the entropy.
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
