### PR TITLE
Fix auto-type regression introduced at #1174

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -332,10 +332,9 @@ bool AutoType::parseActions(const QString& sequence, const Entry* entry, QList<A
                 return false;
             } else if (ch == '}') {
                 QList<AutoTypeAction*> autoType = createActionFromTemplate(tmpl, entry);
-                if (autoType.isEmpty()) {
-                    return false;
+                if (!autoType.isEmpty()) {
+                    actions.append(autoType);
                 }
-                actions.append(autoType);
                 inTmpl = false;
                 tmpl.clear();
             } else {


### PR DESCRIPTION
Fix auto-type regression introduced at #1174 that causes the whole sequence to abort when using {delay=x} at the start.

## Description
Removed the check if the sequence is empty after the first `{}` tag since `{delay=x}` isn't added as an action at `createActionFromTemplate()` and the sequence syntax is already checked beforehand at `verifyAutoTypeSyntax()`.

## How has this been tested?
Manual testing.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
