### PR TITLE
Fix Auto-Type message not raised when no matching entry was found

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -269,8 +269,8 @@ void AutoType::performAutoType(const Entry* entry, QWidget* hideWindow)
 }
 
 /**
- * Global Autotype entry-point funcion
- * Perform global autotype on the active window
+ * Global Autotype entry-point function
+ * Perform global Auto-Type on the active window
  */
 void AutoType::performGlobalAutoType(const QList<Database*>& dbList)
 {
@@ -304,10 +304,19 @@ void AutoType::performGlobalAutoType(const QList<Database*>& dbList)
 
     if (matchList.isEmpty()) {
         m_inAutoType.unlock();
-        QString message = tr("Couldn't find an entry that matches the window title:");
-        message.append("\n\n");
-        message.append(windowTitle);
-        MessageBox::information(nullptr, tr("Auto-Type - KeePassXC"), message);
+
+        if (qobject_cast<QApplication*>(QCoreApplication::instance())) {
+            auto* msgBox = new QMessageBox();
+            msgBox->setAttribute(Qt::WA_DeleteOnClose);
+            msgBox->setWindowTitle(tr("Auto-Type - KeePassXC"));
+            msgBox->setText(tr("Couldn't find an entry that matches the window title:").append("\n\n")
+                                .append(windowTitle));
+            msgBox->setIcon(QMessageBox::Information);
+            msgBox->setStandardButtons(QMessageBox::Ok);
+            msgBox->show();
+            msgBox->raise();
+            msgBox->activateWindow();
+        }
 
         emit autotypeRejected();
     } else if ((matchList.size() == 1) && !config()->get("security/autotypeask").toBool()) {
@@ -315,7 +324,7 @@ void AutoType::performGlobalAutoType(const QList<Database*>& dbList)
         m_inAutoType.unlock();
     } else {
         m_windowFromGlobal = m_plugin->activeWindow();
-        AutoTypeSelectDialog* selectDialog = new AutoTypeSelectDialog();
+        auto* selectDialog = new AutoTypeSelectDialog();
         connect(selectDialog, SIGNAL(matchActivated(AutoTypeMatch)),
                 SLOT(performAutoTypeFromGlobal(AutoTypeMatch)));
         connect(selectDialog, SIGNAL(rejected()), SLOT(resetInAutoType()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch fixed Auto-Type error messages about unmatched entries not being raised to the foreground.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The error message that's shown when Auto-Type couldn't find a matching entry wasn't raised and activated explicitly and therefore more often than not totally invisible to the user. I sometimes noticed that I had a bunch of these hidden behind the KeePassXC main window task bar button.
This problem is especially apparent on Windows.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested Auto-Type on Windows, message box now comes to the foreground as expected.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**