### PR TITLE
Fix compilation without YubiKey

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,7 +239,7 @@ endif()
 if(WITH_XC_YUBIKEY)
     list(APPEND keepassx_SOURCES keys/drivers/YubiKey.cpp)
 else()
-    list(APPEND keepassx_SOURCES keys/drivers/YubiKeyStub.cpp)
+    list(APPEND keepassx_SOURCES keys/drivers/YubiKey.h keys/drivers/YubiKeyStub.cpp)
 endif()
 
 if(WITH_XC_TOUCHID)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
This patch fixes a small regression introduced by #2433 that caused a missing header error when building with the YubiKey flag turned off.

## How has this been tested?
Manually.


## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
