### PR TITLE
Test speedup

### DIFF
--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -35,8 +35,9 @@ void TestAutoType::initTestCase()
 {
     QVERIFY(Crypto::init());
     Config::createTempFileInstance();
-    AutoType::createTestInstance();
+    config()->set("AutoTypeDelay", 1);
     config()->set("security/autotypeask", false);
+    AutoType::createTestInstance();
 
     QPluginLoader loader(filePath()->pluginPath("keepassx-autotype-test"));
     loader.setLoadHints(QLibrary::ResolveAllSymbolsHint);

--- a/tests/TestKdbx4.cpp
+++ b/tests/TestKdbx4.cpp
@@ -34,8 +34,8 @@ QTEST_GUILESS_MAIN(TestKdbx4)
 
 void TestKdbx4::initTestCaseImpl()
 {
-    m_xmlDb->changeKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2));
-    m_kdbxSourceDb->changeKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2));
+    m_xmlDb->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2)));
+    m_kdbxSourceDb->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2)));
 }
 
 Database* TestKdbx4::readXml(const QString& path, bool strictMode, bool& hasError, QString& errorString)
@@ -93,7 +93,7 @@ void TestKdbx4::readKdbx(const QString& path, CompositeKey const& key, QScopedPo
 void TestKdbx4::writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString)
 {
     if (db->kdf()->uuid() == KeePass2::KDF_AES_KDBX3) {
-        db->changeKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2));
+        db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2)));
     }
     KeePass2Writer writer;
     hasError = writer.writeDatabase(device, db);
@@ -137,6 +137,7 @@ void TestKdbx4::testFormat400Upgrade()
     QFETCH(quint32, expectedVersion);
 
     QScopedPointer<Database> sourceDb(new Database());
+    sourceDb->changeKdf(fastKdf(sourceDb->kdf()));
     sourceDb->metadata()->setName("Wubba lubba dub dub");
     QCOMPARE(sourceDb->kdf()->uuid(), KeePass2::KDF_AES_KDBX3);    // default is legacy AES-KDF
 
@@ -148,7 +149,7 @@ void TestKdbx4::testFormat400Upgrade()
     buffer.open(QBuffer::ReadWrite);
 
     // upgrade to KDBX 4 by changing KDF and Cipher
-    sourceDb->changeKdf(KeePass2::uuidToKdf(kdfUuid));
+    sourceDb->changeKdf(fastKdf(KeePass2::uuidToKdf(kdfUuid)));
     sourceDb->setCipher(cipherUuid);
 
     // CustomData in meta should not cause any version change
@@ -235,6 +236,7 @@ void TestKdbx4::testUpgradeMasterKeyIntegrity()
     compositeKey.addChallengeResponseKey(crKey);
 
     QScopedPointer<Database> db(new Database());
+    db->changeKdf(fastKdf(db->kdf()));
     db->setKey(compositeKey);
 
     // upgrade the database by a specific method
@@ -243,11 +245,11 @@ void TestKdbx4::testUpgradeMasterKeyIntegrity()
     } else if (upgradeAction == "meta-customdata") {
         db->metadata()->customData()->set("abc", "def");
     } else if (upgradeAction == "kdf-aes-kdbx3") {
-        db->changeKdf(KeePass2::uuidToKdf(KeePass2::KDF_AES_KDBX3));
+        db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_AES_KDBX3)));
     } else if (upgradeAction == "kdf-argon2") {
-        db->changeKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2));
+        db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2)));
     } else if (upgradeAction == "kdf-aes-kdbx4") {
-        db->changeKdf(KeePass2::uuidToKdf(KeePass2::KDF_AES_KDBX4));
+        db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_AES_KDBX4)));
     } else if (upgradeAction == "public-customdata") {
         db->publicCustomData().insert("abc", "def");
     } else if (upgradeAction == "rootgroup-customdata") {
@@ -402,4 +404,15 @@ void TestKdbx4::testCustomData()
     auto* newEntry = newDb->rootGroup()->children()[0]->entries()[0];
     QCOMPARE(newEntry->customData()->value(customDataKey1), customData1);
     QCOMPARE(newEntry->customData()->value(customDataKey2), customData2);
+}
+
+QSharedPointer<Kdf> TestKdbx4::fastKdf(QSharedPointer<Kdf> kdf)
+{
+    kdf->setRounds(1);
+    kdf->processParameters({
+        {KeePass2::KDFPARAM_ARGON2_MEMORY, 1024},
+        {KeePass2::KDFPARAM_ARGON2_PARALLELISM, 1}
+    });
+
+    return kdf;
 }

--- a/tests/TestKdbx4.cpp
+++ b/tests/TestKdbx4.cpp
@@ -409,10 +409,13 @@ void TestKdbx4::testCustomData()
 QSharedPointer<Kdf> TestKdbx4::fastKdf(QSharedPointer<Kdf> kdf)
 {
     kdf->setRounds(1);
-    kdf->processParameters({
-        {KeePass2::KDFPARAM_ARGON2_MEMORY, 1024},
-        {KeePass2::KDFPARAM_ARGON2_PARALLELISM, 1}
-    });
+
+    if (kdf->uuid() == KeePass2::KDF_ARGON2) {
+        kdf->processParameters({
+           {KeePass2::KDFPARAM_ARGON2_MEMORY, 1024},
+           {KeePass2::KDFPARAM_ARGON2_PARALLELISM, 1}
+        });
+    }
 
     return kdf;
 }

--- a/tests/TestKdbx4.h
+++ b/tests/TestKdbx4.h
@@ -44,6 +44,8 @@ protected:
     void readKdbx(QIODevice* device, CompositeKey const& key, QScopedPointer<Database>& db,
                   bool& hasError, QString& errorString) override;
     void writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString) override;
+
+    QSharedPointer<Kdf> fastKdf(QSharedPointer<Kdf> kdf);
 };
 
 #endif // KEEPASSXC_TEST_KDBX4_H


### PR DESCRIPTION
## Description
This speeds up the slowest tests, AutoType and Kdbx4, by adjusting some parameters which should not influence the tested semantics.

## Motivation and context
Tests are slow. It's more fun to write code with faster test suites.

## How has this been tested?
I ran tests on Debian GNU/Linux on an i7-6700K with ASAN on and off. The times went down from approximately 9.71s and 8.72s respectively to 4.38s and 3.08s for a `make test`. `TestKdbx4` is still slow (still lots of cryptography), but `TestAutoType` is almost negligible.

## Types of changes
- Speed optimization

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**