### PR TITLE
Developer VM for KeePassXC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build*/
 cmake-build-*/
 release*/
 .idea/
+.vagrant/
 *.iml
 *.kdev4
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,113 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "peru/ubuntu-18.04-desktop-amd64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/home/vagrant/keepassxc"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+     export QT5_VERSION=qt511
+     export QT5_PPA_VERSION=qt-5.11.2
+
+     apt-get update
+     apt-get install -y software-properties-common
+
+     add-apt-repository ppa:beineri/opt-${QT5_PPA_VERSION}-bionic
+     add-apt-repository ppa:phoerious/keepassxc
+
+     apt-get update
+     apt-get install -y \
+        cmake \
+        curl \
+        g++ \
+        git \
+        libargon2-0-dev \
+        libcurl4-gnutls-dev \
+        libgcrypt20-dev \
+        libfuse2 \
+        libqrencode-dev \
+        libsodium-dev \
+        libxi-dev \
+        libxtst-dev \
+        libyubikey-dev \
+        libykpers-1-dev \
+        mesa-common-dev \
+        xclip \
+        xvfb \
+        zlib1g-dev \
+        ${QT5_VERSION}base \
+        ${QT5_VERSION}tools \
+        ${QT5_VERSION}x11extras \
+        ${QT5_VERSION}translations \
+        ${QT5_VERSION}imageformats \
+        ${QT5_VERSION}svg \
+
+      echo "/opt/${QT5_VERSION}/lib" > /etc/ld.so.conf.d/${QT5_VERSION}.conf
+      echo "/opt/keepassxc-libs/lib/x86_64-linux-gnu" > /etc/ld.so.conf.d/keepassxc.conf
+
+      curl -L "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" > /usr/bin/linuxdeploy
+      curl -L "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage" > /usr/bin/linuxdeploy-plugin-qt
+      curl -L "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" > /usr/bin/appimagetool
+      chmod +x /usr/bin/linuxdeploy
+      chmod +x /usr/bin/linuxdeploy-plugin-qt
+      chmod +x /usr/bin/appimagetool
+  SHELL
+end


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Developer VM for KeePassXC

Enable a developer to start an Ubuntu 18.04 development environment for
KeePassXC in a virtual machine to avoid having to mess-up their own host
machine.

- Provisions the VM on initial start-up with all dependencies necessary to build and run KeePassXC; based off Dockerfile

- Mounts current directory (i.e. keepasxc top-level) into /home/vagrant/keepassxc in the VM.

Dependencies:
1. Install Virtualbox or Libvirt VM drivers
2. Install Vagrant via your package manager or from web.

## Testing strategy
To start VM: `vagrant up`
To SSH into VM: `vagrant ssh` or login via VM UI

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
