### PR TITLE
favicon fetch improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,9 +202,6 @@ add_feature_info(SSHAgent WITH_XC_SSHAGENT "SSH agent integration compatible wit
 add_feature_info(YubiKey WITH_XC_YUBIKEY "YubiKey HMAC-SHA1 challenge-response")
 
 add_subdirectory(http)
-if(WITH_XC_NETWORKING)
-  find_package(CURL REQUIRED)
-endif()
 
 set(BROWSER_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/browser)
 add_subdirectory(browser)

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -21,7 +21,6 @@
 
 #include <QFileDialog>
 #include <QMessageBox>
-#include <QFileDialog>
 
 #include "core/Config.h"
 #include "core/Group.h"

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -30,9 +30,7 @@
 #include "gui/MessageBox.h"
 
 #ifdef WITH_XC_NETWORKING
-#include <curl/curl.h>
-#include "core/AsyncTask.h"
-#undef MessageBox
+#include <QtNetwork>
 #endif
 
 IconStruct::IconStruct()
@@ -41,10 +39,31 @@ IconStruct::IconStruct()
 {
 }
 
+UrlFetchProgressDialog::UrlFetchProgressDialog(const QUrl &url, QWidget *parent)
+  : QProgressDialog(parent)
+{
+    setWindowTitle(tr("Download Progress"));
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    setLabelText(tr("Downloading %1.").arg(url.toDisplayString()));
+    setMinimum(0);
+    setValue(0);
+    setMinimumDuration(0);
+    setMinimumSize(QSize(400, 75));
+}
+
+void UrlFetchProgressDialog::networkReplyProgress(qint64 bytesRead, qint64 totalBytes)
+{
+    setMaximum(totalBytes);
+    setValue(bytesRead);
+}
+
 EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     : QWidget(parent)
     , m_ui(new Ui::EditWidgetIcons())
     , m_database(nullptr)
+#ifdef WITH_XC_NETWORKING
+    , m_reply(nullptr)
+#endif
     , m_defaultIconModel(new DefaultIconModel(this))
     , m_customIconModel(new CustomIconModel(this))
 {
@@ -135,7 +154,7 @@ void EditWidgetIcons::load(const Uuid& currentUuid, Database* database, const Ic
 void EditWidgetIcons::setUrl(const QString& url)
 {
 #ifdef WITH_XC_NETWORKING
-    m_url = url;
+    m_url = QUrl(url);
     m_ui->faviconButton->setVisible(!url.isEmpty());
 #else
     Q_UNUSED(url);
@@ -143,87 +162,121 @@ void EditWidgetIcons::setUrl(const QString& url)
 #endif
 }
 
+#ifdef WITH_XC_NETWORKING
+namespace {
+    // Try to get the 2nd level domain of the host part of a QUrl. For example,
+    // "foo.bar.example.com" would become "example.com", and "foo.bar.example.co.uk"
+    // would become "example.co.uk".
+    QString getSecondLevelDomain(QUrl url)
+    {
+        QString fqdn = url.host();
+        fqdn.truncate(fqdn.length() - url.topLevelDomain().length());
+        QStringList parts = fqdn.split('.');
+        QString newdom = parts.takeLast() + url.topLevelDomain();
+        return newdom;
+    }
+}
+#endif
+
 void EditWidgetIcons::downloadFavicon()
 {
 #ifdef WITH_XC_NETWORKING
     m_ui->faviconButton->setDisabled(true);
 
-    QUrl url = QUrl(m_url);
-    url.setPath("/favicon.ico");
+    m_urlsToTry.clear();
+
+    QString fullyQualifiedDomain = m_url.host();
+    QString secondLevelDomain = getSecondLevelDomain(m_url);
+
     // Attempt to simply load the favicon.ico file
-    QImage image = fetchFavicon(url);
+    if (fullyQualifiedDomain != secondLevelDomain) {
+        m_urlsToTry.append(QUrl(m_url.scheme() + "://" + fullyQualifiedDomain + "/favicon.ico"));
+    }
+    m_urlsToTry.append(QUrl(m_url.scheme() + "://" + secondLevelDomain + "/favicon.ico"));
+
+    // Try to use Google fallback, if enabled
+    if (config()->get("security/IconDownloadFallbackToGoogle", false).toBool()) {
+        QUrl urlGoogle = QUrl("https://www.google.com/s2/favicons");
+
+        urlGoogle.setQuery("domain=" + QUrl::toPercentEncoding(secondLevelDomain));
+        m_urlsToTry.append(urlGoogle);
+    }
+
+    startFetchFavicon(m_urlsToTry.takeFirst());
+#endif
+}
+
+void EditWidgetIcons::fetchReadyRead()
+{
+#ifdef WITH_XC_NETWORKING
+    m_bytesReceived += m_reply->readAll();
+#endif
+}
+
+void EditWidgetIcons::fetchFinished()
+{
+#ifdef WITH_XC_NETWORKING
+    QImage image;
+    bool googleFallbackEnabled = config()->get("security/IconDownloadFallbackToGoogle", false).toBool();
+    bool error = (m_reply->error() != QNetworkReply::NoError);
+
+    m_reply->deleteLater();
+    m_reply = nullptr;
+
+    if (!error) {
+        image.loadFromData(m_bytesReceived);
+    }
+
     if (!image.isNull()) {
         addCustomIcon(image);
-    } else if (config()->get("security/IconDownloadFallbackToGoogle", false).toBool()) {
-        QUrl faviconUrl = QUrl("https://www.google.com/s2/favicons");
-        faviconUrl.setQuery("domain=" + QUrl::toPercentEncoding(url.host()));
-        // Attempt to load favicon from Google
-        image = fetchFavicon(faviconUrl);
-        if (!image.isNull()) {
-            addCustomIcon(image);
+    } else if (!m_urlsToTry.empty()) {
+        startFetchFavicon(m_urlsToTry.takeFirst());
+        return;
+    } else {
+        if (!googleFallbackEnabled) {
+            emit messageEditEntry(tr("Unable to fetch favicon.") + "\n" +
+                                  tr("Hint: You can enable Google as a fallback under Tools>Settings>Security"),
+                                  MessageWidget::Error);
         } else {
             emit messageEditEntry(tr("Unable to fetch favicon."), MessageWidget::Error);
         }
-    } else {
-        emit messageEditEntry(tr("Unable to fetch favicon.") + "\n" +
-                              tr("Hint: You can enable Google as a fallback under Tools>Settings>Security"),
-                              MessageWidget::Error);
     }
 
     m_ui->faviconButton->setDisabled(false);
 #endif
 }
 
+void EditWidgetIcons::fetchCanceled()
+{
 #ifdef WITH_XC_NETWORKING
-namespace {
-std::size_t writeCurlResponse(char* ptr, std::size_t size, std::size_t nmemb, void* data)
-{
-    QByteArray* response = static_cast<QByteArray*>(data);
-    std::size_t realsize = size * nmemb;
-    response->append(ptr, realsize);
-    return realsize;
-}
-}
-
-QImage EditWidgetIcons::fetchFavicon(const QUrl& url)
-{
-    QImage image;
-    CURL* curl = curl_easy_init();
-    if (curl) {
-        QByteArray imagedata;
-        QByteArray baUrl = url.url().toLatin1();
-
-        curl_easy_setopt(curl, CURLOPT_URL, baUrl.data());
-        curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
-        curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-        curl_easy_setopt(curl, CURLOPT_USERAGENT, "curl");
-        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
-        curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &imagedata);
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &writeCurlResponse);
-#ifdef Q_OS_WIN
-        const QDir appDir = QFileInfo(QCoreApplication::applicationFilePath()).absoluteDir();
-        if (appDir.exists("ssl\\certs")) {
-            curl_easy_setopt(curl, CURLOPT_CAINFO, (appDir.absolutePath() + "\\ssl\\certs\\ca-bundle.crt").toLatin1().data());
-        }
+    m_reply->abort();
 #endif
-
-        // Perform the request in another thread
-        CURLcode result = AsyncTask::runAndWaitForFuture([curl]() {
-            return curl_easy_perform(curl);
-        });
-
-        if (result == CURLE_OK) {
-            image.loadFromData(imagedata);
-        }
-
-        curl_easy_cleanup(curl);
-    }
-
-    return image;
 }
+
+void EditWidgetIcons::startFetchFavicon(const QUrl& url)
+{
+#ifdef WITH_XC_NETWORKING
+    m_bytesReceived.clear();
+
+    QNetworkRequest request(url);
+    request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    m_reply = m_netMgr.get(request);
+    connect(m_reply, &QNetworkReply::finished, this, &EditWidgetIcons::fetchFinished);
+    connect(m_reply, &QIODevice::readyRead, this, &EditWidgetIcons::fetchReadyRead);
+
+    UrlFetchProgressDialog *progress = new UrlFetchProgressDialog(url, this);
+    progress->setAttribute(Qt::WA_DeleteOnClose);
+    connect(m_reply, &QNetworkReply::finished, progress, &QProgressDialog::hide);
+    connect(m_reply, &QNetworkReply::downloadProgress, progress, &UrlFetchProgressDialog::networkReplyProgress);
+    connect(progress, &QProgressDialog::canceled, this, &EditWidgetIcons::fetchCanceled);
+
+    progress->show();
+#else
+    Q_UNUSED(url);
 #endif
+}
 
 void EditWidgetIcons::addCustomIconFromFile()
 {

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -21,7 +21,9 @@
 
 #include <QWidget>
 #include <QSet>
+#include <QProgressDialog>
 #include <QUrl>
+#include <QNetworkAccessManager>
 
 #include "config-keepassx.h"
 #include "core/Global.h"
@@ -31,6 +33,9 @@
 class Database;
 class DefaultIconModel;
 class CustomIconModel;
+#ifdef WITH_XC_NETWORKING
+class QNetworkReply;
+#endif
 
 namespace Ui {
     class EditWidgetIcons;
@@ -42,6 +47,17 @@ struct IconStruct
 
     Uuid uuid;
     int number;
+};
+
+class UrlFetchProgressDialog : public QProgressDialog
+{
+    Q_OBJECT
+
+public:
+    explicit UrlFetchProgressDialog(const QUrl &url, QWidget *parent = nullptr);
+
+public slots:
+    void networkReplyProgress(qint64 bytesRead, qint64 totalBytes);
 };
 
 class EditWidgetIcons : public QWidget
@@ -65,9 +81,10 @@ signals:
 
 private slots:
     void downloadFavicon();
-#ifdef WITH_XC_NETWORKING
-    QImage fetchFavicon(const QUrl& url);
-#endif
+    void startFetchFavicon(const QUrl& url);
+    void fetchFinished();
+    void fetchReadyRead();
+    void fetchCanceled();
     void addCustomIconFromFile();
     void addCustomIcon(const QImage& icon);
     void removeCustomIcon();
@@ -80,7 +97,13 @@ private:
     const QScopedPointer<Ui::EditWidgetIcons> m_ui;
     Database* m_database;
     Uuid m_currentUuid;
-    QString m_url;
+#ifdef WITH_XC_NETWORKING
+    QUrl m_url;
+    QList<QUrl> m_urlsToTry;
+    QByteArray m_bytesReceived;
+    QNetworkAccessManager m_netMgr;
+    QNetworkReply *m_reply;
+#endif
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;
 

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -99,10 +99,12 @@ private:
     Uuid m_currentUuid;
 #ifdef WITH_XC_NETWORKING
     QUrl m_url;
+    QUrl m_fetchUrl;
     QList<QUrl> m_urlsToTry;
     QByteArray m_bytesReceived;
     QNetworkAccessManager m_netMgr;
     QNetworkReply *m_reply;
+    int m_redirects;
 #endif
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,12 +45,29 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 #endif
 #endif
 
+static inline void earlyQNetworkAccessManagerWorkaround()
+{
+    // When QNetworkAccessManager is instantiated it regularly starts polling
+    // all network interfaces to see if anything changes and if so, what. This
+    // creates a latency spike every 10 seconds on Mac OS 10.12+ and Windows 7 >=
+    // when on a wifi connection.
+    // So here we disable it for lack of better measure.
+    // This will also cause this message: QObject::startTimer: Timers cannot
+    // have negative intervals
+    // For more info see:
+    // - https://bugreports.qt.io/browse/QTBUG-40332
+    // - https://bugreports.qt.io/browse/QTBUG-46015
+    qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));
+}
+
 int main(int argc, char** argv)
 {
 #ifdef QT_NO_DEBUG
     Tools::disableCoreDumps();
 #endif
     Tools::setupSearchPaths();
+
+    earlyQNetworkAccessManagerWorkaround();
 
     Application app(argc, argv);
     Application::setApplicationName("keepassxc");


### PR DESCRIPTION
This pull request improves the favicon fetching process.

## Description
Here is a summary of the changes:

* Eliminate dependency on libcurl. We already depend on Qt5Network, so why not use the HTTP fetching from there?

* Show a progress dialog when downloading the favicon. The main utility of this is giving the user the option to cancel a download attempt (e.g. if it's taking too long). If the user clicks "cancel", it will cancel the current download attempt and try the next fallback URL in the list.

* Try three different ways to obtain the favicon, in this order:

  * Direct to fully-qualified domain name (e.g. `https://foo.bar.example.com/favicon.ico`)
  * Direct to 2nd-level domain name (e.g. `https://example.com/favicon.ico`)
  * Google lookup for 2nd-level domain name (if enabled in settings)

I changed the Google lookup because a match is more likely to be found for the 2nd level domain than for the fully-qualified name. But if Google doesn't find a match, it doesn't actually return an error code. Instead, it returns a generic default icon, which is not really the desired result.

### Future work thoughts
I don't approve of Google's behavior when it doesn't find a match. Since the API doesn't provide an error code, we don't have a programmatic way to know whether or not it actually found a result, or whether we need to look elsewhere for an icon. The best we could probably do is hash the icon and recognize that it matches the generic icon. But that's prone to breaking if the generic icon ever changes.

Because of this I'm looking into alternative fallback methods for finding the favicon.

One way would be to fetch and parse the index page for the fully-qualified domain name or second-level domain, and look for `<link>` elements which refer to icons. For example, here's the relevant elements inside `<head>` on `https://doc.qt.io` (line wrapped for readability):
```
<link rel="shortcut icon"
  href="//d33sqmjvzgs8hq.cloudfront.net/wp-content/themes/oneqt/assets/images/favicon.ico.gzip" />
<link rel="icon" type="image/png"
  href="//d33sqmjvzgs8hq.cloudfront.net/wp-content/themes/oneqt/assets/images/favicon-32x32.png" />
<link rel="icon" type="image/png"
  href="//d33sqmjvzgs8hq.cloudfront.net/wp-content/themes/oneqt/assets/images/favicon-16x16.png" />
```
We would probably want some strategy around choosing which icon to use. We'd probably want to prefer image/png over image/x-icon. We'd also probably prefer larger image sizes, as Qt will already scale them to fit the UI. Tha traditional favicon size of 16x16 doesn't look good at all on a high DPI display, but quite a few sites provide icons larger than that if you know where to look.

## Motivation and context
I was actually looking at reducing the Windows build's install footprint. libcurl's contribution to that footprint isn't exactly trivial. In my x86_64 MinGW build, this PR reduces the install size from 66.3MB to 60.8MB. Here's the delta for the directory structure:

```diff
--- keepassxc.files.sort        2018-03-27 17:16:03.091086400 -0700
+++ keepassxc-small.files.sort  2018-03-27 17:16:03.114191300 -0700
@@ -1,8 +1,6 @@
 .
 ./KeePassXC.exe
 ./libbz2-1.dll
-./libcurl-4.dll
-./libeay32.dll
 ./libfreetype-6.dll
 ./libgcc_s_seh-1.dll
 ./libgcrypt-20.dll
@@ -14,17 +12,13 @@
 ./libicudt58.dll
 ./libicuin58.dll
 ./libicuuc58.dll
-./libidn2-0.dll
 ./libintl-8.dll
-./libnghttp2-14.dll
 ./libpcre-1.dll
 ./libpcre2-16-0.dll
 ./libpng16-16.dll
 ./libsodium-18.dll
-./libssh2-1.dll
 ./libssp-0.dll
 ./libstdc++-6.dll
-./libunistring-2.dll
 ./libwinpthread-1.dll
 ./libykpers-1-1.dll
 ./libyubikey-0.dll
@@ -32,8 +26,4 @@
 ./Qt5Gui.dll
 ./Qt5Network.dll
 ./Qt5Widgets.dll
-./ssl
-./ssl/certs
-./ssl/certs/ca-bundle.crt
-./ssleay32.dll
 ./zlib1.dll
```

As a nice side effect, we get a UI improvement, with the ability to cancel a favicon fetch in progress.

## How has this been tested?
Aside from the test suite, I tried fetching favicons for a few different domain names and it worked as expected.

Because of the 2nd-level domain change, this also unbroke a few different favicons for me. For example, I have an entry in my database for `secure.wa.aaa.com`, but that fully qualified domain doesn't have a favicon, and Google just returns their generic icon for it. The 2nd-level domain `aaa.com` does have a favicon, and this change is able to fetch that one properly.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
