### PR TITLE
Adding tests for modified signal on merge.

### DIFF
--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -36,6 +36,8 @@ private slots:
     void testResolveConflictNewer();
     void testResolveConflictExisting();
     void testResolveGroupConflictOlder();
+    void testMergeNotModified();
+    void testMergeModified();
     void testResolveConflictDuplicate();
     void testResolveConflictEntry_Synchronize();
     void testResolveConflictEntry_KeepLocal();


### PR DESCRIPTION
Adding tests on the `modified` signal of the database when merging. This is to make sure that the modified signal is not emitted when nothing was performed during the merge operation.

## Motivation and context
The previous implementation of the `merge` function was always emitting the `modified` signal.


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ other (new tests)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
