### PR TITLE
Add check to see if merging is required

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -403,10 +403,12 @@ void Database::merge(const Database* other)
     }
 
     if (wasModified) {
-        qInfo("Database was modified during merge operation.");
+        // FIXME use qInfo when available (QT5.5).
+        qDebug("Database was modified during merge operation.");
         emit modified();
     } else {
-        qInfo("Database was not modified during merge operation.");
+        // FIXME use qInfo when available (QT5.5).
+        qDebug("Database was not modified during merge operation.");
     }
 }
 

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -391,15 +391,15 @@ void Database::merge(const Database* other)
     for (const QUuid& customIconId : other->metadata()->customIcons().keys()) {
         QImage customIcon = other->metadata()->customIcon(customIconId);
         if (!this->metadata()->containsCustomIcon(customIconId)) {
-            wasModified = true;
             qDebug() << QString("Adding custom icon %1 to database.").arg(customIconId.toString());
             this->metadata()->addCustomIcon(customIconId, customIcon);
+            wasModified = true;
         }
     }
 
     if (m_rootGroup->needsMerging(other->rootGroup())) {
-        wasModified = true;
         m_rootGroup->merge(other->rootGroup());
+        wasModified = true;
     }
 
     if (wasModified) {

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -710,6 +710,10 @@ bool Group::needsMerging(const Group* otherGroup)
         if (timeExisting < timeOther) {
             return true;
         }
+
+        if (timeExisting != timeOther && mergeMode() == KeepBoth) {
+            return true;
+        }
     }
 
     // detect changes in groups
@@ -731,7 +735,9 @@ bool Group::needsMerging(const Group* otherGroup)
             return true;
         }
 
-        return this->needsMerging(otherGroup);
+        if (this->needsMerging(otherGroup)) {
+            return true;
+        }
     }
     return false;
 };

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -153,6 +153,7 @@ public:
                  CloneFlags groupFlags = DefaultCloneFlags) const;
 
     void copyDataFrom(const Group* other);
+    bool needsMerging(const Group* other);
     void merge(const Group* other);
     QString print(bool recursive = false, int depth = 0);
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -27,6 +27,7 @@
 #include "core/CustomData.h"
 #include "core/Database.h"
 #include "core/Entry.h"
+#include "core/Global.h"
 #include "core/TimeInfo.h"
 
 class Group : public QObject

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -27,7 +27,6 @@
 #include "core/CustomData.h"
 #include "core/Database.h"
 #include "core/Entry.h"
-#include "core/Global.h"
 #include "core/TimeInfo.h"
 
 class Group : public QObject

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -569,7 +569,7 @@ void TestMerge::testNeedsMergingNotModified()
     QVERIFY(!dbDestination->rootGroup()->needsMerging(dbSource->rootGroup()));
 }
 
-void TestMerge::testNeedsMergingModified()
+void TestMerge::testNeedsMergingEntryModified()
 {
     Database* dbSource = createTestDatabase();
 
@@ -581,6 +581,22 @@ void TestMerge::testNeedsMergingModified()
 
     Entry* entry = dbSource->rootGroup()->findEntry("entry1");
     entry->setTitle("new title");
+
+    QVERIFY(dbDestination->rootGroup()->needsMerging(dbSource->rootGroup()));
+}
+
+void TestMerge::testNeedsMergingGroupModified()
+{
+    Database* dbSource = createTestDatabase();
+
+    Database* dbDestination = new Database();
+    dbDestination->setRootGroup(dbSource->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
+
+    // Make sure the two changes have a different timestamp.
+    QTest::qSleep(1);
+
+    Group* group = dbSource->rootGroup()->findChildByName("group2");
+    group->setName("new group name");
 
     QVERIFY(dbDestination->rootGroup()->needsMerging(dbSource->rootGroup()));
 }

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -569,6 +569,22 @@ void TestMerge::testNeedsMergingNotModified()
     QVERIFY(!dbDestination->rootGroup()->needsMerging(dbSource->rootGroup()));
 }
 
+void TestMerge::testNeedsMergingModified()
+{
+    Database* dbSource = createTestDatabase();
+
+    Database* dbDestination = new Database();
+    dbDestination->setRootGroup(dbSource->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
+
+    // Make sure the two changes have a different timestamp.
+    QTest::qSleep(1);
+
+    Entry* entry = dbSource->rootGroup()->findEntry("entry1");
+    entry->setTitle("new title");
+
+    QVERIFY(dbDestination->rootGroup()->needsMerging(dbSource->rootGroup()));
+}
+
 Database* TestMerge::createTestDatabase()
 {
     Database* db = new Database();

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -559,6 +559,16 @@ void TestMerge::testResolveGroupConflictOlder()
     delete dbSource;
 }
 
+void TestMerge::testNeedsMergingNotModified()
+{
+    Database* dbSource = createTestDatabase();
+
+    Database* dbDestination = new Database();
+    dbDestination->setRootGroup(dbSource->rootGroup()->clone(Entry::CloneNoFlags, Group::CloneIncludeEntries));
+
+    QVERIFY(!dbDestination->rootGroup()->needsMerging(dbSource->rootGroup()));
+}
+
 Database* TestMerge::createTestDatabase()
 {
     Database* db = new Database();

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -42,6 +42,7 @@ private slots:
     void testUpdateGroupLocation();
     void testMergeAndSync();
     void testMergeCustomIcons();
+    void testNeedsMergingNotModified();
 
 private:
     Database* createTestDatabase();

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -43,7 +43,8 @@ private slots:
     void testMergeAndSync();
     void testMergeCustomIcons();
     void testNeedsMergingNotModified();
-    void testNeedsMergingModified();
+    void testNeedsMergingEntryModified();
+    void testNeedsMergingGroupModified();
 
 private:
     Database* createTestDatabase();

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -42,6 +42,8 @@ private slots:
     void testUpdateGroupLocation();
     void testMergeAndSync();
     void testMergeCustomIcons();
+    void testMergeNotModified();
+    void testMergeModified();
     void testNeedsMergingNotModified();
     void testNeedsMergingEntryModified();
     void testNeedsMergingGroupModified();

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -43,6 +43,7 @@ private slots:
     void testMergeAndSync();
     void testMergeCustomIcons();
     void testNeedsMergingNotModified();
+    void testNeedsMergingModified();
 
 private:
     Database* createTestDatabase();


### PR DESCRIPTION
Add a function to detect when merging is needed.

@mbilloo This is what I had in mind when filing 
https://github.com/keepassxreboot/keepassxc/issues/1010

I think @droidmonkey would like to have your deep comparison operator from https://github.com/keepassxreboot/keepassxc/pull/1836 merged nonetheless. Can you open a new PR
for that?

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/1010

## How has this been tested?
Locally + unit tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
