### PR TITLE
SSH Agent: Always use freshly selected key

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -271,7 +271,7 @@ void EditEntryWidget::setupSSHAgent()
     m_sshAgentUi->publicKeyEdit->setFont(fixedFont);
 
     connect(m_sshAgentUi->attachmentRadioButton, SIGNAL(clicked(bool)), SLOT(updateSSHAgentKeyInfo()));
-    connect(m_sshAgentUi->attachmentComboBox, SIGNAL(currentIndexChanged(int)), SLOT(updateSSHAgentKeyInfo()));
+    connect(m_sshAgentUi->attachmentComboBox, SIGNAL(currentIndexChanged(int)), SLOT(updateSSHAgentAttachment()));
     connect(m_sshAgentUi->externalFileRadioButton, SIGNAL(clicked(bool)), SLOT(updateSSHAgentKeyInfo()));
     connect(m_sshAgentUi->externalFileEdit, SIGNAL(textChanged(QString)), SLOT(updateSSHAgentKeyInfo()));
     connect(m_sshAgentUi->browseButton, SIGNAL(clicked()), SLOT(browsePrivateKey()));
@@ -320,6 +320,12 @@ void EditEntryWidget::updateSSHAgent()
 
     m_sshAgentSettings = settings;
 
+    updateSSHAgentKeyInfo();
+}
+
+void EditEntryWidget::updateSSHAgentAttachment()
+{
+    m_sshAgentUi->attachmentRadioButton->setChecked(true);
     updateSSHAgentKeyInfo();
 }
 
@@ -398,6 +404,8 @@ void EditEntryWidget::browsePrivateKey()
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select private key"), "");
     if (!fileName.isEmpty()) {
         m_sshAgentUi->externalFileEdit->setText(fileName);
+        m_sshAgentUi->externalFileRadioButton->setChecked(true);
+        updateSSHAgentKeyInfo();
     }
 }
 

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -101,6 +101,7 @@ private slots:
     void toggleHideNotes(bool visible);
 #ifdef WITH_XC_SSHAGENT
     void updateSSHAgent();
+    void updateSSHAgentAttachment();
     void updateSSHAgentKeyInfo();
     void browsePrivateKey();
     void addKeyToAgent();


### PR DESCRIPTION
When selecting an attachment or browsing for a file to use as the key, change the radio button selection automatically.

## Motivation and context
I found myself expecting this to happen and it being quite annoying when it didn't.

## How has this been tested?
Manually.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
