### PR TITLE
Change Unix socket location

### DIFF
--- a/src/browser/NativeMessagingBase.cpp
+++ b/src/browser/NativeMessagingBase.cpp
@@ -134,11 +134,12 @@ void NativeMessagingBase::sendReply(const QString& reply)
 
 QString NativeMessagingBase::getLocalServerPath() const
 {
+    const QString serverPath = "/kpxc_server";
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-    // Use XDG_RUNTIME_DIR instead of /tmp/ if it's available
-    QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + "/kpxc_server";
-    return path.isEmpty() ? "/tmp/kpxc_server" : path;
+    // Use XDG_RUNTIME_DIR instead of /tmp if it's available
+    QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    return path.isEmpty() ? QStandardPaths::writableLocation(QStandardPaths::TempLocation) + serverPath : path + serverPath;
 #else // Q_OS_MAC, Q_OS_WIN and others
-    return QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/kpxc_server";
+    return QStandardPaths::writableLocation(QStandardPaths::TempLocation) + serverPath;
 #endif
 }


### PR DESCRIPTION
Changes socket location for Unix systems.

## Description
Returns XDG_RUNTIME_DIR or TempLocation correctly.

## Motivation and context
Previously the runtime path returned was never empty.

## How has this been tested?
Manually.

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
