### PR TITLE
Configurable global autotype start delay

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -220,7 +220,7 @@ void AutoType::executeAutoTypeActions(const Entry* entry, QWidget* hideWindow, c
 #endif
     }
 
-    Tools::wait(m_plugin->initialTimeout());
+    Tools::wait(qMax(100, config()->get("AutoTypeStartDelay", 500).toInt()));
 
     if (!window) {
         window = m_plugin->activeWindow();
@@ -365,7 +365,7 @@ bool AutoType::parseActions(const QString& actionSequence, const Entry* entry, Q
 {
     QString tmpl;
     bool inTmpl = false;
-    m_autoTypeDelay = config()->get("AutoTypeDelay").toInt();
+    m_autoTypeDelay = qMax(config()->get("AutoTypeDelay").toInt(), 0);
 
     QString sequence = actionSequence;
     sequence.replace("{{}", "{LEFTBRACE}");

--- a/src/autotype/AutoTypePlatformPlugin.h
+++ b/src/autotype/AutoTypePlatformPlugin.h
@@ -33,7 +33,6 @@ public:
     virtual bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) = 0;
     virtual void unregisterGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) = 0;
     virtual int platformEventFilter(void* event) = 0;
-    virtual int initialTimeout() = 0;
     virtual bool raiseWindow(WId window) = 0;
     virtual void unload() {}
 

--- a/src/autotype/mac/AutoTypeMac.cpp
+++ b/src/autotype/mac/AutoTypeMac.cpp
@@ -154,11 +154,6 @@ AutoTypeExecutor* AutoTypePlatformMac::createExecutor()
     return new AutoTypeExecutorMac(this);
 }
 
-int AutoTypePlatformMac::initialTimeout()
-{
-    return 500;
-}
-
 //
 // Activate window by process id
 //

--- a/src/autotype/mac/AutoTypeMac.h
+++ b/src/autotype/mac/AutoTypeMac.h
@@ -42,7 +42,6 @@ public:
     bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) override;
     void unregisterGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) override;
     int platformEventFilter(void* event) override;
-    int initialTimeout() override;
     bool raiseWindow(WId pid) override;
     AutoTypeExecutor* createExecutor() override;
 

--- a/src/autotype/test/AutoTypeTest.cpp
+++ b/src/autotype/test/AutoTypeTest.cpp
@@ -103,11 +103,6 @@ void AutoTypePlatformTest::addActionKey(AutoTypeKey* action)
     m_actionChars.append(keyToString(action->key));
 }
 
-int AutoTypePlatformTest::initialTimeout()
-{
-    return 0;
-}
-
 bool AutoTypePlatformTest::raiseWindow(WId window)
 {
     Q_UNUSED(window);

--- a/src/autotype/test/AutoTypeTest.h
+++ b/src/autotype/test/AutoTypeTest.h
@@ -42,7 +42,6 @@ public:
     bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) override;
     void unregisterGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) override;
     int platformEventFilter(void* event) override;
-    int initialTimeout() override;
     bool raiseWindow(WId window) override;
     AutoTypeExecutor* createExecutor() override;
 

--- a/src/autotype/windows/AutoTypeWindows.cpp
+++ b/src/autotype/windows/AutoTypeWindows.cpp
@@ -109,11 +109,6 @@ AutoTypeExecutor* AutoTypePlatformWin::createExecutor()
     return new AutoTypeExecutorWin(this);
 }
 
-int AutoTypePlatformWin::initialTimeout()
-{
-    return 500;
-}
-
 //
 // Set foreground window
 //

--- a/src/autotype/windows/AutoTypeWindows.h
+++ b/src/autotype/windows/AutoTypeWindows.h
@@ -39,7 +39,6 @@ public:
     bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) override;
     void unregisterGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) override;
     int platformEventFilter(void* event) override;
-    int initialTimeout() override;
     bool raiseWindow(WId window) override;
     AutoTypeExecutor* createExecutor() override;
 

--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -844,12 +844,6 @@ void AutoTypeExecutorX11::execClearField(AutoTypeClearField* action = nullptr)
     nanosleep(&ts, nullptr);
 }
 
-
-int AutoTypePlatformX11::initialTimeout()
-{
-    return 500;
-}
-
 bool AutoTypePlatformX11::raiseWindow(WId window)
 {
     if (m_atomNetActiveWindow == None) {

--- a/src/autotype/xcb/AutoTypeXCB.h
+++ b/src/autotype/xcb/AutoTypeXCB.h
@@ -51,7 +51,6 @@ public:
     bool registerGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) override;
     void unregisterGlobalShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers) override;
     int platformEventFilter(void* event) override;
-    int initialTimeout() override;
     bool raiseWindow(WId window) override;
     AutoTypeExecutor* createExecutor() override;
 

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -135,6 +135,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("AutoTypeEntryTitleMatch", true);
     m_defaults.insert("AutoTypeEntryURLMatch", true);
     m_defaults.insert("AutoTypeDelay", 25);
+    m_defaults.insert("AutoTypeStartDelay", 500);
     m_defaults.insert("UseGroupIconOnEntryCreation", true);
     m_defaults.insert("IgnoreGroupExpansion", true);
     m_defaults.insert("security/clearclipboard", true);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -152,6 +152,7 @@ void SettingsWidget::loadSettings()
         }
         m_generalUi->autoTypeShortcutWidget->setAttribute(Qt::WA_MacShowFocusRect, true);
         m_generalUi->autoTypeDelaySpinBox->setValue(config()->get("AutoTypeDelay").toInt());
+        m_generalUi->autoTypeStartDelaySpinBox->setValue(config()->get("AutoTypeStartDelay").toInt());
     }
 
 
@@ -227,6 +228,7 @@ void SettingsWidget::saveSettings()
         config()->set("GlobalAutoTypeModifiers",
                       static_cast<int>(m_generalUi->autoTypeShortcutWidget->modifiers()));
         config()->set("AutoTypeDelay", m_generalUi->autoTypeDelaySpinBox->value());
+        config()->set("AutoTypeStartDelay", m_generalUi->autoTypeStartDelaySpinBox->value());
     }
     config()->set("security/clearclipboard", m_secUi->clearClipboardCheckBox->isChecked());
     config()->set("security/clearclipboardtimeout", m_secUi->clearClipboardSpinBox->value());

--- a/src/gui/SettingsWidgetGeneral.ui
+++ b/src/gui/SettingsWidgetGeneral.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="generalSettingsTabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabGeneral">
       <attribute name="title">
@@ -404,7 +404,7 @@
           <number>10</number>
          </property>
          <item row="1" column="0">
-          <widget class="QLabel" name="autoTypeShortcutLabel_2">
+          <widget class="QLabel" name="autoTypeShortcutLabel">
            <property name="text">
             <string>Global Auto-Type shortcut</string>
            </property>
@@ -420,14 +420,14 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="autoTypeDelayLabel_2">
+         <item row="3" column="0">
+          <widget class="QLabel" name="autoTypeDelayLabel">
            <property name="text">
-            <string>Auto-Type delay</string>
+            <string>Auto-Type typing delay</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="3" column="1">
           <widget class="QSpinBox" name="autoTypeDelaySpinBox">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -442,10 +442,45 @@
             <string/>
            </property>
            <property name="maximum">
-            <number>999</number>
+            <number>1000</number>
            </property>
            <property name="value">
             <number>25</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="autoTypeStartDelayLabel">
+           <property name="text">
+            <string>Auto-Type start delay</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="autoTypeStartDelaySpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="suffix">
+            <string comment="Milliseconds"> ms</string>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="minimum">
+            <number>100</number>
+           </property>
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+           <property name="singleStep">
+            <number>100</number>
+           </property>
+           <property name="value">
+            <number>500</number>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #1864 

Add's a configuration option to set the global autotype start delay. Previously it was hardcoded at 500ms which might be too quick for some people to release the global shortcut keys prior to typing beginning.

![autotype-settings](https://user-images.githubusercontent.com/2809491/39669561-2edea604-50bd-11e8-95fe-2e7e20e861d8.png)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
