### PR TITLE
Add notes for CMake options WITH_XC_TOUCHID, WITH_APP_BUNDLE

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,22 +91,24 @@ These steps place the compiled KeePassXC binary inside the `./build/src/` direct
 	-DWITH_GUI_TESTS=ON
 	```
 
-* cmake accepts the following options:
+* Cmake accepts the following options:
 
 	```
-	  -DWITH_XC_AUTOTYPE=[ON|OFF] Enable/Disable Auto-Type (default: ON)
-	  -DWITH_XC_YUBIKEY=[ON|OFF] Enable/Disable YubiKey HMAC-SHA1 authentication support (default: OFF)
-	  -DWITH_XC_BROWSER=[ON|OFF] Enable/Disable KeePassXC-Browser extension support (default: OFF)
-	  -DWITH_XC_NETWORKING=[ON|OFF] Enable/Disable Networking support (favicon download) (default: OFF)
-	  -DWITH_XC_SSHAGENT=[ON|OFF] Include SSH agent support. (default: OFF)
-	  
-	  -DWITH_XC_ALL=[ON|OFF] Enable/Disable compiling all plugins above (default: OFF)
-	  
-	  -DWITH_TESTS=[ON|OFF] Enable/Disable building of unit tests (default: ON)
-	  -DWITH_GUI_TESTS=[ON|OFF] Enable/Disable building of GUI tests (default: OFF)
-	  -DWITH_DEV_BUILD=[ON|OFF] Enable/Disable deprecated method warnings (default: OFF)
-	  -DWITH_ASAN=[ON|OFF] Enable/Disable address sanitizer checks (Linux / macOS only) (default: OFF)
-	  -DWITH_COVERAGE=[ON|OFF] Enable/Disable coverage tests (GCC only) (default: OFF)	  
+	-DWITH_XC_AUTOTYPE=[ON|OFF] Enable/Disable Auto-Type (default: ON)
+	-DWITH_XC_YUBIKEY=[ON|OFF] Enable/Disable YubiKey HMAC-SHA1 authentication support (default: OFF)
+	-DWITH_XC_BROWSER=[ON|OFF] Enable/Disable KeePassXC-Browser extension support (default: OFF)
+	-DWITH_XC_NETWORKING=[ON|OFF] Enable/Disable Networking support (favicon download) (default: OFF)
+	-DWITH_XC_SSHAGENT=[ON|OFF] Include SSH agent support (default: OFF)
+	-DWITH_XC_TOUCHID=[ON|OFF] Include TouchID support for macOS (default: OFF)
+
+	-DWITH_XC_ALL=[ON|OFF] Enable/Disable compiling all plugins above (default: OFF)
+
+	-DWITH_TESTS=[ON|OFF] Enable/Disable building of unit tests (default: ON)
+	-DWITH_GUI_TESTS=[ON|OFF] Enable/Disable building of GUI tests (default: OFF)
+	-DWITH_DEV_BUILD=[ON|OFF] Enable/Disable deprecated method warnings (default: OFF)
+	-DWITH_ASAN=[ON|OFF] Enable/Disable address sanitizer checks (Linux / macOS only) (default: OFF)
+	-DWITH_COVERAGE=[ON|OFF] Enable/Disable coverage tests (GCC only) (default: OFF)
+	-DWITH_APP_BUNDLE=[ON|OFF] Enable Application Bundle for macOS (default: ON)
 	```
 
 * If you are on MacOS you must add this parameter to **Cmake**, with the Qt version you have installed<br/> `-DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.6.2/lib/cmake/`


### PR DESCRIPTION
## Description
- Add CMake options in building instruction: `WITH_XC_TOUCHID`, `WITH_APP_BUNDLE`.
- Remove some redundant whitespaces.

## Motivation and context
Better documentation.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**