### PR TITLE
Make Entry::m_tmpHistoryItem a QScopedPointer

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -71,6 +71,8 @@ Entry::~Entry()
     }
 
     qDeleteAll(m_history);
+
+    delete m_tmpHistoryItem;
 }
 
 template <class T> inline bool Entry::set(T& property, const T& value)

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -40,7 +40,6 @@ Entry::Entry()
     , m_attachments(new EntryAttachments(this))
     , m_autoTypeAssociations(new AutoTypeAssociations(this))
     , m_customData(new CustomData(this))
-    , m_tmpHistoryItem()
     , m_modifiedSinceBegin(false)
     , m_updateTimeinfo(true)
 {

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -40,7 +40,7 @@ Entry::Entry()
     , m_attachments(new EntryAttachments(this))
     , m_autoTypeAssociations(new AutoTypeAssociations(this))
     , m_customData(new CustomData(this))
-    , m_tmpHistoryItem(nullptr)
+    , m_tmpHistoryItem()
     , m_modifiedSinceBegin(false)
     , m_updateTimeinfo(true)
 {
@@ -71,8 +71,6 @@ Entry::~Entry()
     }
 
     qDeleteAll(m_history);
-
-    delete m_tmpHistoryItem;
 }
 
 template <class T> inline bool Entry::set(T& property, const T& value)
@@ -708,9 +706,9 @@ void Entry::copyDataFrom(const Entry* other)
 
 void Entry::beginUpdate()
 {
-    Q_ASSERT(!m_tmpHistoryItem);
+    Q_ASSERT(m_tmpHistoryItem.isNull());
 
-    m_tmpHistoryItem = new Entry();
+    m_tmpHistoryItem.reset(new Entry());
     m_tmpHistoryItem->setUpdateTimeinfo(false);
     m_tmpHistoryItem->m_uuid = m_uuid;
     m_tmpHistoryItem->m_data = m_data;
@@ -723,16 +721,14 @@ void Entry::beginUpdate()
 
 bool Entry::endUpdate()
 {
-    Q_ASSERT(m_tmpHistoryItem);
+    Q_ASSERT(!m_tmpHistoryItem.isNull());
     if (m_modifiedSinceBegin) {
         m_tmpHistoryItem->setUpdateTimeinfo(true);
-        addHistoryItem(m_tmpHistoryItem);
+        addHistoryItem(m_tmpHistoryItem.take());
         truncateHistory();
-    } else {
-        delete m_tmpHistoryItem;
     }
 
-    m_tmpHistoryItem = nullptr;
+    m_tmpHistoryItem.reset();
 
     return m_modifiedSinceBegin;
 }

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -249,7 +249,7 @@ private:
     QPointer<CustomData> m_customData;
     QList<Entry*> m_history; // Items sorted from oldest to newest
 
-    Entry* m_tmpHistoryItem;
+    QScopedPointer<Entry> m_tmpHistoryItem;
     bool m_modifiedSinceBegin;
     QPointer<Group> m_group;
     bool m_updateTimeinfo;


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

Most of the time, `m_tmpHistoryItem` should be null by the time an `Entry` is destroyed. However, if a caller ever calls `beginUpdate()` without later calling `endUpdate()` -- perhaps because an exception was throw in the meantime -- it may not be null.

This change avoids a memory leak in that case.

Found via https://lgtm.com/projects/g/keepassxreboot/keepassxc/alerts

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

`make test` continues to pass.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
