### PR TITLE
Move useful QTest template specializations to global header file

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,7 +82,6 @@ macro(add_unit_test)
   endif()
 endmacro(add_unit_test)
 
-
 set(TEST_LIBRARIES
     keepassx_core
     ${keepasshttp_LIB}
@@ -96,7 +95,7 @@ set(TEST_LIBRARIES
     ${ZLIB_LIBRARIES}
 )
 
-set(testsupport_SOURCES modeltest.cpp FailDevice.cpp)
+set(testsupport_SOURCES TestGlobal.h modeltest.cpp FailDevice.cpp)
 add_library(testsupport STATIC ${testsupport_SOURCES})
 target_link_libraries(testsupport Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Test)
 
@@ -185,7 +184,7 @@ add_unit_test(NAME testcsvexporter SOURCES TestCsvExporter.cpp
         LIBS ${TEST_LIBRARIES})
 
 add_unit_test(NAME testykchallengeresponsekey
-        SOURCES TestYkChallengeResponseKey.cpp TestYkChallengeResponseKey.h
+        SOURCES TestYkChallengeResponseKey.cpp
         LIBS ${TEST_LIBRARIES})
 
 add_unit_test(NAME testdatabase SOURCES TestDatabase.cpp

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -17,14 +17,12 @@
  */
 
 #include "TestAutoType.h"
+#include "TestGlobal.h"
 
 #include <QPluginLoader>
-#include <QTest>
 
 #include "core/Config.h"
 #include "core/FilePath.h"
-#include "core/Entry.h"
-#include "core/Group.h"
 #include "crypto/Crypto.h"
 #include "autotype/AutoType.h"
 #include "autotype/AutoTypePlatformPlugin.h"

--- a/tests/TestBase32.cpp
+++ b/tests/TestBase32.cpp
@@ -16,8 +16,8 @@
  */
 
 #include "TestBase32.h"
+#include "TestGlobal.h"
 #include "core/Base32.h"
-#include <QTest>
 
 QTEST_GUILESS_MAIN(TestBase32)
 

--- a/tests/TestCryptoHash.cpp
+++ b/tests/TestCryptoHash.cpp
@@ -16,8 +16,7 @@
  */
 
 #include "TestCryptoHash.h"
-
-#include <QTest>
+#include "TestGlobal.h"
 
 #include "crypto/Crypto.h"
 #include "crypto/CryptoHash.h"

--- a/tests/TestCsvExporter.cpp
+++ b/tests/TestCsvExporter.cpp
@@ -17,13 +17,10 @@
  */
 
 #include "TestCsvExporter.h"
+#include "TestGlobal.h"
 
 #include <QBuffer>
-#include <QTest>
 
-#include "core/Database.h"
-#include "core/Entry.h"
-#include "core/Group.h"
 #include "crypto/Crypto.h"
 #include "format/CsvExporter.h"
 

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -17,17 +17,15 @@
  */
 
 #include "TestDatabase.h"
+#include "TestGlobal.h"
 
-#include <QTest>
 #include <QSignalSpy>
 #include <QTemporaryFile>
 
 #include "config-keepassx-tests.h"
-#include "core/Database.h"
 #include "crypto/Crypto.h"
 #include "keys/PasswordKey.h"
 #include "core/Metadata.h"
-#include "core/Group.h"
 #include "format/KeePass2Writer.h"
 
 QTEST_GUILESS_MAIN(TestDatabase)

--- a/tests/TestDeletedObjects.cpp
+++ b/tests/TestDeletedObjects.cpp
@@ -16,11 +16,8 @@
  */
 
 #include "TestDeletedObjects.h"
+#include "TestGlobal.h"
 
-#include <QTest>
-
-#include "core/Database.h"
-#include "core/Group.h"
 #include "crypto/Crypto.h"
 #include "format/KeePass2.h"
 #include "format/KdbxXmlReader.h"

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -16,12 +16,7 @@
  */
 
 #include "TestEntry.h"
-#include "config-keepassx-tests.h"
-
-#include <QTest>
-
-#include "core/Entry.h"
-#include "core/Group.h"
+#include "TestGlobal.h"
 #include "crypto/Crypto.h"
 
 QTEST_GUILESS_MAIN(TestEntry)

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -16,9 +16,9 @@
  */
 
 #include "TestEntryModel.h"
+#include "TestGlobal.h"
 
 #include <QSignalSpy>
-#include <QTest>
 
 #include "modeltest.h"
 #include "core/DatabaseIcons.h"

--- a/tests/TestEntrySearcher.cpp
+++ b/tests/TestEntrySearcher.cpp
@@ -16,8 +16,7 @@
  */
 
 #include "TestEntrySearcher.h"
-
-#include <QTest>
+#include "TestGlobal.h"
 
 QTEST_GUILESS_MAIN(TestEntrySearcher)
 

--- a/tests/TestGlobal.h
+++ b/tests/TestGlobal.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTGLOBAL_H
+#define KEEPASSXC_TESTGLOBAL_H
+
+#include "core/Uuid.h"
+#include "core/Group.h"
+
+#include <QTest>
+#include <QDateTime>
+
+namespace QTest {
+
+template<>
+inline char* toString(const Uuid& uuid)
+{
+    QByteArray ba = "Uuid(";
+    ba += uuid.toHex().toLatin1().constData();
+    ba += ")";
+    return qstrdup(ba.constData());
+}
+
+template<>
+inline char* toString(const Group::TriState& triState)
+{
+    QString value;
+
+    if (triState == Group::Inherit) {
+        value = "null";
+    } else if (triState == Group::Enable) {
+        value = "true";
+    } else {
+        value = "false";
+    }
+
+    return qstrdup(value.toLocal8Bit().constData());
+}
+
+}   // namespace QTest
+
+
+namespace Test {
+
+inline QDateTime datetime(int year, int month, int day, int hour, int min, int second)
+{
+    return QDateTime(
+            QDate(year, month, day),
+            QTime(hour, min, second),
+            Qt::UTC);
+}
+
+}   // namespace Test
+
+#endif //KEEPASSXC_TESTGLOBAL_H

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -17,15 +17,10 @@
  */
 
 #include "TestGroup.h"
+#include "TestGlobal.h"
 
-#include <QDebug>
-#include <QPointer>
-#include <QScopedPointer>
 #include <QSignalSpy>
-#include <QTest>
 
-#include "core/Database.h"
-#include "core/Group.h"
 #include "core/Metadata.h"
 #include "crypto/Crypto.h"
 

--- a/tests/TestGroupModel.cpp
+++ b/tests/TestGroupModel.cpp
@@ -16,13 +16,11 @@
  */
 
 #include "TestGroupModel.h"
+#include "TestGlobal.h"
 
 #include <QSignalSpy>
-#include <QTest>
 
 #include "modeltest.h"
-#include "core/Database.h"
-#include "core/Group.h"
 #include "crypto/Crypto.h"
 #include "gui/group/GroupModel.h"
 

--- a/tests/TestHashedBlockStream.cpp
+++ b/tests/TestHashedBlockStream.cpp
@@ -16,9 +16,9 @@
  */
 
 #include "TestHashedBlockStream.h"
+#include "TestGlobal.h"
 
 #include <QBuffer>
-#include <QTest>
 
 #include "FailDevice.h"
 #include "crypto/Crypto.h"

--- a/tests/TestKdbx2.cpp
+++ b/tests/TestKdbx2.cpp
@@ -16,17 +16,15 @@
  */
 
 #include "TestKdbx2.h"
+#include "TestGlobal.h"
+
 #include "crypto/Crypto.h"
-#include "keys/CompositeKey.h"
 #include "keys/PasswordKey.h"
 #include "format/KeePass2Reader.h"
 #include "format/KeePass2Writer.h"
-#include "core/Entry.h"
-#include "core/Group.h"
 #include "core/Metadata.h"
 #include "config-keepassx-tests.h"
 
-#include <QTest>
 #include <QBuffer>
 
 QTEST_GUILESS_MAIN(TestKdbx2)

--- a/tests/TestKdbx3.cpp
+++ b/tests/TestKdbx3.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "TestKdbx3.h"
+#include "TestGlobal.h"
+
 #include "core/Metadata.h"
 #include "keys/PasswordKey.h"
 #include "format/KeePass2.h"
@@ -26,7 +28,6 @@
 #include "format/KeePass2Repair.h"
 #include "config-keepassx-tests.h"
 
-#include <QTest>
 
 QTEST_GUILESS_MAIN(TestKdbx3)
 

--- a/tests/TestKdbx4.cpp
+++ b/tests/TestKdbx4.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "TestKdbx4.h"
+#include "TestGlobal.h"
+
 #include "core/Metadata.h"
 #include "keys/PasswordKey.h"
 #include "format/KeePass2.h"
@@ -25,7 +27,6 @@
 #include "format/KdbxXmlWriter.h"
 #include "config-keepassx-tests.h"
 
-#include <QTest>
 
 QTEST_GUILESS_MAIN(TestKdbx4)
 

--- a/tests/TestKeePass1Reader.cpp
+++ b/tests/TestKeePass1Reader.cpp
@@ -16,14 +16,11 @@
  */
 
 #include "TestKeePass1Reader.h"
+#include "TestGlobal.h"
 
 #include <QBuffer>
-#include <QTest>
 
 #include "config-keepassx-tests.h"
-#include "core/Database.h"
-#include "core/Entry.h"
-#include "core/Group.h"
 #include "core/Metadata.h"
 #include "crypto/Crypto.h"
 #include "format/KeePass1Reader.h"

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -16,8 +16,8 @@
  */
 
 #include "TestKeePass2Format.h"
+#include "TestGlobal.h"
 
-#include "core/Group.h"
 #include "core/Metadata.h"
 #include "crypto/Crypto.h"
 #include "keys/PasswordKey.h"
@@ -25,9 +25,6 @@
 
 #include "FailDevice.h"
 #include "config-keepassx-tests.h"
-
-#include <QFile>
-#include <QTest>
 
 void TestKeePass2Format::initTestCase()
 {
@@ -80,14 +77,14 @@ void TestKeePass2Format::testXmlMetadata()
 {
     QCOMPARE(m_xmlDb->metadata()->generator(), QString("KeePass"));
     QCOMPARE(m_xmlDb->metadata()->name(), QString("ANAME"));
-    QCOMPARE(m_xmlDb->metadata()->nameChanged(), genDT(2010, 8, 8, 17, 24, 53));
+    QCOMPARE(m_xmlDb->metadata()->nameChanged(), Test::datetime(2010, 8, 8, 17, 24, 53));
     QCOMPARE(m_xmlDb->metadata()->description(), QString("ADESC"));
-    QCOMPARE(m_xmlDb->metadata()->descriptionChanged(), genDT(2010, 8, 8, 17, 27, 12));
+    QCOMPARE(m_xmlDb->metadata()->descriptionChanged(), Test::datetime(2010, 8, 8, 17, 27, 12));
     QCOMPARE(m_xmlDb->metadata()->defaultUserName(), QString("DEFUSERNAME"));
-    QCOMPARE(m_xmlDb->metadata()->defaultUserNameChanged(), genDT(2010, 8, 8, 17, 27, 45));
+    QCOMPARE(m_xmlDb->metadata()->defaultUserNameChanged(), Test::datetime(2010, 8, 8, 17, 27, 45));
     QCOMPARE(m_xmlDb->metadata()->maintenanceHistoryDays(), 127);
     QCOMPARE(m_xmlDb->metadata()->color(), QColor(0xff, 0xef, 0x00));
-    QCOMPARE(m_xmlDb->metadata()->masterKeyChanged(), genDT(2012, 4, 5, 17, 9, 34));
+    QCOMPARE(m_xmlDb->metadata()->masterKeyChanged(), Test::datetime(2012, 4, 5, 17, 9, 34));
     QCOMPARE(m_xmlDb->metadata()->masterKeyChangeRec(), 101);
     QCOMPARE(m_xmlDb->metadata()->masterKeyChangeForce(), -1);
     QCOMPARE(m_xmlDb->metadata()->protectTitle(), false);
@@ -98,9 +95,9 @@ void TestKeePass2Format::testXmlMetadata()
     QCOMPARE(m_xmlDb->metadata()->recycleBinEnabled(), true);
     QVERIFY(m_xmlDb->metadata()->recycleBin() != nullptr);
     QCOMPARE(m_xmlDb->metadata()->recycleBin()->name(), QString("Recycle Bin"));
-    QCOMPARE(m_xmlDb->metadata()->recycleBinChanged(), genDT(2010, 8, 25, 16, 12, 57));
+    QCOMPARE(m_xmlDb->metadata()->recycleBinChanged(), Test::datetime(2010, 8, 25, 16, 12, 57));
     QVERIFY(m_xmlDb->metadata()->entryTemplatesGroup() == nullptr);
-    QCOMPARE(m_xmlDb->metadata()->entryTemplatesGroupChanged(), genDT(2010, 8, 8, 17, 24, 19));
+    QCOMPARE(m_xmlDb->metadata()->entryTemplatesGroupChanged(), Test::datetime(2010, 8, 8, 17, 24, 19));
     QVERIFY(m_xmlDb->metadata()->lastSelectedGroup() != nullptr);
     QCOMPARE(m_xmlDb->metadata()->lastSelectedGroup()->name(), QString("NewDatabase"));
     QVERIFY(m_xmlDb->metadata()->lastTopVisibleGroup() == m_xmlDb->metadata()->lastSelectedGroup());
@@ -147,13 +144,13 @@ void TestKeePass2Format::testXmlGroupRoot()
     QCOMPARE(group->iconUuid(), Uuid());
     QVERIFY(group->isExpanded());
     TimeInfo ti = group->timeInfo();
-    QCOMPARE(ti.lastModificationTime(), genDT(2010, 8, 8, 17, 24, 27));
-    QCOMPARE(ti.creationTime(), genDT(2010, 8, 7, 17, 24, 27));
-    QCOMPARE(ti.lastAccessTime(), genDT(2010, 8, 9, 9, 9, 44));
-    QCOMPARE(ti.expiryTime(), genDT(2010, 8, 8, 17, 24, 17));
+    QCOMPARE(ti.lastModificationTime(), Test::datetime(2010, 8, 8, 17, 24, 27));
+    QCOMPARE(ti.creationTime(), Test::datetime(2010, 8, 7, 17, 24, 27));
+    QCOMPARE(ti.lastAccessTime(), Test::datetime(2010, 8, 9, 9, 9, 44));
+    QCOMPARE(ti.expiryTime(), Test::datetime(2010, 8, 8, 17, 24, 17));
     QVERIFY(!ti.expires());
     QCOMPARE(ti.usageCount(), 52);
-    QCOMPARE(ti.locationChanged(), genDT(2010, 8, 8, 17, 24, 27));
+    QCOMPARE(ti.locationChanged(), Test::datetime(2010, 8, 8, 17, 24, 27));
     QCOMPARE(group->defaultAutoTypeSequence(), QString(""));
     QCOMPARE(group->autoTypeEnabled(), Group::Inherit);
     QCOMPARE(group->searchingEnabled(), Group::Inherit);
@@ -215,13 +212,13 @@ void TestKeePass2Format::testXmlEntry1()
     QCOMPARE(entry->tags(), QString("a b c"));
 
     const TimeInfo ti = entry->timeInfo();
-    QCOMPARE(ti.lastModificationTime(), genDT(2010, 8, 25, 16, 19, 25));
-    QCOMPARE(ti.creationTime(), genDT(2010, 8, 25, 16, 13, 54));
-    QCOMPARE(ti.lastAccessTime(), genDT(2010, 8, 25, 16, 19, 25));
-    QCOMPARE(ti.expiryTime(), genDT(2010, 8, 25, 16, 12, 57));
+    QCOMPARE(ti.lastModificationTime(), Test::datetime(2010, 8, 25, 16, 19, 25));
+    QCOMPARE(ti.creationTime(), Test::datetime(2010, 8, 25, 16, 13, 54));
+    QCOMPARE(ti.lastAccessTime(), Test::datetime(2010, 8, 25, 16, 19, 25));
+    QCOMPARE(ti.expiryTime(), Test::datetime(2010, 8, 25, 16, 12, 57));
     QVERIFY(!ti.expires());
     QCOMPARE(ti.usageCount(), 8);
-    QCOMPARE(ti.locationChanged(), genDT(2010, 8, 25, 16, 13, 54));
+    QCOMPARE(ti.locationChanged(), Test::datetime(2010, 8, 25, 16, 13, 54));
 
     QList<QString> attrs = entry->attributes()->keys();
     QCOMPARE(entry->attributes()->value("Notes"), QString("Notes"));
@@ -320,7 +317,7 @@ void TestKeePass2Format::testXmlEntryHistory()
         const Entry* entry = entryMain->historyItems().at(0);
         QCOMPARE(entry->uuid(), entryMain->uuid());
         QVERIFY(!entry->parent());
-        QCOMPARE(entry->timeInfo().lastModificationTime(), genDT(2010, 8, 25, 16, 13, 54));
+        QCOMPARE(entry->timeInfo().lastModificationTime(), Test::datetime(2010, 8, 25, 16, 13, 54));
         QCOMPARE(entry->timeInfo().usageCount(), 3);
         QCOMPARE(entry->title(), QString("Sample Entry"));
         QCOMPARE(entry->url(), QString("http://www.somesite.com/"));
@@ -330,7 +327,7 @@ void TestKeePass2Format::testXmlEntryHistory()
         const Entry* entry = entryMain->historyItems().at(1);
         QCOMPARE(entry->uuid(), entryMain->uuid());
         QVERIFY(!entry->parent());
-        QCOMPARE(entry->timeInfo().lastModificationTime(), genDT(2010, 8, 25, 16, 15, 43));
+        QCOMPARE(entry->timeInfo().lastModificationTime(), Test::datetime(2010, 8, 25, 16, 15, 43));
         QCOMPARE(entry->timeInfo().usageCount(), 7);
         QCOMPARE(entry->title(), QString("Sample Entry 1"));
         QCOMPARE(entry->url(), QString("http://www.somesite.com/"));
@@ -344,11 +341,11 @@ void TestKeePass2Format::testXmlDeletedObjects()
 
     delObj = objList.takeFirst();
     QCOMPARE(delObj.uuid.toBase64(), QString("5K/bzWCSmkCv5OZxYl4N/w=="));
-    QCOMPARE(delObj.deletionTime, genDT(2010, 8, 25, 16, 14, 12));
+    QCOMPARE(delObj.deletionTime, Test::datetime(2010, 8, 25, 16, 14, 12));
 
     delObj = objList.takeFirst();
     QCOMPARE(delObj.uuid.toBase64(), QString("80h8uSNWgkKhKCp1TgXF7g=="));
-    QCOMPARE(delObj.deletionTime, genDT(2010, 8, 25, 16, 14, 14));
+    QCOMPARE(delObj.deletionTime, Test::datetime(2010, 8, 25, 16, 14, 14));
 
     QVERIFY(objList.isEmpty());
 }
@@ -462,16 +459,16 @@ void TestKeePass2Format::testXmlInvalidXmlChars()
     Entry* entryRead = dbRead->rootGroup()->entries().at(0);
     EntryAttributes* attrRead = entryRead->attributes();
 
-    QCOMPARE(strToBytes(attrRead->value("PlainInvalid")), QByteArray());
-    QCOMPARE(strToBytes(attrRead->value("PlainValid")), strToBytes(strPlainValid));
-    QCOMPARE(strToBytes(attrRead->value("SingleHighSurrogate1")), QByteArray());
-    QCOMPARE(strToBytes(attrRead->value("SingleHighSurrogate2")), strToBytes(QString("12")));
-    QCOMPARE(strToBytes(attrRead->value("HighHighSurrogate")), QByteArray());
-    QCOMPARE(strToBytes(attrRead->value("SingleLowSurrogate1")), QByteArray());
-    QCOMPARE(strToBytes(attrRead->value("SingleLowSurrogate2")), strToBytes(QString("12")));
-    QCOMPARE(strToBytes(attrRead->value("LowLowSurrogate")), QByteArray());
-    QCOMPARE(strToBytes(attrRead->value("SurrogateValid1")), strToBytes(strSurrogateValid1));
-    QCOMPARE(strToBytes(attrRead->value("SurrogateValid2")), strToBytes(strSurrogateValid2));
+    QCOMPARE(attrRead->value("PlainInvalid"), QString());
+    QCOMPARE(attrRead->value("PlainValid"), strPlainValid);
+    QCOMPARE(attrRead->value("SingleHighSurrogate1"), QString());
+    QCOMPARE(attrRead->value("SingleHighSurrogate2"), QString("12"));
+    QCOMPARE(attrRead->value("HighHighSurrogate"), QString());
+    QCOMPARE(attrRead->value("SingleLowSurrogate1"), QString());
+    QCOMPARE(attrRead->value("SingleLowSurrogate2"), QString("12"));
+    QCOMPARE(attrRead->value("LowLowSurrogate"), QString());
+    QCOMPARE(attrRead->value("SurrogateValid1"), strSurrogateValid1);
+    QCOMPARE(attrRead->value("SurrogateValid2"), strSurrogateValid2);
 }
 
 void TestKeePass2Format::testXmlRepairUuidHistoryItem()
@@ -567,56 +564,4 @@ void TestKeePass2Format::testKdbxDeviceFailure()
     writeKdbx(&failDevice, db.data(), hasError, errorString);
     QVERIFY(hasError);
     QCOMPARE(errorString, QString("FAILDEVICE"));
-}
-
-
-
-// ====================================================================================================
-// Helper functions
-// ====================================================================================================
-
-namespace QTest {
-template<>
-char* toString(const Uuid& uuid)
-{
-    QByteArray ba = "Uuid(";
-    ba += uuid.toBase64().toLatin1().constData();
-    ba += ")";
-    return qstrdup(ba.constData());
-}
-
-template<>
-char* toString(const Group::TriState& triState)
-{
-    QString value;
-
-    if (triState == Group::Inherit) {
-        value = "null";
-    } else if (triState == Group::Enable) {
-        value = "true";
-    } else {
-        value = "false";
-    }
-
-    return qstrdup(value.toLocal8Bit().constData());
-}
-}
-
-QDateTime TestKeePass2Format::genDT(int year, int month, int day, int hour, int min, int second)
-{
-    QDate date(year, month, day);
-    QTime time(hour, min, second);
-    return QDateTime(date, time, Qt::UTC);
-}
-
-QByteArray TestKeePass2Format::strToBytes(const QString& str)
-{
-    QByteArray result;
-
-    for (auto i : str) {
-        result.append(static_cast<char>(i.unicode() >> 8));
-        result.append(static_cast<char>(i.unicode() & 0xFF));
-    }
-
-    return result;
 }

--- a/tests/TestKeePass2Format.h
+++ b/tests/TestKeePass2Format.h
@@ -77,9 +77,6 @@ protected:
                           bool& hasError, QString& errorString) = 0;
     virtual void writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString) = 0;
 
-    static QDateTime genDT(int year, int month, int day, int hour, int min, int second);
-    static QByteArray strToBytes(const QString& str);
-
     QScopedPointer<Database> m_xmlDb;
     QScopedPointer<Database> m_kdbxSourceDb;
     QScopedPointer<Database> m_kdbxTargetDb;

--- a/tests/TestKeePass2RandomStream.cpp
+++ b/tests/TestKeePass2RandomStream.cpp
@@ -16,13 +16,11 @@
  */
 
 #include "TestKeePass2RandomStream.h"
-
-#include <QTest>
+#include "TestGlobal.h"
 
 #include "crypto/Crypto.h"
 #include "crypto/CryptoHash.h"
 #include "crypto/SymmetricCipher.h"
-#include "format/KeePass2.h"
 #include "format/KeePass2RandomStream.h"
 
 QTEST_GUILESS_MAIN(TestKeePass2RandomStream)

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -17,13 +17,12 @@
  */
 
 #include "TestKeys.h"
+#include "TestGlobal.h"
 
 #include <QBuffer>
-#include <QTest>
 
 #include "config-keepassx-tests.h"
 
-#include "core/Database.h"
 #include "core/Metadata.h"
 #include "core/Tools.h"
 #include "crypto/Crypto.h"

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -16,12 +16,8 @@
  */
 
 #include "TestMerge.h"
+#include "TestGlobal.h"
 
-#include <QDebug>
-#include <QTest>
-
-#include "core/Database.h"
-#include "core/Group.h"
 #include "core/Metadata.h"
 #include "crypto/Crypto.h"
 

--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -16,9 +16,9 @@
  */
 
 #include "TestOpenSSHKey.h"
-#include "crypto/Crypto.h"
+#include "TestGlobal.h"
 #include "sshagent/OpenSSHKey.h"
-#include <QTest>
+#include "crypto/Crypto.h"
 
 QTEST_GUILESS_MAIN(TestOpenSSHKey)
 

--- a/tests/TestRandom.cpp
+++ b/tests/TestRandom.cpp
@@ -16,11 +16,10 @@
  */
 
 #include "TestRandom.h"
-
+#include "TestGlobal.h"
 #include "core/Endian.h"
 #include "core/Global.h"
 
-#include <QTest>
 
 QTEST_GUILESS_MAIN(TestRandom)
 

--- a/tests/TestSymmetricCipher.cpp
+++ b/tests/TestSymmetricCipher.cpp
@@ -17,9 +17,9 @@
  */
 
 #include "TestSymmetricCipher.h"
+#include "TestGlobal.h"
 
 #include <QBuffer>
-#include <QTest>
 
 #include "crypto/Crypto.h"
 #include "crypto/SymmetricCipher.h"

--- a/tests/TestTotp.cpp
+++ b/tests/TestTotp.cpp
@@ -17,12 +17,7 @@
  */
 
 #include "TestTotp.h"
-
-#include <QDateTime>
-#include <QTest>
-#include <QTextCodec>
-#include <QTime>
-#include <QtEndian>
+#include "TestGlobal.h"
 
 #include "crypto/Crypto.h"
 #include "totp/totp.h"

--- a/tests/TestWildcardMatcher.cpp
+++ b/tests/TestWildcardMatcher.cpp
@@ -16,9 +16,7 @@
  */
 
 #include "TestWildcardMatcher.h"
-
-#include <QTest>
-
+#include "TestGlobal.h"
 #include "autotype/WildcardMatcher.h"
 
 QTEST_GUILESS_MAIN(TestWildcardMatcher)

--- a/tests/TestYkChallengeResponseKey.cpp
+++ b/tests/TestYkChallengeResponseKey.cpp
@@ -18,36 +18,23 @@
  */
 
 #include "TestYkChallengeResponseKey.h"
-
-#include <QTest>
-#include <QtConcurrentRun>
-
+#include "TestGlobal.h"
 #include "crypto/Crypto.h"
-#include "keys/YkChallengeResponseKey.h"
+
+#include <QtConcurrentRun>
 
 QTEST_GUILESS_MAIN(TestYubiKeyChalResp)
 
 void TestYubiKeyChalResp::initTestCase()
 {
-    m_detected = 0;
-    m_key = NULL;
-
     // crypto subsystem needs to be initialized for YubiKey testing
     QVERIFY(Crypto::init());
 }
 
-void TestYubiKeyChalResp::cleanupTestCase()
-{
-    if (m_key)
-        delete m_key;
-}
-
 void TestYubiKeyChalResp::init()
 {
-    bool result = YubiKey::instance()->init();
-
-    if (!result) {
-        QSKIP("Unable to connect to YubiKey", SkipAll);
+    if (!YubiKey::instance()->init()) {
+        QSKIP("Unable to connect to YubiKey");
     }
 }
 
@@ -104,7 +91,7 @@ void TestYubiKeyChalResp::ykDetected(int slot, bool blocking)
 
     /* Key used for later testing */
     if (!m_key)
-        m_key = new YkChallengeResponseKey(slot, blocking);
+        m_key.reset(new YkChallengeResponseKey(slot, blocking));
 }
 
 void TestYubiKeyChalResp::deinit()

--- a/tests/TestYkChallengeResponseKey.h
+++ b/tests/TestYkChallengeResponseKey.h
@@ -20,6 +20,7 @@
 #define KEEPASSX_TESTYUBIKEYCHALRESP_H
 
 #include <QObject>
+#include <QScopedPointer>
 
 #include "keys/YkChallengeResponseKey.h"
 
@@ -29,7 +30,6 @@ class TestYubiKeyChalResp: public QObject
 
 private slots:
     void initTestCase();
-    void cleanupTestCase();
 
     void init();
 
@@ -48,8 +48,8 @@ private slots:
     void ykDetected(int slot, bool blocking);
 
 private:
-    int m_detected;
-    YkChallengeResponseKey *m_key;
+    int m_detected = 0;
+    QScopedPointer<YkChallengeResponseKey> m_key;
 };
 
 #endif // KEEPASSX_TESTYUBIKEYCHALRESP_H

--- a/tests/gui/CMakeLists.txt
+++ b/tests/gui/CMakeLists.txt
@@ -13,6 +13,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+
 add_unit_test(NAME testgui SOURCES TestGui.cpp TemporaryFile.cpp LIBS ${TEST_LIBRARIES})
 
 add_unit_test(NAME testguipixmaps SOURCES TestGuiPixmaps.cpp LIBS ${TEST_LIBRARIES})

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "TestGui.h"
+#include "TestGlobal.h"
 
 #include <QAction>
 #include <QApplication>
@@ -29,7 +30,6 @@
 #include <QPlainTextEdit>
 #include <QComboBox>
 #include <QTemporaryFile>
-#include <QTest>
 #include <QToolBar>
 #include <QToolButton>
 #include <QTimer>

--- a/tests/gui/TestGuiPixmaps.cpp
+++ b/tests/gui/TestGuiPixmaps.cpp
@@ -16,13 +16,8 @@
  */
 
 #include "TestGuiPixmaps.h"
-
-#include <QTest>
-
-#include "core/Database.h"
+#include "TestGlobal.h"
 #include "core/DatabaseIcons.h"
-#include "core/Entry.h"
-#include "core/Group.h"
 #include "core/Metadata.h"
 #include "crypto/Crypto.h"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Move useful QTest template specializations to global header file and fix KDBX test linker errors on Windows.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The KeePass2Format test CPP had a couple of QTest::toString() template specializations which are not only useful for those tests, but for all of our tests (or at least some others). I therefore moved them to a separate header file, which is now to be included now instead of <QTest>.

I also fixed multiple-definition linker errors on Windows due to template specializations not being declared inline (at least I hope so, please test @droidmonkey).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests fine and QCOMPARE() failures with Uuid() objects print a useful UUID hex representation.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**