### PR TITLE
Fix about dialog height on macOS

### DIFF
--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -175,6 +175,12 @@
        </item>
        <item>
         <widget class="QLabel" name="label_7">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>Special thanks from the KeePassXC team go to debfx for creating the original KeePassX.</string>
          </property>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
This patch fixes a small regression introduced by #1492. 

The maintainer list height was being trimmed down on macOS because the last paragraph didn't have a fixed vertical size policy.

## How has this been tested?
Manually.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**