### PR TITLE
Improve resilience against memory attacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,11 @@ endif()
 add_gcc_compiler_cflags("-std=c99")
 add_gcc_compiler_cxxflags("-std=c++11")
 
+if((CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9.99) OR
+    (CMAKE_COMPILER_IS_CLANGXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.6.99))
+    add_gcc_compiler_cxxflags("-fsized-deallocation")
+endif()
+
 if(APPLE)
     add_gcc_compiler_cxxflags("-stdlib=libc++")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ if(NOT ZXCVBN_LIBRARIES)
 endif(NOT ZXCVBN_LIBRARIES)
 
 set(keepassx_SOURCES
+        core/Alloc.cpp
         core/AutoTypeAssociations.cpp
         core/AutoTypeMatch.cpp
         core/Compare.cpp

--- a/src/core/Alloc.cpp
+++ b/src/core/Alloc.cpp
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QtGlobal>
+#include <cstdint>
+#ifdef Q_OS_MACOS
+#include <malloc/malloc.h>
+#else
+#include <malloc.h>
+#endif
+
+/**
+ * Custom sized delete operator which securely zeroes out allocated
+ * memory before freeing it (requires C++14 sized deallocation support).
+ */
+void operator delete(void* ptr, std::size_t size) noexcept
+{
+    if (nullptr == ptr) {
+        return;
+    }
+
+#ifdef __cpp_sized_deallocation
+    volatile auto* mem = static_cast<volatile std::uint8_t*>(ptr);
+    while (size--) {
+        *mem++ = 0;
+    }
+#else
+    Q_UNUSED(size);
+#endif
+
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t size) noexcept
+{
+    ::operator delete(ptr, size);
+}
+
+/**
+ * Custom delete operator which securely zeroes out
+ * allocated memory before freeing it.
+ */
+void operator delete(void* ptr) noexcept
+{
+    if (nullptr == ptr) {
+        return;
+    }
+
+#if defined(Q_OS_WIN)
+    ::operator delete(ptr, _msize(ptr));
+#elif defined(Q_OS_MACOS)
+    ::operator delete(ptr, malloc_size(ptr));
+#elif defined(Q_OS_UNIX)
+    ::operator delete(ptr, malloc_usable_size(ptr));
+#else
+    // whatever this OS is, give up and simply free stuff
+    std::free(ptr);
+#endif
+}
+
+void operator delete[](void* ptr) noexcept
+{
+    ::operator delete(ptr);
+}
+
+/**
+ * Custom insecure delete operator that does not zero out memory before
+ * freeing a buffer. Can be used for better performance.
+ */
+void operator delete(void* ptr, bool) noexcept
+{
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr, bool) noexcept
+{
+    ::operator delete(ptr, false);
+}

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -100,6 +100,20 @@ namespace Tools
 
         return version;
     }
+
+    /**
+     * Securely wipe a memory buffer.
+     *
+     * @param ptr pointer to first buffer element
+     * @param size number of bytes to erase
+     */
+    inline void wipeBuffer(void* ptr, std::size_t size)
+    {
+        volatile auto* mem = static_cast<volatile char*>(ptr);
+        while (size--) {
+            *mem++ = 0;
+        }
+    }
 } // namespace Tools
 
 #endif // KEEPASSX_TOOLS_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMasterKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMasterKey.cpp
@@ -77,11 +77,8 @@ void DatabaseSettingsWidgetMasterKey::load(QSharedPointer<Database> db)
         // database has no key, we are about to add a new one
         m_passwordEditWidget->changeVisiblePage(KeyComponentWidget::Page::Edit);
         m_passwordEditWidget->setPasswordVisible(true);
-        m_isDirty = true;
-        return;
     }
 
-    bool isDirty = false;
     bool hasAdditionalKeys = false;
     for (const auto& key : m_db->key()->keys()) {
         if (key->uuid() == PasswordKey::UUID) {
@@ -103,7 +100,9 @@ void DatabaseSettingsWidgetMasterKey::load(QSharedPointer<Database> db)
 
     setAdditionalKeyOptionsVisible(hasAdditionalKeys);
 
-    m_isDirty = isDirty;
+    connect(m_passwordEditWidget->findChild<QPushButton*>("removeButton"), SIGNAL(clicked()), SLOT(markDirty()));
+    connect(m_keyFileEditWidget->findChild<QPushButton*>("removeButton"), SIGNAL(clicked()), SLOT(markDirty()));
+    connect(m_yubiKeyEditWidget->findChild<QPushButton*>("removeButton"), SIGNAL(clicked()), SLOT(markDirty()));
 }
 
 void DatabaseSettingsWidgetMasterKey::initialize()

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -981,6 +981,13 @@ void EditEntryWidget::clear()
 {
     m_entry = nullptr;
     m_db.reset();
+
+    m_mainUi->titleEdit->setText("");
+    m_mainUi->passwordEdit->setText("");
+    m_mainUi->passwordRepeatEdit->setText("");
+    m_mainUi->urlEdit->setText("");
+    m_mainUi->notesEdit->clear();
+
     m_entryAttributes->clear();
     m_advancedUi->attachmentsWidget->clearAttachments();
     m_autoTypeAssoc->clear();

--- a/src/gui/masterkey/PasswordEditWidget.cpp
+++ b/src/gui/masterkey/PasswordEditWidget.cpp
@@ -84,6 +84,15 @@ void PasswordEditWidget::initComponentEditWidget(QWidget* widget)
     m_compUi->enterPasswordEdit->setFocus();
 }
 
+void PasswordEditWidget::hideEvent(QHideEvent* event)
+{
+    if (!isVisible() && m_compUi->enterPasswordEdit) {
+        m_compUi->enterPasswordEdit->setText("");
+    }
+
+    QWidget::hideEvent(event);
+}
+
 bool PasswordEditWidget::validate(QString& errorMessage) const
 {
     if (m_compUi->enterPasswordEdit->text().isEmpty()) {

--- a/src/gui/masterkey/PasswordEditWidget.h
+++ b/src/gui/masterkey/PasswordEditWidget.h
@@ -43,6 +43,7 @@ public:
 protected:
     QWidget* componentEditWidget() override;
     void initComponentEditWidget(QWidget* widget) override;
+    void hideEvent(QHideEvent* event) override;
 
 private slots:
     void showPasswordGenerator();

--- a/src/keys/FileKey.cpp
+++ b/src/keys/FileKey.cpp
@@ -18,17 +18,33 @@
 
 #include "FileKey.h"
 
-#include <QFile>
-
 #include "core/Tools.h"
 #include "crypto/CryptoHash.h"
 #include "crypto/Random.h"
 
+#include <QFile>
+
+#include <gcrypt.h>
+#include <algorithm>
+#include <cstring>
+
 QUuid FileKey::UUID("a584cbc4-c9b4-437e-81bb-362ca9709273");
+
+constexpr int FileKey::SHA256_SIZE;
 
 FileKey::FileKey()
     : Key(UUID)
+    , m_key(static_cast<char*>(gcry_malloc_secure(SHA256_SIZE)))
 {
+}
+
+FileKey::~FileKey()
+{
+    if (m_key) {
+        Tools::wipeBuffer(m_key, SHA256_SIZE);
+        gcry_free(m_key);
+        m_key = nullptr;
+    }
 }
 
 /**
@@ -148,7 +164,10 @@ bool FileKey::load(const QString& fileName, QString* errorMsg)
  */
 QByteArray FileKey::rawKey() const
 {
-    return m_key;
+    if (!m_key) {
+        return {};
+    }
+    return QByteArray::fromRawData(m_key, SHA256_SIZE);
 }
 
 /**
@@ -223,12 +242,15 @@ bool FileKey::loadXml(QIODevice* device)
         }
     }
 
+    bool ok = false;
     if (!xmlReader.error() && correctMeta && !data.isEmpty()) {
-        m_key = data;
-        return true;
+        std::memcpy(m_key, data.data(), std::min(SHA256_SIZE, data.size()));
+        ok = true;
     }
 
-    return false;
+    Tools::wipeBuffer(data.data(), static_cast<std::size_t>(data.capacity()));
+
+    return ok;
 }
 
 /**
@@ -293,7 +315,8 @@ bool FileKey::loadBinary(QIODevice* device)
     if (!Tools::readAllFromDevice(device, data) || data.size() != 32) {
         return false;
     } else {
-        m_key = data;
+        std::memcpy(m_key, data.data(), std::min(SHA256_SIZE, data.size()));
+        Tools::wipeBuffer(data.data(), static_cast<std::size_t>(data.capacity()));
         return true;
     }
 }
@@ -321,12 +344,15 @@ bool FileKey::loadHex(QIODevice* device)
     }
 
     QByteArray key = QByteArray::fromHex(data);
+    Tools::wipeBuffer(data.data(), static_cast<std::size_t>(data.capacity()));
 
     if (key.size() != 32) {
         return false;
     }
 
-    m_key = key;
+    std::memcpy(m_key, key.data(), std::min(SHA256_SIZE, key.size()));
+    Tools::wipeBuffer(key.data(), static_cast<std::size_t>(key.capacity()));
+
     return true;
 }
 
@@ -348,7 +374,9 @@ bool FileKey::loadHashed(QIODevice* device)
         cryptoHash.addData(buffer);
     } while (!buffer.isEmpty());
 
-    m_key = cryptoHash.result();
+    auto result = cryptoHash.result();
+    std::memcpy(m_key, result.data(), std::min(SHA256_SIZE, result.size()));
+    Tools::wipeBuffer(result.data(), static_cast<std::size_t>(result.capacity()));
 
     return true;
 }

--- a/src/keys/FileKey.h
+++ b/src/keys/FileKey.h
@@ -40,6 +40,7 @@ public:
     };
 
     FileKey();
+    ~FileKey() override;
     bool load(QIODevice* device);
     bool load(const QString& fileName, QString* errorMsg = nullptr);
     QByteArray rawKey() const override;
@@ -48,6 +49,8 @@ public:
     static bool create(const QString& fileName, QString* errorMsg = nullptr, int size = 128);
 
 private:
+    static constexpr int SHA256_SIZE = 32;
+
     bool loadXml(QIODevice* device);
     bool loadXmlMeta(QXmlStreamReader& xmlReader);
     QByteArray loadXmlKey(QXmlStreamReader& xmlReader);
@@ -55,7 +58,7 @@ private:
     bool loadHex(QIODevice* device);
     bool loadHashed(QIODevice* device);
 
-    QByteArray m_key;
+    char* m_key = nullptr;
     Type m_type = None;
 };
 

--- a/src/keys/PasswordKey.cpp
+++ b/src/keys/PasswordKey.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,35 +16,52 @@
  */
 
 #include "PasswordKey.h"
+#include "core/Tools.h"
 
 #include "crypto/CryptoHash.h"
+#include <gcrypt.h>
+#include <algorithm>
+#include <cstring>
 
 QUuid PasswordKey::UUID("77e90411-303a-43f2-b773-853b05635ead");
 
+constexpr int PasswordKey::SHA256_SIZE;
+
 PasswordKey::PasswordKey()
     : Key(UUID)
+    , m_key(static_cast<char*>(gcry_malloc_secure(SHA256_SIZE)))
 {
 }
 
 PasswordKey::PasswordKey(const QString& password)
     : Key(UUID)
+    , m_key(static_cast<char*>(gcry_malloc_secure(SHA256_SIZE)))
 {
     setPassword(password);
+}
+
+PasswordKey::~PasswordKey()
+{
+    if (m_key) {
+        Tools::wipeBuffer(m_key, SHA256_SIZE);
+        gcry_free(m_key);
+        m_key = nullptr;
+    }
 }
 
 QSharedPointer<PasswordKey> PasswordKey::fromRawKey(const QByteArray& rawKey)
 {
     auto result = QSharedPointer<PasswordKey>::create();
-    result->m_key = rawKey;
+    std::memcpy(result->m_key, rawKey.data(), std::min(SHA256_SIZE, rawKey.size()));
     return result;
 }
 
 QByteArray PasswordKey::rawKey() const
 {
-    return m_key;
+    return QByteArray::fromRawData(m_key, SHA256_SIZE);
 }
 
 void PasswordKey::setPassword(const QString& password)
 {
-    m_key = CryptoHash::hash(password.toUtf8(), CryptoHash::Sha256);
+    std::memcpy(m_key, CryptoHash::hash(password.toUtf8(), CryptoHash::Sha256).data(), SHA256_SIZE);
 }

--- a/src/keys/PasswordKey.h
+++ b/src/keys/PasswordKey.h
@@ -30,13 +30,16 @@ public:
 
     PasswordKey();
     explicit PasswordKey(const QString& password);
+    ~PasswordKey() override;
     QByteArray rawKey() const override;
     void setPassword(const QString& password);
 
     static QSharedPointer<PasswordKey> fromRawKey(const QByteArray& rawKey);
 
 private:
-    QByteArray m_key;
+    static constexpr int SHA256_SIZE = 32;
+
+    char* m_key = nullptr;
 };
 
 #endif // KEEPASSX_PASSWORDKEY_H

--- a/src/keys/YkChallengeResponseKey.cpp
+++ b/src/keys/YkChallengeResponseKey.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2014 Kyle Manna <kyle@kylemanna.com>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,6 +32,9 @@
 #include <QXmlStreamReader>
 #include <QtConcurrent>
 
+#include <gcrypt.h>
+#include <cstring>
+
 QUuid YkChallengeResponseKey::UUID("e092495c-e77d-498b-84a1-05ae0d955508");
 
 YkChallengeResponseKey::YkChallengeResponseKey(int slot, bool blocking)
@@ -45,9 +48,19 @@ YkChallengeResponseKey::YkChallengeResponseKey(int slot, bool blocking)
     }
 }
 
+YkChallengeResponseKey::~YkChallengeResponseKey()
+{
+    if (m_key) {
+        Tools::wipeBuffer(m_key, m_keySize);
+        gcry_free(m_key);
+        m_keySize = 0;
+        m_key = nullptr;
+    }
+}
+
 QByteArray YkChallengeResponseKey::rawKey() const
 {
-    return m_key;
+    return QByteArray::fromRawData(m_key, static_cast<int>(m_keySize));
 }
 
 /**
@@ -67,14 +80,23 @@ bool YkChallengeResponseKey::challenge(const QByteArray& challenge, unsigned int
             emit userInteractionRequired();
         }
 
+        QByteArray key;
         auto result = AsyncTask::runAndWaitForFuture(
-            [this, challenge]() { return YubiKey::instance()->challenge(m_slot, true, challenge, m_key); });
+            [this, challenge, &key]() { return YubiKey::instance()->challenge(m_slot, true, challenge, key); });
 
         if (m_blocking) {
             emit userConfirmed();
         }
 
         if (result == YubiKey::SUCCESS) {
+            if (m_key) {
+                Tools::wipeBuffer(m_key, m_keySize);
+                gcry_free(m_key);
+            }
+            m_keySize = static_cast<std::size_t>(key.size());
+            m_key = static_cast<char*>(gcry_malloc_secure(m_keySize));
+            std::memcpy(m_key, key.data(), m_keySize);
+            Tools::wipeBuffer(key.data(), static_cast<std::size_t>(key.capacity()));
             return true;
         }
     } while (retries > 0);

--- a/src/keys/YkChallengeResponseKey.h
+++ b/src/keys/YkChallengeResponseKey.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@ public:
     static QUuid UUID;
 
     explicit YkChallengeResponseKey(int slot = -1, bool blocking = false);
+    ~YkChallengeResponseKey() override;
 
     QByteArray rawKey() const override;
     bool challenge(const QByteArray& challenge) override;
@@ -52,7 +53,8 @@ signals:
     void userConfirmed();
 
 private:
-    QByteArray m_key;
+    char* m_key = nullptr;
+    std::size_t m_keySize = 0;
     int m_slot;
     bool m_blocking;
 };


### PR DESCRIPTION
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
To reduce residual fragments of secret data in memory after deallocation, this patch replaces the global delete operator with a version that zeros out previously allocated memory. It makes use of the new C++14 sized deallocation, but provides an unsized fallback with platform-specific size deductions.

This change is only a minor mitigation and cannot protect against buffer reallocations by the operating system or non-C++ libraries. Thus, we still cannot guarantee all memory to be wiped after free.

As a further improvement, this patch uses libgcrypt to write long-lived master key component hashes into a secure memory area and wipe it afterwards.

Finally, it ensures that all password form fields are cleared when they are not in use anymore and fixes a bug where removing a component from the master key would not mark the database as dirty.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Inspected memory, found the custom delete to be working (mostly, certain buffers containing copies of the raw XML are still out of our reach). ASAN does not complain.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**