### PR TITLE
Add compression options to database settings

### DIFF
--- a/src/gui/DatabaseSettingsWidget.cpp
+++ b/src/gui/DatabaseSettingsWidget.cpp
@@ -79,6 +79,8 @@ void DatabaseSettingsWidget::load(Database* db)
     m_uiGeneral->dbDescriptionEdit->setText(meta->description());
     m_uiGeneral->recycleBinEnabledCheckBox->setChecked(meta->recycleBinEnabled());
     m_uiGeneral->defaultUsernameEdit->setText(meta->defaultUserName());
+    m_uiGeneral->compressionCheckbox->setChecked(m_db->compressionAlgo() != Database::CompressionNone);
+
     if (meta->historyMaxItems() > -1) {
         m_uiGeneral->historyMaxItemsSpinBox->setValue(meta->historyMaxItems());
         m_uiGeneral->historyMaxItemsCheckBox->setChecked(true);
@@ -167,6 +169,8 @@ void DatabaseSettingsWidget::save()
             return;
         }
     }
+
+    m_db->setCompressionAlgo(m_uiGeneral->compressionCheckbox->isChecked() ? Database::CompressionGZip : Database::CompressionNone);
 
     Metadata* meta = m_db->metadata();
 

--- a/src/gui/DatabaseSettingsWidgetGeneral.ui
+++ b/src/gui/DatabaseSettingsWidgetGeneral.ui
@@ -135,6 +135,25 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Additional Database Settings</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="compressionCheckbox">
+        <property name="text">
+         <string>Enable &amp;compression (recommended)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/gui/DatabaseSettingsWidgetGeneral.ui
+++ b/src/gui/DatabaseSettingsWidgetGeneral.ui
@@ -26,9 +26,6 @@
         <property name="text">
          <string>Database name:</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -39,9 +36,6 @@
         <property name="text">
          <string>Database description:</string>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -51,9 +45,6 @@
        <widget class="QLabel" name="defaultUsernameLabel">
         <property name="text">
          <string>Default username:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch adds a radio button group for choosing between GZip and no compression to the database settings.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is not really a reason not to enable compression, but KeePass2 has a setting for this and KeePassXC used to just save with whatever compression setting the database was originally opened with. That way you probably wouldn't notice if compression is (accidentally?) turned off and even if you do, you couldn't change it without downloading KeePass2.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By saving and opening with and without compression in both KeePassXC and KeePass2.

## Screenshots (if appropriate):
![capture](https://user-images.githubusercontent.com/911270/35298168-93da14bc-0081-11e8-8df2-ae6eb1aa766c.PNG)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**