### PR TITLE
Fix Issue #1447 where the wrong path was shown for view/edit when opening via search results

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -819,7 +819,16 @@ void DatabaseWidget::switchToEntryEdit(Entry* entry)
 
 void DatabaseWidget::switchToEntryEdit(Entry* entry, bool create)
 {
-    Group* group = currentGroup();
+    // If creating an entry, it will be in `currentGroup()` so it's
+    // okay to use but when editing, the entry may not be in
+    // `currentGroup()` so we get the entry's group.
+    Group* group;
+    if (create) {
+        group = currentGroup();
+    } else {
+        group = entry->group();
+    }
+
     Q_ASSERT(group);
 
     m_editEntryWidget->loadEntry(entry, create, false, group->name(), m_db);

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -46,6 +46,7 @@ private slots:
     void testAutoreloadDatabase();
     void testTabs();
     void testEditEntry();
+    void testSearchEditEntry();
     void testAddEntry();
     void testPasswordEntryEntropy();
     void testDicewareEntryEntropy();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fix issue in #1447 where the headline was showing the wrong path when a group was selected in the side bar.

## Description
<!--- Describe your changes in detail -->
Added a check in `DatabaseWidget::switchToEntryEdit(Entry* entry, bool create)` that sets the group in the headline to the current group if creating a entry. Otherwise the headline group is the parent group of the entry.

Using the example from the issue, previously the headline would show:
    
    Bad  > Doggy

With this change, we now get:
    
    Good > Doggy

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves issue #1447. 


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually. I had a look at the gui tests to try and add a test for this but I can't find a way to access the headline attribute to check it contains the correct values. If I've missed it and someone can point me in the right direction so I can add some tests that would be awesome.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ~~My change requires a change to the documentation and I have updated it accordingly.~~
-  ~~I have added tests to cover my changes.~~
