### PR TITLE
Fix regression: basic filename, password and keyfile command line parameters being ignored

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,6 +149,7 @@ int main(int argc, char** argv)
                 static QTextStream in(stdin, QIODevice::ReadOnly);
                 password = in.readLine();
             }
+            mainWindow.openDatabase(filename, password, parser.value(keyfileOption));
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->


## Description
<!--- Describe your changes in detail -->
Fixes basic filename, --pw-stdin and --keyfile parameters being ignored.

Resolves #1358, resolves #1533, resolves #1600
Regression was introduced in 06518c5736

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The line for processing basic command line parameters for the file to open, --pw-stdin, and --keyfile was removed. As a result, opening files via double click, or by specifying its name on the command line stopped working. So did specifying a keyfile or a password via STDIN. This patch restores the line.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on Linux and Windows. Filenames (double-click open and explicit command line parameter), --pw-stdin and --keyfile work as expected.
If an instance is already running, the filename parameter is properly passed on to the running instance.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**