### PR TITLE
Password generation option for Add and Edit (CLI)

### DIFF
--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -77,11 +77,6 @@ int Add::execute(const QStringList& arguments)
                               QObject::tr("length"));
     parser.addOption(length);
 
-    QCommandLineOption numeric(QStringList() << "n"
-                                             << "numeric",
-                               QObject::tr("Use numbers."));
-    parser.addOption(numeric);
-
     QCommandLineOption special(QStringList() << "s"
                                              << "special",
                                QObject::tr("Use special characters"));
@@ -164,9 +159,6 @@ int Add::execute(const QStringList& arguments)
 
         classes |= PasswordGenerator::DefaultCharset;
 
-        if (parser.isSet(numeric)) {
-            classes |= PasswordGenerator::Numbers;
-        }
         if (parser.isSet(special)) {
             classes |= PasswordGenerator::SpecialCharacters;
         }

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -77,6 +77,35 @@ int Add::execute(const QStringList& arguments)
                               QObject::tr("length"));
     parser.addOption(length);
 
+    QCommandLineOption numeric(QStringList() << "n"
+                                             << "numeric",
+                               QObject::tr("Use numbers."));
+    parser.addOption(numeric);
+
+    QCommandLineOption special(QStringList() << "s"
+                                             << "special",
+                               QObject::tr("Use special characters"));
+    parser.addOption(special);
+
+    QCommandLineOption extended(QStringList() << "e"
+                                              << "extended",
+                                QObject::tr("Use extended ASCII"));
+    parser.addOption(extended);
+
+    QCommandLineOption exclude(QStringList() << "x"
+                                             << "exclude",
+                               QObject::tr("Exclude character set"),
+                               QObject::tr("chars"));
+    parser.addOption(exclude);
+
+    QCommandLineOption exclude_similar(QStringList() << "exclude-similar",
+                                       QObject::tr("Exclude similar looking characters"));
+    parser.addOption(exclude_similar);
+
+    QCommandLineOption every_group(QStringList() << "every-group",
+                                   QObject::tr("Include characters from every selected group"));
+    parser.addOption(every_group);
+
     parser.addPositionalArgument("entry", QObject::tr("Path of the entry to add."));
 
     parser.addHelpOption();
@@ -131,14 +160,39 @@ int Add::execute(const QStringList& arguments)
     } else if (parser.isSet(generate)) {
         PasswordGenerator passwordGenerator;
 
+        PasswordGenerator::CharClasses classes = 0x0;
+
+        classes |= PasswordGenerator::DefaultCharset;
+
+        if (parser.isSet(numeric)) {
+            classes |= PasswordGenerator::Numbers;
+        }
+        if (parser.isSet(special)) {
+            classes |= PasswordGenerator::SpecialCharacters;
+        }
+        if (parser.isSet(extended)) {
+            classes |= PasswordGenerator::EASCII;
+        }
+
+        PasswordGenerator::GeneratorFlags flags = 0x0;
+
+        if (parser.isSet(exclude_similar)) {
+            flags |= PasswordGenerator::ExcludeLookAlike;
+        }
+        if (parser.isSet(every_group)) {
+            flags |= PasswordGenerator::CharFromEveryGroup;
+        }
+
+        passwordGenerator.setExcludedChars(parser.value(exclude));
+
         if (passwordLength.isEmpty()) {
             passwordGenerator.setLength(PasswordGenerator::DefaultLength);
         } else {
             passwordGenerator.setLength(passwordLength.toInt());
         }
 
-        passwordGenerator.setCharClasses(PasswordGenerator::DefaultCharset);
-        passwordGenerator.setFlags(PasswordGenerator::DefaultFlags);
+        passwordGenerator.setCharClasses(classes);
+        passwordGenerator.setFlags(flags);
         QString password = passwordGenerator.generatePassword();
         entry->setPassword(password);
     }

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -82,11 +82,6 @@ int Edit::execute(const QStringList& arguments)
                               QObject::tr("length"));
     parser.addOption(length);
 
-    QCommandLineOption numeric(QStringList() << "n"
-                                             << "numeric",
-                               QObject::tr("Use numbers."));
-    parser.addOption(numeric);
-
     QCommandLineOption special(QStringList() << "s"
                                              << "special",
                                QObject::tr("Use special characters"));
@@ -178,9 +173,6 @@ int Edit::execute(const QStringList& arguments)
 
         classes |= PasswordGenerator::DefaultCharset;
 
-        if (parser.isSet(numeric)) {
-            classes |= PasswordGenerator::Numbers;
-        }
         if (parser.isSet(special)) {
             classes |= PasswordGenerator::SpecialCharacters;
         }

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -237,27 +237,6 @@ void TestCli::testAdd()
     QCOMPARE(entry->url(), QString("https://example.net/"));
     QCOMPARE(entry->password(), QString("newpassword"));
 
-    // Test numeric
-    Utils::Test::setNextPassword("numericpassword");
-    addCmd.execute({"add",
-                    "-u",
-                    "newuser3",
-                    "--url",
-                    "https://example.net/",
-                    "-gn",
-                    "-l",
-                    "20",
-                    "-p",
-                    m_dbFile->fileName(),
-                    "/newuser-entry3"});
-
-    db = readTestDatabase();
-    entry = db->rootGroup()->findEntryByPath("/newuser-entry3");
-    QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser3"));
-    QCOMPARE(entry->url(), QString("https://example.net/"));
-    QCOMPARE(entry->password(), QString("numericpassword"));
-
     // Test special characters
     Utils::Test::setNextPassword("specialcharpassword");
     addCmd.execute({"add",
@@ -505,17 +484,6 @@ void TestCli::testEdit()
 
     Utils::Test::setNextPassword("a");
     editCmd.execute({"edit", "-g", m_dbFile->fileName(), "/newtitle"});
-    db = readTestDatabase();
-    entry = db->rootGroup()->findEntryByPath("/newtitle");
-    QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser"));
-    QCOMPARE(entry->url(), QString("https://otherurl.example.com/"));
-    QVERIFY(!entry->password().isEmpty());
-    QVERIFY(entry->password() != QString("Password"));
-
-    // Test numeric
-    Utils::Test::setNextPassword("a");
-    editCmd.execute({"edit", "-gn", m_dbFile->fileName(), "/newtitle"});
     db = readTestDatabase();
     entry = db->rootGroup()->findEntryByPath("/newtitle");
     QVERIFY(entry);

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -236,6 +236,48 @@ void TestCli::testAdd()
     QCOMPARE(entry->username(), QString("newuser2"));
     QCOMPARE(entry->url(), QString("https://example.net/"));
     QCOMPARE(entry->password(), QString("newpassword"));
+
+    // Test numeric
+    Utils::Test::setNextPassword("numericpassword");
+    addCmd.execute({"add",
+                    "-u",
+                    "newuser3",
+                    "--url",
+                    "https://example.net/",
+                    "-gn",
+                    "-l",
+                    "20",
+                    "-p",
+                    m_dbFile->fileName(),
+                    "/newuser-entry3"});
+
+    db = readTestDatabase();
+    entry = db->rootGroup()->findEntryByPath("/newuser-entry3");
+    QVERIFY(entry);
+    QCOMPARE(entry->username(), QString("newuser3"));
+    QCOMPARE(entry->url(), QString("https://example.net/"));
+    QCOMPARE(entry->password(), QString("numericpassword"));
+
+    // Test special characters
+    Utils::Test::setNextPassword("specialcharpassword");
+    addCmd.execute({"add",
+                    "-u",
+                    "newuser4",
+                    "--url",
+                    "https://example.net/",
+                    "-gs",
+                    "-l",
+                    "20",
+                    "-p",
+                    m_dbFile->fileName(),
+                    "/newuser-entry4"});
+
+    db = readTestDatabase();
+    entry = db->rootGroup()->findEntryByPath("/newuser-entry4");
+    QVERIFY(entry);
+    QCOMPARE(entry->username(), QString("newuser4"));
+    QCOMPARE(entry->url(), QString("https://example.net/"));
+    QCOMPARE(entry->password(), QString("specialcharpassword"));
 }
 
 bool isTOTP(const QString& value)
@@ -463,6 +505,28 @@ void TestCli::testEdit()
 
     Utils::Test::setNextPassword("a");
     editCmd.execute({"edit", "-g", m_dbFile->fileName(), "/newtitle"});
+    db = readTestDatabase();
+    entry = db->rootGroup()->findEntryByPath("/newtitle");
+    QVERIFY(entry);
+    QCOMPARE(entry->username(), QString("newuser"));
+    QCOMPARE(entry->url(), QString("https://otherurl.example.com/"));
+    QVERIFY(!entry->password().isEmpty());
+    QVERIFY(entry->password() != QString("Password"));
+
+    // Test numeric
+    Utils::Test::setNextPassword("a");
+    editCmd.execute({"edit", "-gn", m_dbFile->fileName(), "/newtitle"});
+    db = readTestDatabase();
+    entry = db->rootGroup()->findEntryByPath("/newtitle");
+    QVERIFY(entry);
+    QCOMPARE(entry->username(), QString("newuser"));
+    QCOMPARE(entry->url(), QString("https://otherurl.example.com/"));
+    QVERIFY(!entry->password().isEmpty());
+    QVERIFY(entry->password() != QString("Password"));
+
+    // Test special characters
+    Utils::Test::setNextPassword("a");
+    editCmd.execute({"edit", "-gs", m_dbFile->fileName(), "/newtitle"});
     db = readTestDatabase();
     entry = db->rootGroup()->findEntryByPath("/newtitle");
     QVERIFY(entry);


### PR DESCRIPTION
[TIP]:  # Extends keepass-cli edit command 

## Type of change
[NOTE]: # 
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context

While using `keepassxc-cli edit` with the `-g` param, you can't choose to generate a random password with special characters. Random generated password contains only digits and letters. So I added code found on cli/Generate.cpp and add these options to `keepassxc-cli edit -g`:

 * numeric
 * special
 * extended
 * exclude
 * exclude-similar
 * every-group

## Screenshots

No screenhots


## Testing strategy

Here is how I use `keepass-cli` to generate password with special characters:

    keepassxc-cli edit -gs -l 100 keepass-db.kdbx keepass-entry"

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**