### PR TITLE
Fix Match URL scheme setting

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -395,7 +395,8 @@ QList<Entry*> BrowserService::searchEntries(Database* db, const QString& hostnam
         QUrl qUrl(url);
 
         // Ignore entry if port or scheme defined in the URL doesn't match    
-        if ((entryQUrl.port() > 0 && entryQUrl.port() != qUrl.port()) || entryScheme.compare(qUrl.scheme()) != 0) {
+        if ((entryQUrl.port() > 0 && entryQUrl.port() != qUrl.port()) ||
+            (BrowserSettings::matchUrlScheme() && entryScheme.compare(qUrl.scheme()) != 0)) {
             continue;
         }
 


### PR DESCRIPTION
Fix Match URL scheme setting with browser integration.

## Description
Previously the setting didn't work and credentials were ignored if the scheme didn't match.

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/2237.

## How has this been tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**