### PR TITLE
Fix inconsistent mutex unlocking due to double slot execution

### DIFF
--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -69,7 +69,7 @@ signals:
 
 private slots:
     void performAutoTypeFromGlobal(AutoTypeMatch match);
-    void resetInAutoType();
+    void autoTypeRejectedFromGlobal();
     void unloadPlugin();
 
 private:
@@ -88,6 +88,7 @@ private:
     bool windowMatches(const QString& windowTitle, const QString& windowPattern);
 
     QMutex m_inAutoType;
+    QMutex m_inGlobalAutoTypeDialog;
     int m_autoTypeDelay;
     Qt::Key m_currentGlobalKey;
     Qt::KeyboardModifiers m_currentGlobalModifiers;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes crash on Windows due to double mutex unlock. Resolves #1561.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On Windows, the rejected() slot of the Auto-Type selection dialog was called twice on screen lock, resulting in a double mutex unlock. I have no idea why it's doing that (perhaps a bug introduced in Qt 5.10), but this patch works around it by making sure the mutex is locked before we try to unlock it.

In addition, I added another mutex for the actual auto-typing (not just the dialog) to ensure we are never auto-typing two sequences at the same time (not that this was an issue, but when we're already at it...)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on Windows. I could not reproduce the crash anymore after applying the patch.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**