### PR TITLE
Handle URL port and scheme when requesting credentials

### DIFF
--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -42,8 +42,8 @@ public:
     Entry*          getConfigEntry(bool create = false);
     QString         getKey(const QString& id);
     void            addEntry(const QString& id, const QString& login, const QString& password, const QString& url, const QString& submitUrl, const QString& realm);
-    QList<Entry*>   searchEntries(Database* db, const QString& hostname);
-    QList<Entry*>   searchEntries(const QString& text, const StringPairList& keyList);
+    QList<Entry*>   searchEntries(Database* db, const QString& hostname, const QString& url);
+    QList<Entry*>   searchEntries(const QString& url, const StringPairList& keyList);
     void            removeSharedEncryptionKeys();
     void            removeStoredPermissions();
 


### PR DESCRIPTION
Handle URL port and scheme when requesting credentials.

## Description
Entries with different port or scheme in URL are ignored. If an entry has a `http` scheme, credentials are not received when accessing a site with `https`.

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/143.
Fixes https://github.com/keepassxreboot/keepassxc/issues/1467.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
