### PR TITLE
Fix browser integration quirks

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -174,15 +174,15 @@ QString BrowserService::storeKey(const QString& key)
 
     Entry* config = getConfigEntry(true);
     if (!config) {
-        return QString();
+        return {};
     }
 
-    bool contains = false;
+    bool contains;
     QMessageBox::StandardButton dialogResult = QMessageBox::No;
 
     do {
         bool ok = false;
-        id = QInputDialog::getText(0, tr("KeePassXC: New key association request"),
+        id = QInputDialog::getText(nullptr, tr("KeePassXC: New key association request"),
                                    tr("You have received an association "
                                       "request for the above key.\n"
                                       "If you would like to allow it access "
@@ -190,13 +190,17 @@ QString BrowserService::storeKey(const QString& key)
                                       "give it a unique name to identify and accept it."),
                                     QLineEdit::Normal, QString(), &ok);
         if (!ok || id.isEmpty()) {
-            return QString();
+            return {};
         }
 
         contains = config->attributes()->contains(QLatin1String(ASSOCIATE_KEY_PREFIX) + id);
-        dialogResult = QMessageBox::warning(0, tr("KeePassXC: Overwrite existing key?"),
-                                                 tr("A shared encryption key with the name \"%1\" already exists.\nDo you want to overwrite it?").arg(id),
-                                                 QMessageBox::Yes | QMessageBox::No);
+        if (contains) {
+            dialogResult = QMessageBox::warning(nullptr, tr("KeePassXC: Overwrite existing key?"),
+                                                tr("A shared encryption key with the name \"%1\" "
+                                                   "already exists.\nDo you want to overwrite it?")
+                                                    .arg(id),
+                                                QMessageBox::Yes | QMessageBox::No);
+        }
     } while (contains && dialogResult == QMessageBox::No);
 
     config->attributes()->set(QLatin1String(ASSOCIATE_KEY_PREFIX) + id, key, true);

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -31,6 +31,7 @@
 #include "core/Metadata.h"
 #include "core/Uuid.h"
 #include "core/PasswordGenerator.h"
+#include "gui/MainWindow.h"
 
 
 // de887cc3-0363-43b8-974b-5911b8816224
@@ -60,11 +61,8 @@ bool BrowserService::isDatabaseOpened() const
         return false;
     }
 
-    if (dbWidget->currentMode() == DatabaseWidget::ViewMode || dbWidget->currentMode() == DatabaseWidget::EditMode) {
-        return true;
-    }
+    return dbWidget->currentMode() == DatabaseWidget::ViewMode || dbWidget->currentMode() == DatabaseWidget::EditMode;
 
-    return false;
 }
 
 bool BrowserService::openDatabase()
@@ -82,7 +80,8 @@ bool BrowserService::openDatabase()
         return true;
     }
 
-    m_dbTabWidget->activateWindow();
+    KEEPASSXC_MAIN_WINDOW->bringToFront();
+
     return false;
 }
 
@@ -181,15 +180,20 @@ QString BrowserService::storeKey(const QString& key)
     QMessageBox::StandardButton dialogResult = QMessageBox::No;
 
     do {
-        bool ok = false;
-        id = QInputDialog::getText(nullptr, tr("KeePassXC: New key association request"),
-                                   tr("You have received an association "
-                                      "request for the above key.\n"
-                                      "If you would like to allow it access "
-                                      "to your KeePassXC database,\n"
-                                      "give it a unique name to identify and accept it."),
-                                    QLineEdit::Normal, QString(), &ok);
-        if (!ok || id.isEmpty()) {
+        QInputDialog keyDialog;
+        keyDialog.setWindowTitle(tr("KeePassXC: New key association request"));
+        keyDialog.setLabelText(tr("You have received an association request for the above key.\n\n"
+                                      "If you would like to allow it access to your KeePassXC database,\n"
+                                      "give it a unique name to identify and accept it."));
+        keyDialog.setOkButtonText(tr("Save and allow access"));
+        keyDialog.show();
+        keyDialog.activateWindow();
+        keyDialog.raise();
+        auto ok = keyDialog.exec();
+
+        id = keyDialog.textValue();
+
+        if (ok != QDialog::Accepted || id.isEmpty()) {
             return {};
         }
 

--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -28,8 +28,7 @@
 const QString HostInstaller::HOST_NAME = "org.keepassxc.keepassxc_browser";
 const QStringList HostInstaller::ALLOWED_ORIGINS = QStringList()
     << "chrome-extension://iopaggbpplllidnfmcghoonnokmjoicf/"
-    << "chrome-extension://fhakpkpdnjecjfceboihdjpfmgajebii/"
-    << "chrome-extension://jaikbblhommnkeialomogohhdlndpfbi/";
+    << "chrome-extension://oboonakemofpalcgghocfoadofidjkkk/";
 
 const QStringList HostInstaller::ALLOWED_EXTENSIONS = QStringList()
     << "keepassxc-browser@keepassxc.org";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch fixes the following browser integration problems:

- Remove unused chrome extension IDs (except the one of @varjolintu's store release which I left for now)
- add extension ID of the to-be official store release
- show a "key already exists" warning only if the key actually does exist in the database when pairing with the browser extension
- activate the key association dialog to bring it to the front (or at least indicate in the task bar, depending on OS window raising policy)
- also properly activate / restore a minimized main window when unlocking (now also works when minimized to tray)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually on Windows.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**