### PR TITLE
allow 12 hour timeout for lockDatabaseIdle

### DIFF
--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -92,7 +92,7 @@
          <number>10</number>
         </property>
         <property name="maximum">
-         <number>9999</number>
+         <number>43200</number>
         </property>
         <property name="value">
          <number>240</number>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Allow users to increase the timeout for lockDatabaseIdle to 12 hours.
## Description
<!--- Describe your changes in detail -->
Increases the maximum lockDatabaseIdleSpinBox value to 43200 seconds.

See https://github.com/keepassxreboot/keepassxc/issues/1331

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are considering enforcing lockDatabaseIdle for all of our users. If this is the case, we want our users to be able to select a much longer maximum timeout.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
