### PR TITLE
Re-implement AutoOpen functionality after refactor

### DIFF
--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -48,8 +48,8 @@ public:
     bool hasLockableDatabases() const;
 
 public slots:
-    void addDatabaseTab(const QString& filePath);
-    void addDatabaseTab(DatabaseWidget* dbWidget);
+    void addDatabaseTab(const QString& filePath, const QString& password = {}, bool inBackground = false);
+    void addDatabaseTab(DatabaseWidget* dbWidget, bool inBackground = false);
     bool closeDatabaseTab(int index);
     bool closeDatabaseTab(DatabaseWidget* dbWidget);
     bool closeAllDatabaseTabs();

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -132,6 +132,7 @@ signals:
     void currentModeChanged(DatabaseWidget::Mode mode);
     void groupChanged();
     void entrySelectionChanged();
+    void requestOpenDatabase(const QString& filePath, const QString& password, bool inBackground);
     void databaseMerged(QSharedPointer<Database> mergedDb);
     void groupContextMenuRequested(const QPoint& globalPos);
     void entryContextMenuRequested(const QPoint& globalPos);
@@ -180,6 +181,7 @@ public slots:
     void switchToOpenMergeDatabase(const QString& filePath);
     void switchToOpenMergeDatabase(const QString& filePath, const QString& password, const QString& keyFile);
     void switchToImportKeepass1(const QString& filePath);
+    void performUnlockDatabase(const QString& password, const QString& keyfile = {});
     void emptyRecycleBin();
 
     // Search related slots
@@ -226,6 +228,7 @@ private:
     int addChildWidget(QWidget* w);
     void setClipboardTextAndMinimize(const QString& text);
     void setIconFromParent();
+    void processAutoOpen();
 
     QSharedPointer<Database> m_db;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Adds AutoOpen functionality back in after the database widget(s) refactor. Adds capability to programmatically unlock a database from the database widget.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Feature was removed after refactor.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
