### PR TITLE
Resize details widget to minimum by default

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -129,6 +129,7 @@ DatabaseWidget::DatabaseWidget(Database* db, QWidget* parent)
 
     m_detailSplitter->setStretchFactor(0, 100);
     m_detailSplitter->setStretchFactor(1, 0);
+    m_detailSplitter->setSizes({1, 1});
 
     m_searchingLabel->setVisible(false);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Resizes the details widget to its minimum size when no saved UI state is available.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Upon first start of KeePassXC, the details widget used to gobble up some 30 or 50% of the vertical screen space instead of just its minimum height. This patch resizes it down to its minimum size hint. If a saved UI state is available (i.e., if this is not the first start), it will override the size with whatever size the user has resized the widget to.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on Windows by deleting the config file.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**