### PR TITLE
Fix freeze and high CPU usage on invalid STDIN data

### DIFF
--- a/src/browser/NativeMessagingHost.cpp
+++ b/src/browser/NativeMessagingHost.cpp
@@ -107,18 +107,26 @@ void NativeMessagingHost::readLength()
 
 void NativeMessagingHost::readStdIn(const quint32 length)
 {
-    if (length > 0) {
-        QByteArray arr;
-        arr.reserve(length);
+    if (length <= 0) {
+        return;
+    }
 
-        for (quint32 i = 0; i < length; ++i) {
-            arr.append(getchar());
-        }
+    QByteArray arr;
+    arr.reserve(length);
 
-        if (arr.length() > 0) {
-            QMutexLocker locker(&m_mutex);
-            sendReply(m_browserClients.readResponse(arr));
+    QMutexLocker locker(&m_mutex);
+
+    for (quint32 i = 0; i < length; ++i) {
+        int c = std::getchar();
+        if (c == EOF) {
+            // message ended prematurely, ignore it and return
+            return;
         }
+        arr.append(static_cast<char>(c));
+    }
+
+    if (arr.length() > 0) {
+        sendReply(m_browserClients.readResponse(arr));
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,12 +143,15 @@ int main(int argc, char** argv)
 
     const bool pwstdin = parser.isSet(pwstdinOption);
     for (const QString& filename: fileNames) {
+        QString password;
+        if (pwstdin) {
+            // we always need consume a line of STDIN if --pw-stdin is set to clear out the
+            // buffer for native messaging, even if the specified file does not exist
+            static QTextStream in(stdin, QIODevice::ReadOnly);
+            password = in.readLine();
+        }
+
         if (!filename.isEmpty() && QFile::exists(filename) && !filename.endsWith(".json", Qt::CaseInsensitive)) {
-            QString password;
-            if (pwstdin) {
-                static QTextStream in(stdin, QIODevice::ReadOnly);
-                password = in.readLine();
-            }
             mainWindow.openDatabase(filename, password, parser.value(keyfileOption));
         }
     }

--- a/src/proxy/NativeMessagingHost.cpp
+++ b/src/proxy/NativeMessagingHost.cpp
@@ -51,18 +51,25 @@ void NativeMessagingHost::readLength()
 
 void NativeMessagingHost::readStdIn(const quint32 length)
 {
-    if (length > 0) {
-        QByteArray arr;
-        arr.reserve(length);
+    if (length <= 0) {
+        return;
+    }
 
-        for (quint32 i = 0; i < length; ++i) {
-            arr.append(getchar());
-        }
+    QByteArray arr;
+    arr.reserve(length);
 
-        if (arr.length() > 0 && m_localSocket && m_localSocket->state() == QLocalSocket::ConnectedState) {
-            m_localSocket->write(arr.constData(), arr.length());
-            m_localSocket->flush();
+    for (quint32 i = 0; i < length; ++i) {
+        int c = std::getchar();
+        if (c == EOF) {
+            // message ended prematurely, ignore it and return
+            return;
         }
+        arr.append(static_cast<char>(c));
+    }
+
+    if (arr.length() > 0 && m_localSocket && m_localSocket->state() == QLocalSocket::ConnectedState) {
+        m_localSocket->write(arr.constData(), arr.length());
+        m_localSocket->flush();
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a freeze and high CPU usage when provided with invalid STDIN data and/or a wrong database filename.
Resolves #1620

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually. The reproduction examples in #1620 don't freeze KeePassXC anymore.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**