### PR TITLE
Fix macOS makefiles for cli and proxy

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -83,6 +83,13 @@ if(APPLE AND WITH_APP_BUNDLE)
                                 "@executable_path/../Frameworks/libykpers-1.1.dylib"
                        keepassxc-cli
                        COMMENT "Changing linking of keepassxc-cli")
+
+    # Copy app to staging directory for pre-install testing
+    set(CLI_APP_DIR "${CMAKE_BINARY_DIR}/src/${CLI_INSTALL_DIR}")
+    add_custom_command(TARGET keepassxc-cli
+                       POST_BUILD
+                       COMMAND ${CMAKE_COMMAND} -E copy keepassxc-cli ${CLI_APP_DIR}/keepassxc-cli
+                       COMMENT "Copying keepassxc-cli inside the application")
 endif()
 
 if(APPLE OR UNIX)

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -45,6 +45,13 @@ if(WITH_XC_BROWSER)
                                     "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork"
                            keepassxc-proxy
                            COMMENT "Changing linking of keepassxc-proxy")
+
+        # Copy app to staging directory for pre-install testing
+        set(PROXY_APP_DIR "${CMAKE_BINARY_DIR}/src/${PROXY_INSTALL_DIR}")
+        add_custom_command(TARGET keepassxc-proxy
+                           POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy keepassxc-proxy ${PROXY_APP_DIR}/keepassxc-proxy
+                           COMMENT "Copying keepassxc-proxy inside the application")
     endif()
     if(MINGW)
       target_link_libraries(keepassxc-proxy Wtsapi32.lib Ws2_32.lib)


### PR DESCRIPTION
Fixes necessary makefiles for keepassxc-cli and keepassxc-proxy. PR https://github.com/keepassxreboot/keepassxc/pull/2165 broke the behaviour and the files were not copied properly under `src/KeePassXC.app/Content/MacOS/` during the build. These files should be copied to the temporary .app for debugging purposes, so it is possible to inspect the application before final `make package`.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
PR https://github.com/keepassxreboot/keepassxc/pull/2165 broke this behaviour.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
