### PR TITLE
Provide warning to users with Qt 5.5.x about potential crash

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -426,11 +426,18 @@ MainWindow::MainWindow()
     }
 #endif
 
-#ifndef KEEPASSXC_BUILD_TYPE_RELEASE
+#if !defined(KEEPASSXC_BUILD_TYPE_RELEASE)
     m_ui->globalMessageWidget->showMessage(tr("WARNING: You are using an unstable build of KeePassXC!\n"
                                               "There is a high risk of corruption, maintain a backup of your databases.\n"
                                               "This version is not meant for production use."),
-                                           MessageWidget::Warning, -1);
+                                          MessageWidget::Warning, -1);
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0) && QT_VERSION < QT_VERSION_CHECK(5, 6, 0))
+    if (!config()->get("QtErrorMessageShown", false).toBool()) {
+        m_ui->globalMessageWidget->showMessage(tr("WARNING: You are using a version of Qt that causes KeePassXC to crash!\n"
+                                                  "We recommend you use the AppImage version available on our downloads page."),
+                                              MessageWidget::Warning, -1);
+        config()->set("QtErrorMessageShown", true);
+    }
 #else
     // Show the HTTP deprecation message if enabled above
     emit m_ui->globalMessageWidget->hideAnimationFinished();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Warns users that crashes can occur if they are running KeePassXC on Qt 5.5. This will assist with reporting issues such as #335, #1254, and #1554.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
