### PR TITLE
Add diceware and passgen to the cli interface

### DIFF
--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -211,7 +211,7 @@ void BrowserSettings::setVivaldiSupport(bool enabled) {
 
 bool BrowserSettings::passwordUseNumbers()
 {
-    return config()->get("generator/Numbers", true).toBool();
+    return config()->get("generator/Numbers", PasswordGenerator::DefaultNumbers).toBool();
 }
 
 void BrowserSettings::setPasswordUseNumbers(bool useNumbers)
@@ -221,7 +221,7 @@ void BrowserSettings::setPasswordUseNumbers(bool useNumbers)
 
 bool BrowserSettings::passwordUseLowercase()
 {
-    return config()->get("generator/LowerCase", true).toBool();
+    return config()->get("generator/LowerCase", PasswordGenerator::DefaultLower).toBool();
 }
 
 void BrowserSettings::setPasswordUseLowercase(bool useLowercase)
@@ -231,7 +231,7 @@ void BrowserSettings::setPasswordUseLowercase(bool useLowercase)
 
 bool BrowserSettings::passwordUseUppercase()
 {
-    return config()->get("generator/UpperCase", true).toBool();
+    return config()->get("generator/UpperCase", PasswordGenerator::DefaultUpper).toBool();
 }
 
 void BrowserSettings::setPasswordUseUppercase(bool useUppercase)
@@ -241,7 +241,7 @@ void BrowserSettings::setPasswordUseUppercase(bool useUppercase)
 
 bool BrowserSettings::passwordUseSpecial()
 {
-    return config()->get("generator/SpecialChars", false).toBool();
+    return config()->get("generator/SpecialChars", PasswordGenerator::DefaultSpecial).toBool();
 }
 
 void BrowserSettings::setPasswordUseSpecial(bool useSpecial)
@@ -251,7 +251,7 @@ void BrowserSettings::setPasswordUseSpecial(bool useSpecial)
 
 bool BrowserSettings::passwordUseEASCII()
 {
-    return config()->get("generator/EASCII", false).toBool();
+    return config()->get("generator/EASCII", PasswordGenerator::DefaultEASCII).toBool();
 }
 
 void BrowserSettings::setPasswordUseEASCII(bool useEASCII)
@@ -261,7 +261,7 @@ void BrowserSettings::setPasswordUseEASCII(bool useEASCII)
 
 int BrowserSettings::passPhraseWordCount()
 {
-    return config()->get("generator/WordCount", 6).toInt();
+    return config()->get("generator/WordCount", PassphraseGenerator::DefaultWordCount).toInt();
 }
 
 void BrowserSettings::setPassPhraseWordCount(int wordCount)
@@ -271,7 +271,7 @@ void BrowserSettings::setPassPhraseWordCount(int wordCount)
 
 QString BrowserSettings::passPhraseWordSeparator()
 {
-    return config()->get("generator/WordSeparator", " ").toString();
+    return config()->get("generator/WordSeparator", PassphraseGenerator::DefaultSeparator).toString();
 }
 
 void BrowserSettings::setPassPhraseWordSeparator(QString separator)
@@ -291,7 +291,7 @@ void BrowserSettings::setGeneratorType(int type)
 
 bool BrowserSettings::passwordEveryGroup()
 {
-    return config()->get("generator/EnsureEvery", true).toBool();
+    return config()->get("generator/EnsureEvery", PasswordGenerator::DefaultFromEveryGroup).toBool();
 }
 
 void BrowserSettings::setPasswordEveryGroup(bool everyGroup)
@@ -301,7 +301,7 @@ void BrowserSettings::setPasswordEveryGroup(bool everyGroup)
 
 bool BrowserSettings::passwordExcludeAlike()
 {
-    return config()->get("generator/ExcludeAlike", true).toBool();
+    return config()->get("generator/ExcludeAlike", PasswordGenerator::DefaultLookAlike).toBool();
 }
 
 void BrowserSettings::setPasswordExcludeAlike(bool excludeAlike)
@@ -311,7 +311,7 @@ void BrowserSettings::setPasswordExcludeAlike(bool excludeAlike)
 
 int BrowserSettings::passwordLength()
 {
-    return config()->get("generator/Length", 20).toInt();
+    return config()->get("generator/Length", PasswordGenerator::DefaultLength).toInt();
 }
 
 void BrowserSettings::setPasswordLength(int length)

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -133,8 +133,7 @@ int Add::execute(QStringList arguments)
             passwordGenerator.setLength(passwordLength.toInt());
         }
 
-        passwordGenerator.setCharClasses(PasswordGenerator::LowerLetters | PasswordGenerator::UpperLetters |
-                                         PasswordGenerator::Numbers);
+        passwordGenerator.setCharClasses(PasswordGenerator::DefaultCharset);
         QString password = passwordGenerator.generatePassword();
         entry->setPassword(password);
     }

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -31,15 +31,15 @@
 
 Add::Add()
 {
-    this->name = QString("add");
-    this->description = QObject::tr("Add a new entry to a database.");
+    name = QString("add");
+    description = QObject::tr("Add a new entry to a database.");
 }
 
 Add::~Add()
 {
 }
 
-int Add::execute(QStringList arguments)
+int Add::execute(const QStringList& arguments)
 {
 
     QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
@@ -134,6 +134,7 @@ int Add::execute(QStringList arguments)
         }
 
         passwordGenerator.setCharClasses(PasswordGenerator::DefaultCharset);
+        passwordGenerator.setFlags(PasswordGenerator::DefaultFlags);
         QString password = passwordGenerator.generatePassword();
         entry->setPassword(password);
     }

--- a/src/cli/Add.h
+++ b/src/cli/Add.h
@@ -25,7 +25,7 @@ class Add : public Command
 public:
     Add();
     ~Add();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
 };
 
 #endif // KEEPASSXC_ADD_H

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -20,6 +20,8 @@ set(cli_SOURCES
     Clip.h
     Command.cpp
     Command.h
+    Diceware.cpp
+    Diceware.h
     Edit.cpp
     Edit.h
     Estimate.cpp
@@ -32,6 +34,8 @@ set(cli_SOURCES
     Locate.h
     Merge.cpp
     Merge.h
+    PassGen.cpp
+    PassGen.h
     Remove.cpp
     Remove.h
     Show.cpp

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -28,14 +28,14 @@ set(cli_SOURCES
     Estimate.h
     Extract.cpp
     Extract.h
+    Generate.cpp
+    Generate.h
     List.cpp
     List.h
     Locate.cpp
     Locate.h
     Merge.cpp
     Merge.h
-    PassGen.cpp
-    PassGen.h
     Remove.cpp
     Remove.h
     Show.cpp

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -32,15 +32,15 @@
 
 Clip::Clip()
 {
-    this->name = QString("clip");
-    this->description = QObject::tr("Copy an entry's password to the clipboard.");
+    name = QString("clip");
+    description = QObject::tr("Copy an entry's password to the clipboard.");
 }
 
 Clip::~Clip()
 {
 }
 
-int Clip::execute(QStringList arguments)
+int Clip::execute(const QStringList& arguments)
 {
 
     QTextStream out(stdout);

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -25,7 +25,7 @@ class Clip : public Command
 public:
     Clip();
     ~Clip();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
     int clipEntry(Database* database, QString entryPath, QString timeout);
 };
 

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -41,7 +41,7 @@ Command::~Command()
 {
 }
 
-int Command::execute(QStringList)
+int Command::execute(const QStringList&)
 {
     return EXIT_FAILURE;
 }

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -24,12 +24,14 @@
 
 #include "Add.h"
 #include "Clip.h"
+#include "Diceware.h"
 #include "Edit.h"
 #include "Estimate.h"
 #include "Extract.h"
 #include "List.h"
 #include "Locate.h"
 #include "Merge.h"
+#include "PassGen.h"
 #include "Remove.h"
 #include "Show.h"
 
@@ -61,12 +63,14 @@ void populateCommands()
     if (commands.isEmpty()) {
         commands.insert(QString("add"), new Add());
         commands.insert(QString("clip"), new Clip());
+        commands.insert(QString("diceware"), new Diceware());
         commands.insert(QString("edit"), new Edit());
         commands.insert(QString("estimate"), new Estimate());
         commands.insert(QString("extract"), new Extract());
         commands.insert(QString("locate"), new Locate());
         commands.insert(QString("ls"), new List());
         commands.insert(QString("merge"), new Merge());
+        commands.insert(QString("passgen"), new PassGen());
         commands.insert(QString("rm"), new Remove());
         commands.insert(QString("show"), new Show());
     }

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -28,10 +28,10 @@
 #include "Edit.h"
 #include "Estimate.h"
 #include "Extract.h"
+#include "Generate.h"
 #include "List.h"
 #include "Locate.h"
 #include "Merge.h"
-#include "PassGen.h"
 #include "Remove.h"
 #include "Show.h"
 
@@ -67,10 +67,10 @@ void populateCommands()
         commands.insert(QString("edit"), new Edit());
         commands.insert(QString("estimate"), new Estimate());
         commands.insert(QString("extract"), new Extract());
+        commands.insert(QString("generate"), new Generate());
         commands.insert(QString("locate"), new Locate());
         commands.insert(QString("ls"), new List());
         commands.insert(QString("merge"), new Merge());
-        commands.insert(QString("passgen"), new PassGen());
         commands.insert(QString("rm"), new Remove());
         commands.insert(QString("show"), new Show());
     }

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -29,7 +29,7 @@ class Command
 {
 public:
     virtual ~Command();
-    virtual int execute(QStringList arguments);
+    virtual int execute(const QStringList& arguments);
     QString name;
     QString description;
     QString getDescriptionLine();

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include "Diceware.h"
+
+#include <QCommandLineParser>
+#include <QTextStream>
+
+#include "core/PassphraseGenerator.h"
+
+Diceware::Diceware()
+{
+    this->name = QString("diceware");
+    this->description = QObject::tr("Generate a new random password.");
+}
+
+Diceware::~Diceware()
+{
+}
+
+int Diceware::execute(QStringList arguments)
+{
+    QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
+    QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(this->description);
+    QCommandLineOption wordlistFile(QStringList() << "w"
+                                             << "wordlist",
+                               QObject::tr("Wordlist fot the diceware generator.\n[Default: EFF English]"),
+                               QObject::tr("path"));
+    parser.addOption(wordlistFile);
+    parser.addPositionalArgument("words", QObject::tr("Word count for the diceware generator."));
+    parser.process(arguments);
+
+    const QStringList args = parser.positionalArguments();
+    if (args.size() != 1) {
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli diceware");
+        return EXIT_FAILURE;
+    }
+
+    PassphraseGenerator dicewareGenerator;
+
+    int words = args.at(0).toInt();
+    dicewareGenerator.setWordCount(words);
+
+    if (!parser.value(wordlistFile).isEmpty()) {
+        dicewareGenerator.setWordList(parser.value(wordlistFile));
+    } else {
+        dicewareGenerator.setDefaultWordList();
+    }
+
+    if (!dicewareGenerator.isValid()) {
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli passgen");
+        return EXIT_FAILURE;
+    }
+    
+    QString password = dicewareGenerator.generatePassphrase();
+    outputTextStream << password << endl;
+
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -27,15 +27,15 @@
 
 Diceware::Diceware()
 {
-    this->name = QString("diceware");
-    this->description = QObject::tr("Generate a new random password.");
+    name = QString("diceware");
+    description = QObject::tr("Generate a new random diceware passphrase.");
 }
 
 Diceware::~Diceware()
 {
 }
 
-int Diceware::execute(QStringList arguments)
+int Diceware::execute(const QStringList& arguments)
 {
     QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
     QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
@@ -48,13 +48,13 @@ int Diceware::execute(QStringList arguments)
     parser.addOption(words);
     QCommandLineOption wordlistFile(QStringList() << "w"
                                              << "word-list",
-                               QObject::tr("Wordlist fot the diceware generator.\n[Default: EFF English]"),
+                               QObject::tr("Wordlist for the diceware generator.\n[Default: EFF English]"),
                                QObject::tr("path"));
     parser.addOption(wordlistFile);
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
-    if (args.size() != 0) {
+    if (!args.isEmpty()) {
         outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli diceware");
         return EXIT_FAILURE;
     }

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -42,24 +42,31 @@ int Diceware::execute(QStringList arguments)
 
     QCommandLineParser parser;
     parser.setApplicationDescription(this->description);
+    QCommandLineOption words(QStringList() << "W" << "words",
+                                QObject::tr("Word count for the diceware passphrase."),
+                                QObject::tr("count"));
+    parser.addOption(words);
     QCommandLineOption wordlistFile(QStringList() << "w"
                                              << "word-list",
                                QObject::tr("Wordlist fot the diceware generator.\n[Default: EFF English]"),
                                QObject::tr("path"));
     parser.addOption(wordlistFile);
-    parser.addPositionalArgument("words", QObject::tr("Word count for the diceware generator."));
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
-    if (args.size() != 1) {
+    if (args.size() != 0) {
         outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli diceware");
         return EXIT_FAILURE;
     }
 
     PassphraseGenerator dicewareGenerator;
 
-    int words = args.at(0).toInt();
-    dicewareGenerator.setWordCount(words);
+    if (parser.value(words).isEmpty()) {
+        dicewareGenerator.setWordCount(PassphraseGenerator::DefaultWordCount);
+    } else {
+        int wordcount = parser.value(words).toInt();
+        dicewareGenerator.setWordCount(wordcount);
+    }
 
     if (!parser.value(wordlistFile).isEmpty()) {
         dicewareGenerator.setWordList(parser.value(wordlistFile));

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -43,7 +43,7 @@ int Diceware::execute(QStringList arguments)
     QCommandLineParser parser;
     parser.setApplicationDescription(this->description);
     QCommandLineOption wordlistFile(QStringList() << "w"
-                                             << "wordlist",
+                                             << "word-list",
                                QObject::tr("Wordlist fot the diceware generator.\n[Default: EFF English]"),
                                QObject::tr("path"));
     parser.addOption(wordlistFile);
@@ -68,7 +68,7 @@ int Diceware::execute(QStringList arguments)
     }
 
     if (!dicewareGenerator.isValid()) {
-        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli passgen");
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli diceware");
         return EXIT_FAILURE;
     }
     

--- a/src/cli/Diceware.h
+++ b/src/cli/Diceware.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_DICEWARE_H
+#define KEEPASSXC_DICEWARE_H
+
+#include "Command.h"
+
+class Diceware : public Command
+{
+public:
+    Diceware();
+    ~Diceware();
+    int execute(QStringList arguments);
+};
+
+#endif // KEEPASSXC_DICEWARE_H

--- a/src/cli/Diceware.h
+++ b/src/cli/Diceware.h
@@ -25,7 +25,7 @@ class Diceware : public Command
 public:
     Diceware();
     ~Diceware();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
 };
 
 #endif // KEEPASSXC_DICEWARE_H

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -149,8 +149,7 @@ int Edit::execute(QStringList arguments)
             passwordGenerator.setLength(passwordLength.toInt());
         }
 
-        passwordGenerator.setCharClasses(PasswordGenerator::LowerLetters | PasswordGenerator::UpperLetters |
-                                         PasswordGenerator::Numbers);
+        passwordGenerator.setCharClasses(PasswordGenerator::DefaultCharset);
         QString password = passwordGenerator.generatePassword();
         entry->setPassword(password);
     }

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -31,15 +31,15 @@
 
 Edit::Edit()
 {
-    this->name = QString("edit");
-    this->description = QObject::tr("Edit an entry.");
+    name = QString("edit");
+    description = QObject::tr("Edit an entry.");
 }
 
 Edit::~Edit()
 {
 }
 
-int Edit::execute(QStringList arguments)
+int Edit::execute(const QStringList& arguments)
 {
 
     QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
@@ -150,6 +150,7 @@ int Edit::execute(QStringList arguments)
         }
 
         passwordGenerator.setCharClasses(PasswordGenerator::DefaultCharset);
+        passwordGenerator.setFlags(PasswordGenerator::DefaultFlags);
         QString password = passwordGenerator.generatePassword();
         entry->setPassword(password);
     }

--- a/src/cli/Edit.h
+++ b/src/cli/Edit.h
@@ -25,7 +25,7 @@ class Edit : public Command
 public:
     Edit();
     ~Edit();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
 };
 
 #endif // KEEPASSXC_EDIT_H

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -34,8 +34,8 @@
 
 Estimate::Estimate()
 {
-    this->name = QString("estimate");
-    this->description = QObject::tr("Estimate the entropy of a password.");
+    name = QString("estimate");
+    description = QObject::tr("Estimate the entropy of a password.");
 }
 
 Estimate::~Estimate()
@@ -138,7 +138,7 @@ static void estimate(const char* pwd, bool advanced)
     }
 }
 
-int Estimate::execute(QStringList arguments)
+int Estimate::execute(const QStringList& arguments)
 {
     QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
     QTextStream outputTextStream(stdout, QIODevice::WriteOnly);

--- a/src/cli/Estimate.h
+++ b/src/cli/Estimate.h
@@ -25,7 +25,7 @@ class Estimate : public Command
 public:
     Estimate();
     ~Estimate();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
 };
 
 #endif // KEEPASSXC_ESTIMATE_H

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -33,15 +33,15 @@
 
 Extract::Extract()
 {
-    this->name = QString("extract");
-    this->description = QObject::tr("Extract and print the content of a database.");
+    name = QString("extract");
+    description = QObject::tr("Extract and print the content of a database.");
 }
 
 Extract::~Extract()
 {
 }
 
-int Extract::execute(QStringList arguments)
+int Extract::execute(const QStringList& arguments)
 {
     QTextStream out(stdout);
     QTextStream errorTextStream(stderr);

--- a/src/cli/Extract.h
+++ b/src/cli/Extract.h
@@ -25,7 +25,7 @@ class Extract : public Command
 public:
     Extract();
     ~Extract();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
 };
 
 #endif // KEEPASSXC_EXTRACT_H

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -18,24 +18,24 @@
 #include <cstdlib>
 #include <stdio.h>
 
-#include "PassGen.h"
+#include "Generate.h"
 
 #include <QCommandLineParser>
 #include <QTextStream>
 
 #include "core/PasswordGenerator.h"
 
-PassGen::PassGen()
+Generate::Generate()
 {
-    this->name = QString("passgen");
+    this->name = QString("generate");
     this->description = QObject::tr("Generate a new random password.");
 }
 
-PassGen::~PassGen()
+Generate::~Generate()
 {
 }
 
-int PassGen::execute(QStringList arguments)
+int Generate::execute(QStringList arguments)
 {
     QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
     QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
@@ -65,7 +65,7 @@ int PassGen::execute(QStringList arguments)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 0) {
-        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli passgen");
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli generate");
         return EXIT_FAILURE;
     }
 
@@ -99,7 +99,7 @@ int PassGen::execute(QStringList arguments)
     passwordGenerator.setCharClasses(classes);
 
     if (!passwordGenerator.isValid()) {
-        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli passgen");
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli generate");
         return EXIT_FAILURE;
     }
 

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -27,15 +27,15 @@
 
 Generate::Generate()
 {
-    this->name = QString("generate");
-    this->description = QObject::tr("Generate a new random password.");
+    name = QString("generate");
+    description = QObject::tr("Generate a new random password.");
 }
 
 Generate::~Generate()
 {
 }
 
-int Generate::execute(QStringList arguments)
+int Generate::execute(const QStringList& arguments)
 {
     QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
     QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
@@ -47,10 +47,10 @@ int Generate::execute(QStringList arguments)
                                 QObject::tr("length"));
     parser.addOption(len);
     QCommandLineOption lower(QStringList() << "l",
-                               QObject::tr("Use lowercase in the generated password."));
+                               QObject::tr("Use lowercase characters in the generated password."));
     parser.addOption(lower);
     QCommandLineOption upper(QStringList() << "u",
-                               QObject::tr("Use uppercase in the generated password."));
+                               QObject::tr("Use uppercase characters in the generated password."));
     parser.addOption(upper);
     QCommandLineOption numeric(QStringList() << "n",
                                QObject::tr("Use numbers in the generated password."));
@@ -59,12 +59,12 @@ int Generate::execute(QStringList arguments)
                                QObject::tr("Use special characters in the generated password."));
     parser.addOption(special);
     QCommandLineOption extended(QStringList() << "e",
-                               QObject::tr("Use extended ascii in the generated password."));
+                               QObject::tr("Use extended ASCII in the generated password."));
     parser.addOption(extended);
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
-    if (args.size() != 0) {
+    if (!args.isEmpty()) {
         outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli generate");
         return EXIT_FAILURE;
     }
@@ -97,6 +97,7 @@ int Generate::execute(QStringList arguments)
     }
 
     passwordGenerator.setCharClasses(classes);
+    passwordGenerator.setFlags(PasswordGenerator::DefaultFlags);
 
     if (!passwordGenerator.isValid()) {
         outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli generate");

--- a/src/cli/Generate.h
+++ b/src/cli/Generate.h
@@ -15,17 +15,17 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSXC_PASSGEN_H
-#define KEEPASSXC_PASSGEN_H
+#ifndef KEEPASSXC_GENERATE_H
+#define KEEPASSXC_GENERATE_H
 
 #include "Command.h"
 
-class PassGen : public Command
+class Generate : public Command
 {
 public:
-    PassGen();
-    ~PassGen();
+    Generate();
+    ~Generate();
     int execute(QStringList arguments);
 };
 
-#endif // KEEPASSXC_PASSGEN_H
+#endif // KEEPASSXC_GENERATE_H

--- a/src/cli/Generate.h
+++ b/src/cli/Generate.h
@@ -25,7 +25,7 @@ class Generate : public Command
 public:
     Generate();
     ~Generate();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
 };
 
 #endif // KEEPASSXC_GENERATE_H

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -29,15 +29,15 @@
 
 List::List()
 {
-    this->name = QString("ls");
-    this->description = QObject::tr("List database entries.");
+    name = QString("ls");
+    description = QObject::tr("List database entries.");
 }
 
 List::~List()
 {
 }
 
-int List::execute(QStringList arguments)
+int List::execute(const QStringList& arguments)
 {
     QTextStream out(stdout);
 

--- a/src/cli/List.h
+++ b/src/cli/List.h
@@ -25,7 +25,7 @@ class List : public Command
 public:
     List();
     ~List();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
     int listGroup(Database* database, QString groupPath = QString(""));
 };
 

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -31,15 +31,15 @@
 
 Locate::Locate()
 {
-    this->name = QString("locate");
-    this->description = QObject::tr("Find entries quickly.");
+    name = QString("locate");
+    description = QObject::tr("Find entries quickly.");
 }
 
 Locate::~Locate()
 {
 }
 
-int Locate::execute(QStringList arguments)
+int Locate::execute(const QStringList& arguments)
 {
 
     QTextStream out(stdout);

--- a/src/cli/Locate.h
+++ b/src/cli/Locate.h
@@ -25,7 +25,7 @@ class Locate : public Command
 public:
     Locate();
     ~Locate();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
     int locateEntry(Database* database, QString searchTerm);
 };
 

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -26,15 +26,15 @@
 
 Merge::Merge()
 {
-    this->name = QString("merge");
-    this->description = QObject::tr("Merge two databases.");
+    name = QString("merge");
+    description = QObject::tr("Merge two databases.");
 }
 
 Merge::~Merge()
 {
 }
 
-int Merge::execute(QStringList arguments)
+int Merge::execute(const QStringList& arguments)
 {
     QTextStream out(stdout);
 

--- a/src/cli/Merge.h
+++ b/src/cli/Merge.h
@@ -25,7 +25,7 @@ class Merge : public Command
 public:
     Merge();
     ~Merge();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
 };
 
 #endif // KEEPASSXC_MERGE_H

--- a/src/cli/PassGen.cpp
+++ b/src/cli/PassGen.cpp
@@ -96,12 +96,7 @@ int PassGen::execute(QStringList arguments)
         classes |= PasswordGenerator::EASCII; 
     }
 
-    if (classes == 0x0) {
-        passwordGenerator.setCharClasses(PasswordGenerator::LowerLetters | PasswordGenerator::UpperLetters |
-                                         PasswordGenerator::Numbers);
-    } else {
-        passwordGenerator.setCharClasses(classes);
-    }
+    passwordGenerator.setCharClasses(classes);
 
     if (!passwordGenerator.isValid()) {
         outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli passgen");

--- a/src/cli/PassGen.cpp
+++ b/src/cli/PassGen.cpp
@@ -42,6 +42,10 @@ int PassGen::execute(QStringList arguments)
 
     QCommandLineParser parser;
     parser.setApplicationDescription(this->description);
+    QCommandLineOption len(QStringList() << "L" << "length",
+                                QObject::tr("Length of the generated password."),
+                                QObject::tr("length"));
+    parser.addOption(len);
     QCommandLineOption lower(QStringList() << "l",
                                QObject::tr("Use lowercase in the generated password."));
     parser.addOption(lower);
@@ -57,19 +61,22 @@ int PassGen::execute(QStringList arguments)
     QCommandLineOption extended(QStringList() << "e",
                                QObject::tr("Use extended ascii in the generated password."));
     parser.addOption(extended);
-    parser.addPositionalArgument("length", QObject::tr("Length of the generated password."));
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
-    if (args.size() != 1) {
+    if (args.size() != 0) {
         outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli passgen");
         return EXIT_FAILURE;
     }
 
     PasswordGenerator passwordGenerator;
 
-    int length = args.at(0).toInt();
-    passwordGenerator.setLength(length);
+    if (parser.value(len).isEmpty()) {
+        passwordGenerator.setLength(PasswordGenerator::DefaultLength);
+    } else {
+        int length = parser.value(len).toInt();
+        passwordGenerator.setLength(length);
+    }
 
     PasswordGenerator::CharClasses classes = 0x0;
 

--- a/src/cli/PassGen.cpp
+++ b/src/cli/PassGen.cpp
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include "PassGen.h"
+
+#include <QCommandLineParser>
+#include <QTextStream>
+
+#include "core/PasswordGenerator.h"
+
+PassGen::PassGen()
+{
+    this->name = QString("passgen");
+    this->description = QObject::tr("Generate a new random password.");
+}
+
+PassGen::~PassGen()
+{
+}
+
+int PassGen::execute(QStringList arguments)
+{
+    QTextStream inputTextStream(stdin, QIODevice::ReadOnly);
+    QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(this->description);
+    QCommandLineOption lower(QStringList() << "l",
+                               QObject::tr("Use lowercase in the generated password."));
+    parser.addOption(lower);
+    QCommandLineOption upper(QStringList() << "u",
+                               QObject::tr("Use uppercase in the generated password."));
+    parser.addOption(upper);
+    QCommandLineOption numeric(QStringList() << "n",
+                               QObject::tr("Use numbers in the generated password."));
+    parser.addOption(numeric);
+    QCommandLineOption special(QStringList() << "s",
+                               QObject::tr("Use special characters in the generated password."));
+    parser.addOption(special);
+    QCommandLineOption extended(QStringList() << "e",
+                               QObject::tr("Use extended ascii in the generated password."));
+    parser.addOption(extended);
+    parser.addPositionalArgument("length", QObject::tr("Length of the generated password."));
+    parser.process(arguments);
+
+    const QStringList args = parser.positionalArguments();
+    if (args.size() != 1) {
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli passgen");
+        return EXIT_FAILURE;
+    }
+
+    PasswordGenerator passwordGenerator;
+
+    int length = args.at(0).toInt();
+    passwordGenerator.setLength(length);
+
+    PasswordGenerator::CharClasses classes = 0x0;
+
+    if (parser.isSet(lower)) {
+        classes |= PasswordGenerator::LowerLetters; 
+    }
+    if (parser.isSet(upper)) {
+        classes |= PasswordGenerator::UpperLetters; 
+    }
+    if (parser.isSet(numeric)) {
+        classes |= PasswordGenerator::Numbers; 
+    }
+    if (parser.isSet(special)) {
+        classes |= PasswordGenerator::SpecialCharacters; 
+    }
+    if (parser.isSet(extended)) {
+        classes |= PasswordGenerator::EASCII; 
+    }
+
+    if (classes == 0x0) {
+        passwordGenerator.setCharClasses(PasswordGenerator::LowerLetters | PasswordGenerator::UpperLetters |
+                                         PasswordGenerator::Numbers);
+    } else {
+        passwordGenerator.setCharClasses(classes);
+    }
+
+    if (!passwordGenerator.isValid()) {
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli passgen");
+        return EXIT_FAILURE;
+    }
+
+    QString password = passwordGenerator.generatePassword();
+    outputTextStream << password << endl;
+
+    return EXIT_SUCCESS;
+}

--- a/src/cli/PassGen.h
+++ b/src/cli/PassGen.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_PASSGEN_H
+#define KEEPASSXC_PASSGEN_H
+
+#include "Command.h"
+
+class PassGen : public Command
+{
+public:
+    PassGen();
+    ~PassGen();
+    int execute(QStringList arguments);
+};
+
+#endif // KEEPASSXC_PASSGEN_H

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -34,15 +34,15 @@
 
 Remove::Remove()
 {
-    this->name = QString("rm");
-    this->description = QString("Remove an entry from the database.");
+    name = QString("rm");
+    description = QString("Remove an entry from the database.");
 }
 
 Remove::~Remove()
 {
 }
 
-int Remove::execute(QStringList arguments)
+int Remove::execute(const QStringList& arguments)
 {
     QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
 

--- a/src/cli/Remove.h
+++ b/src/cli/Remove.h
@@ -27,7 +27,7 @@ class Remove : public Command
 public:
     Remove();
     ~Remove();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
     int removeEntry(Database* database, QString databasePath, QString entryPath);
 };
 

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -29,15 +29,15 @@
 
 Show::Show()
 {
-    this->name = QString("show");
-    this->description = QObject::tr("Show an entry's information.");
+    name = QString("show");
+    description = QObject::tr("Show an entry's information.");
 }
 
 Show::~Show()
 {
 }
 
-int Show::execute(QStringList arguments)
+int Show::execute(const QStringList& arguments)
 {
     QTextStream out(stdout);
 

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -25,7 +25,7 @@ class Show : public Command
 public:
     Show();
     ~Show();
-    int execute(QStringList arguments);
+    int execute(const QStringList& arguments);
     int showEntry(Database* database, QStringList attributes, QString entryPath);
 };
 

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -76,7 +76,7 @@ QString Utils::getPassword()
  * A valid and running event loop is needed to use the global QClipboard,
  * so we need to use this from the CLI.
  */
-int Utils::clipText(QString text)
+int Utils::clipText(const QString& text)
 {
 
     QString programName = "";

--- a/src/cli/Utils.h
+++ b/src/cli/Utils.h
@@ -25,7 +25,7 @@ class Utils
 public:
     static void setStdinEcho(bool enable);
     static QString getPassword();
-    static int clipText(QString text);
+    static int clipText(const QString& text);
 };
 
 #endif // KEEPASSXC_UTILS_H

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -1,4 +1,4 @@
-.TH KEEPASSXC-CLI 1 "Aug 22, 2017"
+.TH KEEPASSXC-CLI 1 "Jan 19, 2018"
 
 .SH NAME
 keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
@@ -19,6 +19,9 @@ Adds a new entry to a database. A password can be generated (\fI-g\fP option), o
 .IP "clip [options] <database> <entry> [timeout]"
 Copies the password of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
 
+.IP "diceware [options] <words>"
+Generate a random diceware passphrase.
+
 .IP "edit [options] <database> <entry>"
 Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
@@ -36,6 +39,9 @@ Lists the contents of a group in a database. If no group is specified, it will d
 
 .IP "merge [options] <database1> <database2>"
 Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
+
+.IP "passgen [options] <length>"
+Generate a random password
 
 .IP "rm [options] <database> <entry>"
 Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
@@ -102,6 +108,33 @@ Perform advanced analysis on the password.
 Names of the attributes to show. This option can be specified more than once,
 with each attribute shown one-per-line in the given order. If no attributes are
 specified, a summary of the default attributes is given.
+
+
+.SS "Diceware options"
+
+.IP "-w, --wordlist <path>"
+Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
+otherwise the program will fail. If the wordlist has < 4000 words a warning will
+be printed to STDERR.
+
+
+.SS "PassGen options"
+
+.IP "-l"
+Use lowercase characters for the password generator
+
+.IP "-u"
+Use uppercase characters for the password generator
+
+.IP "-n"
+Use numbers characters for the password generator
+
+.IP "-s"
+Use special characters for the password generator
+
+.IP "-e"
+Use extended ascii characters for the password generator
+
 
 
 .SH REPORTING BUGS

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -32,7 +32,7 @@ Estimates the entropy of a password. The password to estimate can be provided as
 Extracts and prints the contents of a database to standard output in XML format.
 
 .IP "generate [options]"
-Generate a random password
+Generate a random password.
 
 .IP "locate [options] <database> <term>"
 Locates all the entries that match a specific search term in a database.
@@ -139,7 +139,7 @@ Use numbers characters for the generated password. [Default: Enabled]
 Use special characters for the generated password. [Default: Disabled]
 
 .IP "-e"
-Use extended ascii characters for the generated password. [Default: Disabled]
+Use extended ASCII characters for the generated password. [Default: Disabled]
 
 
 

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -112,7 +112,7 @@ specified, a summary of the default attributes is given.
 
 .SS "Diceware options"
 
-.IP "-w, --wordlist <path>"
+.IP "-w, --word-list <path>"
 Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
 otherwise the program will fail. If the wordlist has < 4000 words a warning will
 be printed to STDERR.

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -19,7 +19,7 @@ Adds a new entry to a database. A password can be generated (\fI-g\fP option), o
 .IP "clip [options] <database> <entry> [timeout]"
 Copies the password of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
 
-.IP "diceware [options] <words>"
+.IP "diceware [options]"
 Generate a random diceware passphrase.
 
 .IP "edit [options] <database> <entry>"
@@ -31,6 +31,9 @@ Estimates the entropy of a password. The password to estimate can be provided as
 .IP "extract [options] <database>"
 Extracts and prints the contents of a database to standard output in XML format.
 
+.IP "generate [options]"
+Generate a random password
+
 .IP "locate [options] <database> <term>"
 Locates all the entries that match a specific search term in a database.
 
@@ -39,9 +42,6 @@ Lists the contents of a group in a database. If no group is specified, it will d
 
 .IP "merge [options] <database1> <database2>"
 Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
-
-.IP "passgen [options] <length>"
-Generate a random password
 
 .IP "rm [options] <database> <entry>"
 Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
@@ -112,28 +112,34 @@ specified, a summary of the default attributes is given.
 
 .SS "Diceware options"
 
+.IP "-W, --words <count>"
+Desired number of words for the generated passphrase. [Default: 7]
+
 .IP "-w, --word-list <path>"
 Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
 otherwise the program will fail. If the wordlist has < 4000 words a warning will
 be printed to STDERR.
 
 
-.SS "PassGen options"
+.SS "Generate options"
+
+.IP "-L, --length <length>"
+Desired length for the generated password. [Default: 16]
 
 .IP "-l"
-Use lowercase characters for the password generator
+Use lowercase characters for the generated password. [Default: Enabled]
 
 .IP "-u"
-Use uppercase characters for the password generator
+Use uppercase characters for the generated password. [Default: Enabled]
 
 .IP "-n"
-Use numbers characters for the password generator
+Use numbers characters for the generated password. [Default: Enabled]
 
 .IP "-s"
-Use special characters for the password generator
+Use special characters for the generated password. [Default: Disabled]
 
 .IP "-e"
-Use extended ascii characters for the password generator
+Use extended ascii characters for the generated password. [Default: Disabled]
 
 
 

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -91,6 +91,11 @@ QString FilePath::pluginPath(const QString& name)
     return QString();
 }
 
+QString FilePath::wordlistPath(const QString& name)
+{
+    return m_instance->dataPath("wordlists/" + name);
+}
+
 QIcon FilePath::applicationIcon()
 {
     bool darkIcon = useDarkIcon();

--- a/src/core/FilePath.h
+++ b/src/core/FilePath.h
@@ -27,6 +27,7 @@ class FilePath
 public:
     QString dataPath(const QString& name);
     QString pluginPath(const QString& name);
+    QString wordlistPath(const QString& name);
     QIcon applicationIcon();
     QIcon trayIconLocked();
     QIcon trayIconUnlocked();

--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -48,7 +48,7 @@ void PassphraseGenerator::setWordCount(int wordCount)
         m_wordCount = wordCount;
     } else {
         // safe default if something goes wrong
-        m_wordCount = 7;
+        m_wordCount = DefaultWordCount;
     }
 
 }

--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -24,9 +24,12 @@
 #include "crypto/Random.h"
 #include "core/FilePath.h"
 
+const QString PassphraseGenerator::DefaultSeparator = " ";
+const QString PassphraseGenerator::DefaultWordList = "eff_large.wordlist";
+
 PassphraseGenerator::PassphraseGenerator()
     : m_wordCount(0)
-    , m_separator(' ')
+    , m_separator(PassphraseGenerator::DefaultSeparator)
 {
     
 }
@@ -76,7 +79,7 @@ void PassphraseGenerator::setWordList(QString path)
 
 void PassphraseGenerator::setDefaultWordList()
 {
-    const QString path = filePath()->dataPath("wordlists/eff_large.wordlist");
+    const QString path = filePath()->wordlistPath(PassphraseGenerator::DefaultWordList);
     setWordList(path);
 }
 

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -37,6 +37,8 @@ public:
     QString generatePassphrase() const;
 
     static const int DefaultWordCount = 7;
+    static const QString DefaultSeparator;
+    static const QString DefaultWordList;
 
 private:
     int m_wordCount;

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -36,6 +36,8 @@ public:
 
     QString generatePassphrase() const;
 
+    static const int DefaultWordCount = 7;
+
 private:
     int m_wordCount;
     QString m_separator;

--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -35,11 +35,19 @@ double PasswordGenerator::calculateEntropy(QString password)
 
 void PasswordGenerator::setLength(int length)
 {
+    if (length <= 0) {
+        m_length = DefaultLength;
+        return;
+    }
     m_length = length;
 }
 
 void PasswordGenerator::setCharClasses(const CharClasses& classes)
 {
+    if (classes == 0) {
+        m_classes =  DefaultCharset;
+        return;
+    }
     m_classes = classes;
 }
 

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -61,13 +61,13 @@ public:
     int getbits() const;
 
     static const int DefaultLength = 16;
-    static const bool DefaultLower = (DefaultCharset & LowerLetters) != 0;
-    static const bool DefaultUpper = (DefaultCharset & UpperLetters) != 0;
-    static const bool DefaultNumbers = (DefaultCharset & Numbers) != 0;
-    static const bool DefaultSpecial = (DefaultCharset & SpecialCharacters) != 0;
-    static const bool DefaultEASCII = (DefaultCharset & EASCII) != 0;
-    static const bool DefaultLookAlike = (DefaultFlags & ExcludeLookAlike) != 0;
-    static const bool DefaultFromEveryGroup = (DefaultFlags & CharFromEveryGroup) != 0;
+    static constexpr bool DefaultLower = (DefaultCharset & LowerLetters) != 0;
+    static constexpr bool DefaultUpper = (DefaultCharset & UpperLetters) != 0;
+    static constexpr bool DefaultNumbers = (DefaultCharset & Numbers) != 0;
+    static constexpr bool DefaultSpecial = (DefaultCharset & SpecialCharacters) != 0;
+    static constexpr bool DefaultEASCII = (DefaultCharset & EASCII) != 0;
+    static constexpr bool DefaultLookAlike = (DefaultFlags & ExcludeLookAlike) != 0;
+    static constexpr bool DefaultFromEveryGroup = (DefaultFlags & CharFromEveryGroup) != 0;
 
 private:
     QVector<PasswordGroup> passwordGroups() const;

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -34,7 +34,8 @@ public:
         UpperLetters      = 0x2,
         Numbers           = 0x4,
         SpecialCharacters = 0x8,
-        EASCII            = 0x10
+        EASCII            = 0x10,
+        DefaultCharset    = LowerLetters | UpperLetters | Numbers
     };
     Q_DECLARE_FLAGS(CharClasses, CharClass)
 

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -42,7 +42,8 @@ public:
     enum GeneratorFlag
     {
         ExcludeLookAlike   = 0x1,
-        CharFromEveryGroup = 0x2
+        CharFromEveryGroup = 0x2,
+        DefaultFlags       = ExcludeLookAlike | CharFromEveryGroup
     };
     Q_DECLARE_FLAGS(GeneratorFlags, GeneratorFlag)
 
@@ -60,6 +61,13 @@ public:
     int getbits() const;
 
     static const int DefaultLength = 16;
+    static const bool DefaultLower = (DefaultCharset & LowerLetters) != 0;
+    static const bool DefaultUpper = (DefaultCharset & UpperLetters) != 0;
+    static const bool DefaultNumbers = (DefaultCharset & Numbers) != 0;
+    static const bool DefaultSpecial = (DefaultCharset & SpecialCharacters) != 0;
+    static const bool DefaultEASCII = (DefaultCharset & EASCII) != 0;
+    static const bool DefaultLookAlike = (DefaultFlags & ExcludeLookAlike) != 0;
+    static const bool DefaultFromEveryGroup = (DefaultFlags & CharFromEveryGroup) != 0;
 
 private:
     QVector<PasswordGroup> passwordGroups() const;

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -68,9 +68,9 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     }
 
     // set default separator to Space
-    m_ui->editWordSeparator->setText(" ");
+    m_ui->editWordSeparator->setText(PassphraseGenerator::DefaultSeparator);
 
-    QDir path(filePath()->dataPath("wordlists/"));
+    QDir path(filePath()->wordlistPath(""));
     QStringList files = path.entryList(QDir::Files);
     m_ui->comboBoxWordList->addItems(files);
     if (files.size() > 1) {
@@ -93,19 +93,19 @@ PasswordGeneratorWidget::~PasswordGeneratorWidget()
 void PasswordGeneratorWidget::loadSettings()
 {
     // Password config
-    m_ui->checkBoxLower->setChecked(config()->get("generator/LowerCase", true).toBool());
-    m_ui->checkBoxUpper->setChecked(config()->get("generator/UpperCase", true).toBool());
-    m_ui->checkBoxNumbers->setChecked(config()->get("generator/Numbers", true).toBool());
-    m_ui->checkBoxSpecialChars->setChecked(config()->get("generator/SpecialChars", false).toBool());
-    m_ui->checkBoxExtASCII->setChecked(config()->get("generator/EASCII", false).toBool());
-    m_ui->checkBoxExcludeAlike->setChecked(config()->get("generator/ExcludeAlike", true).toBool());
-    m_ui->checkBoxEnsureEvery->setChecked(config()->get("generator/EnsureEvery", true).toBool());
+    m_ui->checkBoxLower->setChecked(config()->get("generator/LowerCase", PasswordGenerator::DefaultLower).toBool());
+    m_ui->checkBoxUpper->setChecked(config()->get("generator/UpperCase", PasswordGenerator::DefaultUpper).toBool());
+    m_ui->checkBoxNumbers->setChecked(config()->get("generator/Numbers", PasswordGenerator::DefaultNumbers).toBool());
+    m_ui->checkBoxSpecialChars->setChecked(config()->get("generator/SpecialChars", PasswordGenerator::DefaultSpecial).toBool());
+    m_ui->checkBoxExtASCII->setChecked(config()->get("generator/EASCII", PasswordGenerator::DefaultEASCII).toBool());
+    m_ui->checkBoxExcludeAlike->setChecked(config()->get("generator/ExcludeAlike", PasswordGenerator::DefaultLookAlike).toBool());
+    m_ui->checkBoxEnsureEvery->setChecked(config()->get("generator/EnsureEvery", PasswordGenerator::DefaultFromEveryGroup).toBool());
     m_ui->spinBoxLength->setValue(config()->get("generator/Length", PasswordGenerator::DefaultLength).toInt());
 
     // Diceware config
-    m_ui->spinBoxWordCount->setValue(config()->get("generator/WordCount", 6).toInt());
-    m_ui->editWordSeparator->setText(config()->get("generator/WordSeparator", " ").toString());
-    m_ui->comboBoxWordList->setCurrentText(config()->get("generator/WordList", "eff_large.wordlist").toString());
+    m_ui->spinBoxWordCount->setValue(config()->get("generator/WordCount", PassphraseGenerator::DefaultWordCount).toInt());
+    m_ui->editWordSeparator->setText(config()->get("generator/WordSeparator", PassphraseGenerator::DefaultSeparator).toString());
+    m_ui->comboBoxWordList->setCurrentText(config()->get("generator/WordList", PassphraseGenerator::DefaultWordList).toString());
 
     // Password or diceware?
     m_ui->tabWidget->setCurrentIndex(config()->get("generator/Type", 0).toInt());
@@ -394,7 +394,7 @@ void PasswordGeneratorWidget::updateGenerator()
 
         m_dicewareGenerator->setWordCount(m_ui->spinBoxWordCount->value());
         if (!m_ui->comboBoxWordList->currentText().isEmpty()) {
-            QString path = filePath()->dataPath("wordlists/" + m_ui->comboBoxWordList->currentText());
+            QString path = filePath()->wordlistPath(m_ui->comboBoxWordList->currentText());
             m_dicewareGenerator->setWordList(path);
         }
         m_dicewareGenerator->setWordSeparator(m_ui->editWordSeparator->text());

--- a/src/http/HttpPasswordGeneratorWidget.cpp
+++ b/src/http/HttpPasswordGeneratorWidget.cpp
@@ -48,13 +48,14 @@ HttpPasswordGeneratorWidget::~HttpPasswordGeneratorWidget()
 
 void HttpPasswordGeneratorWidget::loadSettings()
 {
-    m_ui->checkBoxLower->setChecked(config()->get("Http/generator/LowerCase", true).toBool());
-    m_ui->checkBoxUpper->setChecked(config()->get("Http/generator/UpperCase", true).toBool());
-    m_ui->checkBoxNumbers->setChecked(config()->get("Http/generator/Numbers", true).toBool());
-    m_ui->checkBoxSpecialChars->setChecked(config()->get("Http/generator/SpecialChars", false).toBool());
+    m_ui->checkBoxLower->setChecked(config()->get("Http/generator/LowerCase", PasswordGenerator::DefaultLower).toBool());
+    m_ui->checkBoxUpper->setChecked(config()->get("Http/generator/UpperCase", PasswordGenerator::DefaultUpper).toBool());
+    m_ui->checkBoxNumbers->setChecked(config()->get("Http/generator/Numbers", PasswordGenerator::DefaultNumbers).toBool());
+    m_ui->checkBoxSpecialChars->setChecked(config()->get("Http/generator/SpecialChars", PasswordGenerator::DefaultSpecial).toBool());
+    m_ui->checkBoxSpecialChars->setChecked(config()->get("Http/generator/EASCII", PasswordGenerator::DefaultEASCII).toBool());
 
-    m_ui->checkBoxExcludeAlike->setChecked(config()->get("Http/generator/ExcludeAlike", true).toBool());
-    m_ui->checkBoxEnsureEvery->setChecked(config()->get("Http/generator/EnsureEvery", true).toBool());
+    m_ui->checkBoxExcludeAlike->setChecked(config()->get("Http/generator/ExcludeAlike", PasswordGenerator::DefaultLookAlike).toBool());
+    m_ui->checkBoxEnsureEvery->setChecked(config()->get("Http/generator/EnsureEvery", PasswordGenerator::DefaultFromEveryGroup).toBool());
 
     m_ui->spinBoxLength->setValue(config()->get("Http/generator/Length", PasswordGenerator::DefaultLength).toInt());
 }
@@ -65,6 +66,7 @@ void HttpPasswordGeneratorWidget::saveSettings()
     config()->set("Http/generator/UpperCase", m_ui->checkBoxUpper->isChecked());
     config()->set("Http/generator/Numbers", m_ui->checkBoxNumbers->isChecked());
     config()->set("Http/generator/SpecialChars", m_ui->checkBoxSpecialChars->isChecked());
+    config()->set("Http/generator/EASCII", m_ui->checkBoxExtASCII->isChecked());
 
     config()->set("Http/generator/ExcludeAlike", m_ui->checkBoxExcludeAlike->isChecked());
     config()->set("Http/generator/EnsureEvery", m_ui->checkBoxEnsureEvery->isChecked());
@@ -118,6 +120,10 @@ PasswordGenerator::CharClasses HttpPasswordGeneratorWidget::charClasses()
 
     if (m_ui->checkBoxSpecialChars->isChecked()) {
         classes |= PasswordGenerator::SpecialCharacters;
+    }
+
+    if (m_ui->checkBoxExtASCII->isChecked()) {
+        classes |= PasswordGenerator::EASCII;
     }
 
     return classes;

--- a/src/http/HttpPasswordGeneratorWidget.ui
+++ b/src/http/HttpPasswordGeneratorWidget.ui
@@ -143,6 +143,22 @@
          </widget>
         </item>
         <item>
+         <widget class="QToolButton" name="checkBoxExtASCII">
+          <property name="toolTip">
+           <string>Extended ASCII</string>
+          </property>
+          <property name="text">
+           <string>Extended ASCII</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">optionButtons</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>

--- a/src/http/HttpSettings.cpp
+++ b/src/http/HttpSettings.cpp
@@ -145,7 +145,7 @@ void HttpSettings::setHttpPort(int port)
 
 bool HttpSettings::passwordUseNumbers()
 {
-    return config()->get("Http/generator/Numbers", true).toBool();
+    return config()->get("Http/generator/Numbers", PasswordGenerator::DefaultNumbers).toBool();
 }
 
 void HttpSettings::setPasswordUseNumbers(bool useNumbers)
@@ -155,7 +155,7 @@ void HttpSettings::setPasswordUseNumbers(bool useNumbers)
 
 bool HttpSettings::passwordUseLowercase()
 {
-    return config()->get("Http/generator/LowerCase", true).toBool();
+    return config()->get("Http/generator/LowerCase", PasswordGenerator::DefaultLower).toBool();
 }
 
 void HttpSettings::setPasswordUseLowercase(bool useLowercase)
@@ -165,7 +165,7 @@ void HttpSettings::setPasswordUseLowercase(bool useLowercase)
 
 bool HttpSettings::passwordUseUppercase()
 {
-    return config()->get("Http/generator/UpperCase", true).toBool();
+    return config()->get("Http/generator/UpperCase", PasswordGenerator::DefaultUpper).toBool();
 }
 
 void HttpSettings::setPasswordUseUppercase(bool useUppercase)
@@ -175,7 +175,7 @@ void HttpSettings::setPasswordUseUppercase(bool useUppercase)
 
 bool HttpSettings::passwordUseSpecial()
 {
-    return config()->get("Http/generator/SpecialChars", false).toBool();
+    return config()->get("Http/generator/SpecialChars", PasswordGenerator::DefaultSpecial).toBool();
 }
 
 void HttpSettings::setPasswordUseSpecial(bool useSpecial)
@@ -183,9 +183,19 @@ void HttpSettings::setPasswordUseSpecial(bool useSpecial)
     config()->set("Http/generator/SpecialChars", useSpecial);
 }
 
+bool HttpSettings::passwordUseEASCII()
+{
+    return config()->get("Http/generator/EASCII", PasswordGenerator::DefaultEASCII).toBool();
+}
+
+void HttpSettings::setPasswordUseEASCII(bool useExtended)
+{
+    config()->set("Http/generator/EASCII", useExtended);
+}
+
 bool HttpSettings::passwordEveryGroup()
 {
-    return config()->get("Http/generator/EnsureEvery", true).toBool();
+    return config()->get("Http/generator/EnsureEvery", PasswordGenerator::DefaultFromEveryGroup).toBool();
 }
 
 void HttpSettings::setPasswordEveryGroup(bool everyGroup)
@@ -195,7 +205,7 @@ void HttpSettings::setPasswordEveryGroup(bool everyGroup)
 
 bool HttpSettings::passwordExcludeAlike()
 {
-    return config()->get("Http/generator/ExcludeAlike", true).toBool();
+    return config()->get("Http/generator/ExcludeAlike", PasswordGenerator::DefaultLookAlike).toBool();
 }
 
 void HttpSettings::setPasswordExcludeAlike(bool excludeAlike)
@@ -205,7 +215,7 @@ void HttpSettings::setPasswordExcludeAlike(bool excludeAlike)
 
 int HttpSettings::passwordLength()
 {
-    return config()->get("Http/generator/Length", 20).toInt();
+    return config()->get("Http/generator/Length", PasswordGenerator::DefaultLength).toInt();
 }
 
 void HttpSettings::setPasswordLength(int length)
@@ -217,14 +227,21 @@ void HttpSettings::setPasswordLength(int length)
 PasswordGenerator::CharClasses HttpSettings::passwordCharClasses()
 {
     PasswordGenerator::CharClasses classes;
-    if (passwordUseLowercase())
+    if (passwordUseLowercase()) {
         classes |= PasswordGenerator::LowerLetters;
-    if (passwordUseUppercase())
+    }
+    if (passwordUseUppercase()) {
         classes |= PasswordGenerator::UpperLetters;
-    if (passwordUseNumbers())
+    }
+    if (passwordUseNumbers()) {
         classes |= PasswordGenerator::Numbers;
-    if (passwordUseSpecial())
+    }
+    if (passwordUseSpecial()) {
         classes |= PasswordGenerator::SpecialCharacters;
+    }
+    if (passwordUseEASCII()) {
+        classes |= PasswordGenerator::EASCII;
+    }
     return classes;
 }
 

--- a/src/http/HttpSettings.h
+++ b/src/http/HttpSettings.h
@@ -58,6 +58,8 @@ public:
     static void setPasswordUseUppercase(bool useUppercase);
     static bool passwordUseSpecial();
     static void setPasswordUseSpecial(bool useSpecial);
+    static bool passwordUseEASCII();
+    static void setPasswordUseEASCII(bool useExtended);
     static bool passwordEveryGroup();
     static void setPasswordEveryGroup(bool everyGroup);
     static bool passwordExcludeAlike();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the following keepassxc-cli commands:
- passgen
- diceware

Usage:
`keepassxc-cli diceware 7` 
Will generate a passphrase of 7 words from the default wordlist, you can specify a custom wordlist with `-w`/`--wordlist`

`keepassxc-cli passgen -lunes 20`
Will generate a password of 20 letters with *l*owercase, *u*ppercase, *n*umbers, *s*pecial chars and *e*xtended ascii chars

`keepassxc-cli passgen -l 20`
Will generate a password of 20 letters with only *l*owercase chars

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
