### PR TITLE
Extract the OS event filter implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -204,6 +204,11 @@ if(MINGW)
             core/ScreenLockListenerWin.h
             core/ScreenLockListenerWin.cpp)
 endif()
+if(MINGW OR (UNIX AND NOT APPLE))
+    set(keepassx_SOURCES
+            ${keepassx_SOURCES}
+            core/OSEventFilter.cpp)
+endif()
 
 set(keepassx_SOURCES_MAINEXE main.cpp)
 

--- a/src/core/OSEventFilter.cpp
+++ b/src/core/OSEventFilter.cpp
@@ -1,0 +1,27 @@
+#include "OSEventFilter.h"
+
+#include <QByteArray>
+
+#include "autotype/AutoType.h"
+
+OSEventFilter::OSEventFilter()
+{
+}
+
+bool OSEventFilter::nativeEventFilter(const QByteArray& eventType, void* message, long* result)
+{
+    Q_UNUSED(result)
+
+#if defined(Q_OS_UNIX)
+    if (eventType == QByteArrayLiteral("xcb_generic_event_t")) {
+#elif defined(Q_OS_WIN)
+    if (eventType == QByteArrayLiteral("windows_generic_MSG")
+        || eventType == QByteArrayLiteral("windows_dispatcher_MSG")) {
+#endif
+        int retCode = autoType()->callEventFilter(message);
+
+        return retCode == 1;
+    }
+
+    return false;
+}

--- a/src/core/OSEventFilter.h
+++ b/src/core/OSEventFilter.h
@@ -1,0 +1,16 @@
+#ifndef OSEVENTFILTER_H
+#define OSEVENTFILTER_H
+#include <QAbstractNativeEventFilter>
+
+class QByteArray;
+
+class OSEventFilter : public QAbstractNativeEventFilter
+{
+public:
+    OSEventFilter();
+    bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) override;
+private:
+    Q_DISABLE_COPY(OSEventFilter)
+};
+
+#endif // OSEVENTFILTER_H

--- a/src/core/ScreenLockListenerDBus.h
+++ b/src/core/ScreenLockListenerDBus.h
@@ -25,7 +25,7 @@ class ScreenLockListenerDBus : public ScreenLockListenerPrivate
 {
     Q_OBJECT
 public:
-    explicit ScreenLockListenerDBus(QWidget* parent = 0);
+    explicit ScreenLockListenerDBus(QWidget* parent = nullptr);
 
 private slots:
     void gnomeSessionStatusChanged(uint status);

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -21,7 +21,6 @@
 #include "MainWindow.h"
 #include "core/Config.h"
 
-#include <QAbstractNativeEventFilter>
 #include <QFileInfo>
 #include <QFileOpenEvent>
 #include <QLockFile>
@@ -31,6 +30,10 @@
 
 #include "autotype/AutoType.h"
 #include "core/Global.h"
+
+#if defined(Q_OS_WIN) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+#include "core/OSEventFilter.h"
+#endif
 
 #if defined(Q_OS_UNIX)
 #include <signal.h>
@@ -42,46 +45,7 @@ namespace
 {
     constexpr int WaitTimeoutMSec = 150;
     const char BlockSizeProperty[] = "blockSize";
-}
-
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-class XcbEventFilter : public QAbstractNativeEventFilter
-{
-public:
-    bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) override
-    {
-        Q_UNUSED(result)
-
-        if (eventType == QByteArrayLiteral("xcb_generic_event_t")) {
-            int retCode = autoType()->callEventFilter(message);
-            if (retCode == 1) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-};
-#elif defined(Q_OS_WIN)
-class WinEventFilter : public QAbstractNativeEventFilter
-{
-public:
-    bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) override
-    {
-        Q_UNUSED(result);
-
-        if (eventType == QByteArrayLiteral("windows_generic_MSG")
-            || eventType == QByteArrayLiteral("windows_dispatcher_MSG")) {
-            int retCode = autoType()->callEventFilter(message);
-            if (retCode == 1) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-};
-#endif
+} // namespace
 
 Application::Application(int& argc, char** argv)
     : QApplication(argc, argv)
@@ -91,11 +55,12 @@ Application::Application(int& argc, char** argv)
 #endif
     , m_alreadyRunning(false)
     , m_lockFile(nullptr)
+#if defined(Q_OS_WIN) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    , m_osEventFilter(new OSEventFilter())
 {
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    installNativeEventFilter(new XcbEventFilter());
-#elif defined(Q_OS_WIN)
-    installNativeEventFilter(new WinEventFilter());
+    installNativeEventFilter(m_osEventFilter.data());
+#else
+{
 #endif
 #if defined(Q_OS_UNIX)
     registerUnixSignals();

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -23,6 +23,11 @@
 #include <QApplication>
 #include <QtNetwork/QLocalServer>
 
+#if defined(Q_OS_WIN) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+#include <QScopedPointer>
+
+class OSEventFilter;
+#endif
 class QLockFile;
 class QSocketNotifier;
 
@@ -33,7 +38,7 @@ class Application : public QApplication
 public:
     Application(int& argc, char** argv);
     QWidget* mainWindow() const;
-    ~Application();
+    ~Application() override;
     void setMainWindow(QWidget* mainWindow);
 
     bool event(QEvent* event) override;
@@ -70,6 +75,9 @@ private:
     QLockFile* m_lockFile;
     QLocalServer m_lockServer;
     QString m_socketName;
+#if defined(Q_OS_WIN) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    QScopedPointer<OSEventFilter> m_osEventFilter;
+#endif
 };
 
 #endif // KEEPASSX_APPLICATION_H


### PR DESCRIPTION
## Description
The `XcbEventFilter` and `WinEventFilter` classes have been extracted into a separate file and a single class.
The new file has then been added to the build chain.

The new class, called `OSEventFilter`, implements the inherited `nativeEventFilter()` method and a preprocessor condition picks the right test for the `if` statement.

Installing a native event filter has now become this:
```cpp
#if defined(Q_OS_WIN) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
    installNativeEventFilter(new OSEventFilter());
#endif
```
which is oblivious of the actual implementation. The new structure should make it easier to add new event filters for new platforms: you just add a new preprocessor case in the `nativeEventFilter()` implementation.

## Motivation and context
The `XcbEventFilter` and `WinEventFilter` classes had basically the same implementation, except for a single line: the condition in the if statement within the `nativeEventFilter()` method.
This made for a lot of code duplication. In addition to that, the release build generated the following warning:
```
'XcbEventFilter' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit.
```
In order to get rid of the warning, a base class's virtual method must have an out-of-line implementation in one of the derived classes. This will make the compiler place the vtable in that translation unit.
Moreover, `Application.cpp` felt a bit cluttered in my humble opinion: to reach the constructor implementation I had to scroll quite a few lines down.

## How has this been tested?
I performed a dev build and a release build; and ran all the tests.
Tests n.30, n.31 and n.32 failed but they failed before I made any change as well.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
