### PR TITLE
Fix missing Qt platform styles and CA bundles in Windows release deployment

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -384,7 +384,11 @@ if(MINGW)
   
   # install Qt5 plugins
   set(PLUGINS_DIR ${Qt5_PREFIX}/share/qt5/plugins)
-  install(FILES ${PLUGINS_DIR}/platforms/qwindows$<$<CONFIG:Debug>:d>.dll DESTINATION "platforms")
+  install(FILES
+          ${PLUGINS_DIR}/platforms/qwindows$<$<CONFIG:Debug>:d>.dll
+          ${PLUGINS_DIR}/platforms/qdirect2d$<$<CONFIG:Debug>:d>.dll
+        DESTINATION "platforms")
+  install(FILES ${PLUGINS_DIR}/styles/qwindowsvistastyle$<$<CONFIG:Debug>:d>.dll DESTINATION "styles")
   install(FILES ${PLUGINS_DIR}/platforminputcontexts/qtvirtualkeyboardplugin$<$<CONFIG:Debug>:d>.dll DESTINATION "platforminputcontexts")
   install(FILES ${PLUGINS_DIR}/iconengines/qsvgicon$<$<CONFIG:Debug>:d>.dll DESTINATION "iconengines")
   install(FILES
@@ -395,4 +399,7 @@ if(MINGW)
           ${PLUGINS_DIR}/imageformats/qsvg$<$<CONFIG:Debug>:d>.dll
           ${PLUGINS_DIR}/imageformats/qwebp$<$<CONFIG:Debug>:d>.dll
         DESTINATION "imageformats")
+
+  # install CA cert chains
+  install(FILES ${Qt5_PREFIX}/ssl/certs/ca-bundle.crt DESTINATION "ssl/certs")
 endif()

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -202,6 +202,13 @@ QImage EditWidgetIcons::fetchFavicon(const QUrl& url)
         curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &imagedata);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &writeCurlResponse);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+#ifdef Q_OS_WIN
+        const QDir appDir = QFileInfo(QCoreApplication::applicationFilePath()).absoluteDir();
+        if (appDir.exists("ssl\\certs")) {
+            curl_easy_setopt(curl, CURLOPT_CAINFO, (appDir.absolutePath() + "\\ssl\\certs\\ca-bundle.crt").toLatin1().data());
+        }
+#endif
 
         // Perform the request in another thread
         CURLcode result = AsyncTask::runAndWaitForFuture([curl]() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Follow-up PR on #1534, which adds missing Windows platform style plugins and CA bundles.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When no /mingw64 environment was available on the target system, KeePassXC started with Windows 95 classic look due to missing platform styles. I don't know why we didn't have this problem before, but maybe something changed with Qt 5.10.

With this patch I added the missing qwindowsvistastyle.dll and also the qdirect2d.dll platform plugin to the list of deployed plugins.

Another missing piece were CA bundles, without which cURL failed to verify TLS certificates. This was also added.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I renamed my /mingw64 root and started KeePassXC. Platform theme works ok and HTTPS downloads work as well. On the other hand, when run from within the build directory, where no ssl/certs/ca-bundles.crt deployment exists, cURL tries to load the CA bundle from /mingw64/ssl/certs/ca-bundles.crt as expected (paths verified with ProcMon).

I tested TLS verification against cacert.com, where I was able to download a favicon via HTTP, but not via HTTPS, while downloading a favicon from a "trusted" source (e.g., google.com) works. Perhaps we should add an automatic tests for this in the future.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**