### PR TITLE
Quit the password generator with ESC key

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -21,6 +21,7 @@
 
 #include <QLineEdit>
 #include <QDir>
+#include <QKeyEvent>
 
 #include "core/Config.h"
 #include "core/PasswordGenerator.h"
@@ -146,6 +147,20 @@ void PasswordGeneratorWidget::setStandaloneMode(bool standalone)
         togglePasswordShown(true);
     } else {
         m_ui->buttonApply->setText(tr("Apply"));
+    }
+}
+
+void PasswordGeneratorWidget::keyPressEvent(QKeyEvent* e)
+{
+    if (!e->modifiers() || (e->modifiers() & Qt::KeypadModifier && e->key() == Qt::Key_Enter)) {
+        if (e->key() == Qt::Key_Escape && m_standalone == true) {
+            emit dialogTerminated();
+        } else {
+            e->ignore();
+        }
+    }
+    else {
+        e->ignore();
     }
 }
 

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -158,8 +158,7 @@ void PasswordGeneratorWidget::keyPressEvent(QKeyEvent* e)
         } else {
             e->ignore();
         }
-    }
-    else {
+    } else {
         e->ignore();
     }
 }

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -81,6 +81,9 @@ private:
     const QScopedPointer<PasswordGenerator> m_passwordGenerator;
     const QScopedPointer<PassphraseGenerator> m_dicewareGenerator;
     const QScopedPointer<Ui::PasswordGeneratorWidget> m_ui;
+
+protected:
+    void keyPressEvent(QKeyEvent* e) override;
 };
 
 #endif // KEEPASSX_PASSWORDGENERATORWIDGET_H


### PR DESCRIPTION
original PR by @pkill-9  #1044 

## Description
In the password generator (standalone, ie not when you're editing an entry) the ESC key is ignored, however in most other dialogs ESC is a shortcut to quit the dialog.

## Motivation and context
Fix #953 

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
