### PR TITLE
Add unprotected output switch to `keepassxc-cli extract`

### DIFF
--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -142,6 +142,12 @@ Use special characters for the generated password. [Default: Disabled]
 Use extended ASCII characters for the generated password. [Default: Disabled]
 
 
+.SS "Extract options"
+
+.IP "-u, --unprotected"
+Extract the database with all the protected fields as unprotected.
+This will extract passwords etc. as plaintext. [Default: Disabled]
+
 
 .SH REPORTING BUGS
 Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.


### PR DESCRIPTION
Provides a way to output unprotected database XML when using `keepassxc-cli extract`.
As seen in #2164 

## Description
Added a new switch `-u / --unprotected`.
The implementation writes the database to a QBuffer using a KdbxXmlWriter without specifying a random stream, which causes the `KdbxXmlWriter::writeEntry` to write the plaintext value.
This QBuffer is then returned as a string containing the non-protected XML.

## Motivation and context
#2164

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a clean install of Ubuntu 18.04 and with a new database that contains protected values (passwords, custom attributes etc.).
When not using `-u`, the output will have protected fields. When using `-u`, the protected fields are unprotected and do not contain the `Protected` attribute.

## Screenshots (if appropriate):

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.