### PR TITLE
Correct encoding ambiguity in CSV Parser unicode test

### DIFF
--- a/tests/TestCsvParser.cpp
+++ b/tests/TestCsvParser.cpp
@@ -320,6 +320,7 @@ void TestCsvParser::testUnicode() {
     //ERROR QChar g("\u20AC");
     parser->setFieldSeparator(QChar('A'));
     QTextStream out(file.data());
+    out.setCodec("UTF-8");
     out << QString("€1A2śA\"3śAż\"Ażac");
 
     QVERIFY(parser->parse(file.data()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Enforces UTF-8 encoding when performing the Unicode test for the csv parser. Without setting this explicitly, the local environment (eg, MinGW) could incorrectly set this to ASCII causing the tests to fail.

Fixes #612.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
