### PR TITLE
Enable high-DPI scaling to support 4k screens

### DIFF
--- a/src/gui/KMessageWidget.cpp
+++ b/src/gui/KMessageWidget.cpp
@@ -94,7 +94,7 @@ void KMessageWidgetPrivate::init(KMessageWidget *q_ptr)
     QAction *closeAction = new QAction(q);
     closeAction->setText(KMessageWidget::tr("&Close"));
     closeAction->setToolTip(KMessageWidget::tr("Close message"));
-    closeAction->setIcon(FilePath::instance()->icon("actions", "message-close"));
+    closeAction->setIcon(FilePath::instance()->icon("actions", "message-close", false));
     
     QObject::connect(closeAction, SIGNAL(triggered(bool)), q, SLOT(animatedHide()));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,10 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 
 int main(int argc, char** argv)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
     Application app(argc, argv);
     Application::setApplicationName("keepassxc");
     Application::setApplicationVersion(KEEPASSXC_VERSION);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This enables coordinate system scaling for high-DPI displays, which enforces correct proportions even on small 4k displays. The icons are scaled up without interpolation, which makes them crisp, but a bit pixelated. A new scalable icon set will solve this problem, but is not scope of this patch.

Resolves #548, #1381, #1710, #1888

As a small extra cookie, I snuck in enforcement of our icon set for the message box close icon (which has displayed a weird box on my KDE system ever since #2317 was merged).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Icons were tiny, widgets had inhomogeneous proportions and windows were way too small as a result.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a 13.3" 4k Dell InfinityEdge display under Windows 10, works perfectly.

I also tested it in an Ubuntu 18.10 VM. It works in principle, but Gnome does not set all required properties. For Qt to pick up the correct scaling, DPI may need to be set manually using `xrandr` or KeePassXC needs to be started with

    QT_SCREEN_SCALE_FACTORS=2 keepassxc

If the fonts are still slightly off, they can be corrected by also setting `QT_FONT_DPI=225`. I don't think I can fix this any better. It is definitely working, though, Qt just may not pick up all settings automatically.

## Screenshots (if appropriate):
Before:
![before](https://user-images.githubusercontent.com/911270/47254544-3d982780-d464-11e8-965d-942cc0d210a7.png)

After:
![after](https://user-images.githubusercontent.com/911270/47254545-44269f00-d464-11e8-82d0-2d981afb96c8.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**