### PR TITLE
CLI Merge: Only save database file when modified.

### DIFF
--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -84,7 +84,7 @@ int Merge::execute(const QStringList& arguments)
     }
 
     Merger merger(db2.data(), db1.data());
-    merger.merge();
+    bool databaseChanged = merger.merge();
 
     QString errorMessage = db1->saveToFile(args.at(0));
     if (!errorMessage.isEmpty()) {
@@ -92,6 +92,10 @@ int Merge::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    out << "Successfully merged the database files." << endl;
+    if (databaseChanged) {
+        out << "Successfully merged the database files." << endl;
+    } else {
+        out << "Database was not modified by merge operation." << endl;
+    }
     return EXIT_SUCCESS;
 }

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -86,16 +86,16 @@ int Merge::execute(const QStringList& arguments)
     Merger merger(db2.data(), db1.data());
     bool databaseChanged = merger.merge();
 
-    QString errorMessage = db1->saveToFile(args.at(0));
-    if (!errorMessage.isEmpty()) {
-        err << QObject::tr("Unable to save database to file : %1").arg(errorMessage) << endl;
-        return EXIT_FAILURE;
-    }
-
     if (databaseChanged) {
+        QString errorMessage = db1->saveToFile(args.at(0));
+        if (!errorMessage.isEmpty()) {
+            err << QObject::tr("Unable to save database to file : %1").arg(errorMessage) << endl;
+            return EXIT_FAILURE;
+        }
         out << "Successfully merged the database files." << endl;
     } else {
         out << "Database was not modified by merge operation." << endl;
     }
+
     return EXIT_SUCCESS;
 }

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -649,6 +649,15 @@ void TestCli::testMerge()
     QVERIFY(entry1);
     QCOMPARE(entry1->title(), QString("Some Website"));
     QCOMPARE(entry1->password(), QString("secretsecretsecret"));
+
+    // making sure that the message is different if the database was not
+    // modified by the merge operation.
+    pos = m_stdoutFile->pos();
+    Utils::Test::setNextPassword("a");
+    mergeCmd.execute({"merge", "-s", sourceFile.fileName(), sourceFile.fileName()});
+    m_stdoutFile->seek(pos);
+    m_stdoutFile->readLine();
+    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Database was not modified by merge operation.\n"));
 }
 
 void TestCli::testRemove()


### PR DESCRIPTION
Do not save the database when the merge operation did nothing. Also display a different message so that the user knows nothing had to be written.

## How has this been tested?
Locally + unit tests.

```
$ stat --format="%y" ~/1.kdbx 
2018-11-09 18:25:30.118978803 -0500
$ ./src/cli/keepassxc-cli merge ~/1.kdbx ~/1.kdbx -s
Insert password to unlock /home/louib/1.kdbx: 
Merge entry1/entry1 with local on top/under Root
Merge entry2/entry2 with local on top/under Root
Database was not modified by merge operation.
$ stat --format="%y" ~/1.kdbx 
2018-11-09 18:25:30.118978803 -0500
```

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
