### PR TITLE
Show a warning message when native messaging host is not found

### DIFF
--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -39,6 +39,13 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent)
         "<a href=\"https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/\">Firefox</a>",
         "<a href=\"https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">Google Chrome / Chromium / Vivaldi</a>"));
 
+    m_ui->scriptWarningWidget->setVisible(false);
+    m_ui->scriptWarningWidget->setAutoHideTimeout(-1);
+    m_ui->scriptWarningWidget->showMessage(tr("<b>Warning</b>, the keepassxc-proxy application was not found!"
+                                          "<br />Please check the KeePassXC installation directory or confirm the custom path in advanced options."
+                                          "<br />Browser integration WILL NOT WORK without the proxy application."
+                                          "<br />Expected Path: "), MessageWidget::Warning);
+
     m_ui->warningWidget->showMessage(tr("<b>Warning:</b> The following options can be dangerous!"), MessageWidget::Warning);
     m_ui->warningWidget->setCloseButtonVisible(false);
     m_ui->warningWidget->setAutoHideTimeout(-1);
@@ -109,6 +116,17 @@ void BrowserOptionDialog::loadSettings()
     m_ui->browserGlobalWarningWidget->setCloseButtonVisible(false);
     m_ui->browserGlobalWarningWidget->setAutoHideTimeout(-1);
 #endif
+
+    // Check for native messaging host location errors
+    QString path;
+    if (!settings->checkIfProxyExists(path)) {
+        QString text = m_ui->scriptWarningWidget->text();
+        text.append(path);
+        m_ui->scriptWarningWidget->setText(text);
+        m_ui->scriptWarningWidget->setVisible(true);
+    } else {
+        m_ui->scriptWarningWidget->setVisible(false);
+    }
 }
 
 void BrowserOptionDialog::saveSettings()

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -50,6 +50,16 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
+        <widget class="MessageWidget" name="scriptWarningWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="extensionLabel">
         </widget>
        </item>

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -495,3 +495,8 @@ void BrowserSettings::updateBinaryPaths(QString customProxyLocation)
     bool isProxy = supportBrowserProxy();
     m_hostInstaller.updateBinaryPaths(isProxy, customProxyLocation);
 }
+
+bool BrowserSettings::checkIfProxyExists(QString& path)
+{
+    return m_hostInstaller.checkIfProxyExists(supportBrowserProxy(), customProxyLocation(), path);
+}

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -114,6 +114,7 @@ public:
     QString generatePassword();
     int getbits();
     void updateBinaryPaths(QString customProxyLocation = QString());
+    bool checkIfProxyExists(QString& path);
 
 private:
     static BrowserSettings* m_instance;

--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -52,6 +52,12 @@ HostInstaller::HostInstaller()
 {
 }
 
+/**
+ * Checks if the selected browser has native messaging host properly installed
+ *
+ * @param browser Selected browser
+ * @return bool Script is installed correctly
+ */
 bool HostInstaller::checkIfInstalled(SupportedBrowsers browser)
 {
     QString fileName = getPath(browser);
@@ -63,6 +69,29 @@ bool HostInstaller::checkIfInstalled(SupportedBrowsers browser)
 #endif
 }
 
+/**
+ * Checks if keepassxc-proxy location is found
+ *
+ * @param proxy Is keepassxc-proxy enabled
+ * @param location Custom proxy location
+ * @param path The path is set here and returned to the caller
+ * @return bool
+ */
+bool HostInstaller::checkIfProxyExists(const bool& proxy, const QString& location, QString& path) const
+{
+    QString fileName = getProxyPath(proxy, location);
+    path = fileName;
+    return QFile::exists(fileName);
+}
+
+/**
+ * Installs native messaging JSON script for the selected browser
+ *
+ * @param browser Selected browser
+ * @param enabled Is browser integration enabled
+ * @param proxy Is keepassxc-proxy enabled
+ * @param location Custom proxy location
+ */
 void HostInstaller::installBrowser(SupportedBrowsers browser,
                                    const bool& enabled,
                                    const bool& proxy,
@@ -98,6 +127,12 @@ void HostInstaller::installBrowser(SupportedBrowsers browser,
     }
 }
 
+/**
+ * Updates the paths to native messaging host for each browser that has been enabled
+ *
+ * @param proxy Is keepassxc-proxy enabled
+ * @param location Custom proxy location
+ */
 void HostInstaller::updateBinaryPaths(const bool& proxy, const QString& location)
 {
     for (int i = 0; i < 4; ++i) {
@@ -107,6 +142,12 @@ void HostInstaller::updateBinaryPaths(const bool& proxy, const QString& location
     }
 }
 
+/**
+ * Returns the target path for each browser. Windows uses a registry path instead of a file path
+ *
+ * @param browser Selected browser
+ * @return QString Current target path for the selected browser
+ */
 QString HostInstaller::getTargetPath(SupportedBrowsers browser) const
 {
     switch (browser) {
@@ -123,6 +164,13 @@ QString HostInstaller::getTargetPath(SupportedBrowsers browser) const
     }
 }
 
+/**
+ * Returns the browser name 
+ * Needed for Windows to separate Chromium- or Firefox-based scripts
+ *
+ * @param browser Selected browser
+ * @return QString Name of the selected browser
+ */
 QString HostInstaller::getBrowserName(SupportedBrowsers browser) const
 {
     switch (browser) {
@@ -139,6 +187,12 @@ QString HostInstaller::getBrowserName(SupportedBrowsers browser) const
     }
 }
 
+/**
+ * Returns the path of native messaging JSON script for the selected browser
+ *
+ * @param browser Selected browser
+ * @return QString JSON script path for the selected browser
+ */
 QString HostInstaller::getPath(SupportedBrowsers browser) const
 {
 #ifdef Q_OS_WIN
@@ -160,6 +214,12 @@ QString HostInstaller::getPath(SupportedBrowsers browser) const
 #endif
 }
 
+/**
+ * Gets the installation directory for JSON script file (application install path)
+ *
+ * @param browser Selected browser
+ * @return QString Install path
+ */
 QString HostInstaller::getInstallDir(SupportedBrowsers browser) const
 {
     QString path = getTargetPath(browser);
@@ -170,7 +230,14 @@ QString HostInstaller::getInstallDir(SupportedBrowsers browser) const
 #endif
 }
 
-QJsonObject HostInstaller::constructFile(SupportedBrowsers browser, const bool& proxy, const QString& location)
+/**
+ * Gets the path to keepassxc-proxy binary
+ *
+ * @param proxy Is keepassxc-proxy used with KeePassXC
+ * @param location Custom proxy path
+ * @return path Path to keepassxc-proxy
+ */
+QString HostInstaller::getProxyPath(const bool& proxy, const QString& location) const
 {
     QString path;
 #ifdef KEEPASSXC_DIST_APPIMAGE
@@ -198,6 +265,20 @@ QJsonObject HostInstaller::constructFile(SupportedBrowsers browser, const bool& 
 #endif
 
 #endif // #ifdef KEEPASSXC_DIST_APPIMAGE
+    return path;
+}
+
+/**
+ * Constructs the JSON script file used with native messaging
+ *
+ * @param browser Browser (Chromium- and Firefox-based browsers need a different parameters for the script)
+ * @param proxy Is keepassxc-proxy used with KeePassXC
+ * @param location Custom proxy location
+ * @return script The JSON script file
+ */
+QJsonObject HostInstaller::constructFile(SupportedBrowsers browser, const bool& proxy, const QString& location)
+{
+    QString path = getProxyPath(proxy, location);
 
     QJsonObject script;
     script["name"] = HOST_NAME;
@@ -221,11 +302,24 @@ QJsonObject HostInstaller::constructFile(SupportedBrowsers browser, const bool& 
     return script;
 }
 
+/**
+ * Checks if a registry setting is found with default value
+ *
+ * @param settings Registry path
+ * @return bool Is the registry value found
+ */
 bool HostInstaller::registryEntryFound(const QSettings& settings)
 {
     return !settings.value("Default").isNull();
 }
 
+/**
+ * Saves a JSON script file
+ *
+ * @param browser Selected browser
+ * @param script JSON native messaging script object
+ * @return bool Write succeeds
+ */
 bool HostInstaller::saveFile(SupportedBrowsers browser, const QJsonObject& script)
 {
     QString path = getPath(browser);

--- a/src/browser/HostInstaller.h
+++ b/src/browser/HostInstaller.h
@@ -39,6 +39,7 @@ public:
 public:
     HostInstaller();
     bool checkIfInstalled(SupportedBrowsers browser);
+    bool checkIfProxyExists(const bool& proxy, const QString& location, QString& path) const;
     void installBrowser(SupportedBrowsers browser,
                         const bool& enabled,
                         const bool& proxy = false,
@@ -50,6 +51,7 @@ private:
     QString getBrowserName(SupportedBrowsers browser) const;
     QString getPath(SupportedBrowsers browser) const;
     QString getInstallDir(SupportedBrowsers browser) const;
+    QString getProxyPath(const bool& proxy, const QString& location) const;
     QJsonObject constructFile(SupportedBrowsers browser, const bool& proxy, const QString& location);
     bool registryEntryFound(const QSettings& settings);
     bool saveFile(SupportedBrowsers browser, const QJsonObject& script);


### PR DESCRIPTION
## Description
If keepassxc-proxy binary (default or custom location) is not found after support for some browser is enabled, a warning message will be shown in the Browser Integration settings tab. The path where keepassxc-proxy is loaded will be shown in the message. Hopefully this makes the troubleshooting easier.

The warning message should be as non-tech as possible, but still informative. Any suggestions are very welcome.

And because the class is quite hard to read, I also added some documentation to the functions.

This PR is still under `Needs Work` label because I haven't tested this with all platforms.

## Motivation and context
Adds more information about the native messaging host location during troubleshooting.

## How has this been tested?
Manually.

## Screenshots (if appropriate):
![script warning](https://i.imgur.com/iWai86X.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
