### PR TITLE
Code quality updates for 2.4.0

### DIFF
--- a/src/browser/NativeMessagingBase.h
+++ b/src/browser/NativeMessagingBase.h
@@ -53,7 +53,7 @@ protected slots:
 protected:
     virtual void readLength() = 0;
     virtual bool readStdIn(const quint32 length) = 0;
-    void readNativeMessages();
+    virtual void readNativeMessages();
     QString jsonToString(const QJsonObject& json) const;
     void sendReply(const QJsonObject& json);
     void sendReply(const QString& reply);

--- a/src/browser/NativeMessagingHost.h
+++ b/src/browser/NativeMessagingHost.h
@@ -32,7 +32,7 @@ class NativeMessagingHost : public NativeMessagingBase
 
 public:
     explicit NativeMessagingHost(DatabaseTabWidget* parent = nullptr, const bool enabled = false);
-    ~NativeMessagingHost();
+    ~NativeMessagingHost() override;
     int init();
     void run();
     void stop();

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -926,7 +926,7 @@ QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, 
 
     Q_ASSERT(m_group);
     Q_ASSERT(m_group->database());
-    const Entry* refEntry = m_group->findEntryBySearchTerm(searchText, searchInType);
+    const Entry* refEntry = m_group->database()->rootGroup()->findEntryBySearchTerm(searchText, searchInType);
 
     if (refEntry) {
         const QString wantedField = match.captured(EntryAttributes::WantedFieldGroupName);

--- a/src/core/OSEventFilter.cpp
+++ b/src/core/OSEventFilter.cpp
@@ -1,8 +1,30 @@
+/*
+ *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "OSEventFilter.h"
 
 #include <QByteArray>
 
+#include "gui/MainWindow.h"
 #include "autotype/AutoType.h"
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
 
 OSEventFilter::OSEventFilter()
 {
@@ -15,12 +37,18 @@ bool OSEventFilter::nativeEventFilter(const QByteArray& eventType, void* message
 #if defined(Q_OS_UNIX)
     if (eventType == QByteArrayLiteral("xcb_generic_event_t")) {
 #elif defined(Q_OS_WIN)
-    if (eventType == QByteArrayLiteral("windows_generic_MSG")
-        || eventType == QByteArrayLiteral("windows_dispatcher_MSG")) {
+    auto winmsg = static_cast<MSG*>(message);
+    if (winmsg->message == WM_QUERYENDSESSION) {
+        *result = 1;
+        return true;
+    } else if (winmsg->message == WM_ENDSESSION) {
+        getMainWindow()->appExit();
+        *result = 0;
+        return true;
+    } else if (eventType == QByteArrayLiteral("windows_generic_MSG")
+               || eventType == QByteArrayLiteral("windows_dispatcher_MSG")) {
 #endif
-        int retCode = autoType()->callEventFilter(message);
-
-        return retCode == 1;
+        return autoType()->callEventFilter(message) == 1;
     }
 
     return false;

--- a/src/core/OSEventFilter.h
+++ b/src/core/OSEventFilter.h
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef OSEVENTFILTER_H
 #define OSEVENTFILTER_H
 #include <QAbstractNativeEventFilter>

--- a/src/crypto/kdf/Kdf.cpp
+++ b/src/crypto/kdf/Kdf.cpp
@@ -84,7 +84,8 @@ int Kdf::benchmark(int msec) const
 }
 
 Kdf::BenchmarkThread::BenchmarkThread(int msec, const Kdf* kdf)
-    : m_msec(msec)
+    : m_rounds(1)
+    , m_msec(msec)
     , m_kdf(kdf)
 {
 }

--- a/src/crypto/ssh/BinaryStream.cpp
+++ b/src/crypto/ssh/BinaryStream.cpp
@@ -19,12 +19,6 @@
 #include "BinaryStream.h"
 #include <QtEndian>
 
-BinaryStream::BinaryStream(QObject* parent)
-    : QObject(parent)
-    , m_timeout(-1)
-{
-}
-
 BinaryStream::BinaryStream(QIODevice* device)
     : QObject(device)
     , m_timeout(-1)
@@ -36,7 +30,10 @@ BinaryStream::BinaryStream(QByteArray* ba, QObject* parent)
     : QObject(parent)
     , m_timeout(-1)
 {
-    setData(ba);
+    m_buffer.reset(new QBuffer(ba));
+    m_buffer->open(QIODevice::ReadWrite);
+
+    m_device = m_buffer.data();
 }
 
 BinaryStream::~BinaryStream()
@@ -51,19 +48,6 @@ const QString BinaryStream::errorString() const
 QIODevice* BinaryStream::device() const
 {
     return m_device;
-}
-
-void BinaryStream::setDevice(QIODevice* device)
-{
-    m_device = device;
-}
-
-void BinaryStream::setData(QByteArray* ba)
-{
-    m_buffer.reset(new QBuffer(ba));
-    m_buffer->open(QIODevice::ReadWrite);
-
-    m_device = m_buffer.data();
 }
 
 void BinaryStream::setTimeout(int timeout)

--- a/src/crypto/ssh/BinaryStream.h
+++ b/src/crypto/ssh/BinaryStream.h
@@ -26,16 +26,14 @@
 class BinaryStream : QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY(BinaryStream)
 public:
-    BinaryStream(QObject* parent = nullptr);
-    BinaryStream(QIODevice* device);
-    BinaryStream(QByteArray* ba, QObject* parent = nullptr);
-    ~BinaryStream();
+    explicit BinaryStream(QIODevice* device);
+    explicit BinaryStream(QByteArray* ba, QObject* parent = nullptr);
+    ~BinaryStream() override;
 
     const QString errorString() const;
     QIODevice* device() const;
-    void setDevice(QIODevice* device);
-    void setData(QByteArray* ba);
     void setTimeout(int timeout);
 
     bool read(QByteArray& ba);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -713,6 +713,10 @@ void MainWindow::hasUpdateAvailable(bool hasUpdate, const QString& version, bool
         updateCheckDialog->showUpdateCheckResponse(hasUpdate, version);
         updateCheckDialog->show();
     }
+#else
+    Q_UNUSED(hasUpdate)
+    Q_UNUSED(version)
+    Q_UNUSED(isManuallyRequested)
 #endif
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -76,7 +76,7 @@
 class BrowserPlugin : public ISettingsPage
 {
 public:
-    BrowserPlugin(DatabaseTabWidget* tabWidget)
+    explicit BrowserPlugin(DatabaseTabWidget* tabWidget)
     {
         m_nativeMessagingHost =
             QSharedPointer<NativeMessagingHost>(new NativeMessagingHost(tabWidget, browserSettings()->isEnabled()));

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -787,7 +787,7 @@ ShareObserver::Result::Result(const QString& path, ShareObserver::Result::Type t
 
 bool ShareObserver::Result::isValid() const
 {
-    return !path.isEmpty() || !message.isEmpty() || !message.isEmpty() || !message.isEmpty();
+    return !path.isEmpty() || !message.isEmpty();
 }
 
 bool ShareObserver::Result::isError() const

--- a/src/proxy/NativeMessagingHost.cpp
+++ b/src/proxy/NativeMessagingHost.cpp
@@ -19,7 +19,7 @@
 #include <QCoreApplication>
 
 #ifdef Q_OS_WIN
-#include <Winsock2.h>
+#include <winsock2.h>
 #endif
 
 NativeMessagingHost::NativeMessagingHost()
@@ -36,14 +36,12 @@ NativeMessagingHost::NativeMessagingHost()
     }
 #ifdef Q_OS_WIN
     m_running.store(true);
-    m_future =
-        QtConcurrent::run(this, static_cast<void (NativeMessagingHost::*)()>(&NativeMessagingHost::readNativeMessages));
+    m_future = QtConcurrent::run(this, &NativeMessagingHost::readNativeMessages);
 #endif
     connect(m_localSocket, SIGNAL(readyRead()), this, SLOT(newLocalMessage()));
     connect(m_localSocket, SIGNAL(disconnected()), this, SLOT(deleteSocket()));
     connect(m_localSocket,
             SIGNAL(stateChanged(QLocalSocket::LocalSocketState)),
-            this,
             SLOT(socketStateChanged(QLocalSocket::LocalSocketState)));
 }
 

--- a/src/proxy/NativeMessagingHost.h
+++ b/src/proxy/NativeMessagingHost.h
@@ -25,7 +25,7 @@ class NativeMessagingHost : public NativeMessagingBase
     Q_OBJECT
 public:
     NativeMessagingHost();
-    ~NativeMessagingHost();
+    ~NativeMessagingHost() override;
 
 public slots:
     void newLocalMessage();
@@ -33,12 +33,14 @@ public slots:
     void socketStateChanged(QLocalSocket::LocalSocketState socketState);
 
 private:
-    void readNativeMessages();
-    void readLength();
-    bool readStdIn(const quint32 length);
+    void readNativeMessages() override;
+    void readLength() override;
+    bool readStdIn(const quint32 length) override;
 
 private:
     QLocalSocket* m_localSocket;
+
+    Q_DISABLE_COPY(NativeMessagingHost)
 };
 
 #endif // NATIVEMESSAGINGHOST_H

--- a/src/proxy/keepassxc-proxy.cpp
+++ b/src/proxy/keepassxc-proxy.cpp
@@ -57,9 +57,10 @@ void catchUnixSignals(std::initializer_list<int> quitSignals)
 }
 #else
 #include <windows.h>
+
 BOOL WINAPI ConsoleHandler(DWORD dwType)
 {
-    switch(dwType) {
+    switch (dwType) {
     case CTRL_C_EVENT:
     case CTRL_SHUTDOWN_EVENT:
     case CTRL_LOGOFF_EVENT:

--- a/src/proxy/keepassxc-proxy.cpp
+++ b/src/proxy/keepassxc-proxy.cpp
@@ -55,13 +55,28 @@ void catchUnixSignals(std::initializer_list<int> quitSignals)
         sigaction(sig, &sa, nullptr);
     }
 }
+#else
+#include <windows.h>
+BOOL WINAPI ConsoleHandler(DWORD dwType)
+{
+    switch(dwType) {
+    case CTRL_C_EVENT:
+    case CTRL_SHUTDOWN_EVENT:
+    case CTRL_LOGOFF_EVENT:
+        QCoreApplication::quit();
+        break;
+    }
+    return TRUE;
+}
 #endif
 
 int main(int argc, char* argv[])
 {
     QCoreApplication a(argc, argv);
-#if defined(Q_OS_UNIX) || defined(Q_OS_LINUX)
+#ifndef Q_OS_WIN
     catchUnixSignals({SIGQUIT, SIGINT, SIGTERM, SIGHUP});
+#else
+    SetConsoleCtrlHandler(static_cast<PHANDLER_ROUTINE>(ConsoleHandler),TRUE);
 #endif
     NativeMessagingHost host;
     return a.exec();

--- a/src/streams/SymmetricCipherStream.cpp
+++ b/src/streams/SymmetricCipherStream.cpp
@@ -28,6 +28,7 @@ SymmetricCipherStream::SymmetricCipherStream(QIODevice* baseDevice,
     , m_error(false)
     , m_isInitialized(false)
     , m_dataWritten(false)
+    , m_streamCipher(false)
 {
 }
 

--- a/src/updatecheck/UpdateChecker.cpp
+++ b/src/updatecheck/UpdateChecker.cpp
@@ -28,6 +28,7 @@ UpdateChecker::UpdateChecker(QObject* parent)
     : QObject(parent)
     , m_netMgr(new QNetworkAccessManager(this))
     , m_reply(nullptr)
+    , m_isManuallyRequested(false)
 {
 }
 


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
General quality of code improvements for 2.4.0. Also addressing a couple of issues:

* Gracefully close KeePassXC and KeePassXC-Browser when receiving end session notice on Windows
* Fix #2684 - entry references search the whole group tree instead of its current group on down
* Fix #2697 and fix #2699

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Used rmlogotest from the Windows 10 Developer Kit which simulates an actual shutdown/logoff sequence.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
