### PR TITLE
Make 'Welcome to KeePassXC $VERSION' string properly translatable

### DIFF
--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -29,7 +29,7 @@ WelcomeWidget::WelcomeWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
 
-    m_ui->welcomeLabel->setText(m_ui->welcomeLabel->text() + " " + KEEPASSX_VERSION);
+    m_ui->welcomeLabel->setText(tr("Welcome to KeePassXC %1").arg(KEEPASSX_VERSION));
     QFont welcomeLabelFont = m_ui->welcomeLabel->font();
     welcomeLabelFont.setBold(true);
     welcomeLabelFont.setPointSize(welcomeLabelFont.pointSize() + 4);

--- a/src/gui/WelcomeWidget.ui
+++ b/src/gui/WelcomeWidget.ui
@@ -72,9 +72,6 @@
    </item>
    <item>
     <widget class="QLabel" name="welcomeLabel">
-     <property name="text">
-      <string>Welcome to KeePassXC</string>
-     </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Resolves #1236.

## Description
<!--- Describe your changes in detail -->
The "Welcome to KeePassXC $VERSION" string on the WelcomeWidget wan't translatable in some languages.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
