### PR TITLE
Don't upgrade to KDBX 4 when CustomData are present only in meta data section

### DIFF
--- a/src/format/KdbxXmlWriter.cpp
+++ b/src/format/KdbxXmlWriter.cpp
@@ -129,9 +129,7 @@ void KdbxXmlWriter::writeMetadata()
     if (m_kdbxVersion < KeePass2::FILE_VERSION_4) {
         writeBinaries();
     }
-    if (m_kdbxVersion >= KeePass2::FILE_VERSION_4) {
-        writeCustomData(m_meta->customData());
-    }
+    writeCustomData(m_meta->customData());
 
     m_xml.writeEndElement();
 }

--- a/src/format/KeePass2Writer.h
+++ b/src/format/KeePass2Writer.h
@@ -42,6 +42,7 @@ public:
 
 private:
     void raiseError(const QString& errorMessage);
+    bool implicitUpgradeNeeded(Database const* db) const;
 
     bool m_error = false;
     QString m_errorStr = "";

--- a/tests/TestKdbx4.cpp
+++ b/tests/TestKdbx4.cpp
@@ -149,8 +149,10 @@ void TestKdbx4::testFormat400Upgrade()
     sourceDb->changeKdf(KeePass2::uuidToKdf(kdfUuid));
     sourceDb->setCipher(cipherUuid);
 
+    // CustomData in meta should not cause any version change
+    sourceDb->metadata()->customData()->set("CustomPublicData", "Hey look, I turned myself into a pickle!");
     if (addCustomData) {
-        sourceDb->metadata()->customData()->set("CustomPublicData", "Hey look, I turned myself into a pickle!");
+        // this, however, should
         sourceDb->rootGroup()->customData()->set("CustomGroupData", "I just killed my family! I don't care who they were!");
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixed KeePassXC incorrectly (unnecessarily) upgrading to KDBX 4 if CustomData are available on the meta data section.

Resolves #1563 , #1565 and #1584.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
KDBX 4 upgrade should only be done for CustomData in entries or in the KDBX header, not in database meta data. Although an upgrade in itself is not a bad idea, it shouldn't be done automatically if it's not strictly needed.

I know I fixed this bug before and it must have been re-introduced somewhere along the way.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with updated upgrade tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**