### PR TITLE
SSH Agent: Update available attachments immediately

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -281,6 +281,8 @@ void EditEntryWidget::setupSSHAgent()
     connect(m_sshAgentUi->decryptButton, SIGNAL(clicked()), SLOT(decryptPrivateKey()));
     connect(m_sshAgentUi->copyToClipboardButton, SIGNAL(clicked()), SLOT(copyPublicKey()));
 
+    connect(m_advancedUi->attachmentsWidget->entryAttachments(), SIGNAL(modified()), SLOT(updateAttachments()));
+
     addPage(tr("SSH Agent"), FilePath::instance()->icon("apps", "utilities-terminal"), m_sshAgentWidget);
 }
 
@@ -299,6 +301,27 @@ void EditEntryWidget::updateSSHAgent()
     m_sshAgentUi->removeFromAgentButton->setEnabled(false);
     m_sshAgentUi->copyToClipboardButton->setEnabled(false);
 
+    m_sshAgentSettings = settings;
+    updateSSHAgentAttachments();
+
+    if (settings.selectedType() == "attachment") {
+        m_sshAgentUi->attachmentRadioButton->setChecked(true);
+    } else {
+        m_sshAgentUi->externalFileRadioButton->setChecked(true);
+    }
+
+    updateSSHAgentKeyInfo();
+}
+
+void EditEntryWidget::updateSSHAgentAttachment()
+{
+    m_sshAgentUi->attachmentRadioButton->setChecked(true);
+    updateSSHAgentKeyInfo();
+}
+
+void EditEntryWidget::updateSSHAgentAttachments()
+{
+    m_sshAgentUi->attachmentComboBox->clear();
     m_sshAgentUi->attachmentComboBox->addItem("");
 
     auto attachments = m_advancedUi->attachmentsWidget->entryAttachments();
@@ -310,24 +333,8 @@ void EditEntryWidget::updateSSHAgent()
         m_sshAgentUi->attachmentComboBox->addItem(fileName);
     }
 
-    m_sshAgentUi->attachmentComboBox->setCurrentText(settings.attachmentName());
-    m_sshAgentUi->externalFileEdit->setText(settings.fileName());
-
-    if (settings.selectedType() == "attachment") {
-        m_sshAgentUi->attachmentRadioButton->setChecked(true);
-    } else {
-        m_sshAgentUi->externalFileRadioButton->setChecked(true);
-    }
-
-    m_sshAgentSettings = settings;
-
-    updateSSHAgentKeyInfo();
-}
-
-void EditEntryWidget::updateSSHAgentAttachment()
-{
-    m_sshAgentUi->attachmentRadioButton->setChecked(true);
-    updateSSHAgentKeyInfo();
+    m_sshAgentUi->attachmentComboBox->setCurrentText(m_sshAgentSettings.attachmentName());
+    m_sshAgentUi->externalFileEdit->setText(m_sshAgentSettings.fileName());
 }
 
 void EditEntryWidget::updateSSHAgentKeyInfo()

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -103,6 +103,7 @@ private slots:
 #ifdef WITH_XC_SSHAGENT
     void updateSSHAgent();
     void updateSSHAgentAttachment();
+    void updateSSHAgentAttachments();
     void updateSSHAgentKeyInfo();
     void browsePrivateKey();
     void addKeyToAgent();


### PR DESCRIPTION
## Description
The list of available attachments for SSH agent is now updated
immediately when adding or removing file attachments.

## Motivation and context
When adding or removing attachments, the list of available attachments was previously only updated after hitting `Apply` or `OK`.

Closes #1668.

## How has this been tested?
Built on Linux, ran tests and tried adding and removing files with previously empty and non-empty lists. Also checked if removing a selected file would lead to an error.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**