### PR TITLE
Fix libgcrypt and libgpg-errror paths in AppImage

### DIFF
--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -66,14 +66,18 @@ cp "$QXCB_PLUGIN" ".${QT_PLUGIN_PATH}/platforms/"
 
 get_apprun
 copy_deps
+
+# protect our libgpg-error from being deleted
+mv ./opt/gpg-error-127/lib/x86_64-linux-gnu/libgpg-error.so.0 ./protected.so
 delete_blacklisted
+mv ./protected.so ./opt/gpg-error-127/lib/x86_64-linux-gnu/libgpg-error.so.0
 
 get_desktop
 get_icon
 cat << EOF > ./usr/bin/keepassxc_env
 #!/usr/bin/env bash
-export LD_LIBRARY_PATH="/opt/libgcrypt20-18/lib/x86_64-linux-gnu:\${LD_LIBRARY_PATH}"
-export LD_LIBRARY_PATH="/opt/gpg-error-127/lib/x86_64-linux-gnu:\${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="../opt/libgcrypt20-18/lib/x86_64-linux-gnu:\${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="../opt/gpg-error-127/lib/x86_64-linux-gnu:\${LD_LIBRARY_PATH}"
 export LD_LIBRARY_PATH="..$(dirname ${QT_PLUGIN_PATH})/lib:\${LD_LIBRARY_PATH}"
 export QT_PLUGIN_PATH="..${QT_PLUGIN_PATH}:\${KPXC_QT_PLUGIN_PATH}"
 

--- a/release-tool
+++ b/release-tool
@@ -619,17 +619,19 @@ build() {
 
         git archive --format=tar "$TAG_NAME" --prefix="${prefix}/" --output="${OUTPUT_DIR}/${tarball_name}"
 
-        # add .version file to tar
-        mkdir "${prefix}"
-        echo -n ${RELEASE_NAME} > "${prefix}/.version"
-        tar --append --file="${OUTPUT_DIR}/${tarball_name}" "${prefix}/.version"
-        rm "${prefix}/.version"
-        rmdir "${prefix}" 2> /dev/null
+        if ! ${BUILD_SNAPSHOT}; then
+            # add .version file to tar
+            mkdir "${prefix}"
+            echo -n ${RELEASE_NAME} > "${prefix}/.version"
+            tar --append --file="${OUTPUT_DIR}/${tarball_name}" "${prefix}/.version"
+            rm "${prefix}/.version"
+            rmdir "${prefix}" 2> /dev/null
+        fi
 
         xz -6 "${OUTPUT_DIR}/${tarball_name}"
     fi
 
-    if [ -e "${OUTPUT_DIR}/build-release" ]; then
+    if ! ${BUILD_SNAPSHOT} && [ -e "${OUTPUT_DIR}/build-release" ]; then
         logInfo "Cleaning existing build directory..."
         rm -r "${OUTPUT_DIR}/build-release" 2> /dev/null
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes AppImage crashing on older systems, resolves #1522.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The runtime library search paths for libgcrypt and libgpg-error were wrong, so the versions from the host system were used, which doesn't work on Xenial or older.
Additionally, our custom libgpg-error was stripped from the AppImage by the blacklist function, so it couldn't be found even if the paths had been correct. This patch fixes both issues.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran AppImage on Ubuntu Trusty.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
