### PR TITLE
Refactoring database extraction

### DIFF
--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -26,10 +26,6 @@
 #include "cli/TextStream.h"
 #include "cli/Utils.h"
 #include "core/Database.h"
-#include "format/KeePass2Reader.h"
-#include "keys/CompositeKey.h"
-#include "keys/FileKey.h"
-#include "keys/PasswordKey.h"
 
 Extract::Extract()
 {
@@ -60,66 +56,20 @@ int Extract::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    if (!parser.isSet(Command::QuietOption)) {
-        outputTextStream << QObject::tr("Insert password to unlock %1: ").arg(args.at(0)) << flush;
-    }
-
-    auto compositeKey = QSharedPointer<CompositeKey>::create();
-
-    QString line = Utils::getPassword(parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT);
-    auto passwordKey = QSharedPointer<PasswordKey>::create();
-    passwordKey->setPassword(line);
-    compositeKey->addKey(passwordKey);
-
-    QString keyFilePath = parser.value(Command::KeyFileOption);
-    if (!keyFilePath.isEmpty()) {
-        // LCOV_EXCL_START
-        auto fileKey = QSharedPointer<FileKey>::create();
-        QString errorMsg;
-        if (!fileKey->load(keyFilePath, &errorMsg)) {
-            errorTextStream << QObject::tr("Failed to load key file %1: %2").arg(keyFilePath, errorMsg) << endl;
-            return EXIT_FAILURE;
-        }
-
-        if (fileKey->type() != FileKey::Hashed) {
-            errorTextStream << QObject::tr("WARNING: You are using a legacy key file format which may become\n"
-                                           "unsupported in the future.\n\n"
-                                           "Please consider generating a new key file.")
-                            << endl;
-        }
-        // LCOV_EXCL_STOP
-
-        compositeKey->addKey(fileKey);
-    }
-
-    const QString& databaseFilename = args.at(0);
-    QFile dbFile(databaseFilename);
-    if (!dbFile.exists()) {
-        errorTextStream << QObject::tr("File %1 does not exist.").arg(databaseFilename) << endl;
-        return EXIT_FAILURE;
-    }
-    if (!dbFile.open(QIODevice::ReadOnly)) {
-        errorTextStream << QObject::tr("Unable to open file %1.").arg(databaseFilename) << endl;
+    auto db = Utils::unlockDatabase(args.at(0),
+                                    parser.value(Command::KeyFileOption),
+                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
+    if (!db) {
         return EXIT_FAILURE;
     }
 
-    KeePass2Reader reader;
-    reader.setSaveXml(true);
-    auto db = QSharedPointer<Database>::create();
-    reader.readDatabase(&dbFile, compositeKey, db.data());
-
-    QByteArray xmlData = reader.reader()->xmlData();
-
-    if (reader.hasError()) {
-        if (xmlData.isEmpty()) {
-            errorTextStream << QObject::tr("Error while reading the database:\n%1").arg(reader.errorString()) << endl;
-        } else {
-            errorTextStream << QObject::tr("Error while parsing the database:\n%1").arg(reader.errorString()) << endl;
-        }
+    QByteArray xmlData;
+    QString errorMessage;
+    if (!db->extract(xmlData, &errorMessage)) {
+        errorTextStream << QObject::tr("Unable to extract database : %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }
-
     outputTextStream << xmlData.constData() << endl;
-
     return EXIT_SUCCESS;
 }

--- a/src/cli/Extract.cpp
+++ b/src/cli/Extract.cpp
@@ -67,7 +67,7 @@ int Extract::execute(const QStringList& arguments)
     QByteArray xmlData;
     QString errorMessage;
     if (!db->extract(xmlData, &errorMessage)) {
-        errorTextStream << QObject::tr("Unable to extract database : %1").arg(errorMessage) << endl;
+        errorTextStream << QObject::tr("Unable to extract database %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }
     outputTextStream << xmlData.constData() << endl;

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -281,7 +281,6 @@ bool Database::writeDatabase(QIODevice* device, QString* error)
     setEmitModified(true);
 
     if (writer.hasError()) {
-        // the writer failed
         if (error) {
             *error = writer.errorString();
         }
@@ -296,14 +295,13 @@ bool Database::extract(QByteArray& xmlOutput, QString* error)
 {
     KeePass2Writer writer;
     writer.extractDatabase(this, xmlOutput);
-
     if (writer.hasError()) {
-        // the writer failed
         if (error) {
             *error = writer.errorString();
         }
         return false;
     }
+
     return true;
 }
 

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -292,6 +292,21 @@ bool Database::writeDatabase(QIODevice* device, QString* error)
     return true;
 }
 
+bool Database::extract(QByteArray& xmlOutput, QString* error)
+{
+    KeePass2Writer writer;
+    writer.extractDatabase(this, xmlOutput);
+
+    if (writer.hasError()) {
+        // the writer failed
+        if (error) {
+            *error = writer.errorString();
+        }
+        return false;
+    }
+    return true;
+}
+
 /**
  * Remove the old backup and replace it with a new one
  * backups are named <filename>.old.kdbx

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -72,6 +72,7 @@ public:
               bool readOnly = false);
     bool save(QString* error = nullptr, bool atomic = true, bool backup = false);
     bool save(const QString& filePath, QString* error = nullptr, bool atomic = true, bool backup = false);
+    bool extract(QByteArray&, QString* error = nullptr);
 
     bool isInitialized() const;
     void setInitialized(bool initialized);

--- a/src/format/Kdbx3Writer.cpp
+++ b/src/format/Kdbx3Writer.cpp
@@ -63,7 +63,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
     QBuffer header;
     header.open(QIODevice::WriteOnly);
 
-    writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, getFormatVersion());
+    writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, formatVersion());
 
     CHECK_RETURN_FALSE(writeHeaderField<quint16>(&header, KeePass2::HeaderFieldID::CipherID, db->cipher().toRfc4122()));
     CHECK_RETURN_FALSE(
@@ -133,7 +133,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
         return false;
     }
 
-    KdbxXmlWriter xmlWriter(getFormatVersion());
+    KdbxXmlWriter xmlWriter(formatVersion());
     xmlWriter.writeDatabase(outputDevice, db, &randomStream, headerHash);
 
     // Explicitly close/reset streams so they are flushed and we can detect
@@ -158,7 +158,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
     return true;
 }
 
-quint32 Kdbx3Writer::getFormatVersion()
+quint32 Kdbx3Writer::formatVersion()
 {
     return KeePass2::FILE_VERSION_3_1;
 }

--- a/src/format/Kdbx3Writer.cpp
+++ b/src/format/Kdbx3Writer.cpp
@@ -63,7 +63,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
     QBuffer header;
     header.open(QIODevice::WriteOnly);
 
-    writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, m_kdbxVersion);
+    writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, getFormatVersion());
 
     CHECK_RETURN_FALSE(writeHeaderField<quint16>(&header, KeePass2::HeaderFieldID::CipherID, db->cipher().toRfc4122()));
     CHECK_RETURN_FALSE(
@@ -133,7 +133,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
         return false;
     }
 
-    KdbxXmlWriter xmlWriter(m_kdbxVersion);
+    KdbxXmlWriter xmlWriter(getFormatVersion());
     xmlWriter.writeDatabase(outputDevice, db, &randomStream, headerHash);
 
     // Explicitly close/reset streams so they are flushed and we can detect
@@ -156,4 +156,9 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
     }
 
     return true;
+}
+
+quint32 Kdbx3Writer::getFormatVersion()
+{
+    return KeePass2::FILE_VERSION_3_1;
 }

--- a/src/format/Kdbx3Writer.cpp
+++ b/src/format/Kdbx3Writer.cpp
@@ -63,7 +63,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
     QBuffer header;
     header.open(QIODevice::WriteOnly);
 
-    writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, KeePass2::FILE_VERSION_3_1);
+    writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, m_kdbxVersion);
 
     CHECK_RETURN_FALSE(writeHeaderField<quint16>(&header, KeePass2::HeaderFieldID::CipherID, db->cipher().toRfc4122()));
     CHECK_RETURN_FALSE(
@@ -133,7 +133,7 @@ bool Kdbx3Writer::writeDatabase(QIODevice* device, Database* db)
         return false;
     }
 
-    KdbxXmlWriter xmlWriter(KeePass2::FILE_VERSION_3_1);
+    KdbxXmlWriter xmlWriter(m_kdbxVersion);
     xmlWriter.writeDatabase(outputDevice, db, &randomStream, headerHash);
 
     // Explicitly close/reset streams so they are flushed and we can detect

--- a/src/format/Kdbx3Writer.h
+++ b/src/format/Kdbx3Writer.h
@@ -29,8 +29,7 @@ class Kdbx3Writer : public KdbxWriter
 
 public:
     bool writeDatabase(QIODevice* device, Database* db) override;
-
-    quint32 m_kdbxVersion = KeePass2::FILE_VERSION_3_1;
+    quint32 getFormatVersion() override;
 };
 
 #endif // KEEPASSX_KDBX3WRITER_H

--- a/src/format/Kdbx3Writer.h
+++ b/src/format/Kdbx3Writer.h
@@ -29,7 +29,7 @@ class Kdbx3Writer : public KdbxWriter
 
 public:
     bool writeDatabase(QIODevice* device, Database* db) override;
-    quint32 getFormatVersion() override;
+    quint32 formatVersion() override;
 };
 
 #endif // KEEPASSX_KDBX3WRITER_H

--- a/src/format/Kdbx3Writer.h
+++ b/src/format/Kdbx3Writer.h
@@ -29,6 +29,8 @@ class Kdbx3Writer : public KdbxWriter
 
 public:
     bool writeDatabase(QIODevice* device, Database* db) override;
+
+    quint32 m_kdbxVersion = KeePass2::FILE_VERSION_3_1;
 };
 
 #endif // KEEPASSX_KDBX3WRITER_H

--- a/src/format/Kdbx4Writer.cpp
+++ b/src/format/Kdbx4Writer.cpp
@@ -70,7 +70,7 @@ bool Kdbx4Writer::writeDatabase(QIODevice* device, Database* db)
         QBuffer header;
         header.open(QIODevice::WriteOnly);
 
-        writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, m_kdbxVersion);
+        writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, getFormatVersion());
 
         CHECK_RETURN_FALSE(
             writeHeaderField<quint32>(&header, KeePass2::HeaderFieldID::CipherID, db->cipher().toRfc4122()));
@@ -171,7 +171,7 @@ bool Kdbx4Writer::writeDatabase(QIODevice* device, Database* db)
         return false;
     }
 
-    KdbxXmlWriter xmlWriter(m_kdbxVersion);
+    KdbxXmlWriter xmlWriter(getFormatVersion());
     xmlWriter.writeDatabase(outputDevice, db, &randomStream, headerHash);
 
     // Explicitly close/reset streams so they are flushed and we can detect
@@ -310,4 +310,9 @@ bool Kdbx4Writer::serializeVariantMap(const QVariantMap& map, QByteArray& output
     endBytes[0] = static_cast<char>(KeePass2::VariantMapFieldType::End);
     CHECK_RETURN_FALSE(buf.write(endBytes) == 1);
     return true;
+}
+
+quint32 Kdbx4Writer::getFormatVersion()
+{
+    return KeePass2::FILE_VERSION_4;
 }

--- a/src/format/Kdbx4Writer.cpp
+++ b/src/format/Kdbx4Writer.cpp
@@ -70,7 +70,7 @@ bool Kdbx4Writer::writeDatabase(QIODevice* device, Database* db)
         QBuffer header;
         header.open(QIODevice::WriteOnly);
 
-        writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, getFormatVersion());
+        writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, formatVersion());
 
         CHECK_RETURN_FALSE(
             writeHeaderField<quint32>(&header, KeePass2::HeaderFieldID::CipherID, db->cipher().toRfc4122()));
@@ -171,7 +171,7 @@ bool Kdbx4Writer::writeDatabase(QIODevice* device, Database* db)
         return false;
     }
 
-    KdbxXmlWriter xmlWriter(getFormatVersion());
+    KdbxXmlWriter xmlWriter(formatVersion());
     xmlWriter.writeDatabase(outputDevice, db, &randomStream, headerHash);
 
     // Explicitly close/reset streams so they are flushed and we can detect
@@ -312,7 +312,7 @@ bool Kdbx4Writer::serializeVariantMap(const QVariantMap& map, QByteArray& output
     return true;
 }
 
-quint32 Kdbx4Writer::getFormatVersion()
+quint32 Kdbx4Writer::formatVersion()
 {
     return KeePass2::FILE_VERSION_4;
 }

--- a/src/format/Kdbx4Writer.cpp
+++ b/src/format/Kdbx4Writer.cpp
@@ -70,7 +70,7 @@ bool Kdbx4Writer::writeDatabase(QIODevice* device, Database* db)
         QBuffer header;
         header.open(QIODevice::WriteOnly);
 
-        writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, KeePass2::FILE_VERSION_4);
+        writeMagicNumbers(&header, KeePass2::SIGNATURE_1, KeePass2::SIGNATURE_2, m_kdbxVersion);
 
         CHECK_RETURN_FALSE(
             writeHeaderField<quint32>(&header, KeePass2::HeaderFieldID::CipherID, db->cipher().toRfc4122()));
@@ -171,7 +171,7 @@ bool Kdbx4Writer::writeDatabase(QIODevice* device, Database* db)
         return false;
     }
 
-    KdbxXmlWriter xmlWriter(KeePass2::FILE_VERSION_4);
+    KdbxXmlWriter xmlWriter(m_kdbxVersion);
     xmlWriter.writeDatabase(outputDevice, db, &randomStream, headerHash);
 
     // Explicitly close/reset streams so they are flushed and we can detect

--- a/src/format/Kdbx4Writer.h
+++ b/src/format/Kdbx4Writer.h
@@ -29,7 +29,7 @@ class Kdbx4Writer : public KdbxWriter
 
 public:
     bool writeDatabase(QIODevice* device, Database* db) override;
-    quint32 getFormatVersion() override;
+    quint32 formatVersion() override;
 
 private:
     bool writeInnerHeaderField(QIODevice* device, KeePass2::InnerHeaderFieldID fieldId, const QByteArray& data);

--- a/src/format/Kdbx4Writer.h
+++ b/src/format/Kdbx4Writer.h
@@ -30,6 +30,8 @@ class Kdbx4Writer : public KdbxWriter
 public:
     bool writeDatabase(QIODevice* device, Database* db) override;
 
+    quint32 m_kdbxVersion = KeePass2::FILE_VERSION_4;
+
 private:
     bool writeInnerHeaderField(QIODevice* device, KeePass2::InnerHeaderFieldID fieldId, const QByteArray& data);
     void writeAttachments(QIODevice* device, Database* db);

--- a/src/format/Kdbx4Writer.h
+++ b/src/format/Kdbx4Writer.h
@@ -29,8 +29,7 @@ class Kdbx4Writer : public KdbxWriter
 
 public:
     bool writeDatabase(QIODevice* device, Database* db) override;
-
-    quint32 m_kdbxVersion = KeePass2::FILE_VERSION_4;
+    quint32 getFormatVersion() override;
 
 private:
     bool writeInnerHeaderField(QIODevice* device, KeePass2::InnerHeaderFieldID fieldId, const QByteArray& data);

--- a/src/format/KdbxReader.h
+++ b/src/format/KdbxReader.h
@@ -45,9 +45,6 @@ public:
     bool hasError() const;
     QString errorString() const;
 
-    bool saveXml() const;
-    void setSaveXml(bool save);
-    QByteArray xmlData() const;
     KeePass2::ProtectedStreamAlgo protectedStreamAlgo() const;
 
 protected:
@@ -86,8 +83,6 @@ protected:
 
     void raiseError(const QString& errorMessage);
 
-    void decryptXmlInnerStream(QByteArray& xmlOutput, Database* db) const;
-
     quint32 m_kdbxVersion = 0;
 
     QByteArray m_masterSeed;
@@ -96,13 +91,10 @@ protected:
     QByteArray m_protectedStreamKey;
     KeePass2::ProtectedStreamAlgo m_irsAlgo = KeePass2::ProtectedStreamAlgo::InvalidProtectedStreamAlgo;
 
-    QByteArray m_xmlData;
-
 private:
     QPair<quint32, quint32> m_kdbxSignature;
     QPointer<Database> m_db;
 
-    bool m_saveXml = false;
     bool m_error = false;
     QString m_errorStr = "";
 };

--- a/src/format/KdbxWriter.cpp
+++ b/src/format/KdbxWriter.cpp
@@ -71,7 +71,7 @@ void KdbxWriter::extractDatabase(QByteArray& xmlOutput, Database* db)
     QBuffer buffer;
     buffer.setBuffer(&xmlOutput);
     buffer.open(QIODevice::WriteOnly);
-    KdbxXmlWriter writer(m_kdbxVersion);
+    KdbxXmlWriter writer(getFormatVersion());
     writer.disableInnerStreamProtection(true);
     writer.writeDatabase(&buffer, db);
 }

--- a/src/format/KdbxWriter.cpp
+++ b/src/format/KdbxWriter.cpp
@@ -17,6 +17,10 @@
 
 #include "KdbxWriter.h"
 
+#include <QBuffer>
+
+#include "format/KdbxXmlWriter.h"
+
 bool KdbxWriter::hasError() const
 {
     return m_error;
@@ -60,6 +64,16 @@ bool KdbxWriter::writeData(QIODevice* device, const QByteArray& data)
         return false;
     }
     return true;
+}
+
+void KdbxWriter::extractDatabase(QByteArray& xmlOutput, Database* db)
+{
+    QBuffer buffer;
+    buffer.setBuffer(&xmlOutput);
+    buffer.open(QIODevice::WriteOnly);
+    KdbxXmlWriter writer(m_kdbxVersion);
+    writer.disableInnerStreamProtection(true);
+    writer.writeDatabase(&buffer, db);
 }
 
 /**

--- a/src/format/KdbxWriter.cpp
+++ b/src/format/KdbxWriter.cpp
@@ -71,7 +71,7 @@ void KdbxWriter::extractDatabase(QByteArray& xmlOutput, Database* db)
     QBuffer buffer;
     buffer.setBuffer(&xmlOutput);
     buffer.open(QIODevice::WriteOnly);
-    KdbxXmlWriter writer(getFormatVersion());
+    KdbxXmlWriter writer(formatVersion());
     writer.disableInnerStreamProtection(true);
     writer.writeDatabase(&buffer, db);
 }

--- a/src/format/KdbxWriter.h
+++ b/src/format/KdbxWriter.h
@@ -52,7 +52,10 @@ public:
      */
     virtual bool writeDatabase(QIODevice* device, Database* db) = 0;
 
-    virtual quint32 getFormatVersion() = 0;
+    /**
+     * Get the database format version for the writer.
+     */
+    virtual quint32 formatVersion() = 0;
 
     void extractDatabase(QByteArray& xmlOutput, Database* db);
 

--- a/src/format/KdbxWriter.h
+++ b/src/format/KdbxWriter.h
@@ -52,6 +52,8 @@ public:
      */
     virtual bool writeDatabase(QIODevice* device, Database* db) = 0;
 
+    void extractDatabase(QByteArray& xmlOutput, Database* db);
+
     bool hasError() const;
     QString errorString() const;
 
@@ -82,6 +84,8 @@ protected:
 
     bool writeData(QIODevice* device, const QByteArray& data);
     void raiseError(const QString& errorMessage);
+
+    quint32 m_kdbxVersion = 0;
 
     bool m_error = false;
     QString m_errorStr = "";

--- a/src/format/KdbxWriter.h
+++ b/src/format/KdbxWriter.h
@@ -52,6 +52,8 @@ public:
      */
     virtual bool writeDatabase(QIODevice* device, Database* db) = 0;
 
+    virtual quint32 getFormatVersion() = 0;
+
     void extractDatabase(QByteArray& xmlOutput, Database* db);
 
     bool hasError() const;
@@ -84,8 +86,6 @@ protected:
 
     bool writeData(QIODevice* device, const QByteArray& data);
     void raiseError(const QString& errorMessage);
-
-    quint32 m_kdbxVersion = 0;
 
     bool m_error = false;
     QString m_errorStr = "";

--- a/src/format/KeePass2Reader.cpp
+++ b/src/format/KeePass2Reader.cpp
@@ -96,7 +96,6 @@ bool KeePass2Reader::readDatabase(QIODevice* device, QSharedPointer<const Compos
         m_reader.reset(new Kdbx4Reader());
     }
 
-    m_reader->setSaveXml(m_saveXml);
     return m_reader->readDatabase(device, std::move(key), db);
 }
 
@@ -108,16 +107,6 @@ bool KeePass2Reader::hasError() const
 QString KeePass2Reader::errorString() const
 {
     return !m_reader.isNull() ? m_reader->errorString() : m_errorStr;
-}
-
-bool KeePass2Reader::saveXml() const
-{
-    return m_saveXml;
-}
-
-void KeePass2Reader::setSaveXml(bool save)
-{
-    m_saveXml = save;
 }
 
 /**

--- a/src/format/KeePass2Reader.h
+++ b/src/format/KeePass2Reader.h
@@ -41,16 +41,12 @@ public:
     bool hasError() const;
     QString errorString() const;
 
-    bool saveXml() const;
-    void setSaveXml(bool save);
-
     QSharedPointer<KdbxReader> reader() const;
     quint32 version() const;
 
 private:
     void raiseError(const QString& errorMessage);
 
-    bool m_saveXml = false;
     bool m_error = false;
     QString m_errorStr = "";
 

--- a/src/format/KeePass2Writer.cpp
+++ b/src/format/KeePass2Writer.cpp
@@ -84,7 +84,6 @@ bool KeePass2Writer::implicitUpgradeNeeded(Database const* db) const
  * @param db source database
  * @return true on success
  */
-
 bool KeePass2Writer::writeDatabase(QIODevice* device, Database* db)
 {
     m_error = false;
@@ -107,6 +106,22 @@ bool KeePass2Writer::writeDatabase(QIODevice* device, Database* db)
     }
 
     return m_writer->writeDatabase(device, db);
+}
+
+void KeePass2Writer::extractDatabase(Database* db, QByteArray& xmlOutput)
+{
+    m_error = false;
+    m_errorStr.clear();
+
+    if (db->kdf()->uuid() == KeePass2::KDF_AES_KDBX3) {
+        m_version = KeePass2::FILE_VERSION_3_1;
+        m_writer.reset(new Kdbx3Writer());
+    } else {
+        m_version = KeePass2::FILE_VERSION_4;
+        m_writer.reset(new Kdbx4Writer());
+    }
+
+    m_writer->extractDatabase(xmlOutput, db);
 }
 
 bool KeePass2Writer::hasError() const

--- a/src/format/KeePass2Writer.h
+++ b/src/format/KeePass2Writer.h
@@ -33,6 +33,7 @@ class KeePass2Writer
 public:
     bool writeDatabase(const QString& filename, Database* db);
     bool writeDatabase(QIODevice* device, Database* db);
+    void extractDatabase(Database* db, QByteArray& xmlOutput);
 
     QSharedPointer<KdbxWriter> writer() const;
     quint32 version() const;


### PR DESCRIPTION
Previously, extracting the xml from a database was done with the
`saveXml` attribute in the `KeePass2Reader` class.
This had several unfortunate consequences:
* The `KdbxReader` class had to import the `KdbxXmlWriter` class
in order to perform the export (bad separation of concerns);
* The CLI database unlocking logic had to be duplicated only
for the `Extract` command;
* The `xmlData` had to be stored in the `KeePass2Reader` as
a temporary result.
* Lots of `setSaveXml` functions were implemented only
to trickle down this functionality.

Also, The naming of the `saveXml` variable was not really
helpful to understand it's role.

Overall, this change will make it easier to maintain and expand
the CLI database unlocking logic (for example, adding a `--no-password`
option as requested in https://github.com/keepassxreboot/keepassxc/issues/1873)
It also opens to door to other types of extraction/exporting (for
example exporting to CSV, as requested in
https://github.com/keepassxreboot/keepassxc/issues/2572)

Note that I had to add a `m_kdbxVersion` attribute in the `KdbxWriter`,
the same way there's one in the `KdbxReader` class.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor

## Description and Context
I was working on adding yubikey support for the CLI, and saw the duplicated database unlocking
in `Extract` command.


## Testing strategy
unit tests + locally running the `extract` command.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
