### PR TITLE
Allows a separate ID key for browser extension association

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -169,7 +169,9 @@ QJsonObject BrowserAction::handleAssociate(const QJsonObject& json, const QStrin
 
     QMutexLocker locker(&m_mutex);
     if (key.compare(m_clientPublicKey, Qt::CaseSensitive) == 0) {
-        const QString id = m_browserService.storeKey(key);
+        // Check for identification key. If it's not found, ensure backwards compatibility and use the current public key
+        const QString idKey = decrypted.value("idKey").toString();
+        const QString id = m_browserService.storeKey((idKey.isEmpty() ? key: idKey));
         if (id.isEmpty()) {
             return getErrorReply(action, ERROR_KEEPASS_ACTION_CANCELLED_OR_DENIED);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
When connecting first time from KeePassXC-Browser to multiple databases within the same session, the same public key is used as an identification key. This causes the connections to use identical keys.

This PR allows the use of a separate `idKey` when saving the connection to KeePassXC. To ensure backward compatibility, the current public key will be used instead.

## Motivation and context
Fixes using identical identification keys.
Related KeePassXC-Browser PR: https://github.com/keepassxreboot/keepassxc-browser/pull/258.

## How has this been tested?
Manually.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
