### PR TITLE
cli: show: add --attributes flag

### DIFF
--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -49,6 +49,13 @@ int Show::execute(QStringList arguments)
                                QObject::tr("Key file of the database."),
                                QObject::tr("path"));
     parser.addOption(keyFile);
+    QCommandLineOption attributes(QStringList() << "a"
+                                                << "attributes",
+                                  QObject::tr("Names of the attributes to show. "
+                                              "This option can be specified more than once, with each attribute shown one-per-line in the given order. "
+                                              "If no attributes are specified, a summary of the default attributes is given."),
+                                  QObject::tr("attribute"));
+    parser.addOption(attributes);
     parser.addPositionalArgument("entry", QObject::tr("Name of the entry to show."));
     parser.process(arguments);
 
@@ -63,10 +70,10 @@ int Show::execute(QStringList arguments)
         return EXIT_FAILURE;
     }
 
-    return this->showEntry(db, args.at(1));
+    return this->showEntry(db, parser.values(attributes), args.at(1));
 }
 
-int Show::showEntry(Database* database, QString entryPath)
+int Show::showEntry(Database* database, QStringList attributes, QString entryPath)
 {
 
     QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
@@ -78,10 +85,24 @@ int Show::showEntry(Database* database, QString entryPath)
         return EXIT_FAILURE;
     }
 
-    outputTextStream << "   title: " << entry->title() << endl;
-    outputTextStream << "username: " << entry->username() << endl;
-    outputTextStream << "password: " << entry->password() << endl;
-    outputTextStream << "     URL: " << entry->url() << endl;
-    outputTextStream << "   Notes: " << entry->notes() << endl;
-    return EXIT_SUCCESS;
+    // If no attributes specified, output the default attribute set.
+    bool showAttributeNames = attributes.isEmpty();
+    if (attributes.isEmpty()) {
+        attributes = EntryAttributes::DefaultAttributes;
+    }
+
+    // Iterate over the attributes and output them line-by-line.
+    bool sawUnknownAttribute = false;
+    for (QString attribute : attributes) {
+        if (!entry->attributes()->contains(attribute)) {
+            sawUnknownAttribute = true;
+            qCritical("ERROR: unknown attribute '%s'.", qPrintable(attribute));
+            continue;
+        }
+        if (showAttributeNames) {
+            outputTextStream << attribute << ": ";
+        }
+        outputTextStream << entry->attributes()->value(attribute) << endl;
+    }
+    return sawUnknownAttribute ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -26,7 +26,7 @@ public:
     Show();
     ~Show();
     int execute(QStringList arguments);
-    int showEntry(Database* database, QString entryPath);
+    int showEntry(Database* database, QStringList attributes, QString entryPath);
 };
 
 #endif // KEEPASSXC_SHOW_H

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -96,6 +96,14 @@ Specify the title of the entry.
 Perform advanced analysis on the password.
 
 
+.SS "Show options"
+
+.IP "-a, --attributes <attribute>..."
+Names of the attributes to show. This option can be specified more than once,
+with each attribute shown one-per-line in the given order. If no attributes are
+specified, a summary of the default attributes is given.
+
+
 .SH REPORTING BUGS
 Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.
 


### PR DESCRIPTION
In order for scripting to be much simpler with `keepassxc-cli show`,
provide a simple --show-attribute API which effectively is just a CLI
interface for entry->attributes()->value(...). This allows for more
extensibility and prevents changes in our output formatting from
breaking existing users of keepassxc-cli (if they use --show-attribute).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

## Motivation and context
I've recently started scripting around `keepassxc-cli` and I wanted to be able to extract particular fields (especially custom attribute fields) and to avoid having to parse the (unstable) output format.

## How has this been tested?
I tested this on my machine with my existing database. It suffers from #1260, but once #1280 is merged this could be rebased.

## Screenshots (if appropriate):

![keepasspr-attributes](https://user-images.githubusercontent.com/2888411/34069173-d10fd7d2-e29e-11e7-9e4d-f6e826050c19.png)
![keepasspr-help](https://user-images.githubusercontent.com/2888411/34069174-d1423542-e29e-11e7-8ee3-ef5d479aeecf.png)
![keepasspr-summary](https://user-images.githubusercontent.com/2888411/34069175-d17206b4-e29e-11e7-8a8a-c93f1904276d.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
