### PR TITLE
Fix build error on macOS

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -47,8 +47,8 @@
 #endif
 
 #ifdef HAVE_PT_DENY_ATTACH
-#include <sys/ptrace.h>
 #include <sys/types.h>
+#include <sys/ptrace.h>
 #endif
 
 namespace Tools

--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -47,8 +47,10 @@
 #endif
 
 #ifdef HAVE_PT_DENY_ATTACH
+// clang-format off
 #include <sys/types.h>
 #include <sys/ptrace.h>
+// clang-format on
 #endif
 
 namespace Tools


### PR DESCRIPTION
Changing the order of the includes on Tools.cpp at #1191 broke compiling on macOS.

```
In file included from ~/Projects/keepassxc/src/core/Tools.cpp:50:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/sys/ptrace.h:99:38: error: unknown type name 'caddr_t'
int     ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
                                         ^
1 error generated.
make[2]: *** [src/CMakeFiles/autotype.dir/core/Tools.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/autotype.dir/all] Error 2
```

## How has this been tested?
Manually

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**