### PR TITLE
Give visual feedback while starting

### DIFF
--- a/share/linux/org.keepassxc.KeePassXC.desktop
+++ b/share/linux/org.keepassxc.KeePassXC.desktop
@@ -10,6 +10,7 @@ Exec=keepassxc %f
 TryExec=keepassxc
 Icon=keepassxc
 StartupWMClass=keepassxc
+StartupNotify=true
 Terminal=false
 Type=Application
 Version=1.0


### PR DESCRIPTION
I'm working for Tails (https://tails.boum.org/), a privacy-oriented
Linux distribution which includes KeePassX but future versions will include KeePassXC.

While doing usability testing for Tails or getting feedback from
users, we realized how important it was to give feedback very quickly
when the user chooses to open an application. The usual mechanism for
that in GNOME is to change the mouse cursor into a spinner as soon as
the user chooses to open the application from a menu or from the
activities overview.

For example, we've seen time after time people opening the same
application several times when its launcher lacked this feedback.

KeePassXC doesn't provide this feedback but I think it's easy to fix.

Even when an application usually starts fast, there might be some circumstances when it be a bit slower to start (live operating systems like Tails is one of them but it might happen on any busy system).

The Freedesktop specification for such feedback is to uses a combination of `StartupNotify` and StartupWMClass.

See https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)