### PR TITLE
Fix multiple TOTP issues, resolves #1360

### DIFF
--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -210,6 +210,7 @@ private slots:
     void emitDataChanged();
     void updateTimeinfo();
     void updateModifiedSinceBegin();
+    void updateTotp();
 
 private:
     QString resolveMultiplePlaceholdersRecursive(const QString& str, int maxDepth) const;

--- a/src/gui/DetailsWidget.cpp
+++ b/src/gui/DetailsWidget.cpp
@@ -20,16 +20,12 @@
 #include "ui_DetailsWidget.h"
 
 #include <QDebug>
-#include <QTimer>
 #include <QDir>
 #include <QDesktopServices>
-#include <QTemporaryFile>
 
 #include "core/Config.h"
 #include "core/FilePath.h"
-#include "core/TimeInfo.h"
 #include "gui/Clipboard.h"
-#include "gui/DatabaseWidget.h"
 #include "entry/EntryAttachmentsModel.h"
 
 DetailsWidget::DetailsWidget(QWidget* parent)
@@ -70,6 +66,9 @@ DetailsWidget::DetailsWidget(QWidget* parent)
 
 DetailsWidget::~DetailsWidget()
 {
+    if (m_timer) {
+        delete m_timer;
+    }
 }
 
 void DetailsWidget::getSelectedEntry(Entry* selectedEntry)
@@ -154,13 +153,13 @@ void DetailsWidget::getSelectedEntry(Entry* selectedEntry)
     if (m_currentEntry->hasTotp()) {
         m_step = m_currentEntry->totpStep();
 
-        if (nullptr != m_timer) {
-            m_timer->stop();
+        if (m_timer) {
+            delete m_timer;
         }
-        m_timer = new QTimer(this);
+        m_timer = new QTimer(selectedEntry);
         connect(m_timer, SIGNAL(timeout()), this, SLOT(updateTotp()));
         updateTotp();
-        m_timer->start(m_step * 10);
+        m_timer->start(m_step * 1000);
         m_ui->totpButton->show();
     }
 
@@ -288,7 +287,7 @@ void DetailsWidget::updateTotp()
         QString firstHalf = totpCode.left(totpCode.size() / 2);
         QString secondHalf = totpCode.mid(totpCode.size() / 2);
         m_ui->totpLabel->setText(firstHalf + " " + secondHalf);
-    } else if (nullptr != m_timer) {
+    } else if (m_timer) {
         m_timer->stop();
     }
 }

--- a/src/gui/DetailsWidget.h
+++ b/src/gui/DetailsWidget.h
@@ -20,6 +20,7 @@
 
 #include "gui/DatabaseWidget.h"
 #include <QWidget>
+#include <QTimer>
 
 namespace Ui {
     class DetailsWidget;
@@ -67,7 +68,7 @@ private:
     Entry* m_currentEntry;
     Group* m_currentGroup;
     quint8 m_step;
-    QTimer* m_timer;
+    QPointer<QTimer> m_timer = nullptr;
     QWidget* m_attributesTabWidget;
     QWidget* m_attachmentsTabWidget;
     QWidget* m_autotypeTabWidget;

--- a/src/gui/TotpDialog.cpp
+++ b/src/gui/TotpDialog.cpp
@@ -20,33 +20,24 @@
 #include "ui_TotpDialog.h"
 
 #include "core/Config.h"
-#include "core/Entry.h"
-#include "gui/DatabaseWidget.h"
 #include "gui/Clipboard.h"
-
-#include <QTimer>
-#include <QDateTime>
-#include <QPushButton>
 
 
 TotpDialog::TotpDialog(DatabaseWidget* parent, Entry* entry)
     : QDialog(parent)
     , m_ui(new Ui::TotpDialog())
+    , m_totpUpdateTimer(new QTimer(entry))
+    , m_entry(entry)
 {
-    m_entry = entry;
-    m_parent = parent;
-    m_step = m_entry->totpStep();
-
     m_ui->setupUi(this);
 
+    m_step = m_entry->totpStep();
     uCounter = resetCounter();
     updateProgressBar();
 
-    QTimer* timer = new QTimer(this);
-    connect(timer, SIGNAL(timeout()), this, SLOT(updateProgressBar()));
-    connect(timer, SIGNAL(timeout()), this, SLOT(updateSeconds()));
-    timer->start(m_step * 10);
-
+    connect(m_totpUpdateTimer, SIGNAL(timeout()), this, SLOT(updateProgressBar()));
+    connect(m_totpUpdateTimer, SIGNAL(timeout()), this, SLOT(updateSeconds()));
+    m_totpUpdateTimer->start(m_step * 10);
     updateTotp();
 
     setAttribute(Qt::WA_DeleteOnClose);
@@ -61,7 +52,7 @@ void TotpDialog::copyToClipboard()
 {
     clipboard()->setText(m_entry->totp());
     if (config()->get("MinimizeOnCopy").toBool()) {
-        m_parent->window()->showMinimized();
+        qobject_cast<DatabaseWidget*>(parent())->window()->showMinimized();
     }
 }
 
@@ -101,4 +92,7 @@ double TotpDialog::resetCounter()
 
 TotpDialog::~TotpDialog()
 {
+    if (m_totpUpdateTimer) {
+        delete m_totpUpdateTimer;
+    }
 }

--- a/src/gui/TotpDialog.h
+++ b/src/gui/TotpDialog.h
@@ -21,6 +21,8 @@
 
 #include <QDialog>
 #include <QScopedPointer>
+#include <QTimer>
+#include <totp/totp.h>
 #include "core/Entry.h"
 #include "core/Database.h"
 #include "gui/DatabaseWidget.h"
@@ -39,8 +41,9 @@ public:
 
 private:
     double uCounter;
-    quint8 m_step;
+    quint8 m_step = Totp::defaultStep;
     QScopedPointer<Ui::TotpDialog> m_ui;
+    QPointer<QTimer> m_totpUpdateTimer;
 
 private Q_SLOTS:
     void updateTotp();
@@ -51,7 +54,6 @@ private Q_SLOTS:
 
 protected:
     Entry* m_entry;
-    DatabaseWidget* m_parent;
 };
 
 #endif // KEEPASSX_TOTPDIALOG_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR resolves resolves #1360

## Description
<!--- Describe your changes in detail -->
1. Fix crash when deleting TOTP entry
2. Fix memory leak when selecting TOTP entries
3. Fix TOTP update timeout on DetailsWidget
4. Fix TOTP settings attributes not being applied before first call to totpSeed()

## Motivation and Context
1. maintained a TOTP update timer which wasn't deleted when the entry was deleted.
2. used to create a new QTimer instance every time a TOTP entry was selected without deleting the old one
3. was too fast by a factor of 100
4. caused TotpDialog to always use the standard settings on first invocation instead of the actual entry settings

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and by running existing unit tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
