### PR TITLE
Lower after unlock request from KeePassXC-Browser

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -47,7 +47,8 @@ static int        KEEPASSXCBROWSER_DEFAULT_ICON = 1;
 
 BrowserService::BrowserService(DatabaseTabWidget* parent) :
     m_dbTabWidget(parent),
-    m_dialogActive(false)
+    m_dialogActive(false),
+    m_bringToFrontRequested(false)
 {
     connect(m_dbTabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), this, SLOT(databaseLocked(DatabaseWidget*)));
     connect(m_dbTabWidget, SIGNAL(databaseUnlocked(DatabaseWidget*)), this, SLOT(databaseUnlocked(DatabaseWidget*)));
@@ -82,6 +83,7 @@ bool BrowserService::openDatabase(bool triggerUnlock)
 
     if (triggerUnlock) {
         KEEPASSXC_MAIN_WINDOW->bringToFront();
+        m_bringToFrontRequested = true;
     }
 
     return false;
@@ -743,6 +745,10 @@ void BrowserService::databaseLocked(DatabaseWidget* dbWidget)
 void BrowserService::databaseUnlocked(DatabaseWidget* dbWidget)
 {
     if (dbWidget) {
+        if (m_bringToFrontRequested) {
+            KEEPASSXC_MAIN_WINDOW->lower();
+            m_bringToFrontRequested = false;
+        }
         emit databaseUnlocked();
     }
 }

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -78,6 +78,7 @@ private:
 private:
     DatabaseTabWidget* const    m_dbTabWidget;
     bool                        m_dialogActive;
+    bool                        m_bringToFrontRequested;
 };
 
 #endif // BROWSERSERVICE_H


### PR DESCRIPTION
If an unlock request has been sent by KeePassXC-Browser lower the KeePassXC main window after unlock.

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/1715

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
