### PR TITLE
Add support for foreground and background entry colors

### DIFF
--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -700,7 +700,8 @@ Entry* KdbxXmlReader::parseEntry(bool history)
                 entry->setIcon(uuid);
             }
             continue;
-        }if (m_xml.name() == "ForegroundColor") {
+        }
+        if (m_xml.name() == "ForegroundColor") {
             entry->setForegroundColor(readColor());
             continue;
         }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1137,7 +1137,7 @@ QMenu* EditEntryWidget::createPresetsMenu()
     return expirePresetsMenu;
 }
 
-void EditEntryWidget::setupColorButton(bool foreground, QColor color)
+void EditEntryWidget::setupColorButton(bool foreground, const QColor& color)
 {
     QWidget* button = m_advancedUi->fgColorButton;
     QCheckBox* checkBox = m_advancedUi->fgColorCheckBox;
@@ -1165,7 +1165,7 @@ void EditEntryWidget::pickColor()
         oldColor = QColor(m_advancedUi->bgColorButton->property("color").toString());
     }
 
-    QColorDialog colorDialog;
+    QColorDialog colorDialog(this);
     QColor newColor = colorDialog.getColor(oldColor);
     if (newColor.isValid()) {
         setupColorButton(isForeground, newColor);

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -99,6 +99,7 @@ private slots:
     void updateHistoryButtons(const QModelIndex& current, const QModelIndex& previous);
     void useExpiryPreset(QAction* action);
     void toggleHideNotes(bool visible);
+    void pickColor();
 #ifdef WITH_XC_SSHAGENT
     void updateSSHAgent();
     void updateSSHAgentAttachment();
@@ -120,6 +121,7 @@ private:
 #endif
     void setupProperties();
     void setupHistory();
+    void setupColorButton(bool foreground, QColor color);
 
     bool passwordsEqual();
     void setForms(const Entry* entry, bool restore = false);

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -121,7 +121,7 @@ private:
 #endif
     void setupProperties();
     void setupHistory();
-    void setupColorButton(bool foreground, QColor color);
+    void setupColorButton(bool foreground, const QColor& color);
 
     bool passwordsEqual();
     void setForms(const Entry* entry, bool restore = false);

--- a/src/gui/entry/EditEntryWidgetAdvanced.ui
+++ b/src/gui/entry/EditEntryWidgetAdvanced.ui
@@ -2,19 +2,15 @@
 <ui version="4.0">
  <class>EditEntryWidgetAdvanced</class>
  <widget class="QWidget" name="EditEntryWidgetAdvanced">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>532</width>
+    <height>364</height>
+   </rect>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
    <item>
     <widget class="QGroupBox" name="attributesBox">
      <property name="title">
@@ -153,6 +149,96 @@
          </size>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="colorsBox" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <widget class="QCheckBox" name="fgColorCheckBox">
+        <property name="text">
+         <string>Foreground Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="fgColorButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Maximum</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>30</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="bgColorCheckBox">
+        <property name="text">
+         <string>Background Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="bgColorButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -18,6 +18,7 @@
 #include "EntryModel.h"
 
 #include <QFont>
+#include <QFontMetrics>
 #include <QMimeData>
 #include <QPalette>
 #include <QDateTime>
@@ -263,10 +264,26 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             font.setStrikeOut(true);
         }
         return font;
-    } else if (role == Qt::TextColorRole) {
+    } else if (role == Qt::ForegroundRole) {
         if (entry->hasReferences()) {
             QPalette p;
             return QVariant(p.color(QPalette::Active, QPalette::Mid));
+        } else if (entry->foregroundColor().isValid()) {
+            return QVariant(entry->foregroundColor());
+        }
+    } else if (role == Qt::BackgroundRole) {
+        if (entry->backgroundColor().isValid()) {
+            return QVariant(entry->backgroundColor());
+        }
+    } else if (role == Qt::TextAlignmentRole) {
+        if (index.column() == Paperclip) {
+            return Qt::AlignCenter;
+        }
+    } else if (role == Qt::SizeHintRole) {
+        if (index.column() == Paperclip) {
+            QFont font;
+            QFontMetrics fm(font);
+            return fm.width(PaperClipDisplay) / 2;
         }
     }
 
@@ -275,7 +292,9 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
 
 QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
-    if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
+    Q_UNUSED(orientation);
+
+    if (role == Qt::DisplayRole) {
         switch (section) {
         case ParentGroup:
             return tr("Group");
@@ -301,6 +320,11 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return EntryModel::PaperClipDisplay;
         case Attachments:
             return tr("Attachments");
+        }
+    } else if (role == Qt::TextAlignmentRole) {
+        switch (section) {
+        case Paperclip:
+            return Qt::AlignCenter;
         }
     }
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -26,6 +26,7 @@
 #include <QLabel>
 #include <QMimeData>
 #include <QPushButton>
+#include <QCheckBox>
 #include <QSpinBox>
 #include <QPlainTextEdit>
 #include <QComboBox>
@@ -279,6 +280,7 @@ void TestGui::testTabs()
 void TestGui::testEditEntry()
 {
     QToolBar* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
+    int editCount = 0;
 
     // Select the first entry in the database
     EntryView* entryView = m_dbWidget->findChild<EntryView*>("entryView");
@@ -305,7 +307,24 @@ void TestGui::testEditEntry()
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Apply), Qt::LeftButton);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
     QCOMPARE(entry->title(), QString("Sample Entry_test"));
-    QCOMPARE(entry->historyItems().size(), 1);
+    QCOMPARE(entry->historyItems().size(), ++editCount);
+
+    // Test entry colors (simulate choosing a color)
+    editEntryWidget->setCurrentPage(1);
+    auto fgColor = QColor(Qt::red);
+    auto bgColor = QColor(Qt::blue);
+    // Set foreground color
+    auto colorButton = editEntryWidget->findChild<QPushButton*>("fgColorButton");
+    auto colorCheckBox = editEntryWidget->findChild<QCheckBox*>("fgColorCheckBox");
+    colorButton->setProperty("color", fgColor);
+    colorCheckBox->setChecked(true);
+    // Set background color
+    colorButton = editEntryWidget->findChild<QPushButton*>("bgColorButton");
+    colorCheckBox = editEntryWidget->findChild<QCheckBox*>("bgColorCheckBox");
+    colorButton->setProperty("color", bgColor);
+    colorCheckBox->setChecked(true);
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Apply), Qt::LeftButton);
+    QCOMPARE(entry->historyItems().size(), ++editCount);
 
     // Test protected attributes
     editEntryWidget->setCurrentPage(1);
@@ -337,7 +356,11 @@ void TestGui::testEditEntry()
     // Confirm edit was made
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
     QCOMPARE(entry->title(), QString("Sample Entry_test"));
-    QCOMPARE(entry->historyItems().size(), 2);
+    QCOMPARE(entry->foregroundColor(), fgColor);
+    QCOMPARE(entryItem.data(Qt::ForegroundRole), QVariant(fgColor));
+    QCOMPARE(entry->backgroundColor(), bgColor);
+    QCOMPARE(entryItem.data(Qt::BackgroundRole), QVariant(bgColor));
+    QCOMPARE(entry->historyItems().size(), ++editCount);
 
     // Confirm modified indicator is showing
     QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QString("%1*").arg(m_dbFileName));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Description
<!--- Describe your changes in detail -->
Adds full support for displaying foreground and background colors to entry rows. Also centered the paperclip icon in the new extended columns view.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Compatibility with KeePass 2.x

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with KeePass 2.x

## Screenshots (if appropriate):
![entry_colors1](https://user-images.githubusercontent.com/2809491/36395888-78d0b32a-1589-11e8-8506-eb3bbbe8250a.png)
![entry_colors2](https://user-images.githubusercontent.com/2809491/36395890-7a584ae6-1589-11e8-9c5a-a6bd4c2399fc.png)
![entry_colors3](https://user-images.githubusercontent.com/2809491/36395894-7bca1224-1589-11e8-80e9-b94ae2bf27ff.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
