### PR TITLE
Enable translations for 'Extended ASCII' button

### DIFF
--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -318,7 +318,7 @@ QProgressBar::chunk {
                    <string>Extended ASCII</string>
                   </property>
                   <property name="text">
-                   <string notr="true">Extended ASCII</string>
+                   <string>Extended ASCII</string>
                   </property>
                   <property name="checkable">
                    <bool>true</bool>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Enable translations for 'Extended ASCII' button.

## Motivation and context
The label of that specific button is plaintext. It should be translated. Until now, only the tooltip (same text) was translated.

## How has this been tested?
Tested in an environment configured with locale fr_FR. French text is displayed. Translations are already available in the .ts files.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
