### PR TITLE
Add more expiration presets

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1277,7 +1277,9 @@ QMenu* EditEntryWidget::createPresetsMenu()
     expirePresetsMenu->addAction(tr("%n month(s)", 0, 3))->setData(QVariant::fromValue(TimeDelta::fromMonths(3)));
     expirePresetsMenu->addAction(tr("%n month(s)", 0, 6))->setData(QVariant::fromValue(TimeDelta::fromMonths(6)));
     expirePresetsMenu->addSeparator();
-    expirePresetsMenu->addAction(tr("1 year"))->setData(QVariant::fromValue(TimeDelta::fromYears(1)));
+    expirePresetsMenu->addAction(tr("%n year(s)", 0, 1))->setData(QVariant::fromValue(TimeDelta::fromYears(1)));
+    expirePresetsMenu->addAction(tr("%n year(s)", 0, 2))->setData(QVariant::fromValue(TimeDelta::fromYears(2)));
+    expirePresetsMenu->addAction(tr("%n year(s)", 0, 3))->setData(QVariant::fromValue(TimeDelta::fromYears(3)));
     return expirePresetsMenu;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Changed single expiration preset "1 year" to "1 year(s)", "2 year(s)", "3 year(s)", analogous to "week(s)" and "month(s)". Because of the changed literal, translations changed too, and I only updated translations for English and Russian. Others are marked "unfinished". Which is why I consider this a breaking change so far. But perhaps this added flexibility is worth updating translations. Still, I see why these changes might be too much to fix a little inconvenience.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Personally I prefer setting 2 or even 3 year expiration for many less used and less valuable passwords because changing them yearly or renew expiration is too much of a hassle. And for that I have to manually edit date which is also not ideal. And I would assume, I'm not the only one.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It hasn't been tested. I am not a C++ developer but know how long and exhausting setting up the environment often is. The code change is pretty tiny and based on the "month(s)" presets, translation changes are bigger but seem to be fine (except for not being present for most languages). Because of this I decided to give PR a shot without making a build.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
