### PR TITLE
Update tray icon when locking from KeePassXC-Browser

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -59,6 +59,7 @@ BrowserService::BrowserService(DatabaseTabWidget* parent)
                 SIGNAL(activateDatabaseChanged(DatabaseWidget*)),
                 this,
                 SLOT(activateDatabaseChanged(DatabaseWidget*)));
+        connect(this, SIGNAL(lockDatabase(DatabaseWidget*)), m_dbTabWidget, SLOT(lockDatabase(DatabaseWidget*)));
     }
 }
 

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -84,6 +84,7 @@ signals:
     void databaseLocked();
     void databaseUnlocked();
     void databaseChanged();
+    void lockDatabase(DatabaseWidget*);
 
 private:
     enum Access


### PR DESCRIPTION
## Description
When using the lock icon from KeePassXC-Browser, the system tray icon should be updated.

## Motivation and context
Previously the lock icon stayed green all the time.

Fixes https://github.com/keepassxreboot/keepassxc/issues/2480.

## How has this been tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**