### PR TITLE
Browser integration settings rework and KeePassHTTP deprecation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
 #  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+#  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -41,10 +41,17 @@ option(WITH_COVERAGE "Use to build with coverage tests (GCC only)." OFF)
 option(WITH_APP_BUNDLE "Enable Application Bundle for macOS" ON)
 
 option(WITH_XC_AUTOTYPE "Include Auto-Type." ON)
-option(WITH_XC_HTTP "Include KeePassHTTP and Custom Icon Downloads." OFF)
+option(WITH_XC_NETWORKING "Include networking code (e.g. for downlading website icons)." OFF)
+option(WITH_XC_BROWSER "Include browser integration with keepassxc-browser." OFF)
+option(WITH_XC_HTTP "Include KeePassHTTP-compatible browser integration (deprecated, implies WITH_NETWORKING)." OFF)
 option(WITH_XC_YUBIKEY "Include YubiKey support." OFF)
 option(WITH_XC_SSHAGENT "Include SSH agent support." OFF)
-option(WITH_XC_BROWSER "Include browser extension support." OFF)
+
+if(WITH_XC_HTTP)
+  message(WARNING "KeePassHTTP support has been deprecated and will be removed in a future version. Please use WITH_XC_BROWSER instead!\n"
+          "For enabling / disabling network access code, WITH_XC_HTTP has been replaced by WITH_XC_NETWORKING.")
+  set(WITH_XC_NETWORKING ON CACHE BOOL "Include networking code (e.g. for downlading website icons)." FORCE)
+endif()
 
 # Process ui files automatically from source files
 set(CMAKE_AUTOUIC ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,15 +187,21 @@ set(keepassx_SOURCES_MAINEXE
     main.cpp
 )
 
-add_feature_info(AutoType WITH_XC_AUTOTYPE "Automatic password typing")
-add_feature_info(KeePassHTTP WITH_XC_HTTP "Browser integration compatible with ChromeIPass and PassIFox")
-add_feature_info(YubiKey WITH_XC_YUBIKEY "YubiKey HMAC-SHA1 challenge-response")
+add_feature_info(Auto-Type WITH_XC_AUTOTYPE "Automatic password typing")
+add_feature_info(Networking WITH_XC_NETWORKING "Compile KeePassXC with network access code (e.g. for downloading website icons)")
+add_feature_info(keepassxc-browser WITH_XC_BROWSER "Browser integration with keepassxc-browser")
+add_feature_info(KeePassHTTP WITH_XC_HTTP "Browser integration compatible with ChromeIPass and PassIFox (deprecated, implies Networking)")
 add_feature_info(SSHAgent WITH_XC_SSHAGENT "SSH agent integration compatible with KeeAgent")
-add_feature_info(keepassxc-browser WITH_XC_BROWSER "KeePassXC browser support with keepassxc-browser")
+add_feature_info(YubiKey WITH_XC_YUBIKEY "YubiKey HMAC-SHA1 challenge-response")
 
-add_subdirectory(http)
+
 if(WITH_XC_HTTP)
-    set(keepasshttp_LIB keepasshttp qhttp Qt5::Network)
+    add_subdirectory(http)
+    set(keepasshttp_LIB keepasshttp)
+endif()
+if(WITH_XC_NETWORKING)
+    add_subdirectory(http/qhttp)
+    set(keepassxcnetwork_LIB qhttp Qt5::Network)
 endif()
 
 set(BROWSER_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/browser)
@@ -247,8 +253,9 @@ add_library(keepassx_core STATIC ${keepassx_SOURCES})
 
 set_target_properties(keepassx_core PROPERTIES COMPILE_DEFINITIONS KEEPASSX_BUILDING_CORE)
 target_link_libraries(keepassx_core
-                      ${keepasshttp_LIB}
                       ${keepassxcbrowser_LIB}
+                      ${keepasshttp_LIB}
+                      ${keepassxcnetwork_LIB}
                       ${autotype_LIB}
                       ${sshagent_LIB}
                       ${YUBIKEY_LIBRARIES}

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -23,6 +23,7 @@
 #include "core/FilePath.h"
 
 #include <QMessageBox>
+#include <QtWidgets/QFileDialog>
 
 BrowserOptionDialog::BrowserOptionDialog(QWidget* parent) :
     QWidget(parent),
@@ -40,7 +41,10 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent) :
     connect(m_ui->enableBrowserSupport, SIGNAL(toggled(bool)), m_ui->tabWidget, SLOT(setEnabled(bool)));
 
     m_ui->customProxyLocation->setEnabled(m_ui->useCustomProxy->isChecked());
+    m_ui->customProxyLocationBrowseButton->setEnabled(m_ui->useCustomProxy->isChecked());
     connect(m_ui->useCustomProxy, SIGNAL(toggled(bool)), m_ui->customProxyLocation, SLOT(setEnabled(bool)));
+    connect(m_ui->useCustomProxy, SIGNAL(toggled(bool)), m_ui->customProxyLocationBrowseButton, SLOT(setEnabled(bool)));
+    connect(m_ui->customProxyLocationBrowseButton, SIGNAL(clicked()), this, SLOT(showProxyLocationFileDialog()));
 }
 
 BrowserOptionDialog::~BrowserOptionDialog()
@@ -56,6 +60,11 @@ void BrowserOptionDialog::loadSettings()
     m_ui->bestMatchOnly->setChecked(settings.bestMatchOnly());
     m_ui->unlockDatabase->setChecked(settings.unlockDatabase());
     m_ui->matchUrlScheme->setChecked(settings.matchUrlScheme());
+
+    // hide unimplemented options
+    // TODO: fix this
+    m_ui->showNotification->hide();
+    m_ui->bestMatchOnly->hide();
 
     if (settings.sortByUsername()) {
         m_ui->sortByUsername->setChecked(true);
@@ -101,4 +110,17 @@ void BrowserOptionDialog::saveSettings()
     settings.setChromiumSupport(m_ui->chromiumSupport->isChecked());
     settings.setFirefoxSupport(m_ui->firefoxSupport->isChecked());
     settings.setVivaldiSupport(m_ui->vivaldiSupport->isChecked());
+}
+
+void BrowserOptionDialog::showProxyLocationFileDialog()
+{
+#ifdef Q_OS_WIN
+    QString fileTypeFilter(tr("Executable Files (*.exe);;All Files (*.*)"));
+#else
+    QString fileTypeFilter(tr("Executable Files (*.*)"));
+#endif
+    auto proxyLocation = QFileDialog::getOpenFileName(this, tr("Select custom proxy location"),
+                                                      QFileInfo(QCoreApplication::applicationDirPath()).filePath(),
+                                                      fileTypeFilter);
+    m_ui->customProxyLocation->setText(proxyLocation);
 }

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -23,7 +23,7 @@
 #include "core/FilePath.h"
 
 #include <QMessageBox>
-#include <QtWidgets/QFileDialog>
+#include <QFileDialog>
 
 BrowserOptionDialog::BrowserOptionDialog(QWidget* parent) :
     QWidget(parent),
@@ -36,6 +36,7 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent) :
     m_ui->warningWidget->showMessage(tr("The following options can be dangerous!\nChange them only if you know what you are doing."), MessageWidget::Warning);
     m_ui->warningWidget->setIcon(FilePath::instance()->icon("status", "dialog-warning"));
     m_ui->warningWidget->setCloseButtonVisible(false);
+    m_ui->warningWidget->setAutoHideTimeout(-1);
 
     m_ui->tabWidget->setEnabled(m_ui->enableBrowserSupport->isChecked());
     connect(m_ui->enableBrowserSupport, SIGNAL(toggled(bool)), m_ui->tabWidget, SLOT(setEnabled(bool)));

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -33,7 +33,7 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent) :
     connect(m_ui->removeSharedEncryptionKeys, SIGNAL(clicked()), this, SIGNAL(removeSharedEncryptionKeys()));
     connect(m_ui->removeStoredPermissions, SIGNAL(clicked()), this, SIGNAL(removeStoredPermissions()));
 
-    m_ui->warningWidget->showMessage(tr("The following options can be dangerous!\nChange them only if you know what you are doing."), MessageWidget::Warning);
+    m_ui->warningWidget->showMessage(tr("<b>Warning:</b> The following options can be dangerous!"), MessageWidget::Warning);
     m_ui->warningWidget->setCloseButtonVisible(false);
     m_ui->warningWidget->setAutoHideTimeout(-1);
 

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -34,7 +34,6 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent) :
     connect(m_ui->removeStoredPermissions, SIGNAL(clicked()), this, SIGNAL(removeStoredPermissions()));
 
     m_ui->warningWidget->showMessage(tr("The following options can be dangerous!\nChange them only if you know what you are doing."), MessageWidget::Warning);
-    m_ui->warningWidget->setIcon(FilePath::instance()->icon("status", "dialog-warning"));
     m_ui->warningWidget->setCloseButtonVisible(false);
     m_ui->warningWidget->setAutoHideTimeout(-1);
 

--- a/src/browser/BrowserOptionDialog.h
+++ b/src/browser/BrowserOptionDialog.h
@@ -43,6 +43,9 @@ signals:
     void removeSharedEncryptionKeys();
     void removeStoredPermissions();
 
+private slots:
+    void showProxyLocationFileDialog();
+
 private:
     QScopedPointer<Ui::BrowserOptionDialog> m_ui;
 };

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>577</width>
-    <height>404</height>
+    <width>456</width>
+    <height>385</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,7 +32,7 @@
       <string>This is required for accessing your databases with keepassxc-browser</string>
      </property>
      <property name="text">
-      <string>Enable KeepassXC browser extension</string>
+      <string>Enable KeepassXC browser integration</string>
      </property>
     </widget>
    </item>
@@ -47,22 +47,93 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QCheckBox" name="showNotification">
-         <property name="text">
-          <string>Sh&amp;ow a notification when credentials are requested</string>
+        <widget class="QGroupBox" name="browsersGroupBox">
+         <property name="title">
+          <string>Enable integration for these browsers:</string>
          </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="horizontalSpacing">
+           <number>40</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="chromeSupport">
+            <property name="text">
+             <string>&amp;Google Chrome</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="firefoxSupport">
+            <property name="text">
+             <string>&amp;Firefox</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>179</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="chromiumSupport">
+            <property name="text">
+             <string>&amp;Chromium</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="vivaldiSupport">
+            <property name="text">
+             <string>&amp;Vivaldi</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="bestMatchOnly">
-         <property name="toolTip">
-          <string>Only returns the best matches for a specific URL instead of all entries for the whole domain.</string>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>4</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="showNotification">
          <property name="text">
-          <string>&amp;Return only best-matching entries</string>
+          <string>Show a &amp;notification when credentials are requested</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -82,117 +153,82 @@
           <string>Only entries with the same scheme (http://, https://, ...) are returned.</string>
          </property>
          <property name="text">
-          <string>&amp;Match URL schemes</string>
+          <string>&amp;Match URL scheme (e.g., https://...)</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QRadioButton" name="sortByUsername">
+        <widget class="QCheckBox" name="bestMatchOnly">
+         <property name="toolTip">
+          <string>Only returns the best matches for a specific URL instead of all entries for the whole domain.</string>
+         </property>
          <property name="text">
-          <string>Sort matching entries by &amp;username</string>
+          <string>&amp;Return only best-matching credentials</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QRadioButton" name="sortByTitle">
          <property name="text">
-          <string>Sort &amp;matching entries by title</string>
+          <string>Sort &amp;matching credentials by title</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="removeSharedEncryptionKeys">
+        <widget class="QRadioButton" name="sortByUsername">
          <property name="text">
-          <string>R&amp;emove all shared encryption keys from active database</string>
+          <string>Sort matching credentials by &amp;username</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="removeStoredPermissions">
-         <property name="text">
-          <string>Re&amp;move all stored permissions from entries in active database</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
+        <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>10</height>
           </size>
          </property>
         </spacer>
        </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_3">
-      <attribute name="title">
-       <string>Supported browsers</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-        <item>
-          <widget class="QLabel" name="browserLabel1">
-           <property name="text">
-            <string>Native messaging requires certain .json files to be installed. Already installed browsers are automatically detected.</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-        </item>
-        <item>
-          <widget class="QLabel" name="browserLabel2">
-           <property name="text">
-            <string>Enable KeePassXC native messaging extension for these browsers:</string>
-           </property>
-          </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="chromeSupport">
-          <property name="text">
-           <string>Chrome</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="chromiumSupport">
-          <property name="text">
-           <string>Chromium</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="firefoxSupport">
-          <property name="text">
-           <string>Firefox</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="vivaldiSupport">
-          <property name="text">
-           <string>Vivaldi</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
        <item>
-        <spacer name="verticalSpacer_3">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QPushButton" name="removeSharedEncryptionKeys">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&amp;Disconnect all browsers</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="removeStoredPermissions">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Forget all remembered &amp;permissions</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -224,14 +260,14 @@
        <item>
         <widget class="QCheckBox" name="alwaysAllowAccess">
          <property name="text">
-          <string>Always allow &amp;access to entries</string>
+          <string>Never &amp;ask before accessing credentials</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="alwaysAllowUpdate">
          <property name="text">
-          <string>Always allow &amp;updating entries</string>
+          <string>Never ask before &amp;updating credentials</string>
          </property>
         </widget>
        </item>
@@ -241,7 +277,7 @@
           <string>Only the selected database has to be connected with a client.</string>
          </property>
          <property name="text">
-          <string>Searc&amp;h in all opened databases for matching entries</string>
+          <string>Searc&amp;h in all opened databases for matching credentials</string>
          </property>
         </widget>
        </item>
@@ -261,7 +297,7 @@
           <string>Updates KeePassXC or keepassxc-proxy binary path automatically to native messaging scripts on startup.</string>
          </property>
          <property name="text">
-          <string>&amp;Update KeePassXC binary path automatically to native messaging scripts on startup</string>
+          <string>Update &amp;native messaging manifest files at startup</string>
          </property>
         </widget>
        </item>
@@ -271,7 +307,7 @@
           <string>Support a proxy application between KeePassXC and browser extension.</string>
          </property>
          <property name="text">
-          <string>&amp;Enable support for proxy application between KeePassXC and browser extension</string>
+          <string>Use a &amp;proxy application between KeePassXC and browser extension</string>
          </property>
         </widget>
        </item>
@@ -281,19 +317,30 @@
           <string>Use a custom proxy location if you installed a proxy manually.</string>
          </property>
          <property name="text">
-          <string>&amp;Use a custom proxy location</string>
+          <string>Use a &amp;custom proxy location</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="customProxyLocation">
-         <property name="maxLength">
-          <number>999</number>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLineEdit" name="customProxyLocation">
+           <property name="maxLength">
+            <number>999</number>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="customProxyLocationBrowseButton">
+           <property name="text">
+            <string>Browse...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer_4">

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -34,7 +34,7 @@ public:
     static void setShowNotification(bool showNotification);
     static bool bestMatchOnly();     //TODO!!
     static void setBestMatchOnly(bool bestMatchOnly);
-    static bool unlockDatabase();    //TODO!!
+    static bool unlockDatabase();
     static void setUnlockDatabase(bool unlockDatabase);
     static bool matchUrlScheme();
     static void setMatchUrlScheme(bool matchUrlScheme);

--- a/src/config-keepassx.h.cmake
+++ b/src/config-keepassx.h.cmake
@@ -12,11 +12,12 @@
 #define KEEPASSX_PLUGIN_DIR "${PLUGIN_INSTALL_DIR}"
 #define KEEPASSX_DATA_DIR "${DATA_INSTALL_DIR}"
 
-#cmakedefine WITH_XC_HTTP
 #cmakedefine WITH_XC_AUTOTYPE
+#cmakedefine WITH_XC_NETWORKING
+#cmakedefine WITH_XC_BROWSER
+#cmakedefine WITH_XC_HTTP
 #cmakedefine WITH_XC_YUBIKEY
 #cmakedefine WITH_XC_SSHAGENT
-#cmakedefine WITH_XC_BROWSER
 
 #cmakedefine KEEPASSXC_DIST
 #cmakedefine KEEPASSXC_DIST_TYPE "@KEEPASSXC_DIST_TYPE@"

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -78,20 +78,20 @@ AboutDialog::AboutDialog(QWidget* parent)
 #endif
 
     QString extensions;
-#ifdef WITH_XC_HTTP
-    extensions += "\n- KeePassHTTP";
-#endif
 #ifdef WITH_XC_AUTOTYPE
     extensions += "\n- Auto-Type";
 #endif
-#ifdef WITH_XC_YUBIKEY
-    extensions += "\n- YubiKey";
+#ifdef WITH_XC_BROWSER
+    extensions += "\n- Browser Integration";
+#endif
+#ifdef WITH_XC_HTTP
+    extensions += "\n- Legacy Browser Integration (KeePassHTTP)";
 #endif
 #ifdef WITH_XC_SSHAGENT
     extensions += "\n- SSH Agent";
 #endif
-#ifdef WITH_XC_BROWSER
-    extensions += "\n- Native messaging browser extension";
+#ifdef WITH_XC_YUBIKEY
+    extensions += "\n- YubiKey";
 #endif
 
     if (extensions.isEmpty())

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -30,7 +30,7 @@
 #include "gui/IconModels.h"
 #include "gui/MessageBox.h"
 
-#ifdef WITH_XC_HTTP
+#ifdef WITH_XC_NETWORKING
 #include "http/qhttp/qhttpclient.hpp"
 #include "http/qhttp/qhttpclientresponse.hpp"
 
@@ -49,11 +49,13 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     , m_database(nullptr)
     , m_defaultIconModel(new DefaultIconModel(this))
     , m_customIconModel(new CustomIconModel(this))
-    #ifdef WITH_XC_HTTP
+#ifdef WITH_XC_NETWORKING
     , m_fallbackToGoogle(true)
     , m_redirectCount(0)
+#endif
+#ifdef WITH_XC_HTTP
     , m_httpClient(nullptr)
-    #endif
+#endif
 {
     m_ui->setupUi(this);
 
@@ -146,7 +148,7 @@ void EditWidgetIcons::load(const Uuid& currentUuid, Database* database, const Ic
 
 void EditWidgetIcons::setUrl(const QString& url)
 {
-#ifdef WITH_XC_HTTP
+#ifdef WITH_XC_NETWORKING
     m_url = url;
     m_ui->faviconButton->setVisible(!url.isEmpty());
     resetFaviconDownload();
@@ -158,14 +160,14 @@ void EditWidgetIcons::setUrl(const QString& url)
 
 void EditWidgetIcons::downloadFavicon()
 {
-#ifdef WITH_XC_HTTP
+#ifdef WITH_XC_NETWORKING
     QUrl url = QUrl(m_url);
     url.setPath("/favicon.ico");
     fetchFavicon(url);
 #endif
 }
 
-#ifdef WITH_XC_HTTP
+#ifdef WITH_XC_NETWORKING
 void EditWidgetIcons::fetchFavicon(const QUrl& url)
 {
     if (nullptr == m_httpClient) {

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -32,7 +32,7 @@ class Database;
 class DefaultIconModel;
 class CustomIconModel;
 
-#ifdef WITH_XC_HTTP
+#ifdef WITH_XC_NETWORKING
 namespace qhttp {
     namespace client {
         class QHttpClient;
@@ -73,7 +73,7 @@ signals:
 
 private slots:
     void downloadFavicon();
-#ifdef WITH_XC_HTTP
+#ifdef WITH_XC_NETWORKING
     void fetchFavicon(const QUrl& url);
     void fetchFaviconFromGoogle(const QString& domain);
     void resetFaviconDownload(bool clearRedirect = true);
@@ -93,7 +93,7 @@ private:
     QString m_url;
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;
-#ifdef WITH_XC_HTTP
+#ifdef WITH_XC_NETWORKING
     QUrl m_redirectUrl;
     bool m_fallbackToGoogle;
     unsigned short m_redirectCount;

--- a/src/gui/KMessageWidget.cpp
+++ b/src/gui/KMessageWidget.cpp
@@ -287,7 +287,7 @@ void KMessageWidget::setMessageType(KMessageWidget::MessageType type)
             bg1 = palette().highlight().color();
             break;
         case Warning:
-            bg1.setRgb(181, 102, 0); // values taken from kcolorscheme.cpp (Neutral)
+            bg1.setRgb(191, 126, 7); // values taken from kcolorscheme.cpp (Neutral)
             break;
         case Error:
             bg1.setRgb(191, 3, 3); // values taken from kcolorscheme.cpp (Negative)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -77,7 +77,7 @@ public:
 
     QString name() override
     {
-        return QObject::tr("Browser Integration");
+        return QObject::tr("Browser Integration (old)");
     }
 
     QIcon icon() override
@@ -125,7 +125,7 @@ class BrowserPlugin: public ISettingsPage
 
         QString name() override
         {
-            return QObject::tr("Browser extension with native messaging");
+            return QObject::tr("Browser Integration");
         }
 
         QIcon icon() override
@@ -182,16 +182,16 @@ MainWindow::MainWindow()
     m_countDefaultAttributes = m_ui->menuEntryCopyAttribute->actions().size();
 
     restoreGeometry(config()->get("GUI/MainWindowGeometry").toByteArray());
-    #ifdef WITH_XC_HTTP
+#ifdef WITH_XC_BROWSER
+    m_ui->settingsWidget->addSettingsPage(new BrowserPlugin(m_ui->tabWidget));
+#endif
+#ifdef WITH_XC_HTTP
     m_ui->settingsWidget->addSettingsPage(new HttpPlugin(m_ui->tabWidget));
-    #endif
-    #ifdef WITH_XC_SSHAGENT
+#endif
+#ifdef WITH_XC_SSHAGENT
     SSHAgent::init(this);
     m_ui->settingsWidget->addSettingsPage(new AgentSettingsPage(m_ui->tabWidget));
-    #endif
-    #ifdef WITH_XC_BROWSER
-    m_ui->settingsWidget->addSettingsPage(new BrowserPlugin(m_ui->tabWidget));
-    #endif
+#endif
 
     setWindowIcon(filePath()->applicationIcon());
     m_ui->globalMessageWidget->setHidden(true);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -425,14 +425,14 @@ MainWindow::~MainWindow()
 
 void MainWindow::showKeePassHTTPDeprecationNotice()
 {
-    displayGlobalMessage(tr("<p>It looks like you are using KeePassHTTP for browser integration.<br>"
+    displayGlobalMessage(tr("<p>It looks like you are using KeePassHTTP for browser integration. "
                                 "This feature has been deprecated and will be removed in the future.<br>"
-                                "Please switch to keepassxc-browser instead! For help with migration,<br>"
-                                "visit our <a href=\"https://keepassxc.org/docs/keepassxc-browser-migration\">"
+                                "Please switch to keepassxc-browser instead! For help with migration, "
+                                "visit our <a class=\"link\"  href=\"https://keepassxc.org/docs/keepassxc-browser-migration\">"
                                 "keepassxc-browser migration guide</a>.</p>"),
                          MessageWidget::Warning, true, -1);
 
-    config()->set("Http/DeprecationNoticeShown", true);
+//    config()->set("Http/DeprecationNoticeShown", true);
     disconnect(m_ui->tabWidget, SIGNAL(messageDismissGlobal()), this, SLOT(showKeePassHTTPDeprecationNotice()));
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -97,6 +97,8 @@ private slots:
     void repairDatabase();
     void hideTabMessage();
     void handleScreenLock();
+    void showKeePassHTTPDeprecationNotice();
+    void openLink(const QString& link);
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -98,7 +98,6 @@ private slots:
     void hideTabMessage();
     void handleScreenLock();
     void showKeePassHTTPDeprecationNotice();
-    void openLink(const QString& link);
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -21,6 +21,9 @@
     <bool>true</bool>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>0</number>
+    </property>
     <property name="leftMargin">
      <number>0</number>
     </property>
@@ -34,13 +37,28 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="MessageWidget" name="globalMessageWidget" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
+     <widget class="QWidget" name="globalMessageWidgetContainer" native="true">
+      <layout class="QVBoxLayout" name="globalMessageWidgetLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="MessageWidget" name="globalMessageWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">MessageWidget {margin: 90px}</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
     <item>

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -47,6 +47,7 @@ void MessageWidget::showMessage(const QString &text, KMessageWidget::MessageType
 {
     setMessageType(type);
     setText(text);
+    emit showAnimationStarted();
     animatedShow();
     if (autoHideTimeout > 0) {
         m_autoHideTimer->start(autoHideTimeout);

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -18,7 +18,9 @@
 
 #include "MessageWidget.h"
 
-#include "QTimer"
+#include <QTimer>
+#include <QDesktopServices>
+#include <QUrl>
 
 const int MessageWidget::DefaultAutoHideTimeout = 6000;
 const int MessageWidget::DisableAutoHide = -1;
@@ -67,5 +69,18 @@ void MessageWidget::setAutoHideTimeout(int autoHideTimeout)
     m_autoHideTimeout = autoHideTimeout;
     if (autoHideTimeout <= 0) {
         m_autoHideTimer->stop();
+    }
+}
+
+/**
+ * Open a link using the system's default handler.
+ * Links that are not HTTP(S) links are ignored.
+ *
+ * @param link link URL
+ */
+void MessageWidget::openHttpUrl(const QString& link)
+{
+    if (link.startsWith("http://") || link.startsWith("https://")) {
+        QDesktopServices::openUrl(QUrl(link));
     }
 }

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -35,6 +35,9 @@ public:
     static const int DefaultAutoHideTimeout;
     static const int DisableAutoHide;
 
+signals:
+    void showAnimationStarted();
+
 public slots:
     void showMessage(const QString& text, MessageWidget::MessageType type);
     void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -43,6 +43,7 @@ public slots:
     void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);
     void hideMessage();
     void setAutoHideTimeout(int autoHideTimeout);
+    static void openHttpUrl(QString const& url);
 
 private:
     QTimer* m_autoHideTimer;

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -82,7 +82,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     connect(m_secUi->lockDatabaseIdleCheckBox, SIGNAL(toggled(bool)),
             m_secUi->lockDatabaseIdleSpinBox, SLOT(setEnabled(bool)));
 
-#ifndef WITH_XC_HTTP
+#ifndef WITH_XC_NETWORKING
     m_secUi->privacy->setVisible(false);
 #endif
 }

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_subdirectory(qhttp)
-
 if(WITH_XC_HTTP)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
     

--- a/src/http/OptionDialog.cpp
+++ b/src/http/OptionDialog.cpp
@@ -39,6 +39,8 @@ OptionDialog::OptionDialog(QWidget *parent) :
 
     m_ui->tabWidget->setEnabled(m_ui->enableHttpServer->isChecked());
     connect(m_ui->enableHttpServer, SIGNAL(toggled(bool)), m_ui->tabWidget, SLOT(setEnabled(bool)));
+
+    m_ui->deprecationNotice->setOpenExternalLinks(true);
 }
 
 OptionDialog::~OptionDialog()

--- a/src/http/OptionDialog.cpp
+++ b/src/http/OptionDialog.cpp
@@ -33,7 +33,6 @@ OptionDialog::OptionDialog(QWidget *parent) :
     connect(m_ui->removeStoredPermissions, SIGNAL(clicked()), this, SIGNAL(removeStoredPermissions()));
 
     m_ui->warningWidget->showMessage(tr("The following options can be dangerous!\nChange them only if you know what you are doing."), MessageWidget::Warning);
-    m_ui->warningWidget->setIcon(FilePath::instance()->icon("status", "dialog-warning"));
     m_ui->warningWidget->setCloseButtonVisible(false);
     m_ui->warningWidget->setAutoHideTimeout(MessageWidget::DisableAutoHide);
 

--- a/src/http/OptionDialog.cpp
+++ b/src/http/OptionDialog.cpp
@@ -32,14 +32,20 @@ OptionDialog::OptionDialog(QWidget *parent) :
     connect(m_ui->removeSharedEncryptionKeys, SIGNAL(clicked()), this, SIGNAL(removeSharedEncryptionKeys()));
     connect(m_ui->removeStoredPermissions, SIGNAL(clicked()), this, SIGNAL(removeStoredPermissions()));
 
-    m_ui->warningWidget->showMessage(tr("The following options can be dangerous!\nChange them only if you know what you are doing."), MessageWidget::Warning);
+    m_ui->warningWidget->showMessage(tr("<b>Warning:</b> The following options can be dangerous!"), MessageWidget::Warning);
     m_ui->warningWidget->setCloseButtonVisible(false);
     m_ui->warningWidget->setAutoHideTimeout(MessageWidget::DisableAutoHide);
 
     m_ui->tabWidget->setEnabled(m_ui->enableHttpServer->isChecked());
     connect(m_ui->enableHttpServer, SIGNAL(toggled(bool)), m_ui->tabWidget, SLOT(setEnabled(bool)));
 
-    m_ui->deprecationNotice->setOpenExternalLinks(true);
+    m_ui->deprecationNotice->showMessage(tr("<p>KeePassHTTP has been deprecated and will be removed in the future.<br>"
+                                            "Please switch to KeePassXC-Browser instead! For help with migration, visit "
+                                            "our <a href=\"https://keepassxc.org/docs/keepassxc-browser-migration\">"
+                                            "migration guide</a>.</p>"), MessageWidget::Warning);
+    m_ui->deprecationNotice->setCloseButtonVisible(false);
+    m_ui->deprecationNotice->setAutoHideTimeout(-1);
+    connect(m_ui->deprecationNotice, &MessageWidget::linkActivated, &MessageWidget::openHttpUrl);
 }
 
 OptionDialog::~OptionDialog()

--- a/src/http/OptionDialog.ui
+++ b/src/http/OptionDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>577</width>
-    <height>404</height>
+    <width>803</width>
+    <height>433</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,6 +26,13 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item>
+    <widget class="QLabel" name="deprecationNotice">
+     <property name="text">
+      <string>&lt;p&gt;&lt;b&gt;NOTE:&lt;/b&gt; KeePassHTTP has been deprecated and will be removed in the future.&lt;br&gt;Please switch to keepassxc-browser instead! For help with migration, visit our &lt;a href=&quot;https://keepassxc.org/docs/keepassxc-browser-migration&quot;&gt;keepassxc-browser migration guide&lt;/a&gt;.&lt;/p&gt;</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QCheckBox" name="enableHttpServer">
      <property name="toolTip">

--- a/src/http/OptionDialog.ui
+++ b/src/http/OptionDialog.ui
@@ -27,13 +27,6 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QLabel" name="deprecationNotice">
-     <property name="text">
-      <string>&lt;p&gt;&lt;b&gt;NOTE:&lt;/b&gt; KeePassHTTP has been deprecated and will be removed in the future.&lt;br&gt;Please switch to keepassxc-browser instead! For help with migration, visit our &lt;a href=&quot;https://keepassxc.org/docs/keepassxc-browser-migration&quot;&gt;keepassxc-browser migration guide&lt;/a&gt;.&lt;/p&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QCheckBox" name="enableHttpServer">
      <property name="toolTip">
       <string>This is required for accessing your databases from ChromeIPass or PassIFox</string>
@@ -42,6 +35,9 @@
       <string>Enable KeePassHTTP server</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <widget class="MessageWidget" name="deprecationNotice" native="true"/>
    </item>
    <item>
     <widget class="QTabWidget" name="tabWidget">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch makes the following changes to the browser integration settings:
- Reword and reorder options to make them easier to understand and more consistent
- Move browser checkboxes to "General" tab to make them first-class options (will avoid user questions later why integration isn't working)
- Hide unimplemented settings
- Add "Browse..." button to proxy location setting

Furthermore, it deprecates KeePassHTTP and the WITH_XC_HTTP CMake flag and introduces a new WITH_XC_NETWORKING flag which separates general network access code from KeePassHTTP browser integration. Setting WITH_XC_HTTP implies WITH_XC_NETWORKING.

A CMake warning is issued when a user compiles KeePassXC with the deprecated WITH_XC_HTTP flag. Another (one-time) warning is shown to the user upon opening a database if KeePassHTTP is enabled in the settings. This warning links to a migration guide on our website which is yet to be written.

As a last change, the global message widget was redesigned a little. It now has proper margins and the warning background color is a little friendlier (although still not perfect, contrast is hard to get right with this combination of white text and blue links on yellow-ish background).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
KeePassXC continues to compile and run fine with all four (three) possible combinations of the two flags WITH_XC_NETWORKING and WITH_XC_HTTP.

## Screenshots (if appropriate):
![browser-settings1](https://user-images.githubusercontent.com/911270/35020841-50a524fa-fb2e-11e7-85cc-e44ac2d0e9f8.png)
![screenshot_20180117_024319](https://user-images.githubusercontent.com/911270/35021250-5882248c-fb30-11e7-9dc0-9c46db670af4.png)
![message-widget](https://user-images.githubusercontent.com/911270/35020843-50ebaf38-fb2e-11e7-9beb-307c45345622.png)

(warning background color in the last screen shot is not quite accurate)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.