### PR TITLE
SSH Agent: Expect passphrases to be in UTF-8

### DIFF
--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -350,7 +350,7 @@ bool OpenSSHKey::openPrivateKey(const QString& passphrase)
         QByteArray decryptKey;
         decryptKey.fill(0, cipher->keySize() + cipher->blockSize());
 
-        QByteArray phraseData = passphrase.toLatin1();
+        QByteArray phraseData = passphrase.toUtf8();
         if (bcrypt_pbkdf(phraseData, salt, decryptKey, rounds) < 0) {
             m_error = tr("Key derivation failed, key file corrupted?");
             return false;

--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -427,3 +427,29 @@ void TestOpenSSHKey::testDecryptRSAAES256CTR()
     QCOMPARE(key.comment(), QString(""));
     QCOMPARE(key.fingerprint(), QString("SHA256:1Hsebt2WWnmc72FERsUOgvaajIGHkrMONxXylcmk87U"));
 }
+
+void TestOpenSSHKey::testDecryptUTF8()
+{
+    const QString keyString = QString(
+	"-----BEGIN OPENSSH PRIVATE KEY-----\n"
+	"b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABDtSl4OvT\n"
+	"H/wHay2dvjOnpIAAAAEAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIIhrBrn6rb+d3GwF\n"
+	"ifpJ6gYut95lXvwypiQmu9ZpA8H9AAAAsD85Gpn2mbVEWq3ygx11wBnN5mUQXnMuP48rLv\n"
+	"0qwm12IihOkrR925ledwN2Sa5mkkL0XjDz6SsKfIFhFa84hUHQdw5zPR8yVGRWLzkNDmo7\n"
+	"WXNpnoE4ebsX2j0TsBNjP80RUcJdjSXidkt3+aZjaCfquO8cBQn4GJJSDSPwFJYlJeSD/h\n"
+	"vpb72MEQchOD3NNMORYTJ5sOJ73RayhhmwjTVlrG+zYAw6fXW0YXX3+5LE\n"
+	"-----END OPENSSH PRIVATE KEY-----\n"
+    );
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parse(keyData));
+    QVERIFY(key.encrypted());
+    QCOMPARE(key.cipherName(), QString("aes256-ctr"));
+    QVERIFY(!key.openPrivateKey("incorrectpassphrase"));
+    QVERIFY(key.openPrivateKey("äåéëþüúíóö"));
+    QCOMPARE(key.fingerprint(), QString("SHA256:EfUXwvH4rOoys+AlbznCqjMwzIVW8KuhoWu9uT03FYA"));
+    QCOMPARE(key.type(), QString("ssh-ed25519"));
+    QCOMPARE(key.comment(), QString("opensshkey-test-utf8@keepassxc"));
+}

--- a/tests/TestOpenSSHKey.h
+++ b/tests/TestOpenSSHKey.h
@@ -37,6 +37,7 @@ private slots:
     void testDecryptRSAAES256CBC();
     void testDecryptOpenSSHAES256CTR();
     void testDecryptRSAAES256CTR();
+    void testDecryptUTF8();
 };
 
 #endif // TESTOPENSSHKEY_H


### PR DESCRIPTION
## Description
The previous default was to expect passphrases to be ASCII or rather Latin-1. It would be reasonable to expect modern keys to use UTF-8 instead.

This is a non-breaking change if passphrases only use characters that fall within ASCII.

## Motivation and context
Fix #2102.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test added, existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
