### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,6 +99,7 @@ These steps place the compiled KeePassXC binary inside the `./build/src/` direct
 	  -DWITH_XC_YUBIKEY=[ON|OFF] Enable/Disable YubiKey HMAC-SHA1 authentication support (default: OFF)
 	  -DWITH_XC_BROWSER=[ON|OFF] Enable/Disable KeePassXC-Browser extension support (default: OFF)
 	  -DWITH_XC_NETWORKING=[ON|OFF] Enable/Disable Networking support (favicon download) (default: OFF)
+	  -DWITH_XC_SSHAGENT=[ON|OFF] Include SSH agent support. (default: OFF)
 	  
 	  -DWITH_XC_ALL=[ON|OFF] Enable/Disable compiling all plugins above (default: OFF)
 	  
@@ -106,8 +107,7 @@ These steps place the compiled KeePassXC binary inside the `./build/src/` direct
 	  -DWITH_GUI_TESTS=[ON|OFF] Enable/Disable building of GUI tests (default: OFF)
 	  -DWITH_DEV_BUILD=[ON|OFF] Enable/Disable deprecated method warnings (default: OFF)
 	  -DWITH_ASAN=[ON|OFF] Enable/Disable address sanitizer checks (Linux / macOS only) (default: OFF)
-	  -DWITH_COVERAGE=[ON|OFF] Enable/Disable coverage tests (GCC only) (default: OFF)
-	  -DWITH_XC_SSHAGENT=[ON|OFF] Include SSH agent support. (default: OFF)
+	  -DWITH_COVERAGE=[ON|OFF] Enable/Disable coverage tests (GCC only) (default: OFF)	  
 	```
 
 * If you are on MacOS you must add this parameter to **Cmake**, with the Qt version you have installed<br/> `-DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.6.2/lib/cmake/`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,6 @@ The following libraries are required:
 * libxi, libxtst, qtx11extras (optional for auto-type on X11)
 * libsodium (>= 1.0.12, optional for KeePassXC-Browser support)
 * libargon2
-* lcov
 
 Prepare the Building Environment
 ================================

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ The following libraries are required:
 * libxi, libxtst, qtx11extras (optional for auto-type on X11)
 * libsodium (>= 1.0.12, optional for KeePassXC-Browser support)
 * libargon2
-
+* lcov
 
 Prepare the Building Environment
 ================================
@@ -107,6 +107,7 @@ These steps place the compiled KeePassXC binary inside the `./build/src/` direct
 	  -DWITH_DEV_BUILD=[ON|OFF] Enable/Disable deprecated method warnings (default: OFF)
 	  -DWITH_ASAN=[ON|OFF] Enable/Disable address sanitizer checks (Linux / macOS only) (default: OFF)
 	  -DWITH_COVERAGE=[ON|OFF] Enable/Disable coverage tests (GCC only) (default: OFF)
+	  -DWITH_XC_SSHAGENT=[ON|OFF] Include SSH agent support. (default: OFF)
 	```
 
 * If you are on MacOS you must add this parameter to **Cmake**, with the Qt version you have installed<br/> `-DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.6.2/lib/cmake/`


### PR DESCRIPTION
add lcov requirement
add build option for SSH Agent

<!--- Provide a general summary of your changes in the title above -->

## Description
update documentation to add lcov dependency and add the build option (default off) for the ssh-agent

## Motivation and context
tried to compile, an update documentation is required
## How has this been tested?
n/a no change to code
## Screenshots (if appropriate):

## Types of changes
- Documentation Fix

n/a to questions
