### PR TITLE
Don't hardcode install_name_tool change path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,8 @@ if(Qt5Core_VERSION VERSION_LESS "5.2.0")
   message(FATAL_ERROR "Qt version 5.2.0 or higher is required")
 endif()
 
+get_filename_component(Qt5_PREFIX ${Qt5_DIR}/../../.. REALPATH)
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)

--- a/share/translations/CMakeLists.txt
+++ b/share/translations/CMakeLists.txt
@@ -23,12 +23,12 @@ message(STATUS "Including translations...\n")
 qt5_add_translation(QM_FILES ${TRANSLATION_FILES})
 
 if(MINGW)
-    file(GLOB QTBASE_TRANSLATIONS ${Qt5_DIR}/../../../share/qt5/translations/qtbase_*.qm)
+    file(GLOB QTBASE_TRANSLATIONS ${Qt5_PREFIX}/share/qt5/translations/qtbase_*.qm)
 elseif(APPLE OR KEEPASSXC_DIST_APPIMAGE)
     file(GLOB QTBASE_TRANSLATIONS
             /usr/share/qt/translations/qtbase_*.qm
             /usr/share/qt5/translations/qtbase_*.qm
-            ${Qt5_DIR}/../../../translations/qtbase_*.qm)
+            ${Qt5_PREFIX}/translations/qtbase_*.qm)
 endif()
 set(QM_FILES ${QM_FILES} ${QTBASE_TRANSLATIONS})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -382,7 +382,7 @@ if(MINGW)
   include(DeployQt4)
   install_qt4_executable(${PROGNAME}.exe)
   add_custom_command(TARGET ${PROGNAME} POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${Qt5_DIR}/../../../share/qt5/plugins/platforms/qwindows$<$<CONFIG:Debug>:d>.dll
+                     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${Qt5_PREFIX}/share/qt5/plugins/platforms/qwindows$<$<CONFIG:Debug>:d>.dll
                      $<TARGET_FILE_DIR:${PROGNAME}>)
   install(FILES $<TARGET_FILE_DIR:${PROGNAME}>/qwindows$<$<CONFIG:Debug>:d>.dll DESTINATION "platforms")
 endif()

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -42,13 +42,13 @@ if(WITH_XC_BROWSER)
 
         add_custom_command(TARGET keepassxc-proxy
                            POST_BUILD
-                           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore" ${PROXY_APP_DIR}
+                           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${Qt5_PREFIX}/lib/QtCore.framework/Versions/5/QtCore "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore" ${PROXY_APP_DIR}
                            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
                            COMMENT "Changing linking of keepassxc-proxy QtCore")
 
         add_custom_command(TARGET keepassxc-proxy
                            POST_BUILD
-                           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork" ${PROXY_APP_DIR}
+                           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${Qt5_PREFIX}/lib/QtNetwork.framework/Versions/5/QtNetwork "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork" ${PROXY_APP_DIR}
                            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
                            COMMENT "Changing linking of keepassxc-proxy QtNetwork")
     endif()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes hard-coded Qt paths in proxy/CMakeLists.txt, resolves #1518 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The CMakeLists.txt file hard-coded paths to Qt libraries, which only worked with upstream Qt, but not with Homebrew Qt. This resulted in failure of the install_name_tool to change the Qt link library paths for keepassxc_proxy.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compiled on macOS and keepassxc_proxy now correctly links to @executable_path/../* (tested with `otool -L`).

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**