### PR TITLE
Added Linux, MacOS support for Tor Browser.

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -27,7 +27,7 @@ for all your websites, programs, etc.
 * In **Browser Integration**, check **Enable KeePassXC browser integration**
 * Right below that, click the checkbox for the browser(s) you use
 Leave the other options at their defaults.
-* *In your default web browser,* install the KeePassXC Browser extension/add-on. Instructions for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) or [Chrome](https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk)
+* *In your default web browser,* install the KeePassXC Browser extension/add-on. Instructions for [Firefox or Tor Browser](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) or [Chrome](https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk)
 * Click the KeePassXC icon in the upper-right corner. You'll see the dialog below. 
 * Click the blue Connect button to make the browser extension connect to the KeePassXC application. 
 <img src="./KeePassXC-Connect.png" height="200" alt="KeePassXC Connect dialog">

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -60,7 +60,9 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent)
     // Vivaldi uses Chrome's registry settings
     m_ui->vivaldiSupport->setHidden(true);
     m_ui->chromeSupport->setText("Chrome and Vivaldi");
-    m_ui->torBrowserSupport->setText("Tor Browser");
+    // Tor Browser uses Firefox's registry settings
+    m_ui->torBrowserSupport->setHidden(true);
+    m_ui->firefoxSupport->setText("Firefox and Tor Browser");
 #endif
     m_ui->browserGlobalWarningWidget->setVisible(false);
 }
@@ -100,8 +102,10 @@ void BrowserOptionDialog::loadSettings()
     m_ui->chromeSupport->setChecked(settings->chromeSupport());
     m_ui->chromiumSupport->setChecked(settings->chromiumSupport());
     m_ui->firefoxSupport->setChecked(settings->firefoxSupport());
+#ifndef Q_OS_WIN
     m_ui->vivaldiSupport->setChecked(settings->vivaldiSupport());
     m_ui->torBrowserSupport->setChecked(settings->torBrowserSupport());
+#endif
 
 #if defined(KEEPASSXC_DIST_APPIMAGE)
     m_ui->supportBrowserProxy->setChecked(true);
@@ -151,8 +155,10 @@ void BrowserOptionDialog::saveSettings()
     settings->setChromeSupport(m_ui->chromeSupport->isChecked());
     settings->setChromiumSupport(m_ui->chromiumSupport->isChecked());
     settings->setFirefoxSupport(m_ui->firefoxSupport->isChecked());
+#ifndef Q_OS_WIN
     settings->setVivaldiSupport(m_ui->vivaldiSupport->isChecked());
     settings->setTorBrowserSupport(m_ui->torBrowserSupport->isChecked());
+#endif
 }
 
 void BrowserOptionDialog::showProxyLocationFileDialog()

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -60,6 +60,7 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent)
     // Vivaldi uses Chrome's registry settings
     m_ui->vivaldiSupport->setHidden(true);
     m_ui->chromeSupport->setText("Chrome and Vivaldi");
+    m_ui->torBrowserSupport->setText("Tor Browser");
 #endif
     m_ui->browserGlobalWarningWidget->setVisible(false);
 }
@@ -100,6 +101,7 @@ void BrowserOptionDialog::loadSettings()
     m_ui->chromiumSupport->setChecked(settings->chromiumSupport());
     m_ui->firefoxSupport->setChecked(settings->firefoxSupport());
     m_ui->vivaldiSupport->setChecked(settings->vivaldiSupport());
+    m_ui->torBrowserSupport->setChecked(settings->torBrowserSupport());
 
 #if defined(KEEPASSXC_DIST_APPIMAGE)
     m_ui->supportBrowserProxy->setChecked(true);
@@ -150,6 +152,7 @@ void BrowserOptionDialog::saveSettings()
     settings->setChromiumSupport(m_ui->chromiumSupport->isChecked());
     settings->setFirefoxSupport(m_ui->firefoxSupport->isChecked());
     settings->setVivaldiSupport(m_ui->vivaldiSupport->isChecked());
+    settings->setTorBrowserSupport(m_ui->torBrowserSupport->isChecked());
 }
 
 void BrowserOptionDialog::showProxyLocationFileDialog()

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -60,8 +60,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="extensionLabel">
-        </widget>
+        <widget class="QLabel" name="extensionLabel"/>
        </item>
        <item>
         <spacer name="verticalSpacer_1">
@@ -88,6 +87,19 @@
           <property name="horizontalSpacing">
            <number>40</number>
           </property>
+          <item row="0" column="3">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>179</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="chromeSupport">
             <property name="text">
@@ -107,19 +119,6 @@
              <bool>false</bool>
             </property>
            </widget>
-          </item>
-          <item row="0" column="2">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>179</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item row="1" column="0">
            <widget class="QCheckBox" name="chromiumSupport">
@@ -141,14 +140,14 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
+          <item row="0" column="2">
            <widget class="QCheckBox" name="torBrowserSupport">
             <property name="text">
-              <string>&amp;Tor Browser</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
+             <string>&amp;Tor Browser</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
            </widget>
           </item>
          </layout>
@@ -223,22 +222,6 @@
           <string extracomment="Credentials mean login data requested via browser extension">Sort matching credentials by &amp;username</string>
          </property>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item>
         <spacer name="verticalSpacer_2">

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -141,6 +141,16 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="torBrowserSupport">
+            <property name="text">
+              <string>&amp;Tor Browser</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -228,6 +228,17 @@ void BrowserSettings::setVivaldiSupport(bool enabled)
             HostInstaller::SupportedBrowsers::VIVALDI, enabled, supportBrowserProxy(), customProxyLocation());
 }
 
+bool BrowserSettings::torBrowserSupport()
+{
+    return m_hostInstaller.checkIfInstalled(HostInstaller::SupportedBrowsers::TOR_BROWSER);
+}
+
+void BrowserSettings::setTorBrowserSupport(bool enabled)
+{
+    m_hostInstaller.installBrowser(
+        HostInstaller::SupportedBrowsers::TOR_BROWSER, enabled, supportBrowserProxy(), customProxyLocation());
+}
+
 bool BrowserSettings::passwordUseNumbers()
 {
     return config()->get("generator/Numbers", PasswordGenerator::DefaultNumbers).toBool();

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -70,7 +70,9 @@ public:
     void setFirefoxSupport(bool enabled);
     bool vivaldiSupport();
     void setVivaldiSupport(bool enabled);
-
+    bool torBrowserSupport();
+    void setTorBrowserSupport(bool enabled);
+    
     bool passwordUseNumbers();
     void setPasswordUseNumbers(bool useNumbers);
     bool passwordUseLowercase();

--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -49,8 +49,8 @@ HostInstaller::HostInstaller()
     , TARGET_DIR_CHROME("HKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
     , TARGET_DIR_CHROMIUM("HKEY_CURRENT_USER\\Software\\Chromium\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
     , TARGET_DIR_FIREFOX("HKEY_CURRENT_USER\\Software\\Mozilla\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
-    , TARGET_DIR_VIVALDI("HKEY_CURRENT_USER\\Software\\Vivaldi\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
-    , TARGET_DIR_TOR_BROWSER("HKEY_CURRENT_USER\\Software\\TorProject\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
+    , TARGET_DIR_VIVALDI(TARGET_DIR_CHROME)
+    , TARGET_DIR_TOR_BROWSER(TARGET_DIR_FIREFOX)
 #endif
 {
 }

--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -38,16 +38,19 @@ HostInstaller::HostInstaller()
     , TARGET_DIR_CHROMIUM("/Library/Application Support/Chromium/NativeMessagingHosts")
     , TARGET_DIR_FIREFOX("/Library/Application Support/Mozilla/NativeMessagingHosts")
     , TARGET_DIR_VIVALDI("/Library/Application Support/Vivaldi/NativeMessagingHosts")
+    , TARGET_DIR_TOR_BROWSER("/Library/Application Support/TorBrowser-Data/Browser/Mozilla/NativeMessagingHosts")
 #elif defined(Q_OS_LINUX)
     , TARGET_DIR_CHROME("/.config/google-chrome/NativeMessagingHosts")
     , TARGET_DIR_CHROMIUM("/.config/chromium/NativeMessagingHosts")
     , TARGET_DIR_FIREFOX("/.mozilla/native-messaging-hosts")
     , TARGET_DIR_VIVALDI("/.config/vivaldi/NativeMessagingHosts")
+    , TARGET_DIR_TOR_BROWSER("/.tor-browser/app/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts")
 #elif defined(Q_OS_WIN)
     , TARGET_DIR_CHROME("HKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
     , TARGET_DIR_CHROMIUM("HKEY_CURRENT_USER\\Software\\Chromium\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
     , TARGET_DIR_FIREFOX("HKEY_CURRENT_USER\\Software\\Mozilla\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
     , TARGET_DIR_VIVALDI("HKEY_CURRENT_USER\\Software\\Vivaldi\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
+    , TARGET_DIR_TOR_BROWSER("HKEY_CURRENT_USER\\Software\\TorProject\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
 #endif
 {
 }
@@ -159,6 +162,8 @@ QString HostInstaller::getTargetPath(SupportedBrowsers browser) const
         return TARGET_DIR_FIREFOX;
     case SupportedBrowsers::VIVALDI:
         return TARGET_DIR_VIVALDI;
+    case SupportedBrowsers::TOR_BROWSER:
+	    return TARGET_DIR_TOR_BROWSER;
     default:
         return QString();
     }
@@ -182,6 +187,8 @@ QString HostInstaller::getBrowserName(SupportedBrowsers browser) const
         return "firefox";
     case SupportedBrowsers::VIVALDI:
         return "vivaldi";
+    case SupportedBrowsers::TOR_BROWSER:
+	    return "tor-browser";
     default:
         return QString();
     }
@@ -287,7 +294,7 @@ QJsonObject HostInstaller::constructFile(SupportedBrowsers browser, const bool& 
     script["type"] = "stdio";
 
     QJsonArray arr;
-    if (browser == SupportedBrowsers::FIREFOX) {
+    if (browser == SupportedBrowsers::FIREFOX || browser == SupportedBrowsers::TOR_BROWSER) {
         for (const QString& extension : ALLOWED_EXTENSIONS) {
             arr.append(extension);
         }

--- a/src/browser/HostInstaller.h
+++ b/src/browser/HostInstaller.h
@@ -33,7 +33,8 @@ public:
         CHROME = 0,
         CHROMIUM = 1,
         FIREFOX = 2,
-        VIVALDI = 3
+        VIVALDI = 3,
+        TOR_BROWSER = 4
     };
 
 public:
@@ -64,6 +65,7 @@ private:
     const QString TARGET_DIR_CHROMIUM;
     const QString TARGET_DIR_FIREFOX;
     const QString TARGET_DIR_VIVALDI;
+    const QString TARGET_DIR_TOR_BROWSER;
 };
 
 #endif // HOSTINSTALLER_H


### PR DESCRIPTION
## _Pull request live changelog:_ 

1. [Removed translations](https://github.com/keepassxreboot/keepassxc/pull/2387#issuecomment-430262919) as per [request](https://github.com/keepassxreboot/keepassxc/pull/2387#issuecomment-430198858) from @droidmonkey 
2. Added macOS support with help from @varjolintu - correct native-messaging-hosts string added. (Pending screenshots from the man himself for verification.) e98dfb4
3. Added missing m_ui component in BrowserOptionsDialog.cpp e98dfb4.
4. Reordered TOR_BROWSER_TARGET_DIR and others to be at the end of lists as per @varjolintu's request 69a81ec9f3d46bbec7f955f4d974929a3c5b3bfd.
5. Created issue #2392 for help debugging what's going on for the Windows build.

## _Pull request live TODO:_
1. Add UI component to point to Tor Browser installation so this will work for portable installs.
2. Resolve #2392
3. Add UI warning that installing other addons is not recommended by the Tor Project as per discussion with @kneitinger [here](https://github.com/keepassxreboot/keepassxc/pull/2387#issuecomment-430856569)

## Description
### For Linux/macOS:

* native-messaging-hosts support for Tor Browser
* checkbox for Tor Browser under Browser Integration in UI
* settings save/update for Tor Browser
* updated QUICKSTART.md to include Tor Browser under Firefox instructions
~~* updated translations files to include Tor Browser~~


## Motivation and context
I believe great security tools should be able to utilize other great security tools.

## How has this been tested?
This has been tested on my Arch Linux host, I ran from build directory without install and set the keepassxc-proxy to the one built during compilation.

* KeepassXC successfully registered with KeepassXC-Browser extension in Tor Browser and credentials were properly transmitted.
* All ctest suites passed

## Screenshots (if appropriate):
![ui](https://user-images.githubusercontent.com/21355332/47004080-9f176980-d0e5-11e8-9984-9575a02fff8c.png)
![screenshot_2018-10-16_01-45-46](https://user-images.githubusercontent.com/21355332/47004090-a2125a00-d0e5-11e8-9b3b-97ef3940ecf6.png)


## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
