### PR TITLE
Better error message for invalid db file

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -484,11 +484,11 @@ Database* Database::openDatabaseFile(const QString& fileName, QSharedPointer<con
 
     QFile dbFile(fileName);
     if (!dbFile.exists()) {
-        qCritical("File %s does not exist.", qPrintable(fileName));
+        qCritical("Database file %s does not exist.", qPrintable(fileName));
         return nullptr;
     }
     if (!dbFile.open(QIODevice::ReadOnly)) {
-        qCritical("Unable to open file %s.", qPrintable(fileName));
+        qCritical("Unable to open database file %s.", qPrintable(fileName));
         return nullptr;
     }
 


### PR DESCRIPTION
This is what I understand from https://github.com/keepassxreboot/keepassxc/issues/1484.
It's true that we call it a `dbFile` in the code, so might as well talk about database files with the user, this can only be more explicit.

## Motivation and context
https://github.com/keepassxreboot/keepassxc/issues/1484

## How has this been tested?
```
$ ./src/cli/keepassxc-cli show fdsfsdfd fdfdsf
Insert password to unlock fdsfsdfd: 
Database file fdsfsdfd does not exist.
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

