### PR TITLE
Add Git tracking ignore rules for snapcraft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,11 @@ release*/
 .DS_Store
 .version
 \.scannerwork/
+
+/snap/.snapcraft/
+/parts/
+/stage/
+/prime/
+/*.snap
+/*_source.tar.bz2
+


### PR DESCRIPTION
## Description
This patch implements `gitignore(5)` rules for snapcraft, this prevents
snap build artifacts from listed as untracked files.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

After building a snap lots of files listed as untracked item in Git Cola, and the Git frontend slows down quite dramatically

## How has this been tested?
* Git Cola lists no untracked files
* `git status` claims clean worktree

The patch is a set of rules I used in all of my snap packages, the rules are strictly restricted from the root node of this source tree.

The following patch is made to the snapcraft recipe:

```patch
@@ -32,7 +32,8 @@ parts:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DKEEPASSXC_DIST_TYPE=Snap
       - -DKEEPASSXC_BUILD_TYPE=PreRelease
-      - -DWITH_TESTS=OFF
+      - -DWITH_TESTS=YES
+      - -DWITH_ASAN=ON
       - -DWITH_XC_ALL=ON
     build-packages:
       - g++
```

,a snapcraft rebuild has run and the application launches without error, however the following message spew out when I close the application via the close button in the window decoration:

```
$ env LSAN_OPTIONS=verbosity=1:log_threads=1 snap run keepassxc
Qt: Session management error: None of the authentication protocols specified are supported
==3518==LeakSanitizer has encountered a fatal error.
==3518==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==3518==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
```

I don't think that is related with this PR though.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
