### PR TITLE
Remove macro that caused Qt Creator to error out

### DIFF
--- a/src/crypto/kdf/AesKdf.h
+++ b/src/crypto/kdf/AesKdf.h
@@ -35,8 +35,8 @@ protected:
     int benchmarkImpl(int msec) const override;
 
 private:
-    static bool
-    transformKeyRaw(const QByteArray& key, const QByteArray& seed, int rounds, QByteArray* result) Q_REQUIRED_RESULT;
+    Q_REQUIRED_RESULT static bool
+    transformKeyRaw(const QByteArray& key, const QByteArray& seed, int rounds, QByteArray* result);
 };
 
 #endif // KEEPASSX_AESKDF_H

--- a/src/crypto/kdf/Argon2Kdf.h
+++ b/src/crypto/kdf/Argon2Kdf.h
@@ -45,13 +45,13 @@ protected:
     quint32 m_parallelism;
 
 private:
-    static bool transformKeyRaw(const QByteArray& key,
+    Q_REQUIRED_RESULT static bool transformKeyRaw(const QByteArray& key,
                                 const QByteArray& seed,
                                 quint32 version,
                                 quint32 rounds,
                                 quint64 memory,
                                 quint32 parallelism,
-                                QByteArray& result) Q_REQUIRED_RESULT;
+                                QByteArray& result);
 };
 
 #endif // KEEPASSX_ARGON2KDF_H

--- a/src/keys/CompositeKey.h
+++ b/src/keys/CompositeKey.h
@@ -39,7 +39,7 @@ public:
 
     QByteArray rawKey() const override;
     QByteArray rawKey(const QByteArray* transformSeed, bool* ok = nullptr) const;
-    bool transform(const Kdf& kdf, QByteArray& result) const Q_REQUIRED_RESULT;
+    Q_REQUIRED_RESULT bool transform(const Kdf& kdf, QByteArray& result) const;
     bool challenge(const QByteArray& seed, QByteArray& result) const;
 
     void addKey(QSharedPointer<Key> key);


### PR DESCRIPTION
There was a parsing issue in Qt Creator and I solved it by removing a macro that is not part of the Qt public APIs.

## Description
The Q_REQUIRED_RESULT macro was appended to the `transform` method of the
`CompositeKey` class. However, this macro is not part of the Qt public API
and, as such, it may change overtime (even if it's unlikely).
Furthermore, it caused Qt Creator to error out because of a parsing
issue. Removing the macro immediately fixed it.

## Motivation and context
I'm a Qt Creator user and as soon as I open it up to inspect the code I get this warning straight away at the top of `main.cpp`.

```
Warning: The code model could not parse an included file, which might lead to incorrect code completion and highlighting, for example.

CompositeKey.h:42:62: error: 'nodiscard' attribute cannot be applied to types
    main.cpp:1:1: note: in file included from /home/gianluca/Projects/keepassxc/src/main.cpp:1:
    main.cpp:24:10: note: in file included from /home/gianluca/Projects/keepassxc/src/main.cpp:24:
    Bootstrap.h:22:10: note: in file included from /home/gianluca/Projects/keepassxc/src/core/Bootstrap.h:22:
    MainWindow.h:29:10: note: in file included from /home/gianluca/Projects/keepassxc/src/gui/MainWindow.h:29:
    DatabaseWidget.h:29:10: note: in file included from /home/gianluca/Projects/keepassxc/src/gui/DatabaseWidget.h:29:
    CsvImportWizard.h:22:10: note: in file included from /home/gianluca/Projects/keepassxc/src/gui/csvImport/CsvImportWizard.h:22:
    CsvImportWidget.h:31:10: note: in file included from /home/gianluca/Projects/keepassxc/src/gui/csvImport/CsvImportWidget.h:31:
    CsvParserModel.h:26:10: note: in file included from /home/gianluca/Projects/keepassxc/src/gui/csvImport/CsvParserModel.h:26:
    Group.h:28:10: note: in file included from /home/gianluca/Projects/keepassxc/src/core/Group.h:28:
    Database.h:27:10: note: in file included from /home/gianluca/Projects/keepassxc/src/core/Database.h:27:
```

The only way I was able to get rid of the warning, without touching the code, was disabling the code analyzer entirely.
I followed the message in the warning which led me to the `CompositeKey.h` file. The analyzer reported an error at the line of the transform method declaration with the message shown in the screenshot section (sorry, couldn't take a proper screenshot of the tool tip so I grabbed a pic with my phone).


## How has this been tested?
I compiled the code with the following Cmake configuration and ran all the tests.
`cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_XC_ALL=ON -DWITH_GUI_TESTS=ON -DWITH_ASAN=ON`
Tests n.30, n.31 and n.32 failed, but they failed even before I made any change to the code.

## Screenshots (if appropriate):
![qtcreator-warning](https://user-images.githubusercontent.com/28014843/47379369-055e4680-d6fb-11e8-901b-5e508e719af3.jpg)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
