### PR TITLE
Handle credentials requests from HTTP Basic Auths separately

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -251,7 +251,9 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
 
     const QString id = decrypted.value("id").toString();
     const QString submit = decrypted.value("submitUrl").toString();
-    const QJsonArray users = m_browserService.findMatchingEntries(id, url, submit, "", keyList);
+    const QString auth = decrypted.value("httpAuth").toString();
+    const bool httpAuth = auth.compare("true", Qt::CaseSensitive) == 0 ? true : false;
+    const QJsonArray users = m_browserService.findMatchingEntries(id, url, submit, "", keyList, httpAuth);
 
     if (users.isEmpty()) {
         return getErrorReply(action, ERROR_KEEPASS_NO_LOGINS_FOUND);

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -100,6 +100,7 @@ void BrowserOptionDialog::loadSettings()
 
     m_ui->alwaysAllowAccess->setChecked(settings->alwaysAllowAccess());
     m_ui->alwaysAllowUpdate->setChecked(settings->alwaysAllowUpdate());
+    m_ui->httpAuthPermission->setChecked(settings->httpAuthPermission());
     m_ui->searchInAllDatabases->setChecked(settings->searchInAllDatabases());
     m_ui->supportKphFields->setChecked(settings->supportKphFields());
     m_ui->supportBrowserProxy->setChecked(settings->supportBrowserProxy());
@@ -156,6 +157,7 @@ void BrowserOptionDialog::saveSettings()
     settings->setUpdateBinaryPath(m_ui->updateBinaryPath->isChecked());
     settings->setAlwaysAllowAccess(m_ui->alwaysAllowAccess->isChecked());
     settings->setAlwaysAllowUpdate(m_ui->alwaysAllowUpdate->isChecked());
+    settings->setHttpAuthPermission(m_ui->httpAuthPermission->isChecked());
     settings->setSearchInAllDatabases(m_ui->searchInAllDatabases->isChecked());
     settings->setSupportKphFields(m_ui->supportKphFields->isChecked());
 

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -268,6 +268,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="httpAuthPermission">
+         <property name="text">
+          <string extracomment="An extra HTTP Basic Auth setting">Do not ask permission for HTTP &amp;Basic Auth</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="searchInAllDatabases">
          <property name="toolTip">
           <string>Only the selected database has to be connected with a client.</string>

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -67,7 +67,8 @@ public slots:
                                    const QString& url,
                                    const QString& submitUrl,
                                    const QString& realm,
-                                   const StringPairList& keyList);
+                                   const StringPairList& keyList,
+                                   const bool httpAuth = false);
     QString storeKey(const QString& key);
     void updateEntry(const QString& id,
                      const QString& uuid,
@@ -101,7 +102,10 @@ private:
                         const QString& submitHost,
                         const QString& realm);
     QJsonObject prepareEntry(const Entry* entry);
-    Access checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm);
+    Access checkAccess(const Entry* entry,
+                       const QString& host,
+                       const QString& submitHost,
+                       const QString& realm);
     Group* findCreateAddEntryGroup(QSharedPointer<Database> selectedDb = {});
     int
     sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -121,6 +121,16 @@ void BrowserSettings::setAlwaysAllowUpdate(bool alwaysAllowUpdate)
     config()->set("Browser/AlwaysAllowUpdate", alwaysAllowUpdate);
 }
 
+bool BrowserSettings::httpAuthPermission()
+{
+    return config()->get("Browser/HttpAuthPermission", false).toBool();
+}
+
+void BrowserSettings::setHttpAuthPermission(bool httpAuthPermission)
+{
+    config()->set("Browser/HttpAuthPermission", httpAuthPermission);
+}
+
 bool BrowserSettings::searchInAllDatabases()
 {
     return config()->get("Browser/SearchInAllDatabases", false).toBool();

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -51,6 +51,8 @@ public:
     void setAlwaysAllowUpdate(bool alwaysAllowUpdate);
     bool searchInAllDatabases();
     void setSearchInAllDatabases(bool searchInAllDatabases);
+    bool httpAuthPermission();
+    void setHttpAuthPermission(bool httpAuthPermission);
     bool supportKphFields();
     void setSupportKphFields(bool supportKphFields);
 


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
Handle credentials requests from HTTP Basic Auths.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
KeePassXC will detect credential retrieval requests sent from HTTP Basic Auth dialogs. Requests from those dialogs will trigger permission popup every time even if the same URL has been previously denied.

Adds a global setting that can ignore asking HTTP Basic Auth credential permissions.

Related KeePassXC-Browser PR: https://github.com/keepassxreboot/keepassxc-browser/pull/343

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually in a local server with a page that has both HTTP Basic Auth and a basic username & password inputs.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
