### PR TITLE
Fix Windows regression due to faulty static variable initialization

### DIFF
--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -93,7 +93,7 @@ QString FilePath::pluginPath(const QString& name)
 
 QString FilePath::wordlistPath(const QString& name)
 {
-    return m_instance->dataPath("wordlists/" + name);
+    return dataPath("wordlists/" + name);
 }
 
 QIcon FilePath::applicationIcon()

--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -17,32 +17,31 @@
 
 #include "PassphraseGenerator.h"
 
-#include <math.h>
+#include <cmath>
 #include <QFile>
 #include <QTextStream>
 
 #include "crypto/Random.h"
 #include "core/FilePath.h"
 
-const QString PassphraseGenerator::DefaultSeparator = " ";
-const QString PassphraseGenerator::DefaultWordList = "eff_large.wordlist";
+const char* PassphraseGenerator::DefaultSeparator = " ";
+const char* PassphraseGenerator::DefaultWordList = "eff_large.wordlist";
 
 PassphraseGenerator::PassphraseGenerator()
     : m_wordCount(0)
     , m_separator(PassphraseGenerator::DefaultSeparator)
 {
-    
 }
 
-double PassphraseGenerator::calculateEntropy(QString passphrase)
+double PassphraseGenerator::calculateEntropy(const QString& passphrase)
 {
     Q_UNUSED(passphrase);
 
-    if (m_wordlist.size() == 0) {
-        return 0;
+    if (m_wordlist.isEmpty()) {
+        return 0.0;
     }
 
-    return log(m_wordlist.size()) / log(2.0) * m_wordCount;
+    return std::log2(m_wordlist.size()) * m_wordCount;
 }
 
 void PassphraseGenerator::setWordCount(int wordCount)
@@ -56,7 +55,7 @@ void PassphraseGenerator::setWordCount(int wordCount)
 
 }
 
-void PassphraseGenerator::setWordList(QString path)
+void PassphraseGenerator::setWordList(const QString& path)
 {
     m_wordlist.clear();
 
@@ -83,7 +82,7 @@ void PassphraseGenerator::setDefaultWordList()
     setWordList(path);
 }
 
-void PassphraseGenerator::setWordSeparator(QString separator) {
+void PassphraseGenerator::setWordSeparator(const QString& separator) {
     m_separator = separator;
 }
 
@@ -97,8 +96,8 @@ QString PassphraseGenerator::generatePassphrase() const
     }
 
     QStringList words;
-    for (int i = 0; i < m_wordCount; i++) {
-        int wordIndex = randomGen()->randomUInt(m_wordlist.length());
+    for (int i = 0; i < m_wordCount; ++i) {
+        int wordIndex = randomGen()->randomUInt(static_cast<quint32>(m_wordlist.length()));
         words.append(m_wordlist.at(wordIndex));
     }
 
@@ -111,9 +110,5 @@ bool PassphraseGenerator::isValid() const
        return false;
     }
 
-    if (m_wordlist.size() < 1000) {
-        return false;
-    }
-
-    return true;
+    return m_wordlist.size() >= 1000;
 }

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -26,26 +26,25 @@ class PassphraseGenerator
 {
 public:
     PassphraseGenerator();
+    Q_DISABLE_COPY(PassphraseGenerator)
 
-    double calculateEntropy(QString passphrase);
+    double calculateEntropy(const QString& passphrase);
     void setWordCount(int wordCount);
-    void setWordList(QString path);
+    void setWordList(const QString& path);
     void setDefaultWordList();
-    void setWordSeparator(QString separator);
+    void setWordSeparator(const QString& separator);
     bool isValid() const;
 
     QString generatePassphrase() const;
 
-    static const int DefaultWordCount = 7;
-    static const QString DefaultSeparator;
-    static const QString DefaultWordList;
+    static constexpr int DefaultWordCount = 7;
+    static const char* DefaultSeparator;
+    static const char* DefaultWordList;
 
 private:
     int m_wordCount;
     QString m_separator;
     QVector<QString> m_wordlist;
-
-    Q_DISABLE_COPY(PassphraseGenerator)
 };
 
 #endif // KEEPASSX_PASSPHRASEGENERATOR_H


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This patch fixes a Windows regression introduced in 6723f42 and adds some other small code style fixes.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The use of QString in the static `DefaultSeparator` field lead to crashes on Windows, probably because the object wasn't fully initialized at the time it's used inside `PassphraseGenerator`'s initializer list.
This patch changes the QString to a raw `const char*` array.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
KeePassXC and tests are not crashing anymore.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**