### PR TITLE
Search by group name

### DIFF
--- a/src/core/EntrySearcher.cpp
+++ b/src/core/EntrySearcher.cpp
@@ -96,11 +96,12 @@ bool EntrySearcher::searchEntryImpl(const QString& searchString, Entry* entry)
             found = !attachments.filter(term->regex).empty();
             break;
         default:
-            // Terms without a specific field try to match title, username, url, and notes
+            // Terms without a specific field try to match title, username, url, notes and group name.
             found = term->regex.match(entry->resolvePlaceholder(entry->title())).hasMatch()
                     || term->regex.match(entry->resolvePlaceholder(entry->username())).hasMatch()
                     || term->regex.match(entry->resolvePlaceholder(entry->url())).hasMatch()
-                    || term->regex.match(entry->notes()).hasMatch();
+                    || term->regex.match(entry->notes()).hasMatch()
+                    || term->regex.match(entry->resolvePlaceholder(entry->group()->name())).hasMatch();
         }
 
         // Short circuit if we failed to match or we matched and are excluding this term


### PR DESCRIPTION
@droidmonkey mainly a suggestion, but I was surprised to not get results from a matching group when searching with the group name. I can add tests if you feel comfortable with this change.

## Type of change
- ✅ New feature (non-breaking change which adds functionality)


## Testing strategy
Tested locally only for now.


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- :x:  I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- :x:  My change requires a change to the documentation, and I have updated it accordingly.
- :x:  I have added tests to cover my changes.