### PR TITLE
Always hide password on unlock

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -173,6 +173,9 @@ void DatabaseOpenWidget::openDatabase()
         return;
     }
 
+    m_ui->editPassword->setShowPassword(false);
+    QCoreApplication::processEvents();
+
     QFile file(m_filename);
     if (!file.open(QIODevice::ReadOnly)) {
         m_ui->messageWidget->showMessage(


### PR DESCRIPTION
Fixes #1692

<!--- Provide a general summary of your changes in the title above -->

## Description
Always set the password to be hidden on unlock and force processing events to make that change is applied before blocking the UI thread.

## How has this been tested?
Manually on Linux and Windows.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
