### PR TITLE
Fix for building with MacPorts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -306,28 +306,6 @@ if(APPLE AND WITH_APP_BUNDLE)
                      COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
                      COMMENT "Deploying app bundle")
-
-  if(WITH_XC_BROWSER)
-    set(PROXY_BINARY_DIR "${CMAKE_BINARY_DIR}/src/proxy/keepassxc-proxy")
-    set(PROXY_APP_DIR "${PROGNAME}.app/Contents/MacOS/keepassxc-proxy")
-    add_custom_command(TARGET ${PROGNAME}
-                       POST_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E copy ${PROXY_BINARY_DIR} ${PROXY_APP_DIR}
-                       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
-                       COMMENT "Copying keepassxc-proxy inside the application")
-
-    add_custom_command(TARGET ${PROGNAME}
-                       POST_BUILD
-                       COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore" ${PROXY_APP_DIR}
-                       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
-                       COMMENT "Changing linking of keepassxc-proxy QtCore")
-
-    add_custom_command(TARGET ${PROGNAME}
-                       POST_BUILD
-                       COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork" ${PROXY_APP_DIR}
-                       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
-                       COMMENT "Changing linking of keepassxc-proxy QtNetwork")
-  endif()
 endif()
 
 install(TARGETS ${PROGNAME}

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -31,4 +31,25 @@ if(WITH_XC_BROWSER)
             BUNDLE DESTINATION . COMPONENT Runtime
             RUNTIME DESTINATION ${PROXY_INSTALL_DIR} COMPONENT Runtime)
 
+    if(APPLE AND WITH_APP_BUNDLE)
+        set(PROXY_BINARY_DIR "${CMAKE_BINARY_DIR}/src/proxy/keepassxc-proxy")
+        set(PROXY_APP_DIR "KeePassXC.app/Contents/MacOS/keepassxc-proxy")
+        add_custom_command(TARGET keepassxc-proxy
+                           POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy ${PROXY_BINARY_DIR} ${PROXY_APP_DIR}
+                           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+                           COMMENT "Copying keepassxc-proxy inside the application")
+
+        add_custom_command(TARGET keepassxc-proxy
+                           POST_BUILD
+                           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore" ${PROXY_APP_DIR}
+                           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+                           COMMENT "Changing linking of keepassxc-proxy QtCore")
+
+        add_custom_command(TARGET keepassxc-proxy
+                           POST_BUILD
+                           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork" ${PROXY_APP_DIR}
+                           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+                           COMMENT "Changing linking of keepassxc-proxy QtNetwork")
+    endif()
 endif()


### PR DESCRIPTION
Fixes for building with MacPorts

## Description
Fixes the makefiles for building keepassxc-proxy with Qt installed from MacPorts.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ❌ My change requires a change to the documentation and I have updated it accordingly.
- ❌ I have added tests to cover my changes.
