### PR TITLE
Pass TOTP with credential data to KeePassXC-Browser

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -607,6 +607,10 @@ QJsonObject BrowserService::prepareEntry(const Entry* entry)
     res["name"] = entry->resolveMultiplePlaceholders(entry->title());
     res["uuid"] = entry->resolveMultiplePlaceholders(entry->uuid().toHex());
 
+    if (entry->hasTotp()) {
+        res["totp"] = entry->totp();
+    }
+
     if (BrowserSettings::supportKphFields()) {
         const EntryAttributes* attr = entry->attributes();
         QJsonArray stringFields;


### PR DESCRIPTION
When running Set up TOTP a additional KPH attribute for `{TOTP}` is created for browser integration if it doesn't already exist.

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/1652.

## How has this been tested?
Manually.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
