### PR TITLE
Ability to set 7-digit TOTP codes from the UI

### DIFF
--- a/src/gui/TotpSetupDialog.cpp
+++ b/src/gui/TotpSetupDialog.cpp
@@ -46,6 +46,8 @@ void TotpSetupDialog::saveSettings()
     uint digits = Totp::DEFAULT_DIGITS;
     if (m_ui->radio8Digits->isChecked()) {
         digits = 8;
+    else if (m_ui->radio7Digits->isChecked()) {
+        digits = 7;
     } else if (m_ui->radioSteam->isChecked()) {
         digits = Totp::STEAM_DIGITS;
         encShortName = Totp::STEAM_SHORTNAME;

--- a/src/gui/TotpSetupDialog.cpp
+++ b/src/gui/TotpSetupDialog.cpp
@@ -75,6 +75,8 @@ void TotpSetupDialog::init()
             m_ui->radioCustom->setChecked(true);
             if (settings->digits == 8) {
                 m_ui->radio8Digits->setChecked(true);
+            else if (settings->digits == 7) {
+                m_ui->radio7Digits->setChecked(true);
             } else {
                 m_ui->radio6Digits->setChecked(true);
             }

--- a/src/gui/TotpSetupDialog.cpp
+++ b/src/gui/TotpSetupDialog.cpp
@@ -46,7 +46,7 @@ void TotpSetupDialog::saveSettings()
     uint digits = Totp::DEFAULT_DIGITS;
     if (m_ui->radio8Digits->isChecked()) {
         digits = 8;
-    else if (m_ui->radio7Digits->isChecked()) {
+    } else if (m_ui->radio7Digits->isChecked()) {
         digits = 7;
     } else if (m_ui->radioSteam->isChecked()) {
         digits = Totp::STEAM_DIGITS;
@@ -77,7 +77,7 @@ void TotpSetupDialog::init()
             m_ui->radioCustom->setChecked(true);
             if (settings->digits == 8) {
                 m_ui->radio8Digits->setChecked(true);
-            else if (settings->digits == 7) {
+            } else if (settings->digits == 7) {
                 m_ui->radio7Digits->setChecked(true);
             } else {
                 m_ui->radio6Digits->setChecked(true);

--- a/src/gui/TotpSetupDialog.ui
+++ b/src/gui/TotpSetupDialog.ui
@@ -153,6 +153,13 @@
        </widget>
       </item>
       <item row="3" column="1">
+       <widget class="QRadioButton" name="radio7Digits">
+        <property name="text">
+         <string>7 digits</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
        <widget class="QRadioButton" name="radio8Digits">
         <property name="text">
          <string>8 digits</string>


### PR DESCRIPTION
Ability to set 7-digit TOTP codes from the UI

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Support 7-digit TOTP codes through the UI as since things like Authy use them (and our existing way of generating TOTP codes works with the way they do it) - it'd be handy to have it in the UI rather than changing the 'TOTP Settings' attribute manually.

resolves #1762 