### PR TITLE
Allow creating new groups with Browser Integration

### DIFF
--- a/src/browser/BrowserAction.h
+++ b/src/browser/BrowserAction.h
@@ -46,7 +46,8 @@ class BrowserAction : public QObject
         ERROR_KEEPASS_EMPTY_MESSAGE_RECEIVED = 13,
         ERROR_KEEPASS_NO_URL_PROVIDED = 14,
         ERROR_KEEPASS_NO_LOGINS_FOUND = 15,
-        ERROR_KEEPASS_NO_GROUPS_FOUND = 16
+        ERROR_KEEPASS_NO_GROUPS_FOUND = 16,
+        ERROR_KEEPASS_CANNOT_CREATE_NEW_GROUP = 17
     };
 
 public:
@@ -66,6 +67,7 @@ private:
     QJsonObject handleSetLogin(const QJsonObject& json, const QString& action);
     QJsonObject handleLockDatabase(const QJsonObject& json, const QString& action);
     QJsonObject handleGetDatabaseGroups(const QJsonObject& json, const QString& action);
+    QJsonObject handleCreateNewGroup(const QJsonObject& json, const QString& action);
 
     QJsonObject buildMessage(const QString& nonce) const;
     QJsonObject buildResponse(const QString& action, const QJsonObject& message, const QString& nonce);

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -45,6 +45,7 @@ public:
     QString getDatabaseRootUuid();
     QString getDatabaseRecycleBinUuid();
     QJsonObject getDatabaseGroups();
+    QJsonObject createNewGroup(const QString& groupName);
     QString getKey(const QString& id);
     void addEntry(const QString& id,
                   const QString& login,
@@ -121,7 +122,7 @@ private:
     QString baseDomain(const QString& url) const;
     QSharedPointer<Database> getDatabase();
     QSharedPointer<Database> selectedDatabase();
-    QJsonArray addChildrenToGroup(Group* group);
+    QJsonArray getChildrenFromGroup(Group* group);
     bool moveSettingsToCustomData(Entry* entry, const QString& name) const;
     int moveKeysToCustomData(Entry* entry, const QSharedPointer<Database>& db) const;
     bool checkLegacySettings();


### PR DESCRIPTION
With https://github.com/keepassxreboot/keepassxc-browser/pull/396 default group for saving passwords can be specified. Any group name not found in the database will be automatically created when saving new credentials.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. The tests will be included later in a separate browser tests PR.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
