### PR TITLE
We should output to stderr on EXIT_FAILURE

### DIFF
--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -83,7 +83,7 @@ int Add::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 2) {
-        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli add");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli add");
         return EXIT_FAILURE;
     }
 

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -42,7 +42,7 @@ Clip::~Clip()
 
 int Clip::execute(const QStringList& arguments)
 {
-    TextStream out(Utils::STDOUT);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
@@ -62,7 +62,7 @@ int Clip::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 2 && args.size() != 3) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli clip");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli clip");
         return EXIT_FAILURE;
     }
 
@@ -83,11 +83,11 @@ int Clip::clipEntry(QSharedPointer<Database> database,
                     bool clipTotp,
                     bool silent)
 {
-    TextStream err(Utils::STDERR);
+    TextStream errorTextStream(Utils::STDERR);
 
     int timeoutSeconds = 0;
     if (!timeout.isEmpty() && !timeout.toInt()) {
-        err << QObject::tr("Invalid timeout value %1.").arg(timeout) << endl;
+        errorTextStream << QObject::tr("Invalid timeout value %1.").arg(timeout) << endl;
         return EXIT_FAILURE;
     } else if (!timeout.isEmpty()) {
         timeoutSeconds = timeout.toInt();
@@ -96,14 +96,14 @@ int Clip::clipEntry(QSharedPointer<Database> database,
     TextStream outputTextStream(silent ? Utils::DEVNULL : Utils::STDOUT, QIODevice::WriteOnly);
     Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
-        err << QObject::tr("Entry %1 not found.").arg(entryPath) << endl;
+        errorTextStream << QObject::tr("Entry %1 not found.").arg(entryPath) << endl;
         return EXIT_FAILURE;
     }
 
     QString value;
     if (clipTotp) {
         if (!entry->hasTotp()) {
-            err << QObject::tr("Entry with path %1 has no TOTP set up.").arg(entryPath) << endl;
+            errorTextStream << QObject::tr("Entry with path %1 has no TOTP set up.").arg(entryPath) << endl;
             return EXIT_FAILURE;
         }
 

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -38,8 +38,8 @@ Diceware::~Diceware()
 
 int Diceware::execute(const QStringList& arguments)
 {
-    TextStream in(Utils::STDIN, QIODevice::ReadOnly);
-    TextStream out(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
@@ -58,7 +58,7 @@ int Diceware::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (!args.isEmpty()) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli diceware");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli diceware");
         return EXIT_FAILURE;
     }
 
@@ -78,12 +78,12 @@ int Diceware::execute(const QStringList& arguments)
     }
 
     if (!dicewareGenerator.isValid()) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli diceware");
+        outputTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli diceware");
         return EXIT_FAILURE;
     }
 
     QString password = dicewareGenerator.generatePassphrase();
-    out << password << endl;
+    outputTextStream << password << endl;
 
     return EXIT_SUCCESS;
 }

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -156,8 +156,8 @@ static void estimate(const char* pwd, bool advanced)
 
 int Estimate::execute(const QStringList& arguments)
 {
-    TextStream in(Utils::STDIN, QIODevice::ReadOnly);
-    TextStream out(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream inputTextStream(Utils::STDIN, QIODevice::ReadOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
@@ -171,7 +171,7 @@ int Estimate::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() > 1) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli estimate");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli estimate");
         return EXIT_FAILURE;
     }
 
@@ -179,7 +179,7 @@ int Estimate::execute(const QStringList& arguments)
     if (args.size() == 1) {
         password = args.at(0);
     } else {
-        password = in.readLine();
+        password = inputTextStream.readLine();
     }
 
     estimate(password.toLatin1(), parser.isSet(advancedOption));

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -38,8 +38,8 @@ Generate::~Generate()
 
 int Generate::execute(const QStringList& arguments)
 {
-    TextStream in(Utils::STDIN, QIODevice::ReadOnly);
-    TextStream out(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
@@ -84,7 +84,7 @@ int Generate::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (!args.isEmpty()) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli generate");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli generate");
         return EXIT_FAILURE;
     }
 
@@ -128,12 +128,12 @@ int Generate::execute(const QStringList& arguments)
     passwordGenerator.setExcludedChars(parser.value(exclude));
 
     if (!passwordGenerator.isValid()) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli generate");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli generate");
         return EXIT_FAILURE;
     }
 
     QString password = passwordGenerator.generatePassword();
-    out << password << endl;
+    outputTextStream << password << endl;
 
     return EXIT_SUCCESS;
 }

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -40,7 +40,7 @@ List::~List()
 
 int List::execute(const QStringList& arguments)
 {
-    TextStream out(Utils::STDOUT);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
@@ -58,7 +58,7 @@ int List::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 1 && args.size() != 2) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli ls");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli ls");
         return EXIT_FAILURE;
     }
 
@@ -80,20 +80,20 @@ int List::execute(const QStringList& arguments)
 
 int List::listGroup(Database* database, bool recursive, const QString& groupPath)
 {
-    TextStream out(Utils::STDOUT, QIODevice::WriteOnly);
-    TextStream err(Utils::STDERR, QIODevice::WriteOnly);
+    TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     if (groupPath.isEmpty()) {
-        out << database->rootGroup()->print(recursive) << flush;
+        outputTextStream << database->rootGroup()->print(recursive) << flush;
         return EXIT_SUCCESS;
     }
 
     Group* group = database->rootGroup()->findGroupByPath(groupPath);
     if (!group) {
-        err << QObject::tr("Cannot find group %1.").arg(groupPath) << endl;
+        errorTextStream << QObject::tr("Cannot find group %1.").arg(groupPath) << endl;
         return EXIT_FAILURE;
     }
 
-    out << group->print(recursive) << flush;
+    outputTextStream << group->print(recursive) << flush;
     return EXIT_SUCCESS;
 }

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -42,7 +42,7 @@ Locate::~Locate()
 
 int Locate::execute(const QStringList& arguments)
 {
-    TextStream out(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
@@ -55,7 +55,7 @@ int Locate::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 2) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli locate");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli locate");
         return EXIT_FAILURE;
     }
 
@@ -72,17 +72,17 @@ int Locate::execute(const QStringList& arguments)
 
 int Locate::locateEntry(Database* database, const QString& searchTerm)
 {
-    TextStream out(Utils::STDOUT, QIODevice::WriteOnly);
-    TextStream err(Utils::STDERR, QIODevice::WriteOnly);
+    TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QStringList results = database->rootGroup()->locate(searchTerm);
     if (results.isEmpty()) {
-        err << "No results for that search term." << endl;
+        errorTextStream << "No results for that search term." << endl;
         return EXIT_FAILURE;
     }
 
     for (const QString& result : asConst(results)) {
-        out << result << endl;
+        outputTextStream << result << endl;
     }
     return EXIT_SUCCESS;
 }

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -38,8 +38,8 @@ Merge::~Merge()
 
 int Merge::execute(const QStringList& arguments)
 {
-    TextStream out(Utils::STDOUT, QIODevice::WriteOnly);
-    TextStream err(Utils::STDERR, QIODevice::WriteOnly);
+    TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(description);
@@ -64,7 +64,7 @@ int Merge::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 2) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli merge");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli merge");
         return EXIT_FAILURE;
     }
 
@@ -83,7 +83,7 @@ int Merge::execute(const QStringList& arguments)
         db2 = QSharedPointer<Database>::create();
         QString errorMessage;
         if (!db2->open(args.at(1), db1->key(), &errorMessage, false)) {
-            err << QObject::tr("Error reading merge file:\n%1").arg(errorMessage);
+            errorTextStream << QObject::tr("Error reading merge file:\n%1").arg(errorMessage);
             return EXIT_FAILURE;
         }
     }
@@ -94,14 +94,14 @@ int Merge::execute(const QStringList& arguments)
     if (databaseChanged) {
         QString errorMessage;
         if (!db1->save(args.at(0), &errorMessage, true, false)) {
-            err << QObject::tr("Unable to save database to file : %1").arg(errorMessage) << endl;
+            errorTextStream << QObject::tr("Unable to save database to file : %1").arg(errorMessage) << endl;
             return EXIT_FAILURE;
         }
         if (!parser.isSet(Command::QuietOption)) {
-            out << "Successfully merged the database files." << endl;
+            outputTextStream << "Successfully merged the database files." << endl;
         }
     } else if (!parser.isSet(Command::QuietOption)) {
-        out << "Database was not modified by merge operation." << endl;
+        outputTextStream << "Database was not modified by merge operation." << endl;
     }
 
     return EXIT_SUCCESS;

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -44,7 +44,7 @@ Remove::~Remove()
 
 int Remove::execute(const QStringList& arguments)
 {
-    TextStream out(Utils::STDERR, QIODevice::WriteOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QCoreApplication::tr("main", "Remove an entry from the database."));
@@ -57,7 +57,7 @@ int Remove::execute(const QStringList& arguments)
 
     const QStringList args = parser.positionalArguments();
     if (args.size() != 2) {
-        out << parser.helpText().replace("keepassxc-cli", "keepassxc-cli rm");
+        errorTextStream << parser.helpText().replace("keepassxc-cli", "keepassxc-cli rm");
         return EXIT_FAILURE;
     }
 
@@ -74,12 +74,12 @@ int Remove::execute(const QStringList& arguments)
 
 int Remove::removeEntry(Database* database, const QString& databasePath, const QString& entryPath, bool quiet)
 {
-    TextStream out(quiet ? Utils::DEVNULL : Utils::STDOUT, QIODevice::WriteOnly);
-    TextStream err(Utils::STDERR, QIODevice::WriteOnly);
+    TextStream outputTextStream(quiet ? Utils::DEVNULL : Utils::STDOUT, QIODevice::WriteOnly);
+    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
     QPointer<Entry> entry = database->rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
-        err << QObject::tr("Entry %1 not found.").arg(entryPath) << endl;
+        errorTextStream << QObject::tr("Entry %1 not found.").arg(entryPath) << endl;
         return EXIT_FAILURE;
     }
 
@@ -95,14 +95,14 @@ int Remove::removeEntry(Database* database, const QString& databasePath, const Q
 
     QString errorMessage;
     if (!database->save(databasePath, &errorMessage, true, false)) {
-        err << QObject::tr("Unable to save database to file: %1").arg(errorMessage) << endl;
+        errorTextStream << QObject::tr("Unable to save database to file: %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }
 
     if (recycled) {
-        out << QObject::tr("Successfully recycled entry %1.").arg(entryTitle) << endl;
+        outputTextStream << QObject::tr("Successfully recycled entry %1.").arg(entryTitle) << endl;
     } else {
-        out << QObject::tr("Successfully deleted entry %1.").arg(entryTitle) << endl;
+        outputTextStream << QObject::tr("Successfully deleted entry %1.").arg(entryTitle) << endl;
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Making sure we use stderr to output the help
message when there is an invalid number of
arguments, or when there's any error related
to the arguments.

Also, some input text stream where no longer in used, probably dating back to when the password prompt was not centralised in `Utils`.

I also used the `outputTextStream` naming, since I believe it's used in majority by the CLI commands.


[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)




## Testing strategy
Not sure if it's worth adding tests for that. @phoerious what do you think?

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
