### PR TITLE
Replace Google with DuckDuckGo as the optional fallback favicon fetcher

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -148,7 +148,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/passwordscleartext", false);
     m_defaults.insert("security/hidepassworddetails", true);
     m_defaults.insert("security/autotypeask", true);
-    m_defaults.insert("security/IconDownloadFallbackToGoogle", false);
+    m_defaults.insert("security/IconDownloadFallbackToDuckDuckGo", false);
     m_defaults.insert("security/resettouchid", false);
     m_defaults.insert("security/resettouchidtimeout", 30);
     m_defaults.insert("security/resettouchidscreenlock", true);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -148,7 +148,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/passwordscleartext", false);
     m_defaults.insert("security/hidepassworddetails", true);
     m_defaults.insert("security/autotypeask", true);
-    m_defaults.insert("security/IconDownloadFallbackToDuckDuckGo", false);
+    m_defaults.insert("security/IconDownloadFallback", false);
     m_defaults.insert("security/resettouchid", false);
     m_defaults.insert("security/resettouchidtimeout", 30);
     m_defaults.insert("security/resettouchidscreenlock", true);

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -219,12 +219,12 @@ void EditWidgetIcons::downloadFavicon()
     }
     m_urlsToTry.append(QUrl(m_url.scheme() + "://" + secondLevelDomain + "/favicon.ico"));
 
-    // Try to use DuckDuckGo fallback, if enabled
-    if (config()->get("security/IconDownloadFallbackToDuckDuckGo", false).toBool()) {
-        QUrl urlDuckDuckGo = QUrl("https://icons.duckduckgo.com");
+    // Try to use alternative fallback URL, if enabled
+    if (config()->get("security/IconDownloadFallback", false).toBool()) {
+        QUrl fallbackUrl = QUrl("https://icons.duckduckgo.com");
+        fallbackUrl.setPath("/ip3/" + QUrl::toPercentEncoding(fullyQualifiedDomain) + ".ico");
 
-        urlDuckDuckGo.setPath("/ip3/" + QUrl::toPercentEncoding(fullyQualifiedDomain) + ".ico");
-        m_urlsToTry.append(urlDuckDuckGo);
+        m_urlsToTry.append(fallbackUrl);
     }
 
     startFetchFavicon(m_urlsToTry.takeFirst());
@@ -242,7 +242,7 @@ void EditWidgetIcons::fetchFinished()
 {
 #ifdef WITH_XC_NETWORKING
     QImage image;
-    bool duckDuckGoFallbackEnabled = config()->get("security/IconDownloadFallbackToDuckDuckGo", false).toBool();
+    bool fallbackEnabled = config()->get("security/IconDownloadFallback", false).toBool();
     bool error = (m_reply->error() != QNetworkReply::NoError);
     QUrl url = m_reply->url();
     QUrl redirectTarget = getRedirectTarget(m_reply);
@@ -279,7 +279,7 @@ void EditWidgetIcons::fetchFinished()
         startFetchFavicon(m_urlsToTry.takeFirst());
         return;
     } else {
-        if (!duckDuckGoFallbackEnabled) {
+        if (!fallbackEnabled) {
             emit messageEditEntry(tr("Unable to fetch favicon.") + "\n" +
                                   tr("Hint: You can enable DuckDuckGo as a fallback under Tools>Settings>Security"),
                                   MessageWidget::Error);

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -219,12 +219,12 @@ void EditWidgetIcons::downloadFavicon()
     }
     m_urlsToTry.append(QUrl(m_url.scheme() + "://" + secondLevelDomain + "/favicon.ico"));
 
-    // Try to use Google fallback, if enabled
-    if (config()->get("security/IconDownloadFallbackToGoogle", false).toBool()) {
-        QUrl urlGoogle = QUrl("https://www.google.com/s2/favicons");
+    // Try to use DuckDuckGo fallback, if enabled
+    if (config()->get("security/IconDownloadFallbackToDuckDuckGo", false).toBool()) {
+        QUrl urlDuckDuckGo = QUrl("https://icons.duckduckgo.com");
 
-        urlGoogle.setQuery("domain=" + QUrl::toPercentEncoding(secondLevelDomain));
-        m_urlsToTry.append(urlGoogle);
+        urlDuckDuckGo.setPath("/ip3/" + QUrl::toPercentEncoding(fullyQualifiedDomain) + ".ico");
+        m_urlsToTry.append(urlDuckDuckGo);
     }
 
     startFetchFavicon(m_urlsToTry.takeFirst());
@@ -242,7 +242,7 @@ void EditWidgetIcons::fetchFinished()
 {
 #ifdef WITH_XC_NETWORKING
     QImage image;
-    bool googleFallbackEnabled = config()->get("security/IconDownloadFallbackToGoogle", false).toBool();
+    bool duckDuckGoFallbackEnabled = config()->get("security/IconDownloadFallbackToDuckDuckGo", false).toBool();
     bool error = (m_reply->error() != QNetworkReply::NoError);
     QUrl redirectTarget = getRedirectTarget(m_reply);
 
@@ -275,9 +275,9 @@ void EditWidgetIcons::fetchFinished()
         startFetchFavicon(m_urlsToTry.takeFirst());
         return;
     } else {
-        if (!googleFallbackEnabled) {
+        if (!duckDuckGoFallbackEnabled) {
             emit messageEditEntry(tr("Unable to fetch favicon.") + "\n" +
-                                  tr("Hint: You can enable Google as a fallback under Tools>Settings>Security"),
+                                  tr("Hint: You can enable DuckDuckGo as a fallback under Tools>Settings>Security"),
                                   MessageWidget::Error);
         } else {
             emit messageEditEntry(tr("Unable to fetch favicon."), MessageWidget::Error);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -186,7 +186,7 @@ void SettingsWidget::loadSettings()
     m_secUi->lockDatabaseMinimizeCheckBox->setChecked(config()->get("security/lockdatabaseminimize").toBool());
     m_secUi->lockDatabaseOnScreenLockCheckBox->setChecked(config()->get("security/lockdatabasescreenlock").toBool());
     m_secUi->relockDatabaseAutoTypeCheckBox->setChecked(config()->get("security/relockautotype").toBool());
-    m_secUi->fallbackToDuckDuckGo->setChecked(config()->get("security/IconDownloadFallbackToDuckDuckGo").toBool());
+    m_secUi->fallbackToSearch->setChecked(config()->get("security/IconDownloadFallback").toBool());
 
     m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
     m_secUi->passwordDetailsCleartextCheckBox->setChecked(config()->get("security/hidepassworddetails").toBool());
@@ -256,7 +256,7 @@ void SettingsWidget::saveSettings()
     config()->set("security/lockdatabaseminimize", m_secUi->lockDatabaseMinimizeCheckBox->isChecked());
     config()->set("security/lockdatabasescreenlock", m_secUi->lockDatabaseOnScreenLockCheckBox->isChecked());
     config()->set("security/relockautotype", m_secUi->relockDatabaseAutoTypeCheckBox->isChecked());
-    config()->set("security/IconDownloadFallbackToDuckDuckGo", m_secUi->fallbackToDuckDuckGo->isChecked());
+    config()->set("security/IconDownloadFallback", m_secUi->fallbackToSearch->isChecked());
 
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
     config()->set("security/hidepassworddetails", m_secUi->passwordDetailsCleartextCheckBox->isChecked());

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -186,7 +186,7 @@ void SettingsWidget::loadSettings()
     m_secUi->lockDatabaseMinimizeCheckBox->setChecked(config()->get("security/lockdatabaseminimize").toBool());
     m_secUi->lockDatabaseOnScreenLockCheckBox->setChecked(config()->get("security/lockdatabasescreenlock").toBool());
     m_secUi->relockDatabaseAutoTypeCheckBox->setChecked(config()->get("security/relockautotype").toBool());
-    m_secUi->fallbackToGoogle->setChecked(config()->get("security/IconDownloadFallbackToGoogle").toBool());
+    m_secUi->fallbackToDuckDuckGo->setChecked(config()->get("security/IconDownloadFallbackToDuckDuckGo").toBool());
 
     m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
     m_secUi->passwordDetailsCleartextCheckBox->setChecked(config()->get("security/hidepassworddetails").toBool());
@@ -256,7 +256,7 @@ void SettingsWidget::saveSettings()
     config()->set("security/lockdatabaseminimize", m_secUi->lockDatabaseMinimizeCheckBox->isChecked());
     config()->set("security/lockdatabasescreenlock", m_secUi->lockDatabaseOnScreenLockCheckBox->isChecked());
     config()->set("security/relockautotype", m_secUi->relockDatabaseAutoTypeCheckBox->isChecked());
-    config()->set("security/IconDownloadFallbackToGoogle", m_secUi->fallbackToGoogle->isChecked());
+    config()->set("security/IconDownloadFallbackToDuckDuckGo", m_secUi->fallbackToDuckDuckGo->isChecked());
 
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
     config()->set("security/hidepassworddetails", m_secUi->passwordDetailsCleartextCheckBox->isChecked());

--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -203,9 +203,9 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="QCheckBox" name="fallbackToGoogle">
+       <widget class="QCheckBox" name="fallbackToDuckDuckGo">
         <property name="text">
-         <string>Use Google as fallback for downloading website icons</string>
+         <string>Use DuckDuckGo as fallback for downloading website icons</string>
         </property>
        </widget>
       </item>

--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -203,7 +203,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="QCheckBox" name="fallbackToDuckDuckGo">
+       <widget class="QCheckBox" name="fallbackToSearch">
         <property name="text">
          <string>Use DuckDuckGo as fallback for downloading website icons</string>
         </property>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
#### Transition to DuckDuckGo as Fallback Favicon Fetcher
Modified the fallback HTTP request to use DuckDuckGo (which uses paths to specify the site whose favicon should be retrieved) instead of Google which used params to specify the target site).  Additionally, changed references to "Google" to "DuckDuckGo" in ui elements and variables.

#### Close Failed Favicon Fetch Progress Bars
Prior to my fix, when a fetch failed, it was being hidden (and not ever closed) immediately after failing, only to be unhidden by the timeout specified by `setMinimumDuration()` being reached.  In `EditWidgetIcons::fetchFinished()`, the error state of the fetch is established, so it seemed like the correct place to close the `UrlFetchProgressDialog`.  The only issue is that the progress widget is only ever bound to a variable locally in a different function.  The `EditWidgetIcons` object is the parent of the progress widget, so we can get a reference to the progress widget via `findChild()`, however we need a name to lookup to use it.  Since the url being queried is known at widget create time and destroy time, that seemed like the ideal choice to uniquely name the object.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Transition to DuckDuckGo as fallback fetcher fixes #2258 
Closing of progress bars of failed fetches fixes #2265 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
First, ran all existing unit test successfully.  Then, manually tested functionality:

- `https://fedex.com` is a URL that I know will always fall through to the fallback fetcher if enabled, so I deleted it's icon, and tried to fetch:
![attempting to fetch https://fedex.com's favicon with no fallback](https://user-images.githubusercontent.com/5200550/45783143-d0516680-bc19-11e8-9c50-c28c70b94cc8.png)
Screenshot shows that DuckDuckGo is the optional fallback that can be enabled according to the message.
- The Security section of Tools indeed shows DuckDuckGo fallback as an option.  I enabled it:
![Enabling DuckDuckGo favicon fetching in the Security settings](https://user-images.githubusercontent.com/5200550/45783306-42c24680-bc1a-11e8-92d0-d9c0dba9868d.png)
- I returned to the Fedex entry and tried to fetch the favicon with DuckDuckGo fallback enabled.  It successfully retrieved the favicon.
![Fedex icon shown correctly in Custom Icons](https://user-images.githubusercontent.com/5200550/45783424-92a10d80-bc1a-11e8-9838-49954f83a300.png)
- All progress bars are closed (no screenshot available :slightly_smiling_face:)
- To check safe failures when DuckDuckGo cannot fetch the icon, I first created a new entry of a nonexistent url:
![New entry with long random URL that does not point anywhere](https://user-images.githubusercontent.com/5200550/45783551-f3c8e100-bc1a-11e8-9d0e-d3e13a6fb3f2.png)
- I attempted to fetch the icon of this entry.  All three attempts (2 regular attempts to directly grab a `/favicon.ico` file, and DuckDuckGo) fail and their progress bars disappear.  An error message is correctly displayed:
![Correct error popup shown when attempting to fetch nonexistent URL's favicon](https://user-images.githubusercontent.com/5200550/45783655-3a1e4000-bc1b-11e8-9ecf-89e63b97aa4d.png)



## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
