### PR TITLE
Open previously opened databases in correct order

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -933,7 +933,7 @@ void MainWindow::setShortcut(QAction* action, QKeySequence::StandardKey standard
 
 void MainWindow::rememberOpenDatabases(const QString& filePath)
 {
-    m_openDatabases.append(filePath);
+    m_openDatabases.prepend(filePath);
 }
 
 void MainWindow::applySettingsChanges()


### PR DESCRIPTION
Databases are re-opened by traversing LastOpenedDatabases from front to
back, i.e. the last element in the list will be the active tab. However,
the most-recently used database is currently stored at the beginning of
the list. This leads to the least-recently used database to be the
ative tab on next startup.

Previously, this has been fixed in 4c76c97 by opening the databases in
reversed order. This change was accidentally reverted in 165d664.
Instead, change the order of LastOpenedDatabases itself, so no reversal
on opening the databases is necessary.

Resolves #1572

## Motivation and context
All included in the commit message above.

## How has this been tested?
Manual testing of behavior and stored values in keepassxc.ini.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
