### PR TITLE
keepassxc-cli show: resolve references in output

### DIFF
--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -102,7 +102,7 @@ int Show::showEntry(Database* database, QStringList attributes, QString entryPat
         if (showAttributeNames) {
             outputTextStream << attribute << ": ";
         }
-        outputTextStream << entry->attributes()->value(attribute) << endl;
+        outputTextStream << entry->resolveMultiplePlaceholders(entry->attributes()->value(attribute)) << endl;
     }
     return sawUnknownAttribute ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -150,7 +150,7 @@ Entry* Database::findEntryRecursive(const QString& text, EntryReferenceType refe
             found = entry->notes() == text;
             break;
         case EntryReferenceType::Uuid:
-            found = entry->uuid().toHex() == text;
+            found = entry->uuid() == Uuid::fromHex(text);
             break;
         case EntryReferenceType::CustomAttributes:
             found = entry->attributes()->containsValue(text);

--- a/src/http/AccessControlDialog.cpp
+++ b/src/http/AccessControlDialog.cpp
@@ -44,7 +44,9 @@ void AccessControlDialog::setUrl(const QString &url)
 void AccessControlDialog::setItems(const QList<Entry*> &items)
 {
     for (Entry* entry: items) {
-        ui->itemsList->addItem(entry->title() + " - " + entry->username());
+        QString title = entry->resolveMultiplePlaceholders(entry->title());
+        QString username = entry->resolveMultiplePlaceholders(entry->username());
+        ui->itemsList->addItem(title + " - " + username);
     }
 }
 

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -36,6 +36,7 @@ private slots:
     void testResolveRecursivePlaceholders();
     void testResolveReferencePlaceholders();
     void testResolveNonIdPlaceholdersToUuid();
+    void testResolveClonedEntry();
 };
 
 #endif // KEEPASSX_TESTENTRY_H


### PR DESCRIPTION
Previously, `keepassxc-cli show` would not resolve references. This
would make it quite hard to script around its output (since there's not
interface to resolve references manually either). Fix this by using
resolveMultiplePlaceholders as with all other users of ->password() and
related entry fields.

Fixes keepassxreboot/keepassxc#1260
Fixes keepassxreboot/keepassxc#1269
Fixes #1211
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

## How has this been tested?
I tested this on my own KeePassXC database on several different entries (included nested ones), and verified that entries which were references now resolved to the correct value and that non-reference values also are correctly handled.

## Types of changes
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.

`LeakSanitiser` gives errors on `develop` at the moment, but as far as I can tell no additional `ASAN` errors were added by this change.