### PR TITLE
Socket buffer fix

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -20,6 +20,7 @@
 #include <QJsonParseError>
 #include "BrowserAction.h"
 #include "BrowserSettings.h"
+#include "NativeMessagingBase.h"
 #include "sodium.h"
 #include "sodium/crypto_box.h"
 #include "sodium/randombytes.h"
@@ -456,7 +457,7 @@ QString BrowserAction::encrypt(const QString plaintext, const QString nonce)
     std::vector<unsigned char> sk(sa.cbegin(), sa.cend());
 
     std::vector<unsigned char> e;
-    e.resize(max_length);
+    e.resize(NATIVE_MSG_MAX_LENGTH);
 
     if (m.empty() || n.empty() || ck.empty() || sk.empty()) {
         return QString();
@@ -484,7 +485,7 @@ QByteArray BrowserAction::decrypt(const QString encrypted, const QString nonce)
     std::vector<unsigned char> sk(sa.cbegin(), sa.cend());
 
     std::vector<unsigned char> d;
-    d.resize(max_length);
+    d.resize(NATIVE_MSG_MAX_LENGTH);
 
     if (m.empty() || n.empty() || ck.empty() || sk.empty()) {
         return QByteArray();

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -25,8 +25,6 @@
 #include "gui/DatabaseTabWidget.h"
 #include "core/Entry.h"
 
-enum { max_length = 16*1024 };
-
 class BrowserService : public QObject
 {
     Q_OBJECT

--- a/src/browser/NativeMessagingBase.h
+++ b/src/browser/NativeMessagingBase.h
@@ -32,6 +32,13 @@
 #include <iostream>
 #include <unistd.h>
 
+#ifndef Q_OS_WIN
+#include <sys/types.h>
+#include <sys/socket.h> 
+#endif
+
+static const int NATIVE_MSG_MAX_LENGTH = 1024*1024;
+
 class NativeMessagingBase : public QObject
 {
     Q_OBJECT

--- a/src/browser/NativeMessagingHost.cpp
+++ b/src/browser/NativeMessagingHost.cpp
@@ -142,9 +142,15 @@ void NativeMessagingHost::newLocalConnection()
 void NativeMessagingHost::newLocalMessage()
 {
     QLocalSocket* socket = qobject_cast<QLocalSocket*>(QObject::sender());
-
     if (!socket || socket->bytesAvailable() <= 0) {
         return;
+    }
+
+    socket->setReadBufferSize(NATIVE_MSG_MAX_LENGTH);
+    int socketDesc = socket->socketDescriptor();
+    if (socketDesc) {
+        int max = NATIVE_MSG_MAX_LENGTH;
+        setsockopt(socketDesc, SOL_SOCKET, SO_SNDBUF, &max, sizeof(max));
     }
 
     QByteArray arr = socket->readAll();

--- a/src/proxy/NativeMessagingHost.cpp
+++ b/src/proxy/NativeMessagingHost.cpp
@@ -22,6 +22,13 @@ NativeMessagingHost::NativeMessagingHost() : NativeMessagingBase()
 {
     m_localSocket = new QLocalSocket();
     m_localSocket->connectToServer(getLocalServerPath());
+    m_localSocket->setReadBufferSize(NATIVE_MSG_MAX_LENGTH);
+  
+    int socketDesc = m_localSocket->socketDescriptor();
+    if (socketDesc) {
+        int max = NATIVE_MSG_MAX_LENGTH;
+        setsockopt(socketDesc, SOL_SOCKET, SO_SNDBUF, &max, sizeof(max));
+    }
 #ifdef Q_OS_WIN
     m_running.store(true);
     m_future = QtConcurrent::run(this, static_cast<void(NativeMessagingHost::*)()>(&NativeMessagingHost::readNativeMessages));


### PR DESCRIPTION
Increases the maximum buffer size of keepassxc-protocol and Unix Sockets to 1M. This is the maximum messaging size for a single message with native messaging.

## Motivation and context
Solves issues where the message size goes over the maximum default of Unix Socket buffer 8k bytes.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
