### PR TITLE
Add User-Agent header and set request timeout to avoid infinite download hangs

### DIFF
--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -197,12 +197,12 @@ QImage EditWidgetIcons::fetchFavicon(const QUrl& url)
         curl_easy_setopt(curl, CURLOPT_URL, baUrl.data());
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
         curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+        curl_easy_setopt(curl, CURLOPT_USERAGENT, "curl");
         curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-        curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
         curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &imagedata);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &writeCurlResponse);
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
 #ifdef Q_OS_WIN
         const QDir appDir = QFileInfo(QCoreApplication::applicationFilePath()).absoluteDir();
         if (appDir.exists("ssl\\certs")) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes hanging favicon downloads for some websites.
Resolves #1573 and resolves #1645

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some websites seem to accept a TCP connection, but send no HTTP response when no User-Agent header is set. Because we sent no User-Agent and only set a connect timeout, but not a total request timeout, the download hung infinitely.
This patch adds a generic "curl" User-Agent and sets an overall request timeout of 10 seconds.

I removed the `CURLOPT_SSL_VERIFYPEER` option, because `1L` is already [the default](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it with the example URLs provided in the linked issue reports and could download the favicons successfully.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**