### PR TITLE
Toolbar and tool buttons style.

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -186,6 +186,8 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/resettouchidscreenlock", true);
     m_defaults.insert("GUI/Language", "system");
     m_defaults.insert("GUI/HideToolbar", false);
+    m_defaults.insert("GUI/MovableToolbar", false);
+    m_defaults.insert("GUI/ToolButtonStyle", QVariant::fromValue(Qt::ToolButtonIconOnly));
     m_defaults.insert("GUI/ShowTrayIcon", false);
     m_defaults.insert("GUI/DarkTrayIcon", false);
     m_defaults.insert("GUI/MinimizeToTray", false);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -187,7 +187,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("GUI/Language", "system");
     m_defaults.insert("GUI/HideToolbar", false);
     m_defaults.insert("GUI/MovableToolbar", false);
-    m_defaults.insert("GUI/ToolButtonStyle", QVariant::fromValue(Qt::ToolButtonIconOnly));
+    m_defaults.insert("GUI/ToolButtonStyle", Qt::ToolButtonIconOnly);
     m_defaults.insert("GUI/ShowTrayIcon", false);
     m_defaults.insert("GUI/DarkTrayIcon", false);
     m_defaults.insert("GUI/MinimizeToTray", false);

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -80,6 +80,7 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
     connect(
         m_generalUi->autoSaveAfterEveryChangeCheckBox, SIGNAL(toggled(bool)), this, SLOT(enableAutoSaveOnExit(bool)));
     connect(m_generalUi->systrayShowCheckBox, SIGNAL(toggled(bool)), this, SLOT(enableSystray(bool)));
+    connect(m_generalUi->toolbarHideCheckBox, SIGNAL(toggled(bool)), this, SLOT(enableToolbarSettings(bool)));
 
     connect(
         m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)), m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));
@@ -156,6 +157,19 @@ void ApplicationSettingsWidget::loadSettings()
 
     m_generalUi->previewHideCheckBox->setChecked(config()->get("GUI/HidePreviewPanel").toBool());
     m_generalUi->toolbarHideCheckBox->setChecked(config()->get("GUI/HideToolbar").toBool());
+    m_generalUi->toolbarMovableCheckBox->setChecked(config()->get("GUI/MovableToolbar").toBool());
+
+    m_generalUi->toolButtonStyleComboBox->clear();
+    m_generalUi->toolButtonStyleComboBox->addItem(tr("Icon only"), Qt::ToolButtonIconOnly);
+    m_generalUi->toolButtonStyleComboBox->addItem(tr("Text only"), Qt::ToolButtonTextOnly);
+    m_generalUi->toolButtonStyleComboBox->addItem(tr("Text beside icon"), Qt::ToolButtonTextBesideIcon);
+    m_generalUi->toolButtonStyleComboBox->addItem(tr("Text under icon"), Qt::ToolButtonTextUnderIcon);
+    m_generalUi->toolButtonStyleComboBox->addItem(tr("Follow style"), Qt::ToolButtonFollowStyle);
+    int toolButtonStyleIndex = m_generalUi->toolButtonStyleComboBox->findData(config()->get("GUI/ToolButtonStyle"));
+    if (toolButtonStyleIndex > 0) {
+        m_generalUi->toolButtonStyleComboBox->setCurrentIndex(toolButtonStyleIndex);
+    }
+
     m_generalUi->systrayShowCheckBox->setChecked(config()->get("GUI/ShowTrayIcon").toBool());
     m_generalUi->systrayDarkIconCheckBox->setChecked(config()->get("GUI/DarkTrayIcon").toBool());
     m_generalUi->systrayMinimizeToTrayCheckBox->setChecked(config()->get("GUI/MinimizeToTray").toBool());
@@ -232,6 +246,11 @@ void ApplicationSettingsWidget::saveSettings()
 
     config()->set("GUI/HidePreviewPanel", m_generalUi->previewHideCheckBox->isChecked());
     config()->set("GUI/HideToolbar", m_generalUi->toolbarHideCheckBox->isChecked());
+    config()->set("GUI/MovableToolbar", m_generalUi->toolbarMovableCheckBox->isChecked());
+
+    int currentToolButtonStyleIndex = m_generalUi->toolButtonStyleComboBox->currentIndex();
+    config()->set("GUI/ToolButtonStyle", m_generalUi->toolButtonStyleComboBox->itemData(currentToolButtonStyleIndex).toString());
+
     config()->set("GUI/ShowTrayIcon", m_generalUi->systrayShowCheckBox->isChecked());
     config()->set("GUI/DarkTrayIcon", m_generalUi->systrayDarkIconCheckBox->isChecked());
     config()->set("GUI/MinimizeToTray", m_generalUi->systrayMinimizeToTrayCheckBox->isChecked());
@@ -300,3 +319,11 @@ void ApplicationSettingsWidget::enableSystray(bool checked)
     m_generalUi->systrayDarkIconCheckBox->setEnabled(checked);
     m_generalUi->systrayMinimizeToTrayCheckBox->setEnabled(checked);
 }
+
+void ApplicationSettingsWidget::enableToolbarSettings(bool checked)
+{
+    m_generalUi->toolbarMovableCheckBox->setEnabled(!checked);
+    m_generalUi->toolButtonStyleComboBox->setEnabled(!checked);
+    m_generalUi->toolButtonStyleLabel->setEnabled(!checked);
+}
+

--- a/src/gui/ApplicationSettingsWidget.h
+++ b/src/gui/ApplicationSettingsWidget.h
@@ -55,6 +55,7 @@ private slots:
     void reject();
     void enableAutoSaveOnExit(bool checked);
     void enableSystray(bool checked);
+    void enableToolbarSettings(bool checked);
 
 private:
     QWidget* const m_secWidget;

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>684</width>
-    <height>842</height>
+    <height>881</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -185,6 +185,100 @@
              <string>Hide toolbar (icons)</string>
             </property>
            </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="toolbarMovableLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SetMaximumSize</enum>
+            </property>
+            <item>
+             <spacer name="toolbarMovableSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="toolbarMovableCheckBox">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Movable toolbar</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="toolButtonStyleLayout">
+            <property name="spacing">
+             <number>15</number>
+            </property>
+            <item>
+             <spacer name="toolButtonStyleSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item alignment="Qt::AlignRight">
+             <widget class="QLabel" name="toolButtonStyleLabel">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Button style</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="toolButtonStyleComboBox">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QCheckBox" name="minimizeOnCloseCheckBox">

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -135,6 +135,7 @@ MainWindow::MainWindow()
     m_countDefaultAttributes = m_ui->menuEntryCopyAttribute->actions().size();
 
     restoreGeometry(config()->get("GUI/MainWindowGeometry").toByteArray());
+    restoreState(config()->get("GUI/MainWindowState").toByteArray());
 #ifdef WITH_XC_BROWSER
     m_ui->settingsWidget->addSettingsPage(new BrowserPlugin(m_ui->tabWidget));
 #endif
@@ -779,6 +780,7 @@ void MainWindow::saveWindowInformation()
 {
     if (isVisible()) {
         config()->set("GUI/MainWindowGeometry", saveGeometry());
+        config()->set("GUI/MainWindowState", saveState());
     }
 }
 
@@ -904,6 +906,13 @@ void MainWindow::applySettingsChanges()
 #endif
 
     m_ui->toolBar->setHidden(config()->get("GUI/HideToolbar").toBool());
+    m_ui->toolBar->setMovable(config()->get("GUI/MovableToolbar").toBool());
+
+    bool isOk = false;
+    const auto toolButtonStyle = static_cast<Qt::ToolButtonStyle>(config()->get("GUI/ToolButtonStyle").toInt(&isOk));
+    if (isOk) {
+        m_ui->toolBar->setToolButtonStyle(toolButtonStyle);
+    }
 
     updateTrayIcon();
 }


### PR DESCRIPTION
## Description
- Add ability to change toolbar state and tool buttons style via application settings widget.
- Save/restore toolbar state on app start/finish.

## Motivation and context
- Resolves #2343.

## How has this been tested?
Manually.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/43829320/46555974-d455d780-c8ed-11e8-878c-684d5df62c8d.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

