### PR TITLE
Improve proxy path handling for the browser plugin

### DIFF
--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -156,7 +156,10 @@ void BrowserSettings::setUseCustomProxy(bool enabled)
 
 QString BrowserSettings::customProxyLocation()
 {
-    return config()->get("Browser/CustomProxyLocation", " ").toString();
+    if (!useCustomProxy()) {
+        return QString();
+    }
+    return config()->get("Browser/CustomProxyLocation", "").toString();
 }
 
 void BrowserSettings::setCustomProxyLocation(QString location)


### PR DESCRIPTION
## Description

If "Update KeePassXC binary path automatically to native messaging scripts on startup" is not selected (default behavior), native messaging host JSON file contains wrong path " ". This is caused by two issues:

1. Custom proxy path is used even if "Use a custom proxy location if you installed a proxy manually." is not selected
2. BrowserSettings::customProxyLocation() has a wrong fallback

## Motivation and context
I'm testing this new feature :)

## How has this been tested?
Manually with the just updated keepassxc-browser plugin (version 0.4.8) with Firefox Nightly 59.0a1. I tested two scenarios:

1. Default behavior
* Delete the [Browser] section from keepassxc_debug.ini
* Enable "Firefox" in "Supported browsers"
* Check ~/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json and see if it has the correct path
2. Edge case
* Enable using custom proxy path
* Use /foobar as the custom proxy path
* Re-enable Firefox support (uncheck and check Firefox in "Supported browsers")
* Disable using custom proxy path. Now the custom proxy path field is grayed out, but still has the value /foobar
* Check ~/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json and see if it has the correct path

## Screenshots (if appropriate):
N/A

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
-  I have added tests to cover my changes. (requires #25)
