### PR TITLE
Remove resolving placeholders for notes

### DIFF
--- a/src/gui/DetailsWidget.cpp
+++ b/src/gui/DetailsWidget.cpp
@@ -198,7 +198,7 @@ void DetailsWidget::updateEntryNotesTab()
     Q_ASSERT(m_currentEntry);
     const QString notes = m_currentEntry->notes();
     setTabEnabled(m_ui->entryTabWidget, m_ui->entryNotesTab, !notes.isEmpty());
-    m_ui->entryNotesEdit->setText(m_currentEntry->resolveMultiplePlaceholders(notes));
+    m_ui->entryNotesEdit->setText(notes);
 }
 
 void DetailsWidget::updateEntryAttributesTab()

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -185,7 +185,7 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return result;
         case Notes:
             // Display only first line of notes in simplified format
-            result = entry->resolveMultiplePlaceholders(entry->notes().section("\n", 0, 0).simplified());
+            result = entry->notes().section("\n", 0, 0).simplified();
             if (attr->isReference(EntryAttributes::NotesKey)) {
                 result.prepend(tr("Ref: ", "Reference abbreviation"));
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #1812 

Do not resolve placeholders in notes. This is not a desirable behavior since notes are meant to be explicit and should not interpret placeholders. Also prevents inadvertent spillage of passwords.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
