### PR TITLE
Refactor Database and Database widgets

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -268,7 +268,7 @@ void AutoType::performAutoType(const Entry* entry, QWidget* hideWindow)
  * Global Autotype entry-point function
  * Perform global Auto-Type on the active window
  */
-void AutoType::performGlobalAutoType(const QList<Database*>& dbList)
+void AutoType::performGlobalAutoType(const QList<QSharedPointer<Database>>& dbList)
 {
     if (!m_plugin) {
         return;
@@ -287,7 +287,7 @@ void AutoType::performGlobalAutoType(const QList<Database*>& dbList)
 
     QList<AutoTypeMatch> matchList;
 
-    for (Database* db : dbList) {
+    for (const auto& db : dbList) {
         const QList<Entry*> dbEntries = db->rootGroup()->entriesRecursive();
         for (Entry* entry : dbEntries) {
             const QSet<QString> sequences = autoTypeSequences(entry, windowTitle).toSet();

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -58,7 +58,7 @@ public:
     static void createTestInstance();
 
 public slots:
-    void performGlobalAutoType(const QList<Database*>& dbList);
+    void performGlobalAutoType(const QList<QSharedPointer<Database>>& dbList);
     void raiseWindow();
 
 signals:

--- a/src/browser/BrowserEntrySaveDialog.cpp
+++ b/src/browser/BrowserEntrySaveDialog.cpp
@@ -19,6 +19,9 @@
 #include "BrowserEntrySaveDialog.h"
 #include "ui_BrowserEntrySaveDialog.h"
 
+#include "core/Database.h"
+#include "gui/DatabaseWidget.h"
+
 BrowserEntrySaveDialog::BrowserEntrySaveDialog(QWidget* parent)
     : QDialog(parent)
     , m_ui(new Ui::BrowserEntrySaveDialog())
@@ -43,8 +46,8 @@ int BrowserEntrySaveDialog::setItems(QList<DatabaseWidget*>& databaseWidgets, Da
     uint counter = 0;
     int activeIndex = -1;
     for (const auto dbWidget : databaseWidgets) {
-        QString databaseName = dbWidget->databaseName();
-        QString databaseFileName = dbWidget->databaseFilePath();
+        QString databaseName = dbWidget->database()->metadata()->name();
+        QString databaseFileName = dbWidget->database()->filePath();
 
         auto* item = new QListWidgetItem();
         item->setData(Qt::UserRole, counter);

--- a/src/browser/BrowserEntrySaveDialog.cpp
+++ b/src/browser/BrowserEntrySaveDialog.cpp
@@ -43,10 +43,10 @@ int BrowserEntrySaveDialog::setItems(QList<DatabaseWidget*>& databaseWidgets, Da
     uint counter = 0;
     int activeIndex = -1;
     for (const auto dbWidget : databaseWidgets) {
-        QString databaseName = dbWidget->getDatabaseName();
-        QString databaseFileName = dbWidget->getDatabaseFileName();
+        QString databaseName = dbWidget->databaseName();
+        QString databaseFileName = dbWidget->databaseFilePath();
 
-        QListWidgetItem* item = new QListWidgetItem();
+        auto* item = new QListWidgetItem();
         item->setData(Qt::UserRole, counter);
 
         // Show database name (and filename if the name has been set in metadata)

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -779,7 +779,7 @@ QSharedPointer<Database> BrowserService::getDatabase()
             return db;
         }
     }
-    return nullptr;
+    return {};
 }
 
 QSharedPointer<Database> BrowserService::selectedDatabase()
@@ -810,7 +810,7 @@ QSharedPointer<Database> BrowserService::selectedDatabase()
                 return databaseWidgets[index]->database();
             }
         } else {
-            return nullptr;
+            return {};
         }
     }
 
@@ -879,12 +879,9 @@ bool BrowserService::checkLegacySettings()
                                                 "Do you want to upgrade the settings to the latest standard?\n"
                                                 "This is necessary to maintain compatibility with the browser plugin."),
                                              QMessageBox::Yes | QMessageBox::No);
-        
-    if (dialogResult == QMessageBox::No) {
-        return false;
-    }
 
-    return true;
+    return !(dialogResult == QMessageBox::No);
+
 }
 
 void BrowserService::databaseLocked(DatabaseWidget* dbWidget)

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -343,7 +343,7 @@ void BrowserService::updateEntry(const QString& id,
         return;
     }
 
-    Entry* entry = db->resolveEntry(QUuid::fromRfc4122(QByteArray::fromHex(uuid.toLatin1())));
+    Entry* entry = db->rootGroup()->findEntryByUuid(QUuid::fromRfc4122(QByteArray::fromHex(uuid.toLatin1())));
     if (!entry) {
         // If entry is not found for update, add a new one to the selected database
         addEntry(id, login, password, url, submitUrl, "", db);
@@ -665,7 +665,7 @@ Group* BrowserService::findCreateAddEntryGroup(QSharedPointer<Database> selected
 
     for (const Group* g : rootGroup->groupsRecursive(true)) {
         if (g->name() == groupName) {
-            return db->resolveGroup(g->uuid());
+            return db->rootGroup()->findGroupByUuid(g->uuid());
         }
     }
 
@@ -880,8 +880,7 @@ bool BrowserService::checkLegacySettings()
                                                 "This is necessary to maintain compatibility with the browser plugin."),
                                              QMessageBox::Yes | QMessageBox::No);
 
-    return !(dialogResult == QMessageBox::No);
-
+    return dialogResult == QMessageBox::Yes;
 }
 
 void BrowserService::databaseLocked(DatabaseWidget* dbWidget)

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -69,7 +69,7 @@ bool BrowserService::isDatabaseOpened() const
         return false;
     }
 
-    return dbWidget->currentMode() == DatabaseWidget::ViewMode || dbWidget->currentMode() == DatabaseWidget::EditMode;
+    return dbWidget->currentMode() == DatabaseWidget::Mode::ViewMode || dbWidget->currentMode() == DatabaseWidget::Mode::EditMode;
 }
 
 bool BrowserService::openDatabase(bool triggerUnlock)
@@ -83,7 +83,7 @@ bool BrowserService::openDatabase(bool triggerUnlock)
         return false;
     }
 
-    if (dbWidget->currentMode() == DatabaseWidget::ViewMode || dbWidget->currentMode() == DatabaseWidget::EditMode) {
+    if (dbWidget->currentMode() == DatabaseWidget::Mode::ViewMode || dbWidget->currentMode() == DatabaseWidget::Mode::EditMode) {
         return true;
     }
 
@@ -106,7 +106,7 @@ void BrowserService::lockDatabase()
         return;
     }
 
-    if (dbWidget->currentMode() == DatabaseWidget::ViewMode || dbWidget->currentMode() == DatabaseWidget::EditMode) {
+    if (dbWidget->currentMode() == DatabaseWidget::Mode::ViewMode || dbWidget->currentMode() == DatabaseWidget::Mode::EditMode) {
         dbWidget->lock();
     }
 }
@@ -789,8 +789,8 @@ QSharedPointer<Database> BrowserService::selectedDatabase()
         auto* dbWidget = m_dbTabWidget->databaseWidgetFromIndex(i);
         // Add only open databases
         if (dbWidget && dbWidget->database()->hasKey() &&
-            (dbWidget->currentMode() == DatabaseWidget::ViewMode ||
-             dbWidget->currentMode() == DatabaseWidget::EditMode)) {
+            (dbWidget->currentMode() == DatabaseWidget::Mode::ViewMode ||
+             dbWidget->currentMode() == DatabaseWidget::Mode::EditMode)) {
             databaseWidgets.push_back(dbWidget);
             continue;
         }
@@ -909,7 +909,7 @@ void BrowserService::activateDatabaseChanged(DatabaseWidget* dbWidget)
 {
     if (dbWidget) {
         auto currentMode = dbWidget->currentMode();
-        if (currentMode == DatabaseWidget::ViewMode || currentMode == DatabaseWidget::EditMode) {
+        if (currentMode == DatabaseWidget::Mode::ViewMode || currentMode == DatabaseWidget::Mode::EditMode) {
             emit databaseUnlocked();
         } else {
             emit databaseLocked();

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -113,7 +113,7 @@ void BrowserService::lockDatabase()
 
 QString BrowserService::getDatabaseRootUuid()
 {
-    Database* db = getDatabase();
+    auto db = getDatabase();
     if (!db) {
         return {};
     }
@@ -128,7 +128,7 @@ QString BrowserService::getDatabaseRootUuid()
 
 QString BrowserService::getDatabaseRecycleBinUuid()
 {
-    Database* db = getDatabase();
+    auto db = getDatabase();
     if (!db) {
         return {};
     }
@@ -150,7 +150,7 @@ QString BrowserService::storeKey(const QString& key)
         return id;
     }
 
-    Database* db = getDatabase();
+    auto db = getDatabase();
     if (!db) {
         return {};
     }
@@ -194,7 +194,7 @@ QString BrowserService::storeKey(const QString& key)
 
 QString BrowserService::getKey(const QString& id)
 {
-    Database* db = getDatabase();
+    auto db = getDatabase();
     if (!db) {
         return {};
     }
@@ -268,13 +268,10 @@ QJsonArray BrowserService::findMatchingEntries(const QString& id,
     return result;
 }
 
-void BrowserService::addEntry(const QString& id,
-                              const QString& login,
-                              const QString& password,
-                              const QString& url,
-                              const QString& submitUrl,
-                              const QString& realm,
-                              Database* selectedDb)
+void BrowserService::addEntry(const QString& id, const QString& login,
+                              const QString& password, const QString& url,
+                              const QString& submitUrl, const QString& realm,
+                              QSharedPointer<Database> selectedDb)
 {
     if (thread() != QThread::currentThread()) {
         QMetaObject::invokeMethod(this,
@@ -286,10 +283,10 @@ void BrowserService::addEntry(const QString& id,
                                   Q_ARG(QString, url),
                                   Q_ARG(QString, submitUrl),
                                   Q_ARG(QString, realm),
-                                  Q_ARG(Database*, selectedDb));
+                                  Q_ARG(QSharedPointer<Database>, selectedDb));
     }
 
-    Database* db = selectedDb ? selectedDb : selectedDatabase();
+    auto db = selectedDb ? selectedDb : selectedDatabase();
     if (!db) {
         return;
     }
@@ -299,7 +296,7 @@ void BrowserService::addEntry(const QString& id,
         return;
     }
 
-    Entry* entry = new Entry();
+    auto* entry = new Entry();
     entry->setUuid(QUuid::createUuid());
     entry->setTitle(QUrl(url).host());
     entry->setUrl(url);
@@ -341,7 +338,7 @@ void BrowserService::updateEntry(const QString& id,
                                   Q_ARG(QString, submitUrl));
     }
 
-    Database* db = selectedDatabase();
+    auto db = selectedDatabase();
     if (!db) {
         return;
     }
@@ -382,10 +379,10 @@ void BrowserService::updateEntry(const QString& id,
     }
 }
 
-QList<Entry*> BrowserService::searchEntries(Database* db, const QString& hostname, const QString& url)
+QList<Entry*> BrowserService::searchEntries(QSharedPointer<Database> db, const QString& hostname, const QString& url)
 {
     QList<Entry*> entries;
-    Group* rootGroup = db->rootGroup();
+    auto* rootGroup = db->rootGroup();
     if (!rootGroup) {
         return entries;
     }
@@ -415,12 +412,12 @@ QList<Entry*> BrowserService::searchEntries(Database* db, const QString& hostnam
 QList<Entry*> BrowserService::searchEntries(const QString& url, const StringPairList& keyList)
 {
     // Get the list of databases to search
-    QList<Database*> databases;
+    QList<QSharedPointer<Database>> databases;
     if (browserSettings()->searchInAllDatabases()) {
         const int count = m_dbTabWidget->count();
         for (int i = 0; i < count; ++i) {
-            if (DatabaseWidget* dbWidget = qobject_cast<DatabaseWidget*>(m_dbTabWidget->widget(i))) {
-                if (Database* db = dbWidget->database()) {
+            if (auto* dbWidget = qobject_cast<DatabaseWidget*>(m_dbTabWidget->widget(i))) {
+                if (const auto& db = dbWidget->database()) {
                      // Check if database is connected with KeePassXC-Browser
                     for (const StringPair& keyPair : keyList) {
                         QString key = db->metadata()->customData()->value(QLatin1String(ASSOCIATE_KEY_PREFIX) + keyPair.first);
@@ -431,7 +428,7 @@ QList<Entry*> BrowserService::searchEntries(const QString& url, const StringPair
                 }
             }
         }
-    } else if (Database* db = getDatabase()) {
+    } else if (const auto& db = getDatabase()) {
         databases << db;
     }
 
@@ -439,7 +436,7 @@ QList<Entry*> BrowserService::searchEntries(const QString& url, const StringPair
     QString hostname = QUrl(url).host();
     QList<Entry*> entries;
     do {
-        for (Database* db : databases) {
+        for (const auto& db : databases) {
             entries << searchEntries(db, hostname, url);
         }
     } while (entries.isEmpty() && removeFirstDomain(hostname));
@@ -447,9 +444,9 @@ QList<Entry*> BrowserService::searchEntries(const QString& url, const StringPair
     return entries;
 }
 
-void BrowserService::convertAttributesToCustomData(Database *currentDb)
+void BrowserService::convertAttributesToCustomData(QSharedPointer<Database> currentDb)
 {
-    Database* db = currentDb ? currentDb : getDatabase();
+    auto db = currentDb ? currentDb : getDatabase();
     if (!db) {
         return;
     }
@@ -651,9 +648,9 @@ BrowserService::checkAccess(const Entry* entry, const QString& host, const QStri
     return Unknown;
 }
 
-Group* BrowserService::findCreateAddEntryGroup(Database* selectedDb)
+Group* BrowserService::findCreateAddEntryGroup(QSharedPointer<Database> selectedDb)
 {
-    Database* db = selectedDb ? selectedDb : getDatabase();
+    auto db = selectedDb ? selectedDb : getDatabase();
     if (!db) {
         return nullptr;
     }
@@ -672,7 +669,7 @@ Group* BrowserService::findCreateAddEntryGroup(Database* selectedDb)
         }
     }
 
-    Group* group = new Group();
+    auto* group = new Group();
     group->setUuid(QUuid::createUuid());
     group->setName(groupName);
     group->setIcon(KEEPASSXCBROWSER_DEFAULT_ICON);
@@ -775,26 +772,26 @@ QString BrowserService::baseDomain(const QString& url) const
     return baseDomain;
 }
 
-Database* BrowserService::getDatabase()
+QSharedPointer<Database> BrowserService::getDatabase()
 {
     if (DatabaseWidget* dbWidget = m_dbTabWidget->currentDatabaseWidget()) {
-        if (Database* db = dbWidget->database()) {
+        if (const auto& db = dbWidget->database()) {
             return db;
         }
     }
     return nullptr;
 }
 
-Database* BrowserService::selectedDatabase()
+QSharedPointer<Database> BrowserService::selectedDatabase()
 {
     QList<DatabaseWidget*> databaseWidgets;
-    for (int i = 0;; ++i) {
-        const auto dbStruct = m_dbTabWidget->indexDatabaseManagerStruct(i);
+    for (int i = 0; ; ++i) {
+        auto* dbWidget = m_dbTabWidget->databaseWidgetFromIndex(i);
         // Add only open databases
-        if (dbStruct.dbWidget && dbStruct.dbWidget->dbHasKey() && 
-            (dbStruct.dbWidget->currentMode() == DatabaseWidget::ViewMode || 
-             dbStruct.dbWidget->currentMode() == DatabaseWidget::EditMode)) {
-            databaseWidgets.push_back(dbStruct.dbWidget);
+        if (dbWidget && dbWidget->database()->hasKey() &&
+            (dbWidget->currentMode() == DatabaseWidget::ViewMode ||
+             dbWidget->currentMode() == DatabaseWidget::EditMode)) {
+            databaseWidgets.push_back(dbWidget);
             continue;
         }
 
@@ -836,7 +833,7 @@ bool BrowserService::moveSettingsToCustomData(Entry* entry, const QString& name)
     return false;
 }
 
-int BrowserService::moveKeysToCustomData(Entry* entry, Database* db) const
+int BrowserService::moveKeysToCustomData(Entry* entry, QSharedPointer<Database> db) const
 {
     int keyCounter = 0;
     for (const auto& key : entry->attributes()->keys()) {
@@ -857,7 +854,7 @@ int BrowserService::moveKeysToCustomData(Entry* entry, Database* db) const
 
 bool BrowserService::checkLegacySettings()
 {
-    Database* db = getDatabase();
+    auto db = getDatabase();
     if (!db) {
         return false;
     }

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -44,7 +44,6 @@ public:
     bool openDatabase(bool triggerUnlock);
     QString getDatabaseRootUuid();
     QString getDatabaseRecycleBinUuid();
-    Entry* getConfigEntry(bool create = false);
     QString getKey(const QString& id);
     void addEntry(const QString& id,
                   const QString& login,
@@ -52,10 +51,10 @@ public:
                   const QString& url,
                   const QString& submitUrl,
                   const QString& realm,
-                  QSharedPointer<Database> selectedDb = nullptr);
+                  QSharedPointer<Database> selectedDb = {});
     QList<Entry*> searchEntries(QSharedPointer<Database> db, const QString& hostname, const QString& url);
     QList<Entry*> searchEntries(const QString& url, const StringPairList& keyList);
-    void convertAttributesToCustomData(QSharedPointer<Database> currentDb = nullptr);
+    void convertAttributesToCustomData(QSharedPointer<Database> currentDb = {});
 
 public:
     static const char KEEPASSXCBROWSER_NAME[];
@@ -103,7 +102,7 @@ private:
                         const QString& realm);
     QJsonObject prepareEntry(const Entry* entry);
     Access checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm);
-    Group* findCreateAddEntryGroup(QSharedPointer<Database> selectedDb = nullptr);
+    Group* findCreateAddEntryGroup(QSharedPointer<Database> selectedDb = {});
     int
     sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
     bool matchUrlScheme(const QString& url);

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -52,10 +52,10 @@ public:
                   const QString& url,
                   const QString& submitUrl,
                   const QString& realm,
-                  Database* selectedDb = nullptr);
-    QList<Entry*> searchEntries(Database* db, const QString& hostname, const QString& url);
+                  QSharedPointer<Database> selectedDb = nullptr);
+    QList<Entry*> searchEntries(QSharedPointer<Database> db, const QString& hostname, const QString& url);
     QList<Entry*> searchEntries(const QString& url, const StringPairList& keyList);
-    void convertAttributesToCustomData(Database *currentDb = nullptr);
+    void convertAttributesToCustomData(QSharedPointer<Database> currentDb = nullptr);
 
 public:
     static const char KEEPASSXCBROWSER_NAME[];
@@ -103,16 +103,16 @@ private:
                         const QString& realm);
     QJsonObject prepareEntry(const Entry* entry);
     Access checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm);
-    Group* findCreateAddEntryGroup(Database* selectedDb = nullptr);
+    Group* findCreateAddEntryGroup(QSharedPointer<Database> selectedDb = nullptr);
     int
     sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
     bool matchUrlScheme(const QString& url);
     bool removeFirstDomain(QString& hostname);
     QString baseDomain(const QString& url) const;
-    Database* getDatabase();
-    Database* selectedDatabase();
+    QSharedPointer<Database> getDatabase();
+    QSharedPointer<Database> selectedDatabase();
     bool moveSettingsToCustomData(Entry* entry, const QString& name) const;
-    int moveKeysToCustomData(Entry* entry, Database* db) const;
+    int moveKeysToCustomData(Entry* entry, QSharedPointer<Database> db) const;
     bool checkLegacySettings();
 
 private:

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -89,7 +89,7 @@ int Add::execute(const QStringList& arguments)
     const QString& databasePath = args.at(0);
     const QString& entryPath = args.at(1);
 
-    Database* db = Database::unlockFromStdin(databasePath, parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
+    auto db = Database::unlockFromStdin(databasePath, parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }
@@ -126,7 +126,7 @@ int Add::execute(const QStringList& arguments)
         if (passwordLength.isEmpty()) {
             passwordGenerator.setLength(PasswordGenerator::DefaultLength);
         } else {
-            passwordGenerator.setLength(static_cast<size_t>(passwordLength.toInt()));
+            passwordGenerator.setLength(passwordLength.toInt());
         }
 
         passwordGenerator.setCharClasses(PasswordGenerator::DefaultCharset);
@@ -135,8 +135,9 @@ int Add::execute(const QStringList& arguments)
         entry->setPassword(password);
     }
 
-    QString errorMessage = db->saveToFile(databasePath);
-    if (!errorMessage.isEmpty()) {
+    QString errorMessage;
+    bool ok = db->save(databasePath, true, false, &errorMessage);
+    if (!ok) {
         errorTextStream << QObject::tr("Writing the database failed %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -136,8 +136,7 @@ int Add::execute(const QStringList& arguments)
     }
 
     QString errorMessage;
-    bool ok = db->save(databasePath, true, false, &errorMessage);
-    if (!ok) {
+    if (!db->save(databasePath, &errorMessage, true, false)) {
         errorTextStream << QObject::tr("Writing the database failed %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -66,7 +66,7 @@ int Clip::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    Database* db = Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
+    auto db = Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }
@@ -74,7 +74,7 @@ int Clip::execute(const QStringList& arguments)
     return clipEntry(db, args.at(1), args.value(2), parser.isSet(totp));
 }
 
-int Clip::clipEntry(Database* database, const QString& entryPath, const QString& timeout, bool clipTotp)
+int Clip::clipEntry(QSharedPointer<Database> database, const QString& entryPath, const QString& timeout, bool clipTotp)
 {
     TextStream err(Utils::STDERR);
 

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -26,7 +26,7 @@ public:
     Clip();
     ~Clip();
     int execute(const QStringList& arguments) override;
-    int clipEntry(Database* database, const QString& entryPath, const QString& timeout, bool clipTotp);
+    int clipEntry(QSharedPointer<Database> database, const QString& entryPath, const QString& timeout, bool clipTotp);
 };
 
 #endif // KEEPASSXC_CLIP_H

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -153,8 +153,7 @@ int Edit::execute(const QStringList& arguments)
     entry->endUpdate();
 
     QString errorMessage;
-    bool ok = db->save(databasePath, true, false, &errorMessage);
-    if (!ok) {
+    if (!db->save(databasePath, &errorMessage, true, false)) {
         err << QObject::tr("Writing the database failed: %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -93,7 +93,7 @@ int Edit::execute(const QStringList& arguments)
     const QString& databasePath = args.at(0);
     const QString& entryPath = args.at(1);
 
-    Database* db = Database::unlockFromStdin(databasePath, parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
+    auto db = Database::unlockFromStdin(databasePath, parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }
@@ -152,8 +152,9 @@ int Edit::execute(const QStringList& arguments)
 
     entry->endUpdate();
 
-    QString errorMessage = db->saveToFile(databasePath);
-    if (!errorMessage.isEmpty()) {
+    QString errorMessage;
+    bool ok = db->save(databasePath, true, false, &errorMessage);
+    if (!ok) {
         err << QObject::tr("Writing the database failed: %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -104,7 +104,8 @@ int Extract::execute(const QStringList& arguments)
 
     KeePass2Reader reader;
     reader.setSaveXml(true);
-    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), &dbFile, compositeKey));
+    auto db = QSharedPointer<Database>::create();
+    reader.readDatabase(&dbFile, compositeKey, db.data());
 
     QByteArray xmlData = reader.reader()->xmlData();
 

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -104,7 +104,7 @@ int Extract::execute(const QStringList& arguments)
 
     KeePass2Reader reader;
     reader.setSaveXml(true);
-    QScopedPointer<Database> db(reader.readDatabase(&dbFile, compositeKey));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), &dbFile, compositeKey));
 
     QByteArray xmlData = reader.reader()->xmlData();
 

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -64,7 +64,7 @@ int List::execute(const QStringList& arguments)
 
     bool recursive = parser.isSet(recursiveOption);
 
-    QScopedPointer<Database> db(Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR));
+    auto db = Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -61,7 +61,7 @@ int Locate::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    QScopedPointer<Database> db(Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR));
+    auto db = Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -79,8 +79,7 @@ int Merge::execute(const QStringList& arguments)
     } else {
         db2 = QSharedPointer<Database>::create();
         QString errorMessage;
-        bool ok = db2->open(args.at(1), db1->key(), false, &errorMessage);
-        if (!ok) {
+        if (!db2->open(args.at(1), db1->key(), &errorMessage, false)) {
             err << QObject::tr("Error reading merge file:\n%1").arg(errorMessage);
             return EXIT_FAILURE;
         }
@@ -91,8 +90,7 @@ int Merge::execute(const QStringList& arguments)
 
     if (databaseChanged) {
         QString errorMessage;
-        bool ok = db1->save(args.at(0), true, false, &errorMessage);
-        if (!ok) {
+        if (!db1->save(args.at(0), &errorMessage, true, false)) {
             err << QObject::tr("Unable to save database to file : %1").arg(errorMessage) << endl;
             return EXIT_FAILURE;
         }

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -63,7 +63,7 @@ int Remove::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    QScopedPointer<Database> db(Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR));
+    auto db = Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }
@@ -92,8 +92,9 @@ int Remove::removeEntry(Database* database, const QString& databasePath, const Q
         database->recycleEntry(entry);
     };
 
-    QString errorMessage = database->saveToFile(databasePath);
-    if (!errorMessage.isEmpty()) {
+    QString errorMessage;
+    bool ok = database->save(databasePath, true, false, &errorMessage);
+    if (!ok) {
         err << QObject::tr("Unable to save database to file: %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -93,8 +93,7 @@ int Remove::removeEntry(Database* database, const QString& databasePath, const Q
     };
 
     QString errorMessage;
-    bool ok = database->save(databasePath, true, false, &errorMessage);
-    if (!ok) {
+    if (!database->save(databasePath, &errorMessage, true, false)) {
         err << QObject::tr("Unable to save database to file: %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -71,7 +71,7 @@ int Show::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    QScopedPointer<Database> db(Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR));
+    auto db = Database::unlockFromStdin(args.at(0), parser.value(keyFile), Utils::STDOUT, Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -153,6 +153,7 @@ void Config::init(const QString& fileName)
 
     m_defaults.insert("SingleInstance", true);
     m_defaults.insert("RememberLastDatabases", true);
+    m_defaults.insert("NumberOfRememberedLastDatabases", 5);
     m_defaults.insert("RememberLastKeyFiles", true);
     m_defaults.insert("OpenPreviousDatabasesOnStartup", true);
     m_defaults.insert("AutoSaveAfterEveryChange", true);

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -58,7 +58,7 @@ void CustomData::set(const QString& key, const QString& value)
 
     if (addAttribute || changeValue) {
         m_data.insert(key, value);
-        emit modified();
+        emit customDataModified();
     }
 
     if (addAttribute) {
@@ -73,7 +73,7 @@ void CustomData::remove(const QString& key)
     m_data.remove(key);
 
     emit removed(key);
-    emit modified();
+    emit customDataModified();
 }
 
 void CustomData::rename(const QString& oldKey, const QString& newKey)
@@ -92,7 +92,7 @@ void CustomData::rename(const QString& oldKey, const QString& newKey)
     m_data.remove(oldKey);
     m_data.insert(newKey, data);
 
-    emit modified();
+    emit customDataModified();
     emit renamed(oldKey, newKey);
 }
 
@@ -107,7 +107,7 @@ void CustomData::copyDataFrom(const CustomData* other)
     m_data = other->m_data;
 
     emit reset();
-    emit modified();
+    emit customDataModified();
 }
 bool CustomData::operator==(const CustomData& other) const
 {
@@ -126,7 +126,7 @@ void CustomData::clear()
     m_data.clear();
 
     emit reset();
-    emit modified();
+    emit customDataModified();
 }
 
 bool CustomData::isEmpty() const

--- a/src/core/CustomData.h
+++ b/src/core/CustomData.h
@@ -46,7 +46,7 @@ public:
     bool operator!=(const CustomData& other) const;
 
 signals:
-    void modified();
+    void customDataModified();
     void aboutToBeAdded(const QString& key);
     void added(const QString& key);
     void aboutToBeRemoved(const QString& key);

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -54,8 +54,8 @@ Database::Database()
 
     s_uuidMap.insert(m_uuid, this);
 
-    connect(m_metadata, SIGNAL(modified()), this, SIGNAL(modifiedImmediate()));
-    connect(m_metadata, SIGNAL(metadataChanged()), this, SIGNAL(metadataChanged()));
+    connect(m_metadata, SIGNAL(metadataModified()), this, SIGNAL(metadataModified()));
+    connect(m_metadata, SIGNAL(metadataModified()), this, SIGNAL(modifiedImmediate()));
     connect(this, SIGNAL(modifiedImmediate()), this, SLOT(startModifiedTimer()));
     connect(m_timer, SIGNAL(timeout()), SIGNAL(modified()));
 }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -737,7 +737,9 @@ bool Database::isModified() const
 
 void Database::markAsModified()
 {
-    Q_ASSERT(!m_data.isReadOnly);
+    if (isReadOnly()) {
+        return;
+    }
 
     m_modified = true;
     if (m_emitModified) {

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -723,7 +723,6 @@ void Database::emptyRecycleBin()
 
 void Database::setEmitModified(bool value)
 {
-    Q_ASSERT(!m_data.isReadOnly);
     if (m_emitModified && !value) {
         m_timer->stop();
     }
@@ -748,7 +747,6 @@ void Database::markAsModified()
 
 void Database::markAsClean()
 {
-    Q_ASSERT(!m_data.isReadOnly);
     bool emitSignal = m_modified;
     m_modified = false;
     if (emitSignal) {

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -91,7 +91,7 @@ bool Database::open(QSharedPointer<const CompositeKey> key, bool readOnly, QStri
     if (m_data.filePath.isEmpty()) {
         return false;
     }
-    open(m_data.filePath, std::move(key), readOnly, error);
+    return open(m_data.filePath, std::move(key), readOnly, error);
 }
 
 /**
@@ -737,7 +737,7 @@ Database* Database::databaseByUuid(const QUuid& uuid)
  */
 Database* Database::databaseByFilePath(const QString& filePath)
 {
-    return s_fileNameMap.value(filePath, nullptr);
+    return s_filePathMap.value(filePath, nullptr);
 }
 
 void Database::startModifiedTimer()

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -814,7 +814,7 @@ QSharedPointer<Database> Database::unlockFromStdin(QString databaseFilename, QSt
         // LCOV_EXCL_START
         if (!fileKey->load(keyFilename, &errorMessage)) {
             err << QObject::tr("Failed to load key file %1: %2").arg(keyFilename, errorMessage)<< endl;
-            return nullptr;
+            return {};
         }
 
         if (fileKey->type() != FileKey::Hashed) {

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -44,7 +44,7 @@ Database::Database()
     , m_data()
     , m_rootGroup(nullptr)
     , m_timer(new QTimer(this))
-    , m_emitModified(true)
+    , m_emitModified(false)
     , m_uuid(QUuid::createUuid())
 {
     setRootGroup(new Group());
@@ -57,6 +57,9 @@ Database::Database()
     connect(m_metadata, SIGNAL(metadataModified()), this, SIGNAL(metadataModified()));
     connect(m_metadata, SIGNAL(metadataModified()), this, SLOT(markAsModified()));
     connect(m_timer, SIGNAL(timeout()), SIGNAL(modified()));
+
+    m_modified = false;
+    m_emitModified = true;
 }
 
 Database::Database(const QString& filePath)

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -702,10 +702,22 @@ void Database::setEmitModified(bool value)
     m_emitModified = value;
 }
 
+bool Database::isModified() const
+{
+    return m_modified;
+}
+
 void Database::markAsModified()
 {
     Q_ASSERT(!m_data.isReadOnly);
+    m_modified = true;
     emit modified();
+}
+
+void Database::markAsClean()
+{
+    Q_ASSERT(!m_data.isReadOnly);
+    m_modified = false;
 }
 
 /**

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -116,8 +116,6 @@ public:
 
     bool isModified() const;
     void setEmitModified(bool value);
-    void markAsModified();
-    void markAsClean();
 
     Group* resolveGroup(const QUuid& uuid);
     Entry* resolveEntry(const QUuid& uuid);
@@ -127,6 +125,10 @@ public:
     static Database* databaseByFilePath(const QString& filePath);;
     static QSharedPointer<Database> unlockFromStdin(QString databaseFilename, QString keyFilename = {},
                                                     FILE* outputDescriptor = stdout, FILE* errorDescriptor = stderr);
+
+public slots:
+    void markAsModified();
+    void markAsClean();
 
 signals:
     void filePathChanged(const QString& oldPath, const QString& newPath);

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -138,7 +138,6 @@ signals:
     void groupAboutToMove(Group* group, Group* toGroup, int index);
     void groupMoved();
     void modified();
-    void modifiedImmediate();
     void metadataModified();
     void clean();
 

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -181,9 +181,9 @@ private:
     Group* m_rootGroup;
     QList<DeletedObject> m_deletedObjects;
     QPointer<QTimer> m_timer;
+    bool m_unlocked = false;
     bool m_modified = false;
     bool m_emitModified;
-    bool m_unlocked = false;
 
     QUuid m_uuid;
     static QHash<QUuid, QPointer<Database>> s_uuidMap;

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -135,7 +135,6 @@ signals:
     void groupAboutToMove(Group* group, Group* toGroup, int index);
     void groupMoved();
     void databaseModified();
-    void metadataModified();
     void databaseSaved();
     void databaseDiscarded();
 

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -22,6 +22,7 @@
 #include <QDateTime>
 #include <QHash>
 #include <QObject>
+#include <QPointer>
 
 #include "crypto/kdf/Kdf.h"
 #include "format/KeePass2.h"
@@ -74,6 +75,8 @@ public:
     void setFilePath(const QString& filePath);
     bool isReadOnly() const;
     void setReadOnly(bool readOnly);
+    bool isInitialized() const;
+    void setInitialized(bool unlocked);
 
     Group* rootGroup();
     const Group* rootGroup() const;
@@ -136,6 +139,7 @@ signals:
     void groupMoved();
     void metadataChanged();
     void modified();
+    void modifiedImmediate();
     void clean();
 
 private slots:
@@ -175,9 +179,10 @@ private:
     DatabaseData m_data;
     Group* m_rootGroup;
     QList<DeletedObject> m_deletedObjects;
-    QTimer* m_timer;
+    QPointer<QTimer> m_timer;
     bool m_modified = false;
     bool m_emitModified;
+    bool m_unlocked = false;
 
     QUuid m_uuid;
     static QHash<QUuid, QPointer<Database>> s_uuidMap;

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -137,9 +137,9 @@ signals:
     void groupRemoved();
     void groupAboutToMove(Group* group, Group* toGroup, int index);
     void groupMoved();
-    void metadataChanged();
     void modified();
     void modifiedImmediate();
+    void metadataModified();
     void clean();
 
 private slots:

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -111,8 +111,10 @@ public:
     void recycleGroup(Group* group);
     void emptyRecycleBin();
 
+    bool isModified() const;
     void setEmitModified(bool value);
     void markAsModified();
+    void markAsClean();
 
     Group* resolveGroup(const QUuid& uuid);
     Entry* resolveEntry(const QUuid& uuid);
@@ -174,6 +176,7 @@ private:
     Group* m_rootGroup;
     QList<DeletedObject> m_deletedObjects;
     QTimer* m_timer;
+    bool m_modified = false;
     bool m_emitModified;
 
     QUuid m_uuid;

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -122,8 +122,8 @@ public:
 
     static Database* databaseByUuid(const QUuid& uuid);;
     static Database* databaseByFilePath(const QString& filePath);;
-    static Database* unlockFromStdin(QString databaseFilename, QString keyFilename = {},
-        FILE* outputDescriptor = stdout, FILE* errorDescriptor = stderr);
+    static QSharedPointer<Database> unlockFromStdin(QString databaseFilename, QString keyFilename = {},
+                                                    FILE* outputDescriptor = stdout, FILE* errorDescriptor = stderr);
 
 signals:
     void filePathChanged(const QString& oldPath, const QString& newPath);
@@ -134,9 +134,9 @@ signals:
     void groupRemoved();
     void groupAboutToMove(Group* group, Group* toGroup, int index);
     void groupMoved();
-    void nameTextChanged();
+    void metadataChanged();
     void modified();
-    void modifiedImmediate();
+    void clean();
 
 private slots:
     void startModifiedTimer();

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -50,14 +50,14 @@ Entry::Entry()
     m_data.autoTypeObfuscation = 0;
 
     connect(m_attributes, SIGNAL(modified()), SLOT(updateTotp()));
-    connect(m_attributes, SIGNAL(modified()), this, SIGNAL(modified()));
+    connect(m_attributes, SIGNAL(modified()), this, SIGNAL(entryModified()));
     connect(m_attributes, SIGNAL(defaultKeyModified()), SLOT(emitDataChanged()));
-    connect(m_attachments, SIGNAL(modified()), this, SIGNAL(modified()));
-    connect(m_autoTypeAssociations, SIGNAL(modified()), SIGNAL(modified()));
-    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(modified()));
+    connect(m_attachments, SIGNAL(modified()), this, SIGNAL(entryModified()));
+    connect(m_autoTypeAssociations, SIGNAL(modified()), SIGNAL(entryModified()));
+    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(entryModified()));
 
-    connect(this, SIGNAL(modified()), SLOT(updateTimeinfo()));
-    connect(this, SIGNAL(modified()), SLOT(updateModifiedSinceBegin()));
+    connect(this, SIGNAL(entryModified()), SLOT(updateTimeinfo()));
+    connect(this, SIGNAL(entryModified()), SLOT(updateModifiedSinceBegin()));
 }
 
 Entry::~Entry()
@@ -78,7 +78,7 @@ template <class T> inline bool Entry::set(T& property, const T& value)
 {
     if (property != value) {
         property = value;
-        emit modified();
+        emit entryModified();
         return true;
     }
     return false;
@@ -409,7 +409,7 @@ void Entry::setIcon(int iconNumber)
         m_data.iconNumber = iconNumber;
         m_data.customIcon = QUuid();
 
-        emit modified();
+        emit entryModified();
         emitDataChanged();
     }
 }
@@ -422,7 +422,7 @@ void Entry::setIcon(const QUuid& uuid)
         m_data.customIcon = uuid;
         m_data.iconNumber = 0;
 
-        emit modified();
+        emit entryModified();
         emitDataChanged();
     }
 }
@@ -502,7 +502,7 @@ void Entry::setExpires(const bool& value)
 {
     if (m_data.timeInfo.expires() != value) {
         m_data.timeInfo.setExpires(value);
-        emit modified();
+        emit entryModified();
     }
 }
 
@@ -510,7 +510,7 @@ void Entry::setExpiryTime(const QDateTime& dateTime)
 {
     if (m_data.timeInfo.expiryTime() != dateTime) {
         m_data.timeInfo.setExpiryTime(dateTime);
-        emit modified();
+        emit entryModified();
     }
 }
 
@@ -529,7 +529,7 @@ void Entry::addHistoryItem(Entry* entry)
     Q_ASSERT(!entry->parent());
 
     m_history.append(entry);
-    emit modified();
+    emit entryModified();
 }
 
 void Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
@@ -547,7 +547,7 @@ void Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
         delete entry;
     }
 
-    emit modified();
+    emit entryModified();
 }
 
 void Entry::truncateHistory()
@@ -930,7 +930,7 @@ void Entry::setGroup(Group* group)
 
 void Entry::emitDataChanged()
 {
-    emit dataChanged(this);
+    emit entryDataChanged(this);
 }
 
 const Database* Entry::database() const

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -48,10 +48,10 @@ Entry::Entry()
     m_data.autoTypeEnabled = true;
     m_data.autoTypeObfuscation = 0;
 
-    connect(m_attributes, SIGNAL(modified()), SLOT(updateTotp()));
-    connect(m_attributes, SIGNAL(modified()), this, SIGNAL(entryModified()));
+    connect(m_attributes, SIGNAL(entryAttributesModified()), SLOT(updateTotp()));
+    connect(m_attributes, SIGNAL(entryAttributesModified()), this, SIGNAL(entryModified()));
     connect(m_attributes, SIGNAL(defaultKeyModified()), SLOT(emitDataChanged()));
-    connect(m_attachments, SIGNAL(modified()), this, SIGNAL(entryModified()));
+    connect(m_attachments, SIGNAL(entryAttachmentsModified()), this, SIGNAL(entryModified()));
     connect(m_autoTypeAssociations, SIGNAL(modified()), SIGNAL(entryModified()));
     connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(entryModified()));
 
@@ -849,7 +849,7 @@ QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, 
 
     Q_ASSERT(m_group);
     Q_ASSERT(m_group->database());
-    const Entry* refEntry = m_group->database()->resolveEntry(searchText, searchInType);
+    const Entry* refEntry = m_group->findEntryBySearchTerm(searchText, searchInType);
 
     if (refEntry) {
         const QString wantedField = match.captured(EntryAttributes::WantedFieldGroupName);

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -26,7 +26,6 @@
 #include "core/Metadata.h"
 #include "totp/totp.h"
 
-#include <QDebug>
 #include <QDir>
 #include <QRegularExpression>
 #include <utility>
@@ -742,7 +741,7 @@ void Entry::updateModifiedSinceBegin()
 QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxDepth) const
 {
     if (maxDepth <= 0) {
-        qWarning() << QString("Maximum depth of replacement has been reached. Entry uuid: %1").arg(uuid().toString());
+        qWarning("Maximum depth of replacement has been reached. Entry uuid: %s", uuid().toString().toLatin1().data());
         return str;
     }
 
@@ -766,7 +765,7 @@ QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxD
 QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDepth) const
 {
     if (maxDepth <= 0) {
-        qWarning() << QString("Maximum depth of replacement has been reached. Entry uuid: %1").arg(uuid().toString());
+        qWarning("Maximum depth of replacement has been reached. Entry uuid: %s", uuid().toString().toLatin1().data());
         return placeholder;
     }
 
@@ -830,7 +829,7 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
 QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, int maxDepth) const
 {
     if (maxDepth <= 0) {
-        qWarning() << QString("Maximum depth of replacement has been reached. Entry uuid: %1").arg(uuid().toString());
+        qWarning("Maximum depth of replacement has been reached. Entry uuid: %s", uuid().toString().toLatin1().data());
         return placeholder;
     }
 

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -54,7 +54,7 @@ Entry::Entry()
     connect(m_attributes, SIGNAL(defaultKeyModified()), SLOT(emitDataChanged()));
     connect(m_attachments, SIGNAL(modified()), this, SIGNAL(modified()));
     connect(m_autoTypeAssociations, SIGNAL(modified()), SIGNAL(modified()));
-    connect(m_customData, SIGNAL(modified()), this, SIGNAL(modified()));
+    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(modified()));
 
     connect(this, SIGNAL(modified()), SLOT(updateTimeinfo()));
     connect(this, SIGNAL(modified()), SLOT(updateModifiedSinceBegin()));

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -221,9 +221,8 @@ signals:
     /**
      * Emitted when a default attribute has been changed.
      */
-    void dataChanged(Entry* entry);
-
-    void modified();
+    void entryDataChanged(Entry* entry);
+    void entryModified();
 
 private slots:
     void emitDataChanged();

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -66,7 +66,7 @@ void EntryAttachments::set(const QString& key, const QByteArray& value)
     }
 
     if (emitModified) {
-        emit modified();
+        emit entryAttachmentsModified();
     }
 }
 
@@ -82,7 +82,7 @@ void EntryAttachments::remove(const QString& key)
     m_attachments.remove(key);
 
     emit removed(key);
-    emit modified();
+    emit entryAttachmentsModified();
 }
 
 void EntryAttachments::remove(const QStringList& keys)
@@ -106,7 +106,7 @@ void EntryAttachments::remove(const QStringList& keys)
     }
 
     if (isModified) {
-        emit modified();
+        emit entryAttachmentsModified();
     }
 }
 
@@ -126,7 +126,7 @@ void EntryAttachments::clear()
     m_attachments.clear();
 
     emit reset();
-    emit modified();
+    emit entryAttachmentsModified();
 }
 
 void EntryAttachments::copyDataFrom(const EntryAttachments* other)
@@ -137,7 +137,7 @@ void EntryAttachments::copyDataFrom(const EntryAttachments* other)
         m_attachments = other->m_attachments;
 
         emit reset();
-        emit modified();
+        emit entryAttachmentsModified();
     }
 }
 

--- a/src/core/EntryAttachments.h
+++ b/src/core/EntryAttachments.h
@@ -44,7 +44,7 @@ public:
     int attachmentsSize() const;
 
 signals:
-    void modified();
+    void entryAttachmentsModified();
     void keyModified(const QString& key);
     void aboutToBeAdded(const QString& key);
     void added(const QString& key);

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -118,7 +118,7 @@ void EntryAttributes::set(const QString& key, const QString& value, bool protect
     }
 
     if (emitModified) {
-        emit modified();
+        emit entryAttributesModified();
     }
 
     if (defaultAttribute && changeValue) {
@@ -145,7 +145,7 @@ void EntryAttributes::remove(const QString& key)
     m_protectedAttributes.remove(key);
 
     emit removed(key);
-    emit modified();
+    emit entryAttributesModified();
 }
 
 void EntryAttributes::rename(const QString& oldKey, const QString& newKey)
@@ -175,7 +175,7 @@ void EntryAttributes::rename(const QString& oldKey, const QString& newKey)
         m_protectedAttributes.insert(newKey);
     }
 
-    emit modified();
+    emit entryAttributesModified();
     emit renamed(oldKey, newKey);
 }
 
@@ -207,7 +207,7 @@ void EntryAttributes::copyCustomKeysFrom(const EntryAttributes* other)
     }
 
     emit reset();
-    emit modified();
+    emit entryAttributesModified();
 }
 
 bool EntryAttributes::areCustomKeysDifferent(const EntryAttributes* other)
@@ -240,7 +240,7 @@ void EntryAttributes::copyDataFrom(const EntryAttributes* other)
         m_protectedAttributes = other->m_protectedAttributes;
 
         emit reset();
-        emit modified();
+        emit entryAttributesModified();
     }
 }
 
@@ -275,7 +275,7 @@ void EntryAttributes::clear()
     }
 
     emit reset();
-    emit modified();
+    emit entryAttributesModified();
 }
 
 int EntryAttributes::attributesSize() const

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -66,7 +66,7 @@ public:
     static const QString SearchTextGroupName;
 
 signals:
-    void modified();
+    void entryAttributesModified();
     void defaultKeyModified();
     void customKeyModified(const QString& key);
     void aboutToBeAdded(const QString& key);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -43,8 +43,8 @@ Group::Group()
     m_data.searchingEnabled = Inherit;
     m_data.mergeMode = Default;
 
-    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(modified()));
-    connect(this, SIGNAL(modified()), SLOT(updateTimeinfo()));
+    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(groupModified()));
+    connect(this, SIGNAL(groupModified()), SLOT(updateTimeinfo()));
 }
 
 Group::~Group()
@@ -87,7 +87,7 @@ template <class P, class V> inline bool Group::set(P& property, const V& value)
 {
     if (property != value) {
         property = value;
-        emit modified();
+        emit groupModified();
         return true;
     } else {
         return false;
@@ -310,7 +310,7 @@ void Group::setUuid(const QUuid& uuid)
 void Group::setName(const QString& name)
 {
     if (set(m_data.name, name)) {
-        emit dataChanged(this);
+        emit groupDataChanged(this);
     }
 }
 
@@ -324,8 +324,8 @@ void Group::setIcon(int iconNumber)
     if (iconNumber >= 0 && (m_data.iconNumber != iconNumber || !m_data.customIcon.isNull())) {
         m_data.iconNumber = iconNumber;
         m_data.customIcon = QUuid();
-        emit modified();
-        emit dataChanged(this);
+        emit groupModified();
+        emit groupDataChanged(this);
     }
 }
 
@@ -334,8 +334,8 @@ void Group::setIcon(const QUuid& uuid)
     if (!uuid.isNull() && m_data.customIcon != uuid) {
         m_data.customIcon = uuid;
         m_data.iconNumber = 0;
-        emit modified();
-        emit dataChanged(this);
+        emit groupModified();
+        emit groupDataChanged(this);
     }
 }
 
@@ -352,7 +352,7 @@ void Group::setExpanded(bool expanded)
             updateTimeinfo();
             return;
         }
-        emit modified();
+        emit groupModified();
     }
 }
 
@@ -380,7 +380,7 @@ void Group::setExpires(bool value)
 {
     if (m_data.timeInfo.expires() != value) {
         m_data.timeInfo.setExpires(value);
-        emit modified();
+        emit groupModified();
     }
 }
 
@@ -388,7 +388,7 @@ void Group::setExpiryTime(const QDateTime& dateTime)
 {
     if (m_data.timeInfo.expiryTime() != dateTime) {
         m_data.timeInfo.setExpiryTime(dateTime);
-        emit modified();
+        emit groupModified();
     }
 }
 
@@ -444,7 +444,7 @@ void Group::setParent(Group* parent, int index)
             connectDatabaseSignalsRecursive(parent->m_db);
         }
         QObject::setParent(parent);
-        emit aboutToAdd(this, index);
+        emit groupAboutToAdd(this, index);
         Q_ASSERT(index <= parent->m_children.size());
         parent->m_children.insert(index, this);
     } else {
@@ -460,12 +460,12 @@ void Group::setParent(Group* parent, int index)
         m_data.timeInfo.setLocationChanged(Clock::currentDateTimeUtc());
     }
 
-    emit modified();
+    emit groupModified();
 
     if (!moveWithinDatabase) {
-        emit added();
+        emit groupAdded();
     } else {
-        emit moved();
+        emit groupMoved();
     }
 }
 
@@ -798,12 +798,12 @@ void Group::addEntry(Entry* entry)
     emit entryAboutToAdd(entry);
 
     m_entries << entry;
-    connect(entry, SIGNAL(dataChanged(Entry*)), SIGNAL(entryDataChanged(Entry*)));
+    connect(entry, SIGNAL(entryDataChanged(Entry*)), SIGNAL(entryDataChanged(Entry*)));
     if (m_db) {
-        connect(entry, SIGNAL(modified()), m_db, SLOT(markAsModified()));
+        connect(entry, SIGNAL(entryModified()), m_db, SLOT(markAsModified()));
     }
 
-    emit modified();
+    emit groupModified();
     emit entryAdded(entry);
 }
 
@@ -820,21 +820,21 @@ void Group::removeEntry(Entry* entry)
         entry->disconnect(m_db);
     }
     m_entries.removeAll(entry);
-    emit modified();
+    emit groupModified();
     emit entryRemoved(entry);
 }
 
 void Group::connectDatabaseSignalsRecursive(Database* db)
 {
     if (m_db) {
-        disconnect(SIGNAL(dataChanged(Group*)), m_db);
-        disconnect(SIGNAL(aboutToRemove(Group*)), m_db);
-        disconnect(SIGNAL(removed()), m_db);
-        disconnect(SIGNAL(aboutToAdd(Group*, int)), m_db);
-        disconnect(SIGNAL(added()), m_db);
+        disconnect(SIGNAL(groupDataChanged(Group*)), m_db);
+        disconnect(SIGNAL(groupAboutToRemove(Group*)), m_db);
+        disconnect(SIGNAL(groupRemoved()), m_db);
+        disconnect(SIGNAL(groupAboutToAdd(Group*, int)), m_db);
+        disconnect(SIGNAL(groupAdded()), m_db);
         disconnect(SIGNAL(aboutToMove(Group*, Group*, int)), m_db);
-        disconnect(SIGNAL(moved()), m_db);
-        disconnect(SIGNAL(modified()), m_db);
+        disconnect(SIGNAL(groupMoved()), m_db);
+        disconnect(SIGNAL(groupModified()), m_db);
     }
 
     for (Entry* entry : asConst(m_entries)) {
@@ -842,19 +842,19 @@ void Group::connectDatabaseSignalsRecursive(Database* db)
             entry->disconnect(m_db);
         }
         if (db) {
-            connect(entry, SIGNAL(modified()), db, SLOT(markAsModified()));
+            connect(entry, SIGNAL(entryModified()), db, SLOT(markAsModified()));
         }
     }
 
     if (db) {
-        connect(this, SIGNAL(dataChanged(Group*)), db, SIGNAL(groupDataChanged(Group*)));
-        connect(this, SIGNAL(aboutToRemove(Group*)), db, SIGNAL(groupAboutToRemove(Group*)));
-        connect(this, SIGNAL(removed()), db, SIGNAL(groupRemoved()));
-        connect(this, SIGNAL(aboutToAdd(Group*,int)), db, SIGNAL(groupAboutToAdd(Group*,int)));
-        connect(this, SIGNAL(added()), db, SIGNAL(groupAdded()));
+        connect(this, SIGNAL(groupDataChanged(Group*)), db, SIGNAL(groupDataChanged(Group*)));
+        connect(this, SIGNAL(groupAboutToRemove(Group*)), db, SIGNAL(groupAboutToRemove(Group*)));
+        connect(this, SIGNAL(groupRemoved()), db, SIGNAL(groupRemoved()));
+        connect(this, SIGNAL(groupAboutToAdd(Group*, int)), db, SIGNAL(groupAboutToAdd(Group*,int)));
+        connect(this, SIGNAL(groupAdded()), db, SIGNAL(groupAdded()));
         connect(this, SIGNAL(aboutToMove(Group*,Group*,int)), db, SIGNAL(groupAboutToMove(Group*,Group*,int)));
-        connect(this, SIGNAL(moved()), db, SIGNAL(groupMoved()));
-        connect(this, SIGNAL(modified()), db, SLOT(markAsModified()));
+        connect(this, SIGNAL(groupMoved()), db, SIGNAL(groupMoved()));
+        connect(this, SIGNAL(groupModified()), db, SLOT(markAsModified()));
     }
 
     m_db = db;
@@ -867,10 +867,10 @@ void Group::connectDatabaseSignalsRecursive(Database* db)
 void Group::cleanupParent()
 {
     if (m_parent) {
-        emit aboutToRemove(this);
+        emit groupAboutToRemove(this);
         m_parent->m_children.removeAll(this);
-        emit modified();
-        emit removed();
+        emit groupModified();
+        emit groupRemoved();
     }
 }
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -578,6 +578,53 @@ Entry* Group::findEntryByPath(const QString& entryPath)
     return findEntryByPathRecursive(normalizedEntryPath, "/");
 }
 
+Entry* Group::findEntryBySearchTerm(const QString& term, EntryReferenceType referenceType)
+{
+    Q_ASSERT_X(referenceType != EntryReferenceType::Unknown,
+               "Database::findEntryRecursive",
+               "Can't search entry with \"referenceType\" parameter equal to \"Unknown\"");
+
+    const QList<Group*> groups = groupsRecursive(true);
+
+    for (const Group* group : groups) {
+        bool found = false;
+        const QList<Entry*>& entryList = group->entries();
+        for (Entry* entry : entryList) {
+            switch (referenceType) {
+                case EntryReferenceType::Unknown:
+                    return nullptr;
+                case EntryReferenceType::Title:
+                    found = entry->title() == term;
+                    break;
+                case EntryReferenceType::UserName:
+                    found = entry->username() == term;
+                    break;
+                case EntryReferenceType::Password:
+                    found = entry->password() == term;
+                    break;
+                case EntryReferenceType::Url:
+                    found = entry->url() == term;
+                    break;
+                case EntryReferenceType::Notes:
+                    found = entry->notes() == term;
+                    break;
+                case EntryReferenceType::QUuid:
+                    found = entry->uuid() == QUuid::fromRfc4122(QByteArray::fromHex(term.toLatin1()));
+                    break;
+                case EntryReferenceType::CustomAttributes:
+                    found = entry->attributes()->containsValue(term);
+                    break;
+            }
+
+            if (found) {
+                return entry;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
 Entry* Group::findEntryByPathRecursive(const QString& entryPath, const QString& basePath)
 {
     // Return the first entry that matches the full path OR if there is no leading

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -43,7 +43,7 @@ Group::Group()
     m_data.searchingEnabled = Inherit;
     m_data.mergeMode = Default;
 
-    connect(m_customData, SIGNAL(modified()), this, SIGNAL(modified()));
+    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(modified()));
     connect(this, SIGNAL(modified()), SLOT(updateTimeinfo()));
 }
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -789,7 +789,7 @@ void Group::copyDataFrom(const Group* other)
     m_customData->copyDataFrom(other->m_customData);
     m_lastTopVisibleEntry = other->m_lastTopVisibleEntry;
 }
-#include <QDebug>
+
 void Group::addEntry(Entry* entry)
 {
     Q_ASSERT(entry);
@@ -801,7 +801,6 @@ void Group::addEntry(Entry* entry)
     connect(entry, SIGNAL(dataChanged(Entry*)), SIGNAL(entryDataChanged(Entry*)));
     if (m_db) {
         connect(entry, SIGNAL(modified()), m_db, SLOT(markAsModified()));
-        qDebug() << "connected";
     }
 
     emit modified();

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -186,7 +186,7 @@ private:
 
     void setParent(Database* db);
 
-    void recSetDatabase(Database* db);
+    void connectDatabaseSignalsRecursive(Database* db);
     void cleanupParent();
     void recCreateDelObjects();
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -116,6 +116,7 @@ public:
     Group* findChildByName(const QString& name);
     Entry* findEntryByUuid(const QUuid& uuid) const;
     Entry* findEntryByPath(const QString& entryPath);
+    Entry* findEntryBySearchTerm(const QString& term, EntryReferenceType referenceType);
     Group* findGroupByUuid(const QUuid& uuid);
     Group* findGroupByPath(const QString& groupPath);
     QStringList locate(const QString& locateTerm, const QString& currentPath = {"/"}) const;
@@ -149,6 +150,7 @@ public:
     const QList<Group*>& children() const;
     QList<Entry*> entries();
     const QList<Entry*>& entries() const;
+    Entry* findEntryRecursive(const QString& text, EntryReferenceType referenceType, Group* group = nullptr);
     QList<Entry*> entriesRecursive(bool includeHistoryItems = false) const;
     QList<const Group*> groupsRecursive(bool includeSelf) const;
     QList<Group*> groupsRecursive(bool includeSelf);

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -164,14 +164,14 @@ public:
     void removeEntry(Entry* entry);
 
 signals:
-    void dataChanged(Group* group);
-    void aboutToAdd(Group* group, int index);
-    void added();
-    void aboutToRemove(Group* group);
-    void removed();
+    void groupDataChanged(Group* group);
+    void groupAboutToAdd(Group* group, int index);
+    void groupAdded();
+    void groupAboutToRemove(Group* group);
+    void groupRemoved();
     void aboutToMove(Group* group, Group* toGroup, int index);
-    void moved();
-    void modified();
+    void groupMoved();
+    void groupModified();
     void entryAboutToAdd(Entry* entry);
     void entryAdded(Entry* entry);
     void entryAboutToRemove(Entry* entry);

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -53,14 +53,14 @@ Metadata::Metadata(QObject* parent)
     m_masterKeyChanged = now;
     m_settingsChanged = now;
 
-    connect(m_customData, SIGNAL(modified()), this, SIGNAL(modified()));
+    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(metadataModified()));
 }
 
 template <class P, class V> bool Metadata::set(P& property, const V& value)
 {
     if (property != value) {
         property = value;
-        emit modified();
+        emit metadataModified();
         return true;
     } else {
         return false;
@@ -74,7 +74,7 @@ template <class P, class V> bool Metadata::set(P& property, const V& value, QDat
         if (m_updateDatetime) {
             dateTime = Clock::currentDateTimeUtc();
         }
-        emit modified();
+        emit metadataModified();
         return true;
     } else {
         return false;
@@ -391,7 +391,7 @@ void Metadata::addCustomIcon(const QUuid& uuid, const QImage& icon)
     QByteArray hash = hashImage(icon);
     m_customIconsHashes[hash] = uuid;
     Q_ASSERT(m_customIcons.count() == m_customIconsOrder.count());
-    emit modified();
+    emit metadataModified();
 }
 
 void Metadata::addCustomIconScaled(const QUuid& uuid, const QImage& icon)
@@ -426,7 +426,7 @@ void Metadata::removeCustomIcon(const QUuid& uuid)
     m_customIconScaledCacheKeys.remove(uuid);
     m_customIconsOrder.removeAll(uuid);
     Q_ASSERT(m_customIcons.count() == m_customIconsOrder.count());
-    emit modified();
+    emit metadataModified();
 }
 
 QUuid Metadata::findCustomIcon(const QImage &candidate)

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -311,9 +311,7 @@ void Metadata::setGenerator(const QString& value)
 
 void Metadata::setName(const QString& value)
 {
-    if (set(m_data.name, value, m_data.nameChanged)) {
-        emit nameTextChanged();
-    }
+    set(m_data.name, value, m_data.nameChanged);
 }
 
 void Metadata::setNameChanged(const QDateTime& value)

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -148,7 +148,7 @@ public:
     void copyAttributesFrom(const Metadata* other);
 
 signals:
-    void modified();
+    void metadataModified();
 
 private:
     template <class P, class V> bool set(P& property, const V& value);

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -148,7 +148,6 @@ public:
     void copyAttributesFrom(const Metadata* other);
 
 signals:
-    void nameTextChanged();
     void modified();
 
 private:

--- a/src/crypto/SymmetricCipher.cpp
+++ b/src/crypto/SymmetricCipher.cpp
@@ -20,8 +20,6 @@
 #include "config-keepassx.h"
 #include "crypto/SymmetricCipherGcrypt.h"
 
-#include <QDebug>
-
 SymmetricCipher::SymmetricCipher(Algorithm algo, Mode mode, Direction direction)
     : m_backend(createBackend(algo, mode, direction))
     , m_initialized(false)
@@ -102,7 +100,7 @@ SymmetricCipher::Algorithm SymmetricCipher::cipherToAlgorithm(const QUuid& ciphe
         return Twofish;
     }
 
-    qWarning() << "SymmetricCipher::cipherToAlgorithm: invalid UUID " << cipher;
+    qWarning("SymmetricCipher::cipherToAlgorithm: invalid UUID %s", cipher.toString().toLatin1().data());
     return InvalidAlgorithm;
 }
 

--- a/src/format/CsvExporter.cpp
+++ b/src/format/CsvExporter.cpp
@@ -23,7 +23,7 @@
 #include "core/Database.h"
 #include "core/Group.h"
 
-bool CsvExporter::exportDatabase(const QString& filename, const Database* db)
+bool CsvExporter::exportDatabase(const QString& filename, QSharedPointer<const Database> db)
 {
     QFile file(filename);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
@@ -33,7 +33,7 @@ bool CsvExporter::exportDatabase(const QString& filename, const Database* db)
     return exportDatabase(&file, db);
 }
 
-bool CsvExporter::exportDatabase(QIODevice* device, const Database* db)
+bool CsvExporter::exportDatabase(QIODevice* device, QSharedPointer<const Database> db)
 {
     QString header;
     addColumn(header, "Group");

--- a/src/format/CsvExporter.h
+++ b/src/format/CsvExporter.h
@@ -20,6 +20,7 @@
 #define KEEPASSX_CSVEXPORTER_H
 
 #include <QString>
+#include <QtCore/QSharedPointer>
 
 class Database;
 class Group;
@@ -28,8 +29,8 @@ class QIODevice;
 class CsvExporter
 {
 public:
-    bool exportDatabase(const QString& filename, const Database* db);
-    bool exportDatabase(QIODevice* device, const Database* db);
+    bool exportDatabase(const QString& filename, QSharedPointer<const Database> db);
+    bool exportDatabase(QIODevice* device, QSharedPointer<const Database> db);
     QString errorString() const;
 
 private:

--- a/src/format/Kdbx3Reader.cpp
+++ b/src/format/Kdbx3Reader.cpp
@@ -29,77 +29,77 @@
 
 #include <QBuffer>
 
-Database* Kdbx3Reader::readDatabaseImpl(QIODevice* device,
-                                        const QByteArray& headerData,
-                                        QSharedPointer<const CompositeKey> key,
-                                        bool keepDatabase)
+bool Kdbx3Reader::readDatabaseImpl(QIODevice* device,
+                                   const QByteArray& headerData,
+                                   QSharedPointer<const CompositeKey> key,
+                                   Database* db)
 {
     Q_ASSERT(m_kdbxVersion <= KeePass2::FILE_VERSION_3_1);
 
     if (hasError()) {
-        return nullptr;
+        return false;
     }
 
     // check if all required headers were present
     if (m_masterSeed.isEmpty() || m_encryptionIV.isEmpty() || m_streamStartBytes.isEmpty()
         || m_protectedStreamKey.isEmpty()
-        || m_db->cipher().isNull()) {
+        || db->cipher().isNull()) {
         raiseError(tr("missing database headers"));
-        return nullptr;
+        return false;
     }
 
-    if (!m_db->setKey(key, false)) {
+    if (!db->setKey(key, false)) {
         raiseError(tr("Unable to calculate master key"));
-        return nullptr;
+        return false;
     }
 
-    if (!m_db->challengeMasterSeed(m_masterSeed)) {
+    if (!db->challengeMasterSeed(m_masterSeed)) {
         raiseError(tr("Unable to issue challenge-response."));
-        return nullptr;
+        return false;
     }
 
     CryptoHash hash(CryptoHash::Sha256);
     hash.addData(m_masterSeed);
-    hash.addData(m_db->challengeResponseKey());
-    hash.addData(m_db->transformedMasterKey());
+    hash.addData(db->challengeResponseKey());
+    hash.addData(db->transformedMasterKey());
     QByteArray finalKey = hash.result();
 
-    SymmetricCipher::Algorithm cipher = SymmetricCipher::cipherToAlgorithm(m_db->cipher());
+    SymmetricCipher::Algorithm cipher = SymmetricCipher::cipherToAlgorithm(db->cipher());
     SymmetricCipherStream cipherStream(
         device, cipher, SymmetricCipher::algorithmMode(cipher), SymmetricCipher::Decrypt);
     if (!cipherStream.init(finalKey, m_encryptionIV)) {
         raiseError(cipherStream.errorString());
-        return nullptr;
+        return false;
     }
     if (!cipherStream.open(QIODevice::ReadOnly)) {
         raiseError(cipherStream.errorString());
-        return nullptr;
+        return false;
     }
 
     QByteArray realStart = cipherStream.read(32);
 
     if (realStart != m_streamStartBytes) {
         raiseError(tr("Wrong key or database file is corrupt."));
-        return nullptr;
+        return false;
     }
 
     HashedBlockStream hashedStream(&cipherStream);
     if (!hashedStream.open(QIODevice::ReadOnly)) {
         raiseError(hashedStream.errorString());
-        return nullptr;
+        return false;
     }
 
     QIODevice* xmlDevice = nullptr;
     QScopedPointer<QtIOCompressor> ioCompressor;
 
-    if (m_db->compressionAlgo() == Database::CompressionNone) {
+    if (db->compressionAlgo() == Database::CompressionNone) {
         xmlDevice = &hashedStream;
     } else {
         ioCompressor.reset(new QtIOCompressor(&hashedStream));
         ioCompressor->setStreamFormat(QtIOCompressor::GzipFormat);
         if (!ioCompressor->open(QIODevice::ReadOnly)) {
             raiseError(ioCompressor->errorString());
-            return nullptr;
+            return false;
         }
         xmlDevice = ioCompressor.data();
     }
@@ -107,20 +107,17 @@ Database* Kdbx3Reader::readDatabaseImpl(QIODevice* device,
     KeePass2RandomStream randomStream(KeePass2::ProtectedStreamAlgo::Salsa20);
     if (!randomStream.init(m_protectedStreamKey)) {
         raiseError(randomStream.errorString());
-        return nullptr;
+        return false;
     }
 
     Q_ASSERT(xmlDevice);
 
     KdbxXmlReader xmlReader(KeePass2::FILE_VERSION_3_1);
-    xmlReader.readDatabase(xmlDevice, m_db.data(), &randomStream);
+    xmlReader.readDatabase(xmlDevice, db, &randomStream);
 
     if (xmlReader.hasError()) {
         raiseError(xmlReader.errorString());
-        if (keepDatabase) {
-            return m_db.take();
-        }
-        return nullptr;
+        return false;
     }
 
     Q_ASSERT(!xmlReader.headerHash().isEmpty() || m_kdbxVersion < KeePass2::FILE_VERSION_3_1);
@@ -129,15 +126,17 @@ Database* Kdbx3Reader::readDatabaseImpl(QIODevice* device,
         QByteArray headerHash = CryptoHash::hash(headerData, CryptoHash::Sha256);
         if (headerHash != xmlReader.headerHash()) {
             raiseError(tr("Header doesn't match hash"));
-            return nullptr;
+            return false;
         }
     }
 
-    return m_db.take();
+    return true;
 }
 
-bool Kdbx3Reader::readHeaderField(StoreDataStream& headerStream)
+bool Kdbx3Reader::readHeaderField(StoreDataStream& headerStream, Database* db)
 {
+    Q_UNUSED(db);
+
     QByteArray fieldIDArray = headerStream.read(1);
     if (fieldIDArray.size() != 1) {
         raiseError(tr("Invalid header id size"));

--- a/src/format/Kdbx3Reader.cpp
+++ b/src/format/Kdbx3Reader.cpp
@@ -92,7 +92,7 @@ bool Kdbx3Reader::readDatabaseImpl(QIODevice* device,
     QIODevice* xmlDevice = nullptr;
     QScopedPointer<QtIOCompressor> ioCompressor;
 
-    if (db->compressionAlgo() == Database::CompressionNone) {
+    if (db->compressionAlgorithm() == Database::CompressionNone) {
         xmlDevice = &hashedStream;
     } else {
         ioCompressor.reset(new QtIOCompressor(&hashedStream));

--- a/src/format/Kdbx3Reader.h
+++ b/src/format/Kdbx3Reader.h
@@ -29,13 +29,13 @@ class Kdbx3Reader : public KdbxReader
     Q_DECLARE_TR_FUNCTIONS(Kdbx3Reader)
 
 public:
-    Database* readDatabaseImpl(QIODevice* device,
-                               const QByteArray& headerData,
-                               QSharedPointer<const CompositeKey> key,
-                               bool keepDatabase) override;
+    bool readDatabaseImpl(QIODevice* device,
+                          const QByteArray& headerData,
+                          QSharedPointer<const CompositeKey> key,
+                          Database* db) override;
 
 protected:
-    bool readHeaderField(StoreDataStream& headerStream) override;
+    bool readHeaderField(StoreDataStream& headerStream, Database* db) override;
 };
 
 #endif // KEEPASSX_KDBX3READER_H

--- a/src/format/Kdbx3Writer.cpp
+++ b/src/format/Kdbx3Writer.cpp
@@ -67,7 +67,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
 
     CHECK_RETURN_FALSE(writeHeaderField<quint16>(&header, KeePass2::HeaderFieldID::CipherID, db->cipher().toRfc4122()));
     CHECK_RETURN_FALSE(writeHeaderField<quint16>(&header, KeePass2::HeaderFieldID::CompressionFlags,
-                                                 Endian::sizedIntToBytes<qint32>(db->compressionAlgo(),
+                                                 Endian::sizedIntToBytes<qint32>(db->compressionAlgorithm(),
                                                                                  KeePass2::BYTEORDER)));
     auto kdf = db->kdf();
     CHECK_RETURN_FALSE(writeHeaderField<quint16>(&header, KeePass2::HeaderFieldID::MasterSeed, masterSeed));
@@ -112,7 +112,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
     QIODevice* outputDevice = nullptr;
     QScopedPointer<QtIOCompressor> ioCompressor;
 
-    if (db->compressionAlgo() == Database::CompressionNone) {
+    if (db->compressionAlgorithm() == Database::CompressionNone) {
         outputDevice = &hashedStream;
     } else {
         ioCompressor.reset(new QtIOCompressor(&hashedStream));

--- a/src/format/Kdbx4Reader.cpp
+++ b/src/format/Kdbx4Reader.cpp
@@ -28,85 +28,85 @@
 #include "streams/QtIOCompressor"
 #include "streams/SymmetricCipherStream.h"
 
-Database* Kdbx4Reader::readDatabaseImpl(QIODevice* device,
-                                        const QByteArray& headerData,
-                                        QSharedPointer<const CompositeKey> key,
-                                        bool keepDatabase)
+bool Kdbx4Reader::readDatabaseImpl(QIODevice* device,
+                                   const QByteArray& headerData,
+                                   QSharedPointer<const CompositeKey> key,
+                                   Database* db)
 {
     Q_ASSERT(m_kdbxVersion == KeePass2::FILE_VERSION_4);
 
     m_binaryPoolInverse.clear();
 
     if (hasError()) {
-        return nullptr;
+        return false;
     }
 
     // check if all required headers were present
-    if (m_masterSeed.isEmpty() || m_encryptionIV.isEmpty() || m_db->cipher().isNull()) {
+    if (m_masterSeed.isEmpty() || m_encryptionIV.isEmpty() || db->cipher().isNull()) {
         raiseError(tr("missing database headers"));
-        return nullptr;
+        return false;
     }
 
-    if (!m_db->setKey(key, false, false)) {
+    if (!db->setKey(key, false, false)) {
         raiseError(tr("Unable to calculate master key"));
-        return nullptr;
+        return false;
     }
 
     CryptoHash hash(CryptoHash::Sha256);
     hash.addData(m_masterSeed);
-    hash.addData(m_db->transformedMasterKey());
+    hash.addData(db->transformedMasterKey());
     QByteArray finalKey = hash.result();
 
     QByteArray headerSha256 = device->read(32);
     QByteArray headerHmac = device->read(32);
     if (headerSha256.size() != 32 || headerHmac.size() != 32) {
         raiseError(tr("Invalid header checksum size"));
-        return nullptr;
+        return false;
     }
     if (headerSha256 != CryptoHash::hash(headerData, CryptoHash::Sha256)) {
         raiseError(tr("Header SHA256 mismatch"));
-        return nullptr;
+        return false;
     }
 
-    QByteArray hmacKey = KeePass2::hmacKey(m_masterSeed, m_db->transformedMasterKey());
+    QByteArray hmacKey = KeePass2::hmacKey(m_masterSeed, db->transformedMasterKey());
     if (headerHmac
         != CryptoHash::hmac(headerData, HmacBlockStream::getHmacKey(UINT64_MAX, hmacKey), CryptoHash::Sha256)) {
         raiseError(tr("Wrong key or database file is corrupt. (HMAC mismatch)"));
-        return nullptr;
+        return false;
     }
     HmacBlockStream hmacStream(device, hmacKey);
     if (!hmacStream.open(QIODevice::ReadOnly)) {
         raiseError(hmacStream.errorString());
-        return nullptr;
+        return false;
     }
 
-    SymmetricCipher::Algorithm cipher = SymmetricCipher::cipherToAlgorithm(m_db->cipher());
+    SymmetricCipher::Algorithm cipher = SymmetricCipher::cipherToAlgorithm(db->cipher());
     if (cipher == SymmetricCipher::InvalidAlgorithm) {
         raiseError(tr("Unknown cipher"));
-        return nullptr;
+        return false;
     }
     SymmetricCipherStream cipherStream(
         &hmacStream, cipher, SymmetricCipher::algorithmMode(cipher), SymmetricCipher::Decrypt);
     if (!cipherStream.init(finalKey, m_encryptionIV)) {
         raiseError(cipherStream.errorString());
-        return nullptr;
+        return false;
     }
     if (!cipherStream.open(QIODevice::ReadOnly)) {
         raiseError(cipherStream.errorString());
-        return nullptr;
+        return false;
     }
 
     QIODevice* xmlDevice = nullptr;
     QScopedPointer<QtIOCompressor> ioCompressor;
 
-    if (m_db->compressionAlgo() == Database::CompressionNone) {
+    if (db->compressionAlgo() == Database::CompressionNone) {
         xmlDevice = &cipherStream;
     } else {
         ioCompressor.reset(new QtIOCompressor(&cipherStream));
         ioCompressor->setStreamFormat(QtIOCompressor::GzipFormat);
         if (!ioCompressor->open(QIODevice::ReadOnly)) {
             raiseError(ioCompressor->errorString());
-            return nullptr;
+            return false;
         }
         xmlDevice = ioCompressor.data();
     }
@@ -115,32 +115,29 @@ Database* Kdbx4Reader::readDatabaseImpl(QIODevice* device,
     }
 
     if (hasError()) {
-        return nullptr;
+        return false;
     }
 
     KeePass2RandomStream randomStream(m_irsAlgo);
     if (!randomStream.init(m_protectedStreamKey)) {
         raiseError(randomStream.errorString());
-        return nullptr;
+        return false;
     }
 
     Q_ASSERT(xmlDevice);
 
     KdbxXmlReader xmlReader(KeePass2::FILE_VERSION_4, binaryPool());
-    xmlReader.readDatabase(xmlDevice, m_db.data(), &randomStream);
+    xmlReader.readDatabase(xmlDevice, db, &randomStream);
 
     if (xmlReader.hasError()) {
         raiseError(xmlReader.errorString());
-        if (keepDatabase) {
-            return m_db.take();
-        }
-        return nullptr;
+        return false;
     }
 
-    return m_db.take();
+    return true;
 }
 
-bool Kdbx4Reader::readHeaderField(StoreDataStream& device)
+bool Kdbx4Reader::readHeaderField(StoreDataStream& device, Database* db)
 {
     QByteArray fieldIDArray = device.read(1);
     if (fieldIDArray.size() != 1) {
@@ -197,7 +194,7 @@ bool Kdbx4Reader::readHeaderField(StoreDataStream& device)
             raiseError(tr("Unsupported key derivation function (KDF) or invalid parameters"));
             return false;
         }
-        m_db->setKdf(kdf);
+        db->setKdf(kdf);
         break;
     }
 
@@ -206,7 +203,7 @@ bool Kdbx4Reader::readHeaderField(StoreDataStream& device)
         variantBuffer.setBuffer(&fieldData);
         variantBuffer.open(QBuffer::ReadOnly);
         QVariantMap data = readVariantMap(&variantBuffer);
-        m_db->setPublicCustomData(data);
+        db->setPublicCustomData(data);
         break;
     }
 

--- a/src/format/Kdbx4Reader.cpp
+++ b/src/format/Kdbx4Reader.cpp
@@ -99,7 +99,7 @@ bool Kdbx4Reader::readDatabaseImpl(QIODevice* device,
     QIODevice* xmlDevice = nullptr;
     QScopedPointer<QtIOCompressor> ioCompressor;
 
-    if (db->compressionAlgo() == Database::CompressionNone) {
+    if (db->compressionAlgorithm() == Database::CompressionNone) {
         xmlDevice = &cipherStream;
     } else {
         ioCompressor.reset(new QtIOCompressor(&cipherStream));

--- a/src/format/Kdbx4Reader.h
+++ b/src/format/Kdbx4Reader.h
@@ -30,15 +30,15 @@ class Kdbx4Reader : public KdbxReader
     Q_DECLARE_TR_FUNCTIONS(Kdbx4Reader)
 
 public:
-    Database* readDatabaseImpl(QIODevice* device,
-                               const QByteArray& headerData,
-                               QSharedPointer<const CompositeKey> key,
-                               bool keepDatabase) override;
+    bool readDatabaseImpl(QIODevice* device,
+                          const QByteArray& headerData,
+                          QSharedPointer<const CompositeKey> key,
+                          Database* db) override;
     QHash<QByteArray, QString> binaryPoolInverse() const;
     QHash<QString, QByteArray> binaryPool() const;
 
 protected:
-    bool readHeaderField(StoreDataStream& headerStream) override;
+    bool readHeaderField(StoreDataStream& headerStream, Database* db) override;
 
 private:
     bool readInnerHeaderField(QIODevice* device);

--- a/src/format/Kdbx4Writer.cpp
+++ b/src/format/Kdbx4Writer.cpp
@@ -75,7 +75,7 @@ bool Kdbx4Writer::writeDatabase(QIODevice* device, Database* db)
 
         CHECK_RETURN_FALSE(writeHeaderField<quint32>(&header, KeePass2::HeaderFieldID::CipherID, db->cipher().toRfc4122()));
         CHECK_RETURN_FALSE(writeHeaderField<quint32>(&header, KeePass2::HeaderFieldID::CompressionFlags,
-                                                     Endian::sizedIntToBytes(static_cast<int>(db->compressionAlgo()),
+                                                     Endian::sizedIntToBytes(static_cast<int>(db->compressionAlgorithm()),
                                                                              KeePass2::BYTEORDER)));
         CHECK_RETURN_FALSE(writeHeaderField<quint32>(&header, KeePass2::HeaderFieldID::MasterSeed, masterSeed));
         CHECK_RETURN_FALSE(writeHeaderField<quint32>(&header, KeePass2::HeaderFieldID::EncryptionIV, encryptionIV));
@@ -138,7 +138,7 @@ bool Kdbx4Writer::writeDatabase(QIODevice* device, Database* db)
     QIODevice* outputDevice = nullptr;
     QScopedPointer<QtIOCompressor> ioCompressor;
 
-    if (db->compressionAlgo() == Database::CompressionNone) {
+    if (db->compressionAlgorithm() == Database::CompressionNone) {
         outputDevice = cipherStream.data();
     } else {
         ioCompressor.reset(new QtIOCompressor(cipherStream.data()));

--- a/src/format/KdbxReader.cpp
+++ b/src/format/KdbxReader.cpp
@@ -175,7 +175,7 @@ void KdbxReader::setCompressionFlags(const QByteArray& data)
         raiseError(tr("Unsupported compression algorithm"));
         return;
     }
-    m_db->setCompressionAlgo(static_cast<Database::CompressionAlgorithm>(id));
+    m_db->setCompressionAlgorithm(static_cast<Database::CompressionAlgorithm>(id));
 }
 
 /**

--- a/src/format/KdbxReader.cpp
+++ b/src/format/KdbxReader.cpp
@@ -87,7 +87,7 @@ bool KdbxReader::readDatabase(QIODevice* device, QSharedPointer<const CompositeK
     m_kdbxVersion &= KeePass2::FILE_VERSION_CRITICAL_MASK;
 
     // read header fields
-    while (readHeaderField(headerStream, nullptr) && !hasError()) {
+    while (readHeaderField(headerStream, m_db) && !hasError()) {
     }
 
     headerStream.close();
@@ -97,7 +97,7 @@ bool KdbxReader::readDatabase(QIODevice* device, QSharedPointer<const CompositeK
     }
 
     // read payload
-    bool ok = readDatabaseImpl(db, device, headerStream.storedData(), std::move(key));
+    bool ok = readDatabaseImpl(device, headerStream.storedData(), std::move(key), db);
 
     if (saveXml()) {
         m_xmlData.clear();

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -56,7 +56,7 @@ KdbxXmlReader::KdbxXmlReader(quint32 version, QHash<QString, QByteArray>  binary
  * @param device input file
  * @return pointer to the new database
  */
-Database* KdbxXmlReader::readDatabase(const QString& filename)
+QSharedPointer<Database> KdbxXmlReader::readDatabase(const QString& filename)
 {
     QFile file(filename);
     file.open(QIODevice::ReadOnly);

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -69,10 +69,10 @@ Database* KdbxXmlReader::readDatabase(const QString& filename)
  * @param device input device
  * @return pointer to the new database
  */
-Database* KdbxXmlReader::readDatabase(QIODevice* device)
+QSharedPointer<Database> KdbxXmlReader::readDatabase(QIODevice* device)
 {
-    auto db = new Database();
-    readDatabase(device, db);
+    auto db = QSharedPointer<Database>::create();
+    readDatabase(device, db.data());
     return db;
 }
 

--- a/src/format/KdbxXmlReader.h
+++ b/src/format/KdbxXmlReader.h
@@ -45,7 +45,7 @@ public:
     explicit KdbxXmlReader(quint32 version, QHash<QString, QByteArray>  binaryPool);
     virtual ~KdbxXmlReader() = default;
 
-    virtual Database* readDatabase(const QString& filename);
+    virtual QSharedPointer<Database> readDatabase(const QString& filename);
     virtual QSharedPointer<Database> readDatabase(QIODevice* device);
     virtual void readDatabase(QIODevice* device, Database* db, KeePass2RandomStream* randomStream = nullptr);
 

--- a/src/format/KdbxXmlReader.h
+++ b/src/format/KdbxXmlReader.h
@@ -46,7 +46,7 @@ public:
     virtual ~KdbxXmlReader() = default;
 
     virtual Database* readDatabase(const QString& filename);
-    virtual Database* readDatabase(QIODevice* device);
+    virtual QSharedPointer<Database> readDatabase(QIODevice* device);
     virtual void readDatabase(QIODevice* device, Database* db, KeePass2RandomStream* randomStream = nullptr);
 
     bool hasError() const;

--- a/src/format/KdbxXmlWriter.cpp
+++ b/src/format/KdbxXmlWriter.cpp
@@ -190,7 +190,7 @@ void KdbxXmlWriter::writeBinaries()
         m_xml.writeAttribute("ID", QString::number(i.value()));
 
         QByteArray data;
-        if (m_db->compressionAlgo() == Database::CompressionGZip) {
+        if (m_db->compressionAlgorithm() == Database::CompressionGZip) {
             m_xml.writeAttribute("Compressed", "True");
 
             QBuffer buffer;

--- a/src/format/KeePass1Reader.cpp
+++ b/src/format/KeePass1Reader.cpp
@@ -48,8 +48,7 @@ private:
 };
 
 KeePass1Reader::KeePass1Reader()
-    : m_db(nullptr)
-    , m_tmpParent(nullptr)
+    : m_tmpParent(nullptr)
     , m_device(nullptr)
     , m_encryptionFlags(0)
     , m_transformRounds(0)
@@ -70,16 +69,16 @@ QSharedPointer<Database> KeePass1Reader::readDatabase(QIODevice* device, const Q
 
         if (keyfileData.isEmpty()) {
             raiseError(tr("Unable to read keyfile.").append("\n").append(keyfileDevice->errorString()));
-            return nullptr;
+            return {};
         }
         if (!keyfileDevice->seek(0)) {
             raiseError(tr("Unable to read keyfile.").append("\n").append(keyfileDevice->errorString()));
-            return nullptr;
+            return {};
         }
 
         if (!newFileKey->load(keyfileDevice)) {
             raiseError(tr("Unable to read keyfile.").append("\n").append(keyfileDevice->errorString()));
-            return nullptr;
+            return {};
         }
     }
 
@@ -94,19 +93,19 @@ QSharedPointer<Database> KeePass1Reader::readDatabase(QIODevice* device, const Q
     auto signature1 = Endian::readSizedInt<quint32>(m_device, KeePass1::BYTEORDER, &ok);
     if (!ok || signature1 != KeePass1::SIGNATURE_1) {
         raiseError(tr("Not a KeePass database."));
-        return nullptr;
+        return {};
     }
 
     auto signature2 = Endian::readSizedInt<quint32>(m_device, KeePass1::BYTEORDER, &ok);
     if (!ok || signature2 != KeePass1::SIGNATURE_2) {
         raiseError(tr("Not a KeePass database."));
-        return nullptr;
+        return {};
     }
 
     m_encryptionFlags = Endian::readSizedInt<quint32>(m_device, KeePass1::BYTEORDER, &ok);
     if (!ok || !(m_encryptionFlags & KeePass1::Rijndael || m_encryptionFlags & KeePass1::Twofish)) {
         raiseError(tr("Unsupported encryption algorithm."));
-        return nullptr;
+        return {};
     }
 
     auto version = Endian::readSizedInt<quint32>(m_device, KeePass1::BYTEORDER, &ok);
@@ -114,49 +113,49 @@ QSharedPointer<Database> KeePass1Reader::readDatabase(QIODevice* device, const Q
         || (version & KeePass1::FILE_VERSION_CRITICAL_MASK)
                != (KeePass1::FILE_VERSION & KeePass1::FILE_VERSION_CRITICAL_MASK)) {
         raiseError(tr("Unsupported KeePass database version."));
-        return nullptr;
+        return {};
     }
 
     m_masterSeed = m_device->read(16);
     if (m_masterSeed.size() != 16) {
         raiseError("Unable to read master seed");
-        return nullptr;
+        return {};
     }
 
     m_encryptionIV = m_device->read(16);
     if (m_encryptionIV.size() != 16) {
         raiseError(tr("Unable to read encryption IV", "IV = Initialization Vector for symmetric cipher"));
-        return nullptr;
+        return {};
     }
 
     auto numGroups = Endian::readSizedInt<quint32>(m_device, KeePass1::BYTEORDER, &ok);
     if (!ok) {
         raiseError(tr("Invalid number of groups"));
-        return nullptr;
+        return {};
     }
 
     auto numEntries = Endian::readSizedInt<quint32>(m_device, KeePass1::BYTEORDER, &ok);
     if (!ok) {
         raiseError(tr("Invalid number of entries"));
-        return nullptr;
+        return {};
     }
 
     m_contentHashHeader = m_device->read(32);
     if (m_contentHashHeader.size() != 32) {
         raiseError(tr("Invalid content hash size"));
-        return nullptr;
+        return {};
     }
 
     m_transformSeed = m_device->read(32);
     if (m_transformSeed.size() != 32) {
         raiseError(tr("Invalid transform seed size"));
-        return nullptr;
+        return {};
     }
 
     m_transformRounds = Endian::readSizedInt<quint32>(m_device, KeePass1::BYTEORDER, &ok);
     if (!ok) {
         raiseError(tr("Invalid number of transform rounds"));
-        return nullptr;
+        return {};
     }
     auto kdf = QSharedPointer<AesKdf>::create(true);
     kdf->setRounds(m_transformRounds);
@@ -168,14 +167,14 @@ QSharedPointer<Database> KeePass1Reader::readDatabase(QIODevice* device, const Q
     QScopedPointer<SymmetricCipherStream> cipherStream(testKeys(password, keyfileData, contentPos));
 
     if (!cipherStream) {
-        return nullptr;
+        return {};
     }
 
     QList<Group*> groups;
     for (quint32 i = 0; i < numGroups; i++) {
         Group* group = readGroup(cipherStream.data());
         if (!group) {
-            return nullptr;
+            return {};
         }
         groups.append(group);
     }
@@ -184,14 +183,14 @@ QSharedPointer<Database> KeePass1Reader::readDatabase(QIODevice* device, const Q
     for (quint32 i = 0; i < numEntries; i++) {
         Entry* entry = readEntry(cipherStream.data());
         if (!entry) {
-            return nullptr;
+            return {};
         }
         entries.append(entry);
     }
 
     if (!constructGroupTree(groups)) {
         raiseError(tr("Unable to construct group tree"));
-        return nullptr;
+        return {};
     }
 
     for (Entry* entry : asConst(entries)) {
@@ -243,7 +242,7 @@ QSharedPointer<Database> KeePass1Reader::readDatabase(QIODevice* device, const Q
 
     if (!db->setKey(key)) {
         raiseError(tr("Unable to calculate master key"));
-        return nullptr;
+        return {};
     }
 
     return db;
@@ -256,7 +255,7 @@ QSharedPointer<Database> KeePass1Reader::readDatabase(QIODevice* device, const Q
         keyFile.reset(new QFile(keyfileName));
         if (!keyFile->open(QFile::ReadOnly)) {
             raiseError(keyFile->errorString());
-            return nullptr;
+            return {};
         }
     }
 
@@ -268,14 +267,14 @@ QSharedPointer<Database> KeePass1Reader::readDatabase(const QString& filename, c
     QFile dbFile(filename);
     if (!dbFile.open(QFile::ReadOnly)) {
         raiseError(dbFile.errorString());
-        return nullptr;
+        return {};
     }
 
     auto db = readDatabase(&dbFile, password, keyfileName);
 
     if (dbFile.error() != QFile::NoError) {
         raiseError(dbFile.errorString());
-        return nullptr;
+        return {};
     }
 
     return db;
@@ -291,8 +290,7 @@ QString KeePass1Reader::errorString()
     return m_errorStr;
 }
 
-SymmetricCipherStream*
-KeePass1Reader::testKeys(const QString& password, const QByteArray& keyfileData, qint64 contentPos)
+SymmetricCipherStream* KeePass1Reader::testKeys(const QString& password, const QByteArray& keyfileData, qint64 contentPos)
 {
     const QList<PasswordEncoding> encodings = {Windows1252, Latin1, UTF8};
 

--- a/src/format/KeePass1Reader.h
+++ b/src/format/KeePass1Reader.h
@@ -21,6 +21,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QHash>
+#include <QSharedPointer>
 
 class Database;
 class Entry;
@@ -34,9 +35,9 @@ class KeePass1Reader
 
 public:
     KeePass1Reader();
-    Database* readDatabase(QIODevice* device, const QString& password, QIODevice* keyfileDevice);
-    Database* readDatabase(QIODevice* device, const QString& password, const QString& keyfileName);
-    Database* readDatabase(const QString& filename, const QString& password, const QString& keyfileName);
+    QSharedPointer<Database> readDatabase(QIODevice* device, const QString& password, QIODevice* keyfileDevice);
+    QSharedPointer<Database> readDatabase(QIODevice* device, const QString& password, const QString& keyfileName);
+    QSharedPointer<Database> readDatabase(const QString& filename, const QString& password, const QString& keyfileName);
     bool hasError();
     QString errorString();
 
@@ -63,7 +64,7 @@ private:
     static QDateTime dateFromPackedStruct(const QByteArray& data);
     static bool isMetaStream(const Entry* entry);
 
-    Database* m_db;
+    QSharedPointer<Database> m_db;
     Group* m_tmpParent;
     QIODevice* m_device;
     quint32 m_encryptionFlags;

--- a/src/format/KeePass2Reader.h
+++ b/src/format/KeePass2Reader.h
@@ -35,8 +35,8 @@ class KeePass2Reader
     Q_DECLARE_TR_FUNCTIONS(KdbxReader)
 
 public:
-    Database* readDatabase(const QString& filename, QSharedPointer<const CompositeKey> key);
-    Database* readDatabase(QIODevice* device, QSharedPointer<const CompositeKey> key, bool keepDatabase = false);
+    bool readDatabase(const QString& filename, QSharedPointer<const CompositeKey> key, Database* db);
+    bool readDatabase(QIODevice* device, QSharedPointer<const CompositeKey> key, Database* db);
 
     bool hasError() const;
     QString errorString() const;

--- a/src/format/KeePass2Writer.cpp
+++ b/src/format/KeePass2Writer.cpp
@@ -48,8 +48,7 @@ bool KeePass2Writer::writeDatabase(const QString& filename, Database* db)
  */
 bool KeePass2Writer::implicitUpgradeNeeded(Database const* db) const
 {
-    if (db->kdf()->uuid() == KeePass2::KDF_AES_KDBX4 ||
-        db->kdf()->uuid() == KeePass2::KDF_ARGON2 ) {
+    if (db->kdf()->uuid() != KeePass2::KDF_AES_KDBX3 ) {
         return false;
     }
     

--- a/src/format/KeePass2Writer.cpp
+++ b/src/format/KeePass2Writer.cpp
@@ -48,6 +48,11 @@ bool KeePass2Writer::writeDatabase(const QString& filename, Database* db)
  */
 bool KeePass2Writer::implicitUpgradeNeeded(Database const* db) const
 {
+    if (db->kdf()->uuid() == KeePass2::KDF_AES_KDBX4 ||
+        db->kdf()->uuid() == KeePass2::KDF_ARGON2 ) {
+        return false;
+    }
+    
     if (!db->publicCustomData().isEmpty()) {
         return true;
     }

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -105,7 +105,7 @@ void DatabaseOpenWidget::showEvent(QShowEvent* event)
 #ifdef WITH_XC_YUBIKEY
     // showEvent() may be called twice, so make sure we are only polling once
     if (!m_yubiKeyBeingPolled) {
-        connect(YubiKey::instance(), SIGNAL(detected(int, bool)), SLOT(yubikeyDetected(int, bool)), Qt::QueuedConnection);
+        connect(YubiKey::instance(), SIGNAL(detected(int,bool)), SLOT(yubikeyDetected(int,bool)), Qt::QueuedConnection);
         connect(YubiKey::instance(), SIGNAL(detectComplete()), SLOT(yubikeyDetectComplete()), Qt::QueuedConnection);
         connect(YubiKey::instance(), SIGNAL(notFound()), SLOT(noYubikeyFound()), Qt::QueuedConnection);
 

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -158,9 +158,9 @@ void DatabaseOpenWidget::clearForms()
     m_db.reset();
 }
 
-Database* DatabaseOpenWidget::database()
+QSharedPointer<Database> DatabaseOpenWidget::database()
 {
-    return m_db.take();
+    return m_db;
 }
 
 void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -190,7 +190,7 @@ void DatabaseOpenWidget::openDatabase()
     m_db.reset(new Database());
     QString error;
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    bool ok = m_db->open(m_filename, masterKey, false, &error);
+    bool ok = m_db->open(m_filename, masterKey, &error, false);
     QApplication::restoreOverrideCursor();
     if (!ok) {
         m_ui->messageWidget->showMessage(

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -48,7 +48,7 @@ public slots:
     void pollYubikey();
 
 signals:
-    void editFinished(bool accepted);
+    void dialogFinished(bool accepted);
 
 protected:
     void showEvent(QShowEvent* event) override;

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -70,7 +70,7 @@ private slots:
 
 protected:
     const QScopedPointer<Ui::DatabaseOpenWidget> m_ui;
-    Database* m_db;
+    QScopedPointer<Database> m_db;
     QString m_filename;
 
 private:

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -42,7 +42,7 @@ public:
     void load(const QString& filename);
     void clearForms();
     void enterKey(const QString& pw, const QString& keyFile);
-    Database* database();
+    QSharedPointer<Database> database();
 
 public slots:
     void pollYubikey();
@@ -70,7 +70,7 @@ private slots:
 
 protected:
     const QScopedPointer<Ui::DatabaseOpenWidget> m_ui;
-    QScopedPointer<Database> m_db;
+    QSharedPointer<Database> m_db;
     QString m_filename;
 
 private:

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -413,13 +413,18 @@ bool DatabaseTabWidget::hasLockableDatabases() const
 }
 
 /**
- * Get the tab's display name
+ * Get the tab's (original) display name without platform-specific
+ * mangling that may occur when reading back the actual widget's \link tabText()
  *
  * @param index tab index
  * @return tab name
  */
 QString DatabaseTabWidget::tabName(int index)
 {
+    if (index == -1 || index > count()) {
+        return "";
+    }
+
     auto* dbWidget = databaseWidgetFromIndex(index);
 
     auto db = dbWidget->database();

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -168,7 +168,7 @@ void DatabaseTabWidget::addDatabaseTab(DatabaseWidget* dbWidget)
     setCurrentIndex(index);
     toggleTabbar();
 
-    connect(dbWidget, SIGNAL(databaseFilePathChanged(const QString&, const QString&)), SLOT(updateTabName()));
+    connect(dbWidget, SIGNAL(databaseFilePathChanged(QString,QString)), SLOT(updateTabName()));
     connect(dbWidget, SIGNAL(closeRequest()), SLOT(closeDatabaseTabFromSender()));
     connect(dbWidget, SIGNAL(databaseModified()), SLOT(updateTabName()));
     connect(dbWidget, SIGNAL(databaseSaved()), SLOT(updateTabName()));

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -286,6 +286,7 @@ bool DatabaseTabWidget::closeDatabaseTab(DatabaseWidget* dbWidget)
     }
 
     removeTab(tabIndex);
+    delete dbWidget;
     toggleTabbar();
     emit databaseClosed(filePath);
     return true;

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -118,8 +118,7 @@ void DatabaseTabWidget::newDatabase()
 void DatabaseTabWidget::openDatabase()
 {
     QString filter = QString("%1 (*.kdbx);;%2 (*)").arg(tr("KeePass 2 Database"), tr("All files"));
-    QString defaultDir = config()->get("LastDir", QDir::homePath()).toString();
-    QString fileName = fileDialog()->getOpenFileName(this, tr("Open database"), defaultDir, filter);
+    QString fileName = fileDialog()->getOpenFileName(this, tr("Open database"), "", filter);
     if (!fileName.isEmpty()) {
         addDatabaseTab(fileName);
     }
@@ -187,7 +186,7 @@ void DatabaseTabWidget::addDatabaseTab(DatabaseWidget* dbWidget)
 void DatabaseTabWidget::importCsv()
 {
     QString filter = QString("%1 (*.csv);;%2 (*)").arg(tr("CSV file"), tr("All files"));
-    QString fileName = fileDialog()->getOpenFileName(this, tr("Select CSV file"), {}, filter);
+    QString fileName = fileDialog()->getOpenFileName(this, tr("Select CSV file"), "", filter);
 
     if (fileName.isEmpty()) {
         return;
@@ -208,8 +207,7 @@ void DatabaseTabWidget::mergeDatabase()
     auto dbWidget = currentDatabaseWidget();
     if (dbWidget && dbWidget->currentMode() != DatabaseWidget::LockedMode) {
         QString filter = QString("%1 (*.kdbx);;%2 (*)").arg(tr("KeePass 2 Database"), tr("All files"));
-        const QString fileName = fileDialog()->getOpenFileName(this, tr("Merge database"), QString(),
-                                                               filter);
+        const QString fileName = fileDialog()->getOpenFileName(this, tr("Merge database"), "", filter);
         if (!fileName.isEmpty()) {
             mergeDatabase(fileName);
         }
@@ -288,6 +286,7 @@ bool DatabaseTabWidget::closeDatabaseTab(DatabaseWidget* dbWidget)
     }
 
     removeTab(tabIndex);
+    toggleTabbar();
     emit databaseClosed(filePath);
     return true;
 }

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -286,7 +286,7 @@ bool DatabaseTabWidget::closeDatabaseTab(DatabaseWidget* dbWidget)
     }
 
     removeTab(tabIndex);
-    delete dbWidget;
+    dbWidget->deleteLater();
     toggleTabbar();
     emit databaseClosed(filePath);
     return true;

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -112,7 +112,7 @@ void DatabaseTabWidget::newDatabase()
     }
 
     addDatabaseTab(new DatabaseWidget(db, this));
-    emit db->modifiedImmediate();
+    db->markAsModified();
 }
 
 void DatabaseTabWidget::openDatabase()
@@ -495,11 +495,9 @@ DatabaseWidget* DatabaseTabWidget::currentDatabaseWidget()
 void DatabaseTabWidget::lockDatabases()
 {
     for (int i = 0, c = count(); i < c; ++i) {
-        if (!databaseWidgetFromIndex(i)) {
+        if (!databaseWidgetFromIndex(i)->lock()) {
             return;
         }
-
-        updateTabName(i);
     }
 }
 

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -259,55 +259,6 @@ bool DatabaseTabWidget::closeDatabaseTab(DatabaseWidget* dbWidget)
     removeTab(tabIndex);
     return true;
 }
-{
-    Q_ASSERT(db);removeTab(1)
-
-    const DatabaseManagerStruct& dbStruct = m_dbList.value(db);
-    int index = databaseIndex(db);
-    Q_ASSERT(index != -1);
-
-    dbStruct.dbWidget->closeUnlockDialog();
-    QString dbName = tabText(index);
-    if (dbName.right(1) == "*") {
-        dbName.chop(1);
-    }
-    if (dbStruct.dbWidget->isInEditMode() && db->hasKey() && dbStruct.dbWidget->isEditWidgetModified()) {
-        QMessageBox::StandardButton result = MessageBox::question(
-            this,
-            tr("Close?"),
-            tr("\"%1\" is in edit mode.\nDiscard changes and close anyway?").arg(dbName.toHtmlEscaped()),
-            QMessageBox::Discard | QMessageBox::Cancel,
-            QMessageBox::Cancel);
-        if (result == QMessageBox::Cancel) {
-            return false;
-        }
-    }
-    if (dbStruct.modified) {
-        if (config()->get("AutoSaveOnExit").toBool()) {
-            if (!saveDatabase(db)) {
-                return false;
-            }
-        } else if (dbStruct.dbWidget->currentMode() != DatabaseWidget::LockedMode) {
-            QMessageBox::StandardButton result =
-                MessageBox::question(this,
-                                     tr("Save changes?"),
-                                     tr("\"%1\" was modified.\nSave changes?").arg(dbName.toHtmlEscaped()),
-                                     QMessageBox::Yes | QMessageBox::Discard | QMessageBox::Cancel,
-                                     QMessageBox::Yes);
-            if (result == QMessageBox::Yes) {
-                if (!saveDatabase(db)) {
-                    return false;
-                }
-            } else if (result == QMessageBox::Cancel) {
-                return false;
-            }
-        }
-    }
-
-    deleteDatabase(db);
-
-    return true;
-}
 
 /**
  * Attempt to close all opened databases.
@@ -862,6 +813,6 @@ void DatabaseTabWidget::performGlobalAutoType()
         autoType()->performGlobalAutoType(unlockedDatabases);
     } else if (m_dbList.size() > 0) {
         m_dbPendingLock = indexDatabaseManagerStruct(0).dbWidget;
-        m_dbPendingLock->showUnlockDialog();
+        m_dbPendingLock->unlock();
     }
 }

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -118,7 +118,8 @@ void DatabaseTabWidget::newDatabase()
 void DatabaseTabWidget::openDatabase()
 {
     QString filter = QString("%1 (*.kdbx);;%2 (*)").arg(tr("KeePass 2 Database"), tr("All files"));
-    QString fileName = FileDialog::instance()->getOpenFileName(this, tr("Open database"), QDir::homePath(), filter);
+    QString defaultDir = config()->get("LastDir", QDir::homePath()).toString();
+    QString fileName = fileDialog()->getOpenFileName(this, tr("Open database"), defaultDir, filter);
     if (!fileName.isEmpty()) {
         addDatabaseTab(fileName);
     }

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -168,11 +168,10 @@ void DatabaseTabWidget::addDatabaseTab(DatabaseWidget* dbWidget)
     setCurrentIndex(index);
     toggleTabbar();
 
-    connect(dbWidget, SIGNAL(databaseMetadataChanged()), SLOT(updateTabName()));
     connect(dbWidget, SIGNAL(databaseFilePathChanged(const QString&, const QString&)), SLOT(updateTabName()));
     connect(dbWidget, SIGNAL(closeRequest()), SLOT(closeDatabaseTabFromSender()));
     connect(dbWidget, SIGNAL(databaseModified()), SLOT(updateTabName()));
-    connect(dbWidget, SIGNAL(databaseClean()), SLOT(updateTabName()));
+    connect(dbWidget, SIGNAL(databaseSaved()), SLOT(updateTabName()));
     connect(dbWidget, SIGNAL(databaseUnlocked()), SLOT(updateTabName()));
     connect(dbWidget, SIGNAL(databaseUnlocked()), SLOT(emitDatabaseLockChanged()));
     connect(dbWidget, SIGNAL(databaseLocked()), SLOT(updateTabName()));

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -32,19 +32,6 @@ class DatabaseOpenWidget;
 class QFile;
 class MessageWidget;
 
-struct DatabaseManagerStruct
-{
-    DatabaseManagerStruct();
-
-    DatabaseWidget* dbWidget;
-    QFileInfo fileInfo;
-    bool modified;
-    bool readOnly;
-    int saveAttempts;
-};
-
-Q_DECLARE_TYPEINFO(DatabaseManagerStruct, Q_MOVABLE_TYPE);
-
 class DatabaseTabWidget : public QTabWidget
 {
     Q_OBJECT
@@ -52,15 +39,19 @@ class DatabaseTabWidget : public QTabWidget
 public:
     explicit DatabaseTabWidget(QWidget* parent = nullptr);
     ~DatabaseTabWidget() override;
-    void openDatabase(const QString& fileName, const QString& pw = QString(), const QString& keyFile = QString());
-    void mergeDatabase(const QString& fileName);
+    void mergeDatabase(const QString& filePath);
     DatabaseWidget* currentDatabaseWidget();
     bool hasLockableDatabases() const;
-    DatabaseManagerStruct indexDatabaseManagerStruct(int index);
 
     static const int LastDatabasesCount;
 
 public slots:
+    void addDatabaseTab(const QString& filePath);
+    bool closeDatabaseTab(int index);
+    bool closeDatabaseTab(const QString& filePath);
+    bool closeDatabaseTab(DatabaseWidget* dbWidget);
+    bool closeAllDatabaseTabs();
+
     void newDatabase();
     void openDatabase();
     void importCsv();
@@ -71,7 +62,6 @@ public slots:
     void exportToCsv();
     bool closeDatabase(int index = -1);
     void closeDatabaseFromSender();
-    bool closeAllDatabases();
     void changeMasterKey();
     void changeDatabaseSettings();
     bool readOnly(int index = -1);
@@ -107,16 +97,14 @@ private:
     Database* execNewDatabaseWizard();
     bool saveDatabase(Database* db, QString filePath = "");
     bool saveDatabaseAs(Database* db);
-    bool closeDatabase(Database* db);
+    bool closeDatabaseTab(Database* db);
     void deleteDatabase(Database* db);
     int databaseIndex(Database* db);
     Database* indexDatabase(int index);
     Database* databaseFromDatabaseWidget(DatabaseWidget* dbWidget);
-    void insertDatabase(Database* db, const DatabaseManagerStruct& dbStruct);
     void updateLastDatabases(const QString& filename);
     void connectDatabase(Database* newDb, Database* oldDb = nullptr);
 
-    QHash<Database*, DatabaseManagerStruct> m_dbList;
     QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
     QPointer<DatabaseWidget> m_dbPendingLock;
 };

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -53,6 +53,8 @@ public slots:
     bool closeDatabaseTab(int index);
     bool closeDatabaseTab(DatabaseWidget* dbWidget);
     bool closeAllDatabaseTabs();
+    bool closeCurrentDatabaseTab();
+    bool closeDatabaseTabFromSender();
     void updateTabName(int index = -1);
 
     void newDatabase();
@@ -73,14 +75,18 @@ public slots:
     void performGlobalAutoType();
 
 signals:
-    void tabNameChanged();
-    void activateDatabaseChanged(DatabaseWidget* dbWidget);
+    void databaseClosed(const QString& filePath);
+    void databaseUnlocked(DatabaseWidget* dbWidget);
     void databaseLocked(DatabaseWidget* dbWidget);
+    void activateDatabaseChanged(DatabaseWidget* dbWidget);
+    void tabNameChanged();
     void messageGlobal(const QString&, MessageWidget::MessageType type);
+    void messageDismissGlobal();
 
 private slots:
     void toggleTabbar();
     void emitActivateDatabaseChanged();
+    void emitDatabaseLockChanged();
 
 private:
     QSharedPointer<Database> execNewDatabaseWizard();

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -94,8 +94,6 @@ private:
 
     QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
     QPointer<DatabaseWidget> m_dbPendingLock;
-
-    static const int s_lastDatabasesMax;
 };
 
 #endif // KEEPASSX_DATABASETABWIDGET_H

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
- * Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
+ * Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,18 +18,16 @@
 #ifndef KEEPASSX_DATABASETABWIDGET_H
 #define KEEPASSX_DATABASETABWIDGET_H
 
-#include <QFileInfo>
-#include <QHash>
-#include <QTabWidget>
-
-#include "gui/DatabaseWidget.h"
 #include "gui/MessageWidget.h"
 
+#include <QTabWidget>
+#include <QPointer>
+
+class Database;
 class DatabaseWidget;
 class DatabaseWidgetStateSync;
 class DatabaseOpenWidget;
 class QFile;
-class MessageWidget;
 
 class DatabaseTabWidget : public QTabWidget
 {
@@ -40,73 +37,59 @@ public:
     explicit DatabaseTabWidget(QWidget* parent = nullptr);
     ~DatabaseTabWidget() override;
     void mergeDatabase(const QString& filePath);
-    DatabaseWidget* currentDatabaseWidget();
-    bool hasLockableDatabases() const;
 
-    static const int LastDatabasesCount;
+    QString tabName(int index);
+    DatabaseWidget* currentDatabaseWidget();
+    DatabaseWidget* databaseWidgetFromIndex(int index) const;
+
+    bool isReadOnly(int index = -1) const;
+    bool canSave(int index = -1) const;
+    bool isModified(int index = -1) const;
+    bool hasLockableDatabases() const;
 
 public slots:
     void addDatabaseTab(const QString& filePath);
+    void addDatabaseTab(DatabaseWidget* dbWidget);
     bool closeDatabaseTab(int index);
-    bool closeDatabaseTab(const QString& filePath);
     bool closeDatabaseTab(DatabaseWidget* dbWidget);
     bool closeAllDatabaseTabs();
+    void updateTabName(int index = -1);
 
     void newDatabase();
     void openDatabase();
-    void importCsv();
     void mergeDatabase();
+    void importCsv();
     void importKeePass1Database();
     bool saveDatabase(int index = -1);
     bool saveDatabaseAs(int index = -1);
     void exportToCsv();
-    bool closeDatabase(int index = -1);
+
+    void lockDatabases();
     void closeDatabaseFromSender();
+    void relockPendingDatabase();
+
     void changeMasterKey();
     void changeDatabaseSettings();
-    bool readOnly(int index = -1);
-    bool canSave(int index = -1);
-    bool isModified(int index = -1);
     void performGlobalAutoType();
-    void lockDatabases();
-    void relockPendingDatabase();
-    QString databasePath(int index = -1);
 
 signals:
     void tabNameChanged();
-    void databaseWithFileClosed(QString filePath);
     void activateDatabaseChanged(DatabaseWidget* dbWidget);
     void databaseLocked(DatabaseWidget* dbWidget);
-    void databaseUnlocked(DatabaseWidget* dbWidget);
     void messageGlobal(const QString&, MessageWidget::MessageType type);
-    void messageTab(const QString&, MessageWidget::MessageType type);
-    void messageDismissGlobal();
-    void messageDismissTab();
 
 private slots:
-    void updateTabName(Database* db);
-    void updateTabNameFromDbSender();
-    void updateTabNameFromDbWidgetSender();
-    void modified();
     void toggleTabbar();
-    void changeDatabase(Database* newDb, bool unsavedChanges);
     void emitActivateDatabaseChanged();
-    void emitDatabaseUnlockedFromDbWidgetSender();
 
 private:
-    Database* execNewDatabaseWizard();
-    bool saveDatabase(Database* db, QString filePath = "");
-    bool saveDatabaseAs(Database* db);
-    bool closeDatabaseTab(Database* db);
-    void deleteDatabase(Database* db);
-    int databaseIndex(Database* db);
-    Database* indexDatabase(int index);
-    Database* databaseFromDatabaseWidget(DatabaseWidget* dbWidget);
+    QSharedPointer<Database> execNewDatabaseWizard();
     void updateLastDatabases(const QString& filename);
-    void connectDatabase(Database* newDb, Database* oldDb = nullptr);
 
     QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
     QPointer<DatabaseWidget> m_dbPendingLock;
+
+    static const int s_lastDatabasesMax;
 };
 
 #endif // KEEPASSX_DATABASETABWIDGET_H

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -178,8 +178,8 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     connect(m_entryView, SIGNAL(viewStateChanged()), SIGNAL(entryViewStateChanged()));
     connect(m_groupView, SIGNAL(groupChanged(Group*)), this, SLOT(onGroupChanged(Group*)));
     connect(m_groupView, SIGNAL(groupChanged(Group*)), SIGNAL(groupChanged()));
-    connect(m_entryView, SIGNAL(entryActivated(Entry*, EntryModel::ModelColumn)),
-        SLOT(entryActivationSignalReceived(Entry*, EntryModel::ModelColumn)));
+    connect(m_entryView, SIGNAL(entryActivated(Entry*,EntryModel::ModelColumn)),
+        SLOT(entryActivationSignalReceived(Entry*,EntryModel::ModelColumn)));
     connect(m_entryView, SIGNAL(entrySelectionChanged()), SIGNAL(entrySelectionChanged()));
     connect(m_editEntryWidget, SIGNAL(editFinished(bool)), SLOT(switchToView(bool)));
     connect(m_editEntryWidget, SIGNAL(historyEntryActivated(Entry*)), SLOT(switchToHistoryView(Entry*)));
@@ -770,8 +770,8 @@ void DatabaseWidget::switchToGroupEdit(Group* group, bool create)
 void DatabaseWidget::connectDatabaseSignals()
 {
     // relayed Database events
-    connect(m_db.data(), SIGNAL(filePathChanged(const QString&, const QString&)),
-            this, SIGNAL(databaseFilePathChanged(const QString&, const QString&)));
+    connect(m_db.data(), SIGNAL(filePathChanged(QString,QString)),
+            this, SIGNAL(databaseFilePathChanged(QString,QString)));
     connect(m_db.data(), SIGNAL(databaseModified()), this, SIGNAL(databaseModified()));
     connect(m_db.data(), SIGNAL(databaseSaved()), this, SIGNAL(databaseSaved()));
 }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -99,7 +99,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
 {
     m_messageWidget->setHidden(true);
 
-    auto* mainLayout = new QVBoxLayout(this);
+    auto* mainLayout = new QVBoxLayout();
     mainLayout->addWidget(m_messageWidget);
     auto* hbox = new QHBoxLayout();
     mainLayout->addLayout(hbox);
@@ -107,7 +107,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     m_mainWidget->setLayout(mainLayout);
 
     auto* rightHandSideWidget = new QWidget(m_mainSplitter);
-    auto* vbox = new QVBoxLayout(rightHandSideWidget);
+    auto* vbox = new QVBoxLayout();
     vbox->setMargin(0);
     vbox->addWidget(m_searchingLabel);
     vbox->addWidget(m_previewSplitter);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -386,6 +386,10 @@ void DatabaseWidget::setIconFromParent()
 
 void DatabaseWidget::replaceDatabase(QSharedPointer<Database> db)
 {
+    // TODO: instead of increasing the ref count temporarily, there should be a clean
+    // break from the old database. Without this crashes occur due to the change
+    // signals triggering dangling pointers.
+    auto oldDb = m_db;
     m_db = std::move(db);
     m_groupView->changeDatabase(m_db);
 }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -662,8 +662,8 @@ void DatabaseWidget::deleteGroup()
 
     auto* recycleBin = m_db->metadata()->recycleBin();
     bool inRecycleBin = recycleBin && recycleBin->findGroupByUuid(currentGroup->uuid());
-    bool isRecycleBin = (currentGroup == m_db->metadata()->recycleBin());
-    bool isRecycleBinSubgroup = currentGroup->findGroupByUuid(m_db->metadata()->recycleBin()->uuid());
+    bool isRecycleBin = recycleBin && (currentGroup == recycleBin);
+    bool isRecycleBinSubgroup = recycleBin && currentGroup->findGroupByUuid(recycleBin->uuid());
     if (inRecycleBin || isRecycleBin || isRecycleBinSubgroup || !m_db->metadata()->recycleBinEnabled()) {
         QMessageBox::StandardButton result = MessageBox::question(
             this,

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -201,16 +201,6 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     connect(m_groupView, SIGNAL(groupChanged(Group*)), SLOT(emitPressedGroup(Group*)));
     connect(m_editEntryWidget, SIGNAL(editFinished(bool)), SLOT(emitEntrySelectionChanged()));
 
-    // relayed Database events
-    connect(m_db.data(), SIGNAL(metadataModified()), this, SIGNAL(databaseMetadataChanged()));
-    connect(m_db.data(), SIGNAL(filePathChanged(const QString&, const QString&)),
-        this, SIGNAL(databaseFilePathChanged(const QString&, const QString&)));
-    connect(m_db.data(), SIGNAL(modified()), this, SIGNAL(databaseModified()));
-    connect(m_db.data(), &Database::modified, this, [&]() {
-        return;
-    });
-    connect(m_db.data(), SIGNAL(clean()), this, SIGNAL(databaseClean()));
-
     m_fileWatchTimer.setSingleShot(true);
     m_fileWatchUnblockTimer.setSingleShot(true);
     m_ignoreAutoReload = false;
@@ -783,6 +773,14 @@ void DatabaseWidget::loadDatabase(bool accepted)
         replaceDatabase(openWidget->database());
         setCurrentWidget(m_mainWidget);
         m_fileWatcher.addPath(m_db->filePath());
+
+        // relayed Database events
+        connect(m_db.data(), SIGNAL(metadataModified()), this, SIGNAL(databaseMetadataChanged()));
+        connect(m_db.data(), SIGNAL(filePathChanged(const QString&, const QString&)),
+            this, SIGNAL(databaseFilePathChanged(const QString&, const QString&)));
+        connect(m_db.data(), SIGNAL(modified()), this, SIGNAL(databaseModified()));
+        connect(m_db.data(), SIGNAL(clean()), this, SIGNAL(databaseClean()));
+
         emit databaseUnlocked();
     } else {
         m_fileWatcher.removePath(m_db->filePath());

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1115,7 +1115,9 @@ void DatabaseWidget::closeEvent(QCloseEvent* event)
 
 bool DatabaseWidget::lock()
 {
-    Q_ASSERT(currentMode() != DatabaseWidget::LockedMode);
+    if (currentMode() == DatabaseWidget::LockedMode) {
+        return true;
+    }
 
     clipboard()->clearCopiedText();
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1136,8 +1136,13 @@ bool DatabaseWidget::lock()
                 return false;
             }
         } else if (currentMode() != DatabaseWidget::LockedMode) {
-            auto result = MessageBox::question(this, tr("Save changes?"),
-                tr("\"%1\" was modified.\nSave changes?").arg(m_db->metadata()->name().toHtmlEscaped()),
+            QString msg;
+            if (!m_db->metadata()->name().toHtmlEscaped().isEmpty()) {
+                msg = tr("\"%1\" was modified.\nSave changes?").arg(m_db->metadata()->name().toHtmlEscaped());
+            } else {
+                msg = tr("Database was modified.\nSave changes?");
+            }
+            auto result = MessageBox::question(this, tr("Save changes?"), msg,
                 QMessageBox::Yes | QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Yes);
             if (result == QMessageBox::Yes && !m_db->save()) {
                 return false;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1474,9 +1474,10 @@ bool DatabaseWidget::saveAs()
     while (true) {
         QString oldFilePath = m_db->filePath();
         if (!QFileInfo(oldFilePath).exists()) {
-            oldFilePath = QDir::toNativeSeparators(QDir::homePath() + "/" + tr("Passwords").append(".kdbx"));
+            oldFilePath = QDir::toNativeSeparators(config()->get("LastDir", QDir::homePath()).toString()
+                + "/" + tr("Passwords").append(".kdbx"));
         }
-        QString newFilePath = FileDialog::instance()->getSaveFileName(
+        QString newFilePath = fileDialog()->getSaveFileName(
             this, tr("Save database as"), oldFilePath,
             tr("KeePass 2 Database").append(" (*.kdbx)"), nullptr, nullptr, "kdbx");
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -121,10 +121,9 @@ public:
 
 signals:
     // relayed Database signals
-    void databaseMetadataChanged();
     void databaseFilePathChanged(const QString& oldPath, const QString& newPath);
     void databaseModified();
-    void databaseClean();
+    void databaseSaved();
     void databaseUnlocked();
     void databaseLocked();
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -76,9 +76,12 @@ public:
     QSharedPointer<Database> database() const;
 
     bool lock();
-    bool unlock();
+    void prepareUnlock();
+    bool save(int attempt = 0);
+    bool saveAs();
 
     DatabaseWidget::Mode currentMode() const;
+    bool isSearchActive() const;
 
     QString getCurrentSearch();
     void refreshSearch();
@@ -117,6 +120,12 @@ public:
     void setPreviewSplitterSizes(const QList<int>& sizes);
 
 signals:
+    // relayed Database signals
+    void databaseMetadataChanged();
+    void databaseFilePathChanged(const QString& oldPath, const QString& newPath);
+    void databaseModified();
+    void databaseClean();
+
     void closeRequest();
     void currentModeChanged(DatabaseWidget::Mode mode);
     void groupChanged();
@@ -139,6 +148,7 @@ signals:
     void clearSearch();
 
 public slots:
+    void replaceDatabase(QSharedPointer<Database> db);
     void createEntry();
     void cloneEntry();
     void deleteEntries();
@@ -215,7 +225,6 @@ private:
     int addChildWidget(QWidget* w);
     void setClipboardTextAndMinimize(const QString& text);
     void setIconFromParent();
-    void replaceDatabase(QSharedPointer<Database> db);
 
     QSharedPointer<Database> m_db;
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -210,6 +210,7 @@ private slots:
     void emitEntryContextMenuRequested(const QPoint& pos);
     void emitPressedGroup(Group* currentGroup);
     void emitEntrySelectionChanged();
+    void connectDatabaseSignals();
     void loadDatabase(bool accepted);
     void mergeDatabase(bool accepted);
     void unlockDatabase(bool accepted);

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -171,8 +171,6 @@ public slots:
     void switchToOpenMergeDatabase(const QString& filePath);
     void switchToOpenMergeDatabase(const QString& filePath, const QString& password, const QString& keyFile);
     void switchToImportKeepass1(const QString& filePath);
-    void databaseModified();
-    void databaseSaved();
     void emptyRecycleBin();
 
     // Search related slots
@@ -260,7 +258,6 @@ private:
     QTimer m_fileWatchTimer;
     QTimer m_fileWatchUnblockTimer;
     bool m_ignoreAutoReload;
-    bool m_databaseModified;
 };
 
 #endif // KEEPASSX_DATABASEWIDGET_H

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -132,7 +132,6 @@ signals:
     void currentModeChanged(DatabaseWidget::Mode mode);
     void groupChanged();
     void entrySelectionChanged();
-    void databaseChanged(QSharedPointer<Database> newDb, bool unsavedChanges);
     void databaseMerged(QSharedPointer<Database> mergedDb);
     void groupContextMenuRequested(const QPoint& globalPos);
     void entryContextMenuRequested(const QPoint& globalPos);

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -75,14 +75,11 @@ public:
 
     QSharedPointer<Database> database() const;
 
-    void lock();
-    void showUnlockDialog();
-    void closeUnlockDialog();
+    bool lock();
+    bool unlock();
 
-    bool canDeleteCurrentGroup() const;
     DatabaseWidget::Mode currentMode() const;
-    bool isInEditMode() const;
-    bool isInSearchMode() const;
+
     QString getCurrentSearch();
     void refreshSearch();
 
@@ -90,6 +87,7 @@ public:
     EntryView* entryView();
 
     Group* currentGroup() const;
+    bool canDeleteCurrentGroup() const;
     bool isGroupSelected() const;
     bool isRecycleBinSelected() const;
     int numberOfSelectedEntries() const;
@@ -190,6 +188,9 @@ public slots:
     void showErrorMessage(const QString& errorMessage);
     void hideMessage();
 
+protected:
+    void closeEvent(QCloseEvent* event) override;
+
 private slots:
     void updateFilePath(const QString& filePath);
     void entryActivationSignalReceived(Entry* entry, EntryModel::ModelColumn column);
@@ -216,7 +217,7 @@ private:
     int addChildWidget(QWidget* w);
     void setClipboardTextAndMinimize(const QString& text);
     void setIconFromParent();
-    void replaceDatabase(Database* db);
+    void replaceDatabase(QSharedPointer<Database> db);
 
     QSharedPointer<Database> m_db;
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -125,6 +125,8 @@ signals:
     void databaseFilePathChanged(const QString& oldPath, const QString& newPath);
     void databaseModified();
     void databaseClean();
+    void databaseUnlocked();
+    void databaseLocked();
 
     void closeRequest();
     void currentModeChanged(DatabaseWidget::Mode mode);
@@ -136,8 +138,6 @@ signals:
     void entryContextMenuRequested(const QPoint& globalPos);
     void pressedEntry(Entry* selectedEntry);
     void pressedGroup(Group* selectedGroup);
-    void unlockedDatabase();
-    void lockedDatabase();
     void listModeAboutToActivate();
     void listModeActivated();
     void searchModeAboutToActivate();

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -60,7 +60,7 @@ class DatabaseWidget : public QStackedWidget
     Q_OBJECT
 
 public:
-    enum Mode
+    enum class Mode
     {
         None,
         ImportMode,
@@ -81,6 +81,7 @@ public:
     bool saveAs();
 
     DatabaseWidget::Mode currentMode() const;
+    bool isLocked() const;
     bool isSearchActive() const;
 
     QString getCurrentSearch();
@@ -196,6 +197,7 @@ public slots:
 
 protected:
     void closeEvent(QCloseEvent* event) override;
+    void showEvent(QShowEvent* event) override;
 
 private slots:
     void updateFilePath(const QString& filePath);

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -174,8 +174,8 @@ public slots:
     void switchToGroupEdit();
     void switchToMasterKeyChange();
     void switchToDatabaseSettings();
+    void switchToOpenDatabase();
     void switchToOpenDatabase(const QString& filePath);
-    void switchToOpenDatabase(const QString& filePath, const QString& password, const QString& keyFile);
     void switchToCsvImport(const QString& filePath);
     void csvImportFinished(bool accepted);
     void switchToOpenMergeDatabase(const QString& filePath);
@@ -211,7 +211,7 @@ private slots:
     void emitEntryContextMenuRequested(const QPoint& pos);
     void emitPressedGroup(Group* currentGroup);
     void emitEntrySelectionChanged();
-    void openDatabase(bool accepted);
+    void loadDatabase(bool accepted);
     void mergeDatabase(bool accepted);
     void unlockDatabase(bool accepted);
     void emitCurrentModeChanged();

--- a/src/gui/DatabaseWidgetStateSync.cpp
+++ b/src/gui/DatabaseWidgetStateSync.cpp
@@ -74,7 +74,7 @@ void DatabaseWidgetStateSync::setActive(DatabaseWidget* dbWidget)
             m_activeDbWidget->setPreviewSplitterSizes(m_previewSplitterSizes);
         }
 
-        if (m_activeDbWidget->isInSearchMode()) {
+        if (m_activeDbWidget->isSearchActive()) {
             restoreSearchView();
         } else {
             restoreListView();
@@ -177,7 +177,7 @@ void DatabaseWidgetStateSync::updateViewState()
     m_hideUsernames = m_activeDbWidget->isUsernamesHidden();
     m_hidePasswords = m_activeDbWidget->isPasswordsHidden();
 
-    if (m_activeDbWidget->isInSearchMode()) {
+    if (m_activeDbWidget->isSearchActive()) {
         m_searchViewState = m_activeDbWidget->entryViewState();
     } else {
         m_listViewState = m_activeDbWidget->entryViewState();

--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -56,7 +56,7 @@ void EditWidget::addPage(const QString& labelText, const QIcon& icon, QWidget* w
      * from automatic resizing and it now should be able to fit into a user's monitor even if the monitor is only 768
      * pixels high.
      */
-    QScrollArea* scrollArea = new QScrollArea(m_ui->stackedWidget);
+    auto* scrollArea = new QScrollArea(m_ui->stackedWidget);
     scrollArea->setFrameShape(QFrame::NoFrame);
     scrollArea->setWidget(widget);
     scrollArea->setWidgetResizable(true);

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -131,7 +131,10 @@ void EditWidgetIcons::reset()
     m_currentUuid = QUuid();
 }
 
-void EditWidgetIcons::load(const QUuid& currentUuid, Database* database, const IconStruct& iconStruct, const QString& url)
+void EditWidgetIcons::load(const QUuid& currentUuid,
+                           QSharedPointer<Database> database,
+                           const IconStruct& iconStruct,
+                           const QString& url)
 {
     Q_ASSERT(database);
     Q_ASSERT(!currentUuid.isNull());

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -127,7 +127,7 @@ IconStruct EditWidgetIcons::state()
 
 void EditWidgetIcons::reset()
 {
-    m_db = nullptr;
+    m_db.reset();
     m_currentUuid = QUuid();
 }
 

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -481,7 +481,7 @@ void EditWidgetIcons::removeCustomIcon()
             // Reset the current icon view
             updateRadioButtonDefaultIcons();
 
-            if (m_db->resolveEntry(m_currentUuid) != nullptr) {
+            if (m_db->rootGroup()->findEntryByUuid(m_currentUuid) != nullptr) {
                 m_ui->defaultIconsView->setCurrentIndex(m_defaultIconModel->index(Entry::DefaultIconNumber));
             } else {
                 m_ui->defaultIconsView->setCurrentIndex(m_defaultIconModel->index(Group::DefaultIconNumber));

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -71,7 +71,10 @@ public:
 
     IconStruct state();
     void reset();
-    void load(const QUuid& currentUuid, Database* database, const IconStruct& iconStruct, const QString& url = "");
+    void load(const QUuid& currentUuid,
+              QSharedPointer<Database> database,
+              const IconStruct& iconStruct,
+              const QString& url = "");
 
 public slots:
     void setUrl(const QString& url);

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -100,7 +100,7 @@ private slots:
 
 private:
     const QScopedPointer<Ui::EditWidgetIcons> m_ui;
-    Database* m_database;
+    QSharedPointer<Database> m_db;
     QUuid m_currentUuid;
 #ifdef WITH_XC_NETWORKING
     QUrl m_url;

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -19,7 +19,6 @@
 #include "EntryPreviewWidget.h"
 #include "ui_EntryPreviewWidget.h"
 
-#include <QDebug>
 #include <QDesktopServices>
 #include <QDir>
 

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -114,12 +114,12 @@ void EntryPreviewWidget::setGroup(Group* selectedGroup)
 
 void EntryPreviewWidget::setDatabaseMode(DatabaseWidget::Mode mode)
 {
-    m_locked = mode == DatabaseWidget::LockedMode;
+    m_locked = mode == DatabaseWidget::Mode::LockedMode;
     if (m_locked) {
         return;
     }
 
-    if (mode == DatabaseWidget::ViewMode) {
+    if (mode == DatabaseWidget::Mode::ViewMode) {
         if (m_ui->stackedWidget->currentWidget() == m_ui->pageGroup) {
             setGroup(m_currentGroup);
         } else {

--- a/src/gui/KeePass1OpenWidget.cpp
+++ b/src/gui/KeePass1OpenWidget.cpp
@@ -54,8 +54,6 @@ void KeePass1OpenWidget::openDatabase()
         return;
     }
 
-    delete m_db;
-
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
     m_db = reader.readDatabase(&file, password, keyFileName);
     QApplication::restoreOverrideCursor();

--- a/src/gui/KeePass1OpenWidget.cpp
+++ b/src/gui/KeePass1OpenWidget.cpp
@@ -60,7 +60,7 @@ void KeePass1OpenWidget::openDatabase()
 
     if (m_db) {
         m_db->metadata()->setName(QFileInfo(m_filename).completeBaseName());
-        emit editFinished(true);
+        emit dialogFinished(true);
     } else {
         m_ui->messageWidget->showMessage(tr("Unable to open the database.").append("\n").append(reader.errorString()),
                                          MessageWidget::Error);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -279,6 +279,7 @@ MainWindow::MainWindow()
             SLOT(databaseChanged(DatabaseWidget*)));
     connect(m_ui->tabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), search, SLOT(databaseChanged()));
 
+    connect(m_ui->tabWidget, SIGNAL(modified()), SLOT(updateWindowTitle()));
     connect(m_ui->tabWidget, SIGNAL(tabNameChanged()), SLOT(updateWindowTitle()));
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(updateWindowTitle()));
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(databaseTabChanged(int)));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -619,8 +619,8 @@ void MainWindow::updateWindowTitle()
         setWindowFilePath(m_ui->tabWidget->databaseWidgetFromIndex(tabWidgetIndex)->database()->filePath());
     }
 
-    setWindowModified(isModified);
     setWindowTitle(windowTitle);
+    setWindowModified(isModified);
 }
 
 void MainWindow::showAboutDialog()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -493,12 +493,12 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
         DatabaseWidget* dbWidget = m_ui->tabWidget->currentDatabaseWidget();
         Q_ASSERT(dbWidget);
 
-        if (mode == DatabaseWidget::None) {
+        if (mode == DatabaseWidget::Mode::None) {
             mode = dbWidget->currentMode();
         }
 
         switch (mode) {
-        case DatabaseWidget::ViewMode: {
+        case DatabaseWidget::Mode::ViewMode: {
             // bool inSearch = dbWidget->isInSearchMode();
             bool singleEntrySelected = dbWidget->numberOfSelectedEntries() == 1 && dbWidget->currentEntryHasFocus();
             bool entriesSelected = dbWidget->numberOfSelectedEntries() > 0 && dbWidget->currentEntryHasFocus();
@@ -538,9 +538,9 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
 
             break;
         }
-        case DatabaseWidget::EditMode:
-        case DatabaseWidget::ImportMode:
-        case DatabaseWidget::LockedMode: {
+        case DatabaseWidget::Mode::EditMode:
+        case DatabaseWidget::Mode::ImportMode:
+        case DatabaseWidget::Mode::LockedMode: {
             const QList<QAction*> entryActions = m_ui->menuEntries->actions();
             for (QAction* action : entryActions) {
                 action->setEnabled(false);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -450,15 +450,25 @@ void MainWindow::clearLastDatabases()
 
 void MainWindow::openDatabase(const QString& filePath, const QString& pw, const QString& keyFile)
 {
+    if (pw.isEmpty() && keyFile.isEmpty()) {
+        m_ui->tabWidget->addDatabaseTab(filePath);
+        return;
+    }
+
     auto db = QSharedPointer<Database>::create();
     auto key = QSharedPointer<CompositeKey>::create();
-    key->addKey(QSharedPointer<PasswordKey>::create(pw));
-    auto fileKey = QSharedPointer<FileKey>::create();
-    fileKey->load(keyFile);
-    key->addKey(fileKey);
+    if (!pw.isEmpty()) {
+        key->addKey(QSharedPointer<PasswordKey>::create(pw));
+    }
+    if (!keyFile.isEmpty()) {
+        auto fileKey = QSharedPointer<FileKey>::create();
+        fileKey->load(keyFile);
+        key->addKey(fileKey);
+    }
     if (db->open(filePath, key)) {
         auto* dbWidget = new DatabaseWidget(db, this);
         m_ui->tabWidget->addDatabaseTab(dbWidget);
+        dbWidget->switchToView(true);
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -465,7 +465,7 @@ void MainWindow::openDatabase(const QString& filePath, const QString& pw, const 
         fileKey->load(keyFile);
         key->addKey(fileKey);
     }
-    if (db->open(filePath, key)) {
+    if (db->open(filePath, key, nullptr, false)) {
         auto* dbWidget = new DatabaseWidget(db, this);
         m_ui->tabWidget->addDatabaseTab(dbWidget);
         dbWidget->switchToView(true);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -80,7 +80,7 @@ protected:
     void changeEvent(QEvent* event) override;
 
 private slots:
-    void setMenuActionState(DatabaseWidget::Mode mode = DatabaseWidget::None);
+    void setMenuActionState(DatabaseWidget::Mode mode = DatabaseWidget::Mode::None);
     void updateWindowTitle();
     void showAboutDialog();
     void openDonateUrl();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -56,7 +56,7 @@ public:
     };
 
 public slots:
-    void openDatabase(const QString& filePath, const QString& pw = QString(), const QString& keyFile = QString());
+    void openDatabase(const QString& filePath, const QString& pw = {}, const QString& keyFile = {});
     void appExit();
     void displayGlobalMessage(const QString& text,
                               MessageWidget::MessageType type,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -56,7 +56,7 @@ public:
     };
 
 public slots:
-    void openDatabase(const QString& fileName, const QString& pw = QString(), const QString& keyFile = QString());
+    void openDatabase(const QString& filePath, const QString& pw = QString(), const QString& keyFile = QString());
     void appExit();
     void displayGlobalMessage(const QString& text,
                               MessageWidget::MessageType type,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -107,7 +107,6 @@ private slots:
     void trayIconTriggered(QSystemTrayIcon::ActivationReason reason);
     void lockDatabasesAfterInactivity();
     void forgetTouchIDAfterInactivity();
-    void hideTabMessage();
     void handleScreenLock();
     void showErrorMessage(const QString& message);
     void selectNextDatabaseTab();

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -135,7 +135,7 @@ void SearchWidget::databaseChanged(DatabaseWidget* dbWidget)
         // Set current search text from this database
         m_ui->searchEdit->setText(dbWidget->getCurrentSearch());
         // Keyboard focus on search widget at database unlocking
-        connect(dbWidget, SIGNAL(unlockedDatabase()), this, SLOT(searchFocus()));
+        connect(dbWidget, SIGNAL(databaseUnlocked()), this, SLOT(searchFocus()));
         // Enforce search policy
         emit caseSensitiveChanged(m_actionCaseSensitive->isChecked());
         emit limitGroupChanged(m_actionLimitGroup->isChecked());

--- a/src/gui/UnlockDatabaseDialog.cpp
+++ b/src/gui/UnlockDatabaseDialog.cpp
@@ -27,7 +27,7 @@ UnlockDatabaseDialog::UnlockDatabaseDialog(QWidget* parent)
     , m_view(new UnlockDatabaseWidget(this))
 {
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
-    connect(m_view, SIGNAL(editFinished(bool)), this, SLOT(complete(bool)));
+    connect(m_view, SIGNAL(dialogFinished(bool)), this, SLOT(complete(bool)));
 }
 
 void UnlockDatabaseDialog::setFilePath(const QString& filePath)

--- a/src/gui/UnlockDatabaseDialog.cpp
+++ b/src/gui/UnlockDatabaseDialog.cpp
@@ -40,7 +40,7 @@ void UnlockDatabaseDialog::clearForms()
     m_view->clearForms();
 }
 
-Database* UnlockDatabaseDialog::database()
+QSharedPointer<Database> UnlockDatabaseDialog::database()
 {
     return m_view->database();
 }

--- a/src/gui/UnlockDatabaseDialog.h
+++ b/src/gui/UnlockDatabaseDialog.h
@@ -34,7 +34,7 @@ public:
     explicit UnlockDatabaseDialog(QWidget* parent = nullptr);
     void setFilePath(const QString& filePath);
     void clearForms();
-    Database* database();
+    QSharedPointer<Database> database();
 
 signals:
     void unlockDone(bool);

--- a/src/gui/csvImport/CsvParserModel.cpp
+++ b/src/gui/csvImport/CsvParserModel.cpp
@@ -92,9 +92,9 @@ void CsvParserModel::setSkippedRows(int skipped)
     emit layoutChanged();
 }
 
-void CsvParserModel::setHeaderLabels(QStringList l)
+void CsvParserModel::setHeaderLabels(const QStringList& labels)
 {
-    m_columnHeader = std::move(l);
+    m_columnHeader = labels;
 }
 
 int CsvParserModel::rowCount(const QModelIndex& parent) const

--- a/src/gui/csvImport/CsvParserModel.h
+++ b/src/gui/csvImport/CsvParserModel.h
@@ -36,7 +36,7 @@ public:
     QString getFileInfo();
     bool parse();
 
-    void setHeaderLabels(QStringList l);
+    void setHeaderLabels(const QStringList& labels);
     void mapColumns(int csvColumn, int dbColumn);
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/src/gui/dbsettings/DatabaseSettingsDialog.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.cpp
@@ -73,7 +73,7 @@ DatabaseSettingsDialog::~DatabaseSettingsDialog()
 {
 }
 
-void DatabaseSettingsDialog::load(Database* db)
+void DatabaseSettingsDialog::load(QSharedPointer<Database> db)
 {
     m_ui->categoryList->setCurrentCategory(0);
     m_generalWidget->load(db);

--- a/src/gui/dbsettings/DatabaseSettingsDialog.h
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.h
@@ -21,8 +21,9 @@
 #include "gui/DialogyWidget.h"
 #include "config-keepassx.h"
 
-#include <QScopedPointer>
 #include <QPointer>
+#include <QScopedPointer>
+#include <QSharedPointer>
 
 class Database;
 class DatabaseSettingsWidgetGeneral;
@@ -47,7 +48,7 @@ public:
     ~DatabaseSettingsDialog() override;
     Q_DISABLE_COPY(DatabaseSettingsDialog);
 
-    void load(Database* db);
+    void load(QSharedPointer<Database> db);
     void showMasterKeySettings();
 
 signals:
@@ -66,7 +67,7 @@ private:
         Security = 1
     };
 
-    QPointer<Database> m_db;
+    QSharedPointer<Database> m_db;
     const QScopedPointer<Ui::DatabaseSettingsDialog> m_ui;
     QPointer<DatabaseSettingsWidgetGeneral> m_generalWidget;
     QPointer<QTabWidget> m_securityTabWidget;

--- a/src/gui/dbsettings/DatabaseSettingsWidget.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidget.cpp
@@ -36,7 +36,7 @@ DatabaseSettingsWidget::~DatabaseSettingsWidget()
  *
  * @param db database object to be configured
  */
-void DatabaseSettingsWidget::load(Database* db)
+void DatabaseSettingsWidget::load(QSharedPointer<Database> db)
 {
     m_db = db;
     initialize();

--- a/src/gui/dbsettings/DatabaseSettingsWidget.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidget.h
@@ -20,7 +20,7 @@
 
 #include "gui/settings/SettingsWidget.h"
 
-#include <QPointer>
+#include <QSharedPointer>
 
 class Database;
 
@@ -36,7 +36,7 @@ public:
     Q_DISABLE_COPY(DatabaseSettingsWidget);
     ~DatabaseSettingsWidget() override;
 
-    virtual void load(Database* db);
+    virtual void load(QSharedPointer<Database> db);
 
 signals:
     /**
@@ -45,7 +45,7 @@ signals:
     void sizeChanged();
 
 protected:
-    QPointer<Database> m_db;
+    QSharedPointer<Database> m_db;
 };
 
 #endif //KEEPASSXC_DATABASESETTINGSWIDGET_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
@@ -44,7 +44,7 @@ void DatabaseSettingsWidgetGeneral::initialize()
     m_ui->dbDescriptionEdit->setText(meta->description());
     m_ui->recycleBinEnabledCheckBox->setChecked(meta->recycleBinEnabled());
     m_ui->defaultUsernameEdit->setText(meta->defaultUserName());
-    m_ui->compressionCheckbox->setChecked(m_db->compressionAlgo() != Database::CompressionNone);
+    m_ui->compressionCheckbox->setChecked(m_db->compressionAlgorithm() != Database::CompressionNone);
 
     if (meta->historyMaxItems() > -1) {
         m_ui->historyMaxItemsSpinBox->setValue(meta->historyMaxItems());
@@ -75,8 +75,8 @@ void DatabaseSettingsWidgetGeneral::showEvent(QShowEvent* event)
 
 bool DatabaseSettingsWidgetGeneral::save()
 {
-    m_db->setCompressionAlgo(m_ui->compressionCheckbox->isChecked() ? Database::CompressionGZip
-                                                                    : Database::CompressionNone);
+    m_db->setCompressionAlgorithm(m_ui->compressionCheckbox->isChecked() ? Database::CompressionGZip
+                                                                         : Database::CompressionNone);
     Metadata* meta = m_db->metadata();
 
     meta->setName(m_ui->dbNameEdit->text());

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMasterKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMasterKey.cpp
@@ -68,7 +68,7 @@ DatabaseSettingsWidgetMasterKey::~DatabaseSettingsWidgetMasterKey()
 {
 }
 
-void DatabaseSettingsWidgetMasterKey::load(Database* db)
+void DatabaseSettingsWidgetMasterKey::load(QSharedPointer<Database> db)
 {
     DatabaseSettingsWidget::load(db);
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMasterKey.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMasterKey.h
@@ -41,7 +41,7 @@ public:
     Q_DISABLE_COPY(DatabaseSettingsWidgetMasterKey);
     ~DatabaseSettingsWidgetMasterKey() override;
 
-    void load(Database* db) override;
+    void load(QSharedPointer<Database> db) override;
 
     inline bool hasAdvancedMode() const override { return false; }
 

--- a/src/gui/entry/AutoTypeAssociationsModel.cpp
+++ b/src/gui/entry/AutoTypeAssociationsModel.cpp
@@ -49,7 +49,7 @@ void AutoTypeAssociationsModel::setAutoTypeAssociations(AutoTypeAssociations* au
     endResetModel();
 }
 
-void AutoTypeAssociationsModel::setEntry(const Entry* entry)
+void AutoTypeAssociationsModel::setEntry(Entry*)
 {
     m_entry = entry;
 }

--- a/src/gui/entry/AutoTypeAssociationsModel.cpp
+++ b/src/gui/entry/AutoTypeAssociationsModel.cpp
@@ -49,7 +49,7 @@ void AutoTypeAssociationsModel::setAutoTypeAssociations(AutoTypeAssociations* au
     endResetModel();
 }
 
-void AutoTypeAssociationsModel::setEntry(Entry*)
+void AutoTypeAssociationsModel::setEntry(Entry* entry)
 {
     m_entry = entry;
 }

--- a/src/gui/entry/AutoTypeAssociationsModel.h
+++ b/src/gui/entry/AutoTypeAssociationsModel.h
@@ -32,7 +32,7 @@ class AutoTypeAssociationsModel : public QAbstractListModel
 public:
     explicit AutoTypeAssociationsModel(QObject* parent = nullptr);
     void setAutoTypeAssociations(AutoTypeAssociations* autoTypeAssociations);
-    void setEntry(const Entry* entry);
+    void setEntry(Entry*);
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
@@ -49,7 +49,7 @@ public slots:
 
 private:
     AutoTypeAssociations* m_autoTypeAssociations;
-    QPointer<const Entry> m_entry;
+    QSharedPointer<const Entry> m_entry;
 };
 
 #endif // KEEPASSX_AUTOTYPEASSOCIATIONSMODEL_H

--- a/src/gui/entry/AutoTypeAssociationsModel.h
+++ b/src/gui/entry/AutoTypeAssociationsModel.h
@@ -32,7 +32,7 @@ class AutoTypeAssociationsModel : public QAbstractListModel
 public:
     explicit AutoTypeAssociationsModel(QObject* parent = nullptr);
     void setAutoTypeAssociations(AutoTypeAssociations* autoTypeAssociations);
-    void setEntry(Entry*);
+    void setEntry(Entry* entry);
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
@@ -49,7 +49,7 @@ public slots:
 
 private:
     AutoTypeAssociations* m_autoTypeAssociations;
-    QSharedPointer<const Entry> m_entry;
+    QPointer<const Entry> m_entry;
 };
 
 #endif // KEEPASSX_AUTOTYPEASSOCIATIONSMODEL_H

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -342,7 +342,7 @@ void EditEntryWidget::setupSSHAgent()
     connect(m_sshAgentUi->decryptButton, SIGNAL(clicked()), SLOT(decryptPrivateKey()));
     connect(m_sshAgentUi->copyToClipboardButton, SIGNAL(clicked()), SLOT(copyPublicKey()));
 
-    connect(m_advancedUi->attachmentsWidget->entryAttachments(), SIGNAL(modified()), SLOT(updateSSHAgentAttachments()));
+    connect(m_advancedUi->attachmentsWidget->entryAttachments(), SIGNAL(entryAttachmentsModified()), SLOT(updateSSHAgentAttachments()));
 
     addPage(tr("SSH Agent"), FilePath::instance()->icon("apps", "utilities-terminal"), m_sshAgentWidget);
 }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -645,7 +645,7 @@ QString EditEntryWidget::entryTitle() const
 void EditEntryWidget::loadEntry(Entry* entry, bool create, bool history, const QString& parentName, QSharedPointer<Database> database)
 {
     m_entry = entry;
-    m_database = std::move(database);
+    m_db = std::move(database);
     m_create = create;
     m_history = history;
 
@@ -736,7 +736,7 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     IconStruct iconStruct;
     iconStruct.uuid = entry->iconUuid();
     iconStruct.number = entry->iconNumber();
-    m_iconsWidget->load(entry->uuid(), m_database, iconStruct, entry->webUrl());
+    m_iconsWidget->load(entry->uuid(), m_db, iconStruct, entry->webUrl());
     connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), m_iconsWidget, SLOT(setUrl(QString)));
 
     m_autoTypeUi->enableButton->setChecked(entry->autoTypeEnabled());
@@ -926,7 +926,7 @@ void EditEntryWidget::cancel()
         return;
     }
 
-    if (!m_entry->iconUuid().isNull() && !m_database->metadata()->containsCustomIcon(m_entry->iconUuid())) {
+    if (!m_entry->iconUuid().isNull() && !m_db->metadata()->containsCustomIcon(m_entry->iconUuid())) {
         m_entry->setIcon(Entry::DefaultIconNumber);
     }
 
@@ -954,7 +954,7 @@ void EditEntryWidget::cancel()
 void EditEntryWidget::clear()
 {
     m_entry = nullptr;
-    m_database = nullptr;
+    m_db.reset();
     m_entryAttributes->clear();
     m_advancedUi->attachmentsWidget->clearAttachments();
     m_autoTypeAssoc->clear();

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -869,7 +869,7 @@ void EditEntryWidget::acceptEntry()
     }
 }
 
-void EditEntryWidget::updateEntryData(Entry*) const
+void EditEntryWidget::updateEntryData(Entry* entry) const
 {
     QRegularExpression newLineRegex("(?:\r?\n|\r)");
 

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -134,7 +134,7 @@ private:
     bool passwordsEqual();
     void setForms(Entry* entry, bool restore = false);
     QMenu* createPresetsMenu();
-    void updateEntryData(Entry*) const;
+    void updateEntryData(Entry* entry) const;
 #ifdef WITH_XC_SSHAGENT
     bool getOpenSSHKey(OpenSSHKey& key, bool decrypt = false);
     void saveSSHAgentConfig();

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -62,7 +62,11 @@ public:
     explicit EditEntryWidget(QWidget* parent = nullptr);
     ~EditEntryWidget();
 
-    void loadEntry(Entry* entry, bool create, bool history, const QString& parentName, Database* database);
+    void loadEntry(Entry* entry,
+                   bool create,
+                   bool history,
+                   const QString& parentName,
+                   QSharedPointer<Database> database);
 
     void createPresetsMenu(QMenu* expirePresetsMenu);
     QString entryTitle() const;
@@ -128,9 +132,9 @@ private:
     void setupColorButton(bool foreground, const QColor& color);
 
     bool passwordsEqual();
-    void setForms(const Entry* entry, bool restore = false);
+    void setForms(Entry* entry, bool restore = false);
     QMenu* createPresetsMenu();
-    void updateEntryData(Entry* entry) const;
+    void updateEntryData(Entry*) const;
 #ifdef WITH_XC_SSHAGENT
     bool getOpenSSHKey(OpenSSHKey& key, bool decrypt = false);
     void saveSSHAgentConfig();
@@ -138,8 +142,8 @@ private:
 
     void displayAttribute(QModelIndex index, bool showProtected);
 
-    Entry* m_entry;
-    Database* m_database;
+    QPointer<Entry> m_entry;
+    QSharedPointer<Database> m_database;
 
     bool m_create;
     bool m_history;

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -143,7 +143,7 @@ private:
     void displayAttribute(QModelIndex index, bool showProtected);
 
     QPointer<Entry> m_entry;
-    QSharedPointer<Database> m_database;
+    QSharedPointer<Database> m_db;
 
     bool m_create;
     bool m_history;

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -38,7 +38,6 @@ class EntryHistoryModel;
 class QButtonGroup;
 class QMenu;
 class QSortFilterProxyModel;
-class QStackedLayout;
 #ifdef WITH_XC_SSHAGENT
 #include "sshagent/KeeAgentSettings.h"
 class OpenSSHKey;
@@ -60,15 +59,11 @@ class EditEntryWidget : public EditWidget
 
 public:
     explicit EditEntryWidget(QWidget* parent = nullptr);
-    ~EditEntryWidget();
+    ~EditEntryWidget() override;
 
-    void loadEntry(Entry* entry,
-                   bool create,
-                   bool history,
-                   const QString& parentName,
+    void loadEntry(Entry* entry, bool create, bool history, const QString& parentName,
                    QSharedPointer<Database> database);
 
-    void createPresetsMenu(QMenu* expirePresetsMenu);
     QString entryTitle() const;
     void clear();
     bool hasBeenModified() const;

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -437,13 +437,13 @@ void EntryModel::entryDataChanged(Entry* entry)
 
 void EntryModel::severConnections()
 {
-//    if (m_group) {
-//        disconnect(m_group, nullptr, this, nullptr);
-//    }
-//
-//    for (const Group* group : asConst(m_allGroups)) {
-//        disconnect(group, nullptr, this, nullptr);
-//    }
+    if (m_group) {
+        disconnect(m_group, nullptr, this, nullptr);
+    }
+
+    for (const Group* group : asConst(m_allGroups)) {
+        disconnect(group, nullptr, this, nullptr);
+    }
 }
 
 void EntryModel::makeConnections(const Group* group)

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -437,13 +437,13 @@ void EntryModel::entryDataChanged(Entry* entry)
 
 void EntryModel::severConnections()
 {
-    if (m_group) {
-        disconnect(m_group, nullptr, this, nullptr);
-    }
-
-    for (const Group* group : asConst(m_allGroups)) {
-        disconnect(group, nullptr, this, nullptr);
-    }
+//    if (m_group) {
+//        disconnect(m_group, nullptr, this, nullptr);
+//    }
+//
+//    for (const Group* group : asConst(m_allGroups)) {
+//        disconnect(group, nullptr, this, nullptr);
+//    }
 }
 
 void EntryModel::makeConnections(const Group* group)

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -58,7 +58,7 @@ EditGroupWidget::~EditGroupWidget()
 {
 }
 
-void EditGroupWidget::loadGroup(Group* group, bool create, Database* database)
+void EditGroupWidget::loadGroup(Group* group, bool create, QSharedPointer<Database> database)
 {
     m_group = group;
     m_database = database;

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -30,7 +30,6 @@ EditGroupWidget::EditGroupWidget(QWidget* parent)
     , m_editGroupWidgetIcons(new EditWidgetIcons())
     , m_editWidgetProperties(new EditWidgetProperties())
     , m_group(nullptr)
-    , m_database(nullptr)
 {
     m_mainUi->setupUi(m_editGroupWidgetMain);
 
@@ -61,7 +60,7 @@ EditGroupWidget::~EditGroupWidget()
 void EditGroupWidget::loadGroup(Group* group, bool create, QSharedPointer<Database> database)
 {
     m_group = group;
-    m_database = database;
+    m_db = database;
 
     if (create) {
         setHeadline(tr("Add group"));
@@ -141,7 +140,7 @@ void EditGroupWidget::apply()
 
 void EditGroupWidget::cancel()
 {
-    if (!m_group->iconUuid().isNull() && !m_database->metadata()->containsCustomIcon(m_group->iconUuid())) {
+    if (!m_group->iconUuid().isNull() && !m_db->metadata()->containsCustomIcon(m_group->iconUuid())) {
         m_group->setIcon(Entry::DefaultIconNumber);
     }
 
@@ -152,7 +151,7 @@ void EditGroupWidget::cancel()
 void EditGroupWidget::clear()
 {
     m_group = nullptr;
-    m_database = nullptr;
+    m_db.reset();
     m_editGroupWidgetIcons->reset();
 }
 

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -41,7 +41,7 @@ public:
     explicit EditGroupWidget(QWidget* parent = nullptr);
     ~EditGroupWidget();
 
-    void loadGroup(Group* group, bool create, Database* database);
+    void loadGroup(Group* group, bool create, QSharedPointer<Database> database);
     void clear();
 
 signals:
@@ -64,8 +64,8 @@ private:
     QPointer<EditWidgetIcons> m_editGroupWidgetIcons;
     QPointer<EditWidgetProperties> m_editWidgetProperties;
 
-    QPointer<Group> m_group;
-    QPointer<Database> m_database;
+    QSharedPointer<Group> m_group;
+    QSharedPointer<Database> m_database;
 
     Q_DISABLE_COPY(EditGroupWidget)
 };

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -65,7 +65,7 @@ private:
     QPointer<EditWidgetProperties> m_editWidgetProperties;
 
     QPointer<Group> m_group;
-    QSharedPointer<Database> m_database;
+    QSharedPointer<Database> m_db;
 
     Q_DISABLE_COPY(EditGroupWidget)
 };

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -64,7 +64,7 @@ private:
     QPointer<EditWidgetIcons> m_editGroupWidgetIcons;
     QPointer<EditWidgetProperties> m_editWidgetProperties;
 
-    QSharedPointer<Group> m_group;
+    QPointer<Group> m_group;
     QSharedPointer<Database> m_database;
 
     Q_DISABLE_COPY(EditGroupWidget)

--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -229,7 +229,7 @@ bool GroupModel::dropMimeData(const QMimeData* data,
             return false;
         }
 
-        Group* dragGroup = db->resolveGroup(groupUuid);
+        Group* dragGroup = db->rootGroup()->findGroupByUuid(groupUuid);
         if (!dragGroup || !db->rootGroup()->findGroupByUuid(dragGroup->uuid()) || dragGroup == db->rootGroup()) {
             return false;
         }
@@ -273,7 +273,7 @@ bool GroupModel::dropMimeData(const QMimeData* data,
                 continue;
             }
 
-            Entry* dragEntry = db->resolveEntry(entryUuid);
+            Entry* dragEntry = db->rootGroup()->findEntryByUuid(entryUuid);
             if (!dragEntry || !db->rootGroup()->findEntryByUuid(dragEntry->uuid())) {
                 continue;
             }

--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -37,10 +37,6 @@ void GroupModel::changeDatabase(Database* newDb)
 {
     beginResetModel();
 
-    if (m_db) {
-        m_db->disconnect(this);
-    }
-
     m_db = newDb;
 
     connect(m_db, SIGNAL(groupDataChanged(Group*)), SLOT(groupDataChanged(Group*)));

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -51,9 +51,9 @@ GroupView::GroupView(Database* db, QWidget* parent)
     setDefaultDropAction(Qt::MoveAction);
 }
 
-void GroupView::changeDatabase(Database* newDb)
+void GroupView::changeDatabase(QSharedPointer<Database> newDb)
 {
-    m_model->changeDatabase(newDb);
+    m_model->changeDatabase(newDb.data());
 }
 
 void GroupView::dragMoveEvent(QDragMoveEvent* event)

--- a/src/gui/group/GroupView.h
+++ b/src/gui/group/GroupView.h
@@ -30,7 +30,7 @@ class GroupView : public QTreeView
 
 public:
     explicit GroupView(Database* db, QWidget* parent = nullptr);
-    void changeDatabase(Database* newDb);
+    void changeDatabase(QSharedPointer<Database> newDb);
     void setModel(QAbstractItemModel* model) override;
     Group* currentGroup();
     void setCurrentGroup(Group* group);

--- a/src/gui/widgets/ElidedLabel.cpp
+++ b/src/gui/widgets/ElidedLabel.cpp
@@ -17,7 +17,6 @@
 
 #include "ElidedLabel.h"
 
-#include <QDebug>
 #include <QResizeEvent>
 
 namespace

--- a/src/gui/wizard/NewDatabaseWizard.cpp
+++ b/src/gui/wizard/NewDatabaseWizard.cpp
@@ -39,7 +39,7 @@ NewDatabaseWizard::NewDatabaseWizard(QWidget* parent)
             << new NewDatabaseWizardPageEncryption()
             << new NewDatabaseWizardPageMasterKey();
 
-    for (auto const& page: asConst(m_pages)) {
+    for (const auto& page: asConst(m_pages)) {
         addPage(page);
     }
 
@@ -57,20 +57,27 @@ bool NewDatabaseWizard::validateCurrentPage()
     return m_pages[currentId()]->validatePage();
 }
 
-Database* NewDatabaseWizard::takeDatabase()
+/**
+ * Take configured database and reset internal pointer.
+ *
+ * @return the configured database
+ */
+QSharedPointer<Database> NewDatabaseWizard::takeDatabase()
 {
-    return m_db.take();
+    auto tmpPointer = m_db;
+    m_db.reset();
+    return tmpPointer;
 }
 
 void NewDatabaseWizard::initializePage(int id)
 {
     if (id == startId()) {
-        m_db.reset(new Database());
+        m_db = QSharedPointer<Database>::create();
         m_db->rootGroup()->setName(tr("Root", "Root group"));
         m_db->setKdf({});
         m_db->setKey({});
     }
 
-    m_pages[id]->setDatabase(m_db.data());
+    m_pages[id]->setDatabase(m_db);
     m_pages[id]->initializePage();
 }

--- a/src/gui/wizard/NewDatabaseWizard.cpp
+++ b/src/gui/wizard/NewDatabaseWizard.cpp
@@ -54,7 +54,11 @@ NewDatabaseWizard::~NewDatabaseWizard()
 
 bool NewDatabaseWizard::validateCurrentPage()
 {
-    return m_pages[currentId()]->validatePage();
+    bool ok = m_pages[currentId()]->validatePage();
+    if (ok && currentId() == m_pages.size() - 1) {
+        m_db->setInitialized(true);
+    }
+    return ok;
 }
 
 /**

--- a/src/gui/wizard/NewDatabaseWizard.h
+++ b/src/gui/wizard/NewDatabaseWizard.h
@@ -19,7 +19,7 @@
 #define KEEPASSXC_NEWDATABASEWIZARD_H
 
 #include <QPointer>
-#include <QScopedPointer>
+#include <QSharedPointer>
 #include <QWizard>
 
 class Database;
@@ -36,14 +36,14 @@ public:
     explicit NewDatabaseWizard(QWidget* parent = nullptr);
     ~NewDatabaseWizard() override;
 
-    Database* takeDatabase();
+    QSharedPointer<Database> takeDatabase();
     bool validateCurrentPage() override;
 
 protected:
     void initializePage(int id) override;
 
 private:
-    QScopedPointer<Database> m_db;
+    QSharedPointer<Database> m_db;
     QList<QPointer<NewDatabaseWizardPage>> m_pages;
 };
 

--- a/src/gui/wizard/NewDatabaseWizardPage.cpp
+++ b/src/gui/wizard/NewDatabaseWizardPage.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 /*
  *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
  *
@@ -66,9 +68,9 @@ DatabaseSettingsWidget* NewDatabaseWizardPage::pageWidget()
  *
  * @param db database object to be configured
  */
-void NewDatabaseWizardPage::setDatabase(Database* db)
+void NewDatabaseWizardPage::setDatabase(QSharedPointer<Database> db)
 {
-    m_db = db;
+    m_db = std::move(db);
 }
 
 void NewDatabaseWizardPage::initializePage()

--- a/src/gui/wizard/NewDatabaseWizardPage.h
+++ b/src/gui/wizard/NewDatabaseWizardPage.h
@@ -43,7 +43,7 @@ public:
 
     void setPageWidget(DatabaseSettingsWidget* page);
     DatabaseSettingsWidget* pageWidget();
-    void setDatabase(Database* db);
+    void setDatabase(QSharedPointer<Database> db);
 
     void initializePage() override;
     bool validatePage() override;
@@ -53,7 +53,7 @@ public slots:
 
 protected:
     QPointer<DatabaseSettingsWidget> m_pageWidget;
-    QPointer<Database> m_db;
+    QSharedPointer<Database> m_db;
 
     const QScopedPointer<Ui::NewDatabaseWizardPage> m_ui;
 };

--- a/src/keys/drivers/YubiKey.cpp
+++ b/src/keys/drivers/YubiKey.cpp
@@ -18,8 +18,6 @@
 
 #include <stdio.h>
 
-#include <QDebug>
-
 #include <ykcore.h>
 #include <ykdef.h>
 #include <ykstatus.h>
@@ -215,9 +213,9 @@ YubiKey::ChallengeResult YubiKey::challenge(int slot, bool mayBlock, const QByte
              */
 
             if (yk_errno == YK_EUSBERR) {
-                qWarning() << "USB error:" << yk_usb_strerror();
+                qWarning("USB error: %s",  yk_usb_strerror());
             } else {
-                qWarning() << "YubiKey core error:" << yk_strerror(yk_errno);
+                qWarning("YubiKey core error: %s", yk_strerror(yk_errno));
             }
 
             return ERROR;

--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -251,7 +251,7 @@ void SSHAgent::databaseModeChanged(DatabaseWidget::Mode mode)
 
     const QUuid& uuid = widget->database()->uuid();
 
-    if (mode == DatabaseWidget::LockedMode && m_keys.contains(uuid)) {
+    if (mode == DatabaseWidget::Mode::LockedMode && m_keys.contains(uuid)) {
 
         QSet<OpenSSHKey> keys = m_keys.take(uuid);
         for (OpenSSHKey key : keys) {
@@ -259,7 +259,7 @@ void SSHAgent::databaseModeChanged(DatabaseWidget::Mode mode)
                 emit error(m_error);
             }
         }
-    } else if (mode == DatabaseWidget::ViewMode && !m_keys.contains(uuid)) {
+    } else if (mode == DatabaseWidget::Mode::ViewMode && !m_keys.contains(uuid)) {
         for (Entry* e : widget->database()->rootGroup()->entriesRecursive()) {
 
             if (widget->database()->metadata()->recycleBinEnabled()

--- a/src/sshagent/SSHAgent.h
+++ b/src/sshagent/SSHAgent.h
@@ -43,7 +43,7 @@ signals:
     void error(const QString& message);
 
 public slots:
-    void databaseModeChanged(DatabaseWidget::Mode mode = DatabaseWidget::LockedMode);
+    void databaseModeChanged(DatabaseWidget::Mode mode = DatabaseWidget::Mode::LockedMode);
 
 private:
     const quint8 SSH_AGENT_FAILURE = 5;

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -57,7 +57,7 @@ void TestAutoType::init()
     config()->set("AutoTypeEntryTitleMatch", false);
     m_test->clearActions();
 
-    m_db = new Database();
+    m_db = QSharedPointer<Database>::create();
     m_dbList.clear();
     m_dbList.append(m_db);
     m_group = new Group();
@@ -126,7 +126,6 @@ void TestAutoType::init()
 
 void TestAutoType::cleanup()
 {
-    delete m_db;
 }
 
 void TestAutoType::testInternal()

--- a/tests/TestAutoType.h
+++ b/tests/TestAutoType.h
@@ -20,6 +20,7 @@
 #define KEEPASSX_TESTAUTOTYPE_H
 
 #include <QObject>
+#include <QSharedPointer>
 
 class AutoType;
 class AutoTypePlatformInterface;
@@ -53,8 +54,8 @@ private:
     AutoTypePlatformInterface* m_platform;
     AutoTypeTestInterface* m_test;
     AutoType* m_autoType;
-    Database* m_db;
-    QList<Database*> m_dbList;
+    QSharedPointer<Database> m_db;
+    QList<QSharedPointer<Database>> m_dbList;
     Group* m_group;
     Entry* m_entry1;
     Entry* m_entry2;

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -671,7 +671,8 @@ void TestCli::testMerge()
 
     QFile readBack(targetFile1.fileName());
     readBack.open(QIODevice::ReadOnly);
-    QScopedPointer<Database> mergedDb(reader.readDatabase(oldKey, QSharedPointer<const CompositeKey>(), &readBack));
+    auto mergedDb = QSharedPointer<Database>::create();
+    reader.readDatabase(&readBack, oldKey, mergedDb.data());
     readBack.close();
     QVERIFY(mergedDb);
     auto* entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
@@ -691,7 +692,8 @@ void TestCli::testMerge()
 
     readBack.setFileName(targetFile2.fileName());
     readBack.open(QIODevice::ReadOnly);
-    mergedDb.reset(reader.readDatabase(key, QSharedPointer<const CompositeKey>(), &readBack));
+    mergedDb = QSharedPointer<Database>::create();
+    reader.readDatabase(&readBack, key, mergedDb.data());
     readBack.close();
     QVERIFY(mergedDb);
     entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
@@ -740,7 +742,8 @@ void TestCli::testRemove()
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     QFile readBack(m_dbFile->fileName());
     readBack.open(QIODevice::ReadOnly);
-    QScopedPointer<Database> readBackDb(reader.readDatabase(key, QSharedPointer<const CompositeKey>(), &readBack));
+    auto readBackDb = QSharedPointer<Database>::create();
+    reader.readDatabase(&readBack, key, readBackDb.data());
     readBack.close();
     QVERIFY(readBackDb);
     QVERIFY(!readBackDb->rootGroup()->findEntryByPath("/Sample Entry"));
@@ -757,7 +760,8 @@ void TestCli::testRemove()
 
     readBack.setFileName(fileCopy.fileName());
     readBack.open(QIODevice::ReadOnly);
-    readBackDb.reset(reader.readDatabase(key, QSharedPointer<const CompositeKey>(), &readBack));
+    readBackDb = QSharedPointer<Database>::create();
+    reader.readDatabase(&readBack, key, readBackDb.data());
     readBack.close();
     QVERIFY(readBackDb);
     QVERIFY(!readBackDb->rootGroup()->findEntryByPath("/Sample Entry"));

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -671,7 +671,7 @@ void TestCli::testMerge()
 
     QFile readBack(targetFile1.fileName());
     readBack.open(QIODevice::ReadOnly);
-    QScopedPointer<Database> mergedDb(reader.readDatabase(&readBack, oldKey));
+    QScopedPointer<Database> mergedDb(reader.readDatabase(oldKey, QSharedPointer<const CompositeKey>(), &readBack));
     readBack.close();
     QVERIFY(mergedDb);
     auto* entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
@@ -691,7 +691,7 @@ void TestCli::testMerge()
 
     readBack.setFileName(targetFile2.fileName());
     readBack.open(QIODevice::ReadOnly);
-    mergedDb.reset(reader.readDatabase(&readBack, key));
+    mergedDb.reset(reader.readDatabase(key, QSharedPointer<const CompositeKey>(), &readBack));
     readBack.close();
     QVERIFY(mergedDb);
     entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
@@ -740,7 +740,7 @@ void TestCli::testRemove()
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     QFile readBack(m_dbFile->fileName());
     readBack.open(QIODevice::ReadOnly);
-    QScopedPointer<Database> readBackDb(reader.readDatabase(&readBack, key));
+    QScopedPointer<Database> readBackDb(reader.readDatabase(key, QSharedPointer<const CompositeKey>(), &readBack));
     readBack.close();
     QVERIFY(readBackDb);
     QVERIFY(!readBackDb->rootGroup()->findEntryByPath("/Sample Entry"));
@@ -757,7 +757,7 @@ void TestCli::testRemove()
 
     readBack.setFileName(fileCopy.fileName());
     readBack.open(QIODevice::ReadOnly);
-    readBackDb.reset(reader.readDatabase(&readBack, key));
+    readBackDb.reset(reader.readDatabase(key, QSharedPointer<const CompositeKey>(), &readBack));
     readBack.close();
     QVERIFY(readBackDb);
     QVERIFY(!readBackDb->rootGroup()->findEntryByPath("/Sample Entry"));

--- a/tests/TestCsvExporter.cpp
+++ b/tests/TestCsvExporter.cpp
@@ -31,8 +31,8 @@ const QString TestCsvExporter::ExpectedHeaderLine =
 
 void TestCsvExporter::init()
 {
-    m_db = new Database();
-    m_csvExporter = new CsvExporter();
+    m_db = QSharedPointer<Database>::create();
+    m_csvExporter = QSharedPointer<CsvExporter>::create();
 }
 
 void TestCsvExporter::initTestCase()
@@ -42,17 +42,15 @@ void TestCsvExporter::initTestCase()
 
 void TestCsvExporter::cleanup()
 {
-    delete m_db;
-    delete m_csvExporter;
 }
 
 void TestCsvExporter::testExport()
 {
     Group* groupRoot = m_db->rootGroup();
-    Group* group = new Group();
+    auto* group = new Group();
     group->setName("Test Group Name");
     group->setParent(groupRoot);
-    Entry* entry = new Entry();
+    auto* entry = new Entry();
     entry->setGroup(group);
     entry->setTitle("Test Entry Title");
     entry->setUsername("Test Username");
@@ -83,13 +81,13 @@ void TestCsvExporter::testEmptyDatabase()
 void TestCsvExporter::testNestedGroups()
 {
     Group* groupRoot = m_db->rootGroup();
-    Group* group = new Group();
+    auto* group = new Group();
     group->setName("Test Group Name");
     group->setParent(groupRoot);
-    Group* childGroup = new Group();
+    auto* childGroup = new Group();
     childGroup->setName("Test Sub Group Name");
     childGroup->setParent(group);
-    Entry* entry = new Entry();
+    auto* entry = new Entry();
     entry->setGroup(childGroup);
     entry->setTitle("Test Entry Title");
 

--- a/tests/TestCsvExporter.cpp
+++ b/tests/TestCsvExporter.cpp
@@ -63,7 +63,7 @@ void TestCsvExporter::testExport()
     m_csvExporter->exportDatabase(&buffer, m_db);
 
     QString expectedResult =
-        QString().append(ExpectedHeaderLine).append("\"Test Group Name\",\"Test Entry Title\",\"Test Username\",\"Test "
+        QString().append(ExpectedHeaderLine).append("\"Root/Test Group Name\",\"Test Entry Title\",\"Test Username\",\"Test "
                                                     "Password\",\"http://test.url\",\"Test Notes\"\n");
 
     QCOMPARE(QString::fromUtf8(buffer.buffer().constData()), expectedResult);
@@ -98,5 +98,5 @@ void TestCsvExporter::testNestedGroups()
     QCOMPARE(QString::fromUtf8(buffer.buffer().constData()),
              QString()
                  .append(ExpectedHeaderLine)
-                 .append("\"Test Group Name/Test Sub Group Name\",\"Test Entry Title\",\"\",\"\",\"\",\"\"\n"));
+                 .append("\"Root/Test Group Name/Test Sub Group Name\",\"Test Entry Title\",\"\",\"\",\"\",\"\"\n"));
 }

--- a/tests/TestCsvExporter.h
+++ b/tests/TestCsvExporter.h
@@ -20,6 +20,7 @@
 #define KEEPASSX_TESTCSVEXPORTER_H
 
 #include <QObject>
+#include <QSharedPointer>
 
 class Database;
 class CsvExporter;
@@ -40,8 +41,8 @@ private slots:
     void testNestedGroups();
 
 private:
-    Database* m_db;
-    CsvExporter* m_csvExporter;
+    QSharedPointer<Database> m_db;
+    QSharedPointer<CsvExporter> m_csvExporter;
 };
 
 #endif // KEEPASSX_TESTCSVEXPORTER_H

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -40,8 +40,8 @@ void TestDatabase::testEmptyRecycleBinOnDisabled()
     QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinDisabled.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
-    QScopedPointer<Database> db(Database::openDatabaseFile(filename, key));
-    QVERIFY(db);
+    auto db = QSharedPointer<Database>::create();
+    QVERIFY(db->open(filename, key));
 
     QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
 
@@ -55,8 +55,8 @@ void TestDatabase::testEmptyRecycleBinOnNotCreated()
     QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinNotYetCreated.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
-    QScopedPointer<Database> db(Database::openDatabaseFile(filename, key));
-    QVERIFY(db);
+    auto db = QSharedPointer<Database>::create();
+    QVERIFY(db->open(filename, key));
 
     QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
 
@@ -70,8 +70,8 @@ void TestDatabase::testEmptyRecycleBinOnEmpty()
     QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinEmpty.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
-    QScopedPointer<Database> db(Database::openDatabaseFile(filename, key));
-    QVERIFY(db);
+    auto db = QSharedPointer<Database>::create();
+    QVERIFY(db->open(filename, key));
 
     QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
 
@@ -85,8 +85,8 @@ void TestDatabase::testEmptyRecycleBinWithHierarchicalData()
     QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinWithData.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
-    QScopedPointer<Database> db(Database::openDatabaseFile(filename, key));
-    QVERIFY(db);
+    auto db = QSharedPointer<Database>::create();
+    QVERIFY(db->open(filename, key));
 
     QFile originalFile(filename);
     qint64 initialSize = originalFile.size();

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -43,6 +43,10 @@ void TestDatabase::testEmptyRecycleBinOnDisabled()
     auto db = QSharedPointer<Database>::create();
     QVERIFY(db->open(filename, key));
 
+    // Explicitly mark DB as read-write in case it was opened from a read-only drive.
+    // Prevents assertion failures on CI systems when the data dir is not writable
+    db->setReadOnly(false);
+
     QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->emptyRecycleBin();
@@ -57,6 +61,7 @@ void TestDatabase::testEmptyRecycleBinOnNotCreated()
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
     QVERIFY(db->open(filename, key));
+    db->setReadOnly(false);
 
     QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
@@ -72,6 +77,7 @@ void TestDatabase::testEmptyRecycleBinOnEmpty()
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
     QVERIFY(db->open(filename, key));
+    db->setReadOnly(false);
 
     QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
@@ -87,6 +93,7 @@ void TestDatabase::testEmptyRecycleBinWithHierarchicalData()
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
     QVERIFY(db->open(filename, key));
+    db->setReadOnly(false);
 
     QFile originalFile(filename);
     qint64 initialSize = originalFile.size();

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -41,13 +41,13 @@ void TestDatabase::testEmptyRecycleBinOnDisabled()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
+    QVERIFY(db->open(filename, key, nullptr, false));
 
     // Explicitly mark DB as read-write in case it was opened from a read-only drive.
     // Prevents assertion failures on CI systems when the data dir is not writable
     db->setReadOnly(false);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.
@@ -60,10 +60,10 @@ void TestDatabase::testEmptyRecycleBinOnNotCreated()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
+    QVERIFY(db->open(filename, key, nullptr, false));
     db->setReadOnly(false);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.
@@ -76,10 +76,10 @@ void TestDatabase::testEmptyRecycleBinOnEmpty()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
+    QVERIFY(db->open(filename, key, nullptr, false));
     db->setReadOnly(false);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.
@@ -92,7 +92,7 @@ void TestDatabase::testEmptyRecycleBinWithHierarchicalData()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
+    QVERIFY(db->open(filename, key, nullptr, false));
     db->setReadOnly(false);
 
     QFile originalFile(filename);

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -43,11 +43,11 @@ void TestDatabase::testEmptyRecycleBinOnDisabled()
     auto db = QSharedPointer<Database>::create();
     QVERIFY(db->open(filename, key));
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.
-    QCOMPARE(spyModified.count(), 0);
+    QTRY_COMPARE(spyModified.count(), 0);
 }
 
 void TestDatabase::testEmptyRecycleBinOnNotCreated()
@@ -58,11 +58,11 @@ void TestDatabase::testEmptyRecycleBinOnNotCreated()
     auto db = QSharedPointer<Database>::create();
     QVERIFY(db->open(filename, key));
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.
-    QCOMPARE(spyModified.count(), 0);
+    QTRY_COMPARE(spyModified.count(), 0);
 }
 
 void TestDatabase::testEmptyRecycleBinOnEmpty()
@@ -73,11 +73,11 @@ void TestDatabase::testEmptyRecycleBinOnEmpty()
     auto db = QSharedPointer<Database>::create();
     QVERIFY(db->open(filename, key));
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.
-    QCOMPARE(spyModified.count(), 0);
+    QTRY_COMPARE(spyModified.count(), 0);
 }
 
 void TestDatabase::testEmptyRecycleBinWithHierarchicalData()
@@ -97,6 +97,8 @@ void TestDatabase::testEmptyRecycleBinWithHierarchicalData()
     QVERIFY(db->metadata()->recycleBin()->children().empty());
 
     QTemporaryFile afterCleanup;
+    afterCleanup.open();
+
     KeePass2Writer writer;
     writer.writeDatabase(&afterCleanup, db.data());
     QVERIFY(afterCleanup.size() < initialSize);

--- a/tests/TestDeletedObjects.cpp
+++ b/tests/TestDeletedObjects.cpp
@@ -30,7 +30,7 @@ void TestDeletedObjects::initTestCase()
     QVERIFY(Crypto::init());
 }
 
-void TestDeletedObjects::createAndDelete(Database* db, int delObjectsSize)
+void TestDeletedObjects::createAndDelete(QSharedPointer<Database> db, int delObjectsSize)
 {
     QCOMPARE(db->deletedObjects().size(), delObjectsSize);
     Group* root = db->rootGroup();
@@ -89,32 +89,27 @@ void TestDeletedObjects::testDeletedObjectsFromFile()
     KdbxXmlReader reader(KeePass2::FILE_VERSION_3_1);
     reader.setStrictMode(true);
     QString xmlFile = QString(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.xml");
-    Database* db = reader.readDatabase(xmlFile);
+    auto db = reader.readDatabase(xmlFile);
 
     createAndDelete(db, 2);
-
-    delete db;
 }
 
 void TestDeletedObjects::testDeletedObjectsFromNewDb()
 {
-    Database* db = new Database();
-
+    auto db = QSharedPointer<Database>::create();
     createAndDelete(db, 0);
-
-    delete db;
 }
 
 void TestDeletedObjects::testDatabaseChange()
 {
-    Database* db = new Database();
+    auto db = QSharedPointer<Database>::create();
     Group* root = db->rootGroup();
     int delObjectsSize = 0;
-    Database* db2 = new Database();
+    auto db2 = QSharedPointer<Database>::create();
     Group* root2 = db2->rootGroup();
     int delObjectsSize2 = 0;
 
-    Entry* e = new Entry();
+    auto* e = new Entry();
     e->setGroup(root);
 
     QCOMPARE(db->deletedObjects().size(), delObjectsSize);
@@ -130,11 +125,11 @@ void TestDeletedObjects::testDatabaseChange()
     QCOMPARE(db->deletedObjects().size(), delObjectsSize);
     QCOMPARE(db2->deletedObjects().size(), ++delObjectsSize2);
 
-    Group* g1 = new Group();
+    auto* g1 = new Group();
     g1->setParent(root);
     QUuid g1Uuid = QUuid::createUuid();
     g1->setUuid(g1Uuid);
-    Entry* e1 = new Entry();
+    auto* e1 = new Entry();
     e1->setGroup(g1);
     QUuid e1Uuid = QUuid::createUuid();
     e1->setUuid(e1Uuid);
@@ -146,8 +141,8 @@ void TestDeletedObjects::testDatabaseChange()
     QCOMPARE(db->deletedObjects().at(delObjectsSize - 2).uuid, e1Uuid);
     QCOMPARE(db->deletedObjects().at(delObjectsSize - 1).uuid, g1Uuid);
 
-    Group* group = new Group();
-    Entry* entry = new Entry();
+    auto* group = new Group();
+    auto* entry = new Entry();
     entry->setGroup(group);
     entry->setGroup(root);
 
@@ -155,6 +150,4 @@ void TestDeletedObjects::testDatabaseChange()
     QCOMPARE(db2->deletedObjects().size(), delObjectsSize2);
 
     delete group;
-    delete db;
-    delete db2;
 }

--- a/tests/TestDeletedObjects.h
+++ b/tests/TestDeletedObjects.h
@@ -27,7 +27,7 @@ class TestDeletedObjects : public QObject
     Q_OBJECT
 
 private:
-    void createAndDelete(Database* db, int delObjectsSize);
+    void createAndDelete(QSharedPointer<Database> db, int delObjectsSize);
 
 private slots:
     void initTestCase();

--- a/tests/TestKdbx2.cpp
+++ b/tests/TestKdbx2.cpp
@@ -68,7 +68,7 @@ void TestKdbx2::testFormat200()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(filename, key));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
     QCOMPARE(reader.version(), KeePass2::FILE_VERSION_2 & KeePass2::FILE_VERSION_CRITICAL_MASK);
 
     QVERIFY2(!reader.hasError(), reader.errorString().toStdString().c_str());
@@ -81,7 +81,7 @@ void TestKdbx2::testFormat200Upgrade()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(filename, key));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
     QVERIFY2(!reader.hasError(), reader.errorString().toStdString().c_str());
     QVERIFY(!db.isNull());
     QCOMPARE(reader.version(), KeePass2::FILE_VERSION_2 & KeePass2::FILE_VERSION_CRITICAL_MASK);
@@ -99,7 +99,7 @@ void TestKdbx2::testFormat200Upgrade()
 
     // read buffer back
     buffer.seek(0);
-    QScopedPointer<Database> targetDb(reader.readDatabase(&buffer, key));
+    QScopedPointer<Database> targetDb(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, key));
     if (reader.hasError()) {
         QFAIL(qPrintable(QString("Error while reading database: %1").arg(reader.errorString())));
     }

--- a/tests/TestKdbx2.cpp
+++ b/tests/TestKdbx2.cpp
@@ -67,8 +67,9 @@ void TestKdbx2::testFormat200()
     QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/Format200.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
+    auto db = QSharedPointer<Database>::create();
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
+    reader.readDatabase(filename, key, db.data());
     QCOMPARE(reader.version(), KeePass2::FILE_VERSION_2 & KeePass2::FILE_VERSION_CRITICAL_MASK);
 
     QVERIFY2(!reader.hasError(), reader.errorString().toStdString().c_str());
@@ -80,8 +81,9 @@ void TestKdbx2::testFormat200Upgrade()
     QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/Format200.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
+    auto db = QSharedPointer<Database>::create();
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
+    reader.readDatabase(filename, key, db.data());
     QVERIFY2(!reader.hasError(), reader.errorString().toStdString().c_str());
     QVERIFY(!db.isNull());
     QCOMPARE(reader.version(), KeePass2::FILE_VERSION_2 & KeePass2::FILE_VERSION_CRITICAL_MASK);
@@ -99,7 +101,8 @@ void TestKdbx2::testFormat200Upgrade()
 
     // read buffer back
     buffer.seek(0);
-    QScopedPointer<Database> targetDb(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, key));
+    auto targetDb = QSharedPointer<Database>::create();
+    reader.readDatabase(&buffer, key, db.data());
     if (reader.hasError()) {
         QFAIL(qPrintable(QString("Error while reading database: %1").arg(reader.errorString())));
     }

--- a/tests/TestKdbx2.h
+++ b/tests/TestKdbx2.h
@@ -32,7 +32,7 @@ private slots:
     void testFormat200Upgrade();
 
 private:
-    void verifyKdbx2Db(Database* db);
+    void verifyKdbx2Db(QSharedPointer<Database> db);
 };
 
 #endif // KEEPASSXC_TEST_KDBX2_H

--- a/tests/TestKdbx3.cpp
+++ b/tests/TestKdbx3.cpp
@@ -109,7 +109,7 @@ void TestKdbx3::testFormat300()
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     KeePass2Reader reader;
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
+    QVERIFY(reader.readDatabase(filename, key, db.data()));
     QCOMPARE(reader.version(), KeePass2::FILE_VERSION_3);
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
@@ -179,9 +179,6 @@ void TestKdbx3::testBrokenHeaderHash()
     QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/BrokenHeaderHash.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create(""));
-    KeePass2Reader reader;
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
-    QVERIFY(!db.data());
-    QVERIFY(reader.hasError());
+    QVERIFY(!db->open(filename, key));
 }

--- a/tests/TestKdbx3.cpp
+++ b/tests/TestKdbx3.cpp
@@ -125,11 +125,11 @@ void TestKdbx3::testNonAscii()
     key->addKey(QSharedPointer<PasswordKey>::create(QString::fromUtf8("\xce\x94\xc3\xb6\xd8\xb6")));
     KeePass2Reader reader;
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
+    QVERIFY(db->open(filename, key, nullptr, false));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("NonAsciiTest"));
-    QCOMPARE(db->compressionAlgo(), Database::CompressionNone);
+    QCOMPARE(db->compressionAlgorithm(), Database::CompressionNone);
 }
 
 void TestKdbx3::testCompressed()
@@ -139,11 +139,11 @@ void TestKdbx3::testCompressed()
     key->addKey(QSharedPointer<PasswordKey>::create(""));
     KeePass2Reader reader;
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
+    QVERIFY(db->open(filename, key, nullptr, false));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("Compressed"));
-    QCOMPARE(db->compressionAlgo(), Database::CompressionGZip);
+    QCOMPARE(db->compressionAlgorithm(), Database::CompressionGZip);
 }
 
 void TestKdbx3::testProtectedStrings()
@@ -153,7 +153,7 @@ void TestKdbx3::testProtectedStrings()
     key->addKey(QSharedPointer<PasswordKey>::create("masterpw"));
     KeePass2Reader reader;
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(filename, key));
+    QVERIFY(db->open(filename, key, nullptr, false));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("Protected Strings Test"));
@@ -180,5 +180,5 @@ void TestKdbx3::testBrokenHeaderHash()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create(""));
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(!db->open(filename, key));
+    QVERIFY(!db->open(filename, key, nullptr, false));
 }

--- a/tests/TestKdbx3.cpp
+++ b/tests/TestKdbx3.cpp
@@ -68,7 +68,7 @@ void TestKdbx3::readKdbx(QIODevice* device,
                          QString& errorString)
 {
     KeePass2Reader reader;
-    db.reset(reader.readDatabase(device, key));
+    db.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), device, key));
     hasError = reader.hasError();
     if (hasError) {
         errorString = reader.errorString();
@@ -83,7 +83,7 @@ void TestKdbx3::readKdbx(const QString& path,
                          QString& errorString)
 {
     KeePass2Reader reader;
-    db.reset(reader.readDatabase(path, key));
+    db.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), path, key));
     hasError = reader.hasError();
     if (hasError) {
         errorString = reader.errorString();
@@ -108,7 +108,7 @@ void TestKdbx3::testFormat300()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(filename, key));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
     QCOMPARE(reader.version(), KeePass2::FILE_VERSION_3);
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
@@ -123,7 +123,7 @@ void TestKdbx3::testNonAscii()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create(QString::fromUtf8("\xce\x94\xc3\xb6\xd8\xb6")));
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(filename, key));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("NonAsciiTest"));
@@ -136,7 +136,7 @@ void TestKdbx3::testCompressed()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create(""));
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(filename, key));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("Compressed"));
@@ -149,7 +149,7 @@ void TestKdbx3::testProtectedStrings()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("masterpw"));
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(filename, key));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("Protected Strings Test"));
@@ -176,7 +176,7 @@ void TestKdbx3::testBrokenHeaderHash()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create(""));
     KeePass2Reader reader;
-    QScopedPointer<Database> db(reader.readDatabase(filename, key));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), filename, key));
     QVERIFY(!db.data());
     QVERIFY(reader.hasError());
 }

--- a/tests/TestKdbx3.h
+++ b/tests/TestKdbx3.h
@@ -34,18 +34,18 @@ private slots:
 protected:
     void initTestCaseImpl() override;
 
-    Database* readXml(QBuffer* buf, bool strictMode, bool& hasError, QString& errorString) override;
-    Database* readXml(const QString& path, bool strictMode, bool& hasError, QString& errorString) override;
+    QSharedPointer<Database> readXml(QBuffer* buf, bool strictMode, bool& hasError, QString& errorString) override;
+    QSharedPointer<Database> readXml(const QString& path, bool strictMode, bool& hasError, QString& errorString) override;
     void writeXml(QBuffer* buf, Database* db, bool& hasError, QString& errorString) override;
 
     void readKdbx(QIODevice* device,
                   QSharedPointer<const CompositeKey> key,
-                  QScopedPointer<Database>& db,
+                  QSharedPointer<Database> db,
                   bool& hasError,
                   QString& errorString) override;
     void readKdbx(const QString& path,
                   QSharedPointer<const CompositeKey> key,
-                  QScopedPointer<Database>& db,
+                  QSharedPointer<Database> db,
                   bool& hasError,
                   QString& errorString) override;
     void writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString) override;

--- a/tests/TestKdbx4.h
+++ b/tests/TestKdbx4.h
@@ -35,18 +35,18 @@ private slots:
 protected:
     void initTestCaseImpl() override;
 
-    Database* readXml(QBuffer* buf, bool strictMode, bool& hasError, QString& errorString) override;
-    Database* readXml(const QString& path, bool strictMode, bool& hasError, QString& errorString) override;
+    QSharedPointer<Database> readXml(QBuffer* buf, bool strictMode, bool& hasError, QString& errorString) override;
+    QSharedPointer<Database> readXml(const QString& path, bool strictMode, bool& hasError, QString& errorString) override;
     void writeXml(QBuffer* buf, Database* db, bool& hasError, QString& errorString) override;
 
     void readKdbx(const QString& path,
                   QSharedPointer<const CompositeKey> key,
-                  QScopedPointer<Database>& db,
+                  QSharedPointer<Database> db,
                   bool& hasError,
                   QString& errorString) override;
     void readKdbx(QIODevice* device,
                   QSharedPointer<const CompositeKey> key,
-                  QScopedPointer<Database>& db,
+                  QSharedPointer<Database> db,
                   bool& hasError,
                   QString& errorString) override;
     void writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString) override;

--- a/tests/TestKeePass1Reader.cpp
+++ b/tests/TestKeePass1Reader.cpp
@@ -284,7 +284,7 @@ void TestKeePass1Reader::reopenDatabase(Database* db, const QString& password, c
     }
 
     KeePass2Reader reader;
-    QScopedPointer<Database> newDb(reader.readDatabase(&buffer, key));
+    QScopedPointer<Database> newDb(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, key));
     QVERIFY(newDb);
     QVERIFY(!reader.hasError());
 }

--- a/tests/TestKeePass1Reader.h
+++ b/tests/TestKeePass1Reader.h
@@ -20,6 +20,7 @@
 
 #include <QDateTime>
 #include <QObject>
+#include <QSharedPointer>
 
 class Database;
 
@@ -43,9 +44,9 @@ private slots:
 
 private:
     static QDateTime genDT(int year, int month, int day, int hour, int min);
-    static void reopenDatabase(Database* db, const QString& password, const QString& keyfileName);
+    static void reopenDatabase(QSharedPointer<Database> db, const QString& password, const QString& keyfileName);
 
-    Database* m_db;
+    QSharedPointer<Database> m_db;
 };
 
 #endif // KEEPASSX_TESTKEEPASS1READER_H

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -503,6 +503,7 @@ void TestKeePass2Format::testReadBackTargetDb()
     QString errorString;
 
     m_kdbxTargetBuffer.seek(0);
+    m_kdbxTargetDb = QSharedPointer<Database>::create();
     readKdbx(&m_kdbxTargetBuffer, key, m_kdbxTargetDb, hasError, errorString);
     if (hasError) {
         QFAIL(qPrintable(QString("Error while reading database: ").append(errorString)));

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -549,7 +549,7 @@ void TestKeePass2Format::testKdbxDeviceFailure()
     QScopedPointer<Database> db(new Database());
     db->setKey(key);
     // Disable compression so we write a predictable number of bytes.
-    db->setCompressionAlgo(Database::CompressionNone);
+    db->setCompressionAlgorithm(Database::CompressionNone);
 
     auto entry = new Entry();
     entry->setParent(db->rootGroup());

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -34,7 +34,7 @@ void TestKeePass2Format::initTestCase()
     // read raw XML database
     bool hasError;
     QString errorString;
-    m_xmlDb.reset(readXml(QString(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.xml"), true, hasError, errorString));
+    m_xmlDb = readXml(QString(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.xml"), true, hasError, errorString);
     if (hasError) {
         QFAIL(qPrintable(QString("Error while reading XML: ").append(errorString)));
     }
@@ -44,7 +44,7 @@ void TestKeePass2Format::initTestCase()
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("test"));
 
-    m_kdbxSourceDb.reset(new Database());
+    m_kdbxSourceDb = QSharedPointer<Database>::create();
     m_kdbxSourceDb->setKey(key);
     m_kdbxSourceDb->metadata()->setName("TESTDB");
     Group* group = m_kdbxSourceDb->rootGroup();
@@ -351,7 +351,7 @@ void TestKeePass2Format::testXmlBroken()
     QVERIFY(QFile::exists(xmlFile));
     bool hasError;
     QString errorString;
-    QScopedPointer<Database> db(readXml(xmlFile, strictMode, hasError, errorString));
+    auto db = readXml(xmlFile, strictMode, hasError, errorString);
     if (hasError) {
         qWarning("Reader error: %s", qPrintable(errorString));
     }
@@ -392,7 +392,7 @@ void TestKeePass2Format::testXmlEmptyUuids()
     QVERIFY(QFile::exists(xmlFile));
     bool hasError;
     QString errorString;
-    QScopedPointer<Database> dbp(readXml(xmlFile, true, hasError, errorString));
+    auto db = readXml(xmlFile, true, hasError, errorString);
     if (hasError) {
         qWarning("Reader error: %s", qPrintable(errorString));
     }
@@ -446,7 +446,7 @@ void TestKeePass2Format::testXmlInvalidXmlChars()
     QVERIFY(!hasError);
     buffer.seek(0);
 
-    QScopedPointer<Database> dbRead(readXml(&buffer, true, hasError, errorString));
+    auto dbRead = readXml(&buffer, true, hasError, errorString);
     if (hasError) {
         qWarning("Database read error: %s", qPrintable(errorString));
     }
@@ -474,7 +474,7 @@ void TestKeePass2Format::testXmlRepairUuidHistoryItem()
     QVERIFY(QFile::exists(xmlFile));
     bool hasError;
     QString errorString;
-    QScopedPointer<Database> db(readXml(xmlFile, false, hasError, errorString));
+    auto db = readXml(xmlFile, false, hasError, errorString);
     if (hasError) {
         qWarning("Database read error: %s", qPrintable(errorString));
     }
@@ -569,7 +569,7 @@ void TestKeePass2Format::testKdbxDeviceFailure()
  */
 void TestKeePass2Format::testDuplicateAttachments()
 {
-    QScopedPointer<Database> db(new Database());
+    auto db = QSharedPointer<Database>::create();
     db->setKey(QSharedPointer<CompositeKey>::create());
 
     const QByteArray attachment1("abc");

--- a/tests/TestKeePass2Format.h
+++ b/tests/TestKeePass2Format.h
@@ -21,7 +21,7 @@
 #include <QBuffer>
 #include <QDateTime>
 #include <QObject>
-#include <QScopedPointer>
+#include <QSharedPointer>
 
 #include "core/Database.h"
 
@@ -67,25 +67,25 @@ private slots:
 protected:
     virtual void initTestCaseImpl() = 0;
 
-    virtual Database* readXml(QBuffer* buf, bool strictMode, bool& hasError, QString& errorString) = 0;
-    virtual Database* readXml(const QString& path, bool strictMode, bool& hasError, QString& errorString) = 0;
+    virtual QSharedPointer<Database> readXml(QBuffer* buf, bool strictMode, bool& hasError, QString& errorString) = 0;
+    virtual QSharedPointer<Database> readXml(const QString& path, bool strictMode, bool& hasError, QString& errorString) = 0;
     virtual void writeXml(QBuffer* buf, Database* db, bool& hasError, QString& errorString) = 0;
 
     virtual void readKdbx(QIODevice* device,
                           QSharedPointer<const CompositeKey> key,
-                          QScopedPointer<Database>& db,
+                          QSharedPointer<Database> db,
                           bool& hasError,
                           QString& errorString) = 0;
     virtual void readKdbx(const QString& path,
                           QSharedPointer<const CompositeKey> key,
-                          QScopedPointer<Database>& db,
+                          QSharedPointer<Database> db,
                           bool& hasError,
                           QString& errorString) = 0;
     virtual void writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString) = 0;
 
-    QScopedPointer<Database> m_xmlDb;
-    QScopedPointer<Database> m_kdbxSourceDb;
-    QScopedPointer<Database> m_kdbxTargetDb;
+    QSharedPointer<Database> m_xmlDb;
+    QSharedPointer<Database> m_kdbxSourceDb;
+    QSharedPointer<Database> m_kdbxTargetDb;
 
 private:
     QBuffer m_kdbxTargetBuffer;

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -87,7 +87,7 @@ void TestKeys::testFileKey()
 
     compositeKey->addKey(fileKey);
 
-    QScopedPointer<Database> db(reader.readDatabase(dbFilename, compositeKey));
+    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), dbFilename, compositeKey));
     QVERIFY(db);
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("%1 Database").arg(name));
@@ -152,7 +152,7 @@ void TestKeys::testCreateAndOpenFileKey()
     dbBuffer.reset();
 
     KeePass2Reader reader;
-    QScopedPointer<Database> dbRead(reader.readDatabase(&dbBuffer, compositeKey));
+    QScopedPointer<Database> dbRead(reader.readDatabase(QSharedPointer<const CompositeKey>(), &dbBuffer, compositeKey));
     if (reader.hasError()) {
         QFAIL(reader.errorString().toUtf8().constData());
     }
@@ -250,22 +250,22 @@ void TestKeys::testCompositeKeyComponents()
     auto compositeKeyDec1 = QSharedPointer<CompositeKey>::create();
 
     // try decryption and subsequently add key components until decryption is successful
-    db2.reset(reader.readDatabase(&buffer, compositeKeyDec1));
+    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec1));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addKey(passwordKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(&buffer, compositeKeyDec1));
+    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec1));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addKey(fileKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(&buffer, compositeKeyDec1));
+    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec1));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addChallengeResponseKey(challengeResponseKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(&buffer, compositeKeyDec1));
+    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec1));
     // now we should be able to open the database
     if (reader.hasError()) {
         QFAIL(qPrintable(reader.errorString()));
@@ -277,7 +277,7 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec2->addKey(fileKeyEnc);
     compositeKeyDec2->addChallengeResponseKey(challengeResponseKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(&buffer, compositeKeyDec2));
+    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec2));
     QVERIFY(reader.hasError());
 
     auto compositeKeyDec3 = QSharedPointer<CompositeKey>::create();
@@ -290,7 +290,7 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec3->addKey(fileKeyWrong);
     compositeKeyDec3->addChallengeResponseKey(challengeResponseKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(&buffer, compositeKeyDec3));
+    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec3));
     QVERIFY(reader.hasError());
 
     auto compositeKeyDec4 = QSharedPointer<CompositeKey>::create();
@@ -298,6 +298,6 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec4->addKey(fileKeyEnc);
     compositeKeyDec4->addChallengeResponseKey(QSharedPointer<MockChallengeResponseKey>::create(QByteArray(16, 0x20)));
     buffer.seek(0);
-    db2.reset(reader.readDatabase(&buffer, compositeKeyDec4));
+    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec4));
     QVERIFY(reader.hasError());
 }

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -87,8 +87,8 @@ void TestKeys::testFileKey()
 
     compositeKey->addKey(fileKey);
 
-    QScopedPointer<Database> db(reader.readDatabase(QSharedPointer<const CompositeKey>(), dbFilename, compositeKey));
-    QVERIFY(db);
+    auto db = QSharedPointer<Database>::create();
+    QVERIFY(db->open(dbFilename, compositeKey));
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("%1 Database").arg(name));
 }
@@ -152,7 +152,8 @@ void TestKeys::testCreateAndOpenFileKey()
     dbBuffer.reset();
 
     KeePass2Reader reader;
-    QScopedPointer<Database> dbRead(reader.readDatabase(QSharedPointer<const CompositeKey>(), &dbBuffer, compositeKey));
+    QSharedPointer<Database> dbRead;
+    reader.readDatabase(&dbBuffer, compositeKey, dbRead.data());
     if (reader.hasError()) {
         QFAIL(reader.errorString().toUtf8().constData());
     }
@@ -250,22 +251,22 @@ void TestKeys::testCompositeKeyComponents()
     auto compositeKeyDec1 = QSharedPointer<CompositeKey>::create();
 
     // try decryption and subsequently add key components until decryption is successful
-    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec1));
+    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addKey(passwordKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec1));
+    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addKey(fileKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec1));
+    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addChallengeResponseKey(challengeResponseKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec1));
+    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
     // now we should be able to open the database
     if (reader.hasError()) {
         QFAIL(qPrintable(reader.errorString()));
@@ -277,7 +278,7 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec2->addKey(fileKeyEnc);
     compositeKeyDec2->addChallengeResponseKey(challengeResponseKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec2));
+    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec2, db2.data()));
     QVERIFY(reader.hasError());
 
     auto compositeKeyDec3 = QSharedPointer<CompositeKey>::create();
@@ -290,7 +291,7 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec3->addKey(fileKeyWrong);
     compositeKeyDec3->addChallengeResponseKey(challengeResponseKeyEnc);
     buffer.seek(0);
-    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec3));
+    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec3, db2.data()));
     QVERIFY(reader.hasError());
 
     auto compositeKeyDec4 = QSharedPointer<CompositeKey>::create();
@@ -298,6 +299,6 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec4->addKey(fileKeyEnc);
     compositeKeyDec4->addChallengeResponseKey(QSharedPointer<MockChallengeResponseKey>::create(QByteArray(16, 0x20)));
     buffer.seek(0);
-    db2.reset(reader.readDatabase(QSharedPointer<const CompositeKey>(), &buffer, compositeKeyDec4));
+    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec4, db2.data()));
     QVERIFY(reader.hasError());
 }

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -152,7 +152,7 @@ void TestKeys::testCreateAndOpenFileKey()
     dbBuffer.reset();
 
     KeePass2Reader reader;
-    QSharedPointer<Database> dbRead;
+    auto dbRead = QSharedPointer<Database>::create();
     reader.readDatabase(&dbBuffer, compositeKey, dbRead.data());
     if (reader.hasError()) {
         QFAIL(reader.errorString().toUtf8().constData());
@@ -237,7 +237,7 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyEnc->addKey(fileKeyEnc);
     compositeKeyEnc->addChallengeResponseKey(challengeResponseKeyEnc);
 
-    QScopedPointer<Database> db1(new Database());
+    auto db1 = QSharedPointer<Database>::create();
     db1->setKey(compositeKeyEnc);
 
     KeePass2Writer writer;
@@ -246,22 +246,22 @@ void TestKeys::testCompositeKeyComponents()
     QVERIFY(writer.writeDatabase(&buffer, db1.data()));
 
     buffer.seek(0);
-    QScopedPointer<Database> db2;
+    auto db2 = QSharedPointer<Database>::create();
     KeePass2Reader reader;
     auto compositeKeyDec1 = QSharedPointer<CompositeKey>::create();
 
     // try decryption and subsequently add key components until decryption is successful
-    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
+    QVERIFY(!reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addKey(passwordKeyEnc);
     buffer.seek(0);
-    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
+    QVERIFY(!reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addKey(fileKeyEnc);
     buffer.seek(0);
-    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
+    QVERIFY(!reader.readDatabase(&buffer, compositeKeyDec1, db2.data()));
     QVERIFY(reader.hasError());
 
     compositeKeyDec1->addChallengeResponseKey(challengeResponseKeyEnc);
@@ -278,7 +278,7 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec2->addKey(fileKeyEnc);
     compositeKeyDec2->addChallengeResponseKey(challengeResponseKeyEnc);
     buffer.seek(0);
-    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec2, db2.data()));
+    QVERIFY(!reader.readDatabase(&buffer, compositeKeyDec2, db2.data()));
     QVERIFY(reader.hasError());
 
     auto compositeKeyDec3 = QSharedPointer<CompositeKey>::create();
@@ -291,7 +291,7 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec3->addKey(fileKeyWrong);
     compositeKeyDec3->addChallengeResponseKey(challengeResponseKeyEnc);
     buffer.seek(0);
-    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec3, db2.data()));
+    QVERIFY(!reader.readDatabase(&buffer, compositeKeyDec3, db2.data()));
     QVERIFY(reader.hasError());
 
     auto compositeKeyDec4 = QSharedPointer<CompositeKey>::create();
@@ -299,6 +299,6 @@ void TestKeys::testCompositeKeyComponents()
     compositeKeyDec4->addKey(fileKeyEnc);
     compositeKeyDec4->addChallengeResponseKey(QSharedPointer<MockChallengeResponseKey>::create(QByteArray(16, 0x20)));
     buffer.seek(0);
-    QVERIFY(reader.readDatabase(&buffer, compositeKeyDec4, db2.data()));
+    QVERIFY(!reader.readDatabase(&buffer, compositeKeyDec4, db2.data()));
     QVERIFY(reader.hasError());
 }

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -88,7 +88,7 @@ void TestKeys::testFileKey()
     compositeKey->addKey(fileKey);
 
     auto db = QSharedPointer<Database>::create();
-    QVERIFY(db->open(dbFilename, compositeKey));
+    QVERIFY(db->open(dbFilename, compositeKey, nullptr, false));
     QVERIFY(!reader.hasError());
     QCOMPARE(db->metadata()->name(), QString("%1 Database").arg(name));
 }

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -1366,7 +1366,7 @@ void TestMerge::testMergeNotModified()
     QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(modified()));
     Merger merger(dbSource.data(), dbDestination.data());
     merger.merge();
-    QVERIFY(modifiedSignalSpy.empty());
+    QTRY_VERIFY(modifiedSignalSpy.empty());
 }
 
 void TestMerge::testMergeModified()
@@ -1385,7 +1385,7 @@ void TestMerge::testMergeModified()
 
     Merger merger(dbSource.data(), dbDestination.data());
     merger.merge();
-    QVERIFY(!modifiedSignalSpy.empty());
+    QTRY_VERIFY(!modifiedSignalSpy.empty());
 }
 
 Database* TestMerge::createTestDatabase()

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -1363,7 +1363,7 @@ void TestMerge::testMergeNotModified()
     QScopedPointer<Database> dbSource(
         createTestDatabaseStructureClone(dbDestination.data(), Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
-    QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(modified()));
+    QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(databaseModified()));
     Merger merger(dbSource.data(), dbDestination.data());
     merger.merge();
     QTRY_VERIFY(modifiedSignalSpy.empty());
@@ -1375,7 +1375,7 @@ void TestMerge::testMergeModified()
     QScopedPointer<Database> dbSource(
         createTestDatabaseStructureClone(dbDestination.data(), Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
-    QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(modified()));
+    QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(databaseModified()));
     // Make sure the two changes have a different timestamp.
     QTest::qSleep(1);
     Entry* entry = dbSource->rootGroup()->findEntryByPath("entry1");

--- a/tests/TestModified.cpp
+++ b/tests/TestModified.cpp
@@ -61,7 +61,7 @@ void TestModified::testSignals()
 
     QScopedPointer<Database> db(new Database());
     auto* root = db->rootGroup();
-    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
 
     db->setKey(compositeKey);
     ++spyCount;
@@ -88,7 +88,7 @@ void TestModified::testSignals()
 
     QScopedPointer<Database> db2(new Database());
     auto* root2 = db2->rootGroup();
-    QSignalSpy spyModified2(db2.data(), SIGNAL(modified()));
+    QSignalSpy spyModified2(db2.data(), SIGNAL(databaseModified()));
 
     group1->setParent(root2);
     ++spyCount;
@@ -149,7 +149,7 @@ void TestModified::testGroupSets()
     auto* group = new Group();
     group->setParent(root);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
 
     root->setUuid(QUuid::createUuid());
     ++spyCount;
@@ -224,7 +224,7 @@ void TestModified::testEntrySets()
     auto* entry = new Entry();
     entry->setGroup(group);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
 
     entry->setUuid(QUuid::createUuid());
     ++spyCount;
@@ -648,7 +648,7 @@ void TestModified::testCustomData()
     auto* entry = new Entry();
     entry->setGroup(group);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
 
     db->metadata()->customData()->set("Key", "Value");
     ++spyCount;

--- a/tests/TestModified.cpp
+++ b/tests/TestModified.cpp
@@ -61,67 +61,83 @@ void TestModified::testSignals()
 
     QScopedPointer<Database> db(new Database());
     auto* root = db->rootGroup();
-    QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->setKey(compositeKey);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     auto* group1 = new Group();
     group1->setParent(root);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     auto* group2 = new Group();
     group2->setParent(root);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     group2->setParent(root, 0);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     auto* entry1 = new Entry();
     entry1->setGroup(group1);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     QScopedPointer<Database> db2(new Database());
     auto* root2 = db2->rootGroup();
-    QSignalSpy spyModified2(db2.data(), SIGNAL(modifiedImmediate()));
+    QSignalSpy spyModified2(db2.data(), SIGNAL(modified()));
 
     group1->setParent(root2);
-    QCOMPARE(spyModified.count(), ++spyCount);
-    QCOMPARE(spyModified2.count(), ++spyCount2);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
+    ++spyCount2;
+    QTRY_COMPARE(spyModified2.count(), spyCount2);
 
     entry1->setTitle("test");
-    QCOMPARE(spyModified.count(), spyCount);
-    QCOMPARE(spyModified2.count(), ++spyCount2);
+    QTRY_COMPARE(spyModified.count(), spyCount);
+    ++spyCount2;
+    QTRY_COMPARE(spyModified2.count(), spyCount2);
 
     auto* entry2 = new Entry();
     entry2->setGroup(group2);
-    QCOMPARE(spyModified.count(), ++spyCount);
-    QCOMPARE(spyModified2.count(), spyCount2);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified2.count(), spyCount2);
 
     entry2->setGroup(root2);
-    QCOMPARE(spyModified.count(), ++spyCount);
-    QCOMPARE(spyModified2.count(), ++spyCount2);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
+    ++spyCount2;
+    QTRY_COMPARE(spyModified2.count(), spyCount2);
 
     entry2->setTitle("test2");
-    QCOMPARE(spyModified.count(), spyCount);
-    QCOMPARE(spyModified2.count(), ++spyCount2);
+    QTRY_COMPARE(spyModified.count(), spyCount);
+    ++spyCount2;
+    QTRY_COMPARE(spyModified2.count(), spyCount2);
 
     auto* group3 = new Group();
     group3->setParent(root);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     auto* group4 = new Group();
     group4->setParent(group3);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     delete group4;
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     delete entry2;
-    QCOMPARE(spyModified2.count(), ++spyCount2);
+    ++spyCount2;
+    QTRY_COMPARE(spyModified2.count(), spyCount2);
 
-    QCOMPARE(spyModified.count(), spyCount);
-    QCOMPARE(spyModified2.count(), spyCount2);
+    QTRY_COMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified2.count(), spyCount2);
 }
 
 void TestModified::testGroupSets()
@@ -133,58 +149,68 @@ void TestModified::testGroupSets()
     auto* group = new Group();
     group->setParent(root);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     root->setUuid(QUuid::createUuid());
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     root->setUuid(root->uuid());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     root->setName("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     root->setName(root->name());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     root->setNotes("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     root->setNotes(root->notes());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     root->setIcon(1);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     root->setIcon(root->iconNumber());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     root->setIcon(QUuid::createUuid());
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     root->setIcon(root->iconUuid());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
 
     group->setUuid(QUuid::createUuid());
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     group->setUuid(group->uuid());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     group->setName("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     group->setName(group->name());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     group->setNotes("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     group->setNotes(group->notes());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     group->setIcon(1);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     group->setIcon(group->iconNumber());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     group->setIcon(QUuid::createUuid());
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     group->setIcon(group->iconUuid());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 }
 
 void TestModified::testEntrySets()
@@ -198,106 +224,127 @@ void TestModified::testEntrySets()
     auto* entry = new Entry();
     entry->setGroup(group);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     entry->setUuid(QUuid::createUuid());
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setUuid(entry->uuid());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setTitle("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setTitle(entry->title());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setUrl("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setUrl(entry->url());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setUsername("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setUsername(entry->username());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setPassword("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setPassword(entry->password());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setNotes("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setNotes(entry->notes());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setIcon(1);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setIcon(entry->iconNumber());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setIcon(QUuid::createUuid());
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setIcon(entry->iconUuid());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setTags("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setTags(entry->tags());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setExpires(true);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setExpires(entry->timeInfo().expires());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setExpiryTime(Clock::currentDateTimeUtc().addYears(1));
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setExpiryTime(entry->timeInfo().expiryTime());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setAutoTypeEnabled(false);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setAutoTypeEnabled(entry->autoTypeEnabled());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setAutoTypeObfuscation(1);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setAutoTypeObfuscation(entry->autoTypeObfuscation());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setDefaultAutoTypeSequence("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setDefaultAutoTypeSequence(entry->defaultAutoTypeSequence());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setForegroundColor(Qt::red);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setForegroundColor(entry->foregroundColor());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setBackgroundColor(Qt::red);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setBackgroundColor(entry->backgroundColor());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->setOverrideUrl("test");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setOverrideUrl(entry->overrideUrl());
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->attributes()->set("test key", "test value", false);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->attributes()->set("test key", entry->attributes()->value("test key"), false);
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->attributes()->set("test key", entry->attributes()->value("test key"), true);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->attributes()->set("test key", "new test value", true);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->attributes()->set("test key2", "test value2", true);
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->attributes()->set("test key2", entry->attributes()->value("test key2"), true);
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 }
 
 void TestModified::testHistoryItems()
@@ -601,20 +648,23 @@ void TestModified::testCustomData()
     auto* entry = new Entry();
     entry->setGroup(group);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(modifiedImmediate()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->metadata()->customData()->set("Key", "Value");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     db->metadata()->customData()->set("Key", "Value");
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     entry->customData()->set("Key", "Value");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     entry->customData()->set("Key", "Value");
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 
     group->customData()->set("Key", "Value");
-    QCOMPARE(spyModified.count(), ++spyCount);
+    ++spyCount;
+    QTRY_COMPARE(spyModified.count(), spyCount);
     group->customData()->set("Key", "Value");
-    QCOMPARE(spyModified.count(), spyCount);
+    QTRY_COMPARE(spyModified.count(), spyCount);
 }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1305,7 +1305,7 @@ void TestGui::checkDatabase(QString dbFileName)
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     KeePass2Reader reader;
-    QScopedPointer<Database> dbSaved(reader.readDatabase(dbFileName, key));
+    QScopedPointer<Database> dbSaved(reader.readDatabase(QSharedPointer<const CompositeKey>(), dbFileName, key));
     QVERIFY(dbSaved);
     QVERIFY(!reader.hasError());
     QCOMPARE(dbSaved->metadata()->name(), m_db->metadata()->name());

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1307,7 +1307,7 @@ void TestGui::checkDatabase(QString dbFileName)
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     auto dbSaved = QSharedPointer<Database>::create();
-    QVERIFY(dbSaved->open(dbFileName, key));
+    QVERIFY(dbSaved->open(dbFileName, key, nullptr, false));
     QCOMPARE(dbSaved->metadata()->name(), m_db->metadata()->name());
 }
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -424,7 +424,7 @@ void TestGui::testEditEntry()
 
     // Edit the first entry ("Sample Entry")
     QTest::mouseClick(entryEditWidget, Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
     auto* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
     QTest::keyClicks(titleEdit, "_test");
@@ -433,7 +433,7 @@ void TestGui::testEditEntry()
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
     QVERIFY(editEntryWidgetButtonBox);
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Apply), Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
     QCOMPARE(entry->title(), QString("Sample Entry_test"));
     QCOMPARE(entry->historyItems().size(), ++editCount);
 
@@ -474,7 +474,7 @@ void TestGui::testEditEntry()
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
     auto* messageWiget = editEntryWidget->findChild<MessageWidget*>("messageWidget");
     QTRY_VERIFY(messageWiget->isVisible());
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
     QCOMPARE(passwordEdit->text(), QString("newpass"));
     passwordEdit->setText(originalPassword);
 
@@ -483,7 +483,7 @@ void TestGui::testEditEntry()
     QApplication::processEvents();
 
     // Confirm edit was made
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     QCOMPARE(entry->title(), QString("Sample Entry_test"));
     QCOMPARE(entry->foregroundColor(), fgColor);
     QCOMPARE(entryItem.data(Qt::ForegroundRole), QVariant(fgColor));
@@ -496,7 +496,7 @@ void TestGui::testEditEntry()
 
     // Test copy & paste newline sanitization
     QTest::mouseClick(entryEditWidget, Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
     titleEdit->setText("multiline\ntitle");
     editEntryWidget->findChild<QLineEdit*>("usernameEdit")->setText("multiline\nusername");
     editEntryWidget->findChild<QLineEdit*>("passwordEdit")->setText("multiline\npassword");
@@ -556,7 +556,7 @@ void TestGui::testSearchEditEntry()
 
     // Goto "Doggy"'s edit view
     QTest::keyClick(searchTextEdit, Qt::Key_Return);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
 
     // Check the path in header is "parent-group > entry"
     QCOMPARE(m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget")->findChild<QLabel*>("headerLabel")->text(),
@@ -579,7 +579,7 @@ void TestGui::testAddEntry()
 
     // Click the new entry button and check that we enter edit mode
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
 
     // Add entry "test" and confirm added
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
@@ -588,7 +588,7 @@ void TestGui::testAddEntry()
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
 
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     QModelIndex item = entryView->model()->index(1, 1);
     Entry* entry = entryView->entryFromIndex(item);
 
@@ -631,7 +631,7 @@ void TestGui::testPasswordEntryEntropy()
 
     // Click the new entry button and check that we enter edit mode
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
 
     // Add entry "test" and confirm added
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
@@ -703,7 +703,7 @@ void TestGui::testDicewareEntryEntropy()
 
     // Click the new entry button and check that we enter edit mode
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
 
     // Add entry "test" and confirm added
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
@@ -738,7 +738,7 @@ void TestGui::testTotp()
     auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
 
     QCOMPARE(entryView->model()->rowCount(), 1);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     QModelIndex item = entryView->model()->index(0, 1);
     Entry* entry = entryView->entryFromIndex(item);
     clickIndex(item, entryView, Qt::LeftButton);
@@ -768,7 +768,7 @@ void TestGui::testTotp()
     QVERIFY(entryEditWidget->isVisible());
     QVERIFY(entryEditWidget->isEnabled());
     QTest::mouseClick(entryEditWidget, Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
 
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
     editEntryWidget->setCurrentPage(1);
@@ -836,7 +836,7 @@ void TestGui::testSearch()
     QTest::keyClick(searchTextEdit, Qt::Key_Escape);
     QTRY_VERIFY(searchTextEdit->text().isEmpty());
     QTRY_VERIFY(searchTextEdit->hasFocus());
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     // Search for "some"
     QTest::keyClicks(searchTextEdit, "some");
     QTRY_VERIFY(m_dbWidget->isSearchActive());
@@ -901,7 +901,7 @@ void TestGui::testSearch()
     QModelIndex item = entryView->model()->index(0, 1);
     Entry* entry = entryView->entryFromIndex(item);
     QTest::keyClick(searchTextEdit, Qt::Key_Return);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
 
     // Perform the edit and save it
     EditEntryWidget* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
@@ -917,7 +917,7 @@ void TestGui::testSearch()
 
     // Cancel search, should return to normal view
     QTest::keyClick(m_mainWindow.data(), Qt::Key_Escape);
-    QTRY_COMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
+    QTRY_COMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
 }
 
 void TestGui::testDeleteEntry()
@@ -931,7 +931,7 @@ void TestGui::testDeleteEntry()
     auto* entryDeleteAction = m_mainWindow->findChild<QAction*>("actionEntryDelete");
     QWidget* entryDeleteWidget = toolBar->widgetForAction(entryDeleteAction);
 
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     clickIndex(entryView->model()->index(1, 1), entryView, Qt::LeftButton);
     QVERIFY(entryDeleteWidget->isVisible());
     QVERIFY(entryDeleteWidget->isEnabled());
@@ -1024,7 +1024,7 @@ void TestGui::testEntryPlaceholders()
 
     // Click the new entry button and check that we enter edit mode
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::EditMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
 
     // Add entry "test" and confirm added
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
@@ -1039,7 +1039,7 @@ void TestGui::testEntryPlaceholders()
 
     QCOMPARE(entryView->model()->rowCount(), 2);
 
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::ViewMode);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     QModelIndex item = entryView->model()->index(1, 1);
     Entry* entry = entryView->entryFromIndex(item);
 

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -26,6 +26,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QScopedPointer>
+#include <QSharedPointer>
 
 class Database;
 class DatabaseTabWidget;
@@ -88,7 +89,7 @@ private:
     QScopedPointer<MainWindow> m_mainWindow;
     QPointer<DatabaseTabWidget> m_tabWidget;
     QPointer<DatabaseWidget> m_dbWidget;
-    QPointer<Database> m_db;
+    QSharedPointer<Database> m_db;
     QByteArray m_dbData;
     QScopedPointer<TemporaryFile> m_dbFile;
     QString m_dbFileName;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This is the long-overdue refactoring of the Database internals.

The core changes are:
- Move loading and saving logic from widgets into the Database class
- Let database objects keep track of modifications and dirty/clean state instead of handing this to external widgets
- Move GUI interactions for loading and saving from the DatabaseTabWidget into the DatabaseWidget (resolves #2494 as a side-effect)
- Heavily clean up DatabaseTabWidget and degrade it to a slightly glorified QTabWidget
- Use QSharedPointers for all Database objects
- Remove the confusing modifiedImmediate signal (rejoice!)
- Get rid of the pesky DatabaseManagerStruct (wack out!)
- Implement proper tabName() method instead of reading back titles from GUI widgets (resolves #1389 and its duplicates #2146 #855)
- Fix unwanted AES-KDF downgrade if database uses Argon2 and has CustomData
- Make ugly code less ugly

This patch is also the first major step towards solving issues #476 and #2322.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass, behaviour is the same as before (only slightly less buggy).

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**