### PR TITLE
Enable word wrap for long lines on About dialog

### DIFF
--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -148,6 +148,13 @@
         </spacer>
        </item>
        <item>
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Project Maintainers:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="label_4">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -156,15 +163,23 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string notr="true">&lt;p&gt;Project Maintainers:&lt;/p&gt;
-&lt;ul&gt;
+          <string notr="true">&lt;ul&gt;
     &lt;li&gt;droidmonkey&lt;/li&gt;
     &lt;li&gt;phoerious&lt;/li&gt;
     &lt;li&gt;TheZ3ro&lt;/li&gt;
     &lt;li&gt;louib&lt;/li&gt;
     &lt;li&gt;weslly&lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;Special thanks from the KeePassXC team go to debfx for creating the original KeePassX.&lt;/&gt;</string>
+&lt;/ul&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Special thanks from the KeePassXC team go to debfx for creating the original KeePassX.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -198,8 +213,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>423</width>
-            <height>816</height>
+            <width>449</width>
+            <height>803</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_5">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch enables word wrap for long lines on the About dialog and makes more text (everything except the names) translatable.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On platforms with a larger default font size than Windows, the About dialog was a bit too wide, because the KeePassX acknowledgement line didn't break.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
