### PR TITLE
Use copy instead of rename for unsafe saving on Linux

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -537,11 +537,19 @@ QString Database::saveToFile(QString filePath, bool atomic, bool backup)
 
             // Delete the original db and move the temp file in place
             QFile::remove(filePath);
+#ifdef Q_OS_LINUX
+            // workaround to make this workaround work, see: https://bugreports.qt.io/browse/QTBUG-64008
+            if (tempFile.copy(filePath)) {
+                // successfully saved database file
+                return {};
+            }
+#else
             if (tempFile.rename(filePath)) {
                 // successfully saved database file
                 tempFile.setAutoRemove(false);
                 return {};
             }
+#endif
         }
         error = tempFile.errorString();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #1511 by using copy instead of rename for unsafe saves on Linux.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our workaround for the original Qt bug, which we implemented unsafe saves for, got busted by yet another Qt bug, which makes unsave saves with rename fail. See See https://bugreports.qt.io/browse/QTBUG-64008

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on an affected machine.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**