### PR TITLE
Fix group signals

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -865,7 +865,9 @@ Group* Group::clone(Entry::CloneFlags entryFlags, Group::CloneFlags groupFlags) 
 
 void Group::copyDataFrom(const Group* other)
 {
-    m_data = other->m_data;
+    if (set(m_data, other->m_data)) {
+        emit groupDataChanged(this);
+    }
     m_customData->copyDataFrom(other->m_customData);
     m_lastTopVisibleEntry = other->m_lastTopVisibleEntry;
 }

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -1081,7 +1081,7 @@ bool Group::GroupData::equals(const Group::GroupData& other, CompareItemOptions 
     if (::compare(customIcon, other.customIcon) != 0) {
         return false;
     }
-    if (timeInfo.equals(other.timeInfo, options) != 0) {
+    if (!timeInfo.equals(other.timeInfo, options)) {
         return false;
     }
     // TODO HNH: Some properties are configurable - should they be ignored?

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -833,3 +833,11 @@ void TestGroup::testCopyDataFrom()
     QCOMPARE(spyGroupDataChanged.count(), 1);
     QCOMPARE(spyGroupModified.count(), 2);
 }
+
+void TestGroup::testEquals()
+{
+    QScopedPointer<Group> group(new Group());
+    group->setName("TestGroup");
+
+    QVERIFY(group->equals(group.data(), CompareItemDefault));
+}

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -812,8 +812,8 @@ void TestGroup::testCopyDataFrom()
     group3->customData()->set("testKey", "value");
 
 
-    QSignalSpy spyGroupModified(group.data(), &Group::groupModified);
-    QSignalSpy spyGroupDataChanged(group.data(), &Group::groupDataChanged);
+    QSignalSpy spyGroupModified(group.data(), SIGNAL(groupModified()));
+    QSignalSpy spyGroupDataChanged(group.data(), SIGNAL(groupDataChanged(Group*)));
 
     group->copyDataFrom(group2.data());
     QCOMPARE(spyGroupModified.count(), 1);

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -798,3 +798,38 @@ void TestGroup::testIsRecycled()
     db->recycleGroup(group4);
     QVERIFY(group4->isRecycled());
 }
+
+void TestGroup::testCopyDataFrom()
+{
+    QScopedPointer<Group> group(new Group());
+    group->setName("TestGroup");
+
+    QScopedPointer<Group> group2(new Group());
+    group2->setName("TestGroup2");
+
+    QScopedPointer<Group> group3(new Group());
+    group3->setName("TestGroup3");
+    group3->customData()->set("testKey", "value");
+
+
+    QSignalSpy spyGroupModified(group.data(), &Group::groupModified);
+    QSignalSpy spyGroupDataChanged(group.data(), &Group::groupDataChanged);
+
+    group->copyDataFrom(group2.data());
+    QCOMPARE(spyGroupModified.count(), 1);
+    QCOMPARE(spyGroupDataChanged.count(), 1);
+
+    // if no change, no signals
+    spyGroupModified.clear();
+    spyGroupDataChanged.clear();
+    group->copyDataFrom(group2.data());
+    QCOMPARE(spyGroupModified.count(), 0);
+    QCOMPARE(spyGroupDataChanged.count(), 0);
+
+    // custom data change triggers a separate modified signal
+    spyGroupModified.clear();
+    spyGroupDataChanged.clear();
+    group->copyDataFrom(group3.data());
+    QCOMPARE(spyGroupDataChanged.count(), 1);
+    QCOMPARE(spyGroupModified.count(), 2);
+}

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -43,6 +43,7 @@ private slots:
     void testLocate();
     void testAddEntryWithPath();
     void testIsRecycled();
+    void testCopyDataFrom();
 };
 
 #endif // KEEPASSX_TESTGROUP_H

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -44,6 +44,7 @@ private slots:
     void testAddEntryWithPath();
     void testIsRecycled();
     void testCopyDataFrom();
+    void testEquals();
 };
 
 #endif // KEEPASSX_TESTGROUP_H


### PR DESCRIPTION
This PR contains two fixes.
- Make sure `Group::copyDataFrom` emits `groupDataChanged` and `groupModified` singals.
- Fix `Group::GroupData::equals` wrongly uses the result from `timeInfo.equals`

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
The `EditGroupWidget` modifies a temporary `Group` object, and use `copyDataFrom` to apply the changes to the actual object. However, if only data members were changed, no signals are emitted. Thus the database is not marked as modified and changes will be discarded silently if that's the only change.

While adding tests, I noticed another bug in `Group::GroupData::equals`, which is also fixed and tested in this PR.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually. Renaming a group and save and close the database. Reopen it to make sure the change is saved.

Added unit test and passed.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
