### PR TITLE
KdbxReader::readDatabase: abort if reading magic numbers fails

### DIFF
--- a/src/format/KdbxReader.cpp
+++ b/src/format/KdbxReader.cpp
@@ -71,7 +71,9 @@ Database* KdbxReader::readDatabase(QIODevice* device, const CompositeKey& key, b
 
     // read KDBX magic numbers
     quint32 sig1, sig2;
-    readMagicNumbers(&headerStream, sig1, sig2, m_kdbxVersion);
+    if (!readMagicNumbers(&headerStream, sig1, sig2, m_kdbxVersion)) {
+        return nullptr;
+    }
     m_kdbxSignature = qMakePair(sig1, sig2);
 
     // mask out minor version


### PR DESCRIPTION
Building with -flto caught the fact that we were ignoring the return
value of readMagicNumbers(), which potentially left the value of 'sig2'
uninitialized.