### PR TITLE
Add support for quick unlock with TouchID on Macbook Pro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ option(WITH_XC_NETWORKING "Include networking code (e.g. for downlading website 
 option(WITH_XC_BROWSER "Include browser integration with keepassxc-browser." OFF)
 option(WITH_XC_YUBIKEY "Include YubiKey support." OFF)
 option(WITH_XC_SSHAGENT "Include SSH agent support." OFF)
+if(APPLE)
+  option(WITH_XC_TOUCHID "Include TouchID support for macOS." OFF)
+endif()
 
 if(WITH_XC_ALL)
   # Enable all options
@@ -55,6 +58,9 @@ if(WITH_XC_ALL)
   set(WITH_XC_BROWSER ON)
   set(WITH_XC_YUBIKEY ON)
   set(WITH_XC_SSHAGENT ON)
+  if(APPLE)
+    set(WITH_XC_TOUCHID ON)
+  endif()
 endif()
 
 # Process ui files automatically from source files

--- a/share/translations/keepassx_en_US.ts
+++ b/share/translations/keepassx_en_US.ts
@@ -768,6 +768,14 @@ Please consider generating a new key file.</translation>
         <source>Select key file</source>
         <translation>Select key file</translation>
     </message>
+    <message>
+        <source>authenticate to access the database</source>
+        <translation>authenticate to access the database</translation>
+    </message>
+    <message>
+        <source>authenticate a privileged operation</source>
+        <translation>authenticate a privileged operation</translation>
+    </message>
 </context>
 <context>
     <name>DatabaseRepairWidget</name>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,9 @@ add_feature_info(Networking WITH_XC_NETWORKING "Compile KeePassXC with network a
 add_feature_info(KeePassXC-Browser WITH_XC_BROWSER "Browser integration with KeePassXC-Browser")
 add_feature_info(SSHAgent WITH_XC_SSHAGENT "SSH agent integration compatible with KeeAgent")
 add_feature_info(YubiKey WITH_XC_YUBIKEY "YubiKey HMAC-SHA1 challenge-response")
+if(APPLE)
+    add_feature_info(TouchID WITH_XC_TOUCHID "TouchID integration")
+endif()
 
 set(BROWSER_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/browser)
 add_subdirectory(browser)
@@ -239,6 +242,10 @@ else()
   list(APPEND keepassx_SOURCES keys/drivers/YubiKeyStub.cpp)
 endif()
 
+if(WITH_XC_TOUCHID)
+  list(APPEND keepassx_SOURCES touchid/TouchID.mm)
+endif()
+
 add_library(autotype STATIC ${autotype_SOURCES})
 target_link_libraries(autotype Qt5::Core Qt5::Widgets)
 
@@ -265,6 +272,10 @@ if(APPLE)
     target_link_libraries(keepassx_core "-framework Foundation")
     if(Qt5MacExtras_FOUND)
       target_link_libraries(keepassx_core Qt5::MacExtras)
+    endif()
+    if(WITH_XC_TOUCHID)
+      target_link_libraries(keepassx_core "-framework Security")
+      target_link_libraries(keepassx_core "-framework LocalAuthentication")
     endif()
 endif()
 if (UNIX AND NOT APPLE)
@@ -296,6 +307,11 @@ if(APPLE AND WITH_APP_BUNDLE)
   set_target_properties(${PROGNAME} PROPERTIES
                         MACOSX_BUNDLE ON
                         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_BINARY_DIR}/Info.plist)
+
+  if(WITH_XC_TOUCHID)
+    set_target_properties(${PROGNAME} PROPERTIES 
+                          CPACK_BUNDLE_APPLE_ENTITLEMENTS "${CMAKE_SOURCE_DIR}/share/macosx/keepassxc.entitlements" )
+  endif()
 
   if(QT_MAC_USE_COCOA AND EXISTS "${QT_LIBRARY_DIR}/Resources/qt_menu.nib")
     install(DIRECTORY "${QT_LIBRARY_DIR}/Resources/qt_menu.nib"

--- a/src/config-keepassx.h.cmake
+++ b/src/config-keepassx.h.cmake
@@ -17,6 +17,7 @@
 #cmakedefine WITH_XC_BROWSER
 #cmakedefine WITH_XC_YUBIKEY
 #cmakedefine WITH_XC_SSHAGENT
+#cmakedefine WITH_XC_TOUCHID
 
 #cmakedefine KEEPASSXC_BUILD_TYPE "@KEEPASSXC_BUILD_TYPE@"
 #cmakedefine KEEPASSXC_BUILD_TYPE_RELEASE

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -149,6 +149,9 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/hidepassworddetails", true);
     m_defaults.insert("security/autotypeask", true);
     m_defaults.insert("security/IconDownloadFallbackToGoogle", false);
+    m_defaults.insert("security/resettouchid", false);
+    m_defaults.insert("security/resettouchidtimeout", 30);
+    m_defaults.insert("security/resettouchidscreenlock", true);
     m_defaults.insert("GUI/Language", "system");
     m_defaults.insert("GUI/HideToolbar", false);
     m_defaults.insert("GUI/ShowTrayIcon", false);

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -92,6 +92,9 @@ AboutDialog::AboutDialog(QWidget* parent)
 #ifdef WITH_XC_YUBIKEY
     extensions += "\n- " + tr("YubiKey");
 #endif
+#ifdef WITH_XC_TOUCHID
+    extensions += "\n- " + tr("TouchID");
+#endif
 
     if (extensions.isEmpty())
         extensions = " " + tr("None");

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -10,7 +10,7 @@
     <height>302</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,1,0,0,3">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,1,0,0,0">
    <property name="spacing">
     <number>8</number>
    </property>
@@ -142,7 +142,7 @@
        </item>
       </layout>
      </item>
-     <item row="5" column="2">
+     <item row="2" column="2">
       <layout class="QGridLayout" name="gridLayout_2">
        <property name="leftMargin">
         <number>5</number>
@@ -153,7 +153,7 @@
        <property name="verticalSpacing">
         <number>0</number>
        </property>
-       <item row="1" column="1">
+       <item row="0" column="1">
         <widget class="QPushButton" name="buttonRedetectYubikey">
          <property name="enabled">
           <bool>true</bool>
@@ -163,7 +163,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="0" column="0">
         <widget class="QComboBox" name="comboChallengeResponse">
          <property name="enabled">
           <bool>false</bool>
@@ -179,7 +179,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QProgressBar" name="yubikeyProgress">
          <property name="maximumSize">
           <size>
@@ -203,25 +203,35 @@
        </item>
       </layout>
      </item>
-     <item row="5" column="0">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="spacing">
-        <number>0</number>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="checkChallengeResponse">
+       <property name="enabled">
+        <bool>false</bool>
        </property>
-       <property name="bottomMargin">
-        <number>2</number>
+       <property name="text">
+        <string>Challenge Response:</string>
        </property>
-       <item>
-        <widget class="QCheckBox" name="checkChallengeResponse">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Challenge Response:</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="checkTouchID">
+       <property name="text">
+        <string>Use TouchID for quick unlock</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <spacer name="verticalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -55,6 +55,7 @@
 #include "gui/entry/EntryView.h"
 #include "gui/group/EditGroupWidget.h"
 #include "gui/group/GroupView.h"
+#include "touchid/TouchID.h"
 
 #include "config-keepassx.h"
 
@@ -820,6 +821,9 @@ void DatabaseWidget::updateMasterKey(bool accepted)
     if (accepted) {
         QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
         bool result = m_db->setKey(m_changeMasterKeyWidget->newMasterKey(), true, true);
+#ifdef WITH_XC_TOUCHID
+        TouchID::getInstance().reset(m_filePath);
+#endif
         QApplication::restoreOverrideCursor();
 
         if (!result) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -106,6 +106,7 @@ private slots:
     void hideWindow();
     void toggleWindow();
     void lockDatabasesAfterInactivity();
+    void forgetTouchIDAfterInactivity();
     void repairDatabase();
     void hideTabMessage();
     void handleScreenLock();
@@ -133,6 +134,7 @@ private:
     QActionGroup* m_copyAdditionalAttributeActions;
     QStringList m_openDatabases;
     InactivityTimer* m_inactivityTimer;
+    InactivityTimer* m_touchIDinactivityTimer;
     int m_countDefaultAttributes;
     QSystemTrayIcon* m_trayIcon;
     ScreenLockListener* m_screenLockListener;

--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>595</width>
-    <height>446</height>
+    <height>478</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -61,7 +61,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QCheckBox" name="lockDatabaseIdleCheckBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -74,7 +74,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QSpinBox" name="lockDatabaseIdleSpinBox">
         <property name="enabled">
          <bool>false</bool>
@@ -99,6 +99,35 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="touchIDResetSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="suffix">
+         <string> min</string>
+        </property>
+        <property name="maximum">
+         <number>1440</number>
+        </property>
+        <property name="value">
+         <number>30</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="touchIDResetCheckBox">
+        <property name="text">
+         <string>Forget TouchID after inactivity of</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -116,13 +145,20 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="touchIDResetOnScreenLockCheckBox">
+        <property name="text">
+         <string>Forget TouchID when session is locked or lid is closed</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="lockDatabaseMinimizeCheckBox">
         <property name="text">
          <string>Lock databases after minimizing the window</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item>
        <widget class="QCheckBox" name="relockDatabaseAutoTypeCheckBox">
         <property name="text">
          <string>Re-lock previously locked database after performing Auto-Type</string>

--- a/src/keys/PasswordKey.cpp
+++ b/src/keys/PasswordKey.cpp
@@ -28,6 +28,13 @@ PasswordKey::PasswordKey(const QString& password)
     setPassword(password);
 }
 
+PasswordKey PasswordKey::fromRawKey(const QByteArray& rawKey)
+{
+    PasswordKey result;
+    result.m_key = rawKey;
+    return result;
+}
+
 QByteArray PasswordKey::rawKey() const
 {
     return m_key;

--- a/src/keys/PasswordKey.h
+++ b/src/keys/PasswordKey.h
@@ -31,6 +31,7 @@ public:
     void setPassword(const QString& password);
     PasswordKey* clone() const;
 
+    static PasswordKey fromRawKey(const QByteArray& rawKey);
 private:
     QByteArray m_key;
 };

--- a/src/touchid/TouchID.h
+++ b/src/touchid/TouchID.h
@@ -1,0 +1,55 @@
+#ifndef KEEPASSX_TOUCHID_H
+#define KEEPASSX_TOUCHID_H
+
+#define TOUCHID_UNDEFINED -1
+#define TOUCHID_AVAILABLE 1
+#define TOUCHID_NOT_AVAILABLE 0
+
+#include <QHash>
+#include <QString>
+#include <QByteArray>
+#include <QSharedPointer>
+
+class TouchID
+{
+    public:
+        static TouchID& getInstance();
+
+    private:
+        TouchID() {} // Constructor? (the {} brackets) are needed here.
+
+        // C++ 03
+        // ========
+        // Don't forget to declare these two. You want to make sure they
+        // are unacceptable otherwise you may accidentally get copies of
+        // your singleton appearing.
+
+        // TouchID(TouchID const&); // Don't Implement
+        // void operator=(TouchID const&); // Don't implement
+
+        QHash<QString, QByteArray> m_encryptedMasterKeys;
+        int m_available = TOUCHID_UNDEFINED;
+
+    public:
+        // C++ 11
+        // =======
+        // We can use the better technique of deleting the methods
+        // we don't want.
+
+        TouchID(TouchID const&) = delete;
+        void operator=(TouchID const&) = delete;
+
+        // Note: Scott Meyers mentions in his Effective Modern
+        //       C++ book, that deleted functions should generally
+        //       be public as it results in better error messages
+        //       due to the compilers behavior to check accessibility
+        //       before deleted status
+
+        bool storeKey(const QString& databasePath, const QByteArray& passwordKey);
+        QSharedPointer<QByteArray> getKey(const QString& databasePath) const;
+        bool isAvailable();
+        bool authenticate(const QString& message = "") const;
+        void reset(const QString& databasePath = "");
+};
+
+#endif // KEEPASSX_TOUCHID_H

--- a/src/touchid/TouchID.mm
+++ b/src/touchid/TouchID.mm
@@ -1,0 +1,260 @@
+#define SECURITY_ACCOUNT_PREFIX QString("KeepassXC_TouchID_Keys_")
+
+#include "touchid/TouchID.h"
+
+#include "crypto/Random.h"
+#include "crypto/SymmetricCipher.h"
+#include "crypto/CryptoHash.h"
+
+#include <Foundation/Foundation.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <LocalAuthentication/LocalAuthentication.h>
+#include <Security/Security.h>
+
+#include <QCoreApplication>
+
+inline void debug(const char* message, ...)
+{
+    // qWarning(...);
+}
+
+inline QString hash(const QString& value)
+{
+    QByteArray result = CryptoHash::hash(value.toUtf8(), CryptoHash::Sha256).toHex();
+    return QString(result);
+}
+
+/* Singleton */
+TouchID& TouchID::getInstance()
+{
+    static TouchID instance;    // Guaranteed to be destroyed.
+                                // Instantiated on first use.
+    return instance;
+}
+
+/* Generates a random AES 256bit key and uses it to encrypt the PasswordKey that protects the database. The encrypted PasswordKey is kept in memory while the AES key is stored in the macOS KeyChain protected by TouchID. */
+bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKey)
+{
+    if (databasePath.isEmpty() || passwordKey.isEmpty()) {
+        // illegal arguments
+        debug("TouchID::storeKey - Illegal arguments: databasePath = %s, len(passwordKey) = %d", databasePath.toUtf8().constData(), passwordKey.length());
+        return false;
+    }
+
+    if (this->m_encryptedMasterKeys.contains(databasePath)) {
+        // already stored key for this database
+        debug("TouchID::storeKey - Already stored key for this database");
+        return true;
+    }
+
+    // generate random AES 256bit key and IV
+    Random* random = randomGen();
+    QByteArray randomKey = random->randomArray(32);
+    QByteArray randomIV = random->randomArray(16);
+
+    bool ok;
+    SymmetricCipher aes256Encrypt(SymmetricCipher::Aes256, SymmetricCipher::Cbc, SymmetricCipher::Encrypt);
+
+    if (!aes256Encrypt.init(randomKey, randomIV)) {
+        debug("TouchID::storeKey - Error initializing encryption: %s", aes256Encrypt.errorString().toUtf8().constData());
+        return false;
+    }
+
+    // encrypt and keep result in memory
+    QByteArray encryptedMasterKey = aes256Encrypt.process(passwordKey, &ok);
+    if (!ok) {
+        debug("TouchID::storeKey - Error encrypting: %s", aes256Encrypt.errorString().toUtf8().constData());
+        return false;
+    }
+
+    // memorize which database the stored key is for
+    this->m_encryptedMasterKeys.insert(databasePath, encryptedMasterKey);
+
+    NSString* accountName = (SECURITY_ACCOUNT_PREFIX + hash(databasePath)).toNSString(); // autoreleased
+
+    // try to delete an existing entry
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	
+    CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+    CFDictionarySetValue(query, kSecAttrAccount, (__bridge CFStringRef)accountName);
+    CFDictionarySetValue(query, kSecReturnData, kCFBooleanFalse);
+	
+    // get data from the KeyChain
+    OSStatus status = SecItemDelete(query);  
+
+    debug("TouchID::storeKey - Status deleting existing entry: %d", status);
+
+    // prepare adding secure entry to the macOS KeyChain
+    CFErrorRef error = NULL;
+    SecAccessControlRef sacObject = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                                kSecAttrAccessibleWhenUnlockedThisDeviceOnly, 
+                                                kSecAccessControlTouchIDCurrentSet, // depr: kSecAccessControlBiometryCurrentSet, 
+                                                &error);
+
+    if (sacObject == NULL || error != NULL) {
+        NSError* e = (__bridge NSError*) error;
+        debug("TouchID::storeKey - Error creating security flags: %s", e.localizedDescription.UTF8String);
+        return false;
+    }
+
+    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	
+    // prepare data (key) to be stored
+    QByteArray dataBytes = (randomKey + randomIV).toHex();
+
+    CFDataRef valueData = CFDataCreateWithBytesNoCopy(NULL, reinterpret_cast<UInt8*>(dataBytes.data()), dataBytes.length(), NULL);
+
+    CFDictionarySetValue(attributes, kSecClass, kSecClassGenericPassword);
+    CFDictionarySetValue(attributes, kSecAttrAccount, (__bridge CFStringRef)accountName);
+    CFDictionarySetValue(attributes, kSecValueData, valueData);
+    CFDictionarySetValue(attributes, kSecAttrSynchronizable, kCFBooleanFalse);
+    CFDictionarySetValue(attributes, kSecUseAuthenticationUI, kSecUseAuthenticationUIAllow);
+    CFDictionarySetValue(attributes, kSecAttrAccessControl, sacObject);
+
+    // add to KeyChain
+    status =  SecItemAdd(attributes, NULL);
+
+    debug("TouchID::storeKey - Status adding new entry: %d", status); // read w/ e.g. "security error -50" in shell
+
+    CFRelease(sacObject);
+    CFRelease(attributes);
+
+    if (status != errSecSuccess) {
+        debug("TouchID::storeKey - Not successful, resetting TouchID");
+        this->m_encryptedMasterKeys.remove(databasePath);
+        return false;
+    }
+
+    return true;
+}
+
+/* Checks if an encrypted PasswordKey is available for the given database, tries to decrypt it using the KeyChain and if successful, returns it. */
+QSharedPointer<QByteArray> TouchID::getKey(const QString& databasePath) const
+{
+    if (databasePath.isEmpty()) {
+        // illegal arguments
+        debug("TouchID::storeKey - Illegal argument: databasePath = %s", databasePath.toUtf8().constData());
+        return NULL;
+    }
+
+    // checks if encrypted PasswordKey is available and is stored for the given database
+    if (!this->m_encryptedMasterKeys.contains(databasePath)) {
+        debug("TouchID::getKey - No stored key found");
+        return NULL;
+    }
+    
+    // query the KeyChain for the AES key
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	
+    NSString* accountName = (SECURITY_ACCOUNT_PREFIX + hash(databasePath)).toNSString(); // autoreleased
+    NSString* touchPromptMessage = QCoreApplication::translate("DatabaseOpenWidget", "authenticate to access the database").toNSString(); // autoreleased
+
+    CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+    CFDictionarySetValue(query, kSecAttrAccount, (__bridge CFStringRef)accountName);
+    CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
+    CFDictionarySetValue(query, kSecUseOperationPrompt, (__bridge CFStringRef)touchPromptMessage);
+	
+    // get data from the KeyChain
+    CFTypeRef dataTypeRef = NULL;
+    OSStatus status = SecItemCopyMatching(query, &dataTypeRef);  
+    CFRelease(query);
+
+    if (status == errSecUserCanceled) {
+        // user canceled the authentication, need special return value
+        debug("TouchID::getKey - User canceled authentication");
+        return QSharedPointer<QByteArray>::create();
+    } else if (status != errSecSuccess || dataTypeRef == NULL) {
+        debug("TouchID::getKey - Error retrieving result: %d", status);
+        return NULL;
+    }
+
+    CFDataRef valueData = static_cast<CFDataRef>(dataTypeRef);
+    QByteArray dataBytes = QByteArray::fromHex(QByteArray(reinterpret_cast<const char*>(CFDataGetBytePtr(valueData)), CFDataGetLength(valueData)));
+    CFRelease(valueData);
+    
+    // extract AES key and IV from data bytes
+    QByteArray key = dataBytes.left(32);
+    QByteArray iv = dataBytes.right(16);
+
+    bool ok;
+    SymmetricCipher aes256Decrypt(SymmetricCipher::Aes256, SymmetricCipher::Cbc, SymmetricCipher::Decrypt);
+
+    if (!aes256Decrypt.init(key, iv)) {
+        debug("TouchID::getKey - Error initializing decryption: %s", aes256Decrypt.errorString().toUtf8().constData());
+        return NULL;
+    }
+
+    // decrypt PasswordKey from memory using AES
+    QByteArray result = aes256Decrypt.process(this->m_encryptedMasterKeys[databasePath], &ok);
+    if (!ok) {
+        debug("TouchID::getKey - Error decryption: %s", aes256Decrypt.errorString().toUtf8().constData());
+        return NULL;
+    }
+
+    return QSharedPointer<QByteArray>::create(result);
+}
+
+/* Dynamic check if TouchID is available on the current machine. */
+bool TouchID::isAvailable()
+{
+    // cache result
+    if (this->m_available != TOUCHID_UNDEFINED)
+        return (this->m_available == TOUCHID_AVAILABLE);
+
+    @try {
+        LAContext* context = [[LAContext alloc] init];
+        bool canAuthenticate = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil];
+        [context release];
+        this->m_available = canAuthenticate ? TOUCHID_AVAILABLE : TOUCHID_NOT_AVAILABLE;
+        return canAuthenticate;
+    }
+    @catch(NSException*) {
+        this->m_available = TOUCHID_NOT_AVAILABLE;
+        return false;
+    }
+}
+
+typedef enum {
+    kTouchIDResultNone,
+    kTouchIDResultAllowed,
+    kTouchIDResultFailed
+} TouchIDResult;
+
+/* Performs a simple authentication using TouchID. */
+bool TouchID::authenticate(const QString& message) const
+{
+    // message must not be an empty string
+    QString msg = message;
+    if (message.length() == 0)
+        msg = QCoreApplication::translate("DatabaseOpenWidget", "authenticate a privileged operation");
+    
+    @try {
+        LAContext* context = [[LAContext alloc] init];
+        __block TouchIDResult result = kTouchIDResultNone;
+        NSString* authMessage = msg.toNSString(); // autoreleased
+        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:authMessage reply:^(BOOL success, NSError* error) {
+            result = success ? kTouchIDResultAllowed : kTouchIDResultFailed;
+            CFRunLoopWakeUp(CFRunLoopGetCurrent());
+        }];
+        
+        while (result == kTouchIDResultNone)
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
+        
+        [context release];
+        return result == kTouchIDResultAllowed;
+    }
+    @catch(NSException*) {
+        return false;
+    }
+}
+
+/* Resets the inner state either for all or for the given database */
+void TouchID::reset(const QString& databasePath)
+{
+    if (databasePath.isEmpty()) {
+        this->m_encryptedMasterKeys.clear();
+        return;
+    }
+
+    this->m_encryptedMasterKeys.remove(databasePath);
+}


### PR DESCRIPTION
## Description
Unlock your database using TouchID on supported Macbook Pro models.

## Motivation and context
With quick unlock one can simply unlock the database using TouchID without having to enter your password again while the application is still running. #209 

### Features
- TouchID is a option that can be activated on the unlock screen
- TouchID is only used for **temporary quick unlock**
  - Database has to be unlocked once after restart of the application in order to activate quick unlock using TouchID
- TouchID quick unlock **only replaces the password** part of the unlock process
  - With quick unlock activated the password will be encrypted (AES 256) and then kept in memory
  - The random encryption key (and IV) will be protected by the KeyChain using TouchID
- Next time you don't need to enter your password, just press "OK" to unlock your database with TouchID (however you will still need your additional database key, Yubikey, ...)

### Compilation
- Use `-DWITH_XC_TOUCHID=ON`
- Needs code-signature and entitlements in order to work (see issue reference)

### Possible future enhancements:
- Provide abstraction layer for other OS/fingerprint reader.
- Unlock with just putting on fingerprint w/o actively having to click unlock (KeyChain API may not allow this).
- Indicate if TouchID is currently active (i.e. no password is needed)
  - e.g. show special button on TouchBar

## How has this been tested?
- So far only manually on MBP with TouchID.

## Screenshots:
![image](https://user-images.githubusercontent.com/832938/43405877-300f9690-941b-11e8-9689-9a423f534707.png)

![image](https://user-images.githubusercontent.com/832938/43405880-34ad771c-941b-11e8-9d1a-4606f4fa0f22.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
