### PR TITLE
Fix typo in Spanish translation

### DIFF
--- a/share/translations/keepassx_es.ts
+++ b/share/translations/keepassx_es.ts
@@ -391,8 +391,8 @@ If you would like to allow it access to your KeePassXC database,
 give it a unique name to identify and accept it.</source>
         <translation>¿Quiere asociar la base de datos al navegador? 
 
-Si quiere autirizar el acceso a la base de datos de KeePassXC 
-de un nombre único para identificar la autorización
+Si quiere autorizar el acceso a la base de datos de KeePassXC,
+proporcione un nombre único para identificar la autorización
 (se guarda como una entrada más)</translation>
     </message>
     <message>


### PR DESCRIPTION
Fix two small typos in the Spanish translation.

One of the dialogs to interact with the KeepassXC-browser extension has a couple of typos. This PR implements a more accurate traslation.

[ci-skip]