### PR TITLE
Fix build on NetBSD.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,7 @@ if(APPLE)
         core/MacPasteboard.cpp
         )
 endif()
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" OR ${CMAKE_SYSTEM_NAME} STREQUAL "NetBSD")
+if(UNIX AND NOT APPLE)
     set(keepassx_SOURCES ${keepassx_SOURCES}
         core/ScreenLockListenerDBus.h
         core/ScreenLockListenerDBus.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,7 @@ if(APPLE)
         core/MacPasteboard.cpp
         )
 endif()
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD" OR ${CMAKE_SYSTEM_NAME} STREQUAL "NetBSD")
     set(keepassx_SOURCES ${keepassx_SOURCES}
         core/ScreenLockListenerDBus.h
         core/ScreenLockListenerDBus.cpp


### PR DESCRIPTION
Without this patch I see:
````
[ 74%] Linking CXX executable keepassxc
../libkeepassx_core.a(ScreenLockListenerPrivate.cpp.o): In function `ScreenLockListenerPrivate::instance(QWidget*)':
/scratch/security/keepassxc/work/keepassxc-2.3.0/src/core/ScreenLockListenerPrivate.cpp:38: undefined reference to `ScreenLockListenerDBus::ScreenLockListenerDBus(QWidget*)'
[ 74%] Building CXX object src/autotype/xcb/CMakeFiles/keepassx-autotype-xcb.dir/keepassx-autotype-xcb_autogen/mocs_compilation.cpp.o
../libkeepassx_core.a(MainWindow.cpp.o): In function `MainWindow::MainWindow()':
/scratch/security/keepassxc/work/keepassxc-2.3.0/src/gui/MainWindow.cpp:174: undefined reference to `MainWindowAdaptor::MainWindowAdaptor(QObject*)'
--- src/cli/keepassxc-cli ---
...
libkeepassx_core.a(MainWindow.cpp.o): In function `MainWindow::MainWindow()':
/scratch/security/keepassxc/work/keepassxc-2.3.0/src/gui/MainWindow.cpp:174: undefined reference to `MainWindowAdaptor::MainWindowAdaptor(QObject*)'
libkeepassx_core.a(ScreenLockListenerPrivate.cpp.o): In function `ScreenLockListenerPrivate::instance(QWidget*)':
/scratch/security/keepassxc/work/keepassxc-2.3.0/src/core/ScreenLockListenerPrivate.cpp:38: undefined reference to `ScreenLockListenerDBus::ScreenLockListenerDBus(QWidget*)'
--- src/keepassxc ---
*** [src/keepassxc] Error code 1
````

You should consider making this a UNIX check instead, but the patch fixes the immediate problem on NetBSD.