### PR TITLE
Replace all .svgz in paths to .svg

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -56,15 +56,15 @@ Copyright: 2015 halex2005 <akharlov@gmail.com>
 License: MIT
 
 Files: share/icons/application/*/apps/keepassxc.png
-       share/icons/application/scalable/apps/keepassxc.svgz
+       share/icons/application/scalable/apps/keepassxc.svg
        share/icons/application/*/apps/keepassxc-dark.png
-       share/icons/application/scalable/apps/keepassxc-dark.svgz
+       share/icons/application/scalable/apps/keepassxc-dark.svg
        share/icons/application/*/apps/keepassxc-locked.png
-       share/icons/application/scalable/apps/keepassxc-locked.svgz
+       share/icons/application/scalable/apps/keepassxc-locked.svg
        share/icons/application/*/apps/keepassxc-unlocked.png
-       share/icons/application/scalable/apps/keepassxc-unlocked.svgz
+       share/icons/application/scalable/apps/keepassxc-unlocked.svg
        share/icons/application/*/mimetypes/application-x-keepassxc.png
-       share/icons/application/scalable/mimetypes/application-x-keepassxc.svgz
+       share/icons/application/scalable/mimetypes/application-x-keepassxc.svg
 Copyright: 2016, Lorenzo Stella <lorenzo.stl@gmail.com>
 License: LGPL-2
 
@@ -181,7 +181,7 @@ Files: share/icons/application/*/actions/application-exit.png
        share/icons/application/*/status/dialog-information.png
        share/icons/application/*/status/dialog-warning.png
        share/icons/application/*/status/security-high.png
-       share/icons/svg/*.svgz
+       share/icons/svg/*.svg
 Copyright: 2007, Nuno Pinheiro <nuno@oxygen-icons.org>
            2007, David Vignoni <david@icon-king.com>
            2007, David Miller <miller@oxygen-icons.org>

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -25,10 +25,10 @@ install(FILES ${DATABASE_ICONS} DESTINATION ${DATA_INSTALL_DIR}/icons/database)
 
 if(UNIX AND NOT APPLE)
     install(DIRECTORY icons/application/ DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor
-            FILES_MATCHING PATTERN "keepassx*.png" PATTERN "keepassx*.svgz"
+            FILES_MATCHING PATTERN "keepassx*.png" PATTERN "keepassx*.svg"
             PATTERN "status" EXCLUDE PATTERN "actions" EXCLUDE PATTERN "categories" EXCLUDE)
     install(DIRECTORY icons/application/ DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor
-            FILES_MATCHING PATTERN "application-x-keepassxc.png" PATTERN "application-x-keepassxc.svgz"
+            FILES_MATCHING PATTERN "application-x-keepassxc.png" PATTERN "application-x-keepassxc.svg"
             PATTERN "status" EXCLUDE PATTERN "actions" EXCLUDE PATTERN "categories" EXCLUDE)
     install(FILES linux/org.keepassxc.KeePassXC.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
     install(FILES linux/org.keepassxc.KeePassXC.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
@@ -42,84 +42,84 @@ endif()
 install(DIRECTORY wizard/ DESTINATION ${DATA_INSTALL_DIR}/wizard FILES_MATCHING PATTERN "*.png")
 
 install(DIRECTORY icons/application/ DESTINATION ${DATA_INSTALL_DIR}/icons/application
-        FILES_MATCHING PATTERN "*.png" PATTERN "*.svgz")
+        FILES_MATCHING PATTERN "*.png" PATTERN "*.svg")
 
 add_custom_target(icons
                   # SVGZ to PNGs for KeePassXC
                   COMMAND inkscape -z -w 16 -h 16
-                    icons/application/scalable/apps/keepassxc.svgz -e icons/application/16x16/apps/keepassxc.png
+                    icons/application/scalable/apps/keepassxc.svg -e icons/application/16x16/apps/keepassxc.png
                   COMMAND inkscape -z -w  24 -h 24
-                    icons/application/scalable/apps/keepassxc.svgz -e icons/application/24x24/apps/keepassxc.png
+                    icons/application/scalable/apps/keepassxc.svg -e icons/application/24x24/apps/keepassxc.png
                   COMMAND inkscape -z -w  32 -h 32
-                    icons/application/scalable/apps/keepassxc.svgz -e icons/application/32x32/apps/keepassxc.png
+                    icons/application/scalable/apps/keepassxc.svg -e icons/application/32x32/apps/keepassxc.png
                   COMMAND inkscape -z -w 48 -h 48
-                    icons/application/scalable/apps/keepassxc.svgz -e icons/application/48x48/apps/keepassxc.png
+                    icons/application/scalable/apps/keepassxc.svg -e icons/application/48x48/apps/keepassxc.png
                   COMMAND inkscape -z -w 64 -h 64
-                    icons/application/scalable/apps/keepassxc.svgz -e icons/application/64x64/apps/keepassxc.png
+                    icons/application/scalable/apps/keepassxc.svg -e icons/application/64x64/apps/keepassxc.png
                   COMMAND inkscape -z -w 128 -h 128
-                    icons/application/scalable/apps/keepassxc.svgz -e icons/application/128x128/apps/keepassxc.png
+                    icons/application/scalable/apps/keepassxc.svg -e icons/application/128x128/apps/keepassxc.png
                   COMMAND inkscape -z -w 256 -h 256
-                    icons/application/scalable/apps/keepassxc.svgz -e icons/application/256x256/apps/keepassxc.png
+                    icons/application/scalable/apps/keepassxc.svg -e icons/application/256x256/apps/keepassxc.png
 
                   # SVGZ to PNGs for KeePassXC
                   COMMAND inkscape -z -w 16 -h 16
-                    icons/application/scalable/apps/keepassxc-dark.svgz -e icons/application/16x16/apps/keepassxc-dark.png
+                    icons/application/scalable/apps/keepassxc-dark.svg -e icons/application/16x16/apps/keepassxc-dark.png
                   COMMAND inkscape -z -w  24 -h 24
-                    icons/application/scalable/apps/keepassxc-dark.svgz -e icons/application/24x24/apps/keepassxc-dark.png
+                    icons/application/scalable/apps/keepassxc-dark.svg -e icons/application/24x24/apps/keepassxc-dark.png
                   COMMAND inkscape -z -w  32 -h 32
-                    icons/application/scalable/apps/keepassxc-dark.svgz -e icons/application/32x32/apps/keepassxc-dark.png
+                    icons/application/scalable/apps/keepassxc-dark.svg -e icons/application/32x32/apps/keepassxc-dark.png
                   COMMAND inkscape -z -w 48 -h 48
-                    icons/application/scalable/apps/keepassxc-dark.svgz -e icons/application/48x48/apps/keepassxc-dark.png
+                    icons/application/scalable/apps/keepassxc-dark.svg -e icons/application/48x48/apps/keepassxc-dark.png
                   COMMAND inkscape -z -w 64 -h 64
-                    icons/application/scalable/apps/keepassxc-dark.svgz -e icons/application/64x64/apps/keepassxc-dark.png
+                    icons/application/scalable/apps/keepassxc-dark.svg -e icons/application/64x64/apps/keepassxc-dark.png
                   COMMAND inkscape -z -w 128 -h 128
-                    icons/application/scalable/apps/keepassxc-dark.svgz -e icons/application/128x128/apps/keepassxc-dark.png
+                    icons/application/scalable/apps/keepassxc-dark.svg -e icons/application/128x128/apps/keepassxc-dark.png
                   COMMAND inkscape -z -w 256 -h 256
-                    icons/application/scalable/apps/keepassxc-dark.svgz -e icons/application/256x256/apps/keepassxc-dark.png
+                    icons/application/scalable/apps/keepassxc-dark.svg -e icons/application/256x256/apps/keepassxc-dark.png
 
                   # SVGZ to PNGs for KeePassXC
                   COMMAND inkscape -z -w 16 -h 16
-                    icons/application/scalable/apps/keepassxc-locked.svgz -e icons/application/16x16/apps/keepassxc-locked.png
+                    icons/application/scalable/apps/keepassxc-locked.svg -e icons/application/16x16/apps/keepassxc-locked.png
                   COMMAND inkscape -z -w  24 -h 24
-                    icons/application/scalable/apps/keepassxc-locked.svgz -e icons/application/24x24/apps/keepassxc-locked.png
+                    icons/application/scalable/apps/keepassxc-locked.svg -e icons/application/24x24/apps/keepassxc-locked.png
                   COMMAND inkscape -z -w  32 -h 32
-                    icons/application/scalable/apps/keepassxc-locked.svgz -e icons/application/32x32/apps/keepassxc-locked.png
+                    icons/application/scalable/apps/keepassxc-locked.svg -e icons/application/32x32/apps/keepassxc-locked.png
                   COMMAND inkscape -z -w 48 -h 48
-                    icons/application/scalable/apps/keepassxc-locked.svgz -e icons/application/48x48/apps/keepassxc-locked.png
+                    icons/application/scalable/apps/keepassxc-locked.svg -e icons/application/48x48/apps/keepassxc-locked.png
                   COMMAND inkscape -z -w 64 -h 64
-                    icons/application/scalable/apps/keepassxc-locked.svgz -e icons/application/64x64/apps/keepassxc-locked.png
+                    icons/application/scalable/apps/keepassxc-locked.svg -e icons/application/64x64/apps/keepassxc-locked.png
                   COMMAND inkscape -z -w 128 -h 128
-                    icons/application/scalable/apps/keepassxc-locked.svgz -e icons/application/128x128/apps/keepassxc-locked.png
+                    icons/application/scalable/apps/keepassxc-locked.svg -e icons/application/128x128/apps/keepassxc-locked.png
                   COMMAND inkscape -z -w 256 -h 256
-                    icons/application/scalable/apps/keepassxc-locked.svgz -e icons/application/256x256/apps/keepassxc-locked.png
+                    icons/application/scalable/apps/keepassxc-locked.svg -e icons/application/256x256/apps/keepassxc-locked.png
 
                   # SVGZ to PNGs for KeePassXC
                   COMMAND inkscape -z -w 16 -h 16
-                    icons/application/scalable/apps/keepassxc-unlocked.svgz -e icons/application/16x16/apps/keepassxc-unlocked.png
+                    icons/application/scalable/apps/keepassxc-unlocked.svg -e icons/application/16x16/apps/keepassxc-unlocked.png
                   COMMAND inkscape -z -w  24 -h 24
-                    icons/application/scalable/apps/keepassxc-unlocked.svgz -e icons/application/24x24/apps/keepassxc-unlocked.png
+                    icons/application/scalable/apps/keepassxc-unlocked.svg -e icons/application/24x24/apps/keepassxc-unlocked.png
                   COMMAND inkscape -z -w  32 -h 32
-                    icons/application/scalable/apps/keepassxc-unlocked.svgz -e icons/application/32x32/apps/keepassxc-unlocked.png
+                    icons/application/scalable/apps/keepassxc-unlocked.svg -e icons/application/32x32/apps/keepassxc-unlocked.png
                   COMMAND inkscape -z -w 48 -h 48
-                    icons/application/scalable/apps/keepassxc-unlocked.svgz -e icons/application/48x48/apps/keepassxc-unlocked.png
+                    icons/application/scalable/apps/keepassxc-unlocked.svg -e icons/application/48x48/apps/keepassxc-unlocked.png
                   COMMAND inkscape -z -w 64 -h 64
-                    icons/application/scalable/apps/keepassxc-unlocked.svgz -e icons/application/64x64/apps/keepassxc-unlocked.png
+                    icons/application/scalable/apps/keepassxc-unlocked.svg -e icons/application/64x64/apps/keepassxc-unlocked.png
                   COMMAND inkscape -z -w 128 -h 128
-                    icons/application/scalable/apps/keepassxc-unlocked.svgz -e icons/application/128x128/apps/keepassxc-unlocked.png
+                    icons/application/scalable/apps/keepassxc-unlocked.svg -e icons/application/128x128/apps/keepassxc-unlocked.png
                   COMMAND inkscape -z -w 256 -h 256
-                    icons/application/scalable/apps/keepassxc-unlocked.svgz -e icons/application/256x256/apps/keepassxc-unlocked.png
+                    icons/application/scalable/apps/keepassxc-unlocked.svg -e icons/application/256x256/apps/keepassxc-unlocked.png
 
                   # SVGZ to PNGs for KeePassXC MIME-Type
                   COMMAND inkscape -z -w 16 -h 16
-                    icons/application/scalable/mimetypes/application-x-keepassxc.svgz -e icons/application/16x16/mimetypes/application-x-keepassxc.png
+                    icons/application/scalable/mimetypes/application-x-keepassxc.svg -e icons/application/16x16/mimetypes/application-x-keepassxc.png
                   COMMAND inkscape -z -w 22 -h 22
-                    icons/application/scalable/mimetypes/application-x-keepassxc.svgz -e icons/application/22x22/mimetypes/application-x-keepassxc.png
+                    icons/application/scalable/mimetypes/application-x-keepassxc.svg -e icons/application/22x22/mimetypes/application-x-keepassxc.png
                   COMMAND inkscape -z -w 32 -h 32
-                    icons/application/scalable/mimetypes/application-x-keepassxc.svgz -e icons/application/32x32/mimetypes/application-x-keepassxc.png
+                    icons/application/scalable/mimetypes/application-x-keepassxc.svg -e icons/application/32x32/mimetypes/application-x-keepassxc.png
                   COMMAND inkscape -z -w 64 -h 64
-                    icons/application/scalable/mimetypes/application-x-keepassxc.svgz -e icons/application/64x64/mimetypes/application-x-keepassxc.png
+                    icons/application/scalable/mimetypes/application-x-keepassxc.svg -e icons/application/64x64/mimetypes/application-x-keepassxc.png
                   COMMAND inkscape -z -w 128 -h 128
-                    icons/application/scalable/mimetypes/application-x-keepassxc.svgz -e icons/application/128x128/mimetypes/application-x-keepassxc.png
+                    icons/application/scalable/mimetypes/application-x-keepassxc.svg -e icons/application/128x128/mimetypes/application-x-keepassxc.png
 
                   # ICNS for MacOS
                   COMMAND png2icns macosx/keepassxc.icns

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -157,7 +157,7 @@ QIcon FilePath::icon(const QString& category, const QString& name, bool fromThem
                 icon.addFile(filename, QSize(size, size));
             }
         }
-        filename = QString("%1/icons/application/scalable/%2.svgz").arg(m_dataPath, combinedName);
+        filename = QString("%1/icons/application/scalable/%2.svg").arg(m_dataPath, combinedName);
         if (QFile::exists(filename)) {
             icon.addFile(filename);
         }
@@ -200,7 +200,7 @@ QIcon FilePath::onOffIcon(const QString& category, const QString& name)
                 icon.addFile(filename, QSize(size, size), QIcon::Normal, state);
             }
         }
-        filename = QString("%1/icons/application/scalable/%2-%3.svgz").arg(m_dataPath, combinedName, stateName);
+        filename = QString("%1/icons/application/scalable/%2-%3.svg").arg(m_dataPath, combinedName, stateName);
         if (QFile::exists(filename)) {
             icon.addFile(filename, QSize(), QIcon::Normal, state);
         }


### PR DESCRIPTION
## Description
Follow-up of https://github.com/keepassxreboot/keepassxc/pull/2113

## Motivation and context
I noticed that there are some empty directories (e.g., `/usr/share/icons/hicolor/scalable/apps`) in an installed copy.

## How has this been tested?
* Run `make test` and check there svg files are installed
* Run `make icons` and check inkscape commands run fine

_NOT CHECKED_
* If SVG icons are actually loaded or not. I'm not sure how to tell SVG from PNG icons.

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]** - I don't think this is necessary as there are no real code changes.
- My change requires a change to the documentation and I have updated it accordingly.
- I have added tests to cover my changes.
