### PR TITLE
Fix keepassxc-proxy shutdown with Chromium-based browsers under Windows

### DIFF
--- a/src/browser/NativeMessagingBase.h
+++ b/src/browser/NativeMessagingBase.h
@@ -52,7 +52,7 @@ protected slots:
 
 protected:
     virtual void    readLength() = 0;
-    virtual void    readStdIn(const quint32 length) = 0;
+    virtual bool    readStdIn(const quint32 length) = 0;
     void            readNativeMessages();
     QString         jsonToString(const QJsonObject& json) const;
     void            sendReply(const QJsonObject& json);

--- a/src/browser/NativeMessagingHost.cpp
+++ b/src/browser/NativeMessagingHost.cpp
@@ -114,10 +114,10 @@ void NativeMessagingHost::readLength()
     }
 }
 
-void NativeMessagingHost::readStdIn(const quint32 length)
+bool NativeMessagingHost::readStdIn(const quint32 length)
 {
     if (length <= 0) {
-        return;
+        return false;
     }
 
     QByteArray arr;
@@ -129,7 +129,7 @@ void NativeMessagingHost::readStdIn(const quint32 length)
         int c = std::getchar();
         if (c == EOF) {
             // message ended prematurely, ignore it and return
-            return;
+            return false;
         }
         arr.append(static_cast<char>(c));
     }
@@ -137,6 +137,7 @@ void NativeMessagingHost::readStdIn(const quint32 length)
     if (arr.length() > 0) {
         sendReply(m_browserClients.readResponse(arr));
     }
+    return true;
 }
 
 void NativeMessagingHost::newLocalConnection()

--- a/src/browser/NativeMessagingHost.h
+++ b/src/browser/NativeMessagingHost.h
@@ -46,7 +46,7 @@ signals:
 
 private:
     void        readLength();
-    void        readStdIn(const quint32 length);
+    bool        readStdIn(const quint32 length);
     void        sendReplyToAllClients(const QJsonObject& json);
 
 private slots:

--- a/src/proxy/NativeMessagingHost.h
+++ b/src/proxy/NativeMessagingHost.h
@@ -33,11 +33,12 @@ public slots:
     void socketStateChanged(QLocalSocket::LocalSocketState socketState);
 
 private:
+    void readNativeMessages();
     void readLength();
-    void readStdIn(const quint32 length);
+    bool readStdIn(const quint32 length);
 
 private:
-    QLocalSocket*                           m_localSocket;
+    QLocalSocket*   m_localSocket;
 };
 
 #endif // NATIVEMESSAGINGHOST_H


### PR DESCRIPTION
## Description
Fixes shutting down keepassxc-proxy properly with Chromium-based browsers under Windows. Previously a new process was always created and the old process remained open even if the browser was closed.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
