### PR TITLE
Release build when checking out a git-tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,9 @@ set_property(CACHE KEEPASSXC_BUILD_TYPE PROPERTY STRINGS Snapshot Release PreRel
 execute_process(COMMAND git tag --points-at HEAD
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_VARIABLE GIT_TAG)
-if(NOT GIT_TAG AND EXISTS ${CMAKE_SOURCE_DIR}/.version)
+if(GIT_TAG)
+  set(OVERRIDE_VERSION ${GIT_TAG})
+elseif(EXISTS ${CMAKE_SOURCE_DIR}/.version)
   file(READ ${CMAKE_SOURCE_DIR}/.version OVERRIDE_VERSION)
 endif()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
When checking out a tag, if you previously build a snapshot, the `KEEPASSXC_BUILD_TYPE` variable will be cached to `"Snapshot"`.
With this we explicitly force `"Release"` if the git repo is set to a tag by using the `OVERRIDE_VERSION` option

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
