### PR TITLE
Fix possible crash with latest STDIN changes.

### DIFF
--- a/src/browser/NativeMessagingHost.cpp
+++ b/src/browser/NativeMessagingHost.cpp
@@ -78,7 +78,7 @@ void NativeMessagingHost::run()
         QFile::remove(serverPath);
 
         // Ensure that STDIN is not being listened when proxy is used
-        if (m_notifier->isEnabled()) {
+        if (m_notifier && m_notifier->isEnabled()) {
             m_notifier->setEnabled(false);
         }
 


### PR DESCRIPTION
QSocketNotifier can be nullptr and it's not checked. Applies to 2.3.2.

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/1922.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
