### PR TITLE
Avoid double file extension replacement in backup filename

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -570,10 +570,11 @@ QString Database::writeDatabase(QIODevice* device)
  * @param filePath Path to the file to backup
  * @return
  */
+
 bool Database::backupDatabase(QString filePath)
 {
     QString backupFilePath = filePath;
-    auto re = QRegularExpression("(?:\\.kdbx)?$", QRegularExpression::CaseInsensitiveOption);
+    auto re = QRegularExpression("\\.kdbx$|(?<!\\.kdbx)$", QRegularExpression::CaseInsensitiveOption);
     backupFilePath.replace(re, ".old.kdbx");
     QFile::remove(backupFilePath);
     return QFile::copy(filePath, backupFilePath);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Changes the regular expression for generating the backup file name when "Backup database before saving" is turned on to avoid double replacement.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Qt replaced all *possible* occurrences of the regular expression, resulting in a doubled file extension (.old.kdbx.old.kdbx). This patch changes the behavior to only add .old.kdbx. If a file already ends in .old.kdbx, the backup file is named .old.old.kdbx.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**