### PR TITLE
Add option to not show password placeholder when field is empty

### DIFF
--- a/share/keepassxc.ini
+++ b/share/keepassxc.ini
@@ -34,6 +34,7 @@ lockdatabaseidlesec=240
 lockdatabaseminimize=false
 lockdatabasescreenlock=true
 passwordscleartext=false
+passwordemptynodots=false
 passwordsrepeat=false
 
 [Http]

--- a/share/keepassxc.ini
+++ b/share/keepassxc.ini
@@ -34,7 +34,7 @@ lockdatabaseidlesec=240
 lockdatabaseminimize=false
 lockdatabasescreenlock=true
 passwordscleartext=false
-passwordemptynodots=false
+passwordemptynodots=true
 passwordsrepeat=false
 
 [Http]

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -146,6 +146,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/lockdatabasescreenlock", true);
     m_defaults.insert("security/passwordsrepeat", false);
     m_defaults.insert("security/passwordscleartext", false);
+    m_defaults.insert("security/passwordemptynodots", false);
     m_defaults.insert("security/hidepassworddetails", true);
     m_defaults.insert("security/autotypeask", true);
     m_defaults.insert("security/IconDownloadFallback", false);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -146,7 +146,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/lockdatabasescreenlock", true);
     m_defaults.insert("security/passwordsrepeat", false);
     m_defaults.insert("security/passwordscleartext", false);
-    m_defaults.insert("security/passwordemptynodots", false);
+    m_defaults.insert("security/passwordemptynodots", true);
     m_defaults.insert("security/hidepassworddetails", true);
     m_defaults.insert("security/autotypeask", true);
     m_defaults.insert("security/IconDownloadFallback", false);

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -88,10 +88,7 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
             m_secUi->lockDatabaseIdleSpinBox,
             SLOT(setEnabled(bool)));
 
-    connect(m_secUi->touchIDResetCheckBox,
-            SIGNAL(toggled(bool)),
-            m_secUi->touchIDResetSpinBox,
-            SLOT(setEnabled(bool)));
+    connect(m_secUi->touchIDResetCheckBox, SIGNAL(toggled(bool)), m_secUi->touchIDResetSpinBox, SLOT(setEnabled(bool)));
 
 #ifndef WITH_XC_NETWORKING
     m_secUi->privacy->setVisible(false);
@@ -189,6 +186,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->fallbackToSearch->setChecked(config()->get("security/IconDownloadFallback").toBool());
 
     m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
+    m_secUi->passwordShowDotsCheckBox->setChecked(config()->get("security/passwordemptynodots").toBool());
     m_secUi->passwordDetailsCleartextCheckBox->setChecked(config()->get("security/hidepassworddetails").toBool());
     m_secUi->passwordRepeatCheckBox->setChecked(config()->get("security/passwordsrepeat").toBool());
     m_secUi->hideNotesCheckBox->setChecked(config()->get("security/hidenotes").toBool());
@@ -259,6 +257,8 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set("security/IconDownloadFallback", m_secUi->fallbackToSearch->isChecked());
 
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
+    config()->set("security/passwordemptynodots", m_secUi->passwordShowDotsCheckBox->isChecked());
+
     config()->set("security/hidepassworddetails", m_secUi->passwordDetailsCleartextCheckBox->isChecked());
     config()->set("security/passwordsrepeat", m_secUi->passwordRepeatCheckBox->isChecked());
     config()->set("security/hidenotes", m_secUi->hideNotesCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -180,6 +180,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="passwordShowDotsCheckBox">
+        <property name="text">
+         <string>Don't use placeholder for empty password fields</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="passwordDetailsCleartextCheckBox">
         <property name="text">
          <string>Hide passwords in the preview panel</string>

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -24,6 +24,7 @@
 #include <QPainter>
 #include <QPalette>
 
+#include "core/Config.h"
 #include "core/DatabaseIcons.h"
 #include "core/Entry.h"
 #include "core/Global.h"
@@ -172,6 +173,9 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             if (attr->isReference(EntryAttributes::PasswordKey)) {
                 result.prepend(tr("Ref: ", "Reference abbreviation"));
             }
+            if (entry->password().isEmpty() && config()->get("security/passwordemptynodots").toBool()) {
+                result = "";
+            }
             return result;
         case Url:
             result = entry->resolveMultiplePlaceholders(entry->displayUrl());
@@ -202,17 +206,17 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             result = entry->timeInfo().lastAccessTime().toLocalTime().toString(EntryModel::DateFormat);
             return result;
         case Attachments: {
-                // Display comma-separated list of attachments
-                QList<QString> attachments = entry->attachments()->keys();
-                for (int i = 0; i < attachments.size(); ++i) {
-                    if (result.isEmpty()) {
-                        result.append(attachments.at(i));
-                        continue;
-                    }
-                    result.append(QString(", ") + attachments.at(i));
+            // Display comma-separated list of attachments
+            QList<QString> attachments = entry->attachments()->keys();
+            for (int i = 0; i < attachments.size(); ++i) {
+                if (result.isEmpty()) {
+                    result.append(attachments.at(i));
+                    continue;
                 }
-                return result;
+                result.append(QString(", ") + attachments.at(i));
             }
+            return result;
+        }
         case Totp:
             result = entry->hasTotp() ? tr("Yes") : "";
             return result;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Add an option to show an empty password field when there's no password specified within an entry.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2310.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)


## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
 