### PR TITLE
SSH Agent: Fix wrong slot reference

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -281,7 +281,7 @@ void EditEntryWidget::setupSSHAgent()
     connect(m_sshAgentUi->decryptButton, SIGNAL(clicked()), SLOT(decryptPrivateKey()));
     connect(m_sshAgentUi->copyToClipboardButton, SIGNAL(clicked()), SLOT(copyPublicKey()));
 
-    connect(m_advancedUi->attachmentsWidget->entryAttachments(), SIGNAL(modified()), SLOT(updateAttachments()));
+    connect(m_advancedUi->attachmentsWidget->entryAttachments(), SIGNAL(modified()), SLOT(updateSSHAgentAttachments()));
 
     addPage(tr("SSH Agent"), FilePath::instance()->icon("apps", "utilities-terminal"), m_sshAgentWidget);
 }


### PR DESCRIPTION
Fixes an error message and non-working functionality introduced by a
wrong slot referenced in PR #1679. Compare comments in PR.

## Description
Fixed reference.

## Motivation and context
The previous commit referred to a wrong slot and thus did not have any effect but producing an error. This probably happened because the wrong version was pushed into Git.

## How has this been tested?
All tests have been repeated as for the original version, just this time pushed the correct version.