### PR TITLE
Pass command line filenames to already running instance

### DIFF
--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -39,14 +39,20 @@ public:
     bool event(QEvent* event) override;
     bool isAlreadyRunning() const;
 
+    bool sendFileNamesToRunningInstance(const QStringList& fileNames);
+
 signals:
     void openFile(const QString& filename);
     void anotherInstanceStarted();
+    void applicationActivated();
+    void quitSignalReceived();
 
 private slots:
 #if defined(Q_OS_UNIX)
     void quitBySignal();
 #endif
+    void processIncomingConnection();
+    void socketReadyRead();
 
 private:
     QWidget* m_mainWindow;
@@ -63,6 +69,7 @@ private:
     bool m_alreadyRunning;
     QLockFile* m_lockFile;
     QLocalServer m_lockServer;
+    QString m_socketName;
 };
 
 #endif // KEEPASSX_APPLICATION_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1035,6 +1035,9 @@ void MainWindow::dropEvent(QDropEvent* event)
     const QMimeData* mimeData = event->mimeData();
     if (mimeData->hasUrls()) {
         const QStringList kdbxFiles = kdbxFilesFromUrls(mimeData->urls());
+        if (!kdbxFiles.isEmpty()) {
+            event->acceptProposedAction();
+        }
         for (const QString& kdbxFile: kdbxFiles) {
             openDatabase(kdbxFile);
         }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -881,11 +881,7 @@ void MainWindow::toggleWindow()
     if ((QApplication::activeWindow() == this) && isVisible() && !isMinimized()) {
         hideWindow();
     } else {
-        ensurePolished();
-        setWindowState(windowState() & ~Qt::WindowMinimized);
-        show();
-        raise();
-        activateWindow();
+        bringToFront();
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(QT_NO_DBUS) && (QT_VERSION < QT_VERSION_CHECK(5, 9, 0))
         // re-register global D-Bus menu (needed on Ubuntu with Unity)
@@ -993,6 +989,15 @@ void MainWindow::hideYubiKeyPopup()
     setEnabled(true);
 }
 
+void MainWindow::bringToFront()
+{
+    ensurePolished();
+    setWindowState(windowState() & ~Qt::WindowMinimized);
+    show();
+    raise();
+    activateWindow();
+}
+
 void MainWindow::handleScreenLock()
 {
     if (config()->get("security/lockdatabasescreenlock").toBool()){
@@ -1030,7 +1035,7 @@ void MainWindow::dropEvent(QDropEvent* event)
     const QMimeData* mimeData = event->mimeData();
     if (mimeData->hasUrls()) {
         const QStringList kdbxFiles = kdbxFilesFromUrls(mimeData->urls());
-        for(const QString &kdbxFile: kdbxFiles) {
+        for (const QString& kdbxFile: kdbxFiles) {
             openDatabase(kdbxFile);
         }
     }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -61,6 +61,7 @@ public slots:
     void hideGlobalMessage();
     void showYubiKeyPopup();
     void hideYubiKeyPopup();
+    void bringToFront();
 
 protected:
      void closeEvent(QCloseEvent* event) override;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -107,6 +107,10 @@ private:
     void updateTrayIcon();
     bool isTrayIconEnabled() const;
 
+    static QStringList kdbxFilesFromUrls(const QList<QUrl>& urls);
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
+
     const QScopedPointer<Ui::MainWindow> m_ui;
     SignalMultiplexer m_actionMultiplexer;
     QAction* m_clearHistoryAction;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,22 +57,6 @@ int main(int argc, char** argv)
     // don't set organizationName as that changes the return value of
     // QStandardPaths::writableLocation(QDesktopServices::DataLocation)
 
-    if (app.isAlreadyRunning()) {
-        qWarning() << QCoreApplication::translate("Main", "Another instance of KeePassXC is already running.").toUtf8().constData();
-        return 0;
-    }
-    
-    QApplication::setQuitOnLastWindowClosed(false);
-
-    if (!Crypto::init()) {
-        QString error = QCoreApplication::translate("Main",
-                                                    "Fatal error while testing the cryptographic functions.");
-        error.append("\n");
-        error.append(Crypto::errorString());
-        MessageBox::critical(nullptr, QCoreApplication::translate("Main", "KeePassXC - Error"), error);
-        return 1;
-    }
-
     QCommandLineParser parser;
     parser.setApplicationDescription(QCoreApplication::translate("main", "KeePassXC - cross-platform password manager"));
     parser.addPositionalArgument("filename", QCoreApplication::translate("main", "filenames of the password databases to open (*.kdbx)"), "[filename(s)]");
@@ -93,7 +77,26 @@ int main(int argc, char** argv)
     parser.addOption(pwstdinOption);
 
     parser.process(app);
-    const QStringList args = parser.positionalArguments();
+    const QStringList fileNames = parser.positionalArguments();
+
+    if (app.isAlreadyRunning()) {
+        if (!fileNames.isEmpty()) {
+            app.sendFileNamesToRunningInstance(fileNames);
+        }
+        qWarning() << QCoreApplication::translate("Main", "Another instance of KeePassXC is already running.").toUtf8().constData();
+        return 0;
+    }
+    
+    QApplication::setQuitOnLastWindowClosed(false);
+
+    if (!Crypto::init()) {
+        QString error = QCoreApplication::translate("Main",
+                                                    "Fatal error while testing the cryptographic functions.");
+        error.append("\n");
+        error.append(Crypto::errorString());
+        MessageBox::critical(nullptr, QCoreApplication::translate("Main", "KeePassXC - Error"), error);
+        return 1;
+    }
 
     if (parser.isSet(configOption)) {
         Config::createConfigFromFile(parser.value(configOption));
@@ -109,15 +112,10 @@ int main(int argc, char** argv)
     MainWindow mainWindow;
     app.setMainWindow(&mainWindow);
 
-    QObject::connect(&app, &Application::anotherInstanceStarted,
-                    [&]() {
-                        mainWindow.ensurePolished();
-                        mainWindow.setWindowState(mainWindow.windowState() & ~Qt::WindowMinimized);
-                        mainWindow.show();
-                        mainWindow.raise();
-                        mainWindow.activateWindow();
-                    });
+    QObject::connect(&app, SIGNAL(anotherInstanceStarted()), &mainWindow, SLOT(bringToFront()));
+    QObject::connect(&app, SIGNAL(applicationActivated()), &mainWindow, SLOT(bringToFront()));
     QObject::connect(&app, SIGNAL(openFile(QString)), &mainWindow, SLOT(openDatabase(QString)));
+    QObject::connect(&app, SIGNAL(quitSignalReceived()), &mainWindow, SLOT(appExit()), Qt::DirectConnection);
     
     // start minimized if configured
     bool minimizeOnStartup = config()->get("GUI/MinimizeOnStartup").toBool();
@@ -130,20 +128,19 @@ int main(int argc, char** argv)
     }
     
     if (config()->get("OpenPreviousDatabasesOnStartup").toBool()) {
-        const QStringList filenames = config()->get("LastOpenedDatabases").toStringList();
-        for (int ii = filenames.size()-1; ii >= 0; ii--) {
-            QString filename = filenames.at(ii);
+        const QStringList fileNames = config()->get("LastOpenedDatabases").toStringList();
+        for (const QString& filename: fileNames) {
             if (!filename.isEmpty() && QFile::exists(filename)) {
-                mainWindow.openDatabase(filename, QString(), QString());
+                mainWindow.openDatabase(filename);
             }
         }
     }
 
-    for (int ii=0; ii < args.length(); ii++) {
-        QString filename = args[ii];
+    const bool pwstdin = parser.isSet(pwstdinOption);
+    for (const QString& filename: fileNames) {
         if (!filename.isEmpty() && QFile::exists(filename)) {
             QString password;
-            if (parser.isSet(pwstdinOption)) {
+            if (pwstdin) {
                 static QTextStream in(stdin, QIODevice::ReadOnly);
                 password = in.readLine();
             }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -952,6 +952,43 @@ void TestGui::testDatabaseLocking()
     QCOMPARE(m_tabWidget->tabText(0).remove('&'), origDbName);
 }
 
+void TestGui::testDragAndDropKdbxFiles()
+{
+    const int openedDatabasesCount =  m_tabWidget->count();
+
+    const QString badDatabaseFilePath(QString(KEEPASSX_TEST_DATA_DIR).append("/NotDatabase.notkdbx"));
+    QMimeData badMimeData;
+    badMimeData.setUrls({QUrl::fromLocalFile(badDatabaseFilePath)});
+    QDragEnterEvent badDragEvent(QPoint(1, 1), Qt::LinkAction, &badMimeData, Qt::LeftButton, Qt::NoModifier);
+    qApp->notify(m_mainWindow, &badDragEvent);
+    QCOMPARE(badDragEvent.isAccepted(), false);
+
+    QDropEvent badDropEvent(QPoint(1, 1), Qt::LinkAction, &badMimeData, Qt::LeftButton, Qt::NoModifier);
+    qApp->notify(m_mainWindow, &badDropEvent);
+    QCOMPARE(badDropEvent.isAccepted(), false);
+
+    QCOMPARE(m_tabWidget->count(), openedDatabasesCount);
+
+    const QString goodDatabaseFilePath(QString(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.kdbx"));
+    QMimeData goodMimeData;
+    goodMimeData.setUrls({QUrl::fromLocalFile(goodDatabaseFilePath)});
+    QDragEnterEvent goodDragEvent(QPoint(1, 1), Qt::LinkAction, &goodMimeData, Qt::LeftButton, Qt::NoModifier);
+    qApp->notify(m_mainWindow, &goodDragEvent);
+    QCOMPARE(goodDragEvent.isAccepted(), true);
+
+    QDropEvent goodDropEvent(QPoint(1, 1), Qt::LinkAction, &goodMimeData, Qt::LeftButton, Qt::NoModifier);
+    qApp->notify(m_mainWindow, &goodDropEvent);
+    QCOMPARE(goodDropEvent.isAccepted(), true);
+
+    QCOMPARE(m_tabWidget->count(), openedDatabasesCount + 1);
+
+    MessageBox::setNextAnswer(QMessageBox::No);
+    triggerAction("actionDatabaseClose");
+    Tools::wait(100);
+
+    QCOMPARE(m_tabWidget->count(), openedDatabasesCount);
+}
+
 void TestGui::cleanupTestCase()
 {
     delete m_mainWindow;

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -60,6 +60,7 @@ private slots:
     void testDatabaseSettings();
     void testKeePass1Import();
     void testDatabaseLocking();
+    void testDragAndDropKdbxFiles();
 
 private:
     int addCannedEntries();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->

- Implement drag&drop support in main form to open database files 
- Pass command line filenames to already running instance

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To simplify the opening of files when one copy of the program is running (if was enabled the option "Start only a single instance of KeePassXC")

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually on Linux OS

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ❌ My change requires a change to the documentation and I have updated it accordingly.
- ❌ I have added tests to cover my changes.
