### PR TITLE
Add UI for editing tags

### DIFF
--- a/src/core/EntrySearcher.cpp
+++ b/src/core/EntrySearcher.cpp
@@ -70,7 +70,8 @@ bool EntrySearcher::wordMatch(const QString& word, Entry* entry, Qt::CaseSensiti
     return entry->resolvePlaceholder(entry->title()).contains(word, caseSensitivity)
            || entry->resolvePlaceholder(entry->username()).contains(word, caseSensitivity)
            || entry->resolvePlaceholder(entry->url()).contains(word, caseSensitivity)
-           || entry->resolvePlaceholder(entry->notes()).contains(word, caseSensitivity);
+           || entry->resolvePlaceholder(entry->notes()).contains(word, caseSensitivity)
+           || entry->resolvePlaceholder(entry->tags()).contains(word, caseSensitivity);
 }
 
 bool EntrySearcher::matchGroup(const QString& searchTerm, const Group* group, Qt::CaseSensitivity caseSensitivity)

--- a/src/gui/DetailsWidget.cpp
+++ b/src/gui/DetailsWidget.cpp
@@ -173,7 +173,9 @@ void DetailsWidget::updateEntryGeneralTab()
         m_ui->entryPasswordLabel->setToolTip({});
     }
 
-    const QString url = m_currentEntry->webUrl();
+    m_ui->tagsLabel->setText(m_currentEntry->tags());
+
+    QString url = m_currentEntry->webUrl();
     if (!url.isEmpty()) {
         // URL is well formed and can be opened in a browser
         // create a new display url that masks password placeholders

--- a/src/gui/DetailsWidget.ui
+++ b/src/gui/DetailsWidget.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>DetailsWidget</class>
  <widget class="QWidget" name="DetailsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>280</width>
+    <height>267</height>
+   </rect>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_7">
    <property name="spacing">
     <number>0</number>
@@ -154,7 +162,7 @@
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
             <widget class="QWidget" name="entryGeneralWidget" native="true">
-             <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0" columnstretch="0,0,0">
+             <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0" columnstretch="0,0,0">
               <property name="leftMargin">
                <number>0</number>
               </property>
@@ -167,6 +175,19 @@
               <property name="bottomMargin">
                <number>0</number>
               </property>
+              <item row="5" column="2">
+               <spacer name="verticalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
               <item row="1" column="2">
                <widget class="ElidedLabel" name="entryPasswordLabel">
                 <property name="sizePolicy">
@@ -180,6 +201,28 @@
                   <width>100</width>
                   <height>0</height>
                  </size>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLabel" name="entryUrlTitleLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>URL</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                </widget>
               </item>
@@ -205,50 +248,6 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="2">
-               <widget class="QLabel" name="entryUsernameLabel">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>100</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="textInteractionFlags">
-                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="entryUsernameTitleLabel">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="layoutDirection">
-                 <enum>Qt::LeftToRight</enum>
-                </property>
-                <property name="text">
-                 <string>Username</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
               <item row="3" column="1">
                <widget class="QLabel" name="entryExpirationTitleLabel">
                 <property name="sizePolicy">
@@ -271,6 +270,25 @@
                 </property>
                </widget>
               </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="entryUsernameLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>100</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
               <item row="3" column="2">
                <widget class="QLabel" name="entryExpirationLabel">
                 <property name="sizePolicy">
@@ -281,8 +299,8 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="1">
-               <widget class="QLabel" name="entryUrlTitleLabel">
+              <item row="0" column="1">
+               <widget class="QLabel" name="entryUsernameTitleLabel">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -295,8 +313,11 @@
                   <bold>true</bold>
                  </font>
                 </property>
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
                 <property name="text">
-                 <string>URL</string>
+                 <string>Username</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -341,18 +362,28 @@
                 </property>
                </widget>
               </item>
+              <item row="4" column="1">
+               <widget class="QLabel" name="tagsLabel_2">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Tags</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
               <item row="4" column="2">
-               <spacer name="verticalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
+               <widget class="QLabel" name="tagsLabel">
+                <property name="text">
+                 <string/>
                 </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-               </spacer>
+               </widget>
               </item>
              </layout>
             </widget>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -680,6 +680,7 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
     m_advancedUi->editAttributeButton->setEnabled(false);
     m_advancedUi->removeAttributeButton->setEnabled(false);
     m_advancedUi->attributesEdit->setReadOnly(m_history);
+    m_advancedUi->tagsEdit->setReadOnly(m_history);
     QAbstractItemView::EditTriggers editTriggers;
     if (m_history) {
         editTriggers = QAbstractItemView::NoEditTriggers;
@@ -716,6 +717,8 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
         m_advancedUi->attributesEdit->setPlainText("");
         m_advancedUi->attributesEdit->setEnabled(false);
     }
+
+    m_advancedUi->tagsEdit->setText(entry->tags());
 
     QList<int> sizes = m_advancedUi->attributesSplitter->sizes();
     sizes.replace(0, m_advancedUi->attributesSplitter->width() * 0.3);
@@ -864,6 +867,7 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
     QRegularExpression newLineRegex("(?:\r?\n|\r)");
 
     entry->attributes()->copyCustomKeysFrom(m_entryAttributes);
+    entry->setTags(m_advancedUi->tagsEdit->text());
     entry->attachments()->copyDataFrom(m_advancedUi->attachmentsWidget->entryAttachments());
     entry->customData()->copyDataFrom(m_editWidgetProperties->customData());
     entry->setTitle(m_mainUi->titleEdit->text().replace(newLineRegex, " "));

--- a/src/gui/entry/EditEntryWidgetAdvanced.ui
+++ b/src/gui/entry/EditEntryWidgetAdvanced.ui
@@ -135,6 +135,22 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="tagsBox">
+     <property name="title">
+      <string>Tags</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLineEdit" name="tagsEdit">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="attachmentsBox">
      <property name="title">
       <string>Attachments</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
This change exposes the tags field of entries to be viewed/edited in the advanced tab, and to be viewed in the details view. Also, text search is updated to also match tags. I've never touched Qt before, nor am I particularly good at UI things, so I'm happy to get any feedback on fixing this if it doesn't meet your standards.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted to use the tags feature in a script I was writing. I was editing them in windows with KeePass, but found keepassxc much better on Linux, but missing this one thing.

This is related to #508, but does not add all the UI they request.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change should have very minimal impact, doesn't modify any existing behavior, just exposes one more piece of data (that was already being read/written) to the UI in the advanced tab of the entry editor. I tested this on Linux, saw that I was able to edit tags, and the changes were visible to other editors.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
