### PR TITLE
Fix wrong reply size in NativeMessagingBase

### DIFF
--- a/src/browser/NativeMessagingBase.cpp
+++ b/src/browser/NativeMessagingBase.cpp
@@ -121,7 +121,8 @@ void NativeMessagingBase::sendReply(const QJsonObject& json)
 void NativeMessagingBase::sendReply(const QString& reply)
 {
     if (!reply.isEmpty()) {
-        uint len = reply.length();
+        QByteArray bytes = reply.toUtf8();
+        uint len = bytes.size();
         std::cout << char(((len>>0) & 0xFF)) << char(((len>>8) & 0xFF)) << char(((len>>16) & 0xFF)) << char(((len>>24) & 0xFF));
         std::cout << reply.toStdString() << std::flush;
     }


### PR DESCRIPTION
NativeMessagingBase::sendReply send incorrectly formatted payload back to keepassxc-browser extension when using some locales.

## Description
* Using length() on QString won't return correct size in bytes when string
contains UTF-8 chars.

## Motivation and context
This commit fix many bugs with keepassxc-browser when keepassxc locale is set to a language with chars represented by multiple bytes (UTF-8). 
For instance, error string "Aucun identifiant trouvé" ("No logins found" in french) cause keepassxc-browser extension to disconnect from database.

## How has this been tested?
This fix solves my issues in keepassxc-browser (firefox / chromium tested), with keepassxc in french.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

