### PR TITLE
Disable STDIN listening when not needed

### DIFF
--- a/src/browser/NativeMessagingBase.cpp
+++ b/src/browser/NativeMessagingBase.cpp
@@ -36,14 +36,16 @@
 #include <io.h>
 #endif
 
-NativeMessagingBase::NativeMessagingBase()
+NativeMessagingBase::NativeMessagingBase(const bool enabled)
 {
 #ifdef Q_OS_WIN
     _setmode(_fileno(stdin), _O_BINARY);
     _setmode(_fileno(stdout), _O_BINARY);
 #else
-    m_notifier.reset(new QSocketNotifier(fileno(stdin), QSocketNotifier::Read, this));
-    connect(m_notifier.data(), SIGNAL(activated(int)), this, SLOT(newNativeMessage()));
+    if (enabled) {
+        m_notifier.reset(new QSocketNotifier(fileno(stdin), QSocketNotifier::Read, this));
+        connect(m_notifier.data(), SIGNAL(activated(int)), this, SLOT(newNativeMessage()));
+    }
 #endif
 }
 

--- a/src/browser/NativeMessagingBase.h
+++ b/src/browser/NativeMessagingBase.h
@@ -44,7 +44,7 @@ class NativeMessagingBase : public QObject
     Q_OBJECT
 
 public:
-    explicit NativeMessagingBase();
+    explicit NativeMessagingBase(const bool enabled);
     ~NativeMessagingBase() = default;
 
 protected slots:

--- a/src/browser/NativeMessagingHost.cpp
+++ b/src/browser/NativeMessagingHost.cpp
@@ -27,8 +27,8 @@
 #include <Winsock2.h>
 #endif
 
-NativeMessagingHost::NativeMessagingHost(DatabaseTabWidget* parent) :
-    NativeMessagingBase(),
+NativeMessagingHost::NativeMessagingHost(DatabaseTabWidget* parent, const bool enabled) :
+    NativeMessagingBase(enabled),
     m_mutex(QMutex::Recursive),
     m_browserClients(m_browserService),
     m_browserService(parent)
@@ -76,6 +76,11 @@ void NativeMessagingHost::run()
     if (BrowserSettings::supportBrowserProxy()) {
         QString serverPath = getLocalServerPath();
         QFile::remove(serverPath);
+
+        // Ensure that STDIN is not being listened when proxy is used
+        if (m_notifier->isEnabled()) {
+            m_notifier->setEnabled(false);
+        }
 
         if (m_localServer->isListening()) {
             m_localServer->close();

--- a/src/browser/NativeMessagingHost.h
+++ b/src/browser/NativeMessagingHost.h
@@ -31,7 +31,7 @@ class NativeMessagingHost : public NativeMessagingBase
     typedef QList<QLocalSocket*> SocketList;
 
 public:
-    explicit    NativeMessagingHost(DatabaseTabWidget* parent = 0);
+    explicit    NativeMessagingHost(DatabaseTabWidget* parent = 0, const bool enabled = false);
     ~NativeMessagingHost();
     int         init();
     void        run();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -117,7 +117,7 @@ class BrowserPlugin: public ISettingsPage
 {
     public:
         BrowserPlugin(DatabaseTabWidget* tabWidget) {
-            m_nativeMessagingHost = QSharedPointer<NativeMessagingHost>(new NativeMessagingHost(tabWidget));
+            m_nativeMessagingHost = QSharedPointer<NativeMessagingHost>(new NativeMessagingHost(tabWidget, BrowserSettings::isEnabled()));
         }
 
         ~BrowserPlugin() {

--- a/src/proxy/NativeMessagingHost.cpp
+++ b/src/proxy/NativeMessagingHost.cpp
@@ -22,7 +22,7 @@
 #include <Winsock2.h>
 #endif
 
-NativeMessagingHost::NativeMessagingHost() : NativeMessagingBase()
+NativeMessagingHost::NativeMessagingHost() : NativeMessagingBase(true)
 {
     m_localSocket = new QLocalSocket();
     m_localSocket->connectToServer(getLocalServerPath());


### PR DESCRIPTION
STDIN is being listened even if the browser integration is disabled.

## Description
Enables the listening by default for keepassxc-proxy, but for KeePassXC the STDIN will be listened only if proxy is disabled.

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/1574.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**