### PR TITLE
Generate random 128-byte stream instead of legacy XML format when creating key files

### DIFF
--- a/src/keys/FileKey.h
+++ b/src/keys/FileKey.h
@@ -1,4 +1,5 @@
 /*
+*  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
 *  Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
 *
 *  This program is free software: you can redistribute it and/or modify
@@ -24,16 +25,15 @@
 
 class QIODevice;
 
-class FileKey : public Key
+class FileKey: public Key
 {
 public:
-    FileKey();
     bool load(QIODevice* device);
     bool load(const QString& fileName, QString* errorMsg = nullptr);
-    QByteArray rawKey() const;
-    FileKey* clone() const;
-    static void create(QIODevice* device);
-    static bool create(const QString& fileName, QString* errorMsg = nullptr);
+    QByteArray rawKey() const override;
+    FileKey* clone() const override;
+    static void create(QIODevice* device, int size = 128);
+    static bool create(const QString& fileName, QString* errorMsg = nullptr, int size = 128);
 
 private:
     bool loadXml(QIODevice* device);

--- a/tests/TestKeys.h
+++ b/tests/TestKeys.h
@@ -31,6 +31,8 @@ private slots:
     void testFileKey();
     void testFileKey_data();
     void testCreateFileKey();
+    void testCreateAndOpenFileKey();
+    void testFileKeyHash();
     void testFileKeyError();
     void benchmarkTransformKey();
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #1325
This patch implements a stronger key file generator and adds API documentation for the FileKey class.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The old key file generator created an XML key file with a short embedded random secret instead of a longer purely binary random byte string. The original motivation behind this was probably to be compatible with KeePass 2 (which generates the same kind of key files, apparently even with only 16 byte), but since KeePass 2 also supports usage of arbitrary files as key files, there is no reason to continue generating this kind of key files.

The new implementation generates a 128-byte blob of completely random data and no wrapping XML. The byte stream was generated using libgcrypt's cryptographic RNG. With 128 byte, the key file contents are definitely larger than the resulting 32-byte SHA-256 hash, but not immensely larger, which would give no benefits over a shorter string.

Reading of legacy XML files (and also fixed-size binary key files, another legacy format) is still supported, but marked as deprecated.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
When generating a new key file, a 128 byte file is created. Contents look like random binary garbage.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I added tests to cover my changes
