### PR TITLE
Disable merge button when db is locked.

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -423,8 +423,20 @@ void MainWindow::openDatabase(const QString& fileName, const QString& pw, const 
 void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
 {
     int currentIndex = m_ui->stackedWidget->currentIndex();
+
     bool inDatabaseTabWidget = (currentIndex == DatabaseTabScreen);
     bool inWelcomeWidget = (currentIndex == WelcomeScreen);
+    bool inDatabaseTabWidgetOrWelcomeWidget = inDatabaseTabWidget || inWelcomeWidget;
+
+    m_ui->actionDatabaseMerge->setEnabled(inDatabaseTabWidget);
+
+    m_ui->actionDatabaseNew->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
+    m_ui->actionDatabaseOpen->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
+    m_ui->menuRecentDatabases->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
+    m_ui->menuImport->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
+    m_ui->actionRepairDatabase->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
+
+    m_ui->actionLockDatabases->setEnabled(m_ui->tabWidget->hasLockableDatabases());
 
     if (inDatabaseTabWidget && m_ui->tabWidget->currentIndex() != -1) {
         DatabaseWidget* dbWidget = m_ui->tabWidget->currentDatabaseWidget();
@@ -536,16 +548,6 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
 
         m_searchWidgetAction->setEnabled(false);
     }
-
-    bool inDatabaseTabWidgetOrWelcomeWidget = inDatabaseTabWidget || inWelcomeWidget;
-    m_ui->actionDatabaseNew->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
-    m_ui->actionDatabaseOpen->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
-    m_ui->menuRecentDatabases->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
-    m_ui->menuImport->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
-    m_ui->actionDatabaseMerge->setEnabled(inDatabaseTabWidget);
-    m_ui->actionRepairDatabase->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
-
-    m_ui->actionLockDatabases->setEnabled(m_ui->tabWidget->hasLockableDatabases());
 
     if ((currentIndex == PasswordGeneratorScreen) != m_ui->actionPasswordGenerator->isChecked()) {
         bool blocked = m_ui->actionPasswordGenerator->blockSignals(true);

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1042,6 +1042,11 @@ void TestGui::testDatabaseLocking()
 
     QCOMPARE(m_tabWidget->tabText(0).remove('&'), origDbName + " [locked]");
 
+    QAction* actionDatabaseMerge = m_mainWindow->findChild<QAction*>("actionDatabaseMerge", Qt::FindChildrenRecursively);
+    QCOMPARE(actionDatabaseMerge->isEnabled(), false);
+    QAction* actionDatabaseSave = m_mainWindow->findChild<QAction*>("actionDatabaseSave", Qt::FindChildrenRecursively);
+    QCOMPARE(actionDatabaseSave->isEnabled(), false);
+
     QWidget* dbWidget = m_tabWidget->currentDatabaseWidget();
     QWidget* unlockDatabaseWidget = dbWidget->findChild<QWidget*>("unlockDatabaseWidget");
     QWidget* editPassword = unlockDatabaseWidget->findChild<QLineEdit*>("editPassword");
@@ -1051,6 +1056,9 @@ void TestGui::testDatabaseLocking()
     QTest::keyClick(editPassword, Qt::Key_Enter);
 
     QCOMPARE(m_tabWidget->tabText(0).remove('&'), origDbName);
+
+    actionDatabaseMerge = m_mainWindow->findChild<QAction*>("actionDatabaseMerge", Qt::FindChildrenRecursively);
+    QCOMPARE(actionDatabaseMerge->isEnabled(), true);
 }
 
 void TestGui::testDragAndDropKdbxFiles()


### PR DESCRIPTION
Related to https://github.com/keepassxreboot/keepassxc/issues/1875

## Description
This patch disables the merge button when the current database is locked.

## Motivation and context
Attempting to merge the database when the db is locked can cause database corruption, as stated in https://github.com/keepassxreboot/keepassxc/issues/1875

## How has this been tested?
Locally. Had a hard time writing unit tests for the GUI.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
