### PR TITLE
Fix resolving reference in entry field

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -778,17 +778,30 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
     case PlaceholderType::Unknown:
         return placeholder;
     case PlaceholderType::Title:
-        return title();
+        if (placeholderType(title()) == PlaceholderType::Title) {
+            return title();
+        }
+        return resolvePlaceholderRecursive(title(), maxDepth - 1);
     case PlaceholderType::UserName:
-        return username();
+        if (placeholderType(username()) == PlaceholderType::UserName) {
+            return username();
+        }
+        return resolvePlaceholderRecursive(username(), maxDepth - 1);
     case PlaceholderType::Password:
-        return password();
+        if (placeholderType(password()) == PlaceholderType::Password) {
+            return password();
+        }
+        return resolvePlaceholderRecursive(password(), maxDepth - 1);
     case PlaceholderType::Notes:
-        return notes();
-    case PlaceholderType::Totp:
-        return totp();
+        if (placeholderType(notes()) == PlaceholderType::Notes) {
+            return notes();
+        }
+        return resolvePlaceholderRecursive(notes(), maxDepth - 1);
     case PlaceholderType::Url:
-        return url();
+        if (placeholderType(url()) == PlaceholderType::Url) {
+            return url();
+        }
+        return resolvePlaceholderRecursive(url(), maxDepth - 1);
     case PlaceholderType::UrlWithoutScheme:
     case PlaceholderType::UrlScheme:
     case PlaceholderType::UrlHost:
@@ -802,6 +815,9 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
         const QString strUrl = resolveMultiplePlaceholdersRecursive(url(), maxDepth - 1);
         return resolveUrlPlaceholder(strUrl, typeOfPlaceholder);
     }
+    case PlaceholderType::Totp:
+        // totp can't have placeholder inside
+        return totp();
     case PlaceholderType::CustomAttribute: {
         const QString key = placeholder.mid(3, placeholder.length() - 4); // {S:attr} => mid(3, len - 4)
         return attributes()->hasKey(key) ? attributes()->value(key) : QString();

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -772,6 +772,11 @@ QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxD
 
 QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDepth) const
 {
+    if (maxDepth <= 0) {
+        qWarning("Maximum depth of replacement has been reached. Entry uuid: %s", qPrintable(uuid().toHex()));
+        return placeholder;
+    }
+
     const PlaceholderType typeOfPlaceholder = placeholderType(placeholder);
     switch (typeOfPlaceholder) {
     case PlaceholderType::NotPlaceholder:
@@ -831,6 +836,11 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
 
 QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, int maxDepth) const
 {
+    if (maxDepth <= 0) {
+        qWarning("Maximum depth of replacement has been reached. Entry uuid: %s", qPrintable(uuid().toHex()));
+        return placeholder;
+    }
+
     // resolving references in format: {REF:<WantedField>@<SearchIn>:<SearchText>}
     // using format from http://keepass.info/help/base/fieldrefs.html at the time of writing
 
@@ -844,6 +854,9 @@ QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, 
     const QString searchText = match.captured(EntryAttributes::SearchTextGroupName);
 
     const EntryReferenceType searchInType = Entry::referenceType(searchIn);
+
+    Q_ASSERT(m_group);
+    Q_ASSERT(m_group->database());
     const Entry* refEntry = m_group->database()->resolveEntry(searchText, searchInType);
 
     if (refEntry) {

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -188,6 +188,8 @@ void EditEntryWidget::setupAutoType()
     connect(m_autoTypeAssocModel, SIGNAL(modelReset()), SLOT(clearCurrentAssoc()));
     connect(m_autoTypeUi->windowTitleCombo, SIGNAL(editTextChanged(QString)),
             SLOT(applyCurrentAssoc()));
+    connect(m_autoTypeUi->customWindowSequenceButton, SIGNAL(toggled(bool)),
+            SLOT(applyCurrentAssoc()));
     connect(m_autoTypeUi->windowSequenceEdit, SIGNAL(textChanged(QString)),
             SLOT(applyCurrentAssoc()));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This is a 2.3.0 hotfix

Reference resolving in 2.2.4 is broken, you can't resolve a reference if it's in a main field (title, username, etc)

This also prevent recursive loop when resolving references (for example inserting `{TITLE}` in the title field) and fixes a bug in the EditEntry widget not saving AutotypeWindowAssociations.

The code for reference resolving is very repetitive a refactor need to take place in next version.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

