### PR TITLE
Edit entry widget: password generator: fix flicker

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -994,7 +994,9 @@ bool EditEntryWidget::hasBeenModified() const
 
 void EditEntryWidget::togglePasswordGeneratorButton(bool checked)
 {
-    m_mainUi->passwordGenerator->regeneratePassword();
+    if (checked) {
+        m_mainUi->passwordGenerator->regeneratePassword();
+    }
     m_mainUi->passwordGenerator->setVisible(checked);
 }
 


### PR DESCRIPTION
When using the password generator inside the Edit Entry screen and clicking the 'Accept' button, a new password would briefly be shown before the password generator was hidden (even though the original generated password would be applied to the entry).

This issue was only visible when passwords were shown in plain text.

Note that this is purely a cosmetic issue.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

See above.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Tested manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
  - More precisely: my code does not break any tests that aren't already broken in the `develop` branch. For me, the `testcli`, `testgui` and `testguipixmaps` tests are failing on `develop` (I'm on Linux and using `-DWITH_XC_AUTOTYPE=OFF -DWITH_GUI_TESTS=ON -DWITH_ASAN=ON`).
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
