### PR TITLE
Fix missing qtbase translations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN set -x \
         qt${QT5_VERSION}base \
         qt${QT5_VERSION}tools \
         qt${QT5_VERSION}x11extras \
+        qt${QT5_VERSION}translations \
         zlib1g-dev \
         libxi-dev \
         libxtst-dev \

--- a/release-tool
+++ b/release-tool
@@ -678,7 +678,8 @@ build() {
             "$DOCKER_IMAGE" \
             bash -c "cd /keepassxc/out/build-release && \
                 cmake -DCMAKE_BUILD_TYPE=Release -DWITH_TESTS=Off $CMAKE_OPTIONS \
-                    -DCMAKE_INSTALL_PREFIX=\"${INSTALL_PREFIX}\" /keepassxc/src && \
+                    -DCMAKE_INSTALL_PREFIX=\"${INSTALL_PREFIX}\" \
+                    -DKEEPASSXC_DIST_TYPE=AppImage /keepassxc/src && \
                 make $MAKE_OPTIONS && make DESTDIR=/keepassxc/out/bin-release install/strip && \
                 /keepassxc/src/AppImage-Recipe.sh "$APP_NAME" "$RELEASE_NAME""
         

--- a/share/translations/CMakeLists.txt
+++ b/share/translations/CMakeLists.txt
@@ -24,6 +24,11 @@ qt5_add_translation(QM_FILES ${TRANSLATION_FILES})
 
 if(MINGW)
     file(GLOB QTBASE_TRANSLATIONS ${Qt5_DIR}/../../../share/qt5/translations/qtbase_*.qm)
+elseif(APPLE OR KEEPASSXC_DIST_APPIMAGE)
+    file(GLOB QTBASE_TRANSLATIONS
+            /usr/share/qt/translations/qtbase_*.qm
+            /usr/share/qt5/translations/qtbase_*.qm
+            ${Qt5_DIR}/../../../translations/qtbase_*.qm)
 endif()
 set(QM_FILES ${QM_FILES} ${QTBASE_TRANSLATIONS})
 

--- a/share/translations/CMakeLists.txt
+++ b/share/translations/CMakeLists.txt
@@ -1,3 +1,4 @@
+#  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
 #  Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
 #
 #  This program is free software: you can redistribute it and/or modify
@@ -20,6 +21,11 @@ list(REMOVE_ITEM TRANSLATION_FILES ${TRANSLATION_EN_ABS})
 message(STATUS "${TRANSLATION_FILES}")
 
 qt5_add_translation(QM_FILES ${TRANSLATION_FILES})
+
+if(MINGW)
+    file(GLOB QTBASE_TRANSLATIONS ${Qt5_DIR}/../../../share/qt5/translations/qtbase_*.qm)
+endif()
+set(QM_FILES ${QM_FILES} ${QTBASE_TRANSLATIONS})
 
 install(FILES ${QM_FILES} DESTINATION ${DATA_INSTALL_DIR}/translations)
 add_custom_target(translations DEPENDS ${QM_FILES})

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,8 +43,11 @@ parts:
       - libykpers-1-dev
     stage-packages:
       - dbus
+      - qttranslations5-l10n # common translations
     install: |
       sed -i 's|Icon=keepassxc|Icon=${SNAP}/usr/share/icons/hicolor/256x256/apps/keepassxc.png|g' $SNAPCRAFT_PART_INSTALL/usr/share/applications/org.keepassxc.KeePassXC.desktop
+    organize:
+      usr/share/qt5/translations/*.qm: usr/share/keepassxc/translations/
     after: [desktop-qt5]
 
   # Redefine desktop-qt5 stage packages to work with Ubuntu 17.04

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
 #  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+#  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -352,7 +352,7 @@ if(MINGW)
   include(DeployQt4)
   install_qt4_executable(${PROGNAME}.exe)
   add_custom_command(TARGET ${PROGNAME} POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${Qt5Core_DIR}/../../../share/qt5/plugins/platforms/qwindows$<$<CONFIG:Debug>:d>.dll
+                     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${Qt5_DIR}/../../../share/qt5/plugins/platforms/qwindows$<$<CONFIG:Debug>:d>.dll
                      $<TARGET_FILE_DIR:${PROGNAME}>)
   install(FILES $<TARGET_FILE_DIR:${PROGNAME}>/qwindows$<$<CONFIG:Debug>:d>.dll DESTINATION "platforms")
 endif()

--- a/src/core/Translator.cpp
+++ b/src/core/Translator.cpp
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -21,33 +22,45 @@
 #include <QDir>
 #include <QLibraryInfo>
 #include <QLocale>
-#include <QRegExp>
 #include <QTranslator>
+#include <QRegularExpression>
 
 #include "config-keepassx.h"
 #include "core/Config.h"
 #include "core/FilePath.h"
 
-void Translator::installTranslator()
+/**
+ * Install all KeePassXC and Qt translators.
+ */
+void Translator::installTranslators()
 {
     QString language = config()->get("GUI/Language").toString();
     if (language == "system" || language.isEmpty()) {
         language = QLocale::system().name();
     }
 
-    if (!installTranslator(language)) {
-        // English fallback still needs translations for plurals
-        if (!installTranslator("en_plurals")) {
-            qWarning("Couldn't load translations.");
-        }
+    const QStringList paths = {
+#ifdef QT_DEBUG
+        QString("%1/share/translations").arg(KEEPASSX_BINARY_DIR),
+#endif
+        filePath()->dataPath("translations")
+    };
+
+    bool translationsLoaded = false;
+    for (const QString& path : paths) {
+        translationsLoaded |= installTranslator(language, path) || installTranslator("en_plurals", path);
+        installQtTranslator(language, path);
     }
-
-    installQtTranslator(language);
-
-    availableLanguages();
+    if (!translationsLoaded) {
+        // couldn't load configured language or fallback
+        qWarning("Couldn't load translations.");
+    }
 }
 
-QList<QPair<QString, QString> > Translator::availableLanguages()
+/**
+ * @return list of pairs of available language codes and names
+ */
+QList<QPair<QString, QString>> Translator::availableLanguages()
 {
     const QStringList paths = {
 #ifdef QT_DEBUG
@@ -59,12 +72,13 @@ QList<QPair<QString, QString> > Translator::availableLanguages()
     QList<QPair<QString, QString> > languages;
     languages.append(QPair<QString, QString>("system", "System default"));
 
-    QRegExp regExp("keepassx_([a-zA-Z_]+)\\.qm", Qt::CaseInsensitive, QRegExp::RegExp2);
+    QRegularExpression regExp("^keepassx_([a-zA-Z_]+)\\.qm$", QRegularExpression::CaseInsensitiveOption);
     for (const QString& path : paths) {
         const QStringList fileList = QDir(path).entryList();
         for (const QString& filename : fileList) {
-            if (regExp.exactMatch(filename)) {
-                QString langcode = regExp.cap(1);
+            QRegularExpressionMatch match = regExp.match(filename);
+            if (match.hasMatch()) {
+                QString langcode = match.captured(1);
                 if (langcode == "en_plurals") {
                     langcode = "en";
                 }
@@ -85,46 +99,37 @@ QList<QPair<QString, QString> > Translator::availableLanguages()
     return languages;
 }
 
-bool Translator::installTranslator(const QString& language)
+/**
+ * Install KeePassXC translator.
+ *
+ * @param language translator language
+ * @param path local search path
+ * @return true on success
+ */
+bool Translator::installTranslator(const QString& language, const QString& path)
 {
-    const QStringList paths = {
-#ifdef QT_DEBUG
-        QString("%1/share/translations").arg(KEEPASSX_BINARY_DIR),
-#endif
-        filePath()->dataPath("translations")
-    };
-
-    for (const QString& path : paths) {
-        if (installTranslator(language, path)) {
-            return true;
-        }
+    QScopedPointer<QTranslator> translator(new QTranslator(qApp));
+    if (translator->load(QString("keepassx_%1").arg(language), path)) {
+        return QCoreApplication::installTranslator(translator.take());
     }
-
     return false;
 }
 
-bool Translator::installTranslator(const QString& language, const QString& path)
+/**
+ * Install Qt5 base translator from the specified local search path or the default system path
+ * if no qtbase_* translations were found at the local path.
+ *
+ * @param language translator language
+ * @param path local search path
+ * @return true on success
+ */
+bool Translator::installQtTranslator(const QString& language, const QString& path)
 {
-    QTranslator* translator = new QTranslator(qApp);
-    if (translator->load(QString("keepassx_").append(language), path)) {
-        QCoreApplication::installTranslator(translator);
-        return true;
+    QScopedPointer<QTranslator> qtTranslator(new QTranslator(qApp));
+    if (qtTranslator->load(QString("qtbase_%1").arg(language), path)) {
+        return QCoreApplication::installTranslator(qtTranslator.take());
+    } else if (qtTranslator->load(QString("qtbase_%1").arg(language), QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
+        return QCoreApplication::installTranslator(qtTranslator.take());
     }
-    else {
-        delete translator;
-        return false;
-    }
-}
-
-bool Translator::installQtTranslator(const QString& language)
-{
-    QTranslator* qtTranslator = new QTranslator(qApp);
-    if (qtTranslator->load(QString("%1/qtbase_%2").arg(QLibraryInfo::location(QLibraryInfo::TranslationsPath), language))) {
-        QCoreApplication::installTranslator(qtTranslator);
-        return true;
-    }
-    else {
-        delete qtTranslator;
-        return false;
-    }
+    return false;
 }

--- a/src/core/Translator.h
+++ b/src/core/Translator.h
@@ -24,13 +24,12 @@
 class Translator
 {
 public:
-    static void installTranslator();
-    static QList<QPair<QString, QString> > availableLanguages();
+    static void installTranslators();
+    static QList<QPair<QString, QString>> availableLanguages();
 
 private:
-    static bool installTranslator(const QString& language);
     static bool installTranslator(const QString& language, const QString& path);
-    static bool installQtTranslator(const QString& language);
+    static bool installQtTranslator(const QString& language, const QString& path);
 };
 
 #endif // KEEPASSX_TRANSLATOR_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
         Config::createConfigFromFile(parser.value(configOption));
     }
 
-    Translator::installTranslator();
+    Translator::installTranslators();
 
 #ifdef Q_OS_MAC
     // Don't show menu icons on OSX


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This is a work-in-progress PR which resolves #1093.

With this patch, we bundle qtbase translations with KeePassXC builds. For this I refactored the Translator class and added the needed CMake install commands for Windows, macOS and Linux (AppImage only, PPA and other builds should use the system's qt5-translations package).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
KeePassXC didn't bundle qtbase translations, so standard buttons were left untranslated when qtbase translations didn't exist on the user's system at the same location as on the distributor's system (on Windows, even a different Msys2 install location was apparently enough to break translations).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows portable ZIP and installer ship qtbase_*.qm translations files now. I tested that those are loaded correctly by temporarily renaming my /mingw64/usr/share/qt5/translations folder.
macOS DMGs and Linux AppImages ship and successfully load qtbase translations as well.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**