### PR TITLE
Adding debug info to CLI.

### DIFF
--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -56,6 +56,9 @@ Shows the title, username, password, URL and notes of a database entry. Can also
 
 .SS "General options"
 
+.IP "--debug-info"
+Displays debugging information.
+
 .IP "-k, --key-file <path>"
 Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
 
@@ -66,7 +69,7 @@ Silence password prompt and other secondary outputs.
 Displays help information.
 
 .IP "-v, --version"
-Shows the program version.
+Displays the program version.
 
 
 .SS "Merge options"

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -26,6 +26,7 @@
 
 #include "config-keepassx.h"
 #include "core/Bootstrap.h"
+#include "core/Tools.h"
 #include "crypto/Crypto.h"
 
 #if defined(WITH_ASAN) && defined(WITH_LSAN)
@@ -60,6 +61,9 @@ int main(int argc, char** argv)
 
     parser.addPositionalArgument("command", QObject::tr("Name of the command to execute."));
 
+    QCommandLineOption debugInfoOption(QStringList() << "debug-info",
+                                       QObject::tr("Displays debugging information."));
+    parser.addOption(debugInfoOption);
     parser.addHelpOption();
     parser.addVersionOption();
     // TODO : use the setOptionsAfterPositionalArgumentsMode (Qt 5.6) function
@@ -71,6 +75,10 @@ int main(int argc, char** argv)
         if (parser.isSet("version")) {
             // Switch to parser.showVersion() when available (QT 5.4).
             out << KEEPASSXC_VERSION << endl;
+            return EXIT_SUCCESS;
+        } else if (parser.isSet(debugInfoOption)) {
+            QString debugInfo = Tools::debugInfo().append("\n").append(Crypto::debugInfo());
+            out << debugInfo << endl;
             return EXIT_SUCCESS;
         }
         parser.showHelp();

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -32,6 +32,7 @@ class QRegularExpression;
 
 namespace Tools
 {
+    QString debugInfo();
     QString humanReadableFileSize(qint64 bytes, quint32 precision = 2);
     bool readFromDevice(QIODevice* device, QByteArray& data, int size = 16384);
     bool readAllFromDevice(QIODevice* device, QByteArray& data);

--- a/src/crypto/Crypto.cpp
+++ b/src/crypto/Crypto.cpp
@@ -25,7 +25,7 @@
 #include "crypto/CryptoHash.h"
 #include "crypto/SymmetricCipher.h"
 
-bool Crypto::m_initalized(false);
+bool Crypto::m_initialized(false);
 QString Crypto::m_errorStr;
 QString Crypto::m_backendVersion;
 
@@ -35,8 +35,8 @@ Crypto::Crypto()
 
 bool Crypto::init()
 {
-    if (m_initalized) {
-        qWarning("Crypto::init: already initalized");
+    if (m_initialized) {
+        qWarning("Crypto::init: already initialized");
         return true;
     }
 
@@ -48,19 +48,19 @@ bool Crypto::init()
     }
 
     // has to be set before testing Crypto classes
-    m_initalized = true;
+    m_initialized = true;
 
     if (!backendSelfTest() || !selfTest()) {
-        m_initalized = false;
+        m_initialized = false;
         return false;
     }
 
     return true;
 }
 
-bool Crypto::initalized()
+bool Crypto::initialized()
 {
-    return m_initalized;
+    return m_initialized;
 }
 
 QString Crypto::errorString()
@@ -68,9 +68,13 @@ QString Crypto::errorString()
     return m_errorStr;
 }
 
-QString Crypto::backendVersion()
+QString Crypto::debugInfo()
 {
-    return QString("libgcrypt ").append(m_backendVersion);
+    Q_ASSERT(Crypto::initialized());
+
+    QString debugInfo = QObject::tr("Cryptographic libraries:").append("\n");
+    debugInfo.append(" libgcrypt ").append(m_backendVersion).append("\n");
+    return debugInfo;
 }
 
 bool Crypto::backendSelfTest()

--- a/src/crypto/Crypto.h
+++ b/src/crypto/Crypto.h
@@ -24,10 +24,10 @@ class Crypto
 {
 public:
     static bool init();
-    static bool initalized();
+    static bool initialized();
     static bool backendSelfTest();
     static QString errorString();
-    static QString backendVersion();
+    static QString debugInfo();
 
 private:
     Crypto();
@@ -42,7 +42,7 @@ private:
     static bool testSalsa20();
     static bool testChaCha20();
 
-    static bool m_initalized;
+    static bool m_initialized;
     static QString m_errorStr;
     static QString m_backendVersion;
 };

--- a/src/crypto/CryptoHash.cpp
+++ b/src/crypto/CryptoHash.cpp
@@ -33,7 +33,7 @@ CryptoHash::CryptoHash(Algorithm algo, bool hmac)
 {
     Q_D(CryptoHash);
 
-    Q_ASSERT(Crypto::initalized());
+    Q_ASSERT(Crypto::initialized());
 
     int algoGcrypt = -1;
     unsigned int flagsGcrypt = GCRY_MD_FLAG_SECURE;

--- a/src/crypto/Random.cpp
+++ b/src/crypto/Random.cpp
@@ -93,7 +93,7 @@ Random::Random(RandomBackend* backend)
 
 void RandomBackendGcrypt::randomize(void* data, int len)
 {
-    Q_ASSERT(Crypto::initalized());
+    Q_ASSERT(Crypto::initialized());
 
     gcry_randomize(data, len, GCRY_STRONG_RANDOM);
 }

--- a/src/crypto/SymmetricCipherGcrypt.cpp
+++ b/src/crypto/SymmetricCipherGcrypt.cpp
@@ -90,7 +90,7 @@ void SymmetricCipherGcrypt::setError(const gcry_error_t& err)
 
 bool SymmetricCipherGcrypt::init()
 {
-    Q_ASSERT(Crypto::initalized());
+    Q_ASSERT(Crypto::initialized());
 
     gcry_error_t error;
 

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -21,11 +21,11 @@
 
 #include "config-keepassx.h"
 #include "core/FilePath.h"
+#include "core/Tools.h"
 #include "crypto/Crypto.h"
-#include "git-info.h"
 
 #include <QClipboard>
-#include <QSysInfo>
+
 
 static const QString aboutMaintainers = R"(
 <p><ul>
@@ -175,67 +175,7 @@ AboutDialog::AboutDialog(QWidget* parent)
 
     m_ui->iconLabel->setPixmap(filePath()->applicationIcon().pixmap(48));
 
-    QString commitHash;
-    if (!QString(GIT_HEAD).isEmpty()) {
-        commitHash = GIT_HEAD;
-    }
-
-    QString debugInfo = "KeePassXC - ";
-    debugInfo.append(tr("Version %1").arg(KEEPASSXC_VERSION).append("\n"));
-#ifndef KEEPASSXC_BUILD_TYPE_RELEASE
-    debugInfo.append(tr("Build Type: %1").arg(KEEPASSXC_BUILD_TYPE).append("\n"));
-#endif
-    if (!commitHash.isEmpty()) {
-        debugInfo.append(tr("Revision: %1").arg(commitHash.left(7)).append("\n"));
-    }
-
-#ifdef KEEPASSXC_DIST
-    debugInfo.append(tr("Distribution: %1").arg(KEEPASSXC_DIST_TYPE).append("\n"));
-#endif
-
-    debugInfo.append("\n").append(
-        QString("%1\n- Qt %2\n- %3\n\n")
-            .arg(tr("Libraries:"), QString::fromLocal8Bit(qVersion()), Crypto::backendVersion()));
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-    debugInfo.append(tr("Operating system: %1\nCPU architecture: %2\nKernel: %3 %4")
-                         .arg(QSysInfo::prettyProductName(),
-                              QSysInfo::currentCpuArchitecture(),
-                              QSysInfo::kernelType(),
-                              QSysInfo::kernelVersion()));
-
-    debugInfo.append("\n\n");
-#endif
-
-    QString extensions;
-#ifdef WITH_XC_AUTOTYPE
-    extensions += "\n- " + tr("Auto-Type");
-#endif
-#ifdef WITH_XC_BROWSER
-    extensions += "\n- " + tr("Browser Integration");
-#endif
-#ifdef WITH_XC_SSHAGENT
-    extensions += "\n- " + tr("SSH Agent");
-#endif
-#if defined(WITH_XC_KEESHARE_SECURE) && defined(WITH_XC_KEESHARE_INSECURE)
-    extensions += "\n- " + tr("KeeShare (signed and unsigned sharing)");
-#elif defined(WITH_XC_KEESHARE_SECURE)
-    extensions += "\n- " + tr("KeeShare (only signed sharing)");
-#elif defined(WITH_XC_KEESHARE_INSECURE)
-    extensions += "\n- " + tr("KeeShare (only unsigned sharing)");
-#endif
-#ifdef WITH_XC_YUBIKEY
-    extensions += "\n- " + tr("YubiKey");
-#endif
-#ifdef WITH_XC_TOUCHID
-    extensions += "\n- " + tr("TouchID");
-#endif
-
-    if (extensions.isEmpty())
-        extensions = " " + tr("None");
-
-    debugInfo.append(tr("Enabled extensions:").append(extensions));
-
+    QString debugInfo = Tools::debugInfo().append("\n").append(Crypto::debugInfo());
     m_ui->debugInfo->setPlainText(debugInfo);
 
     m_ui->maintainers->setText(aboutMaintainers);


### PR DESCRIPTION
    Adding debug info to CLI.
    
    Adding debug info to the CLI and the general option
    of the main Qt app. Also took time to:
    * use `EXIT_SUCCESS`/`EXIT_FAILURE` constants
    for main.cpp (this is what is used in `src/cli`);
    * fixed `m_initalized` typo;
    * added info on debugging mode being disabled
    or not;
    * regrouped Qt related stuff in the debug output.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor
- ✅ New feature
- ✅ Documentation


## Screenshots
```
$ ./src/cli/keepassxc-cli --debug-info
KeePassXC - Version 2.4.0-snapshot
Build Type: Snapshot
Revision: 39d77b7

Qt 5.9.5
Debugging mode is disabled.

Operating system: Ubuntu 18.04.2 LTS
CPU architecture: x86_64
Kernel: linux 4.15.0-45-generic

Enabled extensions:
- Auto-Type

Cryptographic libraries:
 libgcrypt 1.8.1

```

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
