### PR TITLE
Remove title matching

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -375,14 +375,11 @@ QList<Entry*> BrowserService::searchEntries(Database* db, const QString& hostnam
     }
 
     for (Entry* entry : EntrySearcher().search(hostname, rootGroup, Qt::CaseInsensitive)) {
-        QString title = entry->title();
         QString url = entry->url();
 
-        // Filter to match hostname in Title and Url fields
-        if ((!title.isEmpty() && hostname.contains(title))
-            || (!url.isEmpty() && hostname.contains(url))
-            || (matchUrlScheme(title) && hostname.endsWith(QUrl(title).host()))
-            || (matchUrlScheme(url) && hostname.endsWith(QUrl(url).host())) ) {
+        // Filter to match hostname in URL field
+        if ((!url.isEmpty() && hostname.contains(url))
+            || (matchUrlScheme(url) && hostname.endsWith(QUrl(url).host()))) {
                 entries.append(entry);
         }
     }


### PR DESCRIPTION
Removes title matching with URL's.

## Description
URL's from KeePassXC-Browser shouldn't check entry title at all, only the entry URL. Without the fix wrong credentials can be returned to the extension.

## Motivation and context
If an entry title contains part of requested URL, the credentials are returned to KeePassXC-Browser.
For example:
- Credentials of entry with title "github.com" and URL "https://github.com/login" is returned correctly.
- Credentials of entry with title "github.com" and URL "https://www.example.com" is still returned.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
