### PR TITLE
Support multiple URLs in a single entry

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -392,6 +392,11 @@ QList<Entry*> BrowserService::searchEntries(QSharedPointer<Database> db, const Q
     // XXX: will this include disabled entries or ones in recycle bin?
     // TODO: check if this is compatible with https://github.com/keepassxreboot/keepassxc/pull/2253
     for (Entry* entry : rootGroup->entriesRecursive()) {
+        if (matchAdditionalURLs(entry, hostname, url)) {
+            entries.append(entry);
+            continue;
+        }
+
         QString entryUrl = entry->url();
         QUrl entryQUrl(entryUrl);
         QString entryScheme = entryQUrl.scheme();
@@ -406,8 +411,7 @@ QList<Entry*> BrowserService::searchEntries(QSharedPointer<Database> db, const Q
 
         // Filter to match hostname in URL field
         if ((!entryUrl.isEmpty() && hostname.contains(entryUrl))
-            || (matchUrlScheme(entryUrl) && hostname.endsWith(entryQUrl.host()))
-            || matchAdditionalURLs(entry, hostname, url)) {
+            || (matchUrlScheme(entryUrl) && hostname.endsWith(entryQUrl.host()))) {
                 entries.append(entry);
         }
     }
@@ -418,6 +422,7 @@ QList<Entry*> BrowserService::searchEntries(QSharedPointer<Database> db, const Q
 bool BrowserService::matchAdditionalURLs(const Entry* entry, const QString& hostname, const QString& url)
 {
     for (QString altURL : entry->altURLs()) {
+        // TODO: match port and scheme
         if (matchUrlScheme(altURL) && hostname.endsWith(QUrl(altURL).host())) {
             return true;
         }

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -106,6 +106,7 @@ private:
     int
     sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
     bool matchUrlScheme(const QString& url);
+    bool matchAdditionalURLs(const Entry* entry, const QString& hostname, const QString& url);
     bool removeFirstDomain(QString& hostname);
     QString baseDomain(const QString& url) const;
     QSharedPointer<Database> getDatabase();

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -26,6 +26,7 @@
 #include "core/Metadata.h"
 #include "totp/totp.h"
 
+#include <QDebug>
 #include <QDir>
 #include <QRegularExpression>
 #include <utility>

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -394,6 +394,41 @@ QSharedPointer<Totp::Settings> Entry::totpSettings() const
     return m_data.totpSettings;
 }
 
+QStringList Entry::additionalURLs(QString key) const
+{
+    QStringList urlList;
+
+    if (m_attributes->hasKey(key)) {
+        urlList = m_attributes->value(key).split('\n', QString::SkipEmptyParts);
+    }
+
+    return urlList;
+}
+
+void Entry::migrateAttributes()
+{
+    renameAttribute("altURLs", "URL_ALT");
+    renameAttribute("regExURLs", "URL_REGEX");
+}
+
+void Entry::renameAttribute(const QString& from, const QString& to)
+{
+    if (m_attributes->hasKey(from)) {
+        qDebug() << "Migrate the attribute" << from << " in entry" << title() << "to" << to;
+        m_attributes->rename(from, to);
+    }
+}
+
+QStringList Entry::altURLs() const
+{
+    return additionalURLs("URL_ALT");
+}
+
+QStringList Entry::regExURLs() const
+{
+    return additionalURLs("URL_REGEX");
+}
+
 void Entry::setUuid(const QUuid& uuid)
 {
     Q_ASSERT(!uuid.isNull());

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -107,6 +107,8 @@ public:
     QString notes() const;
     QString totp() const;
     QSharedPointer<Totp::Settings> totpSettings() const;
+    QStringList altURLs() const;
+    QStringList regExURLs() const;
 
     bool hasTotp() const;
     bool isExpired() const;
@@ -218,6 +220,8 @@ public:
     bool canUpdateTimeinfo() const;
     void setUpdateTimeinfo(bool value);
 
+    void migrateAttributes();
+
 signals:
     /**
      * Emitted when a default attribute has been changed.
@@ -240,6 +244,8 @@ private:
     static EntryReferenceType referenceType(const QString& referenceStr);
 
     template <class T> bool set(T& property, const T& value);
+    QStringList additionalURLs(QString key) const;
+    void renameAttribute(const QString& from, const QString& to);
 
     QUuid m_uuid;
     EntryData m_data;

--- a/src/format/KdbxXmlWriter.cpp
+++ b/src/format/KdbxXmlWriter.cpp
@@ -251,6 +251,10 @@ void KdbxXmlWriter::writeRoot()
 
     m_xml.writeStartElement("Root");
 
+    for (Entry* entry : m_db->rootGroup()->entriesRecursive()) {
+        entry->migrateAttributes();
+    }
+
     writeGroup(m_db->rootGroup());
     writeDeletedObjects();
 


### PR DESCRIPTION
**WARNING: This work is far from complete. Use at your own risk.**

## Description

This patch adds several custom fields to an entry to support more complex features than the existing ```URL``` field, including regular expressions and URL blacklists, for URL matching with KeePassXC-Browser.

There are 4 new fields:

* altURLs: Matching against additional URLs
* regExURLs: Matching against regular expressions
* blockedURLs: A blacklist for URL matching
* regExBlockedURLs: Similar to blockedURLs but using regular expressions

Currently only the first two are implemented. To use them, add custom fields from the Advanced page of an entry. For example, in my Facebook entry, I have https://www.messenger.com/ in URL and the following additional fields:

![default](https://user-images.githubusercontent.com/1937689/37771354-4b5ccb6c-2e12-11e8-9b0f-4c097612a215.png)
![default](https://user-images.githubusercontent.com/1937689/37771419-8957b814-2e12-11e8-9147-7012b55aeca9.png)

With those settings, KeePassXC-Browser will match https://www.messenger.com/, https://www.facebookcorewwwi.onion/ and all HTTPS URLs ending with facebook.com, like https://www.facebook.com/ and https://zh-tw.facebook.com/.

## Motivation and context
As described in https://github.com/keepassxreboot/keepassxc/issues/398, supporting multiple URLs in a single bring convenience and benefits over using references.

## How has this been tested?
I've used this for months.

## Screenshots (if appropriate):
N/A

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- All new and existing tests passed. **[REQUIRED]**
- I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- My change requires a change to the documentation and I have updated it accordingly. (TODO)
- I have added tests to cover my changes. (TODO)

## Discussions
* 4 custom attributes, too many or too few?

I steal this idea from [KeeFox](https://github.com/kee-org/KeeFox) as described in https://github.com/keepassxreboot/keepassxc/issues/398#issuecomment-326755012. Another implementation for similar purpose can be found at https://github.com/pfn/keepasshttp/pull/340, which implements one additional field ```RegExp```. Maybe there's a better design than the two existing implementations.

* Compatibility issues

KeePassHTTP is dying, and KeePassXC is a pioneer for a native-messaging-based protocol, but I think we should at least talk with the author of https://github.com/smorks/keepassnatmsg on the design.

* Is it better to put additional URLs in ```KeePassXC-Browser Settings``` than put them in standalone custom attributes? Currently I choose the latter approach for easy hand-editing, which might not be an issue if a GUI is implemented.

* Extensions to the ```Allow``` key in ```KeePassXC-Browser Settings```? For regExURLs, users need to update the ```Allow``` key whenever a new domain name is accepted (by checking "Remember this decision" in confirm access dialog). Maybe adding a regular expression to ```Allow``` is a good choice?

### TODO
* [ ] Implement blockedURLs and regExBlockedURLs
* [ ] Create a GUI for setting those attributes
* [ ] Examine XXX comments in this patch
* [ ] Use uppercase attribute names https://github.com/keepassxreboot/keepassxc/pull/1769#issuecomment-375307723
* [ ] Find a better choice than submitUrl. For example on https://github.com/login, submitUrl is https://github.com/session, which is far from intuitive

### Known issues
* With KeePassXC-Browser, submitUrl is empty if there are no ```<form>```s. As a result, TOTP does not work with those additional fields.