### PR TITLE
Improve translation base strings

### DIFF
--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -130,9 +130,9 @@ void BrowserOptionDialog::saveSettings()
 void BrowserOptionDialog::showProxyLocationFileDialog()
 {
 #ifdef Q_OS_WIN
-    QString fileTypeFilter(tr("Executable Files (*.exe);;All Files (*.*)"));
+    QString fileTypeFilter(QString("%1 (*.exe);;%2 (*.*)").arg(tr("Executable Files"), tr("All Files")));
 #else
-    QString fileTypeFilter(tr("Executable Files (*)"));
+    QString fileTypeFilter(QString("%1 (*)").arg(tr("Executable Files")));
 #endif
     auto proxyLocation = QFileDialog::getOpenFileName(this, tr("Select custom proxy location"),
                                                       QFileInfo(QCoreApplication::applicationDirPath()).filePath(),

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -437,7 +437,7 @@ void BrowserService::removeSharedEncryptionKeys()
 
     if (keysToRemove.isEmpty()) {
         QMessageBox::information(0, tr("KeePassXC: No keys found"),
-                                 tr("No shared encryption keys found in KeePassXC Settings."),
+                                 tr("No shared encryption keys found in KeePassXC settings."),
                                  QMessageBox::Ok);
         return;
     }

--- a/src/core/CsvParser.cpp
+++ b/src/core/CsvParser.cpp
@@ -84,7 +84,7 @@ bool CsvParser::readFile(QFile *device) {
         m_array.replace("\r\n", "\n");
         m_array.replace("\r", "\n");
         if (0 == m_array.size())
-           appendStatusMsg(QObject::tr("file empty !\n"));
+           appendStatusMsg(QObject::tr("file empty").append("\n"));
         m_isFileLoaded = true;
     }
     return m_isFileLoaded;

--- a/src/core/CsvParser.cpp
+++ b/src/core/CsvParser.cpp
@@ -377,10 +377,8 @@ int CsvParser::getCsvRows() const {
 
 
 void CsvParser::appendStatusMsg(QString s, bool isCritical) {
-    m_statusMsg += s
-      .append(": (row,col) " + QString::number(m_currRow))
-      .append(",")
-      .append(QString::number(m_currCol))
+    m_statusMsg += QObject::tr("%1: (row, col) %2,%3")
+      .arg(s, m_currRow, m_currCol)
       .append("\n");
     m_isGood = !isCritical;
 }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -477,7 +477,7 @@ Database* Database::unlockFromStdin(QString databaseFilename, QString keyFilenam
         FileKey fileKey;
         QString errorMessage;
         if (!fileKey.load(keyFilename, &errorMessage)) {
-            errorTextStream << QObject::tr("Failed to load key file %1 : %2").arg(keyFilename, errorMessage);
+            errorTextStream << QObject::tr("Failed to load key file %1: %2").arg(keyFilename, errorMessage);
             errorTextStream << endl;
             return nullptr;
         }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -681,7 +681,7 @@ Entry* Entry::clone(CloneFlags flags) const
     }
 
     if (flags & CloneRenameTitle)
-        entry->setTitle(entry->title() + tr(" - Clone", "Suffix added to cloned entries"));
+        entry->setTitle(tr("%1 - Clone").arg(entry->title()));
 
     return entry;
 }

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -616,7 +616,7 @@ QString Group::print(bool recursive, int depth)
     QString indentation = QString("  ").repeated(depth);
 
     if (entries().isEmpty() && children().isEmpty()) {
-        response += indentation + "[empty]\n";
+        response += indentation + tr("[empty]", "group has no children") + "\n";
         return response;
     }
 
@@ -911,7 +911,7 @@ void Group::markOlderEntry(Entry* entry)
 {
     entry->attributes()->set(
         "merged",
-        QString("older entry merged from database \"%1\"").arg(entry->group()->database()->metadata()->name()));
+        tr("older entry merged from database \"%1\"").arg(entry->group()->database()->metadata()->name()));
 }
 
 bool Group::resolveSearchingEnabled() const

--- a/src/format/Kdbx3Reader.cpp
+++ b/src/format/Kdbx3Reader.cpp
@@ -42,7 +42,7 @@ Database* Kdbx3Reader::readDatabaseImpl(QIODevice* device, const QByteArray& hea
     if (m_masterSeed.isEmpty() || m_encryptionIV.isEmpty()
         || m_streamStartBytes.isEmpty() || m_protectedStreamKey.isEmpty()
         || m_db->cipher().isNull()) {
-        raiseError("missing database headers");
+        raiseError(tr("missing database headers"));
         return nullptr;
     }
 
@@ -134,7 +134,7 @@ Database* Kdbx3Reader::readDatabaseImpl(QIODevice* device, const QByteArray& hea
     if (!xmlReader.headerHash().isEmpty()) {
         QByteArray headerHash = CryptoHash::hash(headerData, CryptoHash::Sha256);
         if (headerHash != xmlReader.headerHash()) {
-            raiseError("Header doesn't match hash");
+            raiseError(tr("Header doesn't match hash"));
             return nullptr;
         }
     }
@@ -146,7 +146,7 @@ bool Kdbx3Reader::readHeaderField(StoreDataStream& headerStream)
 {
     QByteArray fieldIDArray = headerStream.read(1);
     if (fieldIDArray.size() != 1) {
-        raiseError("Invalid header id size");
+        raiseError(tr("Invalid header id size"));
         return false;
     }
     char fieldID = fieldIDArray.at(0);
@@ -154,7 +154,7 @@ bool Kdbx3Reader::readHeaderField(StoreDataStream& headerStream)
     bool ok;
     auto fieldLen = Endian::readSizedInt<quint16>(&headerStream, KeePass2::BYTEORDER, &ok);
     if (!ok) {
-        raiseError("Invalid header field length");
+        raiseError(tr("Invalid header field length"));
         return false;
     }
 
@@ -162,7 +162,7 @@ bool Kdbx3Reader::readHeaderField(StoreDataStream& headerStream)
     if (fieldLen != 0) {
         fieldData = headerStream.read(fieldLen);
         if (fieldData.size() != fieldLen) {
-            raiseError("Invalid header data length");
+            raiseError(tr("Invalid header data length"));
             return false;
         }
     }

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -179,8 +179,9 @@ QString KdbxXmlReader::errorString() const
 {
     if (m_error) {
         return m_errorStr;
-    }if (m_xml.hasError()) {
-        return QString("XML error:\n%1\nLine %2, column %3")
+    }
+    if (m_xml.hasError()) {
+        return tr("XML error:\n%1\nLine %2, column %3")
             .arg(m_xml.errorString())
             .arg(m_xml.lineNumber())
             .arg(m_xml.columnNumber());

--- a/src/format/KeePass1Reader.cpp
+++ b/src/format/KeePass1Reader.cpp
@@ -363,7 +363,7 @@ SymmetricCipherStream* KeePass1Reader::testKeys(const QString& password, const Q
         cipherStream->reset();
         cipherStream->close();
         if (!m_device->seek(contentPos)) {
-            QString msg = "unable to seek to content position";
+            QString msg = tr("unable to seek to content position");
             if (!m_device->errorString().isEmpty()) {
                 msg.append("\n").append(m_device->errorString());
             }

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -82,23 +82,23 @@ AboutDialog::AboutDialog(QWidget* parent)
 
     QString extensions;
 #ifdef WITH_XC_AUTOTYPE
-    extensions += "\n- Auto-Type";
+    extensions += "\n- " + tr("Auto-Type");
 #endif
 #ifdef WITH_XC_BROWSER
-    extensions += "\n- Browser Integration";
+    extensions += "\n- " + tr("Browser Integration");
 #endif
 #ifdef WITH_XC_HTTP
-    extensions += "\n- Legacy Browser Integration (KeePassHTTP)";
+    extensions += "\n- " + tr("Legacy Browser Integration (KeePassHTTP)");
 #endif
 #ifdef WITH_XC_SSHAGENT
-    extensions += "\n- SSH Agent";
+    extensions += "\n- " + tr("SSH Agent");
 #endif
 #ifdef WITH_XC_YUBIKEY
-    extensions += "\n- YubiKey";
+    extensions += "\n- " + tr("YubiKey");
 #endif
 
     if (extensions.isEmpty())
-        extensions = " None";
+        extensions = " " + tr("None");
 
     debugInfo.append(tr("Enabled extensions:").append(extensions));
 

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -53,9 +53,9 @@ AboutDialog::AboutDialog(QWidget* parent)
     }
 
     QString debugInfo = "KeePassXC - ";
-    debugInfo.append(tr("Version %1\n").arg(KEEPASSX_VERSION));
+    debugInfo.append(tr("Version %1").arg(KEEPASSX_VERSION).append("\n"));
 #ifndef KEEPASSXC_BUILD_TYPE_RELEASE
-    debugInfo.append(tr("Build Type: %1\n").arg(KEEPASSXC_BUILD_TYPE));
+    debugInfo.append(tr("Build Type: %1").arg(KEEPASSXC_BUILD_TYPE).append("\n"));
 #endif
     if (!commitHash.isEmpty()) {
         debugInfo.append(tr("Revision: %1").arg(commitHash.left(7)).append("\n"));

--- a/src/gui/ChangeMasterKeyWidget.cpp
+++ b/src/gui/ChangeMasterKeyWidget.cpp
@@ -85,7 +85,7 @@ void ChangeMasterKeyWidget::createKeyFile()
         QString errorMsg;
         bool created = FileKey::create(fileName, &errorMsg);
         if (!created) {
-            m_ui->messageWidget->showMessage(tr("Unable to create Key File : ").append(errorMsg), MessageWidget::Error);
+            m_ui->messageWidget->showMessage(tr("Unable to create key file: %1").arg(errorMsg), MessageWidget::Error);
         }
         else {
             m_ui->keyFileCombo->setEditText(fileName);
@@ -159,7 +159,7 @@ void ChangeMasterKeyWidget::generateKey()
         QString fileKeyName = m_ui->keyFileCombo->currentText();
         if (!fileKey.load(fileKeyName, &errorMsg)) {
             m_ui->messageWidget->showMessage(
-               tr("Failed to set %1 as the Key file:\n%2").arg(fileKeyName, errorMsg), MessageWidget::Error);
+               tr("Failed to set %1 as the key file:\n%2").arg(fileKeyName, errorMsg), MessageWidget::Error);
             return;
         }
         if (fileKey.type() != FileKey::Hashed) {

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -214,7 +214,7 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::databaseKey()
         QString keyFilename = m_ui->comboKeyFile->currentText();
         QString errorMsg;
         if (!key.load(keyFilename, &errorMsg)) {
-            m_ui->messageWidget->showMessage(tr("Can't open key file").append(":\n").append(errorMsg),
+            m_ui->messageWidget->showMessage(tr("Can't open key file:\n%1").arg(errorMsg),
                                              MessageWidget::Error);
             return QSharedPointer<CompositeKey>();
         }

--- a/src/gui/DatabaseRepairWidget.cpp
+++ b/src/gui/DatabaseRepairWidget.cpp
@@ -50,7 +50,7 @@ void DatabaseRepairWidget::openDatabase()
         QString keyFilename = m_ui->comboKeyFile->currentText();
         QString errorMsg;
         if (!key.load(keyFilename, &errorMsg)) {
-            MessageBox::warning(this, tr("Error"), tr("Can't open key file").append(":\n").append(errorMsg));
+            MessageBox::warning(this, tr("Error"), tr("Can't open key file:\n%1").arg(errorMsg));
             emit editFinished(false);
             return;
         }

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -534,12 +534,12 @@ void DatabaseTabWidget::updateTabName(Database* db)
         if (db->metadata()->name().isEmpty()) {
             tabName = tr("New database");
         } else {
-            tabName = QString("%1 [%2]").arg(db->metadata()->name(), tr("New database"));
+            tabName = tr("%1 [New database]", "tab modifier").arg(db->metadata()->name());
         }
     }
 
     if (dbStruct.dbWidget->currentMode() == DatabaseWidget::LockedMode) {
-        tabName.append(QString(" [%1]").arg(tr("locked")));
+        tabName = tr("%1 [locked]", "tab modifier").arg(tabName);
     }
 
     if (dbStruct.modified) {

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -181,8 +181,9 @@ void DatabaseTabWidget::openDatabase(const QString& fileName, const QString& pw,
 
 void DatabaseTabWidget::importCsv()
 {
+    QString filter = QString("%1 (*.csv);;%2 (*)").arg(tr("CSV file"), tr("All files"));
     QString fileName = fileDialog()->getOpenFileName(this, tr("Open CSV file"), QString(),
-            tr("CSV file") + " (*.csv);;" + tr("All files (*)"));
+                                                     filter);
 
     if (fileName.isEmpty()) {
         return;
@@ -213,8 +214,9 @@ void DatabaseTabWidget::mergeDatabase(const QString& fileName)
 
 void DatabaseTabWidget::importKeePass1Database()
 {
+    QString filter = QString("%1 (*.kdb);;%2 (*)").arg(tr("KeePass 1 database"), tr("All files"));
     QString fileName = fileDialog()->getOpenFileName(this, tr("Open KeePass 1 database"), QString(),
-            tr("KeePass 1 database") + " (*.kdb);;" + tr("All files (*)"));
+                                                     filter);
 
     if (fileName.isEmpty()) {
         return;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -479,22 +479,20 @@ void DatabaseWidget::deleteEntries()
 
     bool inRecycleBin = Tools::hasChild(m_db->metadata()->recycleBin(), selectedEntries.first());
     if (inRecycleBin || !m_db->metadata()->recycleBinEnabled()) {
-        QMessageBox::StandardButton result;
-
+        QString prompt;
         if (selected.size() == 1) {
-            result = MessageBox::question(
-                this, tr("Delete entry?"),
-                tr("Do you really want to delete the entry \"%1\" for good?")
-                .arg(selectedEntries.first()->title().toHtmlEscaped()),
-                QMessageBox::Yes | QMessageBox::No);
+            prompt = tr("Do you really want to delete the entry \"%1\" for good?")
+                    .arg(selectedEntries.first()->title().toHtmlEscaped());
         }
         else {
-            result = MessageBox::question(
-                this, tr("Delete entries?"),
-                tr("Do you really want to delete %1 entries for good?")
-                .arg(selected.size()),
-                QMessageBox::Yes | QMessageBox::No);
+            prompt = tr("Do you really want to delete %n entry(s) for good?", "", selected.size());
         }
+
+        QMessageBox::StandardButton result = MessageBox::question(
+                    this,
+                    tr("Delete entry(s)?", "", selected.size()),
+                    prompt,
+                    QMessageBox::Yes | QMessageBox::No);
 
         if (result == QMessageBox::Yes) {
             for (Entry* entry : asConst(selectedEntries)) {
@@ -504,21 +502,19 @@ void DatabaseWidget::deleteEntries()
         }
     }
     else {
-        QMessageBox::StandardButton result;
-
+        QString prompt;
         if (selected.size() == 1) {
-            result = MessageBox::question(
-                this, tr("Move entry to recycle bin?"),
-                tr("Do you really want to move entry \"%1\" to the recycle bin?")
-                .arg(selectedEntries.first()->title().toHtmlEscaped()),
-                QMessageBox::Yes | QMessageBox::No);
+            prompt = tr("Do you really want to move entry \"%1\" to the recycle bin?")
+                    .arg(selectedEntries.first()->title().toHtmlEscaped());
+        } else {
+            prompt = tr("Do you really want to move %n entry(s) to the recycle bin?", "", selected.size());
         }
-        else {
-            result = MessageBox::question(
-                this, tr("Move entries to recycle bin?"),
-                tr("Do you really want to move %n entry(s) to the recycle bin?", 0, selected.size()),
-                QMessageBox::Yes | QMessageBox::No);
-        }
+
+        QMessageBox::StandardButton result = MessageBox::question(
+                    this,
+                    tr("Move entry(s) to recycle bin?", "", selected.size()),
+                    prompt,
+                    QMessageBox::Yes | QMessageBox::No);
 
         if (result == QMessageBox::No) {
             return;

--- a/src/gui/DetailsWidget.cpp
+++ b/src/gui/DetailsWidget.cpp
@@ -216,7 +216,7 @@ void DetailsWidget::updateEntryAttributesTab()
             if (m_currentEntry->attributes()->isProtected(key)) {
                 value = "<i>" + tr("[PROTECTED]") + "</i>";
             }
-            attributesText.append(QString("<b>%1</b>: %2<br/>").arg(key, value));
+            attributesText.append(tr("<b>%1</b>: %2", "attributes line").arg(key, value).append("<br/>"));
         }
         m_ui->entryAttributesEdit->setText(attributesText);
     }

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -305,9 +305,10 @@ void EditWidgetIcons::removeCustomIcon()
             int iconUseCount = entriesWithSameIcon.size() + groupsWithSameIcon.size();
             if (iconUseCount > 0) {
                 QMessageBox::StandardButton ans = MessageBox::question(this, tr("Confirm Delete"),
-                                     tr("This icon is used by %1 entries, and will be replaced "
-                                        "by the default icon. Are you sure you want to delete it?")
-                                     .arg(iconUseCount), QMessageBox::Yes | QMessageBox::No);
+                                     tr("This icon is used by %n entry(s), and will be replaced "
+                                        "by the default icon. Are you sure you want to delete it?",
+                                        "", iconUseCount),
+                                     QMessageBox::Yes | QMessageBox::No);
 
                 if (ans == QMessageBox::No) {
                     // Early out, nothing is changed

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -673,7 +673,7 @@ void MainWindow::updateWindowTitle()
             customWindowTitlePart.remove(customWindowTitlePart.size() - 1, 1);
         }
         if (m_ui->tabWidget->readOnly(tabWidgetIndex)) {
-            customWindowTitlePart.append(QString(" [%1]").arg(tr("read-only")));
+            customWindowTitlePart = tr("%1 [read-only]", "window title modifier").arg(customWindowTitlePart);
         }
         m_ui->actionDatabaseSave->setEnabled(m_ui->tabWidget->canSave(tabWidgetIndex));
     } else if (stackedWidgetIndex == 1) {

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -47,7 +47,7 @@ SearchWidget::SearchWidget(QWidget* parent)
     m_ui->searchEdit->installEventFilter(this);
 
     QMenu* searchMenu = new QMenu();
-    m_actionCaseSensitive = searchMenu->addAction(tr("Case Sensitive"), this, SLOT(updateCaseSensitive()));
+    m_actionCaseSensitive = searchMenu->addAction(tr("Case sensitive"), this, SLOT(updateCaseSensitive()));
     m_actionCaseSensitive->setObjectName("actionSearchCaseSensitive");
     m_actionCaseSensitive->setCheckable(true);
 

--- a/src/gui/TotpDialog.cpp
+++ b/src/gui/TotpDialog.cpp
@@ -72,7 +72,7 @@ void TotpDialog::updateProgressBar()
 void TotpDialog::updateSeconds()
 {
     uint epoch = QDateTime::currentDateTime().toTime_t() - 1;
-    m_ui->timerLabel->setText(tr("Expires in") + " <b>" + QString::number(m_step - (epoch % m_step)) + "</b> " + tr("seconds"));
+    m_ui->timerLabel->setText(tr("Expires in <b>%n</b> second(s)", "", m_step - (epoch % m_step)));
 }
 
 void TotpDialog::updateTotp()

--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -151,10 +151,10 @@ void CsvImportWidget::updatePreview() {
         if (m_ui->checkBoxFieldNames->isChecked()) {
             columnName = m_parserModel->getCsvTable().at(0).at(i);
             if (columnName.isEmpty())
-                columnName = "<" + tr("Empty fieldname ") + QString::number(++emptyId) + ">";
+                columnName = "<" + tr("Empty fieldname %1").arg(++emptyId) + ">";
             list << columnName;
         } else {
-            list << QString(tr("column ")) + QString::number(i);
+            list << QString(tr("column %1").arg(i));
         }
     }
     m_comboModel->setStringList(list);
@@ -176,7 +176,7 @@ void CsvImportWidget::load(const QString& filename, Database* const db) {
     m_ui->labelFilename->setText(filename);
     Group* group = m_db->rootGroup();
     group->setUuid(Uuid::random());
-    group->setNotes(tr("Imported from CSV file").append("\n").append(tr("Original data: ")) + filename);
+    group->setNotes(tr("Imported from CSV file\nOriginal data: %1").arg(filename));
     parse();
 }
 
@@ -188,7 +188,7 @@ void CsvImportWidget::parse() {
     updatePreview();
     QApplication::restoreOverrideCursor();
     if (!good)
-        m_ui->messageWidget->showMessage(tr("Error(s) detected in CSV file !").append("\n")
+        m_ui->messageWidget->showMessage(tr("Error(s) detected in CSV file!").append("\n")
                                          .append(formatStatusText()), MessageWidget::Warning);
     else
         m_ui->messageWidget->setHidden(true);
@@ -201,8 +201,8 @@ QString CsvImportWidget::formatStatusText() const {
     int items = text.count('\n');
     if (items > 2) {
         return text.section('\n', 0, 1)
-                .append("\n[").append(QString::number(items - 2))
-                .append(tr(" more messages skipped]"));
+                .append("\n")
+                .append(tr("[%n more message(s) skipped]", "", items - 2));
     }
     if (items == 1) {
         text.append(QString("\n"));
@@ -247,8 +247,8 @@ void CsvImportWidget::writeDatabase() {
     KeePass2Writer writer;
     writer.writeDatabase(&buffer, m_db);
     if (writer.hasError())
-        MessageBox::warning(this, tr("Error"), tr("CSV import: writer has errors:\n")
-                   .append((writer.errorString())), QMessageBox::Ok, QMessageBox::Ok);
+        MessageBox::warning(this, tr("Error"), tr("CSV import: writer has errors:\n%1")
+                   .arg(writer.errorString()), QMessageBox::Ok, QMessageBox::Ok);
     emit editFinished(true);
 }
 

--- a/src/gui/csvImport/CsvParserModel.cpp
+++ b/src/gui/csvImport/CsvParserModel.cpp
@@ -31,9 +31,10 @@ void CsvParserModel::setFilename(const QString& filename) {
 }
 
 QString CsvParserModel::getFileInfo(){
-    QString a(tr("%n byte(s), ", nullptr, getFileSize()));
-    a.append(tr("%n row(s), ", nullptr, getCsvRows()));
-    a.append(tr("%n column(s)", nullptr, qMax(0, getCsvCols() - 1)));
+    QString a(tr("%1, %2, %3", "file info: bytes, rows, columns")
+              .arg(tr("%n byte(s)", nullptr, getFileSize()))
+              .arg(tr("%n row(s)", nullptr, getCsvRows()))
+              .arg(tr("%n column(s)", nullptr, qMax(0, getCsvCols() - 1))));
     return a;
 }
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -916,7 +916,7 @@ void EditEntryWidget::insertAttribute()
     int i = 1;
 
     while (m_entryAttributes->keys().contains(name)) {
-        name = QString("%1 %2").arg(tr("New attribute")).arg(i);
+        name = tr("New attribute %1").arg(i);
         i++;
     }
 
@@ -979,7 +979,7 @@ void EditEntryWidget::displayAttribute(QModelIndex index, bool showProtected)
     if (index.isValid()) {
         QString key = m_attributesModel->keyByIndex(index);
         if (showProtected) {
-            m_advancedUi->attributesEdit->setPlainText(tr("[PROTECTED]") + " " + tr("Press reveal to view or edit"));
+            m_advancedUi->attributesEdit->setPlainText(tr("[PROTECTED] Press reveal to view or edit"));
             m_advancedUi->attributesEdit->setEnabled(false);
             m_advancedUi->revealAttributeButton->setEnabled(true);
             m_advancedUi->protectAttributeButton->setChecked(true);

--- a/src/gui/entry/EntryAttachmentsWidget.cpp
+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
@@ -162,7 +162,7 @@ void EntryAttachmentsWidget::removeSelectedAttachments()
     }
 
     const QString question = tr("Are you sure you want to remove %n attachment(s)?", "", indexes.count());
-    QMessageBox::StandardButton answer = MessageBox::question(this, tr("Confirm Remove"),
+    QMessageBox::StandardButton answer = MessageBox::question(this, tr("Confirm remove"),
                                                               question, QMessageBox::Yes | QMessageBox::No);
     if (answer == QMessageBox::Yes) {
         QStringList keys;


### PR DESCRIPTION
## Description
This contains multiple different changes to (hopefully) improve translation base strings.

- In file dialog filters, only translate the text describing the filter, not the whole filter setup (e.g. only `"Executable Files"` and `"All Files"` in `"Executable Files (*.exe);;All Files (*.*)"`)
- Fix the capitalization of some base strings to be more consistent with other base strings, as the capitalization difference doesn't seem to be semantically important
- Where trailing whitespace isn't relevant to the translation, remove it from the base strings; where it _is_, instead use positional arguments and request the whole fragment be translated (e.g. `"Unable to create key file: %1"`, not `"Unable to create key file: ".append(…)`)
- Reduce other concatenation of strings (e.g. now `"Expires in <b>%n</b> second(s)"`, as sentence structure varies a lot by language)
- Make a few more strings translatable
- Allow translators to position modifier text (like `"entry name - Clone"`, which could be useful in the case of eg RTL languages)
- Fix pluralization of confirmation prompts (some languages have further plurals, such as a _dual_ plural for "2 items", so it's important we still permit plural translations)

## Motivation and context
Fixes #1647. This will make it easier on translators to provide relevant strings, as they can translate more strings, and can translate whole strings accurately instead of guessing how to translate fragments which were previously stitched together. It also removes some of the clutter when they translate these strings. (Other motivation is described above.)

## How has this been tested?
I'm not sure how to thoroughly test this, except to release it into the wild, or to spend a very long time trying to comb over the codebase. The changes seem to make sense, the code compiles, and I've manually checked some of the strings by looking through the application (as listed below). Both regular and GUI tests pass.

I'm unsure about the locations I've added `tr`s. The code didn't previously use `tr` in all of these locations, and there might be a reason for this that I don't know. Some code might also rely on fixed strings or fixed string lengths – an example of this is the `*` modifier to the window title bar, which I _didn't_ mark as translatable, even though the UI feature might vary by language.

Of these changes, I've manually tested:
- Filters
- About dialog
- "Attributes" tab of details widget
- Search menu
- Cloning attribute
- Locked database window title
- Deleting entries & recycle bin

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ❌ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
  I'm testing on Windows, which doesn't have support for the `-DWITH_ASAN` flag, and these changes don't seem to modify memory-related things so I don't expect this to be a problem.