### PR TITLE
Make password generator length use existing length if available

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -179,9 +179,15 @@ void PasswordGeneratorWidget::saveSettings()
     config()->set("generator/Type", m_ui->tabWidget->currentIndex());
 }
 
-void PasswordGeneratorWidget::reset()
+void PasswordGeneratorWidget::reset(int length)
 {
     m_ui->editNewPassword->setText("");
+    if (length > 0) {
+        m_ui->spinBoxLength->setValue(length);
+    } else {
+        m_ui->spinBoxLength->setValue(config()->get("generator/Length", PasswordGenerator::DefaultLength).toInt());
+    }
+
     setStandaloneMode(false);
     setPasswordVisible(config()->get("security/passwordscleartext").toBool());
     updateGenerator();

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -48,7 +48,7 @@ public:
     ~PasswordGeneratorWidget();
     void loadSettings();
     void saveSettings();
-    void reset();
+    void reset(int length = 0);
     void setStandaloneMode(bool standalone);
     QString getGeneratedPassword();
     bool isPasswordVisible() const;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -681,7 +681,7 @@ void EditEntryWidget::setForms(const Entry* entry, bool restore)
     m_mainUi->notesHint->setVisible(config()->get("security/hidenotes").toBool());
     m_mainUi->togglePasswordGeneratorButton->setChecked(false);
     m_mainUi->togglePasswordGeneratorButton->setDisabled(m_history);
-    m_mainUi->passwordGenerator->reset();
+    m_mainUi->passwordGenerator->reset(entry->password().length());
 
     m_advancedUi->attachmentsWidget->setReadOnly(m_history);
     m_advancedUi->addAttributeButton->setEnabled(!m_history);
@@ -934,6 +934,7 @@ void EditEntryWidget::cancel()
                                            QMessageBox::Cancel | QMessageBox::Save | QMessageBox::Discard,
                                            QMessageBox::Cancel);
         if (result == QMessageBox::Cancel) {
+            m_mainUi->passwordGenerator->reset();
             return;
         }
         if (result == QMessageBox::Save) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Adds optional length parameter to `PasswordGeneratorWidget::reset()` (default=0), which when >0 sets the length SpinBox's value to the value passed in. The EditEntryWidget already called reset() when the password at a time when was known, so the current length was just added to this call (accounts for empty passwords correctly)

This seems like a clean approach to me, as the use of the default parameter keeps all previous usage the same, except when a value is passed in.  Another approach could be to add a public `PasswordGeneratorWidget::setLength()` function. If that is more desired, I would be happy to do that instead.

**Edit:** Additionally, I made the change discussed in [my comment below](https://github.com/keepassxreboot/keepassxc/pull/2318#issuecomment-423872469).  Now, if the entry edit is closed without saving, any changes to the password generator length will not carry over into new entries.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2180
Fixes undesirable behavior discussed in comments of #2318 

## How has this been tested?

1. Changed the value of `[generator]->Length` to something recognizable
    ```
    $ grep ^Length ~/.config/keepassxc/keepassxc.ini
    Length=53
    ```
1. Opened keepassxc and began creating a new entry.  Expanded generator section, and verified that the length still honors that value:
![2018-09-23_19-09-06](https://user-images.githubusercontent.com/5200550/45935825-51836300-bf64-11e8-88a1-c3d2dfe5ab24.png)
1. Opened various entries, all having different lengths and verified that they inherit their existing length:
![2018-09-23_19-11-53](https://user-images.githubusercontent.com/5200550/45935864-ad4dec00-bf64-11e8-89ad-00d5fc5db986.png)
![2018-09-23_19-12-18](https://user-images.githubusercontent.com/5200550/45935865-afb04600-bf64-11e8-9ff5-41d56cc03aa9.png)
1. Created new entry and expanded generator section.  ~It is the last used length (in this case 8). This is identical to the current behavior, happy to change it if another behavior is desired:~ The length is still the value of `[generator]->Length`
![2018-09-23_22-59-43](https://user-images.githubusercontent.com/5200550/45939096-c5356800-bf84-11e8-9562-4ad9cf2831ae.png)
I then cancelled this entry (this is important for the next step).
1. Opened standalone password generator, and it is still using the value of `[generator]->Length` at startup.  ~The generator _widget_ always retains its last state in memory, since it is always just hidden and shown.  It does not actually commit its length to the ini until a generated password is actually used, therefore the standalone generator will not inherit the last used value of a cancelled generation.~
![2018-09-23_19-19-50](https://user-images.githubusercontent.com/5200550/45936030-9c05df00-bf66-11e8-9aff-a2c0a4b95329.png)
1. Created a new test entry with a 44 character generated password and saved it. Checked the ini file, and the length is changed to 44.  Opened standalone generator, and length is set to 44:
![2018-09-23_19-28-23](https://user-images.githubusercontent.com/5200550/45936046-d96a6c80-bf66-11e8-8544-3cc59a504763.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

