### PR TITLE
Implement #1208: CSV Import Created and Modified Dates

### DIFF
--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -37,6 +37,8 @@ const QStringList CsvImportWidget::m_columnHeader = QStringList()
     << QObject::tr("Password")
     << QObject::tr("URL")
     << QObject::tr("Notes")
+    << QObject::tr("Last Modified")
+    << QObject::tr("Created")
 //  << QObject::tr("Future field1")
 //  << QObject::tr("Future field2")
 //  << QObject::tr("Future field3")
@@ -223,6 +225,21 @@ void CsvImportWidget::writeDatabase() {
         entry->setPassword(m_parserModel->data(m_parserModel->index(r, 3)).toString());
         entry->setUrl(m_parserModel->data(m_parserModel->index(r, 4)).toString());
         entry->setNotes(m_parserModel->data(m_parserModel->index(r, 5)).toString());
+
+        TimeInfo timeInfo;
+        if (m_parserModel->data(m_parserModel->index(r, 6)).isValid()) {
+            qint64 lastModified = m_parserModel->data(m_parserModel->index(r, 6)).toString().toLongLong();
+            if (lastModified) {
+                timeInfo.setLastModificationTime(QDateTime::fromMSecsSinceEpoch(lastModified * 1000).toTimeSpec(Qt::UTC));
+            }
+        }
+        if (m_parserModel->data(m_parserModel->index(r, 7)).isValid()) {
+            qint64 created = m_parserModel->data(m_parserModel->index(r, 7)).toString().toLongLong();
+            if (created) {
+                timeInfo.setCreationTime(QDateTime::fromMSecsSinceEpoch(created * 1000).toTimeSpec(Qt::UTC));
+            }
+        }
+        entry->setTimeInfo(timeInfo);
     }
     QBuffer buffer;
     buffer.open(QBuffer::ReadWrite);


### PR DESCRIPTION
## Description
This PR adds support for importing last modified and created timestamps from CSV's exported from 1password. The user is able to map the correct columns in the CSV Import Widget and have these fields added to the new entries.

## Motivation and context
Implements feature request #1208. Currently only supports timestamps in Epoch time, since that's what 1password uses and what the ticket opener requested, although I think some good future work might be to add support for other formats from popular password managers (for instance, LastPass, bitwarden, etc. I'm not sure what format these packages use for their created and modified timestamps).

## How has this been tested?
Tested locally on Arch Linux. Tested with malformed CSVs, CSV's with the fields in different orders, CSV's without the extra fields. Also tested with unit tests with `-DWITH_ASAN=ON -DWITH_TESTS=ON -DWITH_GUI_TESTS=ON`. 

## Screenshots (if appropriate):
Field Mappings for Last Modified and Created during CSV Import:
![csvimport](https://user-images.githubusercontent.com/12201350/34645420-20e8782c-f31b-11e7-8073-320c466dfde2.png)

Created and Modified Fields Added to the Entry:
![created_modified](https://user-images.githubusercontent.com/12201350/34645425-2a585332-f31b-11e7-9917-997198a18a27.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
-  I have added tests to cover my changes.

  