### PR TITLE
Fixes typo in Group::findGroupByPath found by sonarcloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ release*/
 .DS_Store
 .version
 \.scannerwork/
-bw-output/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ release*/
 .DS_Store
 .version
 \.scannerwork/
+bw-output/

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -99,7 +99,6 @@ public:
     Entry* findEntryByUuid(const Uuid& uuid);
     Entry* findEntryByPath(QString entryPath, QString basePath = QString(""));
     Group* findGroupByPath(QString groupPath);
-    Group* findGroupByPathRecursion(QString groupPath, QString basePath);
     QStringList locate(QString locateTerm, QString currentPath = QString("/"));
     Entry* addEntryWithPath(QString entryPath);
     void setUuid(const Uuid& uuid);
@@ -184,6 +183,8 @@ private:
     void recSetDatabase(Database* db);
     void cleanupParent();
     void recCreateDelObjects();
+
+    Group* findGroupByPathRecursion(QString groupPath, QString basePath);
 
     QPointer<Database> m_db;
     Uuid m_uuid;

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -98,7 +98,8 @@ public:
     Entry* findEntry(QString entryId);
     Entry* findEntryByUuid(const Uuid& uuid);
     Entry* findEntryByPath(QString entryPath, QString basePath = QString(""));
-    Group* findGroupByPath(QString groupPath, QString basePath = QString("/"));
+    Group* findGroupByPath(QString groupPath);
+    Group* findGroupByPathRecursion(QString groupPath, QString basePath);
     QStringList locate(QString locateTerm, QString currentPath = QString("/"));
     Entry* addEntryWithPath(QString entryPath);
     void setUuid(const Uuid& uuid);


### PR DESCRIPTION
## Description
Hi.  A first small contribution. As I'm working my way through the codebase to learn it, I noticed an error pointed out by Sonar, and made a few adjustments which, to fix it and, I think, make the intention of the code a bit clearer (to me at least). If you think it's useful, I offer it.

Group.cpp had 
```
if (!groupPath.endsWith("/") && !groupPath.endsWith("/"))
```
which SonarCloud flagged (it clearly was not what was intended, though it would only in practice create an incorrect false positive if basePath were not normalized).

## How has this been tested?
Reran tests, which continue to all pass. The resulting refactor is meant to have the same functionality. 

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Refactor (non-breaking changes which make code clearer,  more maintainable, or less risky)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

