### PR TITLE
attributes: unbreak copy-to-clipboard on KDE

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -598,7 +598,7 @@ void DatabaseWidget::copyAttribute(QAction* action)
         return;
     }
 
-    setClipboardTextAndMinimize(currentEntry->resolveMultiplePlaceholders(currentEntry->attributes()->value(action->text())));
+    setClipboardTextAndMinimize(currentEntry->resolveMultiplePlaceholders(currentEntry->attributes()->value(action->data().toString())));
 }
 
 void DatabaseWidget::setClipboardTextAndMinimize(const QString& text)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -499,6 +499,7 @@ void MainWindow::updateCopyAttributesMenu()
     const QStringList customEntryAttributes = dbWidget->customEntryAttributes();
     for (const QString& key : customEntryAttributes) {
         QAction* action = m_ui->menuEntryCopyAttribute->addAction(key);
+        action->setData(QVariant(key));
         m_copyAdditionalAttributeActions->addAction(action);
     }
 }


### PR DESCRIPTION
The 'text' property of the QAction gets mangled by KDE when it adds its own accelerator shortcuts. But the data property is ours. Use that for keying instead.

---

Fixes #1569. The "not a bug" tag on there is totally misleading. Even if KDE is mangling the text attribute we can avoid breaking users by not using the mutable "text" property for keying into the attributes map.

I doubt that the Qt designers ever intend you to *read* the value of the text property programatically and use that for keying. It's generally assumed that it can be mangled by localization (or KDE's default accelerators thing in this case).