### PR TITLE
Add button to open Custom Auto-type sequence documentation

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -198,10 +198,17 @@ void EditEntryWidget::setupIcon()
     connect(this, SIGNAL(rejected()), m_iconsWidget, SLOT(abortRequests()));
 }
 
+void EditEntryWidget::openAutotypeHelp()
+{
+    QDesktopServices::openUrl(QUrl("https://github.com/keepassxreboot/keepassxc/wiki/Autotype-Custom-Sequence"));
+}
+
 void EditEntryWidget::setupAutoType()
 {
     m_autoTypeUi->setupUi(m_autoTypeWidget);
     addPage(tr("Auto-Type"), FilePath::instance()->icon("actions", "key-enter"), m_autoTypeWidget);
+
+    m_autoTypeUi->openHelpButton->setIcon(filePath()->icon("actions", "system-help"));
 
     m_autoTypeDefaultSequenceGroup->addButton(m_autoTypeUi->inheritSequenceButton);
     m_autoTypeDefaultSequenceGroup->addButton(m_autoTypeUi->customSequenceButton);
@@ -213,6 +220,9 @@ void EditEntryWidget::setupAutoType()
     connect(m_autoTypeUi->enableButton, SIGNAL(toggled(bool)), SLOT(updateAutoTypeEnabled()));
     connect(m_autoTypeUi->customSequenceButton, SIGNAL(toggled(bool)),
             m_autoTypeUi->sequenceEdit, SLOT(setEnabled(bool)));
+    connect(m_autoTypeUi->customSequenceButton, SIGNAL(toggled(bool)),
+            m_autoTypeUi->openHelpButton, SLOT(setEnabled(bool)));
+    connect(m_autoTypeUi->openHelpButton, SIGNAL(clicked()), SLOT(openAutotypeHelp()));
     connect(m_autoTypeUi->customWindowSequenceButton, SIGNAL(toggled(bool)),
             m_autoTypeUi->windowSequenceEdit, SLOT(setEnabled(bool)));
     connect(m_autoTypeUi->assocAddButton, SIGNAL(clicked()), SLOT(insertAutoTypeAssoc()));
@@ -1185,6 +1195,7 @@ void EditEntryWidget::updateAutoTypeEnabled()
     m_autoTypeUi->inheritSequenceButton->setEnabled(!m_history && autoTypeEnabled);
     m_autoTypeUi->customSequenceButton->setEnabled(!m_history && autoTypeEnabled);
     m_autoTypeUi->sequenceEdit->setEnabled(autoTypeEnabled && m_autoTypeUi->customSequenceButton->isChecked());
+    m_autoTypeUi->openHelpButton->setEnabled(autoTypeEnabled && m_autoTypeUi->customSequenceButton->isChecked());
 
     m_autoTypeUi->assocView->setEnabled(autoTypeEnabled);
     m_autoTypeUi->assocAddButton->setEnabled(!m_history);

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -90,6 +90,7 @@ private slots:
     void protectCurrentAttribute(bool state);
     void revealCurrentAttribute();
     void updateAutoTypeEnabled();
+    void openAutotypeHelp();
     void insertAutoTypeAssoc();
     void removeAutoTypeAssoc();
     void loadCurrentAssoc(const QModelIndex& current);

--- a/src/gui/entry/EditEntryWidgetAutoType.ui
+++ b/src/gui/entry/EditEntryWidgetAutoType.ui
@@ -85,6 +85,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QToolButton" name="openHelpButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -268,6 +278,7 @@
   <tabstop>inheritSequenceButton</tabstop>
   <tabstop>customSequenceButton</tabstop>
   <tabstop>sequenceEdit</tabstop>
+  <tabstop>openHelpButton</tabstop>
   <tabstop>assocView</tabstop>
   <tabstop>windowTitleCombo</tabstop>
   <tabstop>customWindowSequenceButton</tabstop>

--- a/src/gui/entry/EditEntryWidgetAutoType.ui
+++ b/src/gui/entry/EditEntryWidgetAutoType.ui
@@ -90,6 +90,12 @@
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="toolTip">
+        <string>Open AutoType help webpage</string>
+       </property>
+       <property name="accessibleName">
+        <string>AutoType help button</string>
+       </property>
        <property name="text">
         <string/>
        </property>


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
When adding custom Auto-Type sequences, I often find myself in a position where I can't remember the syntax exactly. This change adds a button next to the text edit field which opens the [Autotype Custom Sequence](https://github.com/keepassxreboot/keepassxc/wiki/Autotype-Custom-Sequence) wiki page in the default browser.


## Screenshots
![screenshot_20190223_202334](https://user-images.githubusercontent.com/303458/53290796-7432d580-37a9-11e9-8014-bba6d6af3968.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
