### PR TITLE
Fix entry sorting by title

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -543,7 +543,9 @@ QList<Entry*> BrowserService::sortEntries(QList<Entry*>& pwEntries, const QStrin
             // Sort same priority entries by Title or UserName
             auto entries = priorities.values(i);
             std::sort(entries.begin(), entries.end(), [&priorities, &field](Entry* left, Entry* right) {
-                return QString::localeAwareCompare(left->attributes()->value(field), right->attributes()->value(field)) < 0;
+                return (QString::localeAwareCompare(left->attributes()->value(field), right->attributes()->value(field)) < 0) ||
+                       ((QString::localeAwareCompare(left->attributes()->value(field), right->attributes()->value(field)) == 0) && 
+                        (QString::localeAwareCompare(left->attributes()->value("UserName"), right->attributes()->value("UserName")) < 0));
             });
             results << entries;
             if (BrowserSettings::bestMatchOnly() && !pwEntries.isEmpty()) {


### PR DESCRIPTION
Fixes `Sort matching credentials by title`.

## Description
Previously sorting by title didn't sort usernames after the title sort, and the order was not reverse but mixed. The sort provided the following results:
```
c_username (title1)
z_username (title1)
a_username (title1)
z_username (title2)
c_username (title2)
a_username (title2)
...
```

After the fix:
```
a_username (title1)
c_username (title1)
z_username (title1)
a_username (title2)
c_username (title2)
z_username (title2)
```

If the titles are identical another compare is made based on the username.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
