### PR TITLE
Ignore non-connected databases from search with Browser Integration

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -240,9 +240,17 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
         return getErrorReply(action, ERROR_KEEPASS_NO_URL_PROVIDED);
     }
 
+    const QJsonArray keys = decrypted.value("keys").toArray();
+
+    StringPairList keyList;
+    for (const QJsonValue val : keys) {
+        const QJsonObject keyObject = val.toObject();
+        keyList.push_back(qMakePair(keyObject.value("id").toString(), keyObject.value("key").toString()));
+    }
+
     const QString id = decrypted.value("id").toString();
     const QString submit = decrypted.value("submitUrl").toString();
-    const QJsonArray users = m_browserService.findMatchingEntries(id, url, submit, "");
+    const QJsonArray users = m_browserService.findMatchingEntries(id, url, submit, "", keyList);
 
     if (users.isEmpty()) {
         return getErrorReply(action, ERROR_KEEPASS_NO_LOGINS_FOUND);

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -25,6 +25,9 @@
 #include "gui/DatabaseTabWidget.h"
 #include "core/Entry.h"
 
+typedef QPair<QString, QString> StringPair;
+typedef QList<StringPair> StringPairList;
+
 class BrowserService : public QObject
 {
     Q_OBJECT
@@ -40,12 +43,12 @@ public:
     QString         getKey(const QString& id);
     void            addEntry(const QString& id, const QString& login, const QString& password, const QString& url, const QString& submitUrl, const QString& realm);
     QList<Entry*>   searchEntries(Database* db, const QString& hostname);
-    QList<Entry*>   searchEntries(const QString& text);
+    QList<Entry*>   searchEntries(const QString& text, const StringPairList& keyList);
     void            removeSharedEncryptionKeys();
     void            removeStoredPermissions();
 
 public slots:
-    QJsonArray      findMatchingEntries(const QString& id, const QString& url, const QString& submitUrl, const QString& realm);
+    QJsonArray      findMatchingEntries(const QString& id, const QString& url, const QString& submitUrl, const QString& realm, const StringPairList& keyList);
     QString         storeKey(const QString& key);
     void            updateEntry(const QString& id, const QString& uuid, const QString& login, const QString& password, const QString& url);
     void            databaseLocked(DatabaseWidget* dbWidget);


### PR DESCRIPTION
Ignores non-connected databases if search from all databases option is enabled in Browser Integration settings.

## Description
Previously searching from all databases returned entries also from non-connected databases, which is not very secure. This change only searches from databases that are connected with the browser extension. KeePassXC-Browser side change is needed, although it can be merged beforehand.

## Motivation and context
KeePassXC-Browser side PR here: https://github.com/keepassxreboot/keepassxc-browser/pull/108.
Must be merged after https://github.com/keepassxreboot/keepassxc/pull/1497 is merged.

## How has this been tested?
Manually.

## Types of changes
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
