### PR TITLE
Removing password output from Estimate.

### DIFF
--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -42,13 +42,13 @@ Estimate::~Estimate()
 {
 }
 
-static void calculate(const char* pwd, bool advanced)
+static void estimate(const char* pwd, bool advanced)
 {
     double e;
     int len = strlen(pwd);
     if (!advanced) {
         e = ZxcvbnMatch(pwd, 0, 0);
-        printf("Pass '%s' \tLength %d\tEntropy %.3f\tLog10 %.3f\n", pwd, len, e, e * 0.301029996);
+        printf("Length %d\tEntropy %.3f\tLog10 %.3f\n", len, e, e * 0.301029996);
     } else {
         int ChkLen;
         ZxcMatch_t *info, *p;
@@ -58,8 +58,7 @@ static void calculate(const char* pwd, bool advanced)
             m += p->Entrpy;
         }
         m = e - m;
-        printf("Pass '%s' \tLength %d\tEntropy %.3f\tLog10 %.3f\n  Multi-word extra bits %.1f\n",
-               pwd,
+        printf("Length %d\tEntropy %.3f\tLog10 %.3f\n  Multi-word extra bits %.1f\n",
                len,
                e,
                e * 0.301029996,
@@ -170,6 +169,6 @@ int Estimate::execute(QStringList arguments)
         password = inputTextStream.readLine();
     }
 
-    calculate(password.toLatin1(), parser.isSet(advancedOption));
+    estimate(password.toLatin1(), parser.isSet(advancedOption));
     return EXIT_SUCCESS;
 }

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -58,11 +58,7 @@ static void estimate(const char* pwd, bool advanced)
             m += p->Entrpy;
         }
         m = e - m;
-        printf("Length %d\tEntropy %.3f\tLog10 %.3f\n  Multi-word extra bits %.1f\n",
-               len,
-               e,
-               e * 0.301029996,
-               m);
+        printf("Length %d\tEntropy %.3f\tLog10 %.3f\n  Multi-word extra bits %.1f\n", len, e, e * 0.301029996, m);
         p = info;
         ChkLen = 0;
         while (p) {


### PR DESCRIPTION
Previously the `entropy-meter` was accepting multiple passwords on a single invocation. Now we only allow 1, so we don't need to output the password before outputing the entropy stats.


## Motivation and context
Following up on https://github.com/keepassxreboot/keepassxc/pull/1250

## How has this been tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
