### PR TITLE
KdbxXmlReader: Support Protected attribute on most nodes

### DIFF
--- a/src/format/KdbxXmlReader.h
+++ b/src/format/KdbxXmlReader.h
@@ -81,6 +81,7 @@ protected:
     virtual TimeInfo parseTimes();
 
     virtual QString readString();
+    virtual QString readString(bool& isProtected, bool& protectInMemory);
     virtual bool readBool();
     virtual QDateTime readDateTime();
     virtual QColor readColor();
@@ -94,6 +95,7 @@ protected:
     virtual Group* getGroup(const Uuid& uuid);
     virtual Entry* getEntry(const Uuid& uuid);
 
+    virtual bool isTrueValue(const QStringRef& value);
     virtual void raiseError(const QString& errorMessage);
 
     const quint32 m_kdbxVersion;


### PR DESCRIPTION
## Description
When parsing KDBX XML, the KdbXmlReader now supports Protected="true" on all attributes where `readString` or `readBinary` is used.

## Motivation and context
I had a KDBX 3.1 file which contained Binary entries with Protected="true". This lead to KeePassXC mostly reading the file fine, but because of the differences in the state of the random stream all passwords and attached files were silently mangled.

I am not sure which application created those (KeePass2, KyPass or Keepass2Android), but KeePass2 seems to parse Protected="true" in a similar way in its `KdbxFile::ProcessNode` method. To solve this specific case, handling Protected="true" only on `<Binary>` elements would have sufficed, but this could have lead to additional bugs later on if any other element is ever protected. This could corrupt the database. It would be helpful if the file format had a checksum for this stream (or its final state) to detect such errors.

## How has this been tested?
I did check that attachments and passwords work in the KDBX 3.1 file and its KDBX 4 counterpart (contains a couple of hundred entries and a few dozen attached files). I created a Mingw build on Windows 10 Insider Preview with everything but YubiKey support. The automated test suite passed, GUI and CLI also seem to work fine.

## Types of changes
I consider this a bug fix which should allow KeePassXC to load more files successfully instead of silently failing (and possibly corrupting them on save). The code should probably be more thoroughly tested with various databases and test cases.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed.

Not needed from what I can tell:
- My change requires a change to the documentation and I have updated it accordingly.

BUT, I failed to do these:
- I have added tests to cover my changes.
- I have compiled and verified my code with `-DWITH_ASAN=ON`

Existing tests work (including those with protected) and the Windows build environment I tested with didn't allow `-DWITH_ASAN=ON`.