### PR TITLE
Enable use of HiDPI pixmaps by QT

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,7 @@ int main(int argc, char** argv)
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 #ifdef Q_OS_LINUX
     if (qgetenv("XDG_SESSION_TYPE") == QByteArrayLiteral("wayland")) {


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

At the moment KeePassXC does not fully support HiDPI pixmaps. This means on HiDPI screens the icons drawn by KeePassXC are regular pixmaps scaled up (pixel doubling). 

By default QT does not use HiDPI pixmaps meaning every icon is simply rescaled even if hidpi icons are available. By enabling the attribute `AA_UseHighDpiPixmaps` if a HiDPI pixmap is available QT will draw HiDPI pixmaps on HiDPI screens.

In particular icons fetched from a theme will be HiDPI on HiDPI screens (if the theme supports HiDPI). 

**This does not however mean all icons/pixmaps are now HiDPI. For this deeper code changes are required. But it scales better than before.**

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

### HiDPI Screen

**Before the fix (in a HiDPI setup):**

![before-fix-hidpi](https://user-images.githubusercontent.com/588429/52731692-a0d33a00-2fbe-11e9-8b84-d2204887472e.png)

**After the fix (in a HiDPI setup):**

![after-fix-hidpi](https://user-images.githubusercontent.com/588429/52731648-85682f00-2fbe-11e9-9475-2309c8f61009.png)

### Non HiDPI Screen

**Before the fix (in a non HiDPI setup):**

![before-fix-lowdpi](https://user-images.githubusercontent.com/588429/52731818-f3145b00-2fbe-11e9-9804-906a6e5ba2bd.png)

**After the fix (in a non HiDPI setup):**

![after-fix-lowdpi](https://user-images.githubusercontent.com/588429/52731837-fdcef000-2fbe-11e9-8099-4ba94bb9dea6.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

I perform the following checks during testing:
1. On HiDPI screens, icons from theme are not HiDPI before the code change
2. On HiDPI screens, icons from theme are HiDPI after the code change
3. On conventional DPI screens, icons from theme are not HiDPI before the code change
3. On conventional DPI screens, icons from theme are not HiDPI after the code change

To emulate a low DPI screen, I change the resolution and set a 1.0 pixel scaling option. All tests were made on Ubuntu 16.04.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
