### PR TITLE
Prevent password loss when using generator

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -776,26 +776,27 @@ void DatabaseWidget::switchToView(bool accepted)
             m_newGroup->setParent(m_newParent);
             m_groupView->setCurrentGroup(m_newGroup);
             m_groupView->expandGroup(m_newParent);
-        }
-        else {
+        } else {
             delete m_newGroup;
         }
 
         m_newGroup = nullptr;
         m_newParent = nullptr;
-    }
-    else if (m_newEntry) {
+    } else if (m_newEntry) {
         if (accepted) {
             m_newEntry->setGroup(m_newParent);
             m_entryView->setFocus();
             m_entryView->setCurrentEntry(m_newEntry);
-        }
-        else {
+        } else {
             delete m_newEntry;
         }
 
         m_newEntry = nullptr;
         m_newParent = nullptr;
+    }
+
+    if (accepted) {
+        showMessage(tr("Entry updated successfully."), MessageWidget::Positive, false, 2000);
     }
 
     setCurrentWidget(m_mainWidget);

--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -119,7 +119,8 @@ bool EditWidget::readOnly() const
 
 void EditWidget::showMessage(const QString& text, MessageWidget::MessageType type)
 {
-    m_ui->messageWidget->showMessage(text, type);
+    m_ui->messageWidget->setCloseButtonVisible(false);
+    m_ui->messageWidget->showMessage(text, type, 2000);
 }
 
 void EditWidget::hideMessage()

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -151,6 +151,11 @@ void PasswordGeneratorWidget::setStandaloneMode(bool standalone)
     }
 }
 
+QString PasswordGeneratorWidget::getGeneratedPassword()
+{
+    return m_ui->editNewPassword->text();
+}
+
 void PasswordGeneratorWidget::keyPressEvent(QKeyEvent* e)
 {
     if (e->key() == Qt::Key_Escape && m_standalone == true) {

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -49,16 +49,18 @@ public:
     void saveSettings();
     void reset();
     void setStandaloneMode(bool standalone);
-public Q_SLOTS:
+    QString getGeneratedPassword();
+
+public slots:
     void regeneratePassword();
+    void applyPassword();
+    void copyPassword();
     
 signals:
     void appliedPassword(const QString& password);
     void dialogTerminated();
 
 private slots:
-    void applyPassword();
-    void copyPassword();
     void updateButtonsEnabled(const QString& password);
     void updatePasswordStrength(const QString& password);
     void togglePasswordShown(bool hidden);

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -74,7 +74,7 @@ signals:
 
 private slots:
     void acceptEntry();
-    void saveEntry();
+    bool commitEntry();
     void cancel();
     void togglePasswordGeneratorButton(bool checked);
     void setGeneratedPassword(const QString& password);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Adds a warning popup to the user if the password generator is open and the password differs from the one currently in the main password edit field. This change also adds feedback to the user when an entry is successfully updated.

Other changes include:
* Rename saveEntry to commitEntry to accurately capture its purpose
* Add message to user when commit is successful
* Made all inline messages in edit entry view 2 sec visibility

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #870  and fixes #1363 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and unit tests

## Screenshots:
![pass_apply1](https://user-images.githubusercontent.com/2809491/36395648-27e41a34-1588-11e8-8c9a-281fb17127f6.png)

![pass_apply2](https://user-images.githubusercontent.com/2809491/36395650-29fb95d6-1588-11e8-98af-35dc040fcb5e.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
