### PR TITLE
Improve and extend entry view table

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -138,6 +138,13 @@ void Config::init(const QString& fileName)
     m_defaults.insert("GUI/DarkTrayIcon", false);
     m_defaults.insert("GUI/MinimizeToTray", false);
     m_defaults.insert("GUI/MinimizeOnClose", false);
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Set defaults for state of 'Hide Usernames'/'Hide Passwords' settings
+     * of entry view
+     */
+    m_defaults.insert("GUI/EntryHideUsernames", false);
+    m_defaults.insert("GUI/EntryHidePasswords", true);
 }
 
 Config* Config::instance()

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -138,13 +138,8 @@ void Config::init(const QString& fileName)
     m_defaults.insert("GUI/DarkTrayIcon", false);
     m_defaults.insert("GUI/MinimizeToTray", false);
     m_defaults.insert("GUI/MinimizeOnClose", false);
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Set defaults for state of 'Hide Usernames'/'Hide Passwords' settings
-     * of entry view
-     */
-    m_defaults.insert("GUI/EntryHideUsernames", false);
-    m_defaults.insert("GUI/EntryHidePasswords", true);
+    m_defaults.insert("GUI/HideUsernames", false);
+    m_defaults.insert("GUI/HidePasswords", true);
 }
 
 Config* Config::instance()

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -908,12 +908,39 @@ void DatabaseWidget::unlockDatabase(bool accepted)
     }
 }
 
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Add 'copy-on-doubleclick' functionality for certain columns
+ *
+ * TODO:
+ * If pull request #1298 gets merged, double-clicking column 'Attachments'
+ * could open the new details view (see second screenshot)
+ */
 void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::ModelColumn column)
 {
-    if (column == EntryModel::Url && !entry->url().isEmpty()) {
-        openUrlForEntry(entry);
+    /* Should never happen */
+    if (!entry) {
+        Q_ASSERT(false);
+        return;
     }
-    else {
+
+    /* Decide what to do based on specified column */
+    switch (column) {
+    case EntryModel::Username:
+        setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->username()));
+        break;
+    case EntryModel::Password:
+        setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->password()));
+        break;
+    case EntryModel::Url:
+        if (!entry->url().isEmpty()) {
+            openUrlForEntry(entry);
+        }
+        break;
+    case EntryModel::Notes:
+        setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->notes()));
+        break;
+    default:
         switchToEntryEdit(entry);
     }
 }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -181,7 +181,13 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
 
     connect(m_mainSplitter, SIGNAL(splitterMoved(int,int)), SIGNAL(mainSplitterSizesChanged()));
     connect(m_detailSplitter, SIGNAL(splitterMoved(int,int)), SIGNAL(detailSplitterSizesChanged()));
-    connect(m_entryView->header(), SIGNAL(sectionResized(int,int,int)), SIGNAL(entryColumnSizesChanged()));
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Connect signal to pass through state changes of entry view view
+     */
+    connect(m_entryView, SIGNAL(viewStateChanged()), SIGNAL(entryViewStateChanged()));
+
     connect(m_groupView, SIGNAL(groupChanged(Group*)), this, SLOT(onGroupChanged(Group*)));
     connect(m_groupView, SIGNAL(groupChanged(Group*)), SIGNAL(groupChanged()));
     connect(m_entryView, SIGNAL(entryActivated(Entry*, EntryModel::ModelColumn)),
@@ -290,28 +296,58 @@ void DatabaseWidget::setDetailSplitterSizes(const QList<int> &sizes)
     m_detailSplitter->setSizes(sizes);
 }
 
-QList<int> DatabaseWidget::entryHeaderViewSizes() const
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Get current state of entry view 'Hide Usernames' setting
+ */
+bool DatabaseWidget::entryViewHideUsernames() const
 {
-    QList<int> sizes;
-
-    for (int i = 0; i < m_entryView->header()->count(); i++) {
-        sizes.append(m_entryView->header()->sectionSize(i));
-    }
-
-    return sizes;
+    return m_entryView->hideUsernames();
 }
 
-void DatabaseWidget::setEntryViewHeaderSizes(const QList<int>& sizes)
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Set state of entry view 'Hide Usernames' setting
+ */
+void DatabaseWidget::setEntryViewHideUsernames(const bool hide)
 {
-    const bool enoughSizes = sizes.size() == m_entryView->header()->count();
-    Q_ASSERT(enoughSizes);
-    if (!enoughSizes) {
-        return;
-    }
+    m_entryView->setHideUsernames(hide);
+}
 
-    for (int i = 0; i < sizes.size(); i++) {
-        m_entryView->header()->resizeSection(i, sizes[i]);
-    }
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Get current state of entry view 'Hide Passwords' setting
+ */
+bool DatabaseWidget::entryViewHidePasswords() const
+{
+    return m_entryView->hidePasswords();
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Set state of entry view 'Hide Passwords' setting
+ */
+void DatabaseWidget::setEntryViewHidePasswords(const bool hide)
+{
+    m_entryView->setHidePasswords(hide);
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Get current state of entry view view
+ */
+QByteArray DatabaseWidget::entryViewViewState() const
+{
+    return m_entryView->viewState();
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Set state of entry view view
+ */
+bool DatabaseWidget::setEntryViewViewState(const QByteArray& state) const
+{
+    return m_entryView->setViewState(state);
 }
 
 void DatabaseWidget::clearAllWidgets()
@@ -1178,7 +1214,7 @@ bool DatabaseWidget::canDeleteCurrentGroup() const
 
 bool DatabaseWidget::isInSearchMode() const
 {
-    return m_entryView->inEntryListMode();
+    return m_entryView->inSearchMode();
 }
 
 Group* DatabaseWidget::currentGroup() const

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -181,13 +181,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
 
     connect(m_mainSplitter, SIGNAL(splitterMoved(int,int)), SIGNAL(mainSplitterSizesChanged()));
     connect(m_detailSplitter, SIGNAL(splitterMoved(int,int)), SIGNAL(detailSplitterSizesChanged()));
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Connect signal to pass through state changes of entry view view
-     */
     connect(m_entryView, SIGNAL(viewStateChanged()), SIGNAL(entryViewStateChanged()));
-
     connect(m_groupView, SIGNAL(groupChanged(Group*)), this, SLOT(onGroupChanged(Group*)));
     connect(m_groupView, SIGNAL(groupChanged(Group*)), SIGNAL(groupChanged()));
     connect(m_entryView, SIGNAL(entryActivated(Entry*, EntryModel::ModelColumn)),
@@ -297,55 +291,49 @@ void DatabaseWidget::setDetailSplitterSizes(const QList<int> &sizes)
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Get current state of entry view 'Hide Usernames' setting
  */
-bool DatabaseWidget::entryViewHideUsernames() const
+bool DatabaseWidget::isUsernamesHidden() const
 {
-    return m_entryView->hideUsernames();
+    return m_entryView->isUsernamesHidden();
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Set state of entry view 'Hide Usernames' setting
  */
-void DatabaseWidget::setEntryViewHideUsernames(const bool hide)
+void DatabaseWidget::setUsernamesHidden(const bool hide)
 {
-    m_entryView->setHideUsernames(hide);
+    m_entryView->setUsernamesHidden(hide);
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Get current state of entry view 'Hide Passwords' setting
  */
-bool DatabaseWidget::entryViewHidePasswords() const
+bool DatabaseWidget::isPasswordsHidden() const
 {
-    return m_entryView->hidePasswords();
+    return m_entryView->isPasswordsHidden();
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Set state of entry view 'Hide Passwords' setting
  */
-void DatabaseWidget::setEntryViewHidePasswords(const bool hide)
+void DatabaseWidget::setPasswordsHidden(const bool hide)
 {
-    m_entryView->setHidePasswords(hide);
+    m_entryView->setPasswordsHidden(hide);
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
- * Get current state of entry view view
+ * Get current view state of entry view
  */
-QByteArray DatabaseWidget::entryViewViewState() const
+QByteArray DatabaseWidget::entryViewState() const
 {
     return m_entryView->viewState();
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
- * Set state of entry view view
+ * Set view state of entry view
  */
-bool DatabaseWidget::setEntryViewViewState(const QByteArray& state) const
+bool DatabaseWidget::setEntryViewState(const QByteArray& state) const
 {
     return m_entryView->setViewState(state);
 }
@@ -696,8 +684,8 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
 
 void DatabaseWidget::createGroup()
 {
+    Q_ASSERT(m_groupView->currentGroup());
     if (!m_groupView->currentGroup()) {
-        Q_ASSERT(false);
         return;
     }
 
@@ -710,8 +698,8 @@ void DatabaseWidget::createGroup()
 void DatabaseWidget::deleteGroup()
 {
     Group* currentGroup = m_groupView->currentGroup();
+    Q_ASSERT(currentGroup && canDeleteCurrentGroup());
     if (!currentGroup || !canDeleteCurrentGroup()) {
-        Q_ASSERT(false);
         return;
     }
 
@@ -944,23 +932,14 @@ void DatabaseWidget::unlockDatabase(bool accepted)
     }
 }
 
-/**
- * @author Fonic <https://github.com/fonic>
- * Add 'copy-on-doubleclick' functionality for certain columns
- *
- * TODO:
- * If pull request #1298 gets merged, double-clicking column 'Attachments'
- * could open the new details view (see second screenshot)
- */
 void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::ModelColumn column)
 {
-    /* Should never happen */
+    Q_ASSERT(entry);
     if (!entry) {
-        Q_ASSERT(false);
         return;
     }
 
-    /* Decide what to do based on specified column */
+    // Implement 'copy-on-doubleclick' functionality for certain columns
     switch (column) {
     case EntryModel::Username:
         setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->username()));
@@ -973,9 +952,12 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
             openUrlForEntry(entry);
         }
         break;
-    case EntryModel::Notes:
-        setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->notes()));
-        break;
+    // TODO: switch to 'Notes' tab in details view/pane
+    //case EntryModel::Notes:
+    //    break;
+    // TODO: switch to 'Attachments' tab in details view/pane
+    //case EntryModel::Attachments:
+    //    break;
     default:
         switchToEntryEdit(entry);
     }

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -92,23 +92,12 @@ public:
     void setMainSplitterSizes(const QList<int>& sizes);
     QList<int> detailSplitterSizes() const;
     void setDetailSplitterSizes(const QList<int>& sizes);
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Methods to get/set state of entry view 'Hide Usernames'/'Hide
-     * Passwords' settings
-     */
-    bool entryViewHideUsernames() const;
-    void setEntryViewHideUsernames(const bool hide);
-    bool entryViewHidePasswords() const;
-    void setEntryViewHidePasswords(const bool hide);
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Methods to get/set state of entry view view state
-     */
-    QByteArray entryViewViewState() const;
-    bool setEntryViewViewState(const QByteArray& state) const;
-
+    bool isUsernamesHidden() const;
+    void setUsernamesHidden(const bool hide);
+    bool isPasswordsHidden() const;
+    void setPasswordsHidden(const bool hide);
+    QByteArray entryViewState() const;
+    bool setEntryViewState(const QByteArray& state) const;
     void clearAllWidgets();
     bool currentEntryHasTitle();
     bool currentEntryHasUsername();
@@ -142,13 +131,7 @@ signals:
     void searchModeActivated();
     void mainSplitterSizesChanged();
     void detailSplitterSizesChanged();
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Signal to notify about state changes entry view view
-     */
     void entryViewStateChanged();
-
     void updateSearch(QString text);
 
 public slots:

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -92,8 +92,23 @@ public:
     void setMainSplitterSizes(const QList<int>& sizes);
     QList<int> detailSplitterSizes() const;
     void setDetailSplitterSizes(const QList<int>& sizes);
-    QList<int> entryHeaderViewSizes() const;
-    void setEntryViewHeaderSizes(const QList<int>& sizes);
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Methods to get/set state of entry view 'Hide Usernames'/'Hide
+     * Passwords' settings
+     */
+    bool entryViewHideUsernames() const;
+    void setEntryViewHideUsernames(const bool hide);
+    bool entryViewHidePasswords() const;
+    void setEntryViewHidePasswords(const bool hide);
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Methods to get/set state of entry view view state
+     */
+    QByteArray entryViewViewState() const;
+    bool setEntryViewViewState(const QByteArray& state) const;
+
     void clearAllWidgets();
     bool currentEntryHasTitle();
     bool currentEntryHasUsername();
@@ -127,7 +142,13 @@ signals:
     void searchModeActivated();
     void mainSplitterSizesChanged();
     void detailSplitterSizesChanged();
-    void entryColumnSizesChanged();
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Signal to notify about state changes entry view view
+     */
+    void entryViewStateChanged();
+
     void updateSearch(QString text);
 
 public slots:

--- a/src/gui/DatabaseWidgetStateSync.cpp
+++ b/src/gui/DatabaseWidgetStateSync.cpp
@@ -27,40 +27,20 @@ DatabaseWidgetStateSync::DatabaseWidgetStateSync(QObject* parent)
 {
     m_mainSplitterSizes = variantToIntList(config()->get("GUI/SplitterState"));
     m_detailSplitterSizes = variantToIntList(config()->get("GUI/DetailSplitterState"));
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Load state of entry view 'Hide Usernames'/'Hide Passwords' settings
-     */
-    m_entryHideUsernames = config()->get("GUI/EntryHideUsernames").toBool();
-    m_entryHidePasswords = config()->get("GUI/EntryHidePasswords").toBool();
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Load states of entry view list/search view
-     */
-    m_entryListViewState = config()->get("GUI/EntryListViewState").toByteArray();
-    m_entrySearchViewState = config()->get("GUI/EntrySearchViewState").toByteArray();
+    m_hideUsernames = config()->get("GUI/HideUsernames").toBool();
+    m_hidePasswords = config()->get("GUI/HidePasswords").toBool();
+    m_listViewState = config()->get("GUI/ListViewState").toByteArray();
+    m_searchViewState = config()->get("GUI/SearchViewState").toByteArray();
 }
 
 DatabaseWidgetStateSync::~DatabaseWidgetStateSync()
 {
     config()->set("GUI/SplitterState", intListToVariant(m_mainSplitterSizes));
     config()->set("GUI/DetailSplitterState", intListToVariant(m_detailSplitterSizes));
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Save state of entry view 'Hide Usernames'/'Hide Passwords' settings
-     */
-    config()->set("GUI/EntryHideUsernames", m_entryHideUsernames);
-    config()->set("GUI/EntryHidePasswords", m_entryHidePasswords);
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Save states of entry view list/search view
-     */
-    config()->set("GUI/EntryListViewState", m_entryListViewState);
-    config()->set("GUI/EntrySearchViewState", m_entrySearchViewState);
+    config()->set("GUI/HideUsernames", m_hideUsernames);
+    config()->set("GUI/HidePasswords", m_hidePasswords);
+    config()->set("GUI/ListViewState", m_listViewState);
+    config()->set("GUI/SearchViewState", m_searchViewState);
 }
 
 void DatabaseWidgetStateSync::setActive(DatabaseWidget* dbWidget)
@@ -94,14 +74,8 @@ void DatabaseWidgetStateSync::setActive(DatabaseWidget* dbWidget)
                 SLOT(updateSplitterSizes()));
         connect(m_activeDbWidget, SIGNAL(detailSplitterSizesChanged()),
                 SLOT(updateSplitterSizes()));
-
-        /**
-         * @author Fonic <https://github.com/fonic>
-         * Connect signal to receive state changes of entry view view
-         */
         connect(m_activeDbWidget, SIGNAL(entryViewStateChanged()),
                 SLOT(updateViewState()));
-
         connect(m_activeDbWidget, SIGNAL(listModeActivated()),
                 SLOT(restoreListView()));
         connect(m_activeDbWidget, SIGNAL(searchModeActivated()),
@@ -114,58 +88,54 @@ void DatabaseWidgetStateSync::setActive(DatabaseWidget* dbWidget)
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Restore entry view list view state
  *
  * NOTE:
- * States of entry view 'Hide Usernames'/'Hide Passwords' settings are considered
- * 'global', i.e. they are the same for both list and search mode
+ * States of entry view 'Hide Usernames'/'Hide Passwords' settings are global,
+ * i.e. they are the same for both list and search mode
  *
  * NOTE:
- * If m_entryListViewState is empty, it is the first time after clean/invalid
- * config that list view is activated. Thus, save its current state. Without
- * this, m_entryListViewState would remain empty until there is an actual view
- * state change (e.g. column is resized)
+ * If m_listViewState is empty, the list view has been activated for the first
+ * time after starting with a clean (or invalid) config. Thus, save the current
+ * state. Without this, m_listViewState would remain empty until there is an
+ * actual view state change (e.g. column is resized)
  */
 void DatabaseWidgetStateSync::restoreListView()
 {
-    m_activeDbWidget->setEntryViewHideUsernames(m_entryHideUsernames);
-    m_activeDbWidget->setEntryViewHidePasswords(m_entryHidePasswords);
+    m_activeDbWidget->setUsernamesHidden(m_hideUsernames);
+    m_activeDbWidget->setPasswordsHidden(m_hidePasswords);
 
-    if (!m_entryListViewState.isEmpty()) {
-        m_activeDbWidget->setEntryViewViewState(m_entryListViewState);
-    }
-    else {
-        m_entryListViewState = m_activeDbWidget->entryViewViewState();
+    if (!m_listViewState.isEmpty()) {
+        m_activeDbWidget->setEntryViewState(m_listViewState);
+    } else {
+        m_listViewState = m_activeDbWidget->entryViewState();
     }
 
     m_blockUpdates = false;
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Restore entry view search view state
  *
  * NOTE:
- * States of entry view 'Hide Usernames'/'Hide Passwords' settings are considered
- * 'global', i.e. they are the same for both list and search mode
+ * States of entry view 'Hide Usernames'/'Hide Passwords' settings are global,
+ * i.e. they are the same for both list and search mode
  *
  * NOTE:
- * If m_entrySearchViewState is empty, it is the first time after clean/invalid
- * config that search view is activated. Thus, save its current state. Without
- * this, m_entrySearchViewState would remain empty until there is an actual view
- * state change (e.g. column is resized)
+ * If m_searchViewState is empty, the search view has been activated for the
+ * first time after starting with a clean (or invalid) config. Thus, save the
+ * current state. Without this, m_searchViewState would remain empty until
+ * there is an actual view state change (e.g. column is resized)
  */
 void DatabaseWidgetStateSync::restoreSearchView()
 {
-    m_activeDbWidget->setEntryViewHideUsernames(m_entryHideUsernames);
-    m_activeDbWidget->setEntryViewHidePasswords(m_entryHidePasswords);
+    m_activeDbWidget->setUsernamesHidden(m_hideUsernames);
+    m_activeDbWidget->setPasswordsHidden(m_hidePasswords);
 
-    if (!m_entrySearchViewState.isEmpty()) {
-        m_activeDbWidget->setEntryViewViewState(m_entrySearchViewState);
-    }
-    else {
-        m_entrySearchViewState = m_activeDbWidget->entryViewViewState();
+    if (!m_searchViewState.isEmpty()) {
+        m_activeDbWidget->setEntryViewState(m_searchViewState);
+    } else {
+        m_searchViewState = m_activeDbWidget->entryViewState();
     }
 
     m_blockUpdates = false;
@@ -187,10 +157,11 @@ void DatabaseWidgetStateSync::updateSplitterSizes()
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
- * Update entry view list/search view state (NOTE: states of entry view
- * 'Hide Usernames'/'Hide Passwords' settings are considered 'global',
- * i.e. they are the same for both list and search mode)
+ * Update entry view list/search view state
+ *
+ * NOTE:
+ * States of entry view 'Hide Usernames'/'Hide Passwords' settings are global,
+ * i.e. they are the same for both list and search mode
  */
 void DatabaseWidgetStateSync::updateViewState()
 {
@@ -198,14 +169,13 @@ void DatabaseWidgetStateSync::updateViewState()
         return;
     }
 
-    m_entryHideUsernames = m_activeDbWidget->entryViewHideUsernames();
-    m_entryHidePasswords = m_activeDbWidget->entryViewHidePasswords();
+    m_hideUsernames = m_activeDbWidget->isUsernamesHidden();
+    m_hidePasswords = m_activeDbWidget->isPasswordsHidden();
 
     if (m_activeDbWidget->isInSearchMode()) {
-        m_entrySearchViewState = m_activeDbWidget->entryViewViewState();
-    }
-    else {
-        m_entryListViewState = m_activeDbWidget->entryViewViewState();
+        m_searchViewState = m_activeDbWidget->entryViewState();
+    } else {
+        m_listViewState = m_activeDbWidget->entryViewState();
     }
 }
 
@@ -219,8 +189,7 @@ QList<int> DatabaseWidgetStateSync::variantToIntList(const QVariant& variant)
         int size = var.toInt(&ok);
         if (ok) {
             result.append(size);
-        }
-        else {
+        } else {
             result.clear();
             break;
         }
@@ -239,4 +208,3 @@ QVariant DatabaseWidgetStateSync::intListToVariant(const QList<int>& list)
 
     return result;
 }
-

--- a/src/gui/DatabaseWidgetStateSync.h
+++ b/src/gui/DatabaseWidgetStateSync.h
@@ -37,7 +37,12 @@ public slots:
 private slots:
     void blockUpdates();
     void updateSplitterSizes();
-    void updateColumnSizes();
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Slot to update entry view view state
+     */
+    void updateViewState();
 
 private:
     static QList<int> variantToIntList(const QVariant& variant);
@@ -48,8 +53,22 @@ private:
     bool m_blockUpdates;
     QList<int> m_mainSplitterSizes;
     QList<int> m_detailSplitterSizes;
-    QList<int> m_columnSizesList;
-    QList<int> m_columnSizesSearch;
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Properties to store state of entry view 'Hide Usernames'/'Hide
+     * Passwords' settings
+     */
+    bool m_entryHideUsernames;
+    bool m_entryHidePasswords;
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Properties to store states of entry view list/search view (replaces
+     * m_columnSizesList/m_columnSizesSearch)
+     */
+    QByteArray m_entryListViewState;
+    QByteArray m_entrySearchViewState;
 };
 
 #endif // KEEPASSX_DATABASEWIDGETSTATESYNC_H

--- a/src/gui/DatabaseWidgetStateSync.h
+++ b/src/gui/DatabaseWidgetStateSync.h
@@ -37,11 +37,6 @@ public slots:
 private slots:
     void blockUpdates();
     void updateSplitterSizes();
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Slot to update entry view view state
-     */
     void updateViewState();
 
 private:
@@ -54,21 +49,11 @@ private:
     QList<int> m_mainSplitterSizes;
     QList<int> m_detailSplitterSizes;
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Properties to store state of entry view 'Hide Usernames'/'Hide
-     * Passwords' settings
-     */
-    bool m_entryHideUsernames;
-    bool m_entryHidePasswords;
+    bool m_hideUsernames;
+    bool m_hidePasswords;
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Properties to store states of entry view list/search view (replaces
-     * m_columnSizesList/m_columnSizesSearch)
-     */
-    QByteArray m_entryListViewState;
-    QByteArray m_entrySearchViewState;
+    QByteArray m_listViewState;
+    QByteArray m_searchViewState;
 };
 
 #endif // KEEPASSX_DATABASEWIDGETSTATESYNC_H

--- a/src/gui/DetailsWidget.cpp
+++ b/src/gui/DetailsWidget.cpp
@@ -127,7 +127,7 @@ void DetailsWidget::getSelectedEntry(Entry* selectedEntry)
             shortPassword(m_currentEntry->resolveMultiplePlaceholders(m_currentEntry->password())));
         m_ui->passwordLabel->setToolTip(m_currentEntry->resolveMultiplePlaceholders(m_currentEntry->password()));
     } else {
-        m_ui->passwordLabel->setText("****");
+        m_ui->passwordLabel->setText(QString("\u25cf").repeated(6));
     }
 
     QString url = m_currentEntry->webUrl();

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -97,7 +97,7 @@ void EntryModel::setGroup(Group* group)
     makeConnections(group);
 
     endResetModel();
-    emit switchedToGroupMode();
+    emit switchedToListMode();
 }
 
 void EntryModel::setEntryList(const QList<Entry*>& entries)
@@ -134,7 +134,7 @@ void EntryModel::setEntryList(const QList<Entry*>& entries)
     }
 
     endResetModel();
-    emit switchedToEntryListMode();
+    emit switchedToSearchMode();
 }
 
 int EntryModel::rowCount(const QModelIndex& parent) const

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -20,11 +20,6 @@
 #include <QFont>
 #include <QMimeData>
 #include <QPalette>
-/**
- * @author Fonic <https://github.com/fonic>
- * Add include required for additional columns 'Expires', 'Created', 'Modified'
- * and 'Accessed'
- */
 #include <QDateTime>
 
 #include "core/DatabaseIcons.h"
@@ -33,43 +28,15 @@
 #include "core/Group.h"
 #include "core/Metadata.h"
 
-/**
- * @author Fonic <https://github.com/fonic>
- * Define constant string used to display hidden content in columns 'Username'
- * and 'Password'
- *
- * TODO:
- * Decide which of the proposed options should be used (stars, bullet, black
- * circle)
- */
-//const QString EntryModel::HiddenContentDisplay("******");
-//const QString EntryModel::HiddenContentDisplay(QString(QChar(0x2022)).repeated(6));
-const QString EntryModel::HiddenContentDisplay(QString(QChar(0x25CF)).repeated(6));
+// String being displayed when hiding content
+const QString EntryModel::HiddenContentDisplay(QString("\u25cf").repeated(6));
 
-/**
- * @author Fonic <https://github.com/fonic>
- * Define date format used to display dates in columns 'Expires', 'Created',
- * 'Modified' and 'Accessed'
- */
+// Format used to display dates
 const Qt::DateFormat EntryModel::DateFormat = Qt::DefaultLocaleShortDate;
 
-/**
- * @author Fonic <https://github.com/fonic>
- * Define constant string used to display header and data of column 'Paper-
- * clip'
- *
- * TODO:
- * When using unicode, ASAN reports memory leaks, but when using a plain
- * string like 'x', no leaks are reported. Check if this is something to
- * worry about, might as well be a Qt bug
- */
-const QString EntryModel::PaperClipDisplay(QString("\U0001f4ce"));
+// Paperclip symbol
+const QString EntryModel::PaperClipDisplay("\U0001f4ce");
 
-/**
- * @author Fonic <https://github.com/fonic>
- * Initialize 'Hide Usernames' and 'Hide Passwords' settings using sane
- * defaults (usernames visible, passwords hidden)
- */
 EntryModel::EntryModel(QObject* parent)
     : QAbstractTableModel(parent)
     , m_group(nullptr)
@@ -153,27 +120,19 @@ int EntryModel::rowCount(const QModelIndex& parent) const
 {
     if (parent.isValid()) {
         return 0;
-    }
-    else {
+    } else {
         return m_entries.size();
     }
 }
 
 int EntryModel::columnCount(const QModelIndex& parent) const
 {
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Change column count to include additional columns 'Password', 'Notes',
-     * 'Expires', 'Created', 'Modified', 'Accessed', 'Paperclip' and
-     * 'Attachments'. Also, return 0 when parent is valid as advised by Qt
-     * documentation
-     */
+    // Advised by Qt documentation
     if (parent.isValid()) {
         return 0;
     }
-    else {
-        return 12;
-    }
+
+    return 12;
 }
 
 QVariant EntryModel::data(const QModelIndex& index, int role) const
@@ -185,26 +144,6 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
     Entry* entry = entryFromIndex(index);
     EntryAttributes* attr = entry->attributes();
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     *
-     * Add display data providers for additional columns 'Password', 'Notes',
-     * 'Expires', 'Created', 'Modified', 'Accessed', 'Paperclip' and
-     * 'Attachments'
-     *
-     * Add ability to display usernames and passwords hidden or visible
-     * depending on current state of 'Hide Usernames' and 'Hide Passwords'
-     * settings
-     *
-     * TODO:
-     * Decide which of the additional columns should expand placeholders
-     * -> code added where applicable, but currently commented out
-     *
-     * Check what attr->isReference() does and if it applies to any of the
-     * additional columns
-     * -> code added for columns 'Password' and 'Notes', as EntryAttributes::
-     *    PasswordKey and EntryAttributes::NotesKey already existed
-     */
     if (role == Qt::DisplayRole) {
         QString result;
         switch (index.column()) {
@@ -216,63 +155,44 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
         case Title:
             result = entry->resolveMultiplePlaceholders(entry->title());
             if (attr->isReference(EntryAttributes::TitleKey)) {
-                result.prepend(tr("Ref: ","Reference abbreviation"));
+                result.prepend(tr("Ref: ", "Reference abbreviation"));
             }
             return result;
         case Username:
-            /*
-             * Display usernames hidden or visible according to current state
-             * of 'Hide Usernames' setting
-             */
             if (m_hideUsernames) {
                 result = EntryModel::HiddenContentDisplay;
-            }
-            else {
-                //result = entry->username();
+            } else {
                 result = entry->resolveMultiplePlaceholders(entry->username());
             }
             if (attr->isReference(EntryAttributes::UserNameKey)) {
-                result.prepend(tr("Ref: ","Reference abbreviation"));
+                result.prepend(tr("Ref: ", "Reference abbreviation"));
             }
             return result;
         case Password:
-            /*
-             * Display passwords hidden or visible according to current state
-             * of 'Hide Passwords' setting
-             */
             if (m_hidePasswords) {
                 result = EntryModel::HiddenContentDisplay;
-            }
-            else {
-                //result = entry->resolveMultiplePlaceholders(entry->password());
-                result = entry->password();
+            } else {
+                result = entry->resolveMultiplePlaceholders(entry->password());
             }
             if (attr->isReference(EntryAttributes::PasswordKey)) {
-                result.prepend(tr("Ref: ","Reference abbreviation"));
+                result.prepend(tr("Ref: ", "Reference abbreviation"));
             }
             return result;
         case Url:
-            //result = entry->resolveMultiplePlaceholders(entry->displayUrl());
-            result = entry->displayUrl();
+            result = entry->resolveMultiplePlaceholders(entry->displayUrl());
             if (attr->isReference(EntryAttributes::URLKey)) {
-                result.prepend(tr("Ref: ","Reference abbreviation"));
+                result.prepend(tr("Ref: ", "Reference abbreviation"));
             }
             return result;
         case Notes:
-            /*
-             * Display only first line of notes in simplified format like
-             * KeePassX does
-             */
-            //result = entry->resolveMultiplePlaceholders(entry->notes().section("\n", 0, 0).simplified());
-            result = entry->notes().section("\n", 0, 0).simplified();
+            // Display only first line of notes in simplified format
+            result = entry->resolveMultiplePlaceholders(entry->notes().section("\n", 0, 0).simplified());
             if (attr->isReference(EntryAttributes::NotesKey)) {
-                result.prepend(tr("Ref: ","Reference abbreviation"));
+                result.prepend(tr("Ref: ", "Reference abbreviation"));
             }
             return result;
         case Expires:
-            /*
-             * Display either date of expiry or 'Never' like KeePassX does
-             */
+            // Display either date of expiry or 'Never'
             result = entry->timeInfo().expires() ? entry->timeInfo().expiryTime().toLocalTime().toString(EntryModel::DateFormat) : tr("Never");
             return result;
         case Created:
@@ -288,65 +208,25 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             result = entry->attachments()->keys().isEmpty() ? QString() : EntryModel::PaperClipDisplay;
             return result;
         case Attachments:
-            /*
-             * Display comma-separated list of attachments
-             *
-             * TODO:
-             * 'entry->attachments()->keys().join()' works locally, yet it fails
-             * on GitHub/Travis CI, most likely due to an older Qt version, thus
-             * using loop for now (http://doc.qt.io/qt-5/qlist.html#more-members)
-             */
-            //result = entry->resolveMultiplePlaceholders(entry->attachments()->keys().join(", "));
-            //result = entry->attachments()->keys().join(", ");
-
+            // Display comma-separated list of attachments
             QList<QString> attachments = entry->attachments()->keys();
-            for (int i=0; i < attachments.size(); i++) {
+            for (int i = 0; i < attachments.size(); ++i) {
                 if (result.isEmpty()) {
                     result.append(attachments.at(i));
+                    continue;
                 }
-                else {
-                    result.append(QString(", ") + attachments.at(i));
-                }
+                result.append(QString(", ") + attachments.at(i));
             }
-            //result = entry->resolveMultiplePlaceholders(result);
             return result;
         }
-
-    }
-    /**
-     * @author Fonic <https://github.com/fonic>
-     *
-     * Add sort data providers for columns 'Username' and 'Password', required
-     * for correct sorting even if displayed hidden (i.e. settings 'Hide User-
-     * names' and/or 'Hide Passwords' are enabled)
-     *
-     * Add sort data providers for columns 'Expires', 'Created', 'Modified'
-     * and 'Accessed', required for correct sorting of dates (without this,
-     * sorting would be based on string representation of dates, yielding un-
-     * desired results)
-     *
-     * Add sort data provider for column 'Paperclip', required to display
-     * entries with attachments above those without when sorting ascendingly
-     * (and vice versa when sorting descendingly)
-     *
-     * NOTE:
-     * Qt::UserRole is used as sort role, using 'm_sortModel->setSortRole(Qt::
-     * UserRole)' in EntryView.cpp, EntryView::EntryView()
-     */
-    else if (role == Qt::UserRole) {
+    } else if (role == Qt::UserRole) { // Qt::UserRole is used as sort role, see EntryView::EntryView()
         switch (index.column()) {
         case Username:
-            //return entry->username();
             return entry->resolveMultiplePlaceholders(entry->username());
         case Password:
-            //return entry->resolveMultiplePlaceholders(entry->password());
-            return entry->password();
+            return entry->resolveMultiplePlaceholders(entry->password());
         case Expires:
-            /*
-             * TODO:
-             * Is there any better way to return a QDateTime representing
-             * 'Never' / infinity / end of all time?
-             */
+            // There seems to be no better way of expressing 'infinity'
             return entry->timeInfo().expires() ? entry->timeInfo().expiryTime() : QDateTime(QDate(9999, 1, 1));
         case Created:
             return entry->timeInfo().creationTime();
@@ -355,16 +235,15 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
         case Accessed:
             return entry->timeInfo().lastAccessTime();
         case Paperclip:
+            // Display entries with attachments above those without when
+            // sorting ascendingly (and vice versa when sorting descendingly)
             return entry->attachments()->keys().isEmpty() ? 1 : 0;
         default:
-            /*
-             * For all other columns, simply use data provided by Qt::Display-
-             * Role for sorting
-             */
+            // For all other columns, simply use data provided by Qt::Display-
+            // Role for sorting
             return data(index, Qt::DisplayRole);
         }
-    }
-    else if (role == Qt::DecorationRole) {
+    } else if (role == Qt::DecorationRole) {
         switch (index.column()) {
         case ParentGroup:
             if (entry->group()) {
@@ -374,20 +253,17 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
         case Title:
             if (entry->isExpired()) {
                 return databaseIcons()->iconPixmap(DatabaseIcons::ExpiredIconIndex);
-            }
-            else {
+            } else {
                 return entry->iconScaledPixmap();
             }
         }
-    }
-    else if (role == Qt::FontRole) {
+    } else if (role == Qt::FontRole) {
         QFont font;
         if (entry->isExpired()) {
             font.setStrikeOut(true);
         }
         return font;
-    }
-    else if (role == Qt::TextColorRole) {
+    } else if (role == Qt::TextColorRole) {
         if (entry->hasReferences()) {
             QPalette p;
             return QVariant(p.color(QPalette::Active, QPalette::Mid));
@@ -399,11 +275,6 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
 
 QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Add captions for additional columns 'Password', 'Notes', 'Expires',
-     * 'Created', 'Modified', 'Accessed', 'Paperclip' and 'Attachments'
-     */
     if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
         switch (section) {
         case ParentGroup:
@@ -450,8 +321,7 @@ Qt::ItemFlags EntryModel::flags(const QModelIndex& modelIndex) const
 {
     if (!modelIndex.isValid()) {
         return Qt::NoItemFlags;
-    }
-    else {
+    } else {
         return QAbstractItemModel::flags(modelIndex) | Qt::ItemIsDragEnabled;
     }
 }
@@ -492,8 +362,7 @@ QMimeData* EntryModel::mimeData(const QModelIndexList& indexes) const
     if (seenEntries.isEmpty()) {
         delete data;
         return nullptr;
-    }
-    else {
+    } else {
         data->setData(mimeTypes().at(0), encoded);
         return data;
     }
@@ -567,57 +436,51 @@ void EntryModel::makeConnections(const Group* group)
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Get current state of 'Hide Usernames' setting
  */
-bool EntryModel::hideUsernames() const
+bool EntryModel::isUsernamesHidden() const
 {
     return m_hideUsernames;
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Set state of 'Hide Usernames' setting and signal change
  */
-void EntryModel::setHideUsernames(const bool hide)
+void EntryModel::setUsernamesHidden(const bool hide)
 {
     m_hideUsernames = hide;
-    emit hideUsernamesChanged();
+    emit usernamesHiddenChanged();
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Get current state of 'Hide Passwords' setting
  */
-bool EntryModel::hidePasswords() const
+bool EntryModel::isPasswordsHidden() const
 {
     return m_hidePasswords;
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Set state of 'Hide Passwords' setting and signal change
  */
-void EntryModel::setHidePasswords(const bool hide)
+void EntryModel::setPasswordsHidden(const bool hide)
 {
     m_hidePasswords = hide;
-    emit hidePasswordsChanged();
+    emit passwordsHiddenChanged();
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Toggle state of 'Hide Usernames' setting
  */
-void EntryModel::toggleHideUsernames(const bool hide)
+void EntryModel::toggleUsernamesHidden(const bool hide)
 {
-    setHideUsernames(hide);
+    setUsernamesHidden(hide);
 }
 
 /**
- * @author Fonic <https://github.com/fonic>
  * Toggle state of 'Hide Passwords' setting
  */
-void EntryModel::toggleHidePasswords(const bool hide)
+void EntryModel::togglePasswordsHidden(const bool hide)
 {
-    setHidePasswords(hide);
+    setPasswordsHidden(hide);
 }

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -578,3 +578,21 @@ void EntryModel::setHidePasswords(const bool hide)
     m_hidePasswords = hide;
     emit hidePasswordsChanged();
 }
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Toggle state of 'Hide Usernames' setting
+ */
+void EntryModel::toggleHideUsernames(const bool hide)
+{
+    setHideUsernames(hide);
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Toggle state of 'Hide Passwords' setting
+ */
+void EntryModel::toggleHidePasswords(const bool hide)
+{
+    setHidePasswords(hide);
+}

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -28,12 +28,24 @@ class EntryModel : public QAbstractTableModel
     Q_OBJECT
 
 public:
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Add entries for additional columns 'Password', 'Notes', 'Expires',
+     * 'Created', 'Modified', 'Accessed' and 'Attachments'
+     */
     enum ModelColumn
     {
         ParentGroup = 0,
         Title = 1,
         Username = 2,
-        Url = 3
+        Password = 3,
+        Url = 4,
+        Notes = 5,
+        Expires = 6,
+        Created = 7,
+        Modified = 8,
+        Accessed = 9,
+        Attachments = 10
     };
 
     explicit EntryModel(QObject* parent = nullptr);
@@ -52,9 +64,26 @@ public:
 
     void setEntryList(const QList<Entry*>& entries);
 
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Methods to get/set state of 'Hide Usernames' and 'Hide Passwords'
+     * settings
+     */
+    bool hideUsernames() const;
+    void setHideUsernames(const bool hide);
+    bool hidePasswords() const;
+    void setHidePasswords(const bool hide);
+
 signals:
     void switchedToEntryListMode();
     void switchedToGroupMode();
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Signals to notify about state changes of 'Hide Usernames' and 'Hide
+     * Passwords' settings
+     */
+    void hideUsernamesChanged();
+    void hidePasswordsChanged();
 
 public slots:
     void setGroup(Group* group);
@@ -74,6 +103,28 @@ private:
     QList<Entry*> m_entries;
     QList<Entry*> m_orgEntries;
     QList<const Group*> m_allGroups;
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Properties to store state of 'Hide Usernames' and 'Hide Passwords'
+     * settings
+     */
+    bool m_hideUsernames;
+    bool m_hidePasswords;
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Constant string used to display hidden content in columns 'Username'
+     * and 'Password'
+     */
+    static const QString HiddenContent;
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Date format used to display dates in columns 'Expires', 'Created',
+     * 'Modified' and 'Accessed'
+     */
+    static const Qt::DateFormat DateFormat;
 };
 
 #endif // KEEPASSX_ENTRYMODEL_H

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -45,7 +45,8 @@ public:
         Created = 7,
         Modified = 8,
         Accessed = 9,
-        Attachments = 10
+        Paperclip = 10,
+        Attachments = 11
     };
 
     explicit EntryModel(QObject* parent = nullptr);
@@ -130,7 +131,7 @@ private:
      * Constant string used to display hidden content in columns 'Username'
      * and 'Password'
      */
-    static const QString HiddenContent;
+    static const QString HiddenContentDisplay;
 
     /**
      * @author Fonic <https://github.com/fonic>
@@ -138,6 +139,13 @@ private:
      * 'Modified' and 'Accessed'
      */
     static const Qt::DateFormat DateFormat;
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Constant string used to display header and data of column 'Paper-
+     * clip'
+     */
+    static const QString PaperClipDisplay;
 };
 
 #endif // KEEPASSX_ENTRYMODEL_H

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -75,8 +75,13 @@ public:
     void setHidePasswords(const bool hide);
 
 signals:
-    void switchedToEntryListMode();
-    void switchedToGroupMode();
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Signals to notify about list/search mode switches (NOTE: previously
+     * named 'switchedToGroupMode'/'switchedToEntryListMode')
+     */
+    void switchedToListMode();
+    void switchedToSearchMode();
 
     /**
      * @author Fonic <https://github.com/fonic>

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -77,6 +77,7 @@ public:
 signals:
     void switchedToEntryListMode();
     void switchedToGroupMode();
+
     /**
      * @author Fonic <https://github.com/fonic>
      * Signals to notify about state changes of 'Hide Usernames' and 'Hide
@@ -87,6 +88,13 @@ signals:
 
 public slots:
     void setGroup(Group* group);
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Slots to toggle state of 'Hide Usernames' and 'Hide Passwords' settings
+     */
+    void toggleHideUsernames(const bool hide);
+    void toggleHidePasswords(const bool hide);
 
 private slots:
     void entryAboutToAdd(Entry* entry);

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -28,11 +28,6 @@ class EntryModel : public QAbstractTableModel
     Q_OBJECT
 
 public:
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Add entries for additional columns 'Password', 'Notes', 'Expires',
-     * 'Created', 'Modified', 'Accessed' and 'Attachments'
-     */
     enum ModelColumn
     {
         ParentGroup = 0,
@@ -65,42 +60,21 @@ public:
 
     void setEntryList(const QList<Entry*>& entries);
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Methods to get/set state of 'Hide Usernames' and 'Hide Passwords'
-     * settings
-     */
-    bool hideUsernames() const;
-    void setHideUsernames(const bool hide);
-    bool hidePasswords() const;
-    void setHidePasswords(const bool hide);
+    bool isUsernamesHidden() const;
+    void setUsernamesHidden(const bool hide);
+    bool isPasswordsHidden() const;
+    void setPasswordsHidden(const bool hide);
 
 signals:
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Signals to notify about list/search mode switches (NOTE: previously
-     * named 'switchedToGroupMode'/'switchedToEntryListMode')
-     */
     void switchedToListMode();
     void switchedToSearchMode();
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Signals to notify about state changes of 'Hide Usernames' and 'Hide
-     * Passwords' settings
-     */
-    void hideUsernamesChanged();
-    void hidePasswordsChanged();
+    void usernamesHiddenChanged();
+    void passwordsHiddenChanged();
 
 public slots:
     void setGroup(Group* group);
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Slots to toggle state of 'Hide Usernames' and 'Hide Passwords' settings
-     */
-    void toggleHideUsernames(const bool hide);
-    void toggleHidePasswords(const bool hide);
+    void toggleUsernamesHidden(const bool hide);
+    void togglePasswordsHidden(const bool hide);
 
 private slots:
     void entryAboutToAdd(Entry* entry);
@@ -118,33 +92,11 @@ private:
     QList<Entry*> m_orgEntries;
     QList<const Group*> m_allGroups;
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Properties to store state of 'Hide Usernames' and 'Hide Passwords'
-     * settings
-     */
     bool m_hideUsernames;
     bool m_hidePasswords;
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Constant string used to display hidden content in columns 'Username'
-     * and 'Password'
-     */
     static const QString HiddenContentDisplay;
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Date format used to display dates in columns 'Expires', 'Created',
-     * 'Modified' and 'Accessed'
-     */
     static const Qt::DateFormat DateFormat;
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Constant string used to display header and data of column 'Paper-
-     * clip'
-     */
     static const QString PaperClipDisplay;
 };
 

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -32,6 +32,13 @@ EntryView::EntryView(QWidget* parent)
     m_sortModel->setDynamicSortFilter(true);
     m_sortModel->setSortLocaleAware(true);
     m_sortModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Set Qt::UserRole as sort role
+     * -> refer to 'if (role == Qt::UserRole)', EntryModel.cpp, EntryModel::
+     *    data() for details
+     */
+    m_sortModel->setSortRole(Qt::UserRole);
     QTreeView::setModel(m_sortModel);
 
     setUniformRowHeights(true);

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -19,8 +19,25 @@
 
 #include <QHeaderView>
 #include <QKeyEvent>
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Add include required for header context menu
+ */
+#include <QMenu>
 
 #include "gui/SortFilterHideProxyModel.h"
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ *
+ * TODO NOTE:
+ * Currently, 'zombie' columns which are not hidden but have width == 0
+ * (rendering them invisible) may appear. This is caused by DatabaseWidget
+ * StateSync. Corresponding checks/workarounds may be removed once sync
+ * code is updated accordingly
+ * -> relevant code pieces: if (header()->sectionSize(...) == 0) { ... }
+ *
+ */
 
 EntryView::EntryView(QWidget* parent)
     : QTreeView(parent)
@@ -47,7 +64,6 @@ EntryView::EntryView(QWidget* parent)
     setDragEnabled(true);
     setSortingEnabled(true);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
-    header()->setDefaultSectionSize(150);
 
     // QAbstractItemView::startDrag() uses this property as the default drag action
     setDefaultDropAction(Qt::MoveAction);
@@ -58,6 +74,69 @@ EntryView::EntryView(QWidget* parent)
     connect(m_model, SIGNAL(switchedToGroupMode()), SLOT(switchToGroupMode()));
 
     connect(this, SIGNAL(clicked(QModelIndex)), SLOT(emitEntryPressed(QModelIndex)));
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Create header context menu:
+     * - Actions to toggle state of 'Hide Usernames'/'Hide Passwords' settings
+     * - Actions to toggle column visibility, with each action carrying 'its'
+     *   column index as data
+     * - Actions to resize columns
+     * - Action to reset view to defaults
+     */
+    m_headerMenu = new QMenu(this);
+    m_headerMenu->setTitle(tr("Customize View"));
+    m_headerMenu->addSection(tr("Customize View"));
+
+    m_hideUsernamesAction = m_headerMenu->addAction(tr("Hide Usernames"), m_model, SLOT(toggleHideUsernames(bool)));
+    m_hideUsernamesAction->setCheckable(true);
+    m_hidePasswordsAction = m_headerMenu->addAction(tr("Hide Passwords"), m_model, SLOT(toggleHidePasswords(bool)));
+    m_hidePasswordsAction->setCheckable(true);
+    m_headerMenu->addSeparator();
+
+    m_columnActions = new QActionGroup(this);
+    m_columnActions->setExclusive(false);
+    for (int colidx = 1; colidx < header()->count(); colidx++) {
+        QString caption = m_model->headerData(colidx, Qt::Horizontal, Qt::DisplayRole).toString();
+        QAction* action = m_headerMenu->addAction(caption);
+        action->setCheckable(true);
+        action->setData(colidx);
+        m_columnActions->addAction(action);
+    }
+    connect(m_columnActions, SIGNAL(triggered(QAction*)), this, SLOT(toggleColumnVisibility(QAction*)));
+
+    m_headerMenu->addSeparator();
+    m_headerMenu->addAction(tr("Fit to window"), this, SLOT(fitColumnsToWindow()));
+    m_headerMenu->addAction(tr("Fit to contents"), this, SLOT(fitColumnsToContents()));
+    m_headerMenu->addSeparator();
+    m_headerMenu->addAction(tr("Reset to defaults"), this, SLOT(resetViewToDefaults()));
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Configure header:
+     * - Set default section size
+     * - Disable stretching of last section (interferes with fitting columns
+     *   to window)
+     * - Associate with context menu
+     */
+    header()->setDefaultSectionSize(100);
+    header()->setStretchLastSection(false);
+    header()->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(header(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showHeaderMenu(QPoint)));
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Finalize setup by resetting view to defaults. Although not really
+     * necessary at this point, it makes sense in order to avoid duplicating
+     * code (sorting order, visibility of first column etc.)
+     *
+     * TODO:
+     * Not working as expected, columns will end up being very small, most
+     * likely due to EntryView not being sized properly at this time. Either
+     * find a way to make this work by analizing when/where EntryView is
+     * created or remove
+     */
+    //resetViewToDefaults();
 }
 
 void EntryView::keyPressEvent(QKeyEvent* event)
@@ -153,22 +232,201 @@ Entry* EntryView::entryFromIndex(const QModelIndex& index)
 
 void EntryView::switchToEntryListMode()
 {
-    m_sortModel->hideColumn(0, false);
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Use header()->showSection() instead of m_sortModel->hideColumn() as
+     * the latter messes up column indices, interfering with code relying on
+     * proper indices
+     */
+    header()->showSection(EntryModel::ParentGroup);
+    if (header()->sectionSize(EntryModel::ParentGroup) == 0) {
+        header()->resizeSection(EntryModel::ParentGroup, header()->defaultSectionSize());
+    }
 
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Set sorting column and order (TODO: check what first two lines do, if
+     * they are actually necessary, if indices are still correct and if indices
+     * may be replaced by EntryModel::<column>)
+     */
     m_sortModel->sort(1, Qt::AscendingOrder);
     m_sortModel->sort(0, Qt::AscendingOrder);
-    sortByColumn(0, Qt::AscendingOrder);
+    sortByColumn(EntryModel::ParentGroup, Qt::AscendingOrder);
 
     m_inEntryListMode = true;
 }
 
 void EntryView::switchToGroupMode()
 {
-    m_sortModel->hideColumn(0, true);
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Use header()->hideSection() instead of m_sortModel->hideColumn() as
+     * the latter messes up column indices, interfering with code relying on
+     * proper indices
+     */
+    header()->hideSection(EntryModel::ParentGroup);
 
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Set sorting column and order (TODO: check what first two lines do, if
+     * they are actually necessary, if indices are still correct and if indices
+     * may be replaced by EntryModel::<column>)
+     */
     m_sortModel->sort(-1, Qt::AscendingOrder);
     m_sortModel->sort(0, Qt::AscendingOrder);
-    sortByColumn(0, Qt::AscendingOrder);
+    sortByColumn(EntryModel::Title, Qt::AscendingOrder);
 
     m_inEntryListMode = false;
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Sync checkable menu actions to current state and display header context
+ * menu at specified position
+ */
+void EntryView::showHeaderMenu(const QPoint& position)
+{
+    /* Sync checked state of menu actions to current state of view */
+    m_hideUsernamesAction->setChecked(m_model->hideUsernames());
+    m_hidePasswordsAction->setChecked(m_model->hidePasswords());
+    foreach (QAction *action, m_columnActions->actions()) {
+        if (static_cast<QMetaType::Type>(action->data().type()) != QMetaType::Int) {
+            Q_ASSERT(false);
+            continue;
+        }
+        int colidx = action->data().toInt();
+        bool hidden = header()->isSectionHidden(colidx) || (header()->sectionSize(colidx) == 0);
+        action->setChecked(!hidden);
+    }
+
+    /* Display menu */
+    m_headerMenu->popup(mapToGlobal(position));
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Toggle visibility of column referenced by triggering action
+ */
+void EntryView::toggleColumnVisibility(QAction *action)
+{
+    /*
+     * Verify action carries a column index as data. Since QVariant.toInt()
+     * below will accept anything that's interpretable as int, perform a type
+     * check here to make sure data actually IS int
+     */
+    if (static_cast<QMetaType::Type>(action->data().type()) != QMetaType::Int) {
+        Q_ASSERT(false);
+        return;
+    }
+
+    /*
+     * Toggle column visibility. Visible columns will only be hidden if at
+     * least one visible column remains, as the table header will disappear
+     * entirely when all columns are hidden, rendering the context menu in-
+     * accessible
+     */
+    int colidx = action->data().toInt();
+    if (action->isChecked()) {
+        header()->showSection(colidx);
+        if (header()->sectionSize(colidx) == 0) {
+            header()->resizeSection(colidx, header()->defaultSectionSize());
+        }
+    }
+    else {
+        if ((header()->count() - header()->hiddenSectionCount()) > 1) {
+            header()->hideSection(colidx);
+        }
+        else {
+            action->setChecked(true);
+        }
+    }
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Resize columns to fit all visible columns within the available space
+ *
+ * NOTE:
+ * If EntryView::resizeEvent() is overridden at some point in the future,
+ * its implementation MUST call the corresponding parent method using
+ * 'QTreeView::resizeEvent(event)'. Without this, fitting to window will
+ * be broken and/or work unreliably (stumbled upon during testing)
+ */
+void EntryView::fitColumnsToWindow()
+{
+    header()->resizeSections(QHeaderView::Stretch);
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Resize columns to fit current table contents, i.e. make all contents
+ * entirely visible
+ */
+void EntryView::fitColumnsToContents()
+{
+    /* Resize columns to fit contents */
+    header()->resizeSections(QHeaderView::ResizeToContents);
+
+    /*
+     * Determine total width of currently visible columns. If there is
+     * still some space available on the header, equally distribute it to
+     * visible columns and add remaining fraction to last visible column
+     */
+    int width = 0;
+    for (int colidx = 0; colidx < header()->count(); colidx++) {
+        if (!header()->isSectionHidden(colidx)) {
+            width += header()->sectionSize(colidx);
+        }
+    }
+    int visible = header()->count() - header()->hiddenSectionCount();
+    int avail = header()->width() - width;
+    if ((visible > 0) && (avail > 0)) {
+        int add = avail / visible;
+        width = 0;
+        int last = 0;
+        for (int colidx = 0; colidx < header()->count(); colidx++) {
+            if (!header()->isSectionHidden(colidx)) {
+                header()->resizeSection(colidx, header()->sectionSize(colidx) + add);
+                width += header()->sectionSize(colidx);
+                if (header()->visualIndex(colidx) > last) {
+                    last = header()->visualIndex(colidx);
+                }
+            }
+        }
+        header()->resizeSection(header()->logicalIndex(last), header()->sectionSize(last) + (header()->width() - width));
+    }
+}
+
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Reset view to defaults
+ *
+ * NOTE:
+ * header()->saveState()/restoreState() could also be used for this, but
+ * testing showed that it complicates things more than it helps when trying
+ * to account for current list mode
+ */
+void EntryView::resetViewToDefaults()
+{
+    /* Reset state of 'Hide Usernames'/'Hide Passwords' settings */
+    m_model->setHideUsernames(false);
+    m_model->setHidePasswords(true);
+
+    /* Reset visibility, size and position of all columns */
+    for (int colidx = 0; colidx < header()->count(); colidx++) {
+        header()->showSection(colidx);
+        header()->resizeSection(colidx, header()->defaultSectionSize());
+        header()->moveSection(header()->visualIndex(colidx), colidx);
+    }
+
+    /* Reenter current list mode (affects first column and sorting) */
+    if (m_inEntryListMode) {
+        switchToEntryListMode();
+    }
+    else {
+        switchToGroupMode();
+    }
+
+    /* Nicely fitting columns to window feels like a sane default */
+    fitColumnsToWindow();
 }

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -43,9 +43,26 @@ public:
     void setCurrentEntry(Entry* entry);
     Entry* entryFromIndex(const QModelIndex& index);
     void setEntryList(const QList<Entry*>& entries);
-    bool inEntryListMode();
+    bool inSearchMode();
     int numberOfSelectedEntries();
     void setFirstEntryActive();
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Methods to get/set state of 'Hide Usernames'/'Hide Passwords' settings
+     * (NOTE: these are just pass-through methods to avoid exposing entry model)
+     */
+    bool hideUsernames() const;
+    void setHideUsernames(const bool hide);
+    bool hidePasswords() const;
+    void setHidePasswords(const bool hide);
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Methods to get/set state of view
+     */
+    QByteArray viewState() const;
+    bool setViewState(const QByteArray& state) const;
 
 public slots:
     void setGroup(Group* group);
@@ -54,6 +71,11 @@ signals:
     void entryActivated(Entry* entry, EntryModel::ModelColumn column);
     void entryPressed(Entry* entry);
     void entrySelectionChanged();
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Signal to notify about changes of view state
+     */
+    void viewStateChanged();
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
@@ -61,8 +83,13 @@ protected:
 private slots:
     void emitEntryActivated(const QModelIndex& index);
     void emitEntryPressed(const QModelIndex& index);
-    void switchToEntryListMode();
-    void switchToGroupMode();
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Methods to switch to list/search mode (NOTE: previously named 'switch
+     * ToGroupMode'/'switchToEntryListMode')
+     */
+    void switchToListMode();
+    void switchToSearchMode();
 
     /**
      * @author Fonic <https://github.com/fonic>
@@ -77,8 +104,14 @@ private slots:
 private:
     EntryModel* const m_model;
     SortFilterHideProxyModel* const m_sortModel;
-    bool m_inEntryListMode;
+    bool m_inSearchMode;
 
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Properties to store default view states used by resetViewToDefaults()
+     */
+    QByteArray m_defaultListViewState;
+    QByteArray m_defaultSearchViewState;
     /**
      * @author Fonic <https://github.com/fonic>
      * Properties to store header context menu and actions

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -26,6 +26,11 @@ class Entry;
 class EntryModel;
 class Group;
 class SortFilterHideProxyModel;
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Add forward declaration for QActionGroup
+ */
+class QActionGroup;
 
 class EntryView : public QTreeView
 {
@@ -59,10 +64,29 @@ private slots:
     void switchToEntryListMode();
     void switchToGroupMode();
 
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Slots for header context menu and actions
+     */
+    void showHeaderMenu(const QPoint& position);
+    void toggleColumnVisibility(QAction *action);
+    void fitColumnsToWindow();
+    void fitColumnsToContents();
+    void resetViewToDefaults();
+
 private:
     EntryModel* const m_model;
     SortFilterHideProxyModel* const m_sortModel;
     bool m_inEntryListMode;
+
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Properties to store header context menu and actions
+     */
+    QMenu* m_headerMenu;
+    QAction* m_hideUsernamesAction;
+    QAction* m_hidePasswordsAction;
+    QActionGroup* m_columnActions;
 };
 
 #endif // KEEPASSX_ENTRYVIEW_H

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -26,10 +26,6 @@ class Entry;
 class EntryModel;
 class Group;
 class SortFilterHideProxyModel;
-/**
- * @author Fonic <https://github.com/fonic>
- * Add forward declaration for QActionGroup
- */
 class QActionGroup;
 
 class EntryView : public QTreeView
@@ -46,21 +42,10 @@ public:
     bool inSearchMode();
     int numberOfSelectedEntries();
     void setFirstEntryActive();
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Methods to get/set state of 'Hide Usernames'/'Hide Passwords' settings
-     * (NOTE: these are just pass-through methods to avoid exposing entry model)
-     */
-    bool hideUsernames() const;
-    void setHideUsernames(const bool hide);
-    bool hidePasswords() const;
-    void setHidePasswords(const bool hide);
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Methods to get/set state of view
-     */
+    bool isUsernamesHidden() const;
+    void setUsernamesHidden(const bool hide);
+    bool isPasswordsHidden() const;
+    void setPasswordsHidden(const bool hide);
     QByteArray viewState() const;
     bool setViewState(const QByteArray& state) const;
 
@@ -71,10 +56,6 @@ signals:
     void entryActivated(Entry* entry, EntryModel::ModelColumn column);
     void entryPressed(Entry* entry);
     void entrySelectionChanged();
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Signal to notify about changes of view state
-     */
     void viewStateChanged();
 
 protected:
@@ -83,18 +64,8 @@ protected:
 private slots:
     void emitEntryActivated(const QModelIndex& index);
     void emitEntryPressed(const QModelIndex& index);
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Methods to switch to list/search mode (NOTE: previously named 'switch
-     * ToGroupMode'/'switchToEntryListMode')
-     */
     void switchToListMode();
     void switchToSearchMode();
-
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Slots for header context menu and actions
-     */
     void showHeaderMenu(const QPoint& position);
     void toggleColumnVisibility(QAction *action);
     void fitColumnsToWindow();
@@ -106,16 +77,9 @@ private:
     SortFilterHideProxyModel* const m_sortModel;
     bool m_inSearchMode;
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Properties to store default view states used by resetViewToDefaults()
-     */
     QByteArray m_defaultListViewState;
     QByteArray m_defaultSearchViewState;
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Properties to store header context menu and actions
-     */
+
     QMenu* m_headerMenu;
     QAction* m_hideUsernamesAction;
     QAction* m_hidePasswordsAction;

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -288,9 +288,15 @@ void TestEntryModel::testProxyModel()
 
     modelSource->setGroup(db->rootGroup());
 
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Update comparison value of modelProxy->columnCount() to account for
+     * additional columns 'Password', 'Notes', 'Expires', 'Created', 'Modified',
+     * 'Accessed' and 'Attachments'
+     */
     QSignalSpy spyColumnRemove(modelProxy, SIGNAL(columnsAboutToBeRemoved(QModelIndex,int,int)));
     modelProxy->hideColumn(0, true);
-    QCOMPARE(modelProxy->columnCount(), 3);
+    QCOMPARE(modelProxy->columnCount(), 10);
     QVERIFY(spyColumnRemove.size() >= 1);
 
     int oldSpyColumnRemoveSize = spyColumnRemove.size();
@@ -304,9 +310,15 @@ void TestEntryModel::testProxyModel()
     entryList << entry;
     modelSource->setEntryList(entryList);
 
+    /**
+     * @author Fonic <https://github.com/fonic>
+     * Update comparison value of modelProxy->columnCount() to account for
+     * additional columns 'Password', 'Notes', 'Expires', 'Created', 'Modified',
+     * 'Accessed' and 'Attachments'
+     */
     QSignalSpy spyColumnInsert(modelProxy, SIGNAL(columnsAboutToBeInserted(QModelIndex,int,int)));
     modelProxy->hideColumn(0, false);
-    QCOMPARE(modelProxy->columnCount(), 4);
+    QCOMPARE(modelProxy->columnCount(), 11);
     QVERIFY(spyColumnInsert.size() >= 1);
 
     int oldSpyColumnInsertSize = spyColumnInsert.size();

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -292,11 +292,11 @@ void TestEntryModel::testProxyModel()
      * @author Fonic <https://github.com/fonic>
      * Update comparison value of modelProxy->columnCount() to account for
      * additional columns 'Password', 'Notes', 'Expires', 'Created', 'Modified',
-     * 'Accessed' and 'Attachments'
+     * 'Accessed', 'Paperclip' and 'Attachments'
      */
     QSignalSpy spyColumnRemove(modelProxy, SIGNAL(columnsAboutToBeRemoved(QModelIndex,int,int)));
     modelProxy->hideColumn(0, true);
-    QCOMPARE(modelProxy->columnCount(), 10);
+    QCOMPARE(modelProxy->columnCount(), 11);
     QVERIFY(spyColumnRemove.size() >= 1);
 
     int oldSpyColumnRemoveSize = spyColumnRemove.size();
@@ -314,11 +314,11 @@ void TestEntryModel::testProxyModel()
      * @author Fonic <https://github.com/fonic>
      * Update comparison value of modelProxy->columnCount() to account for
      * additional columns 'Password', 'Notes', 'Expires', 'Created', 'Modified',
-     * 'Accessed' and 'Attachments'
+     * 'Accessed', 'Paperclip' and 'Attachments'
      */
     QSignalSpy spyColumnInsert(modelProxy, SIGNAL(columnsAboutToBeInserted(QModelIndex,int,int)));
     modelProxy->hideColumn(0, false);
-    QCOMPARE(modelProxy->columnCount(), 11);
+    QCOMPARE(modelProxy->columnCount(), 12);
     QVERIFY(spyColumnInsert.size() >= 1);
 
     int oldSpyColumnInsertSize = spyColumnInsert.size();

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -686,21 +686,6 @@ void TestGui::testSearch()
     QTRY_COMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
 }
 
-/**
- * @author Fonic <https://github.com/fonic>
- * Update clicks within entry view referencing column indices to account
- * for changed column indices due to new way of showing/hiding column Entry
- * Model::ParentGroup. This column now has fixed index 0 wether it's shown
- * or hidden, thus all indices need to be shifted by +1 when not in search
- * mode (which is the case within this entire method)
- *
- * Old:
- * clickIndex(entryView->model()->index(row, column), button);
- *
- * New:
- * clickIndex(entryView->model()->index(row, column+1), button);
- *
- */
 void TestGui::testDeleteEntry()
 {
     // Add canned entries for consistent testing

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -686,6 +686,21 @@ void TestGui::testSearch()
     QTRY_COMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
 }
 
+/**
+ * @author Fonic <https://github.com/fonic>
+ * Update clicks within entry view referencing column indices to account
+ * for changed column indices due to new way of showing/hiding column Entry
+ * Model::ParentGroup. This column now has fixed index 0 wether it's shown
+ * or hidden, thus all indices need to be shifted by +1 when not in search
+ * mode (which is the case within this entire method)
+ *
+ * Old:
+ * clickIndex(entryView->model()->index(row, column), button);
+ *
+ * New:
+ * clickIndex(entryView->model()->index(row, column+1), button);
+ *
+ */
 void TestGui::testDeleteEntry()
 {
     // Add canned entries for consistent testing
@@ -698,7 +713,7 @@ void TestGui::testDeleteEntry()
     QWidget* entryDeleteWidget = toolBar->widgetForAction(entryDeleteAction);
 
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
-    clickIndex(entryView->model()->index(1, 0), entryView, Qt::LeftButton);
+    clickIndex(entryView->model()->index(1, 1), entryView, Qt::LeftButton);
     QVERIFY(entryDeleteWidget->isVisible());
     QVERIFY(entryDeleteWidget->isEnabled());
     QVERIFY(!m_db->metadata()->recycleBin());
@@ -709,8 +724,8 @@ void TestGui::testDeleteEntry()
     QCOMPARE(entryView->model()->rowCount(), 3);
     QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 1);
 
-    clickIndex(entryView->model()->index(1, 0), entryView, Qt::LeftButton);
-    clickIndex(entryView->model()->index(2, 0), entryView, Qt::LeftButton, Qt::ControlModifier);
+    clickIndex(entryView->model()->index(1, 1), entryView, Qt::LeftButton);
+    clickIndex(entryView->model()->index(2, 1), entryView, Qt::LeftButton, Qt::ControlModifier);
     QCOMPARE(entryView->selectionModel()->selectedRows().size(), 2);
 
     MessageBox::setNextAnswer(QMessageBox::No);
@@ -729,7 +744,7 @@ void TestGui::testDeleteEntry()
                groupView, Qt::LeftButton);
     QCOMPARE(groupView->currentGroup()->name(), m_db->metadata()->recycleBin()->name());
 
-    clickIndex(entryView->model()->index(0, 0), entryView, Qt::LeftButton);
+    clickIndex(entryView->model()->index(0, 1), entryView, Qt::LeftButton);
     MessageBox::setNextAnswer(QMessageBox::No);
     QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
     QCOMPARE(entryView->model()->rowCount(), 3);
@@ -740,8 +755,8 @@ void TestGui::testDeleteEntry()
     QCOMPARE(entryView->model()->rowCount(), 2);
     QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 2);
 
-    clickIndex(entryView->model()->index(0, 0), entryView, Qt::LeftButton);
-    clickIndex(entryView->model()->index(1, 0), entryView, Qt::LeftButton, Qt::ControlModifier);
+    clickIndex(entryView->model()->index(0, 1), entryView, Qt::LeftButton);
+    clickIndex(entryView->model()->index(1, 1), entryView, Qt::LeftButton, Qt::ControlModifier);
     MessageBox::setNextAnswer(QMessageBox::Yes);
     QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
     QCOMPARE(entryView->model()->rowCount(), 0);


### PR DESCRIPTION
## Description

This improves and extends the entry view table,
- Adding additional colums _Password_, _Notes_, _Expires_, _Created_, _Modified_, _Accessed_ and _Attachments_ (addresses #129)
- Adding settings to display usernames/passwords hidden/visible
- Adding a context menu to customize view (toggle column visibility, resize and reset columns) (addresses #17, #129, #397)
- Adding a _'copy-on-doubleclick'_ feature for certain columns (addresses #360)
- Syncing view states when switching between multiple tabs
- Reading/writing last used view settings from/to config

bringing the entry view table in par with KeePassX 0.4.x and even beyond.

**NOTE:**
- KeePassXC's user configuration should be reset prior to testing this
- This is replaces my original pull request #849, providing a clean rewrite with clean commits.

## Motivation
In my opinion, this addresses a major disadvantage of KeePassXC as the time of writing. The additional columns, the ability to customize the views and the _'copy-on-doubleclick'_ feature improve KeePassXC's overall usability and user experience.

## DONE
- Add additional columns to entry view table
- Add code for correct sorting of entries for any given column
- Add settings to display usernames/passwords hidden/visible
- Add context menu to entry view table header for view customization
- Add 'copy-on-doubleclick' feature for columns where applicable
- Add code to sync view states when switching between multiple tabs
- Add code to make view settings persistent using configuration file
- Finalize and clean up code

## Possible follow-ups
- Double-clicking columns 'Attachments' and 'Notes' should open corresponding tab in details view/pane
- Make header context menu available as 'View' in menu bar of main window
- Optionally add header context menu as submenu 'View' to already existing entry list context menu
- Copy-on-doubleclick should give feedback, e.g. progress bar that displays how long the copied element will stay in the clipboard (requested by @droidmonkey)
- Update/modify search mode to work without column 'Group' to simplify state syncing (see #1317)
- Add entropy column displaying password quality (see [this comment](https://github.com/keepassxreboot/keepassxc/pull/1305#issuecomment-354390256))

## How has this been tested?
- locally

## Screenshots
![screenshot_20171221_104349](https://user-images.githubusercontent.com/14027079/34250168-463df4f8-e63c-11e7-95c6-deb386723085.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist (in progress)
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- :negative_squared_cross_mark: My change requires a change to the documentation and I have updated it accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.
