### PR TITLE
Allow multiple image selections when adding favicons

### DIFF
--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -125,8 +125,14 @@ void EditWidget::enableApplyButton(bool enabled)
 
 void EditWidget::showMessage(const QString& text, MessageWidget::MessageType type)
 {
-    m_ui->messageWidget->setCloseButtonVisible(false);
-    m_ui->messageWidget->showMessage(text, type, 2000);
+    // Show error messages for a longer time to make sure the user can read them
+    if (type == MessageWidget::Error) {
+        m_ui->messageWidget->setCloseButtonVisible(true);
+        m_ui->messageWidget->showMessage(text, type, 15000);
+    } else {
+        m_ui->messageWidget->setCloseButtonVisible(false);
+        m_ui->messageWidget->showMessage(text, type, 2000);
+    }
 }
 
 void EditWidget::hideMessage()

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -335,12 +335,11 @@ void EditWidgetIcons::addCustomIconFromFile()
             for (const auto& filename : filenames) {
                 if (!filename.isEmpty()) {
                     auto icon = QImage(filename);
-                    if (!icon.isNull()) {
-                        if (!addCustomIcon(QImage(filename))) {
-                            ++numexisting;
-                        }
-                    } else {
+                    if (icon.isNull()) {
                         errornames << filename;
+                    } else if (!addCustomIcon(icon)) {
+                        // Icon already exists in database
+                        ++numexisting;
                     }
                 }
             }
@@ -349,20 +348,20 @@ void EditWidgetIcons::addCustomIconFromFile()
             QString msg;
 
             if (numloaded > 0) {
-                msg = tr("Successfully loaded %1 of %2 icons").arg(numloaded).arg(filenames.size());
+                msg = tr("Successfully loaded %1 of %n icon(s)", "", filenames.size()).arg(numloaded);
             } else {
                 msg = tr("No icons were loaded");
             }
 
             if (numexisting > 0) {
-                msg += ", " + tr("%1 icons already existed").arg(numexisting);
+                msg += "\n" + tr("%n icon(s) already exist in the database", "", numexisting);
             }
 
             if (!errornames.empty()) {
                 // Show the first 8 icons that failed to load
                 errornames = errornames.mid(0, 8);
-                emit messageEditEntry(msg + "\n" + tr("The following icons failed:") + "\n" + errornames.join("\n"),
-                                      MessageWidget::Error);
+                emit messageEditEntry(msg + "\n" + tr("The following icon(s) failed:", "", errornames.size()) +
+                                      "\n" + errornames.join("\n"), MessageWidget::Error);
             } else if (numloaded > 0) {
                 emit messageEditEntry(msg, MessageWidget::Positive);
             } else {

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -325,13 +325,15 @@ void EditWidgetIcons::addCustomIconFromFile()
     if (m_database) {
         QString filter = QString("%1 (%2);;%3 (*)").arg(tr("Images"), Tools::imageReaderFilter(), tr("All files"));
 
-        QString filename = QFileDialog::getOpenFileName(this, tr("Select Image"), "", filter);
-        if (!filename.isEmpty()) {
-            auto icon = QImage(filename);
-            if (!icon.isNull()) {
-                addCustomIcon(QImage(filename));
-            } else {
-                emit messageEditEntry(tr("Can't read icon"), MessageWidget::Error);
+        auto filenames = QFileDialog::getOpenFileNames(this, tr("Select Image(s)"), "", filter);
+        for (const auto& filename : filenames) {
+            if (!filename.isEmpty()) {
+                auto icon = QImage(filename);
+                if (!icon.isNull()) {
+                    addCustomIcon(QImage(filename));
+                } else {
+                    emit messageEditEntry(tr("Can't read icon"), MessageWidget::Error);
+                }
             }
         }
     }

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -88,7 +88,7 @@ private slots:
     void fetchReadyRead();
     void fetchCanceled();
     void addCustomIconFromFile();
-    void addCustomIcon(const QImage& icon);
+    bool addCustomIcon(const QImage& icon);
     void removeCustomIcon();
     void updateWidgetsDefaultIcons(bool checked);
     void updateWidgetsCustomIcons(bool checked);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Quick tweak to let users select multiple icons when adding favicons from the filesystem. Useful for testing too!

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**