### PR TITLE
Allow Enter key to select recent DB on OS X

### DIFF
--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -16,6 +16,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QKeyEvent>
 #include "WelcomeWidget.h"
 #include "ui_WelcomeWidget.h"
 
@@ -75,4 +76,12 @@ void WelcomeWidget::refreshLastDatabases()
         itm->setText(database);
         m_ui->recentListWidget->addItem(itm);
     }
+}
+
+void WelcomeWidget::keyPressEvent(QKeyEvent *event) {
+    if (m_ui->recentListWidget->hasFocus() && (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)) {
+        openDatabaseFromFile(m_ui->recentListWidget->currentItem());
+    }
+
+    QWidget::keyPressEvent(event);
 }

--- a/src/gui/WelcomeWidget.h
+++ b/src/gui/WelcomeWidget.h
@@ -43,6 +43,9 @@ signals:
     void importKeePass1Database();
     void importCsv();
 
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
+
 private slots:
     void openDatabaseFromFile(QListWidgetItem* item);
 


### PR DESCRIPTION
## Description
Override `keyPressEvent`on WelcomeWidget on OS X to `openDatabaseFromFile`.

## Motivation and context
I work with a few different password DBs. I like to use the keyboard heavily in KeePassXC. I can close an existing DB with Ctrl+W, but I have to use the mouse to open a recent one. Hitting Enter does not work on OS X. Details are below.

My C++ is extremely rusty, so any feedback would be appreciated.

`openDatabaseFromFile` is already invoked via the QListWidget::itemActivated signal, but this signal doesn't fire on OS X for Enter. QListWidget::itemActivated activates on an OS specific activation key. [1] On Windows/X11, this is Enter, which lets the user easily navigate with just the keyboard. On OS X, this is Ctrl+O, which is already bound to Open Database. This means that `itemActivated` cannot fire via the keyboard.

Per StackOverflow [2], a recommended solution is to catch the enter/return key press manually.

This seems like a common problem with Qt. [3] [4] I'm guessing other `QListWidget`s also exhibit this problem, but I don't use them enough for it to be a pain point. This PR fixes this particular widget, but there is likely a more holistic approach for the other widgets.

[1] https://doc.qt.io/archives/qt-4.8/qlistwidget.html#itemActivated
[2] https://stackoverflow.com/questions/31650780/when-does-a-qtreeview-emit-the-activated-signal-on-mac
[3] https://forum.qt.io/topic/36147/pyside-itemactivated-not-triggered-on-mac-os-x-with-return-key
[4] https://github.com/dolphin-emu/dolphin/pull/6099

## How has this been tested?
Manually tested on OS X 10.11.6 with Qt 5.11.2. I have not tested on a Windows/X11 environment to verify that the `#ifdef` is working.

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)=

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ❌ My code follows the code style of this project. **[REQUIRED]** (I was unable to run `make format`. Code change is small and looks like the other code as far as I can tell though)
- ❌   All new and existing tests passed. **[REQUIRED]** (the testgui tests are hanging on my machine on the develop branch. I'm not sure if I broke them on this branch, so going to wait for the CI check instead.
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**