### PR TITLE
Don't obscure password field after invalid password attempt if setting is off 

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -184,7 +184,9 @@ void DatabaseOpenWidget::openDatabase()
         return;
     }
 
-    m_ui->editPassword->setShowPassword(false);
+    if (!m_ui->editPassword->isPasswordVisible()) {
+      m_ui->editPassword->setShowPassword(false);
+    }
     QCoreApplication::processEvents();
 
     QFile file(m_filename);

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -71,6 +71,10 @@ void PasswordEdit::setShowPassword(bool show)
     emit showPasswordChanged(show);
 }
 
+bool PasswordEdit::isPasswordVisible() const {
+  return isEnabled();
+}
+
 bool PasswordEdit::passwordsEqual() const
 {
     return text() == m_basePasswordEdit->text();

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -31,6 +31,7 @@ public:
 
     explicit PasswordEdit(QWidget* parent = nullptr);
     void enableVerifyMode(PasswordEdit* baseEdit);
+    bool isPasswordVisible() const;
 
 public slots:
     void setShowPassword(bool show);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Introduce const function `bool isPasswordVisible()` to detect whether password is visible if not. Add an if-conditional checking if password is selected to be visible or not, and change state of password field depending on return value. 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2344.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
