### PR TITLE
Raise error if challenge-response failed during KDBX4 key transformation

### DIFF
--- a/src/keys/CompositeKey.cpp
+++ b/src/keys/CompositeKey.cpp
@@ -81,13 +81,13 @@ CompositeKey& CompositeKey::operator=(const CompositeKey& key)
  * The key hash does not contain contributions by challenge-response components for
  * backwards compatibility with KeePassXC's pre-KDBX4 challenge-response
  * implementation. To include challenge-response in the raw key,
- * use \link CompositeKey::rawKey(const QByteArray*) instead.
+ * use \link CompositeKey::rawKey(const QByteArray*, bool*) instead.
  *
  * @return key hash
  */
 QByteArray CompositeKey::rawKey() const
 {
-    return rawKey(nullptr);
+    return rawKey(nullptr, nullptr);
 }
 
 /**
@@ -97,9 +97,10 @@ QByteArray CompositeKey::rawKey() const
  * as a challenge to acquire their key contribution.
  *
  * @param transformSeed transform seed to challenge or nullptr to exclude challenge-response components
+ * @param ok true if challenges were successful and all key components could be added to the composite key
  * @return key hash
  */
-QByteArray CompositeKey::rawKey(const QByteArray* transformSeed) const
+QByteArray CompositeKey::rawKey(const QByteArray* transformSeed, bool* ok) const
 {
     CryptoHash cryptoHash(CryptoHash::Sha256);
 
@@ -107,9 +108,16 @@ QByteArray CompositeKey::rawKey(const QByteArray* transformSeed) const
         cryptoHash.addData(key->rawKey());
     }
 
+    if (ok) {
+        *ok = true;
+    }
+
     if (transformSeed) {
         QByteArray challengeResult;
-        challenge(*transformSeed, challengeResult);
+        bool challengeOk = challenge(*transformSeed, challengeResult);
+        if (ok) {
+            *ok = challengeOk;
+        }
         cryptoHash.addData(challengeResult);
     }
 
@@ -138,7 +146,8 @@ bool CompositeKey::transform(const Kdf& kdf, QByteArray& result) const
 
     QByteArray seed = kdf.seed();
     Q_ASSERT(!seed.isEmpty());
-    return kdf.transform(rawKey(&seed), result);
+    bool ok = false;
+    return kdf.transform(rawKey(&seed, &ok), result) && ok;
 }
 
 bool CompositeKey::challenge(const QByteArray& seed, QByteArray& result) const
@@ -152,7 +161,7 @@ bool CompositeKey::challenge(const QByteArray& seed, QByteArray& result) const
 
     CryptoHash cryptoHash(CryptoHash::Sha256);
 
-    for (const auto key : m_challengeResponseKeys) {
+    for (const auto& key : m_challengeResponseKeys) {
         // if the device isn't present or fails, return an error
         if (!key->challenge(seed)) {
             qWarning("Failed to issue challenge");

--- a/src/keys/CompositeKey.h
+++ b/src/keys/CompositeKey.h
@@ -39,7 +39,7 @@ public:
     CompositeKey& operator=(const CompositeKey& key);
 
     QByteArray rawKey() const override;
-    QByteArray rawKey(const QByteArray* transformSeed) const;
+    QByteArray rawKey(const QByteArray* transformSeed, bool* ok = nullptr) const;
     bool transform(const Kdf& kdf, QByteArray& result) const Q_REQUIRED_RESULT;
     bool challenge(const QByteArray& seed, QByteArray &result) const;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fail with an error when challenge-response failed during key transformation instead of silently discarding the key component.

Resolves #1656.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Saving a KDBX 3.1 file failed with an error message when challenge-response failed (e.g. YubiKey wasn't inserted). KDBX 4 silently discarded the key component. This is a user error which we should prevent.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Saving a KDBX 4 file fails when I unplug my YubiKey.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**