### PR TITLE
fix(NativeMessagingBase): always close epoll/kqueue file descriptor

### DIFF
--- a/src/browser/NativeMessagingBase.cpp
+++ b/src/browser/NativeMessagingBase.cpp
@@ -65,6 +65,7 @@ void NativeMessagingBase::newNativeMessage()
     EV_SET(ev, fileno(stdin), EVFILT_READ, EV_ADD, 0, 0, nullptr);
     if (kevent(fd, ev, 1, nullptr, 0, &ts) == -1) {
         m_notifier->setEnabled(false);
+        ::close(fd);
         return;
     }
 
@@ -81,6 +82,7 @@ void NativeMessagingBase::newNativeMessage()
     event.data.fd = 0;
     if (epoll_ctl(fd, EPOLL_CTL_ADD, 0, &event) != 0) {
         m_notifier->setEnabled(false);
+        ::close(fd);
         return;
     }
 


### PR DESCRIPTION
See #2721.

## Type of change

- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context

Should fix #2643 and #2721

## Testing strategy

I'm not able to test these changes but I believe they won't have any impact.

## Checklist:

- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- :x: I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**