### PR TITLE
Fix native hiding of macOS windows

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -55,6 +55,7 @@ BrowserService::BrowserService(DatabaseTabWidget* parent)
     , m_dialogActive(false)
     , m_bringToFrontRequested(false)
     , m_wasMinimized(false)
+    , m_wasHidden(false)
     , m_keepassBrowserUUID(QUuid::fromRfc4122(QByteArray::fromHex("de887cc3036343b8974b5911b8816224")))
 {
     // Don't connect the signals when used from DatabaseSettingsWidgetBrowser (parent is nullptr)
@@ -96,7 +97,6 @@ bool BrowserService::openDatabase(bool triggerUnlock)
 
     if (triggerUnlock) {
         m_bringToFrontRequested = true;
-        m_wasMinimized = getMainWindow()->isMinimized();
         raiseWindow(true);
     }
 
@@ -933,7 +933,11 @@ void BrowserService::hideWindow() const
         getMainWindow()->showMinimized();
     } else {
 #ifdef Q_OS_MACOS
-        macUtils()->raiseLastActiveWindow();
+        if (m_wasHidden) {
+            macUtils()->hideOwnWindow();
+        } else {
+            macUtils()->raiseLastActiveWindow();
+        }
 #else
         getMainWindow()->lower();
 #endif
@@ -944,6 +948,7 @@ void BrowserService::raiseWindow(const bool force)
 {
     m_wasMinimized = getMainWindow()->isMinimized();
 #ifdef Q_OS_MACOS
+    m_wasHidden = macUtils()->isHidden();
     macUtils()->raiseOwnWindow();
     Tools::wait(500);
 #else

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -125,6 +125,7 @@ private:
     bool m_dialogActive;
     bool m_bringToFrontRequested;
     bool m_wasMinimized;
+    bool m_wasHidden;
     QUuid m_keepassBrowserUUID;
 };
 

--- a/src/gui/macutils/AppKit.h
+++ b/src/gui/macutils/AppKit.h
@@ -33,6 +33,8 @@ public:
     pid_t activeProcessId();
     pid_t ownProcessId();
     bool activateProcess(pid_t pid);
+    bool hideProcess(pid_t pid);
+    bool isHidden(pid_t pid);
 
 private:
     void *self;

--- a/src/gui/macutils/AppKitImpl.h
+++ b/src/gui/macutils/AppKitImpl.h
@@ -28,5 +28,7 @@
 - (pid_t) activeProcessId;
 - (pid_t) ownProcessId;
 - (bool) activateProcess:(pid_t) pid;
+- (bool) hideProcess:(pid_t) pid;
+- (bool) isHidden:(pid_t) pid;
 
 @end

--- a/src/gui/macutils/AppKitImpl.mm
+++ b/src/gui/macutils/AppKitImpl.mm
@@ -72,8 +72,25 @@ AppKit::~AppKit()
 - (bool) activateProcess:(pid_t) pid
 {
     NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
-
     return [app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+}
+
+//
+// Hide application by process id
+//
+- (bool) hideProcess:(pid_t) pid
+{
+    NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+    return [app hide];
+}
+
+//
+// Get application hidden state by process id
+//
+- (bool) isHidden:(pid_t) pid
+{
+    NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+    return [app isHidden];
 }
 
 //
@@ -98,6 +115,16 @@ pid_t AppKit::ownProcessId()
 bool AppKit::activateProcess(pid_t pid)
 {
     return [static_cast<id>(self) activateProcess:pid];
+}
+
+bool AppKit::hideProcess(pid_t pid)
+{
+    return [static_cast<id>(self) hideProcess:pid];
+}
+
+bool AppKit::isHidden(pid_t pid)
+{
+    return [static_cast<id>(self) isHidden:pid];
 }
 
 @end

--- a/src/gui/macutils/MacUtils.cpp
+++ b/src/gui/macutils/MacUtils.cpp
@@ -60,3 +60,13 @@ bool MacUtils::raiseLastActiveWindow()
 {
     return m_appkit->activateProcess(m_appkit->lastActiveProcessId());
 }
+
+bool MacUtils::hideOwnWindow()
+{
+    return m_appkit->hideProcess(m_appkit->ownProcessId());
+}
+
+bool MacUtils::isHidden()
+{
+    return m_appkit->isHidden(m_appkit->ownProcessId());
+}

--- a/src/gui/macutils/MacUtils.h
+++ b/src/gui/macutils/MacUtils.h
@@ -35,6 +35,8 @@ public:
     bool raiseWindow(WId pid);
     bool raiseLastActiveWindow();
     bool raiseOwnWindow();
+    bool hideOwnWindow();
+    bool isHidden();
 
 private:
     explicit MacUtils(QObject* parent = nullptr);


### PR DESCRIPTION
Extends the https://github.com/keepassxreboot/keepassxc/pull/1904. Using `QWidget::isHidden()` does not return a correct value when KeePassXC is hidden (via Cmd+H) but not minimized. Instead, a native method is used to retrieve this state and to hide the window back to the previous state.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes https://github.com/keepassxreboot/keepassxc/issues/2579.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
