### PR TITLE
Add clear functionality to group share settings

### DIFF
--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -54,6 +54,7 @@ EditGroupWidgetKeeShare::EditGroupWidgetKeeShare(QWidget* parent)
     connect(m_ui->pathEdit, SIGNAL(editingFinished()), SLOT(selectPath()));
     connect(m_ui->pathSelectionButton, SIGNAL(pressed()), SLOT(launchPathSelectionDialog()));
     connect(m_ui->typeComboBox, SIGNAL(currentIndexChanged(int)), SLOT(selectType()));
+    connect(m_ui->clearButton, SIGNAL(clicked(bool)), SLOT(clearInputs()));
 
     connect(KeeShare::instance(), SIGNAL(activeChanged()), SLOT(showSharingState()));
 
@@ -164,6 +165,17 @@ void EditGroupWidgetKeeShare::update()
     m_ui->passwordGenerator->hide();
     m_ui->togglePasswordGeneratorButton->setChecked(false);
     m_ui->togglePasswordButton->setChecked(false);
+}
+
+void EditGroupWidgetKeeShare::clearInputs()
+{
+    if (m_temporaryGroup) {
+        KeeShare::setReferenceTo(m_temporaryGroup, KeeShareSettings::Reference());
+    }
+    m_ui->passwordEdit->clear();
+    m_ui->pathEdit->clear();
+    m_ui->typeComboBox->setCurrentIndex(KeeShareSettings::Inactive);
+    m_ui->passwordGenerator->setVisible(false);
 }
 
 void EditGroupWidgetKeeShare::togglePasswordGeneratorButton(bool checked)

--- a/src/keeshare/group/EditGroupWidgetKeeShare.h
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.h
@@ -44,6 +44,7 @@ private slots:
 
 private slots:
     void update();
+    void clearInputs();
     void selectType();
     void selectPassword();
     void launchPathSelectionDialog();

--- a/src/keeshare/group/EditGroupWidgetKeeShare.ui
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.ui
@@ -97,6 +97,13 @@
      <item row="5" column="1">
       <widget class="PasswordGeneratorWidget" name="passwordGenerator" native="true"/>
      </item>
+     <item row="6" column="1">
+      <widget class="QPushButton" name="clearButton">
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
Added a 'Clear' button to the group settings for sharing.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Fixes a part of #2657 (clear button)

## Testing strategy
Manual testing.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
