### PR TITLE
Show warning for legacy keyfile usage

### DIFF
--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -82,6 +82,13 @@ int Extract::execute(QStringList arguments)
             return EXIT_FAILURE;
         }
 
+        if (fileKey.type() != FileKey::Hashed) {
+            errorTextStream << QObject::tr("WARNING: You are using a legacy key file format which may become\n"
+                                               "unsupported in the future.\n\n"
+                                               "Please consider generating a new key file.");
+            errorTextStream << endl;
+        }
+
         compositeKey.addKey(fileKey);
     }
 

--- a/src/gui/ChangeMasterKeyWidget.cpp
+++ b/src/gui/ChangeMasterKeyWidget.cpp
@@ -162,6 +162,14 @@ void ChangeMasterKeyWidget::generateKey()
                tr("Failed to set %1 as the Key file:\n%2").arg(fileKeyName, errorMsg), MessageWidget::Error);
             return;
         }
+        if (fileKey.type() != FileKey::Hashed) {
+            QMessageBox::warning(this,
+                                 tr("Legacy key file format"),
+                                 tr("You are using a legacy key file format which may become\n"
+                                        "unsupported in the future.\n\n"
+                                        "Please consider generating a new key file."),
+                                 QMessageBox::Ok);
+        }
         m_key.addKey(fileKey);
     }
 

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -218,6 +218,23 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::databaseKey()
                                              MessageWidget::Error);
             return QSharedPointer<CompositeKey>();
         }
+        if (key.type() != FileKey::Hashed && !config()->get("Messages/NoLegacyKeyFileWarning").toBool()) {
+            QMessageBox legacyWarning;
+            legacyWarning.setWindowTitle(tr("Legacy key file format"));
+            legacyWarning.setText(tr("You are using a legacy key file format which may become\n"
+                                         "unsupported in the future.\n\n"
+                                         "Please consider generating a new key file."));
+            legacyWarning.setIcon(QMessageBox::Icon::Warning);
+            legacyWarning.addButton(QMessageBox::Ok);
+            legacyWarning.setDefaultButton(QMessageBox::Ok);
+            legacyWarning.setCheckBox(new QCheckBox(tr("Don't show this warning again")));
+
+            connect(legacyWarning.checkBox(), &QCheckBox::stateChanged, [](int state){
+                config()->set("Messages/NoLegacyKeyFileWarning", state == Qt::CheckState::Checked);
+            });
+
+            legacyWarning.exec();
+        }
         masterKey->addKey(key);
         lastKeyFiles[m_filename] = keyFilename;
     } else {

--- a/src/keys/FileKey.h
+++ b/src/keys/FileKey.h
@@ -28,10 +28,19 @@ class QIODevice;
 class FileKey: public Key
 {
 public:
+    enum Type {
+        None,
+        Hashed,
+        KeePass2XML,
+        FixedBinary,
+        FixedBinaryHex
+    };
+
     bool load(QIODevice* device);
     bool load(const QString& fileName, QString* errorMsg = nullptr);
     QByteArray rawKey() const override;
     FileKey* clone() const override;
+    Type type() const;
     static void create(QIODevice* device, int size = 128);
     static bool create(const QString& fileName, QString* errorMsg = nullptr, int size = 128);
 
@@ -44,6 +53,7 @@ private:
     bool loadHashed(QIODevice* device);
 
     QByteArray m_key;
+    Type m_type = None;
 };
 
 #endif // KEEPASSX_FILEKEY_H

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -35,6 +35,7 @@
 #include "keys/PasswordKey.h"
 
 QTEST_GUILESS_MAIN(TestKeys)
+Q_DECLARE_METATYPE(FileKey::Type);
 
 void TestKeys::initTestCase()
 {
@@ -84,9 +85,10 @@ void TestKeys::testComposite()
 
 void TestKeys::testFileKey()
 {
-    QFETCH(QString, type);
+    QFETCH(FileKey::Type, type);
+    QFETCH(QString, typeString);
 
-    QString name = QString("FileKey").append(type);
+    QString name = QString("FileKey").append(typeString);
 
     KeePass2Reader reader;
 
@@ -97,6 +99,9 @@ void TestKeys::testFileKey()
     FileKey fileKey;
     QVERIFY(fileKey.load(keyFilename));
     QCOMPARE(fileKey.rawKey().size(), 32);
+
+    QCOMPARE(fileKey.type(), type);
+
     compositeKey.addKey(fileKey);
 
     QScopedPointer<Database> db(reader.readDatabase(dbFilename, compositeKey));
@@ -107,12 +112,13 @@ void TestKeys::testFileKey()
 
 void TestKeys::testFileKey_data()
 {
-    QTest::addColumn<QString>("type");
-    QTest::newRow("Xml") << QString("Xml");
-    QTest::newRow("XmlBrokenBase64") << QString("XmlBrokenBase64");
-    QTest::newRow("Binary") << QString("Binary");
-    QTest::newRow("Hex") << QString("Hex");
-    QTest::newRow("Hashed") << QString("Hashed");
+    QTest::addColumn<FileKey::Type>("type");
+    QTest::addColumn<QString>("typeString");
+    QTest::newRow("Xml")             << FileKey::KeePass2XML    << QString("Xml");
+    QTest::newRow("XmlBrokenBase64") << FileKey::Hashed         << QString("XmlBrokenBase64");
+    QTest::newRow("Binary")          << FileKey::FixedBinary    << QString("Binary");
+    QTest::newRow("Hex")             << FileKey::FixedBinaryHex << QString("Hex");
+    QTest::newRow("Hashed")          << FileKey::Hashed         << QString("Hashed");
 }
 
 void TestKeys::testCreateFileKey()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This is a follow-up PR to #1326, which adds a warning when using legacy key file formats.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When we plan to deprecate old key file formats, we should tell users about it.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with additional unit tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
