### PR TITLE
Hotfix/2657 prevent share overwrite

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -370,7 +370,9 @@ void DatabaseWidget::replaceDatabase(QSharedPointer<Database> db)
     // TODO: instead of increasing the ref count temporarily, there should be a clean
     // break from the old database. Without this crashes occur due to the change
     // signals triggering dangling pointers.
+#if defined(WITH_XC_KEESHARE)
     auto oldDb = m_db;
+#endif
     m_db = std::move(db);
     connectDatabaseSignals();
     m_groupView->changeDatabase(m_db);
@@ -1548,7 +1550,11 @@ bool DatabaseWidget::saveAs()
             // Ensure we don't recurse back into this function
             m_db->setReadOnly(false);
             m_db->setFilePath(newFilePath);
-
+#ifdef WITH_XC_KEESHARE
+            // We need to reregister the database to allow exports
+            // from a newly created database
+            KeeShare::instance()->connectDatabase(m_db, m_db);
+#endif
             if (!save(-1)) {
                 // Failed to save, try again
                 continue;

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    void set(Group* temporaryGroup, const Database* database) const
+    void set(Group* temporaryGroup, QSharedPointer<Database> database) const
     {
         editPage->set(widget, temporaryGroup, database);
     }
@@ -133,7 +133,7 @@ void EditGroupWidget::loadGroup(Group* group, bool create, const QSharedPointer<
     m_editWidgetProperties->setCustomData(m_temporaryGroup->customData());
 
     for (const ExtraPage& page : asConst(m_extraPages)) {
-        page.set(m_temporaryGroup.data(), m_db.data());
+        page.set(m_temporaryGroup.data(), m_db);
     }
 
     setCurrentPage(0);

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -36,9 +36,9 @@ public:
     {
     }
 
-    void set(Group* temporaryGroup) const
+    void set(Group* temporaryGroup, const Database* database) const
     {
-        editPage->set(widget, temporaryGroup);
+        editPage->set(widget, temporaryGroup, database);
     }
 
     void assign() const
@@ -133,7 +133,7 @@ void EditGroupWidget::loadGroup(Group* group, bool create, const QSharedPointer<
     m_editWidgetProperties->setCustomData(m_temporaryGroup->customData());
 
     for (const ExtraPage& page : asConst(m_extraPages)) {
-        page.set(m_temporaryGroup.data());
+        page.set(m_temporaryGroup.data(), m_db.data());
     }
 
     setCurrentPage(0);

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -43,7 +43,7 @@ public:
     virtual QString name() = 0;
     virtual QIcon icon() = 0;
     virtual QWidget* createWidget() = 0;
-    virtual void set(QWidget* widget, Group* tempoaryGroup, const Database* database) = 0;
+    virtual void set(QWidget* widget, Group* tempoaryGroup, QSharedPointer<Database> database) = 0;
     virtual void assign(QWidget* widget) = 0;
 };
 

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -43,7 +43,7 @@ public:
     virtual QString name() = 0;
     virtual QIcon icon() = 0;
     virtual QWidget* createWidget() = 0;
-    virtual void set(QWidget* widget, Group* tempoaryGroup) = 0;
+    virtual void set(QWidget* widget, Group* tempoaryGroup, const Database* database) = 0;
     virtual void assign(QWidget* widget) = 0;
 };
 

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -25,6 +25,7 @@
 #include "core/Entry.h"
 #include "core/FilePath.h"
 #include "core/FileWatcher.h"
+#include "core/Global.h"
 #include "core/Group.h"
 #include "core/Merger.h"
 #include "core/Metadata.h"
@@ -191,7 +192,7 @@ void ShareObserver::reinitialize()
 
     const auto active = KeeShare::active();
     QList<Update> updated;
-    QList<Group*> groups = m_db->rootGroup()->groupsRecursive(true);
+    const QList<Group*> groups = m_db->rootGroup()->groupsRecursive(true);
     for (Group* group : groups) {
         Update couple{group, m_groupToReference.value(group), KeeShare::referenceOf(group)};
         if (couple.oldReference == couple.newReference) {
@@ -214,7 +215,9 @@ void ShareObserver::reinitialize()
     QStringList success;
     QStringList warning;
     QStringList error;
-    for (const auto& update : updated) {
+    QMap<QString, QStringList> imported;
+    QMap<QString, QStringList> exported;
+    for (const auto& update : asConst(updated)) {
         if (!update.oldReference.path.isEmpty()) {
             m_fileWatcher->removePath(update.oldReference.path);
         }
@@ -222,8 +225,12 @@ void ShareObserver::reinitialize()
         if (!update.newReference.path.isEmpty() && update.newReference.type != KeeShareSettings::Inactive) {
             m_fileWatcher->addPath(update.newReference.path);
         }
+        if (update.newReference.isExporting()) {
+            exported[update.newReference.path] << update.group->name();
+        }
 
         if (update.newReference.isImporting()) {
+            imported[update.newReference.path] << update.group->name();
             const auto result = this->importFromReferenceContainer(update.newReference.path);
             if (!result.isValid()) {
                 // tolerable result - blocked import or missing source
@@ -239,6 +246,16 @@ void ShareObserver::reinitialize()
             } else {
                 success << tr("Imported from %1").arg(result.path);
             }
+        }
+    }
+    for (auto it = imported.cbegin(); it != imported.cend(); ++it) {
+        if (it.value().count() > 1) {
+            warning << tr("Multiple import source path to %1 in %2").arg(it.key(), it.value().join(", "));
+        }
+    }
+    for (auto it = exported.cbegin(); it != exported.cend(); ++it) {
+        if (it.value().count() > 1) {
+            error << tr("Conflicting export target path %1 in %2").arg(it.key(), it.value().join(", "));
         }
     }
 
@@ -725,28 +742,55 @@ ShareObserver::Result ShareObserver::exportIntoReferenceUnsignedContainer(const 
 QList<ShareObserver::Result> ShareObserver::exportIntoReferenceContainers()
 {
     QList<Result> results;
+    struct Reference
+    {
+        KeeShareSettings::Reference config;
+        const Group* group;
+    };
+
+    QMap<QString, QList<Reference>> references;
     const auto groups = m_db->rootGroup()->groupsRecursive(true);
     for (const auto* group : groups) {
         const auto reference = KeeShare::referenceOf(group);
         if (!reference.isExporting()) {
             continue;
         }
+        references[reference.path] << Reference{reference, group};
+    }
 
-        m_fileWatcher->ignoreFileChanges(reference.path);
-        QScopedPointer<Database> targetDb(exportIntoContainer(reference, group));
-        QFileInfo info(reference.path);
+    for (auto it = references.cbegin(); it != references.cend(); ++it) {
+        if (it.value().count() != 1) {
+            const auto path = it.value().first().config.path;
+            QStringList groups;
+            for (const auto& reference : it.value()) {
+                groups << reference.group->name();
+            }
+            results << Result{
+                path, Result::Error, tr("Conflicting export target path %1 in %2").arg(path, groups.join(", "))};
+        }
+    }
+    if (!results.isEmpty()) {
+        // We need to block export due to config
+        return results;
+    }
+
+    for (auto it = references.cbegin(); it != references.cend(); ++it) {
+        const auto& reference = it.value().first();
+        m_fileWatcher->ignoreFileChanges(reference.config.path);
+        QScopedPointer<Database> targetDb(exportIntoContainer(reference.config, reference.group));
+        QFileInfo info(reference.config.path);
         if (isOfExportType(info, KeeShare::signedContainerFileType())) {
-            results << exportIntoReferenceSignedContainer(reference, targetDb.data());
+            results << exportIntoReferenceSignedContainer(reference.config, targetDb.data());
             m_fileWatcher->observeFileChanges(true);
             continue;
         }
         if (isOfExportType(info, KeeShare::unsignedContainerFileType())) {
-            results << exportIntoReferenceUnsignedContainer(reference, targetDb.data());
+            results << exportIntoReferenceUnsignedContainer(reference.config, targetDb.data());
             m_fileWatcher->observeFileChanges(true);
             continue;
         }
         Q_ASSERT(false);
-        results << Result{reference.path, Result::Error, tr("Unexpected export error occurred")};
+        results << Result{reference.config.path, Result::Error, tr("Unexpected export error occurred")};
     }
     return results;
 }
@@ -759,6 +803,7 @@ void ShareObserver::handleDatabaseSaved()
     QStringList error;
     QStringList warning;
     QStringList success;
+
     const auto results = exportIntoReferenceContainers();
     for (const Result& result : results) {
         if (!result.isValid()) {

--- a/src/keeshare/group/EditGroupPageKeeShare.cpp
+++ b/src/keeshare/group/EditGroupPageKeeShare.cpp
@@ -42,10 +42,10 @@ QWidget* EditGroupPageKeeShare::createWidget()
     return new EditGroupWidgetKeeShare();
 }
 
-void EditGroupPageKeeShare::set(QWidget* widget, Group* temporaryGroup)
+void EditGroupPageKeeShare::set(QWidget* widget, Group* temporaryGroup, const Database* database)
 {
     EditGroupWidgetKeeShare* settingsWidget = reinterpret_cast<EditGroupWidgetKeeShare*>(widget);
-    settingsWidget->setGroup(temporaryGroup);
+    settingsWidget->setGroup(temporaryGroup, database);
 }
 
 void EditGroupPageKeeShare::assign(QWidget* widget)

--- a/src/keeshare/group/EditGroupPageKeeShare.cpp
+++ b/src/keeshare/group/EditGroupPageKeeShare.cpp
@@ -42,7 +42,7 @@ QWidget* EditGroupPageKeeShare::createWidget()
     return new EditGroupWidgetKeeShare();
 }
 
-void EditGroupPageKeeShare::set(QWidget* widget, Group* temporaryGroup, const Database* database)
+void EditGroupPageKeeShare::set(QWidget* widget, Group* temporaryGroup, QSharedPointer<Database> database)
 {
     EditGroupWidgetKeeShare* settingsWidget = reinterpret_cast<EditGroupWidgetKeeShare*>(widget);
     settingsWidget->setGroup(temporaryGroup, database);

--- a/src/keeshare/group/EditGroupPageKeeShare.h
+++ b/src/keeshare/group/EditGroupPageKeeShare.h
@@ -30,7 +30,7 @@ public:
     QString name() override;
     QIcon icon() override;
     QWidget* createWidget() override;
-    void set(QWidget* widget, Group* temporaryGroup) override;
+    void set(QWidget* widget, Group* temporaryGroup, const Database* database) override;
     void assign(QWidget* widget) override;
 };
 

--- a/src/keeshare/group/EditGroupPageKeeShare.h
+++ b/src/keeshare/group/EditGroupPageKeeShare.h
@@ -30,7 +30,7 @@ public:
     QString name() override;
     QIcon icon() override;
     QWidget* createWidget() override;
-    void set(QWidget* widget, Group* temporaryGroup, const Database* database) override;
+    void set(QWidget* widget, Group* temporaryGroup, QSharedPointer<Database> database) override;
     void assign(QWidget* widget) override;
 };
 

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -84,12 +84,13 @@ EditGroupWidgetKeeShare::~EditGroupWidgetKeeShare()
 {
 }
 
-void EditGroupWidgetKeeShare::setGroup(Group* temporaryGroup)
+void EditGroupWidgetKeeShare::setGroup(Group* temporaryGroup, const Database* database)
 {
     if (m_temporaryGroup) {
         m_temporaryGroup->disconnect(this);
     }
 
+    m_database = database;
     m_temporaryGroup = temporaryGroup;
 
     if (m_temporaryGroup) {
@@ -127,9 +128,43 @@ void EditGroupWidgetKeeShare::showSharingState()
                     .arg(supportedExtensions.join(", ")),
                 MessageWidget::Warning);
             return;
-        } else {
-            m_ui->messageWidget->hide();
         }
+
+        const auto groups = m_database->rootGroup()->groupsRecursive(true);
+        bool conflictExport = false;
+        bool multipleImport = false;
+        bool cycleImportExport = false;
+        for (const auto* group : groups) {
+            if (group->uuid() == m_temporaryGroup->uuid()) {
+                continue;
+            }
+            const auto other = KeeShare::referenceOf(group);
+            if (other.path != reference.path) {
+                continue;
+            }
+            multipleImport |= other.isImporting() && reference.isImporting();
+            conflictExport |= other.isExporting() && reference.isExporting();
+            cycleImportExport |=
+                (other.isImporting() && reference.isExporting()) || (other.isExporting() && reference.isImporting());
+        }
+        if (conflictExport) {
+            m_ui->messageWidget->showMessage(tr("The export container %1 is already referenced.").arg(reference.path),
+                                             MessageWidget::Error);
+            return;
+        }
+        if (multipleImport) {
+            m_ui->messageWidget->showMessage(tr("The import container %1 is already imported.").arg(reference.path),
+                                             MessageWidget::Warning);
+            return;
+        }
+        if (cycleImportExport) {
+            m_ui->messageWidget->showMessage(
+                tr("The container %1 imported and export by different groups.").arg(reference.path),
+                MessageWidget::Warning);
+            return;
+        }
+
+        m_ui->messageWidget->hide();
     }
     const auto active = KeeShare::active();
     if (!active.in && !active.out) {

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -84,7 +84,7 @@ EditGroupWidgetKeeShare::~EditGroupWidgetKeeShare()
 {
 }
 
-void EditGroupWidgetKeeShare::setGroup(Group* temporaryGroup, const Database* database)
+void EditGroupWidgetKeeShare::setGroup(Group* temporaryGroup, QSharedPointer<Database> database)
 {
     if (m_temporaryGroup) {
         m_temporaryGroup->disconnect(this);

--- a/src/keeshare/group/EditGroupWidgetKeeShare.h
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.h
@@ -37,7 +37,7 @@ public:
     explicit EditGroupWidgetKeeShare(QWidget* parent = nullptr);
     ~EditGroupWidgetKeeShare();
 
-    void setGroup(Group* temporaryGroup);
+    void setGroup(Group* temporaryGroup, const Database* database);
 
 private slots:
     void showSharingState();
@@ -54,6 +54,7 @@ private slots:
 private:
     QScopedPointer<Ui::EditGroupWidgetKeeShare> m_ui;
     QPointer<Group> m_temporaryGroup;
+    QPointer<const Database> m_database;
 };
 
 #endif // KEEPASSXC_EDITGROUPWIDGETKEESHARE_H

--- a/src/keeshare/group/EditGroupWidgetKeeShare.h
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.h
@@ -37,7 +37,7 @@ public:
     explicit EditGroupWidgetKeeShare(QWidget* parent = nullptr);
     ~EditGroupWidgetKeeShare();
 
-    void setGroup(Group* temporaryGroup, const Database* database);
+    void setGroup(Group* temporaryGroup, QSharedPointer<Database> database);
 
 private slots:
     void showSharingState();
@@ -54,7 +54,7 @@ private slots:
 private:
     QScopedPointer<Ui::EditGroupWidgetKeeShare> m_ui;
     QPointer<Group> m_temporaryGroup;
-    QPointer<const Database> m_database;
+    QSharedPointer<Database> m_database;
 };
 
 #endif // KEEPASSXC_EDITGROUPWIDGETKEESHARE_H


### PR DESCRIPTION
Added warnings and prevented export when exports are conflicting, added warning when imports are using the same source.

Fixed an additional bug which prevented the usage of exports when a database was newly created. 

Addresses an issue discussed in #2657.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Creation of a new database did not trigger the export even when needed references were defined. 
In case of multiple usage of the same export/import container, there was no indication about that. Now the import/export and configuration gives warnings/errors about those cases.

## Testing strategy
Manually tested.

## Points to discuss
Currently the checking uses the entered paths. We may extend the checking to use canonical paths which may reduce (but not eliminate) the error rate. 
An alternative (but does not prevent export!) would be to open and check the container for an export flag in the public data which indicates if the container was already written within the "transaction" and to abort the following exports for this container. I'm not sure if this would be a better solution to the problem since we do export data partially and (for now) there is no guarantee that the order of exports is deterministic.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
