### PR TITLE
Remove qsvg imageformat plugin to prevent crash when trying to load SVG icons

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -402,7 +402,6 @@ if(MINGW)
           ${PLUGINS_DIR}/imageformats/qicns$<$<CONFIG:Debug>:d>.dll
           ${PLUGINS_DIR}/imageformats/qico$<$<CONFIG:Debug>:d>.dll
           ${PLUGINS_DIR}/imageformats/qjpeg$<$<CONFIG:Debug>:d>.dll
-          ${PLUGINS_DIR}/imageformats/qsvg$<$<CONFIG:Debug>:d>.dll
           ${PLUGINS_DIR}/imageformats/qwebp$<$<CONFIG:Debug>:d>.dll
         DESTINATION "imageformats")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Removes qsvg.dll from the list of installed Qt plugins on Windows.

Resolves #1602

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Windows distribution crashed on some systems when trying to load SVG icons. Without an installed Qt5Svg.dll, this plugin is useless anyway, so we may as well remove it for now.

For KeePassXC 2.4 we will move to windeployqt, which will hopefully fix this issue properly.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I could reproduce crashes after adding Qt5Svg.dll to my installation and removing qsvg.dll fixes them again. I could not test it without Qt5Svg.dll, because qsvg.dll isn't loaded on my system, when Qt5Svg.dll is missing.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**