### PR TITLE
Browser extension: only check for url scheme matches when an entry has a scheme

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -397,7 +397,7 @@ QList<Entry*> BrowserService::searchEntries(Database* db, const QString& hostnam
 
         // Ignore entry if port or scheme defined in the URL doesn't match    
         if ((entryQUrl.port() > 0 && entryQUrl.port() != qUrl.port()) ||
-            (browserSettings()->matchUrlScheme() && entryScheme.compare(qUrl.scheme()) != 0)) {
+            (browserSettings()->matchUrlScheme() && !entryScheme.isEmpty() && entryScheme.compare(qUrl.scheme()) != 0)) {
             continue;
         }
 


### PR DESCRIPTION
## Description
Update the entry scheme excluder to use the same logic as the port match checking code: only check for a match if the entry url has a port defined.

## Motivation and context
I believe this should resolve this issue https://github.com/keepassxreboot/keepassxc-browser/issues/319

## How has this been tested?

I launched the new version locally and verified that the browser extension can now find passwords for entries which don't have a scheme specified (with and w/o the match scheme preference enabled). Before this change all entries with urls like `example.com` would fail to match `https://example.com` and `http://example.com` which didn't seem like the right behavior. 

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
