### PR TITLE
Fix dark tray icon option making all icons dark

### DIFF
--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -98,6 +98,15 @@ QString FilePath::wordlistPath(const QString& name)
 
 QIcon FilePath::applicationIcon()
 {
+#ifdef KEEPASSXC_DIST_SNAP
+    return icon("apps", "keepassxc", false);
+#else
+    return icon("apps", "keepassxc");
+#endif
+}
+
+QIcon FilePath::trayIcon()
+{
     bool darkIcon = useDarkIcon();
 
 #ifdef KEEPASSXC_DIST_SNAP
@@ -106,7 +115,6 @@ QIcon FilePath::applicationIcon()
     return (darkIcon) ? icon("apps", "keepassxc-dark") : icon("apps", "keepassxc");
 #endif
 }
-
 
 QIcon FilePath::trayIconLocked()
 {

--- a/src/core/FilePath.h
+++ b/src/core/FilePath.h
@@ -29,6 +29,7 @@ public:
     QString pluginPath(const QString& name);
     QString wordlistPath(const QString& name);
     QIcon applicationIcon();
+    QIcon trayIcon();
     QIcon trayIconLocked();
     QIcon trayIconUnlocked();
     QIcon icon(const QString& category, const QString& name, bool fromTheme = true);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -899,7 +899,7 @@ void MainWindow::updateTrayIcon()
 
             m_trayIcon->setContextMenu(menu);
             
-            m_trayIcon->setIcon(filePath()->applicationIcon());
+            m_trayIcon->setIcon(filePath()->trayIcon());
             m_trayIcon->show();
         }
         if (m_ui->tabWidget->hasLockableDatabases()) {


### PR DESCRIPTION
## Description
Introduces a separate path for tray icons which are neither locked nor unlocked and uses that when setting the tray icon while always using the default icon as an application icon.

## Motivation and context
Closes #1556.

## How has this been tested?
Built on Linux, ran tests. Checked title bar, about menu, application switcher and tray icon with option turned on and off in KDE. Not sure if all platforms support differing application and tray icons, but I think this should work on the most popular ones.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**