### PR TITLE
High CPU fix for Linux

### DIFF
--- a/src/browser/NativeMessagingHost.cpp
+++ b/src/browser/NativeMessagingHost.cpp
@@ -93,9 +93,10 @@ void NativeMessagingHost::readLength()
 {
     quint32 length = 0;
     std::cin.read(reinterpret_cast<char*>(&length), 4);
-    if (!std::cin.eof() && length > 0)
-    {
+    if (!std::cin.eof() && length > 0) {
         readStdIn(length);
+    } else {
+    	m_notifier->setEnabled(false);
     }
 }
 


### PR DESCRIPTION
Fixes high CPU usage on Linux when stdin is not available.

## Description
Shut's down the QSocketNotifier if no data has been read.

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/1365

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
