### PR TITLE
Fix KeePassHTTP settings to custom data conversion

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -36,6 +36,7 @@
 #include "gui/MainWindow.h"
 
 const char BrowserService::KEEPASSXCBROWSER_NAME[] = "KeePassXC-Browser Settings";
+const char BrowserService::KEEPASSXCBROWSER_OLD_NAME[] = "keepassxc-browser Settings";
 const char BrowserService::ASSOCIATE_KEY_PREFIX[] = "KPXC_BROWSER_";
 static const char KEEPASSXCBROWSER_GROUP_NAME[] = "KeePassXC-Browser Passwords";
 static int KEEPASSXCBROWSER_DEFAULT_ICON = 1;
@@ -467,11 +468,16 @@ void BrowserService::convertAttributesToCustomData(Database *currentDb)
         if (moveSettingsToCustomData(entry, KEEPASSHTTP_NAME)) {
             ++counter;
         }
+
+        if (moveSettingsToCustomData(entry, KEEPASSXCBROWSER_OLD_NAME)) {
+            ++counter;
+        }
+
         if (moveSettingsToCustomData(entry, KEEPASSXCBROWSER_NAME)) {
             ++counter;
         }
 
-        if (entry->title() == KEEPASSHTTP_NAME || entry->title() == KEEPASSXCBROWSER_NAME) {
+        if (entry->title() == KEEPASSHTTP_NAME || entry->title().contains(KEEPASSXCBROWSER_NAME, Qt::CaseInsensitive)) {
             keyCounter += moveKeysToCustomData(entry, db);
             delete entry;
         }
@@ -860,7 +866,7 @@ bool BrowserService::checkLegacySettings()
     QList<Entry*> entries = db->rootGroup()->entriesRecursive();
     for (const auto& e : entries) {
         if ((e->attributes()->contains(KEEPASSHTTP_NAME) || e->attributes()->contains(KEEPASSXCBROWSER_NAME)) ||
-            (e->title() == KEEPASSHTTP_NAME || e->title() == KEEPASSXCBROWSER_NAME)) {
+            (e->title() == KEEPASSHTTP_NAME || e->title().contains(KEEPASSXCBROWSER_NAME, Qt::CaseInsensitive))) {
             legacySettingsFound = true;
             break;
         }

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -59,6 +59,7 @@ public:
 
 public:
     static const char KEEPASSXCBROWSER_NAME[];
+    static const char KEEPASSXCBROWSER_OLD_NAME[];
     static const char ASSOCIATE_KEY_PREFIX[];
     static const char LEGACY_ASSOCIATE_KEY_PREFIX[];
 


### PR DESCRIPTION
Fix KeePassHTTP settings to custom data conversion.

## Description
In the first versions which included KeePassXC-Browser support the data attributes and entries were specified as `keepassxc-browser Settings`. This fix adds the old settings name to the list for attributes and keys that will be converted to the new implementation.

Instead of `toLower()` it was easier just to add a new static string for conversion (QMap doesn't support CaseInsensitive comparison, and you still would have to make a case sensitive selection of the attribute).

## Motivation and context
Fixes https://github.com/keepassxreboot/keepassxc/issues/2417.

## How has this been tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
