### PR TITLE
Add a textbox to exclude certain characters when generating a new password

### DIFF
--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -54,6 +54,7 @@ public:
     void setLength(int length);
     void setCharClasses(const CharClasses& classes);
     void setFlags(const GeneratorFlags& flags);
+    void setExcludeChars(const QString& excludeChars);
 
     bool isValid() const;
 
@@ -71,11 +72,13 @@ public:
 
 private:
     QVector<PasswordGroup> passwordGroups() const;
+    QVector<QChar> passwordChars() const;
     int numCharClasses() const;
 
     int m_length;
     CharClasses m_classes;
     GeneratorFlags m_flags;
+    QString m_excludeChars;
 
     Q_DISABLE_COPY(PasswordGenerator)
 };

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -49,6 +49,8 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     connect(m_ui->sliderLength, SIGNAL(valueChanged(int)), SLOT(passwordSliderMoved()));
     connect(m_ui->spinBoxLength, SIGNAL(valueChanged(int)), SLOT(passwordSpinBoxChanged()));
 
+    connect(m_ui->editExclude, SIGNAL(textChanged(QString)), SLOT(updateGenerator()));
+
     connect(m_ui->sliderWordCount, SIGNAL(valueChanged(int)), SLOT(dicewareSliderMoved()));
     connect(m_ui->spinBoxWordCount, SIGNAL(valueChanged(int)), SLOT(dicewareSpinBoxChanged()));
 
@@ -373,6 +375,8 @@ void PasswordGeneratorWidget::updateGenerator()
         m_passwordGenerator->setLength(m_ui->spinBoxLength->value());
         m_passwordGenerator->setCharClasses(classes);
         m_passwordGenerator->setFlags(flags);
+
+        m_passwordGenerator->setExcludeChars(m_ui->editExclude->text());
 
         if (m_passwordGenerator->isValid()) {
             m_ui->buttonGenerate->setEnabled(true);

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -195,7 +195,62 @@ QProgressBar::chunk {
          <string>Password</string>
         </attribute>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="1" column="0">
+         <item row="0" column="0">
+          <layout class="QHBoxLayout" name="passwordLengthSliderLayout">
+           <property name="spacing">
+            <number>15</number>
+           </property>
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="labelLength">
+             <property name="text">
+              <string>&amp;Length:</string>
+             </property>
+             <property name="buddy">
+              <cstring>spinBoxLength</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSlider" name="sliderLength">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>128</number>
+             </property>
+             <property name="sliderPosition">
+              <number>20</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>8</number>
+             </property>
+            </widget>
+           </item>
+           <item alignment="Qt::AlignRight">
+            <widget class="QSpinBox" name="spinBoxLength">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>999</number>
+             </property>
+             <property name="value">
+              <number>20</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="0">
           <layout class="QHBoxLayout" name="optionsLayout">
            <item>
             <widget class="QGroupBox" name="groupBox">
@@ -376,58 +431,17 @@ QProgressBar::chunk {
            </item>
           </layout>
          </item>
-         <item row="0" column="0">
-          <layout class="QHBoxLayout" name="passwordLengthSliderLayout">
-           <property name="spacing">
-            <number>15</number>
-           </property>
-           <property name="topMargin">
-            <number>6</number>
-           </property>
+         <item row="3" column="0">
+          <layout class="QHBoxLayout" name="excludeLayout">
            <item>
-            <widget class="QLabel" name="labelLength">
+            <widget class="QLabel" name="labelExclude">
              <property name="text">
-              <string>&amp;Length:</string>
-             </property>
-             <property name="buddy">
-              <cstring>spinBoxLength</cstring>
+              <string>Exclude:</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QSlider" name="sliderLength">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>128</number>
-             </property>
-             <property name="sliderPosition">
-              <number>20</number>
-             </property>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="tickPosition">
-              <enum>QSlider::TicksBelow</enum>
-             </property>
-             <property name="tickInterval">
-              <number>8</number>
-             </property>
-            </widget>
-           </item>
-           <item alignment="Qt::AlignRight">
-            <widget class="QSpinBox" name="spinBoxLength">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>999</number>
-             </property>
-             <property name="value">
-              <number>20</number>
-             </property>
-            </widget>
+            <widget class="QLineEdit" name="editExclude"/>
            </item>
           </layout>
          </item>


### PR DESCRIPTION
This commit adds a new textbox to the password generation widget which excludes the provided chars from being chosen.

## Description
UI : A new Layout + Label + Textbox is added under the password-group layout group. 
Code: The PasswordGenerator has a new member, excludeChars and the including setter. This setter is called by the PasswordGeneratorWidget in its updateGenerator method. 
Also, whenever changes are made to the exclude-textbox, the method is called.
The PasswordGenerator has a new private method returning the chars that should be used for creating the password. The functionality was moved from the generatePassword-method and extended to exclude the chars.
The isValid-method now checks if there are any characters to be used and returns false, if not.
In case the CharFromEveryGroup-flag is set, the generatePassword method again excludes the chars.

## Motivation and context
As many websites (e.g. my university website) enforces quite strong password policies, generating a new password was a hard task. Now the string of forbidden characters can be simply copied into the textfield to generate a conforming password.

## How has this been tested?
As this is a quite small feature i only tested it ad-hoc. As the isValid method of passwordGenerator checks if there are any characters available to generate the password, at any time either a valid password is generated, or no generation takes place.
Also, i've not seen tests for the password generation, so i was not sure where to plug my tests in.


## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

