### PR TITLE
Do not delete MacPasteboard instance on exit, resolves #1543

### DIFF
--- a/src/core/MacPasteboard.h
+++ b/src/core/MacPasteboard.h
@@ -20,8 +20,9 @@
 
 #include <QMacPasteboardMime>
 #include <QTextCodec>
+#include <QObject>
 
-class MacPasteboard : public QMacPasteboardMime
+class MacPasteboard : public QObject, public QMacPasteboardMime
 {
 public:
     explicit MacPasteboard() : QMacPasteboardMime(MIME_ALL) {}

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -24,14 +24,19 @@
 #include "core/Config.h"
 
 Clipboard* Clipboard::m_instance(nullptr);
+#ifdef Q_OS_MAC
+QPointer<MacPasteboard> Clipboard::m_pasteboard(nullptr);
+#endif
 
 Clipboard::Clipboard(QObject* parent)
     : QObject(parent)
     , m_timer(new QTimer(this))
-#ifdef Q_OS_MAC
-    , m_pasteboard(new MacPasteboard)
-#endif
 {
+#ifdef Q_OS_MAC
+    if (!m_pasteboard) {
+        m_pasteboard = new MacPasteboard();
+    }
+#endif
     m_timer->setSingleShot(true);
     connect(m_timer, SIGNAL(timeout()), SLOT(clearClipboard()));
     connect(qApp, SIGNAL(aboutToQuit()), SLOT(clearCopiedText()));

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -21,6 +21,7 @@
 #include <QObject>
 #ifdef Q_OS_MAC
 #include "core/MacPasteboard.h"
+#include <QPointer>
 #endif
 
 class QTimer;
@@ -47,7 +48,9 @@ private:
 
     QTimer* m_timer;
 #ifdef Q_OS_MAC
-    QScopedPointer<MacPasteboard> m_pasteboard;
+    // This object lives for the whole program lifetime and we cannot delete it on exit,
+    // so ignore leak warnings. See https://bugreports.qt.io/browse/QTBUG-54832
+    static QPointer<MacPasteboard> m_pasteboard;
 #endif
     QString m_lastCopied;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Removes deletion of the MacPasteboard instance on exit, working around a crash due to a Qt bug. Resolves #1543.

Regression was introduced in 806248ebd

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
QMacPasteboardMime subclasses are registered and de-registered using ctors/dtors, but after deleting an instance, Qt keeps a dangling pointer, which it tries to delete again on program exit (https://bugreports.qt.io/browse/QTBUG-54832).
Since our MacPasteboard instance lives for the whole program duration, anyway, it's no big loss to simply not delete it and let Qt or, at the latest, the OS take care of it.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
KeePassXC doesn't crash anymore when opening and locking a database and then exiting the program with Cmd+Q.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**