### PR TITLE
Fix font size of URL label in the preview panel

### DIFF
--- a/src/gui/DetailsWidget.ui
+++ b/src/gui/DetailsWidget.ui
@@ -224,7 +224,6 @@
              </property>
              <property name="font">
               <font>
-               <pointsize>9</pointsize>
                <weight>75</weight>
                <bold>true</bold>
               </font>


### PR DESCRIPTION
## Description
This is a follow-up of #879 and #1135, which fixes a remaining layout issue in the preview panel.

## Motivation and context
I force font size 18 for all Qt applications (via LXQt's settings). This creates a difference for the URL label (font size 9) and other labels (font size 18)

## How has this been tested?
Manually on Arch Linux. See screenshots below.

## Screenshots (if appropriate):
Before:
![before](https://user-images.githubusercontent.com/1937689/34318248-44fd2744-e7fe-11e7-9dcb-561eebb7c6bd.png)

After:
![after](https://user-images.githubusercontent.com/1937689/34318250-4d2839ae-e7fe-11e7-9d29-50d22f633133.png)


## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- My change requires a change to the documentation and I have updated it accordingly.
- I have added tests to cover my changes.
