### PR TITLE
Multiple browser related fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,7 @@ The following libraries are required:
 * zlib
 * libmicrohttpd
 * libxi, libxtst, qtx11extras (optional for auto-type on X11)
-* libsodium (>= 1.0.12, optional for keepassxc-browser support)
+* libsodium (>= 1.0.12, optional for KeePassXC-Browser support)
 * libargon2
 
 
@@ -88,7 +88,7 @@ These steps place the compiled KeePassXC binary inside the `./build/src/` direct
 	  -DWITH_XC_AUTOTYPE=[ON|OFF] Enable/Disable Auto-Type (default: ON)
 	  -DWITH_XC_HTTP=[ON|OFF] Enable/Disable KeePassHTTP and custom icon downloads (default: OFF)
 	  -DWITH_XC_YUBIKEY=[ON|OFF] Enable/Disable YubiKey HMAC-SHA1 authentication support (default: OFF)
-	  -DWITH_XC_BROWSER=[ON|OFF] Enable/Disable keepassxc-browser extension support (default: OFF)
+	  -DWITH_XC_BROWSER=[ON|OFF] Enable/Disable KeePassXC-Browser extension support (default: OFF)
 
 	  -DWITH_TESTS=[ON|OFF] Enable/Disable building of unit tests (default: ON)
 	  -DWITH_GUI_TESTS=[ON|OFF] Enable/Disable building of GUI tests (default: OFF)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ so please check out your distribution's package list to see if KeePassXC is avai
 [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepasshttp-connector/) and
 [Google Chrome or Chromium](https://chrome.google.com/webstore/detail/keepasshttp-connector/dafgdjggglmmknipkhngniifhplpcldb), and
 [passafari](https://github.com/mmichaa/passafari.safariextension/) in Safari. [[See note about KeePassHTTP]](#Note_about_KeePassHTTP)
-- Browser integration with keepassxc-browser using [native messaging](https://developer.chrome.com/extensions/nativeMessaging) for [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) and [Google Chrome or Chromium](https://chrome.google.com/webstore/detail/keepassxc-browser/iopaggbpplllidnfmcghoonnokmjoicf)
+- Browser integration with KeePassXC-Browser using [native messaging](https://developer.chrome.com/extensions/nativeMessaging) for [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) and [Google Chrome or Chromium](https://chrome.google.com/webstore/detail/keepassxc-browser/iopaggbpplllidnfmcghoonnokmjoicf)
 - Many bug fixes
 
 For a full list of features and changes, read the [CHANGELOG](CHANGELOG) document.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -189,7 +189,7 @@ set(keepassx_SOURCES_MAINEXE
 
 add_feature_info(Auto-Type WITH_XC_AUTOTYPE "Automatic password typing")
 add_feature_info(Networking WITH_XC_NETWORKING "Compile KeePassXC with network access code (e.g. for downloading website icons)")
-add_feature_info(keepassxc-browser WITH_XC_BROWSER "Browser integration with keepassxc-browser")
+add_feature_info(KeePassXC-Browser WITH_XC_BROWSER "Browser integration with KeePassXC-Browser")
 add_feature_info(KeePassHTTP WITH_XC_HTTP "Browser integration compatible with ChromeIPass and PassIFox (deprecated, implies Networking)")
 add_feature_info(SSHAgent WITH_XC_SSHAGENT "SSH agent integration compatible with KeeAgent")
 add_feature_info(YubiKey WITH_XC_YUBIKEY "YubiKey HMAC-SHA1 challenge-response")

--- a/src/browser/BrowserAccessControlDialog.ui
+++ b/src/browser/BrowserAccessControlDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>keepassxc-browser Confirm Access</string>
+   <string>KeePassXC-Browser Confirm Access</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/browser/BrowserAction.h
+++ b/src/browser/BrowserAction.h
@@ -43,7 +43,8 @@ class BrowserAction : public QObject
         ERROR_KEEPASS_NO_SAVED_DATABASES_FOUND =        11,
         ERROR_KEEPASS_INCORRECT_ACTION =                12,
         ERROR_KEEPASS_EMPTY_MESSAGE_RECEIVED =          13,
-        ERROR_KEEPASS_NO_URL_PROVIDED =                 14
+        ERROR_KEEPASS_NO_URL_PROVIDED =                 14,
+        ERROR_KEEPASS_NO_LOGINS_FOUND =                 15
     };
 
 public:

--- a/src/browser/BrowserEntryConfig.cpp
+++ b/src/browser/BrowserEntryConfig.cpp
@@ -21,7 +21,7 @@
 #include "core/Entry.h"
 #include "core/EntryAttributes.h"
 
-static const char KEEPASSBROWSER_NAME[] = "keepassxc-browser Settings";  //TODO: duplicated string (also in Service.cpp)
+static const char KEEPASSBROWSER_NAME[] = "KeePassXC-Browser Settings";
 
 
 BrowserEntryConfig::BrowserEntryConfig(QObject* parent) :

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QCheckBox" name="enableBrowserSupport">
      <property name="toolTip">
-      <string>This is required for accessing your databases with keepassxc-browser</string>
+      <string>This is required for accessing your databases with KeePassXC-Browser</string>
      </property>
      <property name="text">
       <string>Enable KeepassXC browser integration</string>

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -40,9 +40,9 @@ static const unsigned char KEEPASSXCBROWSER_UUID_DATA[] = {
     0x97, 0x4b, 0x59, 0x11, 0xb8, 0x81, 0x62, 0x24
 };
 static const Uuid KEEPASSXCBROWSER_UUID = Uuid(QByteArray::fromRawData(reinterpret_cast<const char *>(KEEPASSXCBROWSER_UUID_DATA), sizeof(KEEPASSXCBROWSER_UUID_DATA)));
-static const char KEEPASSXCBROWSER_NAME[] = "keepassxc-browser Settings";
+static const char KEEPASSXCBROWSER_NAME[] = "KeePassXC-Browser Settings";
 static const char ASSOCIATE_KEY_PREFIX[] = "Public Key: ";
-static const char KEEPASSXCBROWSER_GROUP_NAME[] = "keepassxc-browser Passwords";
+static const char KEEPASSXCBROWSER_GROUP_NAME[] = "KeePassXC-Browser Passwords";
 static int        KEEPASSXCBROWSER_DEFAULT_ICON = 1;
 
 BrowserService::BrowserService(DatabaseTabWidget* parent) :
@@ -65,7 +65,7 @@ bool BrowserService::isDatabaseOpened() const
 
 }
 
-bool BrowserService::openDatabase()
+bool BrowserService::openDatabase(bool triggerUnlock)
 {
     if (!BrowserSettings::unlockDatabase()) {
         return false;
@@ -80,7 +80,9 @@ bool BrowserService::openDatabase()
         return true;
     }
 
-    KEEPASSXC_MAIN_WINDOW->bringToFront();
+    if (triggerUnlock) {
+        KEEPASSXC_MAIN_WINDOW->bringToFront();
+    }
 
     return false;
 }
@@ -189,6 +191,7 @@ QString BrowserService::storeKey(const QString& key)
         keyDialog.show();
         keyDialog.activateWindow();
         keyDialog.raise();
+        keyDialog.setWindowFlags(keyDialog.windowFlags() | Qt::WindowStaysOnTopHint);
         auto ok = keyDialog.exec();
 
         id = keyDialog.textValue();
@@ -221,7 +224,6 @@ QString BrowserService::getKey(const QString& id)
     return config->attributes()->value(QLatin1String(ASSOCIATE_KEY_PREFIX) + id);
 }
 
-// No need to use KeepassHttpProtocol. Just return a JSON array.
 QJsonArray BrowserService::findMatchingEntries(const QString& id, const QString& url, const QString& submitUrl, const QString& realm)
 {
     QJsonArray result;

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -35,7 +35,7 @@ public:
     explicit        BrowserService(DatabaseTabWidget* parent);
 
     bool            isDatabaseOpened() const;
-    bool            openDatabase();
+    bool            openDatabase(bool triggerUnlock);
     QString         getDatabaseRootUuid();
     QString         getDatabaseRecycleBinUuid();
     Entry*          getConfigEntry(bool create = false);

--- a/src/browser/NativeMessagingBase.cpp
+++ b/src/browser/NativeMessagingBase.cpp
@@ -121,7 +121,7 @@ void NativeMessagingBase::sendReply(const QJsonObject& json)
 void NativeMessagingBase::sendReply(const QString& reply)
 {
     if (!reply.isEmpty()) {
-    uint len = reply.length();
+        uint len = reply.length();
         std::cout << char(((len>>0) & 0xFF)) << char(((len>>8) & 0xFF)) << char(((len>>16) & 0xFF)) << char(((len>>24) & 0xFF));
         std::cout << reply.toStdString() << std::flush;
     }

--- a/src/browser/NativeMessagingHost.cpp
+++ b/src/browser/NativeMessagingHost.cpp
@@ -72,6 +72,11 @@ void NativeMessagingHost::run()
     if (BrowserSettings::supportBrowserProxy()) {
         QString serverPath = getLocalServerPath();
         QFile::remove(serverPath);
+
+        if (m_localServer->isListening()) {
+            m_localServer->close();
+        }
+
         m_localServer->listen(serverPath);
         connect(m_localServer.data(), SIGNAL(newConnection()), this, SLOT(newLocalConnection()));
     } else {
@@ -120,8 +125,10 @@ void NativeMessagingHost::readStdIn(const quint32 length)
 void NativeMessagingHost::newLocalConnection()
 {
     QLocalSocket* socket = m_localServer->nextPendingConnection();
-    connect(socket, SIGNAL(readyRead()), this, SLOT(newLocalMessage()));
-    connect(socket, SIGNAL(disconnected()), this, SLOT(disconnectSocket()));
+    if (socket) {
+        connect(socket, SIGNAL(readyRead()), this, SLOT(newLocalMessage()));
+        connect(socket, SIGNAL(disconnected()), this, SLOT(disconnectSocket()));
+    }
 }
 
 void NativeMessagingHost::newLocalMessage()


### PR DESCRIPTION
Multiple browser related fixes.

## Description
- Fixed new key association request popup displaying (didn't show up in the front)
- The main window is raised only when `triggerUnlock` parameter is `true` (before it was raised with every tab change if the database was locked)
- Renamed keepassxc-browser to KeePassXC-Browser in makefiles, dialogs and documents
- Added a new error `NO_LOGINS_FOUND` which is returned when there is no credentials present
- Added a missing incremented nonce to database hash response
- Fixed an error where QLocalServer was listening to an empty socket
- Error messages are returned with tr()

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
