### PR TITLE
Deny expired credentials

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -625,6 +625,9 @@ BrowserService::Access BrowserService::checkAccess(const Entry* entry, const QSt
     if (!config.load(entry)) {
         return Unknown;
     }
+    if (entry->isExpired()) {
+        return Denied;
+    }
     if ((config.isAllowed(host)) && (submitHost.isEmpty() || config.isAllowed(submitHost))) {
         return Allowed;
     }


### PR DESCRIPTION
## Description
With this change, expired credentials are not returned to KeePassXC-Browser.

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/2111.

## How has this been tested?
Manually.

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
