### PR TITLE
Fix problems with the hide/restore functionality on the tray icon (issue #1595) (redone)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -980,7 +980,7 @@ void MainWindow::hideWindow()
 
 void MainWindow::toggleWindow()
 {
-    if ((QApplication::activeWindow() == this) && isVisible() && !isMinimized()) {
+    if (isVisible() && !isMinimized()) {
         hideWindow();
     } else {
         bringToFront();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -971,10 +971,11 @@ void MainWindow::trayIconTriggered(QSystemTrayIcon::ActivationReason reason)
 void MainWindow::hideWindow()
 {
     saveWindowInformation();
-#ifndef Q_OS_LINUX
+#if !defined(Q_OS_LINUX) && !defined(Q_OS_MAC)
     // On some Linux systems, the window should NOT be minimized and hidden (i.e. not shown), at
     // the same time (which would happen if both minimize on startup and minimize to tray are set)
     // since otherwise it causes problems on restore as seen on issue #1595. Hiding it is enough.
+    // TODO: Add an explanation for why this is also not done on Mac (or remove the check)
     setWindowState(windowState() | Qt::WindowMinimized);
 #endif
     QTimer::singleShot(0, this, SLOT(hide()));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -971,9 +971,6 @@ void MainWindow::trayIconTriggered(QSystemTrayIcon::ActivationReason reason)
 void MainWindow::hideWindow()
 {
     saveWindowInformation();
-#ifndef Q_OS_MAC
-    setWindowState(windowState() | Qt::WindowMinimized);
-#endif
     QTimer::singleShot(0, this, SLOT(hide()));
 
     if (config()->get("security/lockdatabaseminimize").toBool()) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -971,6 +971,12 @@ void MainWindow::trayIconTriggered(QSystemTrayIcon::ActivationReason reason)
 void MainWindow::hideWindow()
 {
     saveWindowInformation();
+#ifndef Q_OS_LINUX
+    // On some Linux systems, the window should NOT be minimized and hidden (i.e. not shown), at
+    // the same time (which would happen if both minimize on startup and minimize to tray are set)
+    // since otherwise it causes problems on restore as seen on issue #1595. Hiding it is enough.
+    setWindowState(windowState() | Qt::WindowMinimized);
+#endif
     QTimer::singleShot(0, this, SLOT(hide()));
 
     if (config()->get("security/lockdatabaseminimize").toBool()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char** argv)
     // start minimized if configured
     bool minimizeOnStartup = config()->get("GUI/MinimizeOnStartup").toBool();
     bool minimizeToTray    = config()->get("GUI/MinimizeToTray").toBool();
-    if (minimizeOnStartup) {
+    if (minimizeOnStartup && !minimizeToTray) {
         mainWindow.setWindowState(Qt::WindowMinimized);
     }
     if (!(minimizeOnStartup && minimizeToTray)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,7 +127,14 @@ int main(int argc, char** argv)
     // start minimized if configured
     bool minimizeOnStartup = config()->get("GUI/MinimizeOnStartup").toBool();
     bool minimizeToTray    = config()->get("GUI/MinimizeToTray").toBool();
+#ifndef Q_OS_LINUX
+    if (minimizeOnStartup) {
+#else
+    // On some Linux systems, the window should NOT be minimized and hidden (i.e. not shown), at
+    // the same time (which would happen if both minimize on startup and minimize to tray are set)
+    // since otherwise it causes problems on restore as seen on issue #1595. Hiding it is enough.
     if (minimizeOnStartup && !minimizeToTray) {
+#endif
         mainWindow.setWindowState(Qt::WindowMinimized);
     }
     if (!(minimizeOnStartup && minimizeToTray)) {

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1095,8 +1095,11 @@ void TestGui::testDragAndDropKdbxFiles()
 
 void TestGui::testTrayRestoreHide()
 {
-    QSystemTrayIcon *trayIcon = m_mainWindow->findChild<QSystemTrayIcon*>();
+    if (!QSystemTrayIcon::isSystemTrayAvailable()) {
+        QSKIP("QSystemTrayIcon::isSystemTrayAvailable() = false, skipping tray restore/hide test...");
+    }
 
+    QSystemTrayIcon* trayIcon = m_mainWindow->findChild<QSystemTrayIcon*>();
     QVERIFY(m_mainWindow->isVisible());
 
     trayIcon->activated(QSystemTrayIcon::Trigger);

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -71,6 +71,8 @@ void TestGui::initTestCase()
     Config::createTempFileInstance();
     // Disable autosave so we can test the modified file indicator
     Config::instance()->set("AutoSaveAfterEveryChange", false);
+    // Enable the tray icon so we can test hiding/restoring the window
+    Config::instance()->set("GUI/ShowTrayIcon", true);
 
     m_mainWindow = new MainWindow();
     m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
@@ -1089,6 +1091,29 @@ void TestGui::testDragAndDropKdbxFiles()
     Tools::wait(100);
 
     QCOMPARE(m_tabWidget->count(), openedDatabasesCount);
+}
+
+void TestGui::testTrayRestoreHide()
+{
+    QSystemTrayIcon *trayIcon = m_mainWindow->findChild<QSystemTrayIcon*>();
+
+    QVERIFY(m_mainWindow->isVisible());
+
+    trayIcon->activated(QSystemTrayIcon::Trigger);
+    Tools::wait(100);
+    QVERIFY(!m_mainWindow->isVisible());
+
+    trayIcon->activated(QSystemTrayIcon::Trigger);
+    Tools::wait(100);
+    QVERIFY(m_mainWindow->isVisible());
+
+    trayIcon->activated(QSystemTrayIcon::Trigger);
+    Tools::wait(100);
+    QVERIFY(!m_mainWindow->isVisible());
+
+    trayIcon->activated(QSystemTrayIcon::Trigger);
+    Tools::wait(100);
+    QVERIFY(m_mainWindow->isVisible());
 }
 
 void TestGui::cleanupTestCase()

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -63,6 +63,7 @@ private slots:
     void testKeePass1Import();
     void testDatabaseLocking();
     void testDragAndDropKdbxFiles();
+    void testTrayRestoreHide();
 
 private:
     int addCannedEntries();


### PR DESCRIPTION
**Opening another PR since PR #1700 had the wrong source branch. Sorry for the annoyance...**

Fix/work around tray issues on some Linux systems such as Arch Linux, and Windows. Fixes all cases explained in issue #1595.

## Description
Basically there are two separate issues at play there:
* **The Linux issue:** Sometimes instead of restoring, the KeePassXC window just flickers when restoring the window from the tray. This mostly happens if both the "minimize to tray" and "minimize at startup" options are enabled, and only on the first restore, though sometimes it's enough to set the  "minimize to tray" option is enough and the flicker happens once per every restore, thus the tray having a flicker-restore-hide cycle instead of a restore-hide cycle. I'm not sure why it only happens on Arch but not on Ubuntu, and why it only happens sometimes, but I have found what seems to be the trigger of the issue: If one both minimizes and hides the window by code (or minimizes the window without showing it at all), it seems that a spurious changeEvent with isMinimized()=true is received sometimes when the main window is restored, which causes the bug. I imagine that, internally on the Qt Linux implementation, hiding the window causes further events to be enqueued or something similar, and when restoring the window some events from when the window was minimized are notified.

This can happen both on start (this is the case of the original bug report), if `minimizeOnStartup=true` and `minimizeToTray=true`, then the window is minimized but not shown:

```
    // start minimized if configured
    bool minimizeOnStartup = config()->get("GUI/MinimizeOnStartup").toBool();
    bool minimizeToTray    = config()->get("GUI/MinimizeToTray").toBool();
    if (minimizeOnStartup) {
        mainWindow.setWindowState(Qt::WindowMinimized); // --> MINIMIZE
    }
    if (!(minimizeOnStartup && minimizeToTray)) {
        mainWindow.show(); // --> NO SHOW
}
```

Or when clicking on the tray icon to hide the window, the window is both minimized and hidden by code on `hideWindow()` (this is what is causing my flicker-restore-minimize cycle sometimes):

```
void MainWindow::hideWindow()
{
    saveWindowInformation();
#ifndef Q_OS_MAC
    setWindowState(windowState() | Qt::WindowMinimized); // --> MINIMIZE
#endif
    QTimer::singleShot(0, this, SLOT(hide())); // --> HIDE

    if (config()->get("security/lockdatabaseminimize").toBool()) {
        m_ui->tabWidget->lockDatabases();
    }
}
```

* **The Windows issue:** This is a completely separate issue. The flicker on restore issue explained previously doesn't happen on Windows, but on the other hand it seems impossible to hide the window by clicking on the tray icon on Windows. On `toggleWindow()`, there's a `QApplication::activeWindow() == this` check:

```
void MainWindow::toggleWindow()
{
    if ((QApplication::activeWindow() == this) && isVisible() && !isMinimized()) {
        hideWindow();
    } else {
```

On Windows, when clicking on the tray icon when the window is visible, `QApplication::activeWindow() = NULL`. I think this is due to differences in window focus behavior between Windows and Linux (I believe Windows removes the focus from the window when clicking on the tray).

## Motivation and context
This change is required in order to avoid issues when hiding and restoring the KeePassXC windows from tray. One of those issues happen on Windows, and the other in some Linux systems (what exactly causes some systems and desktop environments to be affected and some not to be affected is not known, though it probably depends on the Qt version, but must also depend on some environment condition since on my system the bug only happens sometimes).

For the Linux issue, I avoid both minimizing and hiding the window at the same time by code. It should suffice to only hide the window if the event is caused by a tray icon click.

For the Windows issue, I just removed the check for QApplication::activeWindow() == this, I think it is unreliable and the other checks in the same line (which were added later) should suffice alone.

Fixes #1595

## How has this been tested?

I set up some VMs for manual testing of the issue, and I found this:

* **Local Arch Linux + XFCE  (Updated):** I experience the flicker-restore-minimize cycle sometimes, and sometimes only the flicker on the first time like in the original report. No idea on what makes the difference. After applying the changes, the bug disappears and no regressions are found.

Environment details:

```
Libraries:
- Qt 5.10.1
- libgcrypt 1.8.2

Operating system: Arch Linux
CPU architecture: x86_64
Kernel: linux 4.15.7-1-ARCH

Enabled extensions:
- Auto-Type
- Browser Integration
- Legacy Browser Integration (KeePassHTTP)
- SSH Agent
- YubiKey
```

* **Local Arch Linux + LXDE (Updated):** I experience the flicker like in the original report. After applying the changes, the bug disappears and no regressions are found.
* **VM Ubuntu 17.10 + Unity,KDE,LXDE (Updated clean install):** No bug experienced. After applying the changes, no regressions are found.
* **VM Arch Linux + LXDE (Updated clean install):** I experience the flicker like in the original report. After applying the changes, the bug disappears and no regressions are found.
* **Local Windows 10  (Updated):** No flicker on restore, but the window cannot be hidden by clicking on the tray icon. After applying the changes, the bug disappears and no regressions are found.
* **VM Windows 7 (Updated clean install):** No flicker on restore, but the window cannot be hidden by clicking on the tray icon.  After applying the changes, the bug disappears and no regressions are found.

I also ran all the automatic tests on my local Arch Linux system and they passed.

## Screenshots (if appropriate):
Windows issue: https://imgur.com/fJW62v7
Linux issue (flicker on first restore): https://imgur.com/cES8olj

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
