### PR TITLE
Fix qtbase translations not being loaded (regression)

### DIFF
--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -2579,6 +2579,33 @@ This is a one-way migration. You won&apos;t be able to open the imported databas
     </message>
 </context>
 <context>
+    <name>KeePass2</name>
+    <message>
+        <source>AES: 256-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Twofish: 256-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ChaCha20: 256-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES-KDF (KDBX 4)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES-KDF (KDBX 3.1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Argon2 (KDBX 4 – recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Existing single-instance lock file is invalid. Launching new instance.</source>
@@ -3474,30 +3501,6 @@ Available commands:
     </message>
     <message>
         <source>missing closing quote</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>AES: 256-bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Twofish: 256-bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>ChaCha20: 256-bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Argon2 (KDBX 4 – recommended)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>AES-KDF (KDBX 4)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>AES-KDF (KDBX 3.1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/core/Translator.cpp
+++ b/src/core/Translator.cpp
@@ -53,6 +53,9 @@ void Translator::installTranslators()
     bool translationsLoaded = false;
     for (const QString& path : paths) {
         translationsLoaded |= installTranslator(language, path) || installTranslator("en_US", path);
+        if (!installQtTranslator(language, path)) {
+            installQtTranslator("en", path);
+        }
     }
     if (!translationsLoaded) {
         // couldn't load configured language or fallback

--- a/src/format/KeePass2.cpp
+++ b/src/format/KeePass2.cpp
@@ -45,15 +45,15 @@ const QString KeePass2::KDFPARAM_ARGON2_SECRET("K");
 const QString KeePass2::KDFPARAM_ARGON2_ASSOCDATA("A");
 
 const QList<QPair<Uuid, QString>> KeePass2::CIPHERS{
-    qMakePair(KeePass2::CIPHER_AES, QObject::tr("AES: 256-bit")),
-    qMakePair(KeePass2::CIPHER_TWOFISH, QObject::tr("Twofish: 256-bit")),
-    qMakePair(KeePass2::CIPHER_CHACHA20, QObject::tr("ChaCha20: 256-bit"))
+    qMakePair(KeePass2::CIPHER_AES, QString(QT_TRANSLATE_NOOP("KeePass2", "AES: 256-bit"))),
+    qMakePair(KeePass2::CIPHER_TWOFISH, QString(QT_TRANSLATE_NOOP("KeePass2", "Twofish: 256-bit"))),
+    qMakePair(KeePass2::CIPHER_CHACHA20, QString(QT_TRANSLATE_NOOP("KeePass2", "ChaCha20: 256-bit")))
 };
 
 const QList<QPair<Uuid, QString>> KeePass2::KDFS{
-    qMakePair(KeePass2::KDF_ARGON2, QObject::tr("Argon2 (KDBX 4 – recommended)")),
-    qMakePair(KeePass2::KDF_AES_KDBX4, QObject::tr("AES-KDF (KDBX 4)")),
-    qMakePair(KeePass2::KDF_AES_KDBX3, QObject::tr("AES-KDF (KDBX 3.1)"))
+    qMakePair(KeePass2::KDF_ARGON2, QString(QT_TRANSLATE_NOOP("KeePass2", "Argon2 (KDBX 4 – recommended)"))),
+    qMakePair(KeePass2::KDF_AES_KDBX4, QString(QT_TRANSLATE_NOOP("KeePass2", "AES-KDF (KDBX 4)"))),
+    qMakePair(KeePass2::KDF_AES_KDBX3, QString(QT_TRANSLATE_NOOP("KeePass2", "AES-KDF (KDBX 3.1)")))
 };
 
 QByteArray KeePass2::hmacKey(QByteArray masterSeed, QByteArray transformedMasterKey) {

--- a/src/gui/DatabaseSettingsWidget.cpp
+++ b/src/gui/DatabaseSettingsWidget.cpp
@@ -102,7 +102,7 @@ void DatabaseSettingsWidget::load(Database* db)
 
     m_uiEncryption->algorithmComboBox->clear();
     for (auto& cipher: asConst(KeePass2::CIPHERS)) {
-        m_uiEncryption->algorithmComboBox->addItem(cipher.second, cipher.first.toByteArray());
+        m_uiEncryption->algorithmComboBox->addItem(QCoreApplication::translate("KeePass2", cipher.second.toUtf8()), cipher.first.toByteArray());
     }
     int cipherIndex = m_uiEncryption->algorithmComboBox->findData(m_db->cipher().toByteArray());
     if (cipherIndex > -1) {
@@ -113,7 +113,7 @@ void DatabaseSettingsWidget::load(Database* db)
     m_uiEncryption->kdfComboBox->blockSignals(true);
     m_uiEncryption->kdfComboBox->clear();
     for (auto& kdf: asConst(KeePass2::KDFS)) {
-        m_uiEncryption->kdfComboBox->addItem(kdf.second, kdf.first.toByteArray());
+        m_uiEncryption->kdfComboBox->addItem(QCoreApplication::translate("KeePass2", kdf.second.toUtf8()), kdf.first.toByteArray());
     }
     m_uiEncryption->kdfComboBox->blockSignals(false);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Despite a previous fix, qtbase translations were not loaded in 2.3.0. This patch fixes this issue.
Also fixes cipher/KDF translations not being applied.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Qt standard widgets were not translated.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by selecting a language other than English.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**