### PR TITLE
Allow for KDF seeds between 8 and 32 bytes

### DIFF
--- a/src/crypto/kdf/Kdf.cpp
+++ b/src/crypto/kdf/Kdf.cpp
@@ -24,7 +24,7 @@
 
 Kdf::Kdf(const QUuid& uuid)
     : m_rounds(KDF_DEFAULT_ROUNDS)
-    , m_seed(QByteArray(KDF_DEFAULT_SEED_SIZE, 0))
+    , m_seed(QByteArray(KDF_MAX_SEED_SIZE, 0))
     , m_uuid(uuid)
 {
 }
@@ -56,7 +56,7 @@ bool Kdf::setRounds(int rounds)
 
 bool Kdf::setSeed(const QByteArray& seed)
 {
-    if (seed.size() != m_seed.size()) {
+    if (seed.size() < KDF_MIN_SEED_SIZE || seed.size() > KDF_MAX_SEED_SIZE) {
         return false;
     }
 

--- a/src/crypto/kdf/Kdf.h
+++ b/src/crypto/kdf/Kdf.h
@@ -21,7 +21,8 @@
 #include <QUuid>
 #include <QVariant>
 
-#define KDF_DEFAULT_SEED_SIZE 32
+#define KDF_MIN_SEED_SIZE 8
+#define KDF_MAX_SEED_SIZE 32
 #define KDF_DEFAULT_ROUNDS 1000000ull
 
 class Kdf


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Provides support for undocumented feature in KDBX for seed sizes from 8 bytes to 32 bytes. Retains byte size on subsequent save. Fixes #2581.

It might be appropriate to issue a warning to upgrade the seed byte size to 32 bytes if the user wants to.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested with supplied Strongbox database.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
