### PR TITLE
Fix issues with group functions

### DIFF
--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -84,7 +84,7 @@ int Clip::clipEntry(Database* database, QString entryPath, QString timeout)
     }
 
     TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
-    Entry* entry = database->rootGroup()->findEntry(entryPath);
+    Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
         err << QObject::tr("Entry %1 not found.").arg(entryPath) << endl;
         return EXIT_FAILURE;

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -82,7 +82,7 @@ int Show::showEntry(Database* database, QStringList attributes, const QString& e
     TextStream out(Utils::STDOUT, QIODevice::WriteOnly);
     TextStream err(Utils::STDERR, QIODevice::WriteOnly);
 
-    Entry* entry = database->rootGroup()->findEntry(entryPath);
+    Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
         err << QObject::tr("Could not find entry with path %1.").arg(entryPath) << endl;
         return EXIT_FAILURE;

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -321,9 +321,7 @@ void Group::setNotes(const QString& notes)
 
 void Group::setIcon(int iconNumber)
 {
-    Q_ASSERT(iconNumber >= 0);
-
-    if (m_data.iconNumber != iconNumber || !m_data.customIcon.isNull()) {
+    if (iconNumber >= 0 && (m_data.iconNumber != iconNumber || !m_data.customIcon.isNull())) {
         m_data.iconNumber = iconNumber;
         m_data.customIcon = QUuid();
         emit modified();
@@ -333,9 +331,7 @@ void Group::setIcon(int iconNumber)
 
 void Group::setIcon(const QUuid& uuid)
 {
-    Q_ASSERT(!uuid.isNull());
-
-    if (m_data.customIcon != uuid) {
+    if (!uuid.isNull() && m_data.customIcon != uuid) {
         m_data.customIcon = uuid;
         m_data.iconNumber = 0;
         emit modified();
@@ -552,59 +548,47 @@ QList<Entry*> Group::entriesRecursive(bool includeHistoryItems) const
     return entryList;
 }
 
-Entry* Group::findEntry(QString entryId)
-{
-    Q_ASSERT(!entryId.isNull());
-
-    Entry* entry;
-    QUuid entryUuid = QUuid::fromRfc4122(QByteArray::fromHex(entryId.toLatin1()));
-    if (!entryUuid.isNull()) {
-        entry = findEntryByUuid(entryUuid);
-        if (entry) {
-            return entry;
-        }
-    }
-
-    entry = findEntryByPath(entryId);
-    if (entry) {
-        return entry;
-    }
-
-    for (Entry* entry : entriesRecursive(false)) {
-        if (entry->title() == entryId) {
-            return entry;
-        }
-    }
-
-    return nullptr;
-}
-
 Entry* Group::findEntryByUuid(const QUuid& uuid) const
 {
-    Q_ASSERT(!uuid.isNull());
-    for (Entry* entry : entriesRecursive(false)) {
-        if (entry->uuid() == uuid) {
-            return entry;
+    if (!uuid.isNull()) {
+        for (Entry* entry : entriesRecursive(false)) {
+            if (entry->uuid() == uuid) {
+                return entry;
+            }
         }
     }
 
     return nullptr;
 }
 
-Entry* Group::findEntryByPath(QString entryPath, QString basePath)
+Entry* Group::findEntryByPath(QString entryPath)
 {
+    if (entryPath.isEmpty()) {
+        return nullptr;
+    }
 
-    Q_ASSERT(!entryPath.isNull());
+    // Add a beginning slash if the search string contains a slash
+    // We don't add a slash by default to allow searching by entry title
+    QString normalizedEntryPath = entryPath;
+    if (!normalizedEntryPath.startsWith("/") && normalizedEntryPath.contains("/")) {
+        normalizedEntryPath = "/" + normalizedEntryPath;
+    }
+    return findEntryByPathRecursion(normalizedEntryPath, "/");
+}
 
-    for (Entry* entry : asConst(m_entries)) {
-        QString currentEntryPath = basePath + entry->title();
-        if (entryPath == currentEntryPath || entryPath == QString("/" + currentEntryPath)) {
+Entry* Group::findEntryByPathRecursion(QString entryPath, QString basePath)
+{
+    // Return the first entry that matches the full path OR if there is no leading
+    // slash, return the first entry title that matches
+    for (Entry* entry : entries()) {
+        if (entryPath == (basePath + entry->title())
+            || (!entryPath.startsWith("/") && entry->title() == entryPath)) {
             return entry;
         }
     }
 
-    for (Group* group : asConst(m_children)) {
-        Entry* entry = group->findEntryByPath(entryPath, basePath + group->name() + QString("/"));
+    for (Group* group : children()) {
+        Entry* entry = group->findEntryByPathRecursion(entryPath, basePath + group->name() + "/");
         if (entry != nullptr) {
             return entry;
         }
@@ -615,17 +599,15 @@ Entry* Group::findEntryByPath(QString entryPath, QString basePath)
 
 Group* Group::findGroupByPath(QString groupPath)
 {
-    Q_ASSERT(!groupPath.isNull());
-
     // normalize the groupPath by adding missing front and rear slashes. once.
     QString normalizedGroupPath;
 
-    if (groupPath == "") {
+    if (groupPath.isEmpty()) {
         normalizedGroupPath = QString("/"); // root group
     } else {
-        normalizedGroupPath = ((groupPath.startsWith("/"))? "" : "/")
+        normalizedGroupPath = (groupPath.startsWith("/") ? "" : "/")
             + groupPath
-            + ((groupPath.endsWith("/") )? "" : "/");
+            + (groupPath.endsWith("/") ? "" : "/");
     }
     return findGroupByPathRecursion(normalizedGroupPath, "/");
 }
@@ -683,7 +665,7 @@ QList<const Group*> Group::groupsRecursive(bool includeSelf) const
         groupList.append(this);
     }
 
-    for (const Group* group : m_children) {
+    for (const Group* group : asConst(m_children)) {
         groupList.append(group->groupsRecursive(true));
     }
 
@@ -728,10 +710,11 @@ QSet<QUuid> Group::customIconsRecursive() const
 
 Group* Group::findGroupByUuid(const QUuid& uuid)
 {
-    Q_ASSERT(!uuid.isNull());
-    for (Group* group : groupsRecursive(true)) {
-        if (group->uuid() == uuid) {
-            return group;
+    if (!uuid.isNull()) {
+        for (Group* group : groupsRecursive(true)) {
+            if (group->uuid() == uuid) {
+                return group;
+            }
         }
     }
 
@@ -936,8 +919,11 @@ bool Group::resolveAutoTypeEnabled() const
 
 QStringList Group::locate(QString locateTerm, QString currentPath)
 {
-    Q_ASSERT(!locateTerm.isNull());
+    // TODO: Replace with EntrySearcher
     QStringList response;
+    if (locateTerm.isEmpty()) {
+        return response;
+    }
 
     for (Entry* entry : asConst(m_entries)) {
         QString entryPath = currentPath + entry->title();
@@ -957,20 +943,15 @@ QStringList Group::locate(QString locateTerm, QString currentPath)
 
 Entry* Group::addEntryWithPath(QString entryPath)
 {
-    Q_ASSERT(!entryPath.isNull());
-    if (this->findEntryByPath(entryPath)) {
+    if (entryPath.isEmpty() || findEntryByPath(entryPath)) {
         return nullptr;
     }
 
     QStringList groups = entryPath.split("/");
     QString entryTitle = groups.takeLast();
     QString groupPath = groups.join("/");
-    if (groupPath.isNull()) {
-        groupPath = QString("");
-    }
 
-    Q_ASSERT(!groupPath.isNull());
-    Group* group = this->findGroupByPath(groupPath);
+    Group* group = findGroupByPath(groupPath);
     if (!group) {
         return nullptr;
     }

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -550,11 +550,13 @@ QList<Entry*> Group::entriesRecursive(bool includeHistoryItems) const
 
 Entry* Group::findEntryByUuid(const QUuid& uuid) const
 {
-    if (!uuid.isNull()) {
-        for (Entry* entry : entriesRecursive(false)) {
-            if (entry->uuid() == uuid) {
-                return entry;
-            }
+    if (uuid.isNull()) {
+        return nullptr;
+    }
+
+    for (Entry* entry : entriesRecursive(false)) {
+        if (entry->uuid() == uuid) {
+            return entry;
         }
     }
 
@@ -573,10 +575,10 @@ Entry* Group::findEntryByPath(QString entryPath)
     if (!normalizedEntryPath.startsWith("/") && normalizedEntryPath.contains("/")) {
         normalizedEntryPath = "/" + normalizedEntryPath;
     }
-    return findEntryByPathRecursion(normalizedEntryPath, "/");
+    return findEntryByPathRecursive(normalizedEntryPath, "/");
 }
 
-Entry* Group::findEntryByPathRecursion(QString entryPath, QString basePath)
+Entry* Group::findEntryByPathRecursive(QString entryPath, QString basePath)
 {
     // Return the first entry that matches the full path OR if there is no leading
     // slash, return the first entry title that matches
@@ -588,7 +590,7 @@ Entry* Group::findEntryByPathRecursion(QString entryPath, QString basePath)
     }
 
     for (Group* group : children()) {
-        Entry* entry = group->findEntryByPathRecursion(entryPath, basePath + group->name() + "/");
+        Entry* entry = group->findEntryByPathRecursive(entryPath, basePath + group->name() + "/");
         if (entry != nullptr) {
             return entry;
         }
@@ -609,10 +611,10 @@ Group* Group::findGroupByPath(QString groupPath)
             + groupPath
             + (groupPath.endsWith("/") ? "" : "/");
     }
-    return findGroupByPathRecursion(normalizedGroupPath, "/");
+    return findGroupByPathRecursive(normalizedGroupPath, "/");
 }
 
-Group* Group::findGroupByPathRecursion(QString groupPath, QString basePath)
+Group* Group::findGroupByPathRecursive(QString groupPath, QString basePath)
 {
     // paths must be normalized
     Q_ASSERT(groupPath.startsWith("/") && groupPath.endsWith("/"));
@@ -624,7 +626,7 @@ Group* Group::findGroupByPathRecursion(QString groupPath, QString basePath)
 
     for (Group* innerGroup : children()) {
         QString innerBasePath = basePath + innerGroup->name() + "/";
-        Group* group = innerGroup->findGroupByPathRecursion(groupPath, innerBasePath);
+        Group* group = innerGroup->findGroupByPathRecursive(groupPath, innerBasePath);
         if (group != nullptr) {
             return group;
         }
@@ -710,11 +712,13 @@ QSet<QUuid> Group::customIconsRecursive() const
 
 Group* Group::findGroupByUuid(const QUuid& uuid)
 {
-    if (!uuid.isNull()) {
-        for (Group* group : groupsRecursive(true)) {
-            if (group->uuid() == uuid) {
-                return group;
-            }
+    if (uuid.isNull()) {
+        return nullptr;
+    }
+
+    for (Group* group : groupsRecursive(true)) {
+        if (group->uuid() == uuid) {
+            return group;
         }
     }
 
@@ -732,6 +736,11 @@ Group* Group::findChildByName(const QString& name)
     return nullptr;
 }
 
+/**
+ * Creates a duplicate of this group.
+ * Note that you need to copy the custom icons manually when inserting the
+ * new group into another database.
+ */
 Group* Group::clone(Entry::CloneFlags entryFlags, Group::CloneFlags groupFlags) const
 {
     Group* clonedGroup = new Group();

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -114,12 +114,11 @@ public:
     static const QString RootAutoTypeSequence;
 
     Group* findChildByName(const QString& name);
-    Entry* findEntry(QString entryId);
     Entry* findEntryByUuid(const QUuid& uuid) const;
-    Entry* findEntryByPath(QString entryPath, QString basePath = QString(""));
+    Entry* findEntryByPath(QString entryPath);
     Group* findGroupByUuid(const QUuid& uuid);
     Group* findGroupByPath(QString groupPath);
-    QStringList locate(QString locateTerm, QString currentPath = QString("/"));
+    QStringList locate(QString locateTerm, QString currentPath = {"/"});
     Entry* addEntryWithPath(QString entryPath);
     void setUuid(const QUuid& uuid);
     void setName(const QString& name);
@@ -201,6 +200,7 @@ private:
     void cleanupParent();
     void recCreateDelObjects();
 
+    Entry* findEntryByPathRecursion(QString entryPath, QString basePath);
     Group* findGroupByPathRecursion(QString groupPath, QString basePath);
 
     QPointer<Database> m_db;

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -153,11 +153,7 @@ public:
     QList<const Group*> groupsRecursive(bool includeSelf) const;
     QList<Group*> groupsRecursive(bool includeSelf);
     QSet<QUuid> customIconsRecursive() const;
-    /**
-     * Creates a duplicate of this group.
-     * Note that you need to copy the custom icons manually when inserting the
-     * new group into another database.
-     */
+
     Group* clone(Entry::CloneFlags entryFlags = DefaultEntryCloneFlags,
                  CloneFlags groupFlags = DefaultCloneFlags) const;
 
@@ -166,27 +162,21 @@ public:
 
     void addEntry(Entry* entry);
     void removeEntry(Entry* entry);
+
 signals:
     void dataChanged(Group* group);
-
     void aboutToAdd(Group* group, int index);
     void added();
     void aboutToRemove(Group* group);
     void removed();
-    /**
-     * Group moved within the database.
-     */
     void aboutToMove(Group* group, Group* toGroup, int index);
     void moved();
-
+    void modified();
     void entryAboutToAdd(Entry* entry);
     void entryAdded(Entry* entry);
     void entryAboutToRemove(Entry* entry);
     void entryRemoved(Entry* entry);
-
     void entryDataChanged(Entry* entry);
-
-    void modified();
 
 private slots:
     void updateTimeinfo();
@@ -200,8 +190,8 @@ private:
     void cleanupParent();
     void recCreateDelObjects();
 
-    Entry* findEntryByPathRecursion(QString entryPath, QString basePath);
-    Group* findGroupByPathRecursion(QString groupPath, QString basePath);
+    Entry* findEntryByPathRecursive(QString entryPath, QString basePath);
+    Group* findGroupByPathRecursive(QString groupPath, QString basePath);
 
     QPointer<Database> m_db;
     QUuid m_uuid;

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -493,56 +493,63 @@ void TestGroup::testFindEntry()
 
     Entry* entry;
 
-    entry = db->rootGroup()->findEntry(entry1->uuidToHex());
+    entry = db->rootGroup()->findEntryByUuid(entry1->uuid());
     QVERIFY(entry != nullptr);
     QCOMPARE(entry->title(), QString("entry1"));
 
-    entry = db->rootGroup()->findEntry(QString("entry1"));
+    entry = db->rootGroup()->findEntryByPath(QString("entry1"));
     QVERIFY(entry != nullptr);
     QCOMPARE(entry->title(), QString("entry1"));
 
     // We also can find the entry with the leading slash.
-    entry = db->rootGroup()->findEntry(QString("/entry1"));
+    entry = db->rootGroup()->findEntryByPath(QString("/entry1"));
     QVERIFY(entry != nullptr);
     QCOMPARE(entry->title(), QString("entry1"));
 
     // But two slashes should not be accepted.
-    entry = db->rootGroup()->findEntry(QString("//entry1"));
+    entry = db->rootGroup()->findEntryByPath(QString("//entry1"));
     QVERIFY(entry == nullptr);
 
-    entry = db->rootGroup()->findEntry(entry2->uuidToHex());
+    entry = db->rootGroup()->findEntryByUuid(entry2->uuid());
     QVERIFY(entry != nullptr);
     QCOMPARE(entry->title(), QString("entry2"));
 
-    entry = db->rootGroup()->findEntry(QString("group1/entry2"));
+    entry = db->rootGroup()->findEntryByPath(QString("group1/entry2"));
     QVERIFY(entry != nullptr);
     QCOMPARE(entry->title(), QString("entry2"));
 
-    entry = db->rootGroup()->findEntry(QString("/entry2"));
+    entry = db->rootGroup()->findEntryByPath(QString("/entry2"));
     QVERIFY(entry == nullptr);
 
     // We also can find the entry with the leading slash.
-    entry = db->rootGroup()->findEntry(QString("/group1/entry2"));
+    entry = db->rootGroup()->findEntryByPath(QString("/group1/entry2"));
     QVERIFY(entry != nullptr);
     QCOMPARE(entry->title(), QString("entry2"));
 
     // Should also find the entry only by title.
-    entry = db->rootGroup()->findEntry(QString("entry2"));
+    entry = db->rootGroup()->findEntryByPath(QString("entry2"));
     QVERIFY(entry != nullptr);
     QCOMPARE(entry->title(), QString("entry2"));
 
-    entry = db->rootGroup()->findEntry(QString("invalid/path/to/entry2"));
+    entry = db->rootGroup()->findEntryByPath(QString("invalid/path/to/entry2"));
     QVERIFY(entry == nullptr);
 
-    entry = db->rootGroup()->findEntry(QString("entry27"));
+    entry = db->rootGroup()->findEntryByPath(QString("entry27"));
     QVERIFY(entry == nullptr);
 
     // A valid UUID that does not exist in this database.
-    entry = db->rootGroup()->findEntry(QString("febfb01ebcdf9dbd90a3f1579dc75281"));
+    entry = db->rootGroup()->findEntryByUuid(QUuid("febfb01ebcdf9dbd90a3f1579dc75281"));
     QVERIFY(entry == nullptr);
 
     // An invalid UUID.
-    entry = db->rootGroup()->findEntry(QString("febfb01ebcdf9dbd90a3f1579dc"));
+    entry = db->rootGroup()->findEntryByUuid(QUuid("febfb01ebcdf9dbd90a3f1579dc"));
+    QVERIFY(entry == nullptr);
+
+    // Empty strings
+    entry = db->rootGroup()->findEntryByUuid({});
+    QVERIFY(entry == nullptr);
+
+    entry = db->rootGroup()->findEntryByPath({});
     QVERIFY(entry == nullptr);
 }
 

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -494,63 +494,63 @@ void TestGroup::testFindEntry()
     Entry* entry;
 
     entry = db->rootGroup()->findEntryByUuid(entry1->uuid());
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QCOMPARE(entry->title(), QString("entry1"));
 
     entry = db->rootGroup()->findEntryByPath(QString("entry1"));
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QCOMPARE(entry->title(), QString("entry1"));
 
     // We also can find the entry with the leading slash.
     entry = db->rootGroup()->findEntryByPath(QString("/entry1"));
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QCOMPARE(entry->title(), QString("entry1"));
 
     // But two slashes should not be accepted.
     entry = db->rootGroup()->findEntryByPath(QString("//entry1"));
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     entry = db->rootGroup()->findEntryByUuid(entry2->uuid());
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QCOMPARE(entry->title(), QString("entry2"));
 
     entry = db->rootGroup()->findEntryByPath(QString("group1/entry2"));
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QCOMPARE(entry->title(), QString("entry2"));
 
     entry = db->rootGroup()->findEntryByPath(QString("/entry2"));
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     // We also can find the entry with the leading slash.
     entry = db->rootGroup()->findEntryByPath(QString("/group1/entry2"));
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QCOMPARE(entry->title(), QString("entry2"));
 
     // Should also find the entry only by title.
     entry = db->rootGroup()->findEntryByPath(QString("entry2"));
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QCOMPARE(entry->title(), QString("entry2"));
 
     entry = db->rootGroup()->findEntryByPath(QString("invalid/path/to/entry2"));
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     entry = db->rootGroup()->findEntryByPath(QString("entry27"));
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     // A valid UUID that does not exist in this database.
     entry = db->rootGroup()->findEntryByUuid(QUuid("febfb01ebcdf9dbd90a3f1579dc75281"));
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     // An invalid UUID.
     entry = db->rootGroup()->findEntryByUuid(QUuid("febfb01ebcdf9dbd90a3f1579dc"));
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     // Empty strings
     entry = db->rootGroup()->findEntryByUuid({});
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     entry = db->rootGroup()->findEntryByPath({});
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 }
 
 void TestGroup::testFindGroupByPath()
@@ -568,51 +568,51 @@ void TestGroup::testFindGroupByPath()
     Group* group;
 
     group = db->rootGroup()->findGroupByPath("/");
-    QVERIFY(group != nullptr);
+    QVERIFY(group);
     QCOMPARE(group->uuid(), db->rootGroup()->uuid());
 
     // We also accept it if the leading slash is missing.
     group = db->rootGroup()->findGroupByPath("");
-    QVERIFY(group != nullptr);
+    QVERIFY(group);
     QCOMPARE(group->uuid(), db->rootGroup()->uuid());
 
     group = db->rootGroup()->findGroupByPath("/group1/");
-    QVERIFY(group != nullptr);
+    QVERIFY(group);
     QCOMPARE(group->uuid(), group1->uuid());
 
     // We also accept it if the leading slash is missing.
     group = db->rootGroup()->findGroupByPath("group1/");
-    QVERIFY(group != nullptr);
+    QVERIFY(group);
     QCOMPARE(group->uuid(), group1->uuid());
 
     // Too many slashes at the end
     group = db->rootGroup()->findGroupByPath("group1//");
-    QVERIFY(group == nullptr);
+    QVERIFY(!group);
 
     // Missing a slash at the end.
     group = db->rootGroup()->findGroupByPath("/group1");
-    QVERIFY(group != nullptr);
+    QVERIFY(group);
     QCOMPARE(group->uuid(), group1->uuid());
 
     // Too many slashes at the start
     group = db->rootGroup()->findGroupByPath("//group1");
-    QVERIFY(group == nullptr);
+    QVERIFY(!group);
 
     group = db->rootGroup()->findGroupByPath("/group1/group2/");
-    QVERIFY(group != nullptr);
+    QVERIFY(group);
     QCOMPARE(group->uuid(), group2->uuid());
 
     // We also accept it if the leading slash is missing.
     group = db->rootGroup()->findGroupByPath("group1/group2/");
-    QVERIFY(group != nullptr);
+    QVERIFY(group);
     QCOMPARE(group->uuid(), group2->uuid());
 
     group = db->rootGroup()->findGroupByPath("group1/group2");
-    QVERIFY(group != nullptr);
+    QVERIFY(group);
     QCOMPARE(group->uuid(), group2->uuid());
 
     group = db->rootGroup()->findGroupByPath("invalid");
-    QVERIFY(group == nullptr);
+    QVERIFY(!group);
 }
 
 void TestGroup::testPrint()
@@ -704,7 +704,7 @@ void TestGroup::testLocate()
     QVERIFY(results.contains("/entry1"));
 
     results = db->rootGroup()->locate("invalid");
-    QVERIFY(results.size() == 0);
+    QVERIFY(results.isEmpty());
 
     results = db->rootGroup()->locate("google");
     QVERIFY(results.size() == 1);
@@ -732,37 +732,37 @@ void TestGroup::testAddEntryWithPath()
     group2->setParent(group1);
 
     Entry* entry = db->rootGroup()->addEntryWithPath("entry1");
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QVERIFY(!entry->uuid().isNull());
 
     entry = db->rootGroup()->addEntryWithPath("entry1");
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     entry = db->rootGroup()->addEntryWithPath("/entry1");
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     entry = db->rootGroup()->addEntryWithPath("entry2");
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QVERIFY(entry->title() == "entry2");
     QVERIFY(!entry->uuid().isNull());
 
     entry = db->rootGroup()->addEntryWithPath("/entry3");
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QVERIFY(entry->title() == "entry3");
     QVERIFY(!entry->uuid().isNull());
 
     entry = db->rootGroup()->addEntryWithPath("/group1/entry4");
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QVERIFY(entry->title() == "entry4");
     QVERIFY(!entry->uuid().isNull());
 
     entry = db->rootGroup()->addEntryWithPath("/group1/group2/entry5");
-    QVERIFY(entry != nullptr);
+    QVERIFY(entry);
     QVERIFY(entry->title() == "entry5");
     QVERIFY(!entry->uuid().isNull());
 
     entry = db->rootGroup()->addEntryWithPath("/group1/invalid_group/entry6");
-    QVERIFY(entry == nullptr);
+    QVERIFY(!entry);
 
     delete db;
 }

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -125,7 +125,7 @@ void TestMerge::testResolveConflictNewer()
     QVERIFY(groupDestinationInitial != nullptr);
     QCOMPARE(groupDestinationInitial->entries().size(), 2);
 
-    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entrySourceInitial != nullptr);
     QVERIFY(entrySourceInitial->group() == groupSourceInitial);
 
@@ -159,7 +159,7 @@ void TestMerge::testResolveConflictNewer()
     QCOMPARE(groupDestinationMerged->entries().size(), 2);
     QCOMPARE(groupDestinationMerged->timeInfo(), groupDestinationInitialTimeInfo);
 
-    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
     QVERIFY(entryDestinationMerged->group() != nullptr);
     QCOMPARE(entryDestinationMerged->password(), QString("password"));
@@ -192,7 +192,7 @@ void TestMerge::testResolveConflictExisting()
     QVERIFY(groupDestinationInitial != nullptr);
     QCOMPARE(groupSourceInitial->entries().size(), 2);
 
-    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entrySourceInitial != nullptr);
     QVERIFY(entrySourceInitial->group() == groupSourceInitial);
 
@@ -213,7 +213,7 @@ void TestMerge::testResolveConflictExisting()
     QPointer<Group> groupDestinationUpdated = dbDestination->rootGroup()->findChildByName("group1");
     QVERIFY(groupDestinationUpdated != nullptr);
     QCOMPARE(groupDestinationUpdated->entries().size(), 2);
-    QPointer<Entry> entryDestinationUpdated = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationUpdated = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationUpdated != nullptr);
     QVERIFY(entryDestinationUpdated->group() == groupDestinationUpdated);
 
@@ -244,7 +244,7 @@ void TestMerge::testResolveConflictExisting()
     QCOMPARE(groupDestinationMerged->entries().size(), 2);
     QCOMPARE(groupDestinationMerged->timeInfo(), groupDestinationUpdatedNewerTimeInfo);
 
-    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
     QCOMPARE(entryDestinationMerged->password(), QString("password2"));
     QCOMPARE(entryDestinationMerged->timeInfo(), entryDestinationUpdatedNewerTimeInfo);
@@ -382,9 +382,9 @@ void TestMerge::testResolveConflictTemplate(int mergeMode, std::function<void(Da
 
     m_clock->advanceMinute(1);
 
-    QPointer<Entry> deletedEntryDestination = dbDestination->rootGroup()->findEntry("deletedDestination");
+    QPointer<Entry> deletedEntryDestination = dbDestination->rootGroup()->findEntryByPath("deletedDestination");
     dbDestination->recycleEntry(deletedEntryDestination);
-    QPointer<Entry> deletedEntrySource = dbSource->rootGroup()->findEntry("deletedSource");
+    QPointer<Entry> deletedEntrySource = dbSource->rootGroup()->findEntryByPath("deletedSource");
     dbSource->recycleEntry(deletedEntrySource);
 
     m_clock->advanceMinute(1);
@@ -428,8 +428,8 @@ void TestMerge::testResolveConflictTemplate(int mergeMode, std::function<void(Da
 
     verification(dbDestination.data(), timestamps);
 
-    QVERIFY(dbDestination->rootGroup()->findEntry("entryDestination"));
-    QVERIFY(dbDestination->rootGroup()->findEntry("entrySource"));
+    QVERIFY(dbDestination->rootGroup()->findEntryByPath("entryDestination"));
+    QVERIFY(dbDestination->rootGroup()->findEntryByPath("entrySource"));
 }
 
 void TestMerge::testDeletionConflictTemplate(int mergeMode, std::function<void(Database*, const QMap<QString, QUuid>&)> verification)
@@ -790,7 +790,7 @@ void TestMerge::testMoveEntry()
     QScopedPointer<Database> dbSource(
         createTestDatabaseStructureClone(dbDestination.data(), Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
-    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entrySourceInitial != nullptr);
 
     QPointer<Group> groupSourceInitial = dbSource->rootGroup()->findChildByName("group2");
@@ -807,7 +807,7 @@ void TestMerge::testMoveEntry()
     Merger merger(dbSource.data(), dbDestination.data());
     merger.merge();
 
-    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
     QCOMPARE(entryDestinationMerged->group()->name(), QString("group2"));
     QCOMPARE(dbDestination->rootGroup()->entriesRecursive().size(), 2);
@@ -824,7 +824,7 @@ void TestMerge::testMoveEntryPreserveChanges()
     QScopedPointer<Database> dbSource(
         createTestDatabaseStructureClone(dbDestination.data(), Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
-    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entrySourceInitial != nullptr);
 
     QPointer<Group> group2Source = dbSource->rootGroup()->findChildByName("group2");
@@ -835,7 +835,7 @@ void TestMerge::testMoveEntryPreserveChanges()
     entrySourceInitial->setGroup(group2Source);
     QCOMPARE(entrySourceInitial->group()->name(), QString("group2"));
 
-    QPointer<Entry> entryDestinationInitial = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationInitial = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationInitial != nullptr);
 
     m_clock->advanceSecond(1);
@@ -849,7 +849,7 @@ void TestMerge::testMoveEntryPreserveChanges()
     Merger merger(dbSource.data(), dbDestination.data());
     merger.merge();
 
-    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
     QCOMPARE(entryDestinationMerged->group()->name(), QString("group2"));
     QCOMPARE(dbDestination->rootGroup()->entriesRecursive().size(), 2);
@@ -892,7 +892,7 @@ void TestMerge::testMoveEntryIntoNewGroup()
     groupSourceCreated->setUuid(QUuid::createUuid());
     groupSourceCreated->setParent(dbSource->rootGroup());
 
-    QPointer<Entry> entrySourceMoved = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entrySourceMoved = dbSource->rootGroup()->findEntryByPath("entry1");
     entrySourceMoved->setGroup(groupSourceCreated);
 
     m_clock->advanceSecond(1);
@@ -907,7 +907,7 @@ void TestMerge::testMoveEntryIntoNewGroup()
     QCOMPARE(groupDestinationMerged->name(), QString("group3"));
     QCOMPARE(groupDestinationMerged->entries().size(), 1);
 
-    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
     QCOMPARE(entryDestinationMerged->group()->name(), QString("group3"));
 }
@@ -929,7 +929,7 @@ void TestMerge::testUpdateEntryDifferentLocation()
 
     m_clock->advanceSecond(1);
 
-    QPointer<Entry> entryDestinationMoved = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationMoved = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMoved != nullptr);
     entryDestinationMoved->setGroup(groupDestinationCreated);
     QUuid uuidBeforeSyncing = entryDestinationMoved->uuid();
@@ -938,7 +938,7 @@ void TestMerge::testUpdateEntryDifferentLocation()
     // Change the entry in the source db.
     m_clock->advanceSecond(1);
 
-    QPointer<Entry> entrySourceMoved = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entrySourceMoved = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entrySourceMoved != nullptr);
     entrySourceMoved->beginUpdate();
     entrySourceMoved->setUsername("username");
@@ -954,7 +954,7 @@ void TestMerge::testUpdateEntryDifferentLocation()
 
     QCOMPARE(dbDestination->rootGroup()->entriesRecursive().size(), 2);
 
-    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
     QVERIFY(entryDestinationMerged->group() != nullptr);
     QCOMPARE(entryDestinationMerged->username(), QString("username"));
@@ -983,7 +983,7 @@ void TestMerge::testUpdateGroup()
     dbSource->metadata()->addCustomIcon(customIconId, customIcon);
     groupSourceInitial->setIcon(customIconId);
 
-    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entrySourceInitial != nullptr);
     entrySourceInitial->setGroup(groupSourceInitial);
     entrySourceInitial->setTitle("entry1 renamed");
@@ -996,7 +996,7 @@ void TestMerge::testUpdateGroup()
 
     QCOMPARE(dbDestination->rootGroup()->entriesRecursive().size(), 2);
 
-    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntry("entry1 renamed");
+    QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1 renamed");
     QVERIFY(entryDestinationMerged != nullptr);
     QVERIFY(entryDestinationMerged->group() != nullptr);
     QCOMPARE(entryDestinationMerged->group()->name(), QString("group2 renamed"));
@@ -1125,7 +1125,7 @@ void TestMerge::testDeletedEntry()
 
     m_clock->advanceSecond(1);
 
-    QPointer<Entry> entry1SourceInitial = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entry1SourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entry1SourceInitial != nullptr);
     QUuid entry1Uuid = entry1SourceInitial->uuid();
     delete entry1SourceInitial;
@@ -1133,7 +1133,7 @@ void TestMerge::testDeletedEntry()
 
     m_clock->advanceSecond(1);
 
-    QPointer<Entry> entry2DestinationInitial = dbDestination->rootGroup()->findEntry("entry2");
+    QPointer<Entry> entry2DestinationInitial = dbDestination->rootGroup()->findEntryByPath("entry2");
     QVERIFY(entry2DestinationInitial != nullptr);
     QUuid entry2Uuid = entry2DestinationInitial->uuid();
     delete entry2DestinationInitial;
@@ -1144,10 +1144,10 @@ void TestMerge::testDeletedEntry()
     Merger merger(dbSource.data(), dbDestination.data());
     merger.merge();
 
-    QPointer<Entry> entry1DestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entry1DestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entry1DestinationMerged);
     QVERIFY(!dbDestination->containsDeletedObject(entry1Uuid));
-    QPointer<Entry> entry2DestinationMerged = dbDestination->rootGroup()->findEntry("entry2");
+    QPointer<Entry> entry2DestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry2");
     QVERIFY(entry2DestinationMerged);
     // Uuid in db and deletedObjects is intended according to KeePass #1752
     QVERIFY(dbDestination->containsDeletedObject(entry2Uuid));
@@ -1176,9 +1176,9 @@ void TestMerge::testDeletedGroup()
 
     QPointer<Group> group1SourceInitial = dbSource->rootGroup()->findChildByName("group1");
     QVERIFY(group1SourceInitial != nullptr);
-    QPointer<Entry> entry1SourceInitial = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entry1SourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entry1SourceInitial != nullptr);
-    QPointer<Entry> entry2SourceInitial = dbSource->rootGroup()->findEntry("entry2");
+    QPointer<Entry> entry2SourceInitial = dbSource->rootGroup()->findEntryByPath("entry2");
     QVERIFY(entry2SourceInitial != nullptr);
     QUuid group1Uuid = group1SourceInitial->uuid();
     QUuid entry1Uuid = entry1SourceInitial->uuid();
@@ -1206,11 +1206,11 @@ void TestMerge::testDeletedGroup()
     QVERIFY(!dbDestination->containsDeletedObject(entry2Uuid));
     QVERIFY(!dbDestination->containsDeletedObject(group2Uuid));
 
-    QPointer<Entry> entry1DestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entry1DestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entry1DestinationMerged);
-    QPointer<Entry> entry2DestinationMerged = dbDestination->rootGroup()->findEntry("entry2");
+    QPointer<Entry> entry2DestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry2");
     QVERIFY(entry2DestinationMerged);
-    QPointer<Entry> entry3DestinationMerged = dbDestination->rootGroup()->findEntry("entry3");
+    QPointer<Entry> entry3DestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry3");
     QVERIFY(entry3DestinationMerged);
     QPointer<Group> group1DestinationMerged = dbDestination->rootGroup()->findChildByName("group1");
     QVERIFY(group1DestinationMerged);
@@ -1228,7 +1228,7 @@ void TestMerge::testDeletedRevertedEntry()
 
     m_clock->advanceSecond(1);
 
-    QPointer<Entry> entry1DestinationInitial = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entry1DestinationInitial = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entry1DestinationInitial != nullptr);
     QUuid entry1Uuid = entry1DestinationInitial->uuid();
     delete entry1DestinationInitial;
@@ -1236,7 +1236,7 @@ void TestMerge::testDeletedRevertedEntry()
 
     m_clock->advanceSecond(1);
 
-    QPointer<Entry> entry2SourceInitial = dbSource->rootGroup()->findEntry("entry2");
+    QPointer<Entry> entry2SourceInitial = dbSource->rootGroup()->findEntryByPath("entry2");
     QVERIFY(entry2SourceInitial != nullptr);
     QUuid entry2Uuid = entry2SourceInitial->uuid();
     delete entry2SourceInitial;
@@ -1244,11 +1244,11 @@ void TestMerge::testDeletedRevertedEntry()
 
     m_clock->advanceSecond(1);
 
-    QPointer<Entry> entry1SourceInitial = dbSource->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entry1SourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entry1SourceInitial != nullptr);
     entry1SourceInitial->setNotes("Updated");
 
-    QPointer<Entry> entry2DestinationInitial = dbDestination->rootGroup()->findEntry("entry2");
+    QPointer<Entry> entry2DestinationInitial = dbDestination->rootGroup()->findEntryByPath("entry2");
     QVERIFY(entry2DestinationInitial != nullptr);
     entry2DestinationInitial->setNotes("Updated");
 
@@ -1259,10 +1259,10 @@ void TestMerge::testDeletedRevertedEntry()
     QVERIFY(dbDestination->containsDeletedObject(entry1Uuid));
     QVERIFY(!dbDestination->containsDeletedObject(entry2Uuid));
 
-    QPointer<Entry> entry1DestinationMerged = dbDestination->rootGroup()->findEntry("entry1");
+    QPointer<Entry> entry1DestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entry1DestinationMerged);
     QVERIFY(entry1DestinationMerged->notes() == "Updated");
-    QPointer<Entry> entry2DestinationMerged = dbDestination->rootGroup()->findEntry("entry2");
+    QPointer<Entry> entry2DestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry2");
     QVERIFY(entry2DestinationMerged);
     QVERIFY(entry2DestinationMerged->notes() == "Updated");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #2408

Just some cleanup and streamlining in the Group class. Eliminated function that had undetermined results based on heuristics of the input (Group::findEntry). Aligned Group::findEntryByPath with Group::findGroupByPath.

Eliminated unnecessary Q_ASSERTS and integrated the checks into the code function instead.

**Recommendation:** rename Group::children() to Group::groups(). Children overshadows QObject function AND it is the only place where the name children is used, otherwise we just call them groups...

**Recommendation 2:** Look for other places where QString::isNull() is used and evaluate whether it makes sense. This function is for legacy purposes only and QString::isEmpty() is preferred by the Qt Docs.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Refactor of code

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
 