### PR TITLE
Feature/fix kdbx4 attachment mapping

### DIFF
--- a/src/format/Kdbx4Reader.h
+++ b/src/format/Kdbx4Reader.h
@@ -32,6 +32,7 @@ Q_DECLARE_TR_FUNCTIONS(Kdbx4Reader)
 public:
     Database* readDatabaseImpl(QIODevice* device, const QByteArray& headerData,
                                const CompositeKey& key, bool keepDatabase) override;
+    QHash<QByteArray, QString> binaryPoolInverse() const;
     QHash<QString, QByteArray> binaryPool() const;
 
 protected:
@@ -41,7 +42,7 @@ private:
     bool readInnerHeaderField(QIODevice* device);
     QVariantMap readVariantMap(QIODevice* device);
 
-    QHash<QString, QByteArray> m_binaryPool;
+    QHash<QByteArray, QString> m_binaryPoolInverse;
 };
 
 #endif // KEEPASSX_KDBX4READER_H

--- a/src/format/Kdbx4Writer.cpp
+++ b/src/format/Kdbx4Writer.cpp
@@ -211,12 +211,20 @@ bool Kdbx4Writer::writeInnerHeaderField(QIODevice* device, KeePass2::InnerHeader
 void Kdbx4Writer::writeAttachments(QIODevice* device, Database* db)
 {
     const QList<Entry*> allEntries = db->rootGroup()->entriesRecursive(true);
+    QSet<QByteArray> writtenAttachments;
+
     for (Entry* entry : allEntries) {
         const QList<QString> attachmentKeys = entry->attachments()->keys();
         for (const QString& key : attachmentKeys) {
-            QByteArray data = entry->attachments()->value(key);
-            data.prepend("\x01");
+            QByteArray data("\x01");
+            data.append(entry->attachments()->value(key));
+
+            if (writtenAttachments.contains(data)) {
+                continue;
+            }
+
             writeInnerHeaderField(device, KeePass2::InnerHeaderFieldID::Binary, data);
+            writtenAttachments.insert(data);
         }
     }
 }

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -40,7 +40,7 @@ KdbxXmlReader::KdbxXmlReader(quint32 version)
  * @param version KDBX version
  * @param binaryPool binary pool
  */
-KdbxXmlReader::KdbxXmlReader(quint32 version, QHash<QString, QByteArray>& binaryPool)
+KdbxXmlReader::KdbxXmlReader(quint32 version, const QHash<QString, QByteArray>& binaryPool)
     : m_kdbxVersion(version)
     , m_binaryPool(binaryPool)
 {

--- a/src/format/KdbxXmlReader.h
+++ b/src/format/KdbxXmlReader.h
@@ -42,7 +42,7 @@ Q_DECLARE_TR_FUNCTIONS(KdbxXmlReader)
 
 public:
     explicit KdbxXmlReader(quint32 version);
-    explicit KdbxXmlReader(quint32 version, QHash<QString, QByteArray>& binaryPool);
+    explicit KdbxXmlReader(quint32 version, const QHash<QString, QByteArray>& binaryPool);
     virtual ~KdbxXmlReader() = default;
 
     virtual Database* readDatabase(const QString& filename);

--- a/tests/TestKdbx4.h
+++ b/tests/TestKdbx4.h
@@ -28,6 +28,7 @@ private slots:
     void testFormat400();
     void testFormat400Upgrade();
     void testFormat400Upgrade_data();
+    void testDuplicateAttachments();
 
 protected:
     void initTestCaseImpl() override;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch fixes a serious KDBX4 reader/writer attachment mapping error.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous implementation used to write duplicate BLOBs to the KDBX4 inner header, while entries actually referred to a de-duplicated version of the binary pool. This caused a mapping problem between the binary pool and referencing entries.

Duplicate entries can occur when the user adds the same file as attachment twice (with different attachment names or to different entries), but are much more common when attachment entries are edited and history is turned on. If either case occurs, the KDBX binary pool and entry attachment mappings get out of sync with the effect that attachment contents are replaced by other attachments and successive saves will silently drop attachment data.

KeePass2 could still open such a broken database without mapping issues, since it just skips duplicate BLOBs. With this patch, we now also skip duplicate attachments both when writing and reading a database.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a new unit test which checks mappings for duplicate attachments. I tested it both before and after applying the patch. As expected, the unfixed version fails, while the fixed version doesn't).

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
