### PR TITLE
fix missing include for Qt 5.11

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -32,6 +32,7 @@
 #include <QStackedLayout>
 #include <QStandardPaths>
 #include <QTemporaryFile>
+#include <QButtonGroup>
 
 #include "autotype/AutoType.h"
 #include "core/Config.h"


### PR DESCRIPTION
Qt 5.11 cleans up the internal headers and so consumers could fail by missing includes.

## Description
The build is broken because of a missing include on Qt 5.11.
A log of the build is added as attachment here: https://bugs.gentoo.org/655844

## Motivation and context
Let's compile the project using Qt 5.11

## How has this been tested?
Compilation works again.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**