### PR TITLE
Avoid conditional use of possibly uninitialized value in CategoryListWidgetDelegate

### DIFF
--- a/src/gui/CategoryListWidget.cpp
+++ b/src/gui/CategoryListWidget.cpp
@@ -152,8 +152,9 @@ void CategoryListWidget::emitCategoryChanged(int index)
 CategoryListWidgetDelegate::CategoryListWidgetDelegate(QListWidget* parent)
     : QStyledItemDelegate(parent),
       m_listWidget(parent),
-      m_size(minWidth(), 96)
+      m_size(96, 96)
 {
+    m_size.setWidth(minWidth());
     if (m_listWidget && m_listWidget->width() > m_size.width()) {
         m_size.setWidth(m_listWidget->width());
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes usage of possibly undefined value in a branch condition.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found this bug with valgrind.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No more valgrind warnings about "Conditional jump or move depends on uninitialised value(s)".

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
