### PR TITLE
LayeredStream dtor: fully qualify 'close()' call

### DIFF
--- a/src/streams/LayeredStream.cpp
+++ b/src/streams/LayeredStream.cpp
@@ -26,7 +26,7 @@ LayeredStream::LayeredStream(QIODevice* baseDevice)
 
 LayeredStream::~LayeredStream()
 {
-    close();
+    QIODevice::close();
 }
 
 bool LayeredStream::isSequential() const


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

`close()` is a virtual function. Since we are calling it from a destructor, make it clear that we are specifically calling the base class (`QIODevice`) implementation, as opposed to an implementation in any derived class.

[Found by lgtm.com](https://lgtm.com/projects/g/keepassxreboot/keepassxc/alerts)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

`make test` continues to succeed.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**