### PR TITLE
 Make keepassxc-cli show return all matching entries.

### DIFF
--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -78,7 +78,7 @@ int Show::execute(const QStringList& arguments)
 int Show::showEntries(Database* database, QStringList attributes, QString entryPath)
 {
     int result = EXIT_SUCCESS;
-    QMap<QUuid, Entry*> entries = database->rootGroup()->findEntries(entryPath);
+    QSet<Entry*> entries = database->rootGroup()->findEntries(entryPath);
 
     if(entries.isEmpty()) {
         qCritical("could not find entry with path %s.", qPrintable(entryPath));
@@ -91,7 +91,7 @@ int Show::showEntries(Database* database, QStringList attributes, QString entryP
         attributes = EntryAttributes::DefaultAttributes;
     }
 
-    for(Entry* entry : entries.values()) {
+    for(Entry* entry : entries) {
         if(showEntry(entry, attributes, showAttributeNames) != EXIT_SUCCESS) {
             result = EXIT_FAILURE;
         }

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -26,7 +26,8 @@ public:
     Show();
     ~Show();
     int execute(const QStringList& arguments);
-    int showEntry(Database* database, QStringList attributes, QString entryPath);
+    int showEntries(Database* database, QStringList attributes, QString entryPath);
+    int showEntry(Entry* entry, QStringList attributes, bool showAttributeNames);
 };
 
 #endif // KEEPASSXC_SHOW_H

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -47,7 +47,7 @@ Merges two databases together. The first database file is going to be replaced b
 Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
 
 .IP "show [options] <database> <entry>"
-Shows the title, username, password, URL and notes of a database entry. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
+Shows the title, username, password, URL and notes of a database entry. 
 
 .SH OPTIONS
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -552,17 +552,17 @@ QList<Entry*> Group::entriesRecursive(bool includeHistoryItems) const
     return entryList;
 }
 
-QMap<QUuid, Entry*> Group::findEntries(QString entryId) 
+QSet<Entry*> Group::findEntries(QString entryId) 
 {
     Q_ASSERT(!entryId.isNull());
-    QMap<QUuid, Entry*> entries;
+    QSet<Entry*> entries;
 
     QUuid entryUuid = QUuid::fromRfc4122(QByteArray::fromHex(entryId.toLatin1()));
     if (!entryUuid.isNull()) {
         Entry* entry;
         entry = findEntryByUuid(entryUuid);
         if (entry) {
-            entries.insert(entryUuid, entry);
+            entries.insert(entry);
             return entries; // If an entry with a matching UUID has been found return. No more entries can be found
         }
     } 
@@ -571,22 +571,22 @@ QMap<QUuid, Entry*> Group::findEntries(QString entryId)
 
     for (Entry* entry : entriesRecursive(false)) {
         if (entry->title() == entryId) {
-            entries.insert(entry->uuid(), entry);
+            entries.insert(entry);
         }
     }
 
     return entries;
 }
 
-QMap<QUuid, Entry*> Group::findEntriesByPath(QString entryPath, QString basePath)
+QSet<Entry*> Group::findEntriesByPath(QString entryPath, QString basePath)
 {
     Q_ASSERT(!entryPath.isNull());
-    QMap<QUuid, Entry*> entries;
+    QSet<Entry*> entries;
 
     for (Entry* entry : asConst(m_entries)) {
         QString currentEntryPath = basePath + entry->title();
         if (entryPath == currentEntryPath || entryPath == QString("/" + currentEntryPath)) {
-            entries.insert(entry->uuid(), entry);
+            entries.insert(entry);
         }
     }
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -116,8 +116,8 @@ public:
     Entry* findEntry(QString entryId);
     Entry* findEntryByUuid(const QUuid& uuid) const;
     Entry* findEntryByPath(QString entryPath, QString basePath = QString(""));
-    QMap<QUuid, Entry*> findEntries(QString entryId);
-    QMap<QUuid, Entry*> findEntriesByPath(QString entryPath, QString basePath = QString(""));
+    QSet<Entry*> findEntries(QString entryId);
+    QSet<Entry*> findEntriesByPath(QString entryPath, QString basePath = QString(""));
     Group* findGroupByUuid(const QUuid& uuid);
     Group* findGroupByPath(QString groupPath);
     QStringList locate(QString locateTerm, QString currentPath = QString("/"));

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -34,8 +34,7 @@ class Group : public QObject
     Q_OBJECT
 
 public:
-    enum TriState
-    {
+    enum TriState {
         Inherit,
         Enable,
         Disable
@@ -117,6 +116,8 @@ public:
     Entry* findEntry(QString entryId);
     Entry* findEntryByUuid(const QUuid& uuid) const;
     Entry* findEntryByPath(QString entryPath, QString basePath = QString(""));
+    QMap<QUuid, Entry*> findEntries(QString entryId);
+    QMap<QUuid, Entry*> findEntriesByPath(QString entryPath, QString basePath = QString(""));
     Group* findGroupByUuid(const QUuid& uuid);
     Group* findGroupByPath(QString groupPath);
     QStringList locate(QString locateTerm, QString currentPath = QString("/"));


### PR DESCRIPTION
As mentioned in issue #1967 show should return all matching items
instead of the first one. If a UUID is passed to show it will return one
entry if there is a match. For a path or name it will return all
matching entries.

## Motivation and context
Closes #1967 

## How has this been tested?
Situations:
- One matching item
- No matching item's
- Multiple matching item's in the same group
- Multiple matching item's in different groups on the same levels
- Multiple matching item's in different groups on different levels

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
