### PR TITLE
Fix Windows build with socket size

### DIFF
--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -55,4 +55,7 @@ if(WITH_XC_BROWSER)
                            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
                            COMMENT "Changing linking of keepassxc-proxy")
     endif()
+    if(MINGW)
+      target_link_libraries(keepassxc-proxy Wtsapi32.lib Ws2_32.lib)
+    endif()
 endif()

--- a/src/proxy/NativeMessagingHost.cpp
+++ b/src/proxy/NativeMessagingHost.cpp
@@ -18,6 +18,10 @@
 #include <QCoreApplication>
 #include "NativeMessagingHost.h"
 
+#ifdef Q_OS_WIN
+#include <Winsock2.h>
+#endif
+
 NativeMessagingHost::NativeMessagingHost() : NativeMessagingBase()
 {
     m_localSocket = new QLocalSocket();
@@ -27,7 +31,7 @@ NativeMessagingHost::NativeMessagingHost() : NativeMessagingBase()
     int socketDesc = m_localSocket->socketDescriptor();
     if (socketDesc) {
         int max = NATIVE_MSG_MAX_LENGTH;
-        setsockopt(socketDesc, SOL_SOCKET, SO_SNDBUF, &max, sizeof(max));
+        setsockopt(socketDesc, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<char*>(&max), sizeof(max));
     }
 #ifdef Q_OS_WIN
     m_running.store(true);


### PR DESCRIPTION
Fixes Windows build of https://github.com/keepassxreboot/keepassxc/pull/1720.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
