### PR TITLE
Replace deprecated parts of code

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -142,7 +142,7 @@ QStringList AutoType::windowTitles()
 
 void AutoType::raiseWindow()
 {
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     m_plugin->raiseOwnWindow();
 #endif
 }
@@ -213,7 +213,7 @@ void AutoType::executeAutoTypeActions(const Entry* entry, QWidget* hideWindow, c
     }
 
     if (hideWindow) {
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
         m_plugin->raiseLastActiveWindow();
 #else
         hideWindow->showMinimized();
@@ -327,7 +327,7 @@ void AutoType::performGlobalAutoType(const QList<Database*>& dbList)
         connect(selectDialog, SIGNAL(rejected()), SLOT(autoTypeRejectedFromGlobal()));
 
         selectDialog->setMatchList(matchList);
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
         m_plugin->raiseOwnWindow();
         Tools::wait(500);
 #endif

--- a/src/autotype/AutoTypePlatformPlugin.h
+++ b/src/autotype/AutoTypePlatformPlugin.h
@@ -42,7 +42,7 @@ public:
 
     virtual AutoTypeExecutor* createExecutor() = 0;
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     virtual bool raiseLastActiveWindow() = 0;
     virtual bool raiseOwnWindow() = 0;
 #endif

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -19,7 +19,11 @@
 #include "AutoTypeSelectDialog.h"
 
 #include <QApplication>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+#include <QScreen>
+#else
 #include <QDesktopWidget>
+#endif
 #include <QDialogButtonBox>
 #include <QHeaderView>
 #include <QLabel>
@@ -44,7 +48,11 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     setWindowTitle(tr("Auto-Type - KeePassXC"));
     setWindowIcon(filePath()->applicationIcon());
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    QRect screenGeometry = QApplication::screenAt(QCursor::pos())->availableGeometry();
+#else
     QRect screenGeometry = QApplication::desktop()->availableGeometry(QCursor::pos());
+#endif
     QSize size = config()->get("GUI/AutoTypeSelectDialogSize", QSize(600, 250)).toSize();
     size.setWidth(qMin(size.width(), screenGeometry.width()));
     size.setHeight(qMin(size.height(), screenGeometry.height()));

--- a/src/autotype/test/AutoTypeTest.cpp
+++ b/src/autotype/test/AutoTypeTest.cpp
@@ -110,7 +110,7 @@ bool AutoTypePlatformTest::raiseWindow(WId window)
     return false;
 }
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
 bool AutoTypePlatformTest::raiseLastActiveWindow()
 {
     return false;

--- a/src/autotype/test/AutoTypeTest.h
+++ b/src/autotype/test/AutoTypeTest.h
@@ -43,7 +43,7 @@ public:
     bool raiseWindow(WId window) override;
     AutoTypeExecutor* createExecutor() override;
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     bool raiseLastActiveWindow() override;
     bool raiseOwnWindow() override;
 #endif

--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -33,7 +33,7 @@ HostInstaller::HostInstaller()
     , ALLOWED_EXTENSIONS(QStringList() << "keepassxc-browser@keepassxc.org")
     , ALLOWED_ORIGINS(QStringList() << "chrome-extension://iopaggbpplllidnfmcghoonnokmjoicf/"
                                     << "chrome-extension://oboonakemofpalcgghocfoadofidjkkk/")
-#if defined(Q_OS_OSX)
+#if defined(Q_OS_MACOS)
     , TARGET_DIR_CHROME("/Library/Application Support/Google/Chrome/NativeMessagingHosts")
     , TARGET_DIR_CHROMIUM("/Library/Application Support/Chromium/NativeMessagingHosts")
     , TARGET_DIR_FIREFOX("/Library/Application Support/Mozilla/NativeMessagingHosts")

--- a/src/browser/NativeMessagingBase.cpp
+++ b/src/browser/NativeMessagingBase.cpp
@@ -135,11 +135,11 @@ void NativeMessagingBase::sendReply(const QString& reply)
 QString NativeMessagingBase::getLocalServerPath() const
 {
     const QString serverPath = "/kpxc_server";
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     // Use XDG_RUNTIME_DIR instead of /tmp if it's available
     QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
     return path.isEmpty() ? QStandardPaths::writableLocation(QStandardPaths::TempLocation) + serverPath : path + serverPath;
-#else // Q_OS_MAC, Q_OS_WIN and others
+#else // Q_OS_MACOS, Q_OS_WIN and others
     return QStandardPaths::writableLocation(QStandardPaths::TempLocation) + serverPath;
 #endif
 }

--- a/src/core/Bootstrap.cpp
+++ b/src/core/Bootstrap.cpp
@@ -57,7 +57,7 @@ void bootstrapApplication()
     applyEarlyQNetworkAccessManagerWorkaround();
     Translator::installTranslators();
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     // Don't show menu icons on OSX
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -110,7 +110,7 @@ Config::Config(QObject* parent)
         QString userPath;
         QString homePath = QDir::homePath();
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
         // we can't use QStandardPaths on X11 as it uses XDG_DATA_HOME instead of XDG_CONFIG_HOME
         QByteArray env = qgetenv("XDG_CONFIG_HOME");
         if (env.isEmpty()) {

--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -50,7 +50,7 @@ QString FilePath::pluginPath(const QString& name)
     // for TestAutoType
     pluginPaths << QCoreApplication::applicationDirPath() + "/../src/autotype/test";
 
-#if defined(Q_OS_MAC) && defined(WITH_APP_BUNDLE)
+#if defined(Q_OS_MACOS) && defined(WITH_APP_BUNDLE)
     pluginPaths << QCoreApplication::applicationDirPath() + "/../PlugIns";
 #endif
 
@@ -223,13 +223,13 @@ FilePath::FilePath()
     else if (testSetDir(QString(KEEPASSX_SOURCE_DIR) + "/share")) {
     }
 #endif
-#if defined(Q_OS_UNIX) && !(defined(Q_OS_MAC) && defined(WITH_APP_BUNDLE))
+#if defined(Q_OS_UNIX) && !(defined(Q_OS_MACOS) && defined(WITH_APP_BUNDLE))
     else if (isDataDirAbsolute && testSetDir(KEEPASSX_DATA_DIR)) {
     } else if (!isDataDirAbsolute && testSetDir(QString("%1/../%2").arg(appDirPath, KEEPASSX_DATA_DIR))) {
     } else if (!isDataDirAbsolute && testSetDir(QString("%1/%2").arg(KEEPASSX_PREFIX_DIR, KEEPASSX_DATA_DIR))) {
     }
 #endif
-#if defined(Q_OS_MAC) && defined(WITH_APP_BUNDLE)
+#if defined(Q_OS_MACOS) && defined(WITH_APP_BUNDLE)
     else if (testSetDir(appDirPath + "/../Resources")) {
     }
 #endif

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -450,7 +450,11 @@ void Metadata::copyCustomIcons(const QSet<QUuid>& iconList, const Metadata* othe
 
 QByteArray Metadata::hashImage(const QImage& image)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    auto data = QByteArray(reinterpret_cast<const char*>(image.bits()), static_cast<int>(image.sizeInBytes()));
+#else
     auto data = QByteArray(reinterpret_cast<const char*>(image.bits()), image.byteCount());
+#endif
     return QCryptographicHash::hash(data, QCryptographicHash::Md5);
 }
 

--- a/src/core/ScreenLockListenerPrivate.cpp
+++ b/src/core/ScreenLockListenerPrivate.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "ScreenLockListenerPrivate.h"
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
 #include "ScreenLockListenerMac.h"
 #elif defined(Q_OS_UNIX)
 #include "ScreenLockListenerDBus.h"
@@ -31,7 +31,7 @@ ScreenLockListenerPrivate::ScreenLockListenerPrivate(QWidget* parent)
 
 ScreenLockListenerPrivate* ScreenLockListenerPrivate::instance(QWidget* parent)
 {
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     Q_UNUSED(parent);
     return ScreenLockListenerMac::instance();
 #elif defined(Q_OS_UNIX)

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -44,7 +44,7 @@ namespace
     const char BlockSizeProperty[] = "blockSize";
 }
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_OSX)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
 class XcbEventFilter : public QAbstractNativeEventFilter
 {
 public:
@@ -92,7 +92,7 @@ Application::Application(int& argc, char** argv)
     , m_alreadyRunning(false)
     , m_lockFile(nullptr)
 {
-#if defined(Q_OS_UNIX) && !defined(Q_OS_OSX)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     installNativeEventFilter(new XcbEventFilter());
 #elif defined(Q_OS_WIN)
     installNativeEventFilter(new WinEventFilter());
@@ -195,7 +195,7 @@ bool Application::event(QEvent* event)
         emit openFile(static_cast<QFileOpenEvent*>(event)->file());
         return true;
     }
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     // restore main window when clicking on the docker icon
     else if (event->type() == QEvent::ApplicationActivate) {
         emit applicationActivated();

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -26,7 +26,7 @@
 #include "core/Config.h"
 
 Clipboard* Clipboard::m_instance(nullptr);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 QPointer<MacPasteboard> Clipboard::m_pasteboard(nullptr);
 #endif
 
@@ -34,7 +34,7 @@ Clipboard::Clipboard(QObject* parent)
     : QObject(parent)
     , m_timer(new QTimer(this))
 {
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     if (!m_pasteboard) {
         m_pasteboard = new MacPasteboard();
     }
@@ -49,7 +49,7 @@ void Clipboard::setText(const QString& text)
     QClipboard* clipboard = QApplication::clipboard();
 
     QMimeData* mime = new QMimeData;
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     mime->setText(text);
     mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());
     clipboard->setMimeData(mime, QClipboard::Clipboard);

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -20,7 +20,7 @@
 #define KEEPASSX_CLIPBOARD_H
 
 #include <QObject>
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include "core/MacPasteboard.h"
 #include <QPointer>
 #endif
@@ -48,7 +48,7 @@ private:
     static Clipboard* m_instance;
 
     QTimer* m_timer;
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     // This object lives for the whole program lifetime and we cannot delete it on exit,
     // so ignore leak warnings. See https://bugreports.qt.io/browse/QTBUG-54832
     static QPointer<MacPasteboard> m_pasteboard;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1432,7 +1432,7 @@ void DatabaseWidget::showUnlockDialog()
     m_unlockDatabaseDialog->clearForms();
     m_unlockDatabaseDialog->setFilePath(m_filePath);
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     autoType()->raiseWindow();
     Tools::wait(500);
 #endif

--- a/src/gui/DialogyWidget.cpp
+++ b/src/gui/DialogyWidget.cpp
@@ -28,7 +28,7 @@ DialogyWidget::DialogyWidget(QWidget* parent)
 
 void DialogyWidget::keyPressEvent(QKeyEvent* e)
 {
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     if (e->modifiers() == Qt::ControlModifier && e->key() == Qt::Key_Period) {
         if (!clickButton(QDialogButtonBox::Cancel)) {
             e->ignore();

--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -97,7 +97,7 @@ QString FileDialog::getSaveFileName(QWidget* parent,
         }
 
         QString result;
-#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
         Q_UNUSED(defaultExtension);
         // the native dialogs on these platforms already append the file extension
         result = QFileDialog::getSaveFileName(parent, caption, dir, filter, selectedFilter, options);

--- a/src/gui/KMessageWidget.cpp
+++ b/src/gui/KMessageWidget.cpp
@@ -102,7 +102,7 @@ void KMessageWidgetPrivate::init(KMessageWidget *q_ptr)
     closeButton->setAutoRaise(true);
     closeButton->setDefaultAction(closeAction);
     closeButtonPixmap = QPixmap(closeButton->icon().pixmap(closeButton->icon().actualSize(QSize(16, 16))));
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     closeButton->setStyleSheet("QToolButton { background: transparent;"
                                    "border-radius: 2px; padding: 3px; }"
                                "QToolButton::hover, QToolButton::focus {"

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -47,7 +47,7 @@
 #include "browser/NativeMessagingHost.h"
 #endif
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(QT_NO_DBUS)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) && !defined(QT_NO_DBUS)
 #include "gui/MainWindowAdaptor.h"
 #include <QList>
 #include <QtDBus/QtDBus>
@@ -117,7 +117,7 @@ MainWindow::MainWindow()
 {
     m_ui->setupUi(this);
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(QT_NO_DBUS)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) && !defined(QT_NO_DBUS)
     new MainWindowAdaptor(this);
     QDBusConnection dbus = QDBusConnection::sessionBus();
     dbus.registerObject("/keepassxc", this);
@@ -314,7 +314,7 @@ MainWindow::MainWindow()
     connect(m_ui->actionDonate, SIGNAL(triggered()), SLOT(openDonateUrl()));
     connect(m_ui->actionBugReport, SIGNAL(triggered()), SLOT(openBugReportUrl()));
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     setUnifiedTitleAndToolBarOnMac(true);
 #endif
 
@@ -817,7 +817,7 @@ void MainWindow::updateTrayIcon()
             QAction* actionToggle = new QAction(tr("Toggle window"), menu);
             menu->addAction(actionToggle);
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
             QAction* actionQuit = new QAction(tr("Quit KeePassXC"), menu);
             menu->addAction(actionQuit);
 
@@ -918,7 +918,7 @@ void MainWindow::trayIconTriggered(QSystemTrayIcon::ActivationReason reason)
 void MainWindow::hideWindow()
 {
     saveWindowInformation();
-#if !defined(Q_OS_LINUX) && !defined(Q_OS_MAC)
+#if !defined(Q_OS_LINUX) && !defined(Q_OS_MACOS)
     // On some Linux systems, the window should NOT be minimized and hidden (i.e. not shown), at
     // the same time (which would happen if both minimize on startup and minimize to tray are set)
     // since otherwise it causes problems on restore as seen on issue #1595. Hiding it is enough.
@@ -944,7 +944,7 @@ void MainWindow::toggleWindow()
     } else {
         bringToFront();
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(QT_NO_DBUS) && (QT_VERSION < QT_VERSION_CHECK(5, 9, 0))
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) && !defined(QT_NO_DBUS) && (QT_VERSION < QT_VERSION_CHECK(5, 9, 0))
         // re-register global D-Bus menu (needed on Ubuntu with Unity)
         // see https://github.com/keepassxreboot/keepassxc/issues/271
         // and https://bugreports.qt.io/browse/QTBUG-58723

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -39,7 +39,7 @@ class MainWindow : public QMainWindow
 {
     Q_OBJECT
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(QT_NO_DBUS)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) && !defined(QT_NO_DBUS)
     Q_CLASSINFO("D-Bus Interface", "org.keepassxc.KeePassXC.MainWindow")
 #endif
 

--- a/src/gui/csvImport/CsvImportWidget.h
+++ b/src/gui/csvImport/CsvImportWidget.h
@@ -23,7 +23,6 @@
 #include <QList>
 #include <QPushButton>
 #include <QScopedPointer>
-#include <QSignalMapper>
 #include <QStackedWidget>
 #include <QStringListModel>
 
@@ -50,7 +49,7 @@ signals:
 
 private slots:
     void parse();
-    void comboChanged(int comboId);
+    void comboChanged(QComboBox* currentSender, int comboId);
     void skippedChanged(int rows);
     void writeDatabase();
     void updatePreview();
@@ -62,7 +61,6 @@ private:
     const QScopedPointer<Ui::CsvImportWidget> m_ui;
     CsvParserModel* const m_parserModel;
     QStringListModel* const m_comboModel;
-    QSignalMapper* m_comboMapper;
     QList<QComboBox*> m_combos;
     Database* m_db;
 

--- a/src/gui/entry/AutoTypeMatchView.cpp
+++ b/src/gui/entry/AutoTypeMatchView.cpp
@@ -51,7 +51,7 @@ void AutoTypeMatchView::keyPressEvent(QKeyEvent* event)
 {
     if ((event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) && currentIndex().isValid()) {
         emitMatchActivated(currentIndex());
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
         // Pressing return does not emit the QTreeView::activated signal on mac os
         emit activated(currentIndex());
 #endif

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -123,7 +123,7 @@ void EntryView::keyPressEvent(QKeyEvent* event)
 {
     if ((event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) && currentIndex().isValid()) {
         emitEntryActivated(currentIndex());
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
         // Pressing return does not emit the QTreeView::activated signal on mac os
         emit activated(currentIndex());
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@
 
 #if defined(Q_OS_WIN)
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
-#elif defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+#elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 #endif
 #endif


### PR DESCRIPTION
Performing a dev build against the latest version of Qt fails because of some deprecated members.

## Description
As of Qt 5.10, two functions and one class that were used in the code are deprecated.
Since this project supports Qt version 5.2 and higher, I replaced the two functions marked as deprecated with their updated versions and wrapped the new code in a compile-time check which enables it only if the project is being compiled against Qt 5.10 and up.

In the CSV import utility, the `QSignalMapper` class was used, which is entirely deprecated now. In place of it, lambdas can be used, which are part of the C++11 standard so I don't think that compile-time checks are required here since it's the version that the project is using, looking at the CMake scripts.
I removed the usage of the aforementioned class and used a lambda to achieve the same effect.

## Motivation and context
I'm running Archlinux, which uses the latest version of Qt (5.11.2), and I wasn't able to compile the project with the `-DWITH_DEV_BUILD` flag.

## How has this been tested?
Built with `-DWITH_ASAN`, `-DWITH_TESTS` and `-DWITH_GUI_TESTS`; test n.30, n.31 and n.32 failed but they failed before I made any change as well.
I manually tested the parts of code I changed: I auto-typed my password on a few sites; tried to re-import my database previously exported in .csv format and changed some columns around with the comboboxes. Everything worked as expected.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
