### PR TITLE
Correct intermittent crash due to stale history items

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -795,10 +795,6 @@ void DatabaseWidget::switchToView(bool accepted)
         m_newParent = nullptr;
     }
 
-    if (accepted) {
-        showMessage(tr("Entry updated successfully."), MessageWidget::Positive, false, 2000);
-    }
-
     setCurrentWidget(m_mainWidget);
 }
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -755,6 +755,8 @@ bool EditEntryWidget::commitEntry()
     }
 #endif
 
+    m_historyModel->setEntries(m_entry->historyItems());
+
     showMessage(tr("Entry updated successfully."), MessageWidget::Positive);
     return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
There was a crash that occurred when the history was truncated and an entry was committed. This became apparent when we started showing the entry save successful message. The root cause is a stale entry pointer that is stored in the history model, but not updated when the actual pointer is deleted.

Also remove the entry update message when you hit "OK"

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Crashes are bad... and this one loses data!

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
