### PR TITLE
Print version information with --version even if another instance is already running

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
                                           "handle");
 
     parser.addHelpOption();
-    parser.addVersionOption();
+    QCommandLineOption versionOption = parser.addVersionOption();
     parser.addOption(configOption);
     parser.addOption(keyfileOption);
     parser.addOption(pwstdinOption);
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
     parser.process(app);
     const QStringList fileNames = parser.positionalArguments();
 
-    if (app.isAlreadyRunning()) {
+    if (app.isAlreadyRunning() && !parser.isSet(versionOption)) {
         if (!fileNames.isEmpty()) {
             app.sendFileNamesToRunningInstance(fileNames);
         }


### PR DESCRIPTION
## Description
Fix #1362 by checking if the version option is set when deciding whether to print the "Keepassxc is already running" error message.

## How has this been tested?
Built locally and ran. Passes all unit tests.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- [ ] My change requires a change to the documentation and I have updated it accordingly.
- [ ] I have added tests to cover my changes.
