### PR TITLE
Fix checking subdomains

### DIFF
--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -101,6 +101,7 @@ private:
     sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
     bool matchUrlScheme(const QString& url);
     bool removeFirstDomain(QString& hostname);
+    QString baseDomain(const QString& url) const;
     Database* getDatabase();
 
 private:


### PR DESCRIPTION
Fix checking subdomains when retrieving credentials.

## Description
After title matching was removed with release 2.3.4 the subdomain handling broke. Base domain of the URL will be used for EntrySearcher instead of hostname.

With this fix:
- Entry URL `https://google.com`: matches `https://*.google.com`, does not match `http://*.google.com`
- Entry URL `google.com` with scheme matching off: matches `*://*.google.com`
- Entry URL `https://accounts.google.com`: matches `https://accounts.google.com`, does not match with `https://*.google.com`
- Entry URL `accounts.google.com` with scheme matching off: matches `*://accounts.google.com`

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/283.
Fixes #2291
~~~Depends on https://github.com/keepassxreboot/keepassxc/pull/2232.~~~

## How has this been tested?
Manually, and with local tests.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]** 