### PR TITLE
Fix occasional crash when favicon progress dialog is closed

### DIFF
--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -45,16 +45,13 @@ UrlFetchProgressDialog::UrlFetchProgressDialog(const QUrl &url, QWidget *parent)
     setWindowTitle(tr("Download Progress"));
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     setLabelText(tr("Downloading %1.").arg(url.toDisplayString()));
-    setMinimum(0);
-    setValue(0);
-    setMinimumDuration(0);
+    setMinimumDuration(2000);
     setMinimumSize(QSize(400, 75));
 }
 
 void UrlFetchProgressDialog::networkReplyProgress(qint64 bytesRead, qint64 totalBytes)
 {
-    setMaximum(totalBytes);
-    setValue(bytesRead);
+    setValue(static_cast<int>(bytesRead/totalBytes));
 }
 
 EditWidgetIcons::EditWidgetIcons(QWidget* parent)
@@ -280,7 +277,9 @@ void EditWidgetIcons::fetchFinished()
 void EditWidgetIcons::fetchCanceled()
 {
 #ifdef WITH_XC_NETWORKING
-    m_reply->abort();
+    if (m_reply) {
+        m_reply->abort();
+    }
 #endif
 }
 

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -51,7 +51,7 @@ UrlFetchProgressDialog::UrlFetchProgressDialog(const QUrl &url, QWidget *parent)
 
 void UrlFetchProgressDialog::networkReplyProgress(qint64 bytesRead, qint64 totalBytes)
 {
-    setValue(static_cast<int>(bytesRead/totalBytes));
+    setValue(static_cast<int>(bytesRead / totalBytes));
 }
 
 EditWidgetIcons::EditWidgetIcons(QWidget* parent)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Fix #1936 

Also removes some unnecessary code and changes the progress to a true percentage.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Crashes are bad, mm'kay.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
