### PR TITLE
Document list -R option.

### DIFF
--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -51,7 +51,7 @@ int List::execute(const QStringList& arguments)
                                QObject::tr("path"));
     parser.addOption(keyFile);
     QCommandLineOption recursiveOption(QStringList() << "R" << "recursive",
-                                       QObject::tr("Recursive mode, list elements recursively"));
+                                       QObject::tr("Recursively list the elements of the group."));
     parser.addOption(recursiveOption);
     parser.addHelpOption();
     parser.process(arguments);

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -121,6 +121,12 @@ otherwise the program will fail. If the wordlist has < 4000 words a warning will
 be printed to STDERR.
 
 
+.SS "List options"
+
+.IP "-R, --recursive"
+Recursively list the elements of the group.
+
+
 .SS "Generate options"
 
 .IP "-L, --length <length>"


### PR DESCRIPTION
Following up on https://github.com/keepassxreboot/keepassxc/pull/2345
The new option was missing from the man page.

## Types of changes
Other (documentation)