### PR TITLE
Add gui dialog when merge makes no changes #2550

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -797,7 +797,11 @@ void DatabaseWidget::mergeDatabase(bool accepted)
         }
 
         Merger merger(srcDb.data(), m_db.data());
-        merger.merge();
+        bool databaseChanged = merger.merge();
+
+        if (!databaseChanged) {
+            showMessage(tr("Database was not modified by merge operation."), MessageWidget::Information);
+        }
     }
 
     switchToMainView();


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Add gui dialog that notifies the user when no changes were made after a merge operation. This keeps the gui consistent with the cli.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/44148378/50034600-8d9df100-ffb2-11e8-8bb8-ec39549ad83d.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual testing:

1. Create and save a database
2. Open the database using the gui
3. Duplicate the database file
4. Merge the duplicate into the current database
5. Modify the duplicate
6. Merge the modified duplicate into the current database

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ❎ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]** (in progress)
