### PR TITLE
Small fixes for Browser Integration

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -630,7 +630,7 @@ QList<Entry*> BrowserService::sortEntries(QList<Entry*>& pwEntries, const QStrin
 {
     QUrl url(entryUrl);
     if (url.scheme().isEmpty()) {
-        url.setScheme("http");
+        url.setScheme("https");
     }
 
     const QString submitUrl = url.toString(QUrl::StripTrailingSlash);

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -186,7 +186,7 @@ void BrowserSettings::setCustomProxyLocation(const QString& location)
 
 bool BrowserSettings::updateBinaryPath()
 {
-    return config()->get("Browser/UpdateBinaryPath", false).toBool();
+    return config()->get("Browser/UpdateBinaryPath", true).toBool();
 }
 
 void BrowserSettings::setUpdateBinaryPath(bool enabled)


### PR DESCRIPTION
The following small fixes are made for Browser Integration:
- Default URL matching scheme changed from `http` to `https`
- Auto-updating native messaging manifest files is enabled by default

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes https://github.com/keepassxreboot/keepassxc/issues/2715.
Fixes https://github.com/keepassxreboot/keepassxc/issues/2706.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually.


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
