### PR TITLE
CLI: fix missing check for correct credentials

### DIFF
--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -79,6 +79,9 @@ int Merge::execute(const QStringList& arguments)
     QSharedPointer<Database> db2;
     if (!parser.isSet("same-credentials")) {
         db2 = Utils::unlockDatabase(args.at(1), parser.value(keyFileFromOption), Utils::STDOUT, Utils::STDERR);
+        if (!db2) {
+            return EXIT_FAILURE;
+        }
     } else {
         db2 = QSharedPointer<Database>::create();
         QString errorMessage;

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -135,8 +135,14 @@ QSharedPointer<Database> unlockDatabase(const QString& databaseFilename,
     }
 
     auto db = QSharedPointer<Database>::create();
-    db->open(databaseFilename, compositeKey, nullptr, false);
-    return db;
+    QString error;
+    if (db->open(databaseFilename, compositeKey, &error, false)) {
+        return db;
+    }
+    else {
+        err << error << endl;
+        return {};
+    }
 }
 
 /**


### PR DESCRIPTION
Before this fix, most/all CLI commands had incorrect behaviour when bad credentials were supplied: they would carry on regardless, with potentially catastrophic results. In particular, the `add` subcommand seemed to corrupt the database (luckily I was using a test database). `ls` would always report an empty database. Haven't tested any others.

Also fixed a related missing check specific to the `merge` subcommand.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

See above.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

N/A

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Briefly tested manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**