### PR TITLE
Fix quiet option for Merge (CLI)

### DIFF
--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -78,7 +78,10 @@ int Merge::execute(const QStringList& arguments)
 
     QSharedPointer<Database> db2;
     if (!parser.isSet("same-credentials")) {
-        db2 = Utils::unlockDatabase(args.at(1), parser.value(keyFileFromOption), Utils::STDOUT, Utils::STDERR);
+        db2 = Utils::unlockDatabase(args.at(1),
+                                    parser.value(keyFileFromOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
         if (!db2) {
             return EXIT_FAILURE;
         }

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -883,6 +883,14 @@ void TestCli::testMerge()
     mergeCmd.execute({"merge", "-q", "-s", sourceFile.fileName(), sourceFile.fileName()});
     m_stdoutFile->seek(pos);
     QCOMPARE(m_stdoutFile->readAll(), QByteArray(""));
+
+    // Quiet option without the -s option
+    pos = m_stdoutFile->pos();
+    Utils::Test::setNextPassword("a");
+    Utils::Test::setNextPassword("a");
+    mergeCmd.execute({"merge", "-q", sourceFile.fileName(), sourceFile.fileName()});
+    m_stdoutFile->seek(pos);
+    QCOMPARE(m_stdoutFile->readAll(), QByteArray(""));
 }
 
 void TestCli::testRemove()


### PR DESCRIPTION
Looks like the `-q` option was not implemented when different credentials are used in the merge command. Fixed that and added a unit test.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)


## Testing strategy
unit test.


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
