### PR TITLE
Keep blowfish code unmodified

### DIFF
--- a/src/sshagent/blf.h
+++ b/src/sshagent/blf.h
@@ -34,17 +34,7 @@
 #ifndef _BLF_H_
 #define _BLF_H_
 
-#ifdef _WIN32
-
-#include <stdint.h>
-
-typedef uint32_t u_int32_t;
-typedef uint16_t u_int16_t;
-typedef uint8_t u_int8_t;
-
-#define bzero(p,s) memset(p, 0, s)
-
-#endif
+#include "includes.h"
 
 #if !defined(HAVE_BCRYPT_PBKDF) && !defined(HAVE_BLH_H)
 

--- a/src/sshagent/blowfish.c
+++ b/src/sshagent/blowfish.c
@@ -39,7 +39,7 @@
  * Bruce Schneier.
  */
 
-#define HAVE_BLF_H
+#include "includes.h"
 
 #if !defined(HAVE_BCRYPT_PBKDF) && (!defined(HAVE_BLOWFISH_INITSTATE) || \
     !defined(HAVE_BLOWFISH_EXPAND0STATE) || !defined(HAVE_BLF_ENC))
@@ -51,7 +51,7 @@
 
 #include <sys/types.h>
 #ifdef HAVE_BLF_H
-#include "blf.h"
+#include <blf.h>
 #endif
 
 #undef inline

--- a/src/sshagent/includes.h
+++ b/src/sshagent/includes.h
@@ -1,0 +1,20 @@
+// mimic openSSH-portable's includes.h file to be able to use
+// its unmodified blowfish code
+
+#define HAVE_BLF_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* activate extra prototypes for glibc */
+#endif
+#include <sys/types.h>
+
+
+#ifdef _WIN32
+#include <stdint.h>
+
+typedef uint32_t u_int32_t;
+typedef uint16_t u_int16_t;
+typedef uint8_t u_int8_t;
+
+#define bzero(p,s) memset(p, 0, s)
+#endif


### PR DESCRIPTION
## Description
Both `blf.h`and `blowfish.c` are restored to their current [**upstream's state**](https://github.com/openssh/openssh-portable/tree/58fd4c5c0140f6636227ca7acbb149ab0c2509b9/openbsd-compat), and a reduced `includes.h` is added, that also keeps the windows specific modifications formely contained in `blf.h`.

## Motivation and context
Musl-libc needs explicit inclusion of `<sys/types.h>`, so keepassxc couldn't be built.
In specific,  `u_int32_t` types were not declared.

## How has this been tested?
I built `2.3.1` including this patch using Void Linux' build system [**xbps-src**](https://github.com/voidlinux/void-packages) against glibc and musl-libc, which works now.
Also see [**here**](https://github.com/voidlinux/void-packages/pull/12441).

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**