### PR TITLE
Fix settings not being persisted on exit

### DIFF
--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -20,10 +20,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Project Maintainers:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
@@ -68,6 +64,11 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Enabled extensions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Build Type: Snapshot
+</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -819,6 +820,22 @@ If you keep this number, your database may be too easy to crack!</source>
         <source>Failed to transform key with new KDF parameters; KDF unchanged.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message numerus="yes">
+        <source> MiB</source>
+        <comment>Abbreviation for Mebibytes (KDF settings)</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source> thread(s)</source>
+        <comment>Threads for parallel execution (KDF settings)</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetEncryption</name>
@@ -851,15 +868,7 @@ If you keep this number, your database may be too easy to crack!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> MB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Parallelism:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> thread</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -899,6 +908,14 @@ If you keep this number, your database may be too easy to crack!</source>
     </message>
     <message>
         <source>Use recycle bin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Additional Database Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable &amp;compression (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1016,6 +1033,15 @@ Please press cancel to finish your changes or discard them.</source>
         <source>This database has been modified.
 Do you want to save the database before locking it?
 Otherwise your changes are lost.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable safe saves?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC has failed to save the database multiple times. This is likely caused by file sync services holding a lock on the save file.
+Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1815,6 +1841,65 @@ Do you want to merge your changes?</source>
     </message>
     <message>
         <source>URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expires</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Modified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attachments</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EntryView</name>
+    <message>
+        <source>Customize View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Usernames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Passwords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fit to window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fit to contents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2692,6 +2777,12 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
     </message>
     <message>
         <source>Please touch the button on your YubiKey!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WARNING: You are using an unstable build of KeePassXC!
+There is a high risk of corruption, maintain a backup of your databases.
+This version is not meant for production use.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3650,6 +3741,30 @@ Please unlock the selected database or choose another one which is unlocked.</so
         <comment>Milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Safely save database files (may be incompatible with Dropbox, etc)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backup database file before saving</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Entry Management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsWidgetSecurity</name>
@@ -3788,10 +3903,6 @@ Please unlock the selected database or choose another one which is unlocked.</so
 <context>
     <name>WelcomeWidget</name>
     <message>
-        <source>Welcome to KeePassXC</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Start storing your passwords securely in a KeePassXC database</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3813,6 +3924,10 @@ Please unlock the selected database or choose another one which is unlocked.</so
     </message>
     <message>
         <source>Recent databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Welcome to KeePassXC %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -26,15 +26,18 @@ class QSettings;
 
 class Config : public QObject
 {
-    Q_OBJECT
+Q_OBJECT
 
 public:
-    ~Config();
+    Q_DISABLE_COPY(Config)
+
+    ~Config() override;
     QVariant get(const QString& key);
     QVariant get(const QString& key, const QVariant& defaultValue);
     QString getFileName();
     void set(const QString& key, const QVariant& value);
     bool hasAccessError();
+    void sync();
 
     static Config* instance();
     static void createConfigFromFile(const QString& file);
@@ -49,8 +52,6 @@ private:
 
     QScopedPointer<QSettings> m_settings;
     QHash<QString, QVariant> m_defaults;
-
-    Q_DISABLE_COPY(Config)
 };
 
 inline Config* config() {

--- a/src/gui/DatabaseSettingsWidget.cpp
+++ b/src/gui/DatabaseSettingsWidget.cpp
@@ -57,6 +57,9 @@ DatabaseSettingsWidget::DatabaseSettingsWidget(QWidget* parent)
     connect(m_uiEncryption->transformBenchmarkButton, SIGNAL(clicked()), SLOT(transformRoundsBenchmark()));
     connect(m_uiEncryption->kdfComboBox, SIGNAL(currentIndexChanged(int)), SLOT(kdfChanged(int)));
 
+    connect(m_uiEncryption->memorySpinBox, SIGNAL(valueChanged(int)), this, SLOT(memoryChanged(int)));
+    connect(m_uiEncryption->parallelismSpinBox, SIGNAL(valueChanged(int)), this, SLOT(parallelismChanged(int)));
+
     m_ui->categoryList->addCategory(tr("General"), FilePath::instance()->icon("categories", "preferences-other"));
     m_ui->categoryList->addCategory(tr("Encryption"), FilePath::instance()->icon("actions", "document-encrypt"));
     m_ui->stackedWidget->addWidget(m_uiGeneralPage);
@@ -121,7 +124,7 @@ void DatabaseSettingsWidget::load(Database* db)
         kdfChanged(kdfIndex);
     }
 
-    // properly initialize parallelism spin box (may be overwritten by actual KDF values)
+    m_uiEncryption->memorySpinBox->setValue(64);
     m_uiEncryption->parallelismSpinBox->setValue(QThread::idealThreadCount());
 
     // Setup kdf parameters
@@ -288,4 +291,22 @@ void DatabaseSettingsWidget::kdfChanged(int index)
     m_uiEncryption->parallelismSpinBox->setEnabled(parallelismEnabled);
 
     transformRoundsBenchmark();
+}
+
+/**
+ * Update memory spin box suffix on value change.
+ */
+void DatabaseSettingsWidget::memoryChanged(int value)
+{
+    m_uiEncryption->memorySpinBox->setSuffix(
+        tr(" MiB", "Abbreviation for Mebibytes (KDF settings)", value));
+}
+
+/**
+ * Update parallelism spin box suffix on value change.
+ */
+void DatabaseSettingsWidget::parallelismChanged(int value)
+{
+    m_uiEncryption->parallelismSpinBox->setSuffix(
+        tr(" thread(s)", "Threads for parallel execution (KDF settings)", value));
 }

--- a/src/gui/DatabaseSettingsWidget.h
+++ b/src/gui/DatabaseSettingsWidget.h
@@ -54,6 +54,8 @@ private slots:
     void reject();
     void transformRoundsBenchmark();
     void kdfChanged(int index);
+    void memoryChanged(int value);
+    void parallelismChanged(int value);
 
 private:
     void truncateHistories();

--- a/src/gui/DatabaseSettingsWidgetEncryption.ui
+++ b/src/gui/DatabaseSettingsWidgetEncryption.ui
@@ -139,17 +139,11 @@
        <height>16777215</height>
       </size>
      </property>
-     <property name="suffix">
-      <string> MB</string>
-     </property>
      <property name="minimum">
       <number>1</number>
      </property>
      <property name="maximum">
       <number>1048576</number>
-     </property>
-     <property name="value">
-      <number>64</number>
      </property>
     </widget>
    </item>
@@ -173,9 +167,6 @@
        <width>150</width>
        <height>16777215</height>
       </size>
-     </property>
-     <property name="suffix">
-      <string> thread</string>
      </property>
      <property name="minimum">
       <number>1</number>

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -1,19 +1,19 @@
 /*
- *  Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 or (at your option)
- *  version 3 of the License.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef KEEPASSX_DATABASETABWIDGET_H
@@ -51,7 +51,7 @@ class DatabaseTabWidget : public QTabWidget
 
 public:
     explicit DatabaseTabWidget(QWidget* parent = nullptr);
-    ~DatabaseTabWidget();
+    ~DatabaseTabWidget() override;
     void openDatabase(const QString& fileName, const QString& pw = QString(),
                       const QString& keyFile = QString());
     void mergeDatabase(const QString& fileName);
@@ -116,7 +116,7 @@ private:
     void connectDatabase(Database* newDb, Database* oldDb = nullptr);
 
     QHash<Database*, DatabaseManagerStruct> m_dbList;
-    DatabaseWidgetStateSync* m_dbWidgetStateSync;
+    QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
 };
 
 #endif // KEEPASSX_DATABASETABWIDGET_H

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1,19 +1,19 @@
 /*
- *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 or (at your option)
- *  version 3 of the License.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "DatabaseWidget.h"

--- a/src/gui/DatabaseWidgetStateSync.cpp
+++ b/src/gui/DatabaseWidgetStateSync.cpp
@@ -1,24 +1,26 @@
 /*
- *  Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2014 Florian Geyer <blueice@fobos.de>
+ * Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
+ * Copyright (C) 2014 Florian Geyer <blueice@fobos.de>
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 or (at your option)
- *  version 3 of the License.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "DatabaseWidgetStateSync.h"
 
 #include "core/Config.h"
+#include <QCoreApplication>
 
 DatabaseWidgetStateSync::DatabaseWidgetStateSync(QObject* parent)
     : QObject(parent)
@@ -31,9 +33,18 @@ DatabaseWidgetStateSync::DatabaseWidgetStateSync(QObject* parent)
     m_hidePasswords = config()->get("GUI/HidePasswords").toBool();
     m_listViewState = config()->get("GUI/ListViewState").toByteArray();
     m_searchViewState = config()->get("GUI/SearchViewState").toByteArray();
+
+    connect(qApp, &QCoreApplication::aboutToQuit, this, &DatabaseWidgetStateSync::sync);
 }
 
 DatabaseWidgetStateSync::~DatabaseWidgetStateSync()
+{
+}
+
+/**
+ * Sync state with persistent storage.
+ */
+void DatabaseWidgetStateSync::sync()
 {
     config()->set("GUI/SplitterState", intListToVariant(m_mainSplitterSizes));
     config()->set("GUI/DetailSplitterState", intListToVariant(m_detailSplitterSizes));
@@ -41,12 +52,13 @@ DatabaseWidgetStateSync::~DatabaseWidgetStateSync()
     config()->set("GUI/HidePasswords", m_hidePasswords);
     config()->set("GUI/ListViewState", m_listViewState);
     config()->set("GUI/SearchViewState", m_searchViewState);
+    config()->sync();
 }
 
 void DatabaseWidgetStateSync::setActive(DatabaseWidget* dbWidget)
 {
     if (m_activeDbWidget) {
-        disconnect(m_activeDbWidget, 0, this, 0);
+        disconnect(m_activeDbWidget, nullptr, this, nullptr);
     }
 
     m_activeDbWidget = dbWidget;

--- a/src/gui/DatabaseWidgetStateSync.h
+++ b/src/gui/DatabaseWidgetStateSync.h
@@ -1,19 +1,20 @@
 /*
- *  Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2014 Florian Geyer <blueice@fobos.de>
+ * Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
+ * Copyright (C) 2014 Florian Geyer <blueice@fobos.de>
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 or (at your option)
- *  version 3 of the License.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef KEEPASSX_DATABASEWIDGETSTATESYNC_H
@@ -27,7 +28,7 @@ class DatabaseWidgetStateSync : public QObject
 
 public:
     explicit DatabaseWidgetStateSync(QObject* parent = nullptr);
-    ~DatabaseWidgetStateSync();
+    ~DatabaseWidgetStateSync() override;
 
 public slots:
     void setActive(DatabaseWidget* dbWidget);
@@ -38,12 +39,13 @@ private slots:
     void blockUpdates();
     void updateSplitterSizes();
     void updateViewState();
+    void sync();
 
 private:
     static QList<int> variantToIntList(const QVariant& variant);
     static QVariant intListToVariant(const QList<int>& list);
 
-    DatabaseWidget* m_activeDbWidget;
+    QPointer<DatabaseWidget> m_activeDbWidget;
 
     bool m_blockUpdates;
     QList<int> m_mainSplitterSizes;

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -1,18 +1,19 @@
 /*
- *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ * Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 or (at your option)
- *  version 3 of the License.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "EntryView.h"
@@ -88,11 +89,11 @@ EntryView::EntryView(QWidget* parent)
     // Stretching of last section interferes with fitting columns to window
     header()->setStretchLastSection(false);
     header()->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(header(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showHeaderMenu(QPoint)));
-    connect(header(), SIGNAL(sectionCountChanged(int, int)), this, SIGNAL(viewStateChanged()));
-    connect(header(), SIGNAL(sectionMoved(int, int, int)), this, SIGNAL(viewStateChanged()));
-    connect(header(), SIGNAL(sectionResized(int, int, int)), this, SIGNAL(viewStateChanged()));
-    connect(header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SIGNAL(viewStateChanged()));
+    connect(header(), SIGNAL(customContextMenuRequested(QPoint)), SLOT(showHeaderMenu(QPoint)));
+    connect(header(), SIGNAL(sectionCountChanged(int, int)), SIGNAL(viewStateChanged()));
+    connect(header(), SIGNAL(sectionMoved(int, int, int)), SIGNAL(viewStateChanged()));
+    connect(header(), SIGNAL(sectionResized(int, int, int)), SIGNAL(viewStateChanged()));
+    connect(header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), SIGNAL(viewStateChanged()));
 
     // TODO: not working as expected, columns will end up being very small,
     // most likely due to the widget not being sized properly at this time

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -1,18 +1,19 @@
 /*
- *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ * Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 or (at your option)
- *  version 3 of the License.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef KEEPASSX_ENTRYVIEW_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch fixes various not explicitly user-defined settings (e.g. opened databases, window geometry, entry view columns) etc. not being persisted reliably on application exit.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Persistence of non-user-defined settings relied on destructors of various QObjects/QWidgets being called after exiting the main event loop and closing the application. This is not guaranteed to happen and therefore many settings weren't synced to persistent storage. I changed the behavior to listen for `QCoreApplication::aboutToQuit()` instead, which is the officially recommended way of doing last-minute activities in Qt.

Actual user settings were not affected, because those are explicitly synced when leaving the settings dialog.

In addition, I snuck in a small translation fix for properly handling plurals in KDF parameters.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Closing the application now reliably writes all settings.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**