### PR TITLE
Prevent post-compilation Qt downgrades

### DIFF
--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -85,6 +85,20 @@ namespace Tools
         void clear();
         QByteArray content() const;
     };
+
+    inline int qtRuntimeVersion()
+    {
+        // Cache the result since the Qt version can't change during
+        // the execution, computing it once will be enough
+        const static int version = []() {
+            const auto sq = QString::fromLatin1(qVersion());
+            return (sq.section(QChar::fromLatin1('.'), 0, 0).toInt() << 16)
+                   + (sq.section(QChar::fromLatin1('.'), 1, 1).toInt() << 8)
+                   + (sq.section(QChar::fromLatin1('.'), 2, 2).toInt());
+        }();
+
+        return version;
+    }
 } // namespace Tools
 
 #endif // KEEPASSX_TOOLS_H

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -41,8 +41,10 @@ namespace Tools
     void sleep(int ms);
     void wait(int ms);
     QString uuidToHex(const QUuid& uuid);
-    QRegularExpression convertToRegex(const QString& string, bool useWildcards = false,
-                                      bool exactMatch = false, bool caseSensitive = false);
+    QRegularExpression convertToRegex(const QString& string,
+                                      bool useWildcards = false,
+                                      bool exactMatch = false,
+                                      bool caseSensitive = false);
 
     template <typename RandomAccessIterator, typename T>
     RandomAccessIterator binaryFind(RandomAccessIterator begin, RandomAccessIterator end, const T& value)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -33,6 +33,7 @@
 #include "core/FilePath.h"
 #include "core/InactivityTimer.h"
 #include "core/Metadata.h"
+#include "core/Tools.h"
 #include "gui/AboutDialog.h"
 #include "gui/DatabaseWidget.h"
 #include "gui/SearchWidget.h"
@@ -1017,11 +1018,14 @@ void MainWindow::toggleWindow()
         // see https://github.com/keepassxreboot/keepassxc/issues/271
         // and https://bugreports.qt.io/browse/QTBUG-58723
         // check for !isVisible(), because isNativeMenuBar() does not work with appmenu-qt5
-        if (!m_ui->menubar->isVisible()) {
-            QDBusMessage msg = QDBusMessage::createMethodCall("com.canonical.AppMenu.Registrar",
-                                                              "/com/canonical/AppMenu/Registrar",
-                                                              "com.canonical.AppMenu.Registrar",
-                                                              "RegisterWindow");
+        const static auto isDesktopSessionUnity = qgetenv("XDG_CURRENT_DESKTOP") == "Unity";
+
+        if (isDesktopSessionUnity && Tools::qtRuntimeVersion() < QT_VERSION_CHECK(5, 9, 0)
+            && !m_ui->menubar->isVisible()) {
+            QDBusMessage msg = QDBusMessage::createMethodCall(QStringLiteral("com.canonical.AppMenu.Registrar"),
+                                                              QStringLiteral("/com/canonical/AppMenu/Registrar"),
+                                                              QStringLiteral("com.canonical.AppMenu.Registrar"),
+                                                              QStringLiteral("RegisterWindow"));
             QList<QVariant> args;
             args << QVariant::fromValue(static_cast<uint32_t>(winId()))
                  << QVariant::fromValue(QDBusObjectPath("/MenuBar/1"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,8 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 
 int main(int argc, char** argv)
 {
+    QT_REQUIRE_VERSION(argc, argv, QT_VERSION_STR)
+
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif


### PR DESCRIPTION
Require the same version of Qt the app was compiled against (or higher).

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Since the Qt framework is dynamically linked to the app, it may happen that the app is compiled against a version of Qt higher than the one it'll be running with.
Snippets of code that are added/selected _at compile time_, such as this:
```cpp
#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
#endif
```
will break if the app is compiled against, say, Qt 5.11 and then run in an environment with Qt 5.2 (which is the minimum supported version according to the build instructions).

This patch stops the execution of the app right away if a situation like this occurs.

## Testing strategy
I simply ran all existing tests.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
