### PR TITLE
SSH Agent: Helpful error message for adding keys

### DIFF
--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -186,7 +186,17 @@ bool SSHAgent::addIdentity(OpenSSHKey& key, quint32 lifetime, bool confirm)
     }
 
     if (responseData.length() < 1 || static_cast<quint8>(responseData[0]) != SSH_AGENT_SUCCESS) {
-        m_error = tr("Agent refused this identity.");
+        m_error = tr("Agent refused this identity. Possible reasons include:")
+            + "\n" + tr("The key has already been added.");
+
+        if (lifetime > 0) {
+            m_error += "\n" + tr("Restricted lifetime is not supported by the agent (check options).");
+        }
+
+        if (confirm) {
+            m_error += "\n" + tr("A confirmation request is not supported by the agent (check options).");
+        }
+
         return false;
     }
 


### PR DESCRIPTION
## Description
This adds more helpful error messages when adding keys to an agent
fails.

## Motivation and context
With the generic error message it is unclear as to where the error is. This would probably happen alot to people using the popular PuTTY agent on Windows.

Closes #1667.

## How has this been tested?
I compiled on Windows and Linux, ran the test suites and checked whether the messages where shown as expected.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
