### PR TITLE
Remove duplicate statement from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,6 @@ if(WITH_XC_ALL)
   set(WITH_XC_SSHAGENT ON)
 endif()
 
-# Process ui files automatically from source files
-set(CMAKE_AUTOUIC ON)
-
 set(KEEPASSXC_VERSION_MAJOR "2")
 set(KEEPASSXC_VERSION_MINOR "3")
 set(KEEPASSXC_VERSION_PATCH "4")
@@ -309,8 +306,11 @@ endif()
 
 get_filename_component(Qt5_PREFIX ${Qt5_DIR}/../../.. REALPATH)
 
+# Process moc automatically
 set(CMAKE_AUTOMOC ON)
+# Process .ui files automatically
 set(CMAKE_AUTOUIC ON)
+# Process .qrc files automatically
 set(CMAKE_AUTORCC ON)
 
 if(APPLE)


### PR DESCRIPTION
## Description
I was browsing the code base and I noticed that the `CMakeLists.txt` file in the project root contained a duplicate statement. More specifically, the `CMAKE_AUTOUIC` variable was set to `ON` at line 61, but was already set to `ON` down below at line 313, along with `CMAKE_AUTOMOC` and `CMAKE_AUTORCC`.

## How has this been tested?
I cleared the CMake cache in CLion, performed a clean build and ran all the tests (GUI tests included).

## Types of changes
- ✅ Code clean-up.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
