### PR TITLE
Implement best matches only option with browser integration

### DIFF
--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -67,7 +67,6 @@ void BrowserOptionDialog::loadSettings()
     // hide unimplemented options
     // TODO: fix this
     m_ui->showNotification->hide();
-    m_ui->bestMatchOnly->hide();
 
     if (settings.sortByUsername()) {
         m_ui->sortByUsername->setChecked(true);

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -533,15 +533,12 @@ QList<Entry*> BrowserService::sortEntries(QList<Entry*>& pwEntries, const QStrin
     // Build map of prioritized entries
     QMultiMap<int, Entry*> priorities;
     for (Entry* entry : pwEntries) {
-        int priority = sortPriority(entry, host, submitUrl, baseSubmitUrl);
-        if (priority > 0) {
-            priorities.insert(priority, entry);
-        }
+        priorities.insert(sortPriority(entry, host, submitUrl, baseSubmitUrl), entry);
     }
 
     QList<Entry*> results;
     QString field = BrowserSettings::sortByTitle() ? "Title" : "UserName";
-    for (int i = 100; i > 0; i -= 5) {
+    for (int i = 100; i >= 0; i -= 5) {
         if (priorities.count(i) > 0) {
             // Sort same priority entries by Title or UserName
             auto entries = priorities.values(i);

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -530,21 +530,33 @@ QList<Entry*> BrowserService::sortEntries(QList<Entry*>& pwEntries, const QStrin
     const QString submitUrl = url.toString(QUrl::StripTrailingSlash);
     const QString baseSubmitUrl = url.toString(QUrl::StripTrailingSlash | QUrl::RemovePath | QUrl::RemoveQuery | QUrl::RemoveFragment);
 
-    QMultiMap<int, const Entry*> priorities;
-    for (const Entry* entry : pwEntries) {
-        priorities.insert(sortPriority(entry, host, submitUrl, baseSubmitUrl), entry);
+    // Build map of prioritized entries
+    QMultiMap<int, Entry*> priorities;
+    for (Entry* entry : pwEntries) {
+        int priority = sortPriority(entry, host, submitUrl, baseSubmitUrl);
+        if (priority > 0) {
+            priorities.insert(priority, entry);
+        }
     }
 
+    QList<Entry*> results;
     QString field = BrowserSettings::sortByTitle() ? "Title" : "UserName";
-    std::sort(pwEntries.begin(), pwEntries.end(), [&priorities, &field](const Entry* left, const Entry* right) {
-        int res = priorities.key(left) - priorities.key(right);
-        if (res == 0) {
-            return QString::localeAwareCompare(left->attributes()->value(field), right->attributes()->value(field)) < 0;
+    for (int i = 100; i > 0; i -= 5) {
+        if (priorities.count(i) > 0) {
+            // Sort same priority entries by Title or UserName
+            auto entries = priorities.values(i);
+            std::sort(entries.begin(), entries.end(), [&priorities, &field](Entry* left, Entry* right) {
+                return QString::localeAwareCompare(left->attributes()->value(field), right->attributes()->value(field)) < 0;
+            });
+            results << entries;
+            if (BrowserSettings::bestMatchOnly() && !pwEntries.isEmpty()) {
+                // Early out once we find the highest batch of matches
+                break;
+            }
         }
-        return res < 0;
-    });
+    }
 
-    return pwEntries;
+    return results;
 }
 
 bool BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm, const QString& url, const QString& host, const QString& submitHost, const QString& realm)

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -32,7 +32,7 @@ public:
 
     static bool showNotification();  //TODO!!
     static void setShowNotification(bool showNotification);
-    static bool bestMatchOnly();     //TODO!!
+    static bool bestMatchOnly();
     static void setBestMatchOnly(bool bestMatchOnly);
     static bool unlockDatabase();
     static void setUnlockDatabase(bool unlockDatabase);
@@ -46,7 +46,7 @@ public:
     static void setAlwaysAllowAccess(bool alwaysAllowAccess);
     static bool alwaysAllowUpdate();
     static void setAlwaysAllowUpdate(bool alwaysAllowUpdate);
-    static bool searchInAllDatabases();//TODO!!
+    static bool searchInAllDatabases();
     static void setSearchInAllDatabases(bool searchInAllDatabases);
     static bool supportKphFields();
     static void setSupportKphFields(bool supportKphFields);


### PR DESCRIPTION
Returning only the best matched entries option hasn't worked properly. This fixes it and only returns entries with sort priority 100.

## Description
It's not perfect but a small improvement. If you can think anything that could improve this PR please let me know.

## Motivation and context
Fixes 
https://github.com/keepassxreboot/keepassxc-browser/issues/84

Fixes #1112

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
 