### PR TITLE
Implement feedback for CustomData

### DIFF
--- a/src/core/AutoTypeAssociations.cpp
+++ b/src/core/AutoTypeAssociations.cpp
@@ -35,14 +35,12 @@ AutoTypeAssociations::AutoTypeAssociations(QObject* parent)
 
 void AutoTypeAssociations::copyDataFrom(const AutoTypeAssociations* other)
 {
-    if (m_associations == other->m_associations) {
-        return;
+    if (m_associations != other->m_associations) {
+        emit aboutToReset();
+        m_associations = other->m_associations;
+        emit reset();
+        emit modified();
     }
-
-    emit aboutToReset();
-    m_associations = other->m_associations;
-    emit reset();
-    emit modified();
 }
 
 void AutoTypeAssociations::add(const AutoTypeAssociations::Association& association)

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -108,16 +108,14 @@ void CustomData::rename(const QString& oldKey, const QString& newKey)
 
 void CustomData::copyDataFrom(const CustomData* other)
 {
-    if (*this == *other) {
-        return;
+    if (*this != *other) {
+        emit aboutToBeReset();
+
+        m_data = other->m_data;
+
+        emit reset();
+        emit modified();
     }
-
-    emit aboutToBeReset();
-
-    m_data = other->m_data;
-
-    emit reset();
-    emit modified();
 }
 bool CustomData::operator==(const CustomData& other) const
 {

--- a/src/gui/EditWidgetProperties.cpp
+++ b/src/gui/EditWidgetProperties.cpp
@@ -51,7 +51,7 @@ void EditWidgetProperties::setCustomData(const CustomData* customData)
     Q_ASSERT(customData);
     m_customData->copyDataFrom(customData);
 
-    this->updateModel();
+    updateModel();
 }
 
 const CustomData* EditWidgetProperties::customData() const


### PR DESCRIPTION
Implemented feedback from #1477 / #1494 and adjusted code style.

Assertions in `*::copyDataFrom` are not possible (at least for now) since self assignment is possible in  `KdbxXmlReader`. Changing the behavior of this class would be out of scope for the ticket.