### PR TITLE
Don't hardcode HINTS to macdeployqt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,7 @@ set(CMAKE_AUTORCC ON)
 
 if(APPLE)
   set(CMAKE_MACOSX_RPATH TRUE)
-  find_program(MACDEPLOYQT_EXE macdeployqt HINTS /usr/local/opt/qt5/bin ENV PATH)
+  find_program(MACDEPLOYQT_EXE macdeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
   if(NOT MACDEPLOYQT_EXE)
     message(FATAL_ERROR "macdeployqt is required to build in macOS")
   else()

--- a/release-tool
+++ b/release-tool
@@ -658,17 +658,12 @@ build() {
     if [ "" == "$DOCKER_IMAGE" ]; then
         if [ "$(uname -s)" == "Darwin" ]; then
             # Building on macOS
-            local qt_vers="$(ls /usr/local/Cellar/qt 2> /dev/null | sort -r | head -n1)"
-            if [ "" == "$qt_vers" ]; then
-                exitError "Couldn't find Qt5! Please make sure it is available in '/usr/local/Cellar/qt'."
-            fi
-
             export MACOSX_DEPLOYMENT_TARGET=10.10
 
             logInfo "Configuring build..."
             cmake -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-              -DCMAKE_PREFIX_PATH="/usr/local/Cellar/qt/${qt_vers}/lib/cmake" \
+              -DCMAKE_PREFIX_PATH="/usr/local/opt/qt/lib/cmake" \
               ${CMAKE_OPTIONS} "$SRC_DIR"
 
             logInfo "Compiling and packaging sources..."

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -42,14 +42,17 @@ if(WITH_XC_BROWSER)
 
         add_custom_command(TARGET keepassxc-proxy
                            POST_BUILD
-                           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${Qt5_PREFIX}/lib/QtCore.framework/Versions/5/QtCore "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore" ${PROXY_APP_DIR}
+                           COMMAND ${CMAKE_INSTALL_NAME_TOOL}
+                                -change ${Qt5_PREFIX}/lib/QtCore.framework/Versions/5/QtCore
+                                    "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore"
+                                -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore
+                                    "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore"
+                                -change ${Qt5_PREFIX}/lib/QtNetwork.framework/Versions/5/QtNetwork
+                                    "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork"
+                                -change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork
+                                    "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork"
+                           ${PROXY_APP_DIR}
                            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
-                           COMMENT "Changing linking of keepassxc-proxy QtCore")
-
-        add_custom_command(TARGET keepassxc-proxy
-                           POST_BUILD
-                           COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${Qt5_PREFIX}/lib/QtNetwork.framework/Versions/5/QtNetwork "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork" ${PROXY_APP_DIR}
-                           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
-                           COMMENT "Changing linking of keepassxc-proxy QtNetwork")
+                           COMMENT "Changing linking of keepassxc-proxy")
     endif()
 endif()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Replaces the hardcoded path HINT for macdeployqt with  a dynamic one.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In #1529 I added a new `${Qt5_PREFIX}` CMake variable, which points to the Qt install location on Windows and macOS, which we can use here instead of hardcoding a path to /usr/local/opt.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not at all, @varjolintu @weslly someone of you please test, I don't have a Mac here atm.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**