### PR TITLE
Don't show application if we're only showing the help / version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
                                           QCoreApplication::translate("main", "Parent window handle"),
                                           "handle");
 
-    parser.addHelpOption();
+    QCommandLineOption helpOption = parser.addHelpOption();
     QCommandLineOption versionOption = parser.addVersionOption();
     parser.addOption(configOption);
     parser.addOption(keyfileOption);
@@ -103,6 +103,12 @@ int main(int argc, char** argv)
     parser.addOption(parentWindowOption);
 
     parser.process(app);
+    
+    // Don't try and do anything with the application if we're only showing the help / version
+    if (parser.isSet(versionOption) || parser.isSet(helpOption)) {
+        return 0;
+    }
+    
     const QStringList fileNames = parser.positionalArguments();
 
     if (app.isAlreadyRunning() && !parser.isSet(versionOption)) {


### PR DESCRIPTION
Don't launch the application when just trying to show the help or version.

## Description
With a window already running, executing `keepassxc --help` will both show help, and raise the application.

## Motivation and context
Raising the application is unnecessary in this context.

## How has this been tested?
By reading the code, the best kind of testing! ;)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ~✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**~
- ~✅ I have added tests to cover my changes.~
