### PR TITLE
Relock database after successful autotype

### DIFF
--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -64,6 +64,8 @@ public slots:
 
 signals:
     void globalShortcutTriggered();
+    void autotypePerformed();
+    void autotypeRejected();
 
 private slots:
     void performAutoTypeFromGlobal(AutoTypeMatch match);

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -35,6 +35,7 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     : QDialog(parent)
     , m_view(new AutoTypeSelectView(this))
     , m_matchActivatedEmitted(false)
+    , m_rejected(false)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     // Places the window on the active (virtual) desktop instead of where the main window is.
@@ -83,6 +84,13 @@ void AutoTypeSelectDialog::done(int r)
     QDialog::done(r);
 }
 
+void AutoTypeSelectDialog::reject()
+{
+    m_rejected = true;
+
+    QDialog::reject();
+}
+
 void AutoTypeSelectDialog::emitMatchActivated(const QModelIndex& index)
 {
     // make sure we don't emit the signal twice when both activated() and clicked() are triggered
@@ -98,6 +106,10 @@ void AutoTypeSelectDialog::emitMatchActivated(const QModelIndex& index)
 
 void AutoTypeSelectDialog::matchRemoved()
 {
+    if (m_rejected) {
+        return;
+    }
+    
     if (m_view->model()->rowCount() == 0) {
         reject();
     }

--- a/src/autotype/AutoTypeSelectDialog.h
+++ b/src/autotype/AutoTypeSelectDialog.h
@@ -39,6 +39,7 @@ signals:
 
 public slots:
     void done(int r) override;
+    void reject() override;
 
 private slots:
     void emitMatchActivated(const QModelIndex& index);
@@ -47,6 +48,7 @@ private slots:
 private:
     AutoTypeSelectView* const m_view;
     bool m_matchActivatedEmitted;
+    bool m_rejected;
 };
 
 #endif // KEEPASSX_AUTOTYPESELECTDIALOG_H

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -79,6 +79,7 @@ public slots:
     bool isModified(int index = -1);
     void performGlobalAutoType();
     void lockDatabases();
+    void relockPendingDatabase();
     QString databasePath(int index = -1);
 
 signals:
@@ -117,6 +118,7 @@ private:
 
     QHash<Database*, DatabaseManagerStruct> m_dbList;
     QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
+    QPointer<DatabaseWidget> m_dbPendingLock;
 };
 
 #endif // KEEPASSX_DATABASETABWIDGET_H

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -161,6 +161,7 @@ void SettingsWidget::loadSettings()
     m_secUi->lockDatabaseIdleSpinBox->setValue(config()->get("security/lockdatabaseidlesec").toInt());
     m_secUi->lockDatabaseMinimizeCheckBox->setChecked(config()->get("security/lockdatabaseminimize").toBool());
     m_secUi->lockDatabaseOnScreenLockCheckBox->setChecked(config()->get("security/lockdatabasescreenlock").toBool());
+    m_secUi->relockDatabaseAutoTypeCheckBox->setChecked(config()->get("security/relockautotype").toBool());
     m_secUi->fallbackToGoogle->setChecked(config()->get("security/IconDownloadFallbackToGoogle").toBool());
 
     m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
@@ -233,6 +234,7 @@ void SettingsWidget::saveSettings()
     config()->set("security/lockdatabaseidlesec", m_secUi->lockDatabaseIdleSpinBox->value());
     config()->set("security/lockdatabaseminimize", m_secUi->lockDatabaseMinimizeCheckBox->isChecked());
     config()->set("security/lockdatabasescreenlock", m_secUi->lockDatabaseOnScreenLockCheckBox->isChecked());
+    config()->set("security/relockautotype", m_secUi->relockDatabaseAutoTypeCheckBox->isChecked());
     config()->set("security/IconDownloadFallbackToGoogle", m_secUi->fallbackToGoogle->isChecked());
 
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());

--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -122,6 +122,13 @@
         </property>
        </widget>
       </item>
+      <item row="6" column="0">
+       <widget class="QCheckBox" name="relockDatabaseAutoTypeCheckBox">
+        <property name="text">
+         <string>Re-lock previously locked database after performing Auto-Type</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QCheckBox" name="passwordRepeatCheckBox">
         <property name="text">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
When the main Database is locked and autotype is performed, KeePassXC asks the user to unlock the database and then perform autotype.
This PR add support for re-locking the unlocked DB if autotype is successful, also adding signals for unsuccessful autotype (maybe useful in the future).

Relock is performed only if autotype is successful so if it isn't the user doesn't have to unlock the DB again.
If this behavior isn't acceptable we can connect unsuccessful autotype signals.

The option for relocking after autotype is selectable in the Settings (disabled by default)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #152 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with make test

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

