### PR TITLE
Fix GCC 8 memset warning and set -Werror only for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,10 +157,14 @@ if(WITH_APP_BUNDLE)
 endif()
 
 add_gcc_compiler_flags("-fno-common")
-add_gcc_compiler_flags("-Wall -Werror -Wextra -Wundef -Wpointer-arith -Wno-long-long")
+add_gcc_compiler_flags("-Wall -Wextra -Wundef -Wpointer-arith -Wno-long-long")
 add_gcc_compiler_flags("-Wformat=2 -Wmissing-format-attribute")
 add_gcc_compiler_flags("-fvisibility=hidden")
 add_gcc_compiler_cxxflags("-fvisibility-inlines-hidden")
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_gcc_compiler_flags("-Werror")
+endif()
 
 if((CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.8.999) OR CMAKE_COMPILER_IS_CLANGXX)
     add_gcc_compiler_flags("-fstack-protector-strong")

--- a/src/http/Server.cpp
+++ b/src/http/Server.cpp
@@ -140,7 +140,11 @@ void Server::generatePassword(const Request &r, Response *protocolResp)
     protocolResp->setVerifier(key);
     protocolResp->setEntries(QList<Entry>() << Entry("generate-password", bits, password, "generate-password"));
 
-    memset(password.data(), 0, password.length());
+    int size = password.capacity();
+    volatile auto* mem = reinterpret_cast<volatile ushort*>(password.data());
+    while (size--) {
+        *mem++ = 0;
+    }
 }
 
 void Server::handleRequest(const QByteArray& data, QHttpResponse* response)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #1558 by overwriting the KeePassHTTP password string without the use of memset() and enabling -Werror only for debug builds.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
GCC 8 issued a warning about use of memset for non-trivial type QChar.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I don't have GCC 8, so I could only test with GCC 7.2 that everything continues to work.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**