### PR TITLE
Move debugInfo into core.

### DIFF
--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -59,6 +59,9 @@ Specifies a path to a key file for unlocking the database. In a merge operation 
 .IP "-h, --help"
 Displays help information.
 
+.IP "-d, --debug-info"
+Show debugging information and exit.
+
 .IP "-v, --version"
 Shows the program version.
 

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -61,6 +61,10 @@ int main(int argc, char** argv)
     parser.setApplicationDescription(description);
 
     parser.addPositionalArgument("command", QObject::tr("Name of the command to execute."));
+    QCommandLineOption showDebugInfo(QStringList() << "d"
+                                                   << "debug-info",
+                                     QObject::tr("Show debugging information and exit."));
+    parser.addOption(showDebugInfo);
 
     parser.addHelpOption();
     parser.addVersionOption();
@@ -73,6 +77,10 @@ int main(int argc, char** argv)
         if (parser.isSet("version")) {
             // Switch to parser.showVersion() when available (QT 5.4).
             out << KEEPASSX_VERSION << endl;
+            return EXIT_SUCCESS;
+        }
+        if (parser.isSet(showDebugInfo)) {
+            out << Tools::getDebugInfo() << endl;
             return EXIT_SUCCESS;
         }
         parser.showHelp();

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -43,6 +43,7 @@ void wait(int ms);
 void disableCoreDumps();
 void setupSearchPaths();
 bool createWindowsDACL();
+QString getDebugInfo();
 
 template <typename RandomAccessIterator, typename T>
 RandomAccessIterator binaryFind(RandomAccessIterator begin, RandomAccessIterator end, const T& value)

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -20,12 +20,10 @@
 #include "ui_AboutDialog.h"
 
 #include "config-keepassx.h"
-#include "version.h"
 #include "core/FilePath.h"
-#include "crypto/Crypto.h"
+#include "core/Tools.h"
 
 #include <QClipboard>
-#include <QSysInfo>
 
 AboutDialog::AboutDialog(QWidget* parent)
     : QDialog(parent),
@@ -44,64 +42,7 @@ AboutDialog::AboutDialog(QWidget* parent)
 
     m_ui->iconLabel->setPixmap(filePath()->applicationIcon().pixmap(48));
 
-    QString commitHash;
-    if (!QString(GIT_HEAD).isEmpty()) {
-        commitHash = GIT_HEAD;
-    }
-    else if (!QString(DIST_HASH).contains("Format")) {
-        commitHash = DIST_HASH;
-    }
-
-    QString debugInfo = "KeePassXC - ";
-    debugInfo.append(tr("Version %1").arg(KEEPASSX_VERSION).append("\n"));
-#ifndef KEEPASSXC_BUILD_TYPE_RELEASE
-    debugInfo.append(tr("Build Type: %1").arg(KEEPASSXC_BUILD_TYPE).append("\n"));
-#endif
-    if (!commitHash.isEmpty()) {
-        debugInfo.append(tr("Revision: %1").arg(commitHash.left(7)).append("\n"));
-    }
-
-#ifdef KEEPASSXC_DIST
-    debugInfo.append(tr("Distribution: %1").arg(KEEPASSXC_DIST_TYPE).append("\n"));
-#endif
-
-    debugInfo.append("\n").append(QString("%1\n- Qt %2\n- %3\n\n")
-             .arg(tr("Libraries:"))
-             .arg(QString::fromLocal8Bit(qVersion()))
-             .arg(Crypto::backendVersion()));
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-    debugInfo.append(tr("Operating system: %1\nCPU architecture: %2\nKernel: %3 %4")
-             .arg(QSysInfo::prettyProductName(),
-                  QSysInfo::currentCpuArchitecture(),
-                  QSysInfo::kernelType(),
-                  QSysInfo::kernelVersion()));
-
-    debugInfo.append("\n\n");
-#endif
-
-    QString extensions;
-#ifdef WITH_XC_AUTOTYPE
-    extensions += "\n- " + tr("Auto-Type");
-#endif
-#ifdef WITH_XC_BROWSER
-    extensions += "\n- " + tr("Browser Integration");
-#endif
-#ifdef WITH_XC_HTTP
-    extensions += "\n- " + tr("Legacy Browser Integration (KeePassHTTP)");
-#endif
-#ifdef WITH_XC_SSHAGENT
-    extensions += "\n- " + tr("SSH Agent");
-#endif
-#ifdef WITH_XC_YUBIKEY
-    extensions += "\n- " + tr("YubiKey");
-#endif
-
-    if (extensions.isEmpty())
-        extensions = " " + tr("None");
-
-    debugInfo.append(tr("Enabled extensions:").append(extensions));
-
+    QString debugInfo = Tools::getDebugInfo();
     m_ui->debugInfo->setPlainText(debugInfo);
 
     setAttribute(Qt::WA_DeleteOnClose);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,6 +75,9 @@ int main(int argc, char** argv)
                                                         << "parent-window",
                                                         QCoreApplication::translate("main", "Parent window handle"),
                                                         "handle");
+    QCommandLineOption showDebugInfo(QStringList() << "d"
+                                                   << "debug-info",
+                                     QObject::tr("Show debugging information and exit."));
 
     parser.addHelpOption();
     parser.addVersionOption();
@@ -82,10 +85,16 @@ int main(int argc, char** argv)
     parser.addOption(keyfileOption);
     parser.addOption(pwstdinOption);
     parser.addOption(parentWindowOption);
+    parser.addOption(showDebugInfo);
 
     parser.process(app);
-    const QStringList fileNames = parser.positionalArguments();
+    if (parser.isSet(showDebugInfo)) {
+        QTextStream out(stdout, QIODevice::WriteOnly);
+        out << Tools::getDebugInfo() << endl;
+        return EXIT_SUCCESS;
+    }
 
+    const QStringList fileNames = parser.positionalArguments();
     if (app.isAlreadyRunning()) {
         if (!fileNames.isEmpty()) {
             app.sendFileNamesToRunningInstance(fileNames);


### PR DESCRIPTION
Allow debugging information to be displayed from the command line.

## Motivation and context
I sometimes want to verify that info without having to open the GUI application, for example before using the `merge` command.

## How has this been tested?
Locally

## Screenshots (if appropriate):
```
$ keepassxc-cli --debug-info
KeePassXC - Version 2.3.1-snapshot
Build Type: Snapshot
Revision: c4bbe32

Libraries:
- Qt 5.5.1
- libgcrypt 1.8.1

Operating system: Ubuntu 16.04.4 LTS
CPU architecture: x86_64
Kernel: linux 4.13.0-37-generic

Enabled extensions:
- Auto-Type
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
