### PR TITLE
Add share indication label in group view

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -61,8 +61,6 @@
 #include "keeshare/KeeShare.h"
 #include "touchid/TouchID.h"
 
-#include "config-keepassx.h"
-
 #ifdef Q_OS_LINUX
 #include <sys/vfs.h>
 #endif
@@ -80,6 +78,9 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     , m_previewView(new EntryPreviewWidget(this))
     , m_previewSplitter(new QSplitter(m_mainWidget))
     , m_searchingLabel(new QLabel(this))
+#ifdef WITH_XC_KEESHARE
+    , m_shareLabel(new QLabel(this))
+#endif
     , m_csvImportWizard(new CsvImportWizard(this))
     , m_editEntryWidget(new EditEntryWidget(this))
     , m_editGroupWidget(new EditGroupWidget(this))
@@ -103,6 +104,9 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     auto* vbox = new QVBoxLayout();
     vbox->setMargin(0);
     vbox->addWidget(m_searchingLabel);
+#ifdef WITH_XC_KEESHARE
+    vbox->addWidget(m_shareLabel);
+#endif
     vbox->addWidget(m_previewSplitter);
     rightHandSideWidget->setLayout(vbox);
     m_entryView = new EntryView(rightHandSideWidget);
@@ -133,6 +137,16 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
                                     "border: 2px solid rgb(190, 190, 190);"
                                     "border-radius: 4px;");
     m_searchingLabel->setVisible(false);
+
+#ifdef WITH_XC_KEESHARE
+    m_shareLabel->setText(tr("Shared group..."));
+    m_shareLabel->setAlignment(Qt::AlignCenter);
+    m_shareLabel->setStyleSheet("color: rgb(0, 0, 0);"
+                                "background-color: rgb(255, 253, 160);"
+                                "border: 2px solid rgb(190, 190, 190);"
+                                "border-radius: 4px;");
+    m_shareLabel->setVisible(false);
+#endif
 
     m_previewView->hide();
     m_previewSplitter->addWidget(m_entryView);
@@ -1117,6 +1131,15 @@ void DatabaseWidget::onGroupChanged(Group* group)
     }
 
     m_previewView->setGroup(group);
+
+#ifdef WITH_XC_KEESHARE
+    if (group && KeeShare::isShared(group)) {
+        m_shareLabel->setText(KeeShare::sharingLabel(group));
+        m_shareLabel->setVisible(true);
+    } else {
+        m_shareLabel->setVisible(false);
+    }
+#endif
 }
 
 void DatabaseWidget::onDatabaseModified()

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -779,9 +779,9 @@ void DatabaseWidget::switchToMainView(bool previousDialogAccepted)
 
     setCurrentWidget(m_mainWidget);
 
-    if (sender() == m_entryView) {
+    if (sender() == m_entryView || sender() == m_editEntryWidget) {
         onEntryChanged(m_entryView->currentEntry());
-    } else if (sender() == m_groupView) {
+    } else if (sender() == m_groupView || sender() == m_editGroupWidget) {
         onGroupChanged(m_groupView->currentGroup());
     }
 }
@@ -1103,6 +1103,7 @@ void DatabaseWidget::search(const QString& searchtext)
     }
 
     m_searchingLabel->setVisible(true);
+    m_shareLabel->setVisible(false);
 
     emit searchModeActivated();
 }
@@ -1133,8 +1134,9 @@ void DatabaseWidget::onGroupChanged(Group* group)
     m_previewView->setGroup(group);
 
 #ifdef WITH_XC_KEESHARE
-    if (group && KeeShare::isShared(group)) {
-        m_shareLabel->setText(KeeShare::sharingLabel(group));
+    auto shareLabel = KeeShare::sharingLabel(group);
+    if (!shareLabel.isEmpty()) {
+        m_shareLabel->setText(shareLabel);
         m_shareLabel->setVisible(true);
     } else {
         m_shareLabel->setVisible(false);
@@ -1163,6 +1165,7 @@ void DatabaseWidget::endSearch()
 
         // Show the normal entry view of the current group
         m_entryView->displayGroup(currentGroup());
+        onGroupChanged(currentGroup());
 
         emit listModeActivated();
     }

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -29,6 +29,8 @@
 #include "gui/csvImport/CsvImportWizard.h"
 #include "gui/entry/EntryModel.h"
 
+#include "config-keepassx.h"
+
 class DatabaseOpenWidget;
 class KeePass1OpenWidget;
 class DatabaseSettingsDialog;
@@ -233,6 +235,9 @@ private:
     QPointer<EntryPreviewWidget> m_previewView;
     QPointer<QSplitter> m_previewSplitter;
     QPointer<QLabel> m_searchingLabel;
+#ifdef WITH_XC_KEESHARE
+    QPointer<QLabel> m_shareLabel;
+#endif
     QPointer<CsvImportWizard> m_csvImportWizard;
     QPointer<EditEntryWidget> m_editEntryWidget;
     QPointer<EditGroupWidget> m_editGroupWidget;

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -120,6 +120,7 @@ bool SearchWidget::eventFilter(QObject* obj, QEvent* event)
 
 void SearchWidget::connectSignals(SignalMultiplexer& mx)
 {
+    // Connects basically only to the current DatabaseWidget, but allows to switch between instances!
     mx.connect(this, SIGNAL(search(QString)), SLOT(search(QString)));
     mx.connect(this, SIGNAL(caseSensitiveChanged(bool)), SLOT(setSearchCaseSensitive(bool)));
     mx.connect(this, SIGNAL(limitGroupChanged(bool)), SLOT(setSearchLimitGroup(bool)));

--- a/src/keeshare/KeeShare.cpp
+++ b/src/keeshare/KeeShare.cpp
@@ -142,6 +142,25 @@ bool KeeShare::isEnabled(const Group* group)
     return (reference.isImporting() && active.in) || (reference.isExporting() && active.out);
 }
 
+QString KeeShare::sharingLabel(const Group* group)
+{
+    if (!isShared(group)) {
+        return "";
+    }
+    const auto reference = referenceOf(group);
+    switch (reference.type) {
+    case KeeShareSettings::Inactive:
+        return tr("Disabled share %1").arg(reference.path);
+    case KeeShareSettings::ImportFrom:
+        return tr("Import from share %1").arg(reference.path);
+    case KeeShareSettings::ExportTo:
+        return tr("Export to share %1").arg(reference.path);
+    case KeeShareSettings::SynchronizeWith:
+        return tr("Synchronize with share %1").arg(reference.path);
+    }
+    return "";
+}
+
 QPixmap KeeShare::indicatorBadge(const Group* group, QPixmap pixmap)
 {
     if (!isShared(group)) {

--- a/src/keeshare/KeeShare.h
+++ b/src/keeshare/KeeShare.h
@@ -43,6 +43,8 @@ public:
     static bool isShared(const Group* group);
     static bool isEnabled(const Group* group);
 
+    static QString sharingLabel(const Group* group);
+
     static KeeShareSettings::Own own();
     static KeeShareSettings::Active active();
     static KeeShareSettings::Foreign foreign();

--- a/src/keeshare/KeeShare.h
+++ b/src/keeshare/KeeShare.h
@@ -43,6 +43,7 @@ public:
     static bool isShared(const Group* group);
     static bool isEnabled(const Group* group);
 
+    static const Group* resolveSharedGroup(const Group* group);
     static QString sharingLabel(const Group* group);
 
     static KeeShareSettings::Own own();


### PR DESCRIPTION
Added a sharing label to DatabaseWidget to indicate shared containers.

## Type of change
- ✅ Improved feature (non-breaking change which adds functionality)

## Description and Context
To highlight that a group is shared, a label is shown with the synchronization method and the path to synchronize to. Improvement is part of #2657
Added a small comment which may allow next reader to see the connection between `DatabaseWidget` and `SearchWidget` using the `SignalMultiplexer`.

## Restrictions
The label is only updated enter/leave of a group. It would be possible to observe the changes of the custom data if needed and wished for. 

## Testing strategy
Manually tested.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
