### PR TITLE
Performance fixes

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -482,7 +482,8 @@ void BrowserService::updateEntry(const QString& id,
     }
 }
 
-QList<Entry*> BrowserService::searchEntries(const QSharedPointer<Database>& db, const QString& hostname, const QString& url)
+QList<Entry*>
+BrowserService::searchEntries(const QSharedPointer<Database>& db, const QString& hostname, const QString& url)
 {
     QList<Entry*> entries;
     auto* rootGroup = db->rootGroup();

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -348,7 +348,7 @@ void BrowserService::addEntry(const QString& id,
                               const QString& realm,
                               const QString& group,
                               const QString& groupUuid,
-                              QSharedPointer<Database> selectedDb)
+                              const QSharedPointer<Database>& selectedDb)
 {
     if (thread() != QThread::currentThread()) {
         QMetaObject::invokeMethod(this,
@@ -482,7 +482,7 @@ void BrowserService::updateEntry(const QString& id,
     }
 }
 
-QList<Entry*> BrowserService::searchEntries(QSharedPointer<Database> db, const QString& hostname, const QString& url)
+QList<Entry*> BrowserService::searchEntries(const QSharedPointer<Database>& db, const QString& hostname, const QString& url)
 {
     QList<Entry*> entries;
     auto* rootGroup = db->rootGroup();
@@ -549,7 +549,7 @@ QList<Entry*> BrowserService::searchEntries(const QString& url, const StringPair
     return entries;
 }
 
-void BrowserService::convertAttributesToCustomData(QSharedPointer<Database> currentDb)
+void BrowserService::convertAttributesToCustomData(const QSharedPointer<Database>& currentDb)
 {
     auto db = currentDb ? currentDb : getDatabase();
     if (!db) {
@@ -770,7 +770,7 @@ BrowserService::checkAccess(const Entry* entry, const QString& host, const QStri
     return Unknown;
 }
 
-Group* BrowserService::findCreateAddEntryGroup(QSharedPointer<Database> selectedDb)
+Group* BrowserService::findCreateAddEntryGroup(const QSharedPointer<Database>& selectedDb)
 {
     auto db = selectedDb ? selectedDb : getDatabase();
     if (!db) {
@@ -955,7 +955,7 @@ bool BrowserService::moveSettingsToCustomData(Entry* entry, const QString& name)
     return false;
 }
 
-int BrowserService::moveKeysToCustomData(Entry* entry, QSharedPointer<Database> db) const
+int BrowserService::moveKeysToCustomData(Entry* entry, const QSharedPointer<Database>& db) const
 {
     int keyCounter = 0;
     for (const auto& key : entry->attributes()->keys()) {

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -54,10 +54,10 @@ public:
                   const QString& realm,
                   const QString& group,
                   const QString& groupUuid,
-                  QSharedPointer<Database> selectedDb = {});
-    QList<Entry*> searchEntries(QSharedPointer<Database> db, const QString& hostname, const QString& url);
+                  const QSharedPointer<Database>& selectedDb = {});
+    QList<Entry*> searchEntries(const QSharedPointer<Database>& db, const QString& hostname, const QString& url);
     QList<Entry*> searchEntries(const QString& url, const StringPairList& keyList);
-    void convertAttributesToCustomData(QSharedPointer<Database> currentDb = {});
+    void convertAttributesToCustomData(const QSharedPointer<Database>& currentDb = {});
 
 public:
     static const char KEEPASSXCBROWSER_NAME[];
@@ -106,7 +106,7 @@ private:
                         const QString& realm);
     QJsonObject prepareEntry(const Entry* entry);
     Access checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm);
-    Group* findCreateAddEntryGroup(QSharedPointer<Database> selectedDb = {});
+    Group* findCreateAddEntryGroup(const QSharedPointer<Database>& selectedDb = {});
     int
     sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
     bool matchUrlScheme(const QString& url);
@@ -116,7 +116,7 @@ private:
     QSharedPointer<Database> selectedDatabase();
     QJsonArray addChildrenToGroup(Group* group);
     bool moveSettingsToCustomData(Entry* entry, const QString& name) const;
-    int moveKeysToCustomData(Entry* entry, QSharedPointer<Database> db) const;
+    int moveKeysToCustomData(Entry* entry, const QSharedPointer<Database>& db) const;
     bool checkLegacySettings();
     void hideWindow() const;
     void raiseWindow(const bool force = false);

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -77,7 +77,7 @@ int Clip::execute(const QStringList& arguments)
     return clipEntry(db, args.at(1), args.value(2), parser.isSet(totp), parser.isSet(Command::QuietOption));
 }
 
-int Clip::clipEntry(QSharedPointer<Database> database,
+int Clip::clipEntry(const QSharedPointer<Database>& database,
                     const QString& entryPath,
                     const QString& timeout,
                     bool clipTotp,

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -26,7 +26,7 @@ public:
     Clip();
     ~Clip();
     int execute(const QStringList& arguments) override;
-    int clipEntry(QSharedPointer<Database> database,
+    int clipEntry(const QSharedPointer<Database>& database,
                   const QString& entryPath,
                   const QString& timeout,
                   bool clipTotp,

--- a/src/cli/Create.cpp
+++ b/src/cli/Create.cpp
@@ -74,7 +74,7 @@ int Create::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    QString databaseFilename = args.at(0);
+    const QString& databaseFilename = args.at(0);
     if (QFileInfo::exists(databaseFilename)) {
         err << QObject::tr("File %1 already exists.").arg(databaseFilename) << endl;
         return EXIT_FAILURE;
@@ -150,7 +150,7 @@ QSharedPointer<PasswordKey> Create::getPasswordFromStdin()
  * @param fileKey Resulting fileKey
  * @return true if the key file was loaded succesfully
  */
-bool Create::loadFileKey(QString path, QSharedPointer<FileKey>& fileKey)
+bool Create::loadFileKey(const QString& path, QSharedPointer<FileKey>& fileKey)
 {
     QTextStream err(Utils::STDERR, QIODevice::WriteOnly);
 

--- a/src/cli/Create.h
+++ b/src/cli/Create.h
@@ -33,7 +33,7 @@ public:
 private:
     QSharedPointer<PasswordKey> getPasswordFromStdin();
     QSharedPointer<FileKey> getFileKeyFromStdin();
-    bool loadFileKey(QString path, QSharedPointer<FileKey>& fileKey);
+    bool loadFileKey(const QString& path, QSharedPointer<FileKey>& fileKey);
 };
 
 #endif // KEEPASSXC_CREATE_H

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -135,13 +135,13 @@ namespace Utils
 
         auto db = QSharedPointer<Database>::create();
         QString error;
-    if (db->open(databaseFilename, compositeKey, &error, false)) {
-        return db;
-    }else {
-        err << error << endl;
-        return {};
+        if (db->open(databaseFilename, compositeKey, &error, false)) {
+            return db;
+        } else {
+            err << error << endl;
+            return {};
+        }
     }
-}
 
     /**
      * Read a user password from STDIN or return a password previously

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -91,7 +91,8 @@ void Config::sync()
 
 void Config::upgrade()
 {
-    for (const auto& setting : deprecationMap.keys()) {
+    const auto keys = deprecationMap.keys();
+    for (const auto& setting : keys) {
         if (m_settings->contains(setting)) {
             if (!deprecationMap.value(setting).isEmpty()) {
                 // Add entry with new name and old entry's value

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -32,13 +32,13 @@
  */
 static const QMap<QString, QString> deprecationMap = {
     // >2.3.4
-    {"security/hidepassworddetails", "security/HidePasswordPreviewPanel"},
+    {QStringLiteral("security/hidepassworddetails"), QStringLiteral("security/HidePasswordPreviewPanel")},
     // >2.3.4
-    {"GUI/HideDetailsView", "GUI/HidePreviewPanel"},
+    {QStringLiteral("GUI/HideDetailsView"), QStringLiteral("GUI/HidePreviewPanel")},
     // >2.3.4
-    {"GUI/DetailSplitterState", "GUI/PreviewSplitterState"},
+    {QStringLiteral("GUI/DetailSplitterState"), QStringLiteral("GUI/PreviewSplitterState")},
     // >2.3.4
-    {"security/IconDownloadFallbackToGoogle", "security/IconDownloadFallback"},
+    {QStringLiteral("security/IconDownloadFallbackToGoogle"), QStringLiteral("security/IconDownloadFallback")},
 };
 
 Config* Config::m_instance(nullptr);

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -17,6 +17,8 @@
 
 #include "CustomData.h"
 
+#include "core/Global.h"
+
 CustomData::CustomData(QObject* parent)
     : QObject(parent)
 {
@@ -44,7 +46,7 @@ bool CustomData::contains(const QString& key) const
 
 bool CustomData::containsValue(const QString& value) const
 {
-    return m_data.values().contains(value);
+    return asConst(m_data).values().contains(value);
 }
 
 void CustomData::set(const QString& key, const QString& value)

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -17,6 +17,8 @@
 
 #include "EntryAttachments.h"
 
+#include "core/Global.h"
+
 #include <QSet>
 #include <QStringList>
 
@@ -37,7 +39,7 @@ bool EntryAttachments::hasKey(const QString& key) const
 
 QSet<QByteArray> EntryAttachments::values() const
 {
-    return m_attachments.values().toSet();
+    return asConst(m_attachments).values().toSet();
 }
 
 QByteArray EntryAttachments::value(const QString& key) const

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -18,6 +18,8 @@
 
 #include "EntryAttributes.h"
 
+#include "core/Global.h"
+
 const QString EntryAttributes::TitleKey = "Title";
 const QString EntryAttributes::UserNameKey = "UserName";
 const QString EntryAttributes::PasswordKey = "Password";
@@ -72,7 +74,7 @@ bool EntryAttributes::contains(const QString& key) const
 
 bool EntryAttributes::containsValue(const QString& value) const
 {
-    return m_attributes.values().contains(value);
+    return asConst(m_attributes).values().contains(value);
 }
 
 bool EntryAttributes::isProtected(const QString& key) const

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -616,7 +616,8 @@ Merger::ChangeList Merger::mergeMetadata(const MergeContext& context)
     auto* sourceMetadata = context.m_sourceDb->metadata();
     auto* targetMetadata = context.m_targetDb->metadata();
 
-    for (QUuid customIconId : sourceMetadata->customIcons().keys()) {
+    const auto keys = sourceMetadata->customIcons().keys();
+    for (QUuid customIconId : keys) {
         QImage customIcon = sourceMetadata->customIcon(customIconId);
         if (!targetMetadata->containsCustomIcon(customIconId)) {
             targetMetadata->addCustomIcon(customIconId, customIcon);

--- a/src/format/CsvExporter.cpp
+++ b/src/format/CsvExporter.cpp
@@ -23,7 +23,7 @@
 #include "core/Database.h"
 #include "core/Group.h"
 
-bool CsvExporter::exportDatabase(const QString& filename, QSharedPointer<const Database> db)
+bool CsvExporter::exportDatabase(const QString& filename, const QSharedPointer<const Database>& db)
 {
     QFile file(filename);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
@@ -33,7 +33,7 @@ bool CsvExporter::exportDatabase(const QString& filename, QSharedPointer<const D
     return exportDatabase(&file, db);
 }
 
-bool CsvExporter::exportDatabase(QIODevice* device, QSharedPointer<const Database> db)
+bool CsvExporter::exportDatabase(QIODevice* device, const QSharedPointer<const Database>& db)
 {
     QString header;
     addColumn(header, "Group");

--- a/src/format/CsvExporter.h
+++ b/src/format/CsvExporter.h
@@ -29,8 +29,8 @@ class QIODevice;
 class CsvExporter
 {
 public:
-    bool exportDatabase(const QString& filename, QSharedPointer<const Database> db);
-    bool exportDatabase(QIODevice* device, QSharedPointer<const Database> db);
+    bool exportDatabase(const QString& filename, const QSharedPointer<const Database>& db);
+    bool exportDatabase(QIODevice* device, const QSharedPointer<const Database>& db);
     QString errorString() const;
 
 private:

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -124,8 +124,8 @@ void KdbxXmlReader::readDatabase(QIODevice* device, Database* db, KeePass2Random
         qWarning("KdbxXmlReader::readDatabase: found %d invalid entry reference(s)", m_tmpParent->children().size());
     }
 
-    const QSet<QString> poolKeys = m_binaryPool.keys().toSet();
-    const QSet<QString> entryKeys = m_binaryMap.keys().toSet();
+    const QSet<QString> poolKeys = asConst(m_binaryPool).keys().toSet();
+    const QSet<QString> entryKeys = asConst(m_binaryMap).keys().toSet();
     const QSet<QString> unmappedKeys = entryKeys - poolKeys;
     const QSet<QString> unusedKeys = poolKeys - entryKeys;
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1532,7 +1532,7 @@ bool DatabaseWidget::saveAs()
 {
     while (true) {
         QString oldFilePath = m_db->filePath();
-        if (!QFileInfo(oldFilePath).exists()) {
+        if (!QFileInfo::exists(oldFilePath)) {
             oldFilePath = QDir::toNativeSeparators(config()->get("LastDir", QDir::homePath()).toString() + "/"
                                                    + tr("Passwords").append(".kdbx"));
         }

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -229,7 +229,6 @@ void EditWidgetIcons::fetchFinished()
     QImage image;
     bool fallbackEnabled = config()->get("security/IconDownloadFallback", false).toBool();
     bool error = (m_reply->error() != QNetworkReply::NoError);
-    QUrl url = m_reply->url();
     QUrl redirectTarget = getRedirectTarget(m_reply);
 
     m_reply->deleteLater();

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -113,7 +113,7 @@ void EditWidgetIcons::reset()
 }
 
 void EditWidgetIcons::load(const QUuid& currentUuid,
-                           QSharedPointer<Database> database,
+                           const QSharedPointer<Database>& database,
                            const IconStruct& iconStruct,
                            const QString& url)
 {

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -60,7 +60,7 @@ public:
     IconStruct state();
     void reset();
     void load(const QUuid& currentUuid,
-              QSharedPointer<Database> database,
+              const QSharedPointer<Database>& database,
               const IconStruct& iconStruct,
               const QString& url = "");
 

--- a/src/gui/MessageBox.cpp
+++ b/src/gui/MessageBox.cpp
@@ -20,8 +20,8 @@
 
 MessageBox::Button MessageBox::m_nextAnswer(MessageBox::NoButton);
 
-QMap<QAbstractButton*, MessageBox::Button> MessageBox::m_addedButtonLookup =
-    QMap<QAbstractButton*, MessageBox::Button>();
+QHash<QAbstractButton*, MessageBox::Button> MessageBox::m_addedButtonLookup =
+    QHash<QAbstractButton*, MessageBox::Button>();
 
 QMap<MessageBox::Button, std::pair<QString, QMessageBox::ButtonRole>> MessageBox::m_buttonDefs =
     QMap<MessageBox::Button, std::pair<QString, QMessageBox::ButtonRole>>();

--- a/src/gui/MessageBox.h
+++ b/src/gui/MessageBox.h
@@ -19,6 +19,7 @@
 #ifndef KEEPASSX_MESSAGEBOX_H
 #define KEEPASSX_MESSAGEBOX_H
 
+#include <QHash>
 #include <QMap>
 #include <QMessageBox>
 #include <QPushButton>
@@ -102,7 +103,7 @@ public:
 
 private:
     static Button m_nextAnswer;
-    static QMap<QAbstractButton*, Button> m_addedButtonLookup;
+    static QHash<QAbstractButton*, Button> m_addedButtonLookup;
     static QMap<Button, std::pair<QString, QMessageBox::ButtonRole>> m_buttonDefs;
 
     static Button messageBox(QWidget* parent,

--- a/src/gui/dbsettings/DatabaseSettingsDialog.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.cpp
@@ -105,7 +105,7 @@ DatabaseSettingsDialog::~DatabaseSettingsDialog()
 {
 }
 
-void DatabaseSettingsDialog::load(QSharedPointer<Database> db)
+void DatabaseSettingsDialog::load(const QSharedPointer<Database>& db)
 {
     m_ui->categoryList->setCurrentCategory(0);
     m_generalWidget->load(db);

--- a/src/gui/dbsettings/DatabaseSettingsDialog.h
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.h
@@ -61,7 +61,7 @@ public:
     ~DatabaseSettingsDialog() override;
     Q_DISABLE_COPY(DatabaseSettingsDialog);
 
-    void load(QSharedPointer<Database> db);
+    void load(const QSharedPointer<Database>& db);
     void addSettingsPage(IDatabaseSettingsPage* page);
     void showMasterKeySettings();
 

--- a/src/gui/dbsettings/DatabaseSettingsWidget.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidget.cpp
@@ -18,6 +18,8 @@
 #include "DatabaseSettingsWidget.h"
 #include "core/Database.h"
 
+#include <utility>
+
 #include <QTimer>
 #include <QWidget>
 
@@ -38,6 +40,6 @@ DatabaseSettingsWidget::~DatabaseSettingsWidget()
  */
 void DatabaseSettingsWidget::load(QSharedPointer<Database> db)
 {
-    m_db = db;
+    m_db = std::move(db);
     initialize();
 }

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -91,7 +91,7 @@ EditGroupWidget::~EditGroupWidget()
 {
 }
 
-void EditGroupWidget::loadGroup(Group* group, bool create, QSharedPointer<Database> database)
+void EditGroupWidget::loadGroup(Group* group, bool create, const QSharedPointer<Database>& database)
 {
     m_group = group;
     m_db = database;

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -55,7 +55,7 @@ public:
     explicit EditGroupWidget(QWidget* parent = nullptr);
     ~EditGroupWidget();
 
-    void loadGroup(Group* group, bool create, QSharedPointer<Database> database);
+    void loadGroup(Group* group, bool create, const QSharedPointer<Database>& database);
     void clear();
 
     void addEditPage(IEditGroupPage* page);

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -50,7 +50,7 @@ GroupView::GroupView(Database* db, QWidget* parent)
     setDefaultDropAction(Qt::MoveAction);
 }
 
-void GroupView::changeDatabase(QSharedPointer<Database> newDb)
+void GroupView::changeDatabase(const QSharedPointer<Database>& newDb)
 {
     m_model->changeDatabase(newDb.data());
 }

--- a/src/gui/group/GroupView.h
+++ b/src/gui/group/GroupView.h
@@ -30,7 +30,7 @@ class GroupView : public QTreeView
 
 public:
     explicit GroupView(Database* db, QWidget* parent = nullptr);
-    void changeDatabase(QSharedPointer<Database> newDb);
+    void changeDatabase(const QSharedPointer<Database>& newDb);
     void setModel(QAbstractItemModel* model) override;
     Group* currentGroup();
     void setCurrentGroup(Group* group);

--- a/src/gui/wizard/NewDatabaseWizardPage.h
+++ b/src/gui/wizard/NewDatabaseWizardPage.h
@@ -38,7 +38,7 @@ class NewDatabaseWizardPage : public QWizardPage
 
 public:
     explicit NewDatabaseWizardPage(QWidget* parent = nullptr);
-    Q_DISABLE_COPY(NewDatabaseWizardPage);
+    Q_DISABLE_COPY(NewDatabaseWizardPage)
     ~NewDatabaseWizardPage() override;
 
     void setPageWidget(DatabaseSettingsWidget* page);


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Just a few more performance improvements spotted thanks to Clang-Tidy and Clazy.

- **Use `QFileInfo`'s exists() static method**
[According to the docs](https://doc.qt.io/qt-5/qfileinfo.html#exists-1), this static method is faster than the instance method of the same class. I simply replaced it accordingly.

- **Replace `QMap` with `QHash` when the key is a pointer**:
In a map where the key is a pointer, hash-based lookups are faster than tree-based lookups, as you only have to compute the hash of a number which is an O(1) operation, as opposed to the O(log(n)) complexity of the Red-Black tree of `QMap`s.

- **Avoid copying `QSharedPointer`s when not needed**
Many `QSharedPointer`s were passed by value even though they did not modify the object pointed to in any way. They have been changed to `const QSharedPointer<*>&`. Also a few copies were avoided thanks to `std::move()`.
Actually I took a while to inspect the code a little more carefully and to me it feels like they can all be `QScopedPonter`s or `std::unique_ptr`s passed by const reference (i.e. without taking ownership) but I didn't want to change that because I thought I may be missing something so I'm just bringing this up for now waiting for your feedback.

- **Avoid creation of temporary containers**
I know we've discussed this already but I couldn't figure out why the static analyzer kept complaining about the creation of temporary containers. It turns out that Qt containers may detach when used as rvalues in a loop. [These code examples](https://doc.qt.io/qt-5/qtglobal.html#qAsConst) show that containers must be used as a const lvalue to make sure they won't detach. Basically, by simply storing them in a const variable did the trick in the case of rvalues, using `asConst` in `core/Global.h` worked for lvalues; now the static analyzer no longer shows the warnings about temporary containers.
To prove that, I set up Qt in a local instance of [Compiler Explorer](https://github.com/mattgodbolt/compiler-explorer) and gave it this test code:
```cpp
#include <QtGlobal>
#include <QMap>
#include <QString>

static const QMap<QString, QString> deprecationMap = {
    // >2.3.4
    {"security/hidepassworddetails", "security/HidePasswordPreviewPanel"},
    // >2.3.4
    {"GUI/HideDetailsView", "GUI/HidePreviewPanel"},
    // >2.3.4
    {"GUI/DetailSplitterState", "GUI/PreviewSplitterState"},
    // >2.3.4
    {"security/IconDownloadFallbackToGoogle", "security/IconDownloadFallback"},
};

void upgrade()
{
    const auto keys = deprecationMap.keys(); // <--
    for (const auto& setting : keys) {
        qWarning("%s\n", setting);
    }
}
```
The Assembly produced by this was 50 lines shorter than the same code using `deprecationMap.keys()` in the loop directly. (compiled with `gcc -O3`)

- **Wrap static literal strings with `QStringLiteral`**
The `QString`s in the deprecation map were implicitly constructed with the `const char*` constructor which creates a dynamically-allocated string. The map, however, is used in read-only mode and the values are all known at compile time so they can be allocated statically with `QStringLiteral`.

## Testing strategy
I ran all existing tests and they all passed.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
