### PR TITLE
Do not ignore MainWindow closeEvent when closing to tray

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -797,7 +797,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
                            config()->get("GUI/MinimizeOnClose").toBool();
     if (minimizeOnClose && !m_appExitCalled)
     {
-        event->ignore();
+        event->accept();
         hideWindow();
 
         if (config()->get("security/lockdatabaseminimize").toBool()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Description
<!--- Describe your changes in detail -->

Ignoring closeEvent signals that the application doesn't want the widget to be closed. This may cause unwanted shutdown interruption. There's no difference between close() and hide() unless WA_DeleteOnClose is set, so it's better to just accept the event if we're hiding the window
afterwards anyway.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change *should* fix the issue #856, however I can't test it on all platforms to vouch

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this on Plasma 5.11.5, it fixes the shutdown interruption
However, I can't test it on Windows or Mac to confirm that it truly fixes the issue everywhere

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
