### PR TITLE
Add missing colon to SettingsWidgetKeeShare.ui

### DIFF
--- a/src/keeshare/SettingsWidgetKeeShare.ui
+++ b/src/keeshare/SettingsWidgetKeeShare.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>327</width>
-    <height>434</height>
+    <width>378</width>
+    <height>508</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
@@ -82,7 +82,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="ownCertificateSignerLabel">
         <property name="text">
-         <string>Signer</string>
+         <string>Signer:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Working on the Russian translation for KeePassXC 2.4.0 (which is about to be released) I noticed that SettingsWidgetKeeShare.ui lacks a colon after "Signer" (all other labels in the same group have it). So I have added it for consistency.


## Screenshots
Before
![screenshot_20190301_155719](https://user-images.githubusercontent.com/11542782/53639675-f0f70100-3c3a-11e9-870e-c720a765322e.jpg)
After
![screenshot_20190301_160336](https://user-images.githubusercontent.com/11542782/53639924-b6da2f00-3c3b-11e9-850b-967647c6a5db.jpg)




## Testing strategy
Manual testing.


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

