### PR TITLE
Select password locking if an empty password is entered

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -44,6 +44,7 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     m_ui->setupUi(this);
 
     m_ui->messageWidget->setHidden(true);
+    m_ui->checkPassword->setChecked(true);
 
     QFont font = m_ui->labelHeadline->font();
     font.setBold(true);
@@ -138,7 +139,7 @@ void DatabaseOpenWidget::clearForms()
 {
     m_ui->editPassword->clear();
     m_ui->comboKeyFile->clear();
-    m_ui->checkPassword->setChecked(false);
+    m_ui->checkPassword->setChecked(true);
     m_ui->checkKeyFile->setChecked(false);
     m_ui->checkChallengeResponse->setChecked(false);
     m_ui->buttonTogglePassword->setChecked(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Resolve #570 dilemma

## Description
<!--- Describe your changes in detail -->
Automatically check the password checkbox if no selection is made from user at all.
Basically validates the scenario of unlocking a DB locked with an empty password.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Coherence with the fact that a DB with empty password is legal.
Until now an error message is issued telling the user that the password is wrong (it isn't).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
