### PR TITLE
Global const for KeyFileOption (CLI)

### DIFF
--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -49,11 +49,7 @@ int Add::execute(const QStringList& arguments)
     parser.setApplicationDescription(description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
     parser.addOption(Command::QuietOption);
-
-    QCommandLineOption keyFile(QStringList() << "k" << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
+    parser.addOption(Command::KeyFileOption);
 
     QCommandLineOption username(QStringList() << "u"  << "username",
                                 QObject::tr("Username for the entry."),
@@ -91,7 +87,7 @@ int Add::execute(const QStringList& arguments)
     const QString& entryPath = args.at(1);
 
     auto db = Database::unlockFromStdin(databasePath,
-                                        parser.value(keyFile),
+                                        parser.value(Command::KeyFileOption),
                                         parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                         Utils::STDERR);
     if (!db) {

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -47,11 +47,9 @@ int Clip::execute(const QStringList& arguments)
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
-    QCommandLineOption keyFile(QStringList() << "k" << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
     parser.addOption(Command::QuietOption);
+    parser.addOption(Command::KeyFileOption);
+
     QCommandLineOption totp(QStringList() << "t"  << "totp",
                             QObject::tr("Copy the current TOTP to the clipboard."));
     parser.addOption(totp);
@@ -68,7 +66,7 @@ int Clip::execute(const QStringList& arguments)
     }
 
     auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(keyFile),
+                                        parser.value(Command::KeyFileOption),
                                         parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                         Utils::STDERR);
     if (!db) {

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -39,6 +39,12 @@ const QCommandLineOption Command::QuietOption =
     QCommandLineOption(QStringList() << "q"
                                      << "quiet",
                        QObject::tr("Silence password prompt and other secondary outputs."));
+
+const QCommandLineOption Command::KeyFileOption(QStringList() << "k"
+                                                              << "key-file",
+                                                QObject::tr("Key file of the database."),
+                                                QObject::tr("path"));
+
 QMap<QString, Command*> commands;
 
 Command::~Command()

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -40,10 +40,11 @@ const QCommandLineOption Command::QuietOption =
                                      << "quiet",
                        QObject::tr("Silence password prompt and other secondary outputs."));
 
-const QCommandLineOption Command::KeyFileOption(QStringList() << "k"
-                                                              << "key-file",
-                                                QObject::tr("Key file of the database."),
-                                                QObject::tr("path"));
+const QCommandLineOption Command::KeyFileOption =
+    QCommandLineOption(QStringList() << "k"
+                                     << "key-file",
+                       QObject::tr("Key file of the database."),
+                       QObject::tr("path"));
 
 QMap<QString, Command*> commands;
 

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -39,6 +39,7 @@ public:
     static Command* getCommand(const QString& commandName);
 
     static const QCommandLineOption QuietOption;
+    static const QCommandLineOption KeyFileOption;
 };
 
 #endif // KEEPASSXC_COMMAND_H

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -49,11 +49,7 @@ int Edit::execute(const QStringList& arguments)
     parser.setApplicationDescription(description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
     parser.addOption(Command::QuietOption);
-
-    QCommandLineOption keyFile(QStringList() << "k" << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
+    parser.addOption(Command::KeyFileOption);
 
     QCommandLineOption username(QStringList() << "u" << "username",
                                 QObject::tr("Username for the entry."),
@@ -95,7 +91,7 @@ int Edit::execute(const QStringList& arguments)
     const QString& entryPath = args.at(1);
 
     auto db = Database::unlockFromStdin(databasePath,
-                                        parser.value(keyFile),
+                                        parser.value(Command::KeyFileOption),
                                         parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                         Utils::STDERR);
     if (!db) {

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -50,10 +50,7 @@ int Extract::execute(const QStringList& arguments)
     parser.setApplicationDescription(description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database to extract."));
     parser.addOption(Command::QuietOption);
-    QCommandLineOption keyFile(QStringList() << "k" << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
+    parser.addOption(Command::KeyFileOption);
     parser.addHelpOption();
     parser.process(arguments);
 
@@ -74,7 +71,7 @@ int Extract::execute(const QStringList& arguments)
     passwordKey->setPassword(line);
     compositeKey->addKey(passwordKey);
 
-    QString keyFilePath = parser.value(keyFile);
+    QString keyFilePath = parser.value(Command::KeyFileOption);
     if (!keyFilePath.isEmpty()) {
         // LCOV_EXCL_START
         auto fileKey = QSharedPointer<FileKey>::create();

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -47,10 +47,8 @@ int List::execute(const QStringList& arguments)
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
     parser.addPositionalArgument("group", QObject::tr("Path of the group to list. Default is /"), "[group]");
     parser.addOption(Command::QuietOption);
-    QCommandLineOption keyFile(QStringList() << "k" << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
+    parser.addOption(Command::KeyFileOption);
+
     QCommandLineOption recursiveOption(QStringList() << "R" << "recursive",
                                        QObject::tr("Recursively list the elements of the group."));
     parser.addOption(recursiveOption);
@@ -66,7 +64,7 @@ int List::execute(const QStringList& arguments)
     bool recursive = parser.isSet(recursiveOption);
 
     auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(keyFile),
+                                        parser.value(Command::KeyFileOption),
                                         parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                         Utils::STDERR);
     if (!db) {

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -49,10 +49,7 @@ int Locate::execute(const QStringList& arguments)
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
     parser.addPositionalArgument("term", QObject::tr("Search term."));
     parser.addOption(Command::QuietOption);
-    QCommandLineOption keyFile(QStringList() << "k" << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
+    parser.addOption(Command::KeyFileOption);
     parser.addHelpOption();
     parser.process(arguments);
 
@@ -63,7 +60,7 @@ int Locate::execute(const QStringList& arguments)
     }
 
     auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(keyFile),
+                                        parser.value(Command::KeyFileOption),
                                         parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                         Utils::STDERR);
     if (!db) {

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -50,14 +50,12 @@ int Merge::execute(const QStringList& arguments)
     QCommandLineOption samePasswordOption(QStringList() << "s" << "same-credentials",
                                           QObject::tr("Use the same credentials for both database files."));
     parser.addOption(samePasswordOption);
-    QCommandLineOption keyFile(QStringList() << "k" << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
-    QCommandLineOption keyFileFrom(QStringList() << "f" << "key-file-from",
-                                   QObject::tr("Key file of the database to merge from."),
-                                   QObject::tr("path"));
-    parser.addOption(keyFileFrom);
+    parser.addOption(Command::KeyFileOption);
+
+    QCommandLineOption keyFileFromOption(QStringList() << "f" << "key-file-from",
+                                         QObject::tr("Key file of the database to merge from."),
+                                         QObject::tr("path"));
+    parser.addOption(keyFileFromOption);
 
     parser.addHelpOption();
     parser.process(arguments);
@@ -69,7 +67,7 @@ int Merge::execute(const QStringList& arguments)
     }
 
     auto db1 = Database::unlockFromStdin(args.at(0),
-                                         parser.value(keyFile),
+                                         parser.value(Command::KeyFileOption),
                                          parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                          Utils::STDERR);
     if (!db1) {
@@ -78,10 +76,7 @@ int Merge::execute(const QStringList& arguments)
 
     QSharedPointer<Database> db2;
     if (!parser.isSet("same-credentials")) {
-        db2 = Database::unlockFromStdin(args.at(1),
-                                        parser.value(keyFileFrom),
-                                        parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                        Utils::STDERR);
+        db2 = Database::unlockFromStdin(args.at(1), parser.value(keyFileFromOption), Utils::STDOUT, Utils::STDERR);
     } else {
         db2 = QSharedPointer<Database>::create();
         QString errorMessage;

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -50,10 +50,7 @@ int Remove::execute(const QStringList& arguments)
     parser.setApplicationDescription(QCoreApplication::tr("main", "Remove an entry from the database."));
     parser.addPositionalArgument("database", QCoreApplication::tr("main", "Path of the database."));
     parser.addOption(Command::QuietOption);
-    QCommandLineOption keyFile(QStringList() << "k" << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
+    parser.addOption(Command::KeyFileOption);
     parser.addPositionalArgument("entry", QCoreApplication::tr("main", "Path of the entry to remove."));
     parser.addHelpOption();
     parser.process(arguments);
@@ -65,7 +62,7 @@ int Remove::execute(const QStringList& arguments)
     }
 
     auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(keyFile),
+                                        parser.value(Command::KeyFileOption),
                                         parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                         Utils::STDERR);
     if (!db) {

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -46,11 +46,8 @@ int Show::execute(const QStringList& arguments)
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
     parser.addPositionalArgument("database", QObject::tr("Path of the database."));
-    QCommandLineOption keyFile(QStringList() << "k"  << "key-file",
-                               QObject::tr("Key file of the database."),
-                               QObject::tr("path"));
-    parser.addOption(keyFile);
     parser.addOption(Command::QuietOption);
+    parser.addOption(Command::KeyFileOption);
     QCommandLineOption totp(QStringList() << "t"  << "totp",
                             QObject::tr("Show the entry's current TOTP."));
     parser.addOption(totp);
@@ -73,7 +70,7 @@ int Show::execute(const QStringList& arguments)
     }
 
     auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(keyFile),
+                                        parser.value(Command::KeyFileOption),
                                         parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                         Utils::STDERR);
     if (!db) {


### PR DESCRIPTION
## Motivation and context
Same option is defined in most of the CLI commands. Also, more global options might appear in the future (`--no--password`, `--silent`, `--yubikey`, for example).

## How has this been tested?
unit tests.


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Refactoring

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
