### PR TITLE
Fix icons not using default theme

### DIFF
--- a/src/gui/KMessageWidget.cpp
+++ b/src/gui/KMessageWidget.cpp
@@ -94,7 +94,7 @@ void KMessageWidgetPrivate::init(KMessageWidget *q_ptr)
     QAction *closeAction = new QAction(q);
     closeAction->setText(KMessageWidget::tr("&Close"));
     closeAction->setToolTip(KMessageWidget::tr("Close message"));
-    closeAction->setIcon(FilePath::instance()->icon("actions", "message-close", false));
+    closeAction->setIcon(FilePath::instance()->icon("actions", "message-close"));
     
     QObject::connect(closeAction, SIGNAL(triggered(bool)), q, SLOT(animatedHide()));
 

--- a/src/gui/LineEdit.cpp
+++ b/src/gui/LineEdit.cpp
@@ -37,7 +37,7 @@ LineEdit::LineEdit(QWidget* parent)
     if (icon.isNull()) {
         icon = QIcon::fromTheme("edit-clear");
         if (icon.isNull()) {
-            icon = filePath()->icon("actions", iconNameDirected, false);
+            icon = filePath()->icon("actions", iconNameDirected);
         }
     }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -218,26 +218,26 @@ MainWindow::MainWindow()
     m_ui->actionDatabaseSaveAs->setIcon(filePath()->icon("actions", "document-save-as"));
     m_ui->actionDatabaseClose->setIcon(filePath()->icon("actions", "document-close"));
     m_ui->actionChangeDatabaseSettings->setIcon(filePath()->icon("actions", "document-edit"));
-    m_ui->actionChangeMasterKey->setIcon(filePath()->icon("actions", "database-change-key", false));
-    m_ui->actionLockDatabases->setIcon(filePath()->icon("actions", "document-encrypt", false));
+    m_ui->actionChangeMasterKey->setIcon(filePath()->icon("actions", "database-change-key"));
+    m_ui->actionLockDatabases->setIcon(filePath()->icon("actions", "document-encrypt"));
     m_ui->actionQuit->setIcon(filePath()->icon("actions", "application-exit"));
 
-    m_ui->actionEntryNew->setIcon(filePath()->icon("actions", "entry-new", false));
-    m_ui->actionEntryClone->setIcon(filePath()->icon("actions", "entry-clone", false));
-    m_ui->actionEntryEdit->setIcon(filePath()->icon("actions", "entry-edit", false));
-    m_ui->actionEntryDelete->setIcon(filePath()->icon("actions", "entry-delete", false));
-    m_ui->actionEntryAutoType->setIcon(filePath()->icon("actions", "auto-type", false));
-    m_ui->actionEntryCopyUsername->setIcon(filePath()->icon("actions", "username-copy", false));
-    m_ui->actionEntryCopyPassword->setIcon(filePath()->icon("actions", "password-copy", false));
-    m_ui->actionEntryCopyURL->setIcon(filePath()->icon("actions", "url-copy", false));
+    m_ui->actionEntryNew->setIcon(filePath()->icon("actions", "entry-new"));
+    m_ui->actionEntryClone->setIcon(filePath()->icon("actions", "entry-clone"));
+    m_ui->actionEntryEdit->setIcon(filePath()->icon("actions", "entry-edit"));
+    m_ui->actionEntryDelete->setIcon(filePath()->icon("actions", "entry-delete"));
+    m_ui->actionEntryAutoType->setIcon(filePath()->icon("actions", "auto-type"));
+    m_ui->actionEntryCopyUsername->setIcon(filePath()->icon("actions", "username-copy"));
+    m_ui->actionEntryCopyPassword->setIcon(filePath()->icon("actions", "password-copy"));
+    m_ui->actionEntryCopyURL->setIcon(filePath()->icon("actions", "url-copy"));
 
-    m_ui->actionGroupNew->setIcon(filePath()->icon("actions", "group-new", false));
-    m_ui->actionGroupEdit->setIcon(filePath()->icon("actions", "group-edit", false));
-    m_ui->actionGroupDelete->setIcon(filePath()->icon("actions", "group-delete", false));
-    m_ui->actionGroupEmptyRecycleBin->setIcon(filePath()->icon("actions", "group-empty-trash", false));
+    m_ui->actionGroupNew->setIcon(filePath()->icon("actions", "group-new"));
+    m_ui->actionGroupEdit->setIcon(filePath()->icon("actions", "group-edit"));
+    m_ui->actionGroupDelete->setIcon(filePath()->icon("actions", "group-delete"));
+    m_ui->actionGroupEmptyRecycleBin->setIcon(filePath()->icon("actions", "group-empty-trash"));
 
     m_ui->actionSettings->setIcon(filePath()->icon("actions", "configure"));
-    m_ui->actionPasswordGenerator->setIcon(filePath()->icon("actions", "password-generator", false));
+    m_ui->actionPasswordGenerator->setIcon(filePath()->icon("actions", "password-generator"));
 
     m_ui->actionAbout->setIcon(filePath()->icon("actions", "help-about"));
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -119,7 +119,7 @@ void EditEntryWidget::setupMain()
     addPage(tr("Entry"), FilePath::instance()->icon("actions", "document-edit"), m_mainWidget);
 
     m_mainUi->togglePasswordButton->setIcon(filePath()->onOffIcon("actions", "password-show"));
-    m_mainUi->togglePasswordGeneratorButton->setIcon(filePath()->icon("actions", "password-generator", false));
+    m_mainUi->togglePasswordGeneratorButton->setIcon(filePath()->icon("actions", "password-generator"));
     connect(m_mainUi->togglePasswordButton, SIGNAL(toggled(bool)), m_mainUi->passwordEdit, SLOT(setShowPassword(bool)));
     connect(m_mainUi->togglePasswordGeneratorButton, SIGNAL(toggled(bool)), SLOT(togglePasswordGeneratorButton(bool)));
     connect(m_mainUi->expireCheck, SIGNAL(toggled(bool)), m_mainUi->expireDatePicker, SLOT(setEnabled(bool)));


### PR DESCRIPTION
KeepassXC tries to load the theme icon first and then falls back to the internal icon unless the check is explicitely disabled. Remove the check from most icons

Fixes #756

I just compiled and ran. One of the icons that doesn't have a system
icon is the copy URL icon. I suggest that we change it.

- ✅ Bug fix

- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**