### PR TITLE
Correct simultaneous saving with Yubikey

### DIFF
--- a/src/keys/YkChallengeResponseKey.h
+++ b/src/keys/YkChallengeResponseKey.h
@@ -35,7 +35,7 @@ public:
 
     QByteArray rawKey() const override;
     bool challenge(const QByteArray& challenge) override;
-    bool challenge(const QByteArray& challenge, unsigned retries);
+    bool challenge(const QByteArray& challenge, unsigned int retries);
     QString getName() const;
     bool isBlocking() const;
 

--- a/src/keys/drivers/YubiKey.h
+++ b/src/keys/drivers/YubiKey.h
@@ -68,7 +68,7 @@ public:
      * @param mayBlock operation is allowed to block
      * @param challenge challenge input to YubiKey
      * @param response response output from YubiKey
-     * @return true on success
+     * @return challenge result
      */
     ChallengeResult challenge(int slot, bool mayBlock, const QByteArray& challenge, QByteArray& response);
 
@@ -99,19 +99,9 @@ signals:
     void detectComplete();
 
     /**
-     * Emitted when the YubiKey was challenged and has returned a response.
-     */
-    void challenged();
-
-    /**
      * Emitted when no Yubikey could be found.
      */
     void notFound();
-
-    /**
-     * Emitted when detection is already running.
-     */
-    void alreadyRunning();
 
 private:
     explicit YubiKey();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
* Move mutex lock to right before challenge call and wait for up to 1 second for unlock
* Fix bug where ALREADY_RUNNING was interpreted as success and causing database corruption

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #2436 - prevent database corruption when autosave saves two yubikey enabled databases at the same time

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
