### PR TITLE
Prevent unnecessary key transformations, resolves #2704

### DIFF
--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -108,7 +108,8 @@ public:
     QSharedPointer<const CompositeKey> key() const;
     bool setKey(const QSharedPointer<const CompositeKey>& key,
                 bool updateChangedTime = true,
-                bool updateTransformSalt = false);
+                bool updateTransformSalt = false,
+                bool transformKey = true);
     QByteArray challengeResponseKey() const;
     bool challengeMasterSeed(const QByteArray& masterSeed);
     bool verifyKey(const QSharedPointer<CompositeKey>& key) const;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
@@ -81,7 +81,7 @@ void DatabaseSettingsWidgetEncryption::initialize()
         isDirty = true;
     }
     if (!m_db->key()) {
-        m_db->setKey(QSharedPointer<CompositeKey>::create());
+        m_db->setKey(QSharedPointer<CompositeKey>::create(), true, false, false);
         m_db->setCipher(KeePass2::CIPHER_AES256);
         isDirty = true;
     }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMasterKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMasterKey.cpp
@@ -190,9 +190,13 @@ bool DatabaseSettingsWidgetMasterKey::save()
         }
     }
 
-    m_db->setKey(newKey);
+    m_db->setKey(newKey, true, false, false);
 
     emit editFinished(true);
+    if (m_isDirty) {
+        m_db->markAsModified();
+    }
+
     return true;
 }
 


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
This patch resolves #2704.

The database master key settings widget does not actually need to (re-)transform the master key, it only needs to update the Key object on the database. Transformation can be deferred until the Database is persisted to disk. This avoids delays and unnecessary user interaction with challenge-response dongles by eliminating redundant key transformations.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**