### PR TITLE
Fix for issue #1010 - Merging always marks the database as dirty

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -404,6 +404,11 @@ void Database::emptyRecycleBin()
 
 void Database::merge(const Database* other)
 {
+    // If root groups are equivalent no need to merge (databases are equivalent)
+    if (*m_rootGroup == *(other->rootGroup())) {
+        return;
+    }
+
     m_rootGroup->merge(other->rootGroup());
 
     for (Uuid customIconId : other->metadata()->customIcons().keys()) {

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -92,6 +92,20 @@ void Entry::setUpdateTimeinfo(bool value)
     m_updateTimeinfo = value;
 }
 
+bool Entry::operator==(const Entry& other) const
+{
+    return (m_data == other.m_data
+            && *(m_attributes) == *(other.m_attributes)
+            && *(m_attachments) == *(other.m_attachments));
+}
+
+bool Entry::operator!=(const Entry& other) const
+{
+    return (m_data != other.m_data
+            || *m_attributes != *(other.m_attributes)
+            || *m_attachments != *(other.m_attachments));
+}
+
 EntryReferenceType Entry::referenceType(const QString& referenceStr)
 {
     const QString referenceLowerStr = referenceStr.toLower();
@@ -838,6 +852,49 @@ QString Entry::referenceFieldValue(EntryReferenceType referenceType) const
         break;
     }
     return QString();
+}
+
+bool EntryData::operator==(const EntryData& other) const
+{
+    bool retVal =
+    (iconNumber == other.iconNumber
+            && customIcon == other.customIcon
+            && foregroundColor == other.foregroundColor
+            && backgroundColor == other.backgroundColor
+            && overrideUrl == other.overrideUrl
+            && tags == other.tags
+            && autoTypeEnabled == other.autoTypeEnabled
+            && autoTypeObfuscation == other.autoTypeObfuscation
+            && defaultAutoTypeSequence == other.defaultAutoTypeSequence
+            && timeInfo == other.timeInfo
+            && totpDigits == other.totpDigits
+            && totpStep == other.totpStep);
+
+    return retVal;
+}
+
+bool EntryData::operator!=(const EntryData& other) const
+{
+    int overrideUrlEquals = overrideUrl.localeAwareCompare(other.overrideUrl);
+    int tagsEquals = tags.localeAwareCompare(other.tags);
+    int defaultAutoEquals = defaultAutoTypeSequence.localeAwareCompare(other.defaultAutoTypeSequence);
+
+    overrideUrlEquals = overrideUrlEquals;
+    tagsEquals = tagsEquals;
+    defaultAutoEquals = defaultAutoEquals;
+
+    return (iconNumber != other.iconNumber
+            || customIcon != other.customIcon
+            || foregroundColor != other.foregroundColor
+            || backgroundColor != other.backgroundColor
+            || (overrideUrl.localeAwareCompare(other.overrideUrl) != 0)
+            || (tags.localeAwareCompare(other.tags) != 0)
+            || autoTypeEnabled != other.autoTypeEnabled
+            || autoTypeObfuscation != other.autoTypeObfuscation
+            || (defaultAutoTypeSequence.localeAwareCompare(other.defaultAutoTypeSequence) != 0)
+            || timeInfo != other.timeInfo
+            || totpDigits != other.totpDigits
+            || totpStep != other.totpStep);
 }
 
 Group* Entry::group()

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -61,6 +61,8 @@ struct EntryData
     TimeInfo timeInfo;
     mutable quint8 totpDigits;
     mutable quint8 totpStep;
+    bool operator==(const EntryData& other) const;
+    bool operator!=(const EntryData& other) const;
 };
 
 class Entry : public QObject
@@ -198,6 +200,9 @@ public:
 
     void setUpdateTimeinfo(bool value);
 
+    bool operator==(const Entry& other) const;
+    bool operator!=(const Entry& other) const;
+    //bool equals(Entry* other);
 signals:
     /**
      * Emitted when a default attribute has been changed.
@@ -215,12 +220,12 @@ private:
     QString resolveMultiplePlaceholdersRecursive(const QString& str, int maxDepth) const;
     QString resolvePlaceholderRecursive(const QString& placeholder, int maxDepth) const;
     QString resolveReferencePlaceholderRecursive(const QString& placeholder, int maxDepth) const;
-    QString referenceFieldValue(EntryReferenceType referenceType) const;
+    QString referenceFieldValue(EntryReferenceType referenceType) const; 
 
     static EntryReferenceType referenceType(const QString& referenceStr);
 
     const Database* database() const;
-    template <class T> bool set(T& property, const T& value);
+    template <class T> bool set(T& property, const T& value);    
 
     Uuid m_uuid;
     EntryData m_data;

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -624,12 +624,15 @@ QString Group::print(bool recursive, int depth)
 
 bool Group::operator==(const Group& other) const
 {
+    if (m_children.size() != other.m_children.size()) {
+        return false;
+    }
+
     if (m_data != other.m_data) {
         return false;
     }
 
-    // Putting the comparison of the leaf nodes first because when we compare children that
-    // are not leaves, this operator will be called as the tree is traversed
+    // Base case for later recursive operator calls
     if (m_children.size() == 0) {
         if (m_entries.size() != other.m_entries.size()) {
             return false;
@@ -640,14 +643,14 @@ bool Group::operator==(const Group& other) const
                 return false;
             }
         }
-    }
-
-    QList<Group*>::const_iterator i, j;
-    for (i = m_children.begin(), j = other.m_children.begin(); i != m_children.end(), j != other.m_children.end(); ++i, ++j) {
-        if (*(*i) == *(*j)) {
-            continue;
-        } else {
-            return false;
+    } else {
+        QList<Group*>::const_iterator i, j;
+        for (i = m_children.begin(), j = other.m_children.begin(); i != m_children.end(), j != other.m_children.end(); ++i, ++j) {
+            if (*(*i) == *(*j)) {
+                continue;
+            } else {
+                return false;
+            }
         }
     }
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -622,6 +622,66 @@ QString Group::print(bool recursive, int depth)
     return response;
 }
 
+bool Group::operator==(const Group& other) const
+{
+    if (m_data != other.m_data) {
+        return false;
+    }
+
+    // Putting the comparison of the leaf nodes first because when we compare children that
+    // are not leaves, this operator will be called as the tree is traversed
+    if (m_children.size() == 0) {
+        if (m_entries.size() != other.m_entries.size()) {
+            return false;
+        }
+        QList<Entry*>::const_iterator i, j;
+        for (i = m_entries.begin(), j = other.m_entries.begin(); i != m_entries.end(), j != other.m_entries.end(); ++i, ++j) {
+            if (*(*i) != *(*j)) {
+                return false;
+            }
+        }
+    }
+
+    QList<Group*>::const_iterator i, j;
+    for (i = m_children.begin(), j = other.m_children.begin(); i != m_children.end(), j != other.m_children.end(); ++i, ++j) {
+        if (*(*i) == *(*j)) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool Group::GroupData::operator==(const GroupData& other) const
+{
+    return (name == other.name
+            && notes == other.notes
+            && iconNumber == other.iconNumber
+            && customIcon == other.customIcon
+            && timeInfo == other.timeInfo
+            && isExpanded == other.isExpanded
+            && defaultAutoTypeSequence == other.defaultAutoTypeSequence
+            && autoTypeEnabled == other.autoTypeEnabled
+            && searchingEnabled == other.searchingEnabled
+            && mergeMode == other.mergeMode);
+}
+
+bool Group::GroupData::operator!=(const GroupData& other) const
+{
+    return (name != other.name
+            || notes != other.notes
+            || iconNumber != other.iconNumber
+            || customIcon != other.customIcon
+            || timeInfo != other.timeInfo
+            || isExpanded != other.isExpanded
+            || defaultAutoTypeSequence != other.defaultAutoTypeSequence
+            || autoTypeEnabled != other.autoTypeEnabled
+            || searchingEnabled != other.searchingEnabled
+            || mergeMode != other.mergeMode);
+}
+
 QList<const Group*> Group::groupsRecursive(bool includeSelf) const
 {
     QList<const Group*> groupList;

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -57,6 +57,8 @@ public:
         Group::TriState autoTypeEnabled;
         Group::TriState searchingEnabled;
         Group::MergeMode mergeMode;
+        bool operator==(const GroupData& other) const;
+        bool operator!=(const GroupData& other) const;
     };
 
     Group();
@@ -140,6 +142,7 @@ public:
     void copyDataFrom(const Group* other);
     void merge(const Group* other);
     QString print(bool recursive = false, int depth = 0);
+    bool operator==(const Group& other) const;
 
 signals:
     void dataChanged(Group* group);

--- a/src/core/TimeInfo.cpp
+++ b/src/core/TimeInfo.cpp
@@ -105,3 +105,23 @@ void TimeInfo::setLocationChanged(const QDateTime& dateTime)
     Q_ASSERT(dateTime.timeSpec() == Qt::UTC);
     m_locationChanged = dateTime;
 }
+
+bool TimeInfo::operator==(const TimeInfo& other) const
+{
+    return (m_lastModificationTime == other.m_lastModificationTime
+            && m_creationTime == other.m_creationTime
+            && m_lastAccessTime == other.m_lastAccessTime
+            && m_expiryTime == other.m_expiryTime
+            && m_expires == other.m_expires
+            && m_locationChanged == other.m_locationChanged);
+}
+
+bool TimeInfo::operator!=(const TimeInfo& other) const
+{
+    return (m_lastModificationTime != other.m_lastModificationTime
+            || m_creationTime != other.m_creationTime
+            || m_lastAccessTime != other.m_lastAccessTime
+            || m_expiryTime != other.m_expiryTime
+            || m_expires != other.m_expires
+            || m_locationChanged != other.m_locationChanged);
+}

--- a/src/core/TimeInfo.h
+++ b/src/core/TimeInfo.h
@@ -40,6 +40,8 @@ public:
     void setExpires(bool expires);
     void setUsageCount(int count);
     void setLocationChanged(const QDateTime& dateTime);
+    bool operator==(const TimeInfo& other) const;
+    bool operator!=(const TimeInfo& other) const;
 
 private:
     QDateTime m_lastModificationTime;

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -19,6 +19,7 @@
 
 #include <QDebug>
 #include <QTest>
+#include <QSignalSpy>
 
 #include "core/Database.h"
 #include "core/Group.h"
@@ -564,6 +565,29 @@ void TestMerge::testResolveGroupConflictOlder()
     delete dbSource;
 }
 
+/**
+  * If identical databases are merged, the modified signal
+  * should not be emitted. If different databases are merged,
+  * the modified signal should be emitted.
+  */
+void TestMerge::testModifiedEmission()
+{
+    Database* dbDestination = createTestDatabase();
+    QSignalSpy spy(dbDestination, SIGNAL(modified()));
+    int spyCount = 0;
+
+    // Identical databases shouldn't emit a modified signal when merged
+    dbDestination->merge(dbDestination);
+    QCOMPARE(spy.count(), spyCount);
+
+    // Different databases should emit a modified signal when merged
+    Database* dbSource = new Database();
+    dbDestination->merge(dbSource);
+    QCOMPARE(spy.count(), spyCount);
+
+    delete dbDestination;
+    delete dbSource;
+}
 
 Database* TestMerge::createTestDatabase()
 {

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -42,7 +42,7 @@ private slots:
     void testUpdateGroupLocation();
     void testMergeAndSync();
     void testMergeCustomIcons();
-
+    void testModifiedEmission();
 private:
     Database* createTestDatabase();
 };


### PR DESCRIPTION
## Description
Added appropriate overloaded comparison operators to determine whether two databases are equivalent, and to not merge them if they are equal.

## Motivation and context
Fixes #1010

## How has this been tested?
Tested using test case described on issue page as well as adding a test under the tests directory.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
