### PR TITLE
Add desktop and wayland interfaces

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 apps:
   keepassxc:
     command: desktop-launch keepassxc
-    plugs: [unity7, x11, opengl, gsettings, home, network, network-bind, removable-media, raw-usb]
+    plugs: [unity7, x11, opengl, gsettings, home, network, network-bind, removable-media, raw-usb, desktop, wayland]
     desktop: usr/share/applications/org.keepassxc.KeePassXC.desktop
   cli:
     command: keepassxc-cli


### PR DESCRIPTION
I saw someone [report an issue with Keepassxc when running on Wayland](https://forum.snapcraft.io/t/keepassxc-blank-text/7008).

## Description

This pull request adds the `desktop` and `wayland` interfaces which address the issue reported.

## Motivation and context

The `desktop` interface enables access to assorted desktop integration capabilities. The `wayland` interface` enables access to the Wayland socket.

## How has this been tested?

I have not tested this, it is a drive-by commit. That said the `desktop` and `wayland` have been available for some considerable time now and are intended to be enabled by default for desktop applications using GTK or Qt.

## Screenshots (if appropriate):

## Types of changes

- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:

- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.