### PR TITLE
SSH Agent: Support old unencrypted DSA and RSA keys

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -444,6 +444,10 @@ bool EditEntryWidget::getOpenSSHKey(OpenSSHKey& key)
         return false;
     }
 
+    if (key.comment().isEmpty()) {
+        key.setComment(m_entry->username());
+    }
+
     return true;
 }
 

--- a/src/sshagent/ASN1Key.cpp
+++ b/src/sshagent/ASN1Key.cpp
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (C) 2018 Toni Spets <toni.spets@iki.fi>
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ASN1Key.h"
+#include <gcrypt.h>
+
+namespace {
+    constexpr quint8 TAG_INT         = 0x02;
+    constexpr quint8 TAG_SEQUENCE    = 0x30;
+    constexpr quint8 KEY_ZERO        = 0x0;
+
+    bool nextTag(BinaryStream& stream, quint8& tag, quint32& len)
+    {
+        stream.read(tag);
+
+        quint8 lenByte;
+        stream.read(lenByte);
+
+        if (lenByte & 0x80) {
+            quint32 bytes = lenByte & ~0x80;
+            if (bytes == 1) {
+                stream.read(lenByte);
+                len = lenByte;
+            } else if (bytes == 2) {
+                quint16 lenShort;
+                stream.read(lenShort);
+                len = lenShort;
+            } else if (bytes == 4) {
+                stream.read(len);
+            } else {
+                return false;
+            }
+        } else {
+            len = lenByte;
+        }
+
+        return true;
+    }
+
+    bool parseHeader(BinaryStream& stream, quint8 wantedType)
+    {
+        quint8 tag;
+        quint32 len;
+
+        nextTag(stream, tag, len);
+
+        if (tag != TAG_SEQUENCE) {
+            return false;
+        }
+
+        nextTag(stream, tag, len);
+
+        if (tag != TAG_INT || len != 1) {
+            return false;
+        }
+
+        quint8 keyType;
+        stream.read(keyType);
+
+        return (keyType == wantedType);
+    }
+
+    bool readInt(BinaryStream& stream, QByteArray& target)
+    {
+        quint8 tag;
+        quint32 len;
+
+        nextTag(stream, tag, len);
+
+        if (tag != TAG_INT) {
+            return false;
+        }
+
+        target.resize(len);
+        stream.read(target);
+        return true;
+    }
+
+    QByteArray calculateIqmp(QByteArray& bap, QByteArray& baq)
+    {
+        gcry_mpi_t u, p, q;
+        QByteArray iqmp_hex;
+
+        u = gcry_mpi_snew(bap.length() * 8);
+        gcry_mpi_scan(&p, GCRYMPI_FMT_HEX, bap.toHex().data(), 0, nullptr);
+        gcry_mpi_scan(&q, GCRYMPI_FMT_HEX, baq.toHex().data(), 0, nullptr);
+
+        mpi_invm(u, q, p);
+
+        iqmp_hex.resize((bap.length() + 1) * 2);
+        gcry_mpi_print(GCRYMPI_FMT_HEX, reinterpret_cast<unsigned char*>(iqmp_hex.data()), iqmp_hex.length(), nullptr, u);
+
+        gcry_mpi_release(u);
+        gcry_mpi_release(p);
+        gcry_mpi_release(q);
+
+        return QByteArray::fromHex(iqmp_hex);
+    }
+}
+
+bool ASN1Key::parseDSA(QByteArray& ba, OpenSSHKey& key)
+{
+    BinaryStream stream(&ba);
+
+    if (!parseHeader(stream, KEY_ZERO)) {
+        return false;
+    }
+
+    QByteArray p,q,g,y,x;
+    readInt(stream, p);
+    readInt(stream, q);
+    readInt(stream, g);
+    readInt(stream, y);
+    readInt(stream, x);
+
+    QList<QByteArray> publicData;
+    publicData.append(p);
+    publicData.append(q);
+    publicData.append(g);
+    publicData.append(y);
+
+    QList<QByteArray> privateData;
+    privateData.append(p);
+    privateData.append(q);
+    privateData.append(g);
+    privateData.append(y);
+    privateData.append(x);
+
+    key.setType("ssh-dss");
+    key.setPublicData(publicData);
+    key.setPrivateData(privateData);
+    key.setComment("");
+    return true;
+}
+
+bool ASN1Key::parseRSA(QByteArray& ba, OpenSSHKey& key)
+{
+    BinaryStream stream(&ba);
+
+    if (!parseHeader(stream, KEY_ZERO)) {
+        return false;
+    }
+
+    QByteArray n,e,d,p,q,dp,dq,qinv;
+    readInt(stream, n);
+    readInt(stream, e);
+    readInt(stream, d);
+    readInt(stream, p);
+    readInt(stream, q);
+    readInt(stream, dp);
+    readInt(stream, dq);
+    readInt(stream, qinv);
+
+    QList<QByteArray> publicData;
+    publicData.append(e);
+    publicData.append(n);
+
+    QList<QByteArray> privateData;
+    privateData.append(n);
+    privateData.append(e);
+    privateData.append(d);
+    privateData.append(calculateIqmp(p, q));
+    privateData.append(p);
+    privateData.append(q);
+
+    key.setType("ssh-rsa");
+    key.setPublicData(publicData);
+    key.setPrivateData(privateData);
+    key.setComment("");
+    return true;
+}

--- a/src/sshagent/ASN1Key.h
+++ b/src/sshagent/ASN1Key.h
@@ -1,5 +1,6 @@
 /*
- *  Copyright (C) 2017 Toni Spets <toni.spets@iki.fi>
+ *  Copyright (C) 2018 Toni Spets <toni.spets@iki.fi>
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,24 +16,16 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TESTOPENSSHKEY_H
-#define TESTOPENSSHKEY_H
+#ifndef ASN1KEY_H
+#define ASN1KEY_H
 
-#include <QObject>
+#include "OpenSSHKey.h"
+#include <QtCore>
 
-class OpenSSHKey;
-
-class TestOpenSSHKey : public QObject
+namespace ASN1Key
 {
-    Q_OBJECT
+    bool parseDSA(QByteArray& ba, OpenSSHKey& key);
+    bool parseRSA(QByteArray& ba, OpenSSHKey& key);
+}
 
-private slots:
-    void initTestCase();
-    void testParse();
-    void testParseDSA();
-    void testParseRSA();
-    void testDecryptAES256CBC();
-    void testDecryptAES256CTR();
-};
-
-#endif // TESTOPENSSHKEY_H
+#endif // ASN1KEY_H

--- a/src/sshagent/CMakeLists.txt
+++ b/src/sshagent/CMakeLists.txt
@@ -9,6 +9,7 @@ if(WITH_XC_SSHAGENT)
         BinaryStream.cpp
         KeeAgentSettings.cpp
         OpenSSHKey.cpp
+        ASN1Key.cpp
         SSHAgent.cpp
     )
 

--- a/src/sshagent/OpenSSHKey.h
+++ b/src/sshagent/OpenSSHKey.h
@@ -55,6 +55,10 @@ public:
     bool writePrivate(BinaryStream& stream);
 
 private:
+    static const QString TYPE_DSA;
+    static const QString TYPE_RSA;
+    static const QString TYPE_OPENSSH;
+
     bool parsePEM(const QByteArray& in, QByteArray& out);
 
     QString m_type;
@@ -64,6 +68,7 @@ private:
     QByteArray m_rawPrivateData;
     QList<QByteArray> m_publicData;
     QList<QByteArray> m_privateData;
+    QString m_privateType;
     QString m_comment;
     QString m_error;
 };

--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -260,6 +260,10 @@ void SSHAgent::databaseModeChanged(DatabaseWidget::Mode mode)
                 continue;
             }
 
+            if (key.comment().isEmpty()) {
+                key.setComment(e->username());
+            }
+
             if (settings.removeAtDatabaseClose()) {
                 removeIdentityAtLock(key, uuid);
             }

--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -50,6 +50,7 @@ void TestOpenSSHKey::testParse()
     QCOMPARE(key.cipherName(), QString("none"));
     QCOMPARE(key.type(), QString("ssh-ed25519"));
     QCOMPARE(key.comment(), QString("opensshkey-test-parse@keepassxc"));
+    QCOMPARE(key.fingerprint(), QString("SHA256:D1fVmA15YXzaJ5sdO9dXxo5coHL/pnNaIfCvokHzTA4"));
 
     QByteArray publicKey, privateKey;
     BinaryStream publicStream(&publicKey), privateStream(&privateKey);
@@ -59,6 +60,77 @@ void TestOpenSSHKey::testParse()
 
     QVERIFY(publicKey.length() == 51);
     QVERIFY(privateKey.length() == 154);
+}
+
+void TestOpenSSHKey::testParseDSA()
+{
+    const QString keyString = QString(
+        "-----BEGIN DSA PRIVATE KEY-----\n"
+        "MIIBuwIBAAKBgQCudjbvSh8JxQOr2laCqZM1t4kNWBETVOXz5vgk9iw6Z5opB9/k\n"
+        "g4nFc1PVq7fdAIc8W/5WCAjugKcxPb9PIHfcwY2fimmiPWFK68/eHKLoCuIn2wxB\n"
+        "63ig2hAhx5U5aYG9QHkNCaT6VX7rc19nToSeZXlpja4x54/DaQaqOEWYsQIVAOer\n"
+        "UQWfccz7KXUu6+x7heGob6I3AoGAVDRFJIlL0DI/4nePIcgwgwbfgs2ojSu21g4w\n"
+        "dQoXvqU34XydPgPQ985XIIuiDkaomRw4yYd/Sh4ZapFcrP++iJ1V+WS6kLcWPHMq\n"
+        "poYwk8mq6GLbPFLEjr+n6HgX5ln15n3i4WAopNH7mEl0glY9L0rxmcN0XOpqw6Ux\n"
+        "ETGEfAwCgYAiOeYwblMkkTIGtVx5NvNsOlfrBYL4GqUP9oQMO5I+xLZLWQIf+7Jp\n"
+        "8t6mwxSBz0RHjNVQ11vZowNjq3587aLy57bVwf2lIm9KSvS6z9HoNbHgQimcBorR\n"
+        "J9l9RUrj7TnsZgiVw66j2r34nHRHRtggiO+qrMtw7MJc0Q7jiuTmzgIVAMXbk0T9\n"
+        "nBfSLWQz/L8RexU2GR4e\n"
+        "-----END DSA PRIVATE KEY-----\n"
+    );
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parse(keyData));
+    QVERIFY(!key.encrypted());
+    QCOMPARE(key.cipherName(), QString("none"));
+    QCOMPARE(key.type(), QString("ssh-dss"));
+    QCOMPARE(key.comment(), QString(""));
+    QCOMPARE(key.fingerprint(), QString("SHA256:tbbNuLN1hja8JNASDTlLOZQsbTlJDzJlz/oAGK3sX18"));
+}
+
+void TestOpenSSHKey::testParseRSA()
+{
+    const QString keyString = QString(
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEAsCHtJicDPWnvHSIKbnTZaJkIB9vgE0pmLdK580JUqBuonVbB\n"
+        "y1QTy0ZQ7/TtqvLPgwPK88TR46OLO/QGCzo2+XxgJ85uy0xfuyUYRmSuw0drsErN\n"
+        "mH8vU91lSBxsGDp9LtBbgHKoR23vMWZ34IxFRc55XphrIH48ijsMaL6bXBwF/3tD\n"
+        "9T3lm2MpP1huyVNnIY9+GRRWCy4f9LMj/UGu/n4RtwwfpOZBBRwYkq5QkzA9lPm/\n"
+        "VzF3MP1rKTMkvAw+Nfb383mkmc6MRnsa6uh6iDa9aVB7naegM13UJQX/PY1Ks6pO\n"
+        "XDpy/MQ7iCh+HmYNq5dRmARyaNl9xIXJNhz1cQIDAQABAoIBAQCnEUc1LUQxeM5K\n"
+        "wANNCqE+SgoIClPdeHC7fmrLh1ttqe6ib6ybBUFRS31yXs0hnfefunVEDKlaV8K2\n"
+        "N52UAMAsngFHQNRvGh6kEWeZPd9Xc+N98TZbNCjcT+DGKc+Om8wqH5DrodZlCq4c\n"
+        "GaoT4HnE4TjWtZTH2XXrWF9I66PKFWf070R44nvyVcvaZi4pC2YmURRPuGF6K1iK\n"
+        "dH8zM6HHG1UGu2W6hLNn+K01IulG0Lb8eWNaNYMmtQWaxyp7I2IWkkecUs3nCuiR\n"
+        "byFOoomCjdh8r9yZFvwxjGUhgtkALN9GCU0Mwve+s11IB2gevruN+q9/Qejbyfdm\n"
+        "IlgLAeTRAoGBANRcVzW9CYeobCf+U9hKJFEOur8XO+J2mTMaELA0EjWpTJFAeIT7\n"
+        "KeRpCRG4/vOSklxxRF6vP1EACA4Z+5BlN+FTipHHs+bSEgqkPZiiANDH7Zot5Iqv\n"
+        "1q0fRyldNRZNZK7DWp08BPNVWGA/EnEuKJiURxnxBaxNXbUyMCdjxvMvAoGBANRT\n"
+        "utbrqS/bAa/DcHKn3V6DRqBl3TDOfvCNjiKC84a67F2uXgzLIdMktr4d1NyCZVJd\n"
+        "7/zVgWORLIdg1eAi6rYGoOvNV39wwga7CF+m9sBY0wAaKYCELe6L26r4aQHVCX6n\n"
+        "rnIgUv+4o4itmU2iP0r3wlmDC9pDRQP82vfvQPlfAoGASwhleANW/quvq2HdViq8\n"
+        "Mje2HBalfhrRfpDTHK8JUBSFjTzuWG42GxJRtgVbb8x2ElujAKGDCaetMO5VSGu7\n"
+        "Fs5hw6iAFCpdXY0yhl+XUi2R8kwM2EPQ4lKO3jqkq0ClNmqn9a5jQWcCVt9yMLNS\n"
+        "fLbHeI8EpiCf34ngIcrLXNkCgYEAzlcEZuKkC46xB+dNew8pMTUwSKZVm53BfPKD\n"
+        "44QRN6imFbBjU9mAaJnwQbfp6dWKs834cGPolyM4++MeVfB42iZ88ksesgmZdUMD\n"
+        "szkl6O0pOJs0I+HQZVdjRbadDZvD22MHQ3+oST1dJ3FVXz3Cdo9qPuT8esMO6f4r\n"
+        "qfDH2s8CgYAXC/lWWHQ//PGP0pH4oiEXisx1K0X1u0xMGgrChxBRGRiKZUwNMIvJ\n"
+        "TqUu7IKizK19cLHF/NBvxHYHFw+m7puNjn6T1RtRCUjRZT7Dx1VHfVosL9ih5DA8\n"
+        "tpbZA5KGKcvHtB5DDgT0MHwzBZnb4Q//Rhovzn+HXZPsJTTgHHy3NQ==\n"
+        "-----END RSA PRIVATE KEY-----\n"
+    );
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parse(keyData));
+    QVERIFY(!key.encrypted());
+    QCOMPARE(key.cipherName(), QString("none"));
+    QCOMPARE(key.type(), QString("ssh-rsa"));
+    QCOMPARE(key.comment(), QString(""));
+    QCOMPARE(key.fingerprint(), QString("SHA256:DYdaZciYNxCejr+/8x+OKYxeTU1D5UsuIFUG4PWRFkk"));
 }
 
 void TestOpenSSHKey::testDecryptAES256CBC()


### PR DESCRIPTION
Adds support for plain DSA and RSA keys in the "regular" format people actually use.

Candidate for 2.3.0 as it will prevent some support noise.

## Description
Not too fond of the partial ASN.1 parser but it works well enough for these key types. Supporting encrypted keys would require importing even more code just for KDF so at this time I'm leaving it out. The integration of these keys into OpenSSHKey class is done in a way decryption is straightforward to add later.

The empty comment thing is so that the username field of an entry is used as it for these keys as the private key file does not contain a comment.

## Motivation and context
SSH Agent was first introduced supporting only the "new" private key file format which does support all existing key types but the file format is not used by default except for ED25519 keys. This is very confusing for users who are moving their existing keys into KeePassXC.

## How has this been tested?
New tests cover both new key types and existing tests for OpenSSHKey pass.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
