### PR TITLE
OpenSSHKey: when writing to agent, ensure comment string is at least one byte

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -420,12 +420,16 @@ void EditEntryWidget::browsePrivateKey()
 
 bool EditEntryWidget::getOpenSSHKey(OpenSSHKey& key, bool decrypt)
 {
+    QString fileName;
     QByteArray privateKeyData;
 
     if (m_sshAgentUi->attachmentRadioButton->isChecked()) {
-        privateKeyData = m_advancedUi->attachmentsWidget->getAttachment(m_sshAgentUi->attachmentComboBox->currentText());
+        fileName = m_sshAgentUi->attachmentComboBox->currentText();
+        privateKeyData = m_advancedUi->attachmentsWidget->getAttachment(fileName);
     } else {
         QFile localFile(m_sshAgentUi->externalFileEdit->text());
+        QFileInfo localFileInfo(localFile);
+        fileName = localFileInfo.fileName();
 
         if (localFile.fileName().isEmpty()) {
             return false;
@@ -462,6 +466,10 @@ bool EditEntryWidget::getOpenSSHKey(OpenSSHKey& key, bool decrypt)
 
     if (key.comment().isEmpty()) {
         key.setComment(m_entry->username());
+    }
+
+    if (key.comment().isEmpty()) {
+        key.setComment(fileName);
     }
 
     return true;

--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -268,10 +268,15 @@ void SSHAgent::databaseModeChanged(DatabaseWidget::Mode mode)
             }
 
             QByteArray keyData;
+            QString fileName;
             if (settings.selectedType() == "attachment") {
-                keyData = e->attachments()->value(settings.attachmentName());
+                fileName = settings.attachmentName();
+                keyData = e->attachments()->value(fileName);
             } else if (!settings.fileName().isEmpty()) {
                 QFile file(settings.fileName());
+                QFileInfo fileInfo(file);
+
+                fileName = fileInfo.fileName();
 
                 if (file.size() > 1024 * 1024) {
                     continue;
@@ -300,6 +305,10 @@ void SSHAgent::databaseModeChanged(DatabaseWidget::Mode mode)
 
             if (key.comment().isEmpty()) {
                 key.setComment(e->username());
+            }
+
+            if (key.comment().isEmpty()) {
+                key.setComment(fileName);
             }
 
             if (settings.removeAtDatabaseClose()) {


### PR DESCRIPTION
## Description
gpg-agent doesn't understand how to handle comment strings that are zero-length. It correctly reads the length of the comment string, but then requests a read of 0 bytes, which stupidly returns an EOF error code:
```
$ gpg-error 67125247
67125247 = (4, 16383) = (GPG_ERR_SOURCE_GPGAGENT, GPG_ERR_EOF) = (GPG Agent, End of file)
```
I looked at ensuring the `m_comment` string is always at least length 1, but that turned out to be a much uglier change.

## Motivation and context
I'm not able to use the OpenSSH-provided ssh-agent, because most of my SSH keypairs are actually PGP keys stored on YubiKeys -- and those require gpg-agent to use. For the remainder of my on-disk PEM keys, I can load those into KeePassXC... But only if gpg-agent will accept the keys.

## How has this been tested?
I found the issue by trying to add my SSH keypairs to KeePassXC and found that gpg-agent was rejecting all of them. I added a bunch of printf debugging to gpg-agent to pin down why it was rejecting them, and it ended up being the comment string.

By sending a comment string that is not zero bytes long, gpg-agent will happily accept the key. I tested this with two unencrypted RSA keys stored in my KeePassXC database.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
