### PR TITLE
Strip newlines from title, username and URL when saving entries

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -772,12 +772,14 @@ void EditEntryWidget::acceptEntry()
 
 void EditEntryWidget::updateEntryData(Entry* entry) const
 {
+    QRegularExpression newLineRegex("(?:\r?\n|\r)");
+
     entry->attributes()->copyCustomKeysFrom(m_entryAttributes);
     entry->attachments()->copyDataFrom(m_advancedUi->attachmentsWidget->entryAttachments());
     entry->customData()->copyDataFrom(m_editWidgetProperties->customData());
-    entry->setTitle(m_mainUi->titleEdit->text());
-    entry->setUsername(m_mainUi->usernameEdit->text());
-    entry->setUrl(m_mainUi->urlEdit->text());
+    entry->setTitle(m_mainUi->titleEdit->text().replace(newLineRegex, " "));
+    entry->setUsername(m_mainUi->usernameEdit->text().replace(newLineRegex, " "));
+    entry->setUrl(m_mainUi->urlEdit->text().replace(newLineRegex, " "));
     entry->setPassword(m_mainUi->passwordEdit->text());
     entry->setExpires(m_mainUi->expireCheck->isChecked());
     entry->setExpiryTime(m_mainUi->expireDatePicker->dateTime().toUTC());

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -364,6 +364,22 @@ void TestGui::testEditEntry()
 
     // Confirm modified indicator is showing
     QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QString("%1*").arg(m_dbFileName));
+
+    // Test copy & paste newline sanitization
+    QTest::mouseClick(entryEditWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    titleEdit->setText("multiline\ntitle");
+    editEntryWidget->findChild<QLineEdit*>("usernameEdit")->setText("multiline\nusername");
+    editEntryWidget->findChild<QLineEdit*>("passwordEdit")->setText("multiline\npassword");
+    editEntryWidget->findChild<QLineEdit*>("passwordRepeatEdit")->setText("multiline\npassword");
+    editEntryWidget->findChild<QLineEdit*>("urlEdit")->setText("multiline\nurl");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+
+    QCOMPARE(entry->title(), QString("multiline title"));
+    QCOMPARE(entry->username(), QString("multiline username"));
+    // here we keep newlines, so users can't lock themselves out accidentally
+    QCOMPARE(entry->password(), QString("multiline\npassword"));
+    QCOMPARE(entry->url(), QString("multiline url"));
 }
 
 void TestGui::testSearchEditEntry()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Replaces newlines in entry title, username and URL with spaces when saving an entry. Resolves #1502 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevents awkward newlines in entry listings when copy-pasting data into KeePassXC.
Since the affected fields are single-line input fields and display newlines as spaces, they should also be saved as such. Only exception is the password field, here I skipped newline sanitization and retain the password as-is, so people don't lock themselves out of their services accidentally.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with added test cases.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**