### PR TITLE
Change `--pw-stdin` to use `getPassword()`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,8 @@
 #include "gui/MainWindow.h"
 #include "gui/MessageBox.h"
 
+#include "cli/Utils.h"
+
 #if defined(WITH_ASAN) && defined(WITH_LSAN)
 #include <sanitizer/lsan_interface.h>
 #endif
@@ -148,7 +150,9 @@ int main(int argc, char** argv)
             // we always need consume a line of STDIN if --pw-stdin is set to clear out the
             // buffer for native messaging, even if the specified file does not exist
             static QTextStream in(stdin, QIODevice::ReadOnly);
-            password = in.readLine();
+            static QTextStream out(stdout, QIODevice::WriteOnly);
+            out << QCoreApplication::translate("Main", "Database password: ") << flush;
+            password = Utils::getPassword();
         }
 
         if (!filename.isEmpty() && QFile::exists(filename) && !filename.endsWith(".json", Qt::CaseInsensitive)) {


### PR DESCRIPTION
Make `--pw-stdin` use `getPassword()` instead of `readLine()`

## Description
A minor change to use the `getPassword()` function from CLI.
I've also updated the translation files and I'd like a thumbs up on that.

## Motivation and context
Fixes #1673

## How has this been tested?
Manual testing plus `make test`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

