### PR TITLE
Change socket location in macOS to temporary dir

### DIFF
--- a/src/browser/NativeMessagingBase.cpp
+++ b/src/browser/NativeMessagingBase.cpp
@@ -131,13 +131,11 @@ void NativeMessagingBase::sendReply(const QString& reply)
 
 QString NativeMessagingBase::getLocalServerPath() const
 {
-#if defined(Q_OS_WIN)
-    return QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/kpxc_server";
-#elif defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
     // Use XDG_RUNTIME_DIR instead of /tmp/ if it's available
     QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + "/kpxc_server";
     return path.isEmpty() ? "/tmp/kpxc_server" : path;
-#else // Q_OS_MAC and others
-    return "/tmp/kpxc_server";
+#else // Q_OS_MAC, Q_OS_WIN and others
+    return QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/kpxc_server";
 #endif
 }


### PR DESCRIPTION
Changes socket location in macOS from `/tmp/kpxc_server` to user's temporary dir.

## Description
Allows multiple users.

## Motivation and context
Solves https://github.com/keepassxreboot/keepassxc/issues/1745.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
