### PR TITLE
Move unlockDatabase to CLI/Utils

### DIFF
--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -90,10 +90,10 @@ int Add::execute(const QStringList& arguments)
     const QString& databasePath = args.at(0);
     const QString& entryPath = args.at(1);
 
-    auto db = Database::unlockFromStdin(databasePath,
-                                        parser.value(Command::KeyFileOption),
-                                        parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                        Utils::STDERR);
+    auto db = Utils::unlockDatabase(databasePath,
+                                    parser.value(Command::KeyFileOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -66,10 +66,10 @@ int Clip::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(Command::KeyFileOption),
-                                        parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                        Utils::STDERR);
+    auto db = Utils::unlockDatabase(args.at(0),
+                                    parser.value(Command::KeyFileOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -95,10 +95,10 @@ int Edit::execute(const QStringList& arguments)
     const QString& databasePath = args.at(0);
     const QString& entryPath = args.at(1);
 
-    auto db = Database::unlockFromStdin(databasePath,
-                                        parser.value(Command::KeyFileOption),
-                                        parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                        Utils::STDERR);
+    auto db = Utils::unlockDatabase(databasePath,
+                                    parser.value(Command::KeyFileOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -64,10 +64,10 @@ int List::execute(const QStringList& arguments)
 
     bool recursive = parser.isSet(recursiveOption);
 
-    auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(Command::KeyFileOption),
-                                        parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                        Utils::STDERR);
+    auto db = Utils::unlockDatabase(args.at(0),
+                                    parser.value(Command::KeyFileOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -59,10 +59,10 @@ int Locate::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(Command::KeyFileOption),
-                                        parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                        Utils::STDERR);
+    auto db = Utils::unlockDatabase(args.at(0),
+                                    parser.value(Command::KeyFileOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -68,17 +68,17 @@ int Merge::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    auto db1 = Database::unlockFromStdin(args.at(0),
-                                         parser.value(Command::KeyFileOption),
-                                         parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                         Utils::STDERR);
+    auto db1 = Utils::unlockDatabase(args.at(0),
+                                     parser.value(Command::KeyFileOption),
+                                     parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                     Utils::STDERR);
     if (!db1) {
         return EXIT_FAILURE;
     }
 
     QSharedPointer<Database> db2;
     if (!parser.isSet("same-credentials")) {
-        db2 = Database::unlockFromStdin(args.at(1), parser.value(keyFileFromOption), Utils::STDOUT, Utils::STDERR);
+        db2 = Utils::unlockDatabase(args.at(1), parser.value(keyFileFromOption), Utils::STDOUT, Utils::STDERR);
     } else {
         db2 = QSharedPointer<Database>::create();
         QString errorMessage;

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -61,10 +61,10 @@ int Remove::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(Command::KeyFileOption),
-                                        parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                        Utils::STDERR);
+    auto db = Utils::unlockDatabase(args.at(0),
+                                    parser.value(Command::KeyFileOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -71,10 +71,10 @@ int Show::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    auto db = Database::unlockFromStdin(args.at(0),
-                                        parser.value(Command::KeyFileOption),
-                                        parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                        Utils::STDERR);
+    auto db = Utils::unlockDatabase(args.at(0),
+                                    parser.value(Command::KeyFileOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
     if (!db) {
         return EXIT_FAILURE;
     }

--- a/src/cli/Utils.h
+++ b/src/cli/Utils.h
@@ -19,6 +19,10 @@
 #define KEEPASSXC_UTILS_H
 
 #include "cli/TextStream.h"
+#include "core/Database.h"
+#include "keys/CompositeKey.h"
+#include "keys/FileKey.h"
+#include "keys/PasswordKey.h"
 #include <QtCore/qglobal.h>
 
 namespace Utils
@@ -31,6 +35,10 @@ namespace Utils
     void setStdinEcho(bool enable);
     QString getPassword(FILE* outputDescriptor = STDOUT);
     int clipText(const QString& text);
+    QSharedPointer<Database> unlockDatabase(const QString& databaseFilename,
+                                                   const QString& keyFilename = {},
+                                                   FILE* outputDescriptor = STDOUT,
+                                                   FILE* errorDescriptor = STDERR);
 
     namespace Test
     {

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -18,8 +18,6 @@
 
 #include "Database.h"
 
-#include "cli/Utils.h"
-#include "cli/TextStream.h"
 #include "core/Clock.h"
 #include "core/Group.h"
 #include "core/Merger.h"
@@ -699,45 +697,6 @@ void Database::startModifiedTimer()
 QSharedPointer<const CompositeKey> Database::key() const
 {
     return m_data.key;
-}
-
-QSharedPointer<Database> Database::unlockFromStdin(const QString& databaseFilename, const QString& keyFilename,
-                                                   FILE* outputDescriptor, FILE* errorDescriptor)
-{
-    auto compositeKey = QSharedPointer<CompositeKey>::create();
-    TextStream out(outputDescriptor);
-    TextStream err(errorDescriptor);
-
-    out << QObject::tr("Insert password to unlock %1: ").arg(databaseFilename) << flush;
-
-    QString line = Utils::getPassword(outputDescriptor);
-    auto passwordKey = QSharedPointer<PasswordKey>::create();
-    passwordKey->setPassword(line);
-    compositeKey->addKey(passwordKey);
-
-    if (!keyFilename.isEmpty()) {
-        auto fileKey = QSharedPointer<FileKey>::create();
-        QString errorMessage;
-        // LCOV_EXCL_START
-        if (!fileKey->load(keyFilename, &errorMessage)) {
-            err << QObject::tr("Failed to load key file %1: %2").arg(keyFilename, errorMessage) << endl;
-            return {};
-        }
-
-        if (fileKey->type() != FileKey::Hashed) {
-            err << QObject::tr("WARNING: You are using a legacy key file format which may become\n"
-                               "unsupported in the future.\n\n"
-                               "Please consider generating a new key file.")
-                << endl;
-        }
-        // LCOV_EXCL_STOP
-
-        compositeKey->addKey(fileKey);
-    }
-
-    auto db = QSharedPointer<Database>::create();
-    db->open(databaseFilename, compositeKey, nullptr, false);
-    return db;
 }
 
 QSharedPointer<Kdf> Database::kdf() const

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -118,8 +118,6 @@ public:
 
     static Database* databaseByUuid(const QUuid& uuid);
     static Database* databaseByFilePath(const QString& filePath);
-    static QSharedPointer<Database> unlockFromStdin(const QString& databaseFilename, const QString& keyFilename = {},
-                                                    FILE* outputDescriptor = stdout, FILE* errorDescriptor = stderr);
 
 public slots:
     void markAsModified();


### PR DESCRIPTION
Mainly because... It's a utility function only used by the CLI.
Also removes the need to import stuff from the cli module from `/core`.

@phoerious I think I remember you proposing that at some point. There you go :tada: 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
