### PR TITLE
Add option to list elements recursively in the cli

### DIFF
--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -50,7 +50,11 @@ int List::execute(const QStringList& arguments)
                                QObject::tr("Key file of the database."),
                                QObject::tr("path"));
     parser.addOption(keyFile);
-    parser.addOption({{"R", "recursive"}, "Recursive mode, list elements recursively"});
+
+    QCommandLineOption recursiveOption(QStringList() << "R"
+                                                     << "recursive",
+                                       QObject::tr("Recursive mode, list elements recursively"));
+    parser.addOption(recursiveOption);
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
@@ -59,7 +63,7 @@ int List::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    bool recursive = parser.isSet({"R", "recursive"});
+    bool recursive = parser.isSet(recursiveOption);
 
     Database* db = Database::unlockFromStdin(args.at(0), parser.value(keyFile));
     if (db == nullptr) {

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -50,6 +50,7 @@ int List::execute(const QStringList& arguments)
                                QObject::tr("Key file of the database."),
                                QObject::tr("path"));
     parser.addOption(keyFile);
+    parser.addOption({{"R", "recursive"}, "Recursive mode, list elements recursively"});
     parser.process(arguments);
 
     const QStringList args = parser.positionalArguments();
@@ -58,22 +59,24 @@ int List::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
+    bool recursive = parser.isSet({"R", "recursive"});
+
     Database* db = Database::unlockFromStdin(args.at(0), parser.value(keyFile));
     if (db == nullptr) {
         return EXIT_FAILURE;
     }
 
     if (args.size() == 2) {
-        return this->listGroup(db, args.at(1));
+        return this->listGroup(db, recursive, args.at(1));
     }
-    return this->listGroup(db);
+    return this->listGroup(db, recursive);
 }
 
-int List::listGroup(Database* database, QString groupPath)
+int List::listGroup(Database* database, bool recursive, QString groupPath)
 {
     QTextStream outputTextStream(stdout, QIODevice::WriteOnly);
     if (groupPath.isEmpty()) {
-        outputTextStream << database->rootGroup()->print();
+        outputTextStream << database->rootGroup()->print(recursive);
         outputTextStream.flush();
         return EXIT_SUCCESS;
     }
@@ -84,7 +87,7 @@ int List::listGroup(Database* database, QString groupPath)
         return EXIT_FAILURE;
     }
 
-    outputTextStream << group->print();
+    outputTextStream << group->print(recursive);
     outputTextStream.flush();
     return EXIT_SUCCESS;
 }

--- a/src/cli/List.h
+++ b/src/cli/List.h
@@ -26,7 +26,7 @@ public:
     List();
     ~List();
     int execute(const QStringList& arguments);
-    int listGroup(Database* database, QString groupPath = QString(""));
+    int listGroup(Database* database, bool recursive, QString groupPath = QString(""));
 };
 
 #endif // KEEPASSXC_LIST_H


### PR DESCRIPTION
## Description
In keepassxc-cli it's possible to list the elements in the database but there was no way to list them recursively, this pull request add's that option.

The functionality to recursively print the database was already in the codebase. This pull request only enables the functionality to be used by the end user.

## Motivation and context
Removes the need to use "extract" when doing simple scripting tasks. 

## How has this been tested?
Tested it with several commands:
-  `keepasxc-cli ls database.kdbx`
Lists only the top elements in the database
-  `keepasxc-cli ls -R database.kdbx`
Lists everything from the top element of the database
-  `keepasxc-cli ls database.kdbx group`
Lists only the top elements of the specified group
-  `keepasxc-cli ls -R database.kdbx group`
Lists everything from the specified group down
-  `keepasxc-cli ls `
Shows a help screen including the new option.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**