### PR TITLE
Create history item when setting up a TOTP seed

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -350,6 +350,7 @@ QString Entry::totp() const
 
 void Entry::setTotp(const QString& seed, quint8& step, quint8& digits)
 {
+    beginUpdate();
     if (step == 0) {
         step = Totp::defaultStep;
     }
@@ -376,6 +377,7 @@ void Entry::setTotp(const QString& seed, quint8& step, quint8& digits)
         }
         m_attributes->set("TOTP Settings", data);
     }
+    endUpdate();
 }
 
 QString Entry::totpSeed() const

--- a/tests/TestTotp.cpp
+++ b/tests/TestTotp.cpp
@@ -164,3 +164,15 @@ void TestTotp::testSteamTotp()
     time = 1511200714;
     QCOMPARE(Totp::generateTotp(seed, time, Totp::ENCODER_STEAM, 30), QString("9P3VP"));
 }
+
+void TestTotp::testEntryHistory()
+{
+    Entry entry;
+    quint8 step = 16;
+    quint8 digits = 6;
+    QCOMPARE(entry.historyItems().size(), 0);
+    entry.setTotp("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ", step, digits);
+    QCOMPARE(entry.historyItems().size(), 1);
+    entry.setTotp("foo", step, digits);
+    QCOMPARE(entry.historyItems().size(), 2);
+}

--- a/tests/TestTotp.h
+++ b/tests/TestTotp.h
@@ -33,6 +33,7 @@ private slots:
     void testTotpCode();
     void testEncoderData();
     void testSteamTotp();
+    void testEntryHistory();
 };
 
 #endif // KEEPASSX_TESTTOTP_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #1445 by wrapping TOTP setup into a transaction.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Setting up TOTP seeds for an entry did not add a history item.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by adding TOTP seeds and with added unit tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
