### PR TITLE
Enable keepassxc_proxy for AppImage builds

### DIFF
--- a/AppImage-Recipe.sh
+++ b/AppImage-Recipe.sh
@@ -88,6 +88,11 @@ unset XDG_DATA_DIRS
 if [ "\${1}" == "cli" ]; then
     shift
     exec keepassxc-cli "\$@"
+elif [ "\${1}" == "proxy" ]; then
+    shift
+    exec keepassxc-proxy "\$@"
+elif [ -v CHROME_WRAPPER ] || [ -v MOZ_LAUNCHED_CHILD ]; then
+    exec keepassxc-proxy "\$@"
 else
     exec keepassxc "\$@"
 fi

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -47,10 +47,7 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent) :
     connect(m_ui->useCustomProxy, SIGNAL(toggled(bool)), m_ui->customProxyLocationBrowseButton, SLOT(setEnabled(bool)));
     connect(m_ui->customProxyLocationBrowseButton, SIGNAL(clicked()), this, SLOT(showProxyLocationFileDialog()));
 
-#ifdef KEEPASSXC_DIST_APPIMAGE
-    m_ui->supportBrowserProxy->setChecked(true);
-    m_ui->supportBrowserProxy->setEnabled(false);
-#endif
+    m_ui->browserGlobalWarningWidget->setVisible(false);
 }
 
 BrowserOptionDialog::~BrowserOptionDialog()
@@ -90,6 +87,18 @@ void BrowserOptionDialog::loadSettings()
     m_ui->chromiumSupport->setChecked(settings.chromiumSupport());
     m_ui->firefoxSupport->setChecked(settings.firefoxSupport());
     m_ui->vivaldiSupport->setChecked(settings.vivaldiSupport());
+
+#if defined(KEEPASSXC_DIST_APPIMAGE)
+    m_ui->supportBrowserProxy->setChecked(true);
+    m_ui->supportBrowserProxy->setEnabled(false);
+#elif defined(KEEPASSXC_DIST_SNAP)
+    m_ui->enableBrowserSupport->setChecked(false);
+    m_ui->enableBrowserSupport->setEnabled(false);
+    m_ui->browserGlobalWarningWidget->showMessage(
+        tr("We're sorry, but KeePassXC-Browser is not supported for Snap releases at the moment."), MessageWidget::Warning);
+    m_ui->browserGlobalWarningWidget->setCloseButtonVisible(false);
+    m_ui->browserGlobalWarningWidget->setAutoHideTimeout(-1);
+#endif
 }
 
 void BrowserOptionDialog::saveSettings()

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -19,6 +19,7 @@
 
 #include "BrowserOptionDialog.h"
 #include "ui_BrowserOptionDialog.h"
+#include "config-keepassx.h"
 #include "BrowserSettings.h"
 #include "core/FilePath.h"
 
@@ -45,6 +46,11 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent) :
     connect(m_ui->useCustomProxy, SIGNAL(toggled(bool)), m_ui->customProxyLocation, SLOT(setEnabled(bool)));
     connect(m_ui->useCustomProxy, SIGNAL(toggled(bool)), m_ui->customProxyLocationBrowseButton, SLOT(setEnabled(bool)));
     connect(m_ui->customProxyLocationBrowseButton, SIGNAL(clicked()), this, SLOT(showProxyLocationFileDialog()));
+
+#ifdef KEEPASSXC_DIST_APPIMAGE
+    m_ui->supportBrowserProxy->setChecked(true);
+    m_ui->supportBrowserProxy->setEnabled(false);
+#endif
 }
 
 BrowserOptionDialog::~BrowserOptionDialog()

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -27,6 +27,9 @@
     <number>0</number>
    </property>
    <item>
+    <widget class="MessageWidget" name="browserGlobalWarningWidget" native="true"/>
+   </item>
+   <item>
     <widget class="QCheckBox" name="enableBrowserSupport">
      <property name="toolTip">
       <string>This is required for accessing your databases with KeePassXC-Browser</string>

--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -17,12 +17,14 @@
 */
 
 #include "HostInstaller.h"
+#include "config-keepassx.h"
 #include <QDir>
 #include <QFile>
 #include <QStandardPaths>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QCoreApplication>
+#include <QProcessEnvironment>
 #include <QMessageBox>
 
 const QString HostInstaller::HOST_NAME = "org.keepassxc.keepassxc_browser";
@@ -161,6 +163,13 @@ QString HostInstaller::getInstallDir(SupportedBrowsers browser) const
 QJsonObject HostInstaller::constructFile(SupportedBrowsers browser, const bool& proxy, const QString& location)
 {
     QString path;
+#ifdef KEEPASSXC_DIST_APPIMAGE
+    if (proxy && !location.isEmpty()) {
+        path = location;
+    } else {
+        path = QProcessEnvironment::systemEnvironment().value("APPIMAGE");
+    }
+#else
     if (proxy) {
         if (!location.isEmpty()) {
             path = location;
@@ -177,6 +186,8 @@ QJsonObject HostInstaller::constructFile(SupportedBrowsers browser, const bool& 
 #ifdef Q_OS_WIN
     path.replace("/","\\");
 #endif
+
+#endif  // #ifdef KEEPASSXC_DIST_APPIMAGE
 
     QJsonObject script;
     script["name"]          = HostInstaller::HOST_NAME;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This patch enables proper interaction between KeePassXC-Browser and KeePassXC AppImages.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
KeePassXC-Browser used to execute either the keepassxc_proxy or keepassxc binary directly from the AppImage mount path (depending on the user settings). This only works if the user has the correct version of all necessary libraries installed.

This patch changes the behaviour for AppImages so that the AppImage binary is launched by the browser. The AppImage distinguishes between regular calls and browser calls by checking if the `CHROME_WRAPPER` or `MOZ_LAUNCHED_CHILD` environment variables are set. In addition, a user can explicitly launch the proxy by starting the AppImage with a positional `proxy` parameter (unfortunately, that doesn't work with native messaging manifest files).

Furthermore, if KeePassXC is compiled as an AppImage, the "Use a proxy..." option is always enabled and cannot be changed. This is because we cannot distinguish if the browser has launched KeePassXC or the proxy, because both are the same binary and we cannot use command line parameters.

**Security consideration:** when compiled as an AppImage, we copy the contents of the `APPIMAGE` environment variable to the native messaging manifest. This can be manipulated, but I don't see a security vulnerability for two reasons:

- if KeePassXC is launched through the AppImage's AppRun binary (which is always the case for regular AppImage launches), it will override the value of this environment variable with the actual AppImage path
- if KeePassXC is compiled as an AppImage, but isn't run through AppRun (for whatever reason), an attacker who can modify environment variables could probably also just edit the manifest file directly (or do even worse things)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on Arch Linux with all four supported browsers.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**