### PR TITLE
Improve password generator, add option to minimize recurrences

### DIFF
--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -20,7 +20,7 @@
 
 #include "crypto/Random.h"
 #include <zxcvbn.h>
-#include <QDebug>
+//#include <QDebug>
 
 PasswordGenerator::PasswordGenerator()
     : m_length(0)
@@ -65,7 +65,7 @@ QString PasswordGenerator::generatePassword() const
     QVector<QChar> passwordChars = passwordChars_original;
 
     QString password;
-    qDebug().noquote().nospace() << "*** Begin generating password ***";
+    //qDebug().noquote().nospace() << "*** Begin generating password ***";
 
     if (m_flags & CharFromEveryGroup) {
 
@@ -106,12 +106,12 @@ QString PasswordGenerator::generatePassword() const
             int pos = randomGen()->randomUInt(groups[group].size());
             password.append(groups[group][pos]);
 
-            qDebug().noquote().nospace() << "i: " << i << ", group: " << group << ", pos: " << pos << ", groups[group][pos]: '" << groups[group][pos] << "', groups[group]: " << groups[group];
+            //qDebug().noquote().nospace() << "i: " << i << ", group: " << group << ", pos: " << pos << ", groups[group][pos]: '" << groups[group][pos] << "', groups[group]: " << groups[group];
 
             if (m_flags & MinimizeRecurrence) {
                 groups[group].remove(pos);
                 if (groups[group].isEmpty()) {
-                    qDebug().noquote().nospace() << "exhausted group " << group << ", resetting";
+                    //qDebug().noquote().nospace() << "exhausted group " << group << ", resetting";
                     groups[group] = groups_original[group];
                 }
             }
@@ -133,19 +133,19 @@ QString PasswordGenerator::generatePassword() const
             int pos = randomGen()->randomUInt(passwordChars.size());
             password.append(passwordChars[pos]);
 
-            qDebug().noquote().nospace() << "i: " << i << ", pos: " << pos << ", passwordChars[pos]: '" << passwordChars[pos] << "', passwordChars: " << passwordChars;
+            //qDebug().noquote().nospace() << "i: " << i << ", pos: " << pos << ", passwordChars[pos]: '" << passwordChars[pos] << "', passwordChars: " << passwordChars;
 
             if (m_flags & MinimizeRecurrence) {
                 passwordChars.remove(pos);
                 if (passwordChars.isEmpty()) {
-                    qDebug().noquote().nospace() << "exhausted passwordChars, resetting";
+                    //qDebug().noquote().nospace() << "exhausted passwordChars, resetting";
                     passwordChars = passwordChars_original;
                 }
             }
         }
     }
 
-    qDebug().noquote().nospace() << "*** End generating password ***";
+    //qDebug().noquote().nospace() << "*** End generating password ***";
     return password;
 }
 

--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -20,6 +20,7 @@
 
 #include "crypto/Random.h"
 #include <zxcvbn.h>
+#include <QDebug>
 
 PasswordGenerator::PasswordGenerator()
     : m_length(0)
@@ -52,47 +53,99 @@ QString PasswordGenerator::generatePassword() const
 {
     Q_ASSERT(isValid());
 
-    const QVector<PasswordGroup> groups = passwordGroups();
+    const QVector<PasswordGroup> groups_original = passwordGroups();
+    QVector<PasswordGroup> groups = groups_original;
 
-    QVector<QChar> passwordChars;
+    QVector<QChar> passwordChars_original;
     for (const PasswordGroup& group : groups) {
         for (QChar ch : group) {
-            passwordChars.append(ch);
+            passwordChars_original.append(ch);
         }
     }
+    QVector<QChar> passwordChars = passwordChars_original;
 
     QString password;
+    qDebug().noquote().nospace() << "*** Begin generating password ***";
 
     if (m_flags & CharFromEveryGroup) {
-        for (int i = 0; i < groups.size(); i++) {
-            int pos = randomGen()->randomUInt(groups[i].size());
 
-            password.append(groups[i][pos]);
+        /*
+         * Continuously add one random character from each group until pass-
+         * word has reached the desired length
+         *
+         * NOTE:
+         * Same as below, but more readable, just for reference
+         */
+        /*while (password.length() < m_length) {
+            for (int i = 0; i < groups.size(); i++) {
+                int pos = randomGen()->randomUInt(groups[i].size());
+                password.append(groups[i][pos]);
+
+                if (m_flags & MinimizeRecurrence) {
+                    groups[i].remove(pos);
+                    if (groups[i].isEmpty()) {
+                        groups[i] = groups_original[i];
+                    }
+                }
+
+                if (password.length() >= m_length) {
+                    break;
+                }
+            }
+        }*/
+
+        /*
+         * Continuously add one random character from each group until pass-
+         * word has reached the desired length
+         *
+         * NOTE:
+         * Optimized variant of above algorithm
+         */
+        for (int i = 0; i < m_length; i++) {
+            int group = i % groups.size();
+            int pos = randomGen()->randomUInt(groups[group].size());
+            password.append(groups[group][pos]);
+
+            qDebug().noquote().nospace() << "i: " << i << ", group: " << group << ", pos: " << pos << ", groups[group][pos]: '" << groups[group][pos] << "', groups[group]: " << groups[group];
+
+            if (m_flags & MinimizeRecurrence) {
+                groups[group].remove(pos);
+                if (groups[group].isEmpty()) {
+                    qDebug().noquote().nospace() << "exhausted group " << group << ", resetting";
+                    groups[group] = groups_original[group];
+                }
+            }
         }
 
-        for (int i = groups.size(); i < m_length; i++) {
-            int pos = randomGen()->randomUInt(passwordChars.size());
-
-            password.append(passwordChars[pos]);
-        }
-
-        // shuffle chars
+        /*
+         * Shuffle characters to dissolve pattern caused by generation loop
+         */
         for (int i = (password.size() - 1); i >= 1; i--) {
             int j = randomGen()->randomUInt(i + 1);
-
             QChar tmp = password[i];
             password[i] = password[j];
             password[j] = tmp;
         }
+
     }
     else {
         for (int i = 0; i < m_length; i++) {
             int pos = randomGen()->randomUInt(passwordChars.size());
-
             password.append(passwordChars[pos]);
+
+            qDebug().noquote().nospace() << "i: " << i << ", pos: " << pos << ", passwordChars[pos]: '" << passwordChars[pos] << "', passwordChars: " << passwordChars;
+
+            if (m_flags & MinimizeRecurrence) {
+                passwordChars.remove(pos);
+                if (passwordChars.isEmpty()) {
+                    qDebug().noquote().nospace() << "exhausted passwordChars, resetting";
+                    passwordChars = passwordChars_original;
+                }
+            }
         }
     }
 
+    qDebug().noquote().nospace() << "*** End generating password ***";
     return password;
 }
 

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -41,7 +41,8 @@ public:
     enum GeneratorFlag
     {
         ExcludeLookAlike   = 0x1,
-        CharFromEveryGroup = 0x2
+        CharFromEveryGroup = 0x2,
+        MinimizeRecurrence = 0x4
     };
     Q_DECLARE_FLAGS(GeneratorFlags, GeneratorFlag)
 

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -99,6 +99,7 @@ void PasswordGeneratorWidget::loadSettings()
     m_ui->checkBoxExtASCII->setChecked(config()->get("generator/EASCII", false).toBool());
     m_ui->checkBoxExcludeAlike->setChecked(config()->get("generator/ExcludeAlike", true).toBool());
     m_ui->checkBoxEnsureEvery->setChecked(config()->get("generator/EnsureEvery", true).toBool());
+    m_ui->checkBoxMinimizeRec->setChecked(config()->get("generator/MinimizeRec", false).toBool());
     m_ui->spinBoxLength->setValue(config()->get("generator/Length", PasswordGenerator::DefaultLength).toInt());
 
     // Diceware config
@@ -120,6 +121,7 @@ void PasswordGeneratorWidget::saveSettings()
     config()->set("generator/EASCII", m_ui->checkBoxExtASCII->isChecked());
     config()->set("generator/ExcludeAlike", m_ui->checkBoxExcludeAlike->isChecked());
     config()->set("generator/EnsureEvery", m_ui->checkBoxEnsureEvery->isChecked());
+    config()->set("generator/MinimizeRec", m_ui->checkBoxMinimizeRec->isChecked());
     config()->set("generator/Length", m_ui->spinBoxLength->value());
 
     // Diceware config
@@ -332,6 +334,10 @@ PasswordGenerator::GeneratorFlags PasswordGeneratorWidget::generatorFlags()
 
     if (m_ui->checkBoxEnsureEvery->isChecked()) {
         flags |= PasswordGenerator::CharFromEveryGroup;
+    }
+
+    if (m_ui->checkBoxMinimizeRec->isChecked()) {
+        flags |= PasswordGenerator::MinimizeRecurrence;
     }
 
     return flags;

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -198,31 +198,6 @@ QProgressBar::chunk {
               <item>
                <layout class="QHBoxLayout" name="alphabetLayout" stretch="0,0,0,0,1,0">
                 <item>
-                 <widget class="QToolButton" name="checkBoxUpper">
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>25</height>
-                   </size>
-                  </property>
-                  <property name="focusPolicy">
-                   <enum>Qt::StrongFocus</enum>
-                  </property>
-                  <property name="toolTip">
-                   <string>Upper Case Letters</string>
-                  </property>
-                  <property name="text">
-                   <string notr="true">A-Z</string>
-                  </property>
-                  <property name="checkable">
-                   <bool>true</bool>
-                  </property>
-                  <attribute name="buttonGroup">
-                   <string notr="true">optionButtons</string>
-                  </attribute>
-                 </widget>
-                </item>
-                <item>
                  <widget class="QToolButton" name="checkBoxLower">
                   <property name="minimumSize">
                    <size>
@@ -238,6 +213,31 @@ QProgressBar::chunk {
                   </property>
                   <property name="text">
                    <string notr="true">a-z</string>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <attribute name="buttonGroup">
+                   <string notr="true">optionButtons</string>
+                  </attribute>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QToolButton" name="checkBoxUpper">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>25</height>
+                   </size>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::StrongFocus</enum>
+                  </property>
+                  <property name="toolTip">
+                   <string>Upper Case Letters</string>
+                  </property>
+                  <property name="text">
+                   <string notr="true">A-Z</string>
                   </property>
                   <property name="checkable">
                    <bool>true</bool>
@@ -357,6 +357,16 @@ QProgressBar::chunk {
                <widget class="QCheckBox" name="checkBoxEnsureEvery">
                 <property name="text">
                  <string>Pick characters from every group</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">optionButtons</string>
+                </attribute>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxMinimizeRec">
+                <property name="text">
+                 <string>Minimize recurrences</string>
                 </property>
                 <attribute name="buttonGroup">
                  <string notr="true">optionButtons</string>
@@ -593,13 +603,24 @@ QProgressBar::chunk {
  <tabstops>
   <tabstop>editNewPassword</tabstop>
   <tabstop>togglePasswordButton</tabstop>
+  <tabstop>tabWidget</tabstop>
   <tabstop>sliderLength</tabstop>
   <tabstop>spinBoxLength</tabstop>
-  <tabstop>checkBoxUpper</tabstop>
   <tabstop>checkBoxLower</tabstop>
+  <tabstop>checkBoxUpper</tabstop>
   <tabstop>checkBoxNumbers</tabstop>
   <tabstop>checkBoxSpecialChars</tabstop>
+  <tabstop>checkBoxExtASCII</tabstop>
   <tabstop>checkBoxExcludeAlike</tabstop>
+  <tabstop>checkBoxEnsureEvery</tabstop>
+  <tabstop>checkBoxMinimizeRec</tabstop>
+  <tabstop>comboBoxWordList</tabstop>
+  <tabstop>sliderWordCount</tabstop>
+  <tabstop>spinBoxWordCount</tabstop>
+  <tabstop>editWordSeparator</tabstop>
+  <tabstop>buttonGenerate</tabstop>
+  <tabstop>buttonCopy</tabstop>
+  <tabstop>buttonApply</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
## Description
This improves the password generator and adds a new option/feature:
- Add new option/feature _'Minimize recurrences'_: when enabled, picked characters are not considered for further picks by eliminating them from the corresponding groups; groups are reset once exhausted
- Modify implementation of _'Pick characters from every group'_ option to actually do what it says: continuously pick characters from each selected group until password has reached the desired length
- Switch location of character group buttons _'a-z'_ and _'A-Z'_ in GUI to match group indices of algorithm

## Motivation
I often wondered why passwords such as _'Rb<73<U<@>gPW97f''_ are generated. Instead of having recurring characters, I'd like the algorithm to choose as many distinct characters as possible, such as _'Rb!73<U]@>gPW91f'_.

Also, while reviewing the existing implementation, I noticed the _'Pick characters from every group'_ only adds **one** character of each selected group, all other characters are picked entirely random, thus one could theoretically end up with a password like _'aA0?abcdefg'_, which is not what the option suggests, in my opinion.

## DONE
- Add new option/feature 'Minimize recurrences' (GUI option, config load/save, algorithm)
- Modify implementation of 'Pick characters from every group' option to actually do what it says
- Switch location of character group buttons 'a-z' and 'A-Z'

## TODO
- Determine cause of memory leaks / heap overflow

## How has this been tested?
- locally

## Screenshots:
![screenshot_20171229_111435](https://user-images.githubusercontent.com/14027079/34434849-7211e410-ec89-11e7-9f23-a32550692dee.png)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ❌ My change requires a change to the documentation and I have updated it accordingly.
- ❌ I have added tests to cover my changes.
