### PR TITLE
Add extend entry-size calculation (resolved #1387)

### DIFF
--- a/src/core/AutoTypeAssociations.cpp
+++ b/src/core/AutoTypeAssociations.cpp
@@ -103,6 +103,15 @@ int AutoTypeAssociations::size() const
     return m_associations.size();
 }
 
+int AutoTypeAssociations::associationsSize() const
+{
+    int size = 0;
+    foreach (const Association &association, m_associations) {
+        size += association.sequence.toUtf8().size() + association.window.toUtf8().size();
+    }
+    return size;
+}
+
 void AutoTypeAssociations::clear()
 {
     m_associations.clear();

--- a/src/core/AutoTypeAssociations.cpp
+++ b/src/core/AutoTypeAssociations.cpp
@@ -106,7 +106,7 @@ int AutoTypeAssociations::size() const
 int AutoTypeAssociations::associationsSize() const
 {
     int size = 0;
-    foreach (const Association &association, m_associations) {
+    for (const Association &association : m_associations) {
         size += association.sequence.toUtf8().size() + association.window.toUtf8().size();
     }
     return size;

--- a/src/core/AutoTypeAssociations.h
+++ b/src/core/AutoTypeAssociations.h
@@ -43,6 +43,7 @@ public:
     AutoTypeAssociations::Association get(int index) const;
     QList<AutoTypeAssociations::Association> getAll() const;
     int size() const;
+    int associationsSize() const;
     void clear();
 
 private:

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -586,6 +586,7 @@ void Entry::truncateHistory()
 
         QMutableListIterator<Entry*> i(m_history);
         i.toBack();
+        const QRegularExpression delimiter(",|:|;");
         while (i.hasPrevious()) {
             Entry* historyItem = i.previous();
 
@@ -594,7 +595,8 @@ void Entry::truncateHistory()
                 size += historyItem->attributes()->attributesSize();
                 size += historyItem->autoTypeAssociations()->associationsSize();
                 size += historyItem->attachments()->attachmentsSize(foundAttachments);
-                foreach( const QString &tag, historyItem->tags().split(QRegExp(",|;|:"), QString::SkipEmptyParts)){
+                const QStringList tags = historyItem->tags().split(delimiter, QString::SkipEmptyParts);
+                for (const QString& tag : tags) {
                     size += tag.toUtf8().size();
                 }
                 foundAttachments += historyItem->attachments()->values();

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -582,7 +582,7 @@ void Entry::truncateHistory()
     int histMaxSize = db->metadata()->historyMaxSize();
     if (histMaxSize > -1) {
         int size = 0;
-        QSet<QByteArray> foundAttachments = attachments()->values().toSet();
+        QSet<QByteArray> foundAttachments = attachments()->values();
 
         QMutableListIterator<Entry*> i(m_history);
         i.toBack();
@@ -592,12 +592,12 @@ void Entry::truncateHistory()
             // don't calculate size if it's already above the maximum
             if (size <= histMaxSize) {
                 size += historyItem->attributes()->attributesSize();
-
-                const QSet<QByteArray> newAttachments = historyItem->attachments()->values().toSet() - foundAttachments;
-                for (const QByteArray& attachment : newAttachments) {
-                    size += attachment.size();
+                size += historyItem->autoTypeAssociations()->associationsSize();
+                size += historyItem->attachments()->attachmentsSize(foundAttachments);
+                foreach( const QString &tag, historyItem->tags().split(QRegExp(",|;|:"), QString::SkipEmptyParts)){
+                    size += tag.toUtf8().size();
                 }
-                foundAttachments += newAttachments;
+                foundAttachments += historyItem->attachments()->values();
             }
 
             if (size > histMaxSize) {

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -633,7 +633,7 @@ Entry* Entry::clone(CloneFlags flags) const
         entry->m_attributes->set(EntryAttributes::PasswordKey, password.toUpper(), m_attributes->isProtected(EntryAttributes::PasswordKey));
     }
 
-    entry->m_autoTypeAssociations->copyDataFrom(this->m_autoTypeAssociations);
+    entry->m_autoTypeAssociations->copyDataFrom(m_autoTypeAssociations);
     if (flags & CloneIncludeHistory) {
         for (Entry* historyItem : m_history) {
             Entry* historyItemClone = historyItem->clone(flags & ~CloneIncludeHistory & ~CloneNewUuid);
@@ -679,6 +679,7 @@ void Entry::beginUpdate()
     m_tmpHistoryItem->m_data = m_data;
     m_tmpHistoryItem->m_attributes->copyDataFrom(m_attributes);
     m_tmpHistoryItem->m_attachments->copyDataFrom(m_attachments);
+    m_tmpHistoryItem->m_autoTypeAssociations->copyDataFrom(m_autoTypeAssociations);
 
     m_modifiedSinceBegin = false;
 }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -594,7 +594,7 @@ void Entry::truncateHistory()
             if (size <= histMaxSize) {
                 size += historyItem->attributes()->attributesSize();
                 size += historyItem->autoTypeAssociations()->associationsSize();
-                size += historyItem->attachments()->attachmentsSize(foundAttachments);
+                size += historyItem->attachments()->attachmentsSize();
                 const QStringList tags = historyItem->tags().split(delimiter, QString::SkipEmptyParts);
                 for (const QString& tag : tags) {
                     size += tag.toUtf8().size();

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -153,13 +153,11 @@ bool EntryAttachments::operator!=(const EntryAttachments& other) const
     return m_attachments != other.m_attachments;
 }
 
-int EntryAttachments::attachmentsSize(const QSet<QByteArray>& ignoredAttachments) const
+int EntryAttachments::attachmentsSize() const
 {
     int size = 0;
     for (auto it = m_attachments.constBegin(); it != m_attachments.constEnd(); ++it) {
-        if (!ignoredAttachments.contains(it.value())) {
-            size += it.key().toUtf8().size() + it.value().size();
-        }
+        size += it.key().toUtf8().size() + it.value().size();
     }
     return size;
 }

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -153,16 +153,13 @@ bool EntryAttachments::operator!=(const EntryAttachments& other) const
     return m_attachments != other.m_attachments;
 }
 
-int EntryAttachments::attachmentsSize(const QSet<QByteArray> &ignoredAttachments) const
+int EntryAttachments::attachmentsSize(const QSet<QByteArray>& ignoredAttachments) const
 {
     int size = 0;
-
-    QMapIterator<QString, QByteArray> i(m_attachments);
-    while (i.hasNext()) {
-        i.next();
-        if( ! ignoredAttachments.contains( i.value() )){
-            size += i.key().toUtf8().size() + i.value().size();
-         }
+    for (auto it = m_attachments.constBegin(); it != m_attachments.constEnd(); ++it) {
+        if (!ignoredAttachments.contains(it.value())) {
+            size += it.key().toUtf8().size() + it.value().size();
+        }
     }
     return size;
 }

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -18,6 +18,7 @@
 #include "EntryAttachments.h"
 
 #include <QStringList>
+#include <QSet>
 
 EntryAttachments::EntryAttachments(QObject* parent)
     : QObject(parent)
@@ -34,9 +35,9 @@ bool EntryAttachments::hasKey(const QString& key) const
     return m_attachments.contains(key);
 }
 
-QList<QByteArray> EntryAttachments::values() const
+QSet<QByteArray> EntryAttachments::values() const
 {
-    return m_attachments.values();
+    return m_attachments.values().toSet();
 }
 
 QByteArray EntryAttachments::value(const QString& key) const
@@ -150,4 +151,14 @@ bool EntryAttachments::operator==(const EntryAttachments& other) const
 bool EntryAttachments::operator!=(const EntryAttachments& other) const
 {
     return m_attachments != other.m_attachments;
+}
+
+int EntryAttachments::attachmentsSize(const QSet<QByteArray> &ignoredAttachments) const
+{
+    int size = 0;
+    const QSet<QByteArray> consideredAttachments = m_attachments.values().toSet() - ignoredAttachments;
+    for (const QByteArray& attachment : consideredAttachments) {
+        size += attachment.size();
+    }
+    return size;
 }

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -156,9 +156,13 @@ bool EntryAttachments::operator!=(const EntryAttachments& other) const
 int EntryAttachments::attachmentsSize(const QSet<QByteArray> &ignoredAttachments) const
 {
     int size = 0;
-    const QSet<QByteArray> consideredAttachments = m_attachments.values().toSet() - ignoredAttachments;
-    for (const QByteArray& attachment : consideredAttachments) {
-        size += attachment.size();
+
+    QMapIterator<QString, QByteArray> i(m_attachments);
+    while (i.hasNext()) {
+        i.next();
+        if( ! ignoredAttachments.contains( i.value() )){
+            size += i.key().toUtf8().size() + i.value().size();
+         }
     }
     return size;
 }

--- a/src/core/EntryAttachments.h
+++ b/src/core/EntryAttachments.h
@@ -31,7 +31,7 @@ public:
     explicit EntryAttachments(QObject* parent = nullptr);
     QList<QString> keys() const;
     bool hasKey(const QString& key) const;
-    QList<QByteArray> values() const;
+    QSet<QByteArray> values() const;
     QByteArray value(const QString& key) const;
     void set(const QString& key, const QByteArray& value);
     void remove(const QString& key);
@@ -41,6 +41,7 @@ public:
     void copyDataFrom(const EntryAttachments* other);
     bool operator==(const EntryAttachments& other) const;
     bool operator!=(const EntryAttachments& other) const;
+    int attachmentsSize(const QSet<QByteArray> &ignoredAttachments) const;
 
 signals:
     void modified();

--- a/src/core/EntryAttachments.h
+++ b/src/core/EntryAttachments.h
@@ -41,7 +41,7 @@ public:
     void copyDataFrom(const EntryAttachments* other);
     bool operator==(const EntryAttachments& other) const;
     bool operator!=(const EntryAttachments& other) const;
-    int attachmentsSize(const QSet<QByteArray> &ignoredAttachments) const;
+    int attachmentsSize(const QSet<QByteArray>& ignoredAttachments) const;
 
 signals:
     void modified();

--- a/src/core/EntryAttachments.h
+++ b/src/core/EntryAttachments.h
@@ -41,7 +41,7 @@ public:
     void copyDataFrom(const EntryAttachments* other);
     bool operator==(const EntryAttachments& other) const;
     bool operator!=(const EntryAttachments& other) const;
-    int attachmentsSize(const QSet<QByteArray>& ignoredAttachments) const;
+    int attachmentsSize() const;
 
 signals:
     void modified();

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -286,11 +286,8 @@ void EntryAttributes::clear()
 int EntryAttributes::attributesSize() const
 {
     int size = 0;
-
-    QMapIterator<QString, QString> i(m_attributes);
-    while (i.hasNext()) {
-        i.next();
-        size += i.key().toUtf8().size() + i.value().toUtf8().size();
+    for (auto it = m_attributes.constBegin(); it != m_attributes.constEnd(); ++it) {
+        size += it.key().toUtf8().size() + it.value().toUtf8().size();
     }
     return size;
 }

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -283,14 +283,14 @@ void EntryAttributes::clear()
     emit modified();
 }
 
-int EntryAttributes::attributesSize()
+int EntryAttributes::attributesSize() const
 {
     int size = 0;
 
     QMapIterator<QString, QString> i(m_attributes);
     while (i.hasNext()) {
         i.next();
-        size += i.value().toUtf8().size();
+        size += i.key().toUtf8().size() + i.value().toUtf8().size();
     }
     return size;
 }

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -45,7 +45,7 @@ public:
     void copyCustomKeysFrom(const EntryAttributes* other);
     bool areCustomKeysDifferent(const EntryAttributes* other);
     void clear();
-    int attributesSize();
+    int attributesSize() const;
     void copyDataFrom(const EntryAttributes* other);
     bool operator==(const EntryAttributes& other) const;
     bool operator!=(const EntryAttributes& other) const;

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -20,7 +20,6 @@
 
 #include <QTest>
 
-#include "core/Database.h"
 #include "core/Entry.h"
 #include "core/Group.h"
 #include "crypto/Crypto.h"
@@ -48,6 +47,7 @@ void TestEntry::testHistoryItemDeletion()
 
     delete entry;
 }
+
 void TestEntry::testCopyDataFrom()
 {
     Entry* entry = new Entry();

--- a/tests/TestModified.cpp
+++ b/tests/TestModified.cpp
@@ -465,5 +465,52 @@ void TestModified::testHistoryItem()
     entry3->endUpdate();
     QCOMPARE(entry3->historyItems().size(), 2);
 
+    Entry* entry4 = new Entry();
+    entry4->setGroup(root);
+    QCOMPARE(entry4->historyItems().size(), 0);
+
+    int reservedSize = entry4->attributes()->attributesSize();
+    entry4->beginUpdate();
+    entry4->attachments()->set("test1", QByteArray(17000 - 5 - reservedSize + 1, 'a'));
+    entry4->endUpdate();
+    QCOMPARE(entry4->historyItems().size(), 1);
+
+    entry4->beginUpdate();
+    entry4->attachments()->remove("test1");
+    entry4->endUpdate();
+    QCOMPARE(entry4->historyItems().size(), 0);
+
+    entry4->beginUpdate();
+    entry4->setTags(QByteArray(17000 - reservedSize + 1, 'a'));
+    entry4->endUpdate();
+    QCOMPARE(entry4->historyItems().size(), 1);
+
+    entry4->beginUpdate();
+    entry4->setTags("");
+    entry4->endUpdate();
+    QCOMPARE(entry4->historyItems().size(), 0);
+
+    entry4->beginUpdate();
+    entry4->attributes()->set("test3", QByteArray(17000 - 5 - reservedSize + 1, 'a'));
+    entry4->endUpdate();
+    QCOMPARE(entry4->historyItems().size(), 1);
+
+    entry4->beginUpdate();
+    entry4->attributes()->remove("test3");
+    entry4->endUpdate();
+    QCOMPARE(entry4->historyItems().size(), 0);
+
+    entry4->beginUpdate();
+    AutoTypeAssociations::Association association;
+    association.window = "test3";
+    association.sequence = QByteArray(17000 - 5 - reservedSize + 1, 'a');
+    entry4->autoTypeAssociations()->add(association);
+    entry4->endUpdate();
+    QCOMPARE(entry4->historyItems().size(), 1);
+
+    entry4->beginUpdate();
+    entry4->autoTypeAssociations()->remove(0);
+    entry4->endUpdate();
+    QCOMPARE(entry4->historyItems().size(), 0);
     delete db;
 }

--- a/tests/TestModified.cpp
+++ b/tests/TestModified.cpp
@@ -400,8 +400,10 @@ void TestModified::testHistoryItem()
     entry2->endUpdate();
     QCOMPARE(entry2->historyItems().size(), 0);
 
+    const int historyMaxSize = 17000;
+
     db->metadata()->setHistoryMaxItems(-1);
-    db->metadata()->setHistoryMaxSize(17000);
+    db->metadata()->setHistoryMaxSize(historyMaxSize);
 
     entry2->beginUpdate();
     entry2->attachments()->set("test", QByteArray(18000, 'X'));
@@ -469,19 +471,21 @@ void TestModified::testHistoryItem()
     entry4->setGroup(root);
     QCOMPARE(entry4->historyItems().size(), 0);
 
+    const QString key("test");
+
     int reservedSize = entry4->attributes()->attributesSize();
     entry4->beginUpdate();
-    entry4->attachments()->set("test1", QByteArray(17000 - 5 - reservedSize + 1, 'a'));
+    entry4->attachments()->set(key, QByteArray(historyMaxSize - key.size() - reservedSize + 1, 'a'));
     entry4->endUpdate();
     QCOMPARE(entry4->historyItems().size(), 1);
 
     entry4->beginUpdate();
-    entry4->attachments()->remove("test1");
+    entry4->attachments()->remove(key);
     entry4->endUpdate();
     QCOMPARE(entry4->historyItems().size(), 0);
 
     entry4->beginUpdate();
-    entry4->setTags(QByteArray(17000 - reservedSize + 1, 'a'));
+    entry4->setTags(QByteArray(historyMaxSize - reservedSize + 1, 'a'));
     entry4->endUpdate();
     QCOMPARE(entry4->historyItems().size(), 1);
 
@@ -491,19 +495,19 @@ void TestModified::testHistoryItem()
     QCOMPARE(entry4->historyItems().size(), 0);
 
     entry4->beginUpdate();
-    entry4->attributes()->set("test3", QByteArray(17000 - 5 - reservedSize + 1, 'a'));
+    entry4->attributes()->set(key, QByteArray(historyMaxSize - key.size() - reservedSize + 1, 'a'));
     entry4->endUpdate();
     QCOMPARE(entry4->historyItems().size(), 1);
 
     entry4->beginUpdate();
-    entry4->attributes()->remove("test3");
+    entry4->attributes()->remove(key);
     entry4->endUpdate();
     QCOMPARE(entry4->historyItems().size(), 0);
 
     entry4->beginUpdate();
     AutoTypeAssociations::Association association;
-    association.window = "test3";
-    association.sequence = QByteArray(17000 - 5 - reservedSize + 1, 'a');
+    association.window = key;
+    association.sequence = QByteArray(historyMaxSize - key.size() - reservedSize + 1, 'a');
     entry4->autoTypeAssociations()->add(association);
     entry4->endUpdate();
     QCOMPARE(entry4->historyItems().size(), 1);

--- a/tests/TestModified.h
+++ b/tests/TestModified.h
@@ -29,7 +29,8 @@ private slots:
     void testSignals();
     void testGroupSets();
     void testEntrySets();
-    void testHistoryItem();
+    void testHistoryItems();
+    void testHistoryMaxSize();
 };
 
 #endif // KEEPASSX_TESTMODIFIED_H


### PR DESCRIPTION
Extended the calculation for the size of history items to match KeePass2
Small refactoring regarding readability in EntryAttachements. Fixed issue with AutoTypeAssociations which were not pushed to history.

<!--- Provide a general summary of your changes in the title above -->
Extended the calculation of the size for entries in the history to match the algorithm in KeePass2

## Description
Added calculation of the size of AutoTypeAssociations and Tags, includes the keys of EntryAttributes. Refactored EntryAttachements to match the general pattern for size calculation. AutoTypeAssociations are now copied to temp-history items to ensure that changes would be pushed to history correctly.

## Motivation and context
Please see #1387.

## How has this been tested?
Changes tested due to unit tests

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
