### PR TITLE
Allow references to be part of a field

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -801,27 +801,27 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
         if (placeholderType(title()) == PlaceholderType::Title) {
             return title();
         }
-        return resolvePlaceholderRecursive(title(), maxDepth - 1);
+        return resolveMultiplePlaceholdersRecursive(title(), maxDepth - 1);
     case PlaceholderType::UserName:
         if (placeholderType(username()) == PlaceholderType::UserName) {
             return username();
         }
-        return resolvePlaceholderRecursive(username(), maxDepth - 1);
+        return resolveMultiplePlaceholdersRecursive(username(), maxDepth - 1);
     case PlaceholderType::Password:
         if (placeholderType(password()) == PlaceholderType::Password) {
             return password();
         }
-        return resolvePlaceholderRecursive(password(), maxDepth - 1);
+        return resolveMultiplePlaceholdersRecursive(password(), maxDepth - 1);
     case PlaceholderType::Notes:
         if (placeholderType(notes()) == PlaceholderType::Notes) {
             return notes();
         }
-        return resolvePlaceholderRecursive(notes(), maxDepth - 1);
+        return resolveMultiplePlaceholdersRecursive(notes(), maxDepth - 1);
     case PlaceholderType::Url:
         if (placeholderType(url()) == PlaceholderType::Url) {
             return url();
         }
-        return resolvePlaceholderRecursive(url(), maxDepth - 1);
+        return resolveMultiplePlaceholdersRecursive(url(), maxDepth - 1);
     case PlaceholderType::UrlWithoutScheme:
     case PlaceholderType::UrlScheme:
     case PlaceholderType::UrlHost:


### PR DESCRIPTION
Currently, when a field value contains a reference plus other things, then:

* Auto-type is broken with that field
* References to this field are not properly resolved

This commit fixes both issues.

## Description
When editing database entries, one can use placeholders such as `{USERNAME}`, `{PASSWORD}`, `{URL:HOST}` (these will typically be used in auto-type patterns), but also reference placeholders like [`{REF:x@y:zzzz}`](http://keepass.info/help/base/fieldrefs.html), that indicate to use a value from a given field in a given entry.

The function `resolvePlaceholderRecursive`, will attempt to replace a placeholder with the final value it points to. It calls itself if the resulting value consists of a placeholder, such as reference to reference is also supported. However when the resulting value contains a placeholder, it fails to replace it because it expects its input to span over a single placeholder.

For example, if an entry contains `{USERNAME}` in the auto-type pattern, when performing auto-type, `resolvePlaceholderRecursive` will be called with `{USERNAME}` as a parameter. After expansion, it can result in something like `{REF:U@I:xxxx-…}@baz.com`, and the function would call itself again. This time however, the input string would not be recognized as a valid placeholder, and therefore is returned without further expansion.

The fix is to call `resolveMultiplePlaceholdersRecursive` instead in the recursion step, such that the string is parsed again in order to look for placeholders.

## Motivation and context
This change fixes auto-type for entries in which an auto-typed field contains a reference to another entry field. For example a base entry with login information, and a derived entry with more complete login for use in a certain setup, prefixed with domain for example.

## How has this been tested?
I only tested that my use case was fixed.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✗ My change requires a change to the documentation and I have updated it accordingly.
- ✗ I have added tests to cover my changes.

## Post-scriptum
Sorry for the initial, non-conformant, pull request.