### PR TITLE
src/cli/CMakeLists.txt: Don't call mandb

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -94,5 +94,4 @@ endif()
 
 if(APPLE OR UNIX)
     install(FILES keepassxc-cli.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)
-    execute_process(COMMAND mandb -q)
 endif()


### PR DESCRIPTION
There are other man implementations beside man-db so it is not even sure
that the "mandb" binary even exists on all unices. Other than that, usually
there's a cron job running "mandb" on a daily basis.