### PR TITLE
Verifying passwords against HIBP

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -36,6 +36,8 @@ set(cli_SOURCES
     Locate.h
     Merge.cpp
     Merge.h
+    Pawned.cpp
+    Pawned.h
     Remove.cpp
     Remove.h
     Show.cpp

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -32,6 +32,7 @@
 #include "List.h"
 #include "Locate.h"
 #include "Merge.h"
+#include "Pawned.h"
 #include "Remove.h"
 #include "Show.h"
 
@@ -71,6 +72,7 @@ void populateCommands()
         commands.insert(QString("locate"), new Locate());
         commands.insert(QString("ls"), new List());
         commands.insert(QString("merge"), new Merge());
+        commands.insert(QString("pawned"), new Pawned());
         commands.insert(QString("rm"), new Remove());
         commands.insert(QString("show"), new Show());
     }

--- a/src/cli/Pawned.cpp
+++ b/src/cli/Pawned.cpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include "Pawned.h"
+
+#include <QCommandLineParser>
+#include <QFile>
+#include <QTextStream>
+
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "crypto/CryptoHash.h"
+
+Pawned::Pawned()
+{
+    name = QString("pawned");
+    description = QObject::tr("Queries the database's passwords against the haveibeenpwned dump.");
+}
+
+Pawned::~Pawned()
+{
+}
+
+int Pawned::execute(const QStringList& arguments)
+{
+    QTextStream out(stdout);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(this->description);
+    parser.addPositionalArgument("database", QObject::tr("Path of the database."));
+    parser.addPositionalArgument("hibp-database", QObject::tr("Path of the HIBP database."));
+    QCommandLineOption keyFile(QStringList() << "k"
+                                             << "key-file",
+                               QObject::tr("Key file of the database."),
+                               QObject::tr("path"));
+    parser.addOption(keyFile);
+    parser.process(arguments);
+
+    const QStringList args = parser.positionalArguments();
+    if (args.size() != 2) {
+        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli pawned");
+        return EXIT_FAILURE;
+    }
+
+    Database* db = Database::unlockFromStdin(args.at(0), parser.value(keyFile));
+    if (db == nullptr) {
+        return EXIT_FAILURE;
+    }
+
+    QFile passwordDatabase(args.at(1));
+    if (!passwordDatabase.open(QIODevice::ReadOnly)) {
+        qCritical("Could not open pawned passwords database %s.", qPrintable(args.at(1)));
+        return EXIT_FAILURE;
+    }
+
+    QMap<QString, QByteArray> entryMap;
+    for (Entry* entry : db->rootGroup()->entriesRecursive()) {
+      // This is to make sure the entry title is unique.
+      QString entryTitle = entry->title() + " (" + entry->uuid().toHex() + ")";
+      if (entry->password().isEmpty()) {
+        continue;
+      }
+      entryMap[entryTitle] = CryptoHash::hash(entry->password().toLatin1(), CryptoHash::Sha1).toHex().toUpper();
+    }
+
+    while (!passwordDatabase.atEnd()) {
+      QString pawnedPasswordLine = passwordDatabase.readLine();
+      if (pawnedPasswordLine.split(":").length() != 2) {
+        qCritical("Invalid format for pawned passwords database.");
+        return EXIT_FAILURE;
+      }
+
+      QString pawnedPasswordHash = pawnedPasswordLine.split(":").at(0);
+      QString pawnedPasswordCount = pawnedPasswordLine.split(":").at(1).simplified();
+      
+      for (QString entryTitle: entryMap.keys()) {
+        QByteArray entryHash = entryMap[entryTitle];
+        if (entryHash == pawnedPasswordHash) {
+          out << "Password for " << entryTitle << " was pawned " << pawnedPasswordCount << " times." << endl;
+        }
+      }
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Pawned.h
+++ b/src/cli/Pawned.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_PAWNED_H
+#define KEEPASSXC_PAWNED_H
+
+#include "Command.h"
+
+class Pawned : public Command
+{
+public:
+    Pawned();
+    ~Pawned();
+    int execute(const QStringList& arguments);
+};
+
+#endif // KEEPASSXC_PAWNED_H

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -43,6 +43,9 @@ Lists the contents of a group in a database. If no group is specified, it will d
 .IP "merge [options] <database1> <database2>"
 Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
 
+.IP "pawned [options] <database> <hibp-database>"
+Queries the database's passwords against the haveibeenpwned dump. This database can be found at https://haveibeenpwned.com/Passwords.
+
 .IP "rm [options] <database> <entry>"
 Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
 

--- a/src/crypto/CryptoHash.cpp
+++ b/src/crypto/CryptoHash.cpp
@@ -47,6 +47,10 @@ CryptoHash::CryptoHash(Algorithm algo, bool hmac)
         algoGcrypt = GCRY_MD_SHA512;
         break;
 
+    case CryptoHash::Sha1:
+        algoGcrypt = GCRY_MD_SHA1;
+        break;
+
     default:
         Q_ASSERT(false);
         break;

--- a/src/crypto/CryptoHash.h
+++ b/src/crypto/CryptoHash.h
@@ -28,7 +28,8 @@ public:
     enum Algorithm
     {
         Sha256,
-        Sha512
+        Sha512,
+        Sha1
     };
 
     explicit CryptoHash(Algorithm algo, bool hmac = false);


### PR DESCRIPTION
New CLI command to verify a password database against the HIBP database dump.

## Motivation and context
Was inspired by https://news.ycombinator.com/item?id=16446020

## How has this been tested?
Locally.

## Screenshots (if appropriate):
```
$ keepassxc-cli pawned ~/1.kdbx ~/Downloads/pwned-passwords-2.0.txt
Insert password to unlock /home/louib/1.kdbx: 
Password for entry2 (fdd9d458b34d1157ffa3053787674971) was pawned 14434 times.
Password for entry1 (eff7485a277952b289456b3d71a3b300) was pawned 5401 times.
Password for entry3 (08a7c64479e9a54cc22f93439bd0cd7a) was pawned 5401 times.
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.