### PR TITLE
Remediate errors in various favicon fetch scenarios (#2779)

### DIFF
--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -30,6 +30,7 @@
 #include "gui/MessageBox.h"
 
 #ifdef WITH_XC_NETWORKING
+#include <QHostInfo>
 #include <QNetworkAccessManager>
 #include <QtNetwork>
 #endif
@@ -195,13 +196,27 @@ void EditWidgetIcons::downloadFavicon()
     m_urlsToTry.clear();
 
     QString fullyQualifiedDomain = m_url.host();
-    QString secondLevelDomain = getSecondLevelDomain(m_url);
 
-    // Attempt to simply load the favicon.ico file
-    if (fullyQualifiedDomain != secondLevelDomain) {
-        m_urlsToTry.append(QUrl(m_url.scheme() + "://" + fullyQualifiedDomain + "/favicon.ico"));
+    m_urlsToTry.append(QUrl(m_url.scheme() + "://" + fullyQualifiedDomain + "/favicon.ico"));
+
+    // Determine if host portion of URL is an IP address by resolving it and
+    // searching for a match with the returned address(es).
+    bool hostIsIp = false;
+    QList<QHostAddress> hostAddressess = QHostInfo::fromName(fullyQualifiedDomain).addresses();
+    for (auto addr : hostAddressess) {
+        if (addr.toString() == fullyQualifiedDomain) {
+            hostIsIp = true;
+        }
     }
-    m_urlsToTry.append(QUrl(m_url.scheme() + "://" + secondLevelDomain + "/favicon.ico"));
+
+    if (!hostIsIp) {
+        QString secondLevelDomain = getSecondLevelDomain(m_url);
+
+        // Attempt to simply load the favicon.ico file
+        if (fullyQualifiedDomain != secondLevelDomain) {
+            m_urlsToTry.append(QUrl(m_url.scheme() + "://" + secondLevelDomain + "/favicon.ico"));
+        }
+    }
 
     // Try to use alternative fallback URL, if enabled
     if (config()->get("security/IconDownloadFallback", false).toBool()) {
@@ -209,6 +224,15 @@ void EditWidgetIcons::downloadFavicon()
         fallbackUrl.setPath("/ip3/" + QUrl::toPercentEncoding(fullyQualifiedDomain) + ".ico");
 
         m_urlsToTry.append(fallbackUrl);
+
+        if (!hostIsIp) {
+            QString secondLevelDomain = getSecondLevelDomain(m_url);
+
+            if (fullyQualifiedDomain != secondLevelDomain) {
+                fallbackUrl.setPath("/ip3/" + QUrl::toPercentEncoding(secondLevelDomain) + ".ico");
+                m_urlsToTry.append(fallbackUrl);
+            }
+        }
     }
 
     startFetchFavicon(m_urlsToTry.takeFirst());
@@ -276,7 +300,7 @@ void EditWidgetIcons::fetchFinished()
 #endif
 }
 
-void EditWidgetIcons::fetchCanceled()
+void EditWidgetIcons::abortRequests()
 {
 #ifdef WITH_XC_NETWORKING
     if (m_reply) {

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -19,7 +19,6 @@
 #ifndef KEEPASSX_EDITWIDGETICONS_H
 #define KEEPASSX_EDITWIDGETICONS_H
 
-#include <QSet>
 #include <QUrl>
 #include <QUuid>
 #include <QWidget>
@@ -66,6 +65,7 @@ public:
 
 public slots:
     void setUrl(const QString& url);
+    void abortRequests();
 
 signals:
     void messageEditEntry(QString, MessageWidget::MessageType);
@@ -77,7 +77,6 @@ private slots:
     void startFetchFavicon(const QUrl& url);
     void fetchFinished();
     void fetchReadyRead();
-    void fetchCanceled();
     void addCustomIconFromFile();
     bool addCustomIcon(const QImage& icon);
     void removeCustomIcon();

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -194,6 +194,8 @@ void EditEntryWidget::setupAdvanced()
 void EditEntryWidget::setupIcon()
 {
     addPage(tr("Icon"), FilePath::instance()->icon("apps", "preferences-desktop-icons"), m_iconsWidget);
+    connect(this, SIGNAL(accepted()), m_iconsWidget, SLOT(abortRequests()));
+    connect(this, SIGNAL(rejected()), m_iconsWidget, SLOT(abortRequests()));
 }
 
 void EditEntryWidget::setupAutoType()


### PR DESCRIPTION
Fixes stuck "Download favicon" button on icon download attempts for IP
address hosts by skipping attempts to get 2nd level domain resources
(which resulted in calls to 0.0.0.<rightmost octet of original IP>).

Fixes some cases when DuckDuckGo fallback fails to find icon of >2-level
domains, by adding a request to a DDG URL based on entry's 2nd level
domain.

Repurposes EditWidgetIcons' private fetchCanceled slot (which as of #2439,
is unused by any code) into public abortRequests slot, which is
connected to the entry edit widget's accepted and rejected signals (in
other words, Ok or Cancel was pressed).

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes issues discussed in comments of #2779 
- Stuck button: [[issue](https://github.com/keepassxreboot/keepassxc/issues/2779#issuecomment-471276323)] [[investigation](https://github.com/keepassxreboot/keepassxc/issues/2779#issuecomment-473513140)]
- DDG fallback failing for certain URLs with >2 levels of domains: [[context](https://github.com/keepassxreboot/keepassxc/issues/2779#issuecomment-473514407)]


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Test cases:

1. When an entry's URL is an IP address, requests should not hang, and "Download favicon" button should not be stuck in pressed state for this entry and later edited entries:
   - Created entry with an IP address as URL
   - Clicked "Download favicon button"
   - Verified that either red failure banner or green success banner appeared, and "Download favicon" button is not still depressed in this entry's edit widget.
   - Navigated to new entry, verified that "Download favicon" button was clickable.
1. When an entry needs to rely on DDG fallback for favicon download, if there are >2 levels of domains and FQDN fails in DDG, 2nd level domain should be attempted in DDG
    - Created entry with previously problematic URL `https://www.secretescapes.de/`
    - Clicked "Download favicon button"
    - Verified icon successfully downloaded
1. Upon clicking "Ok" or "Cancel" buttons in the entry edit widget, any remaining request should be aborted.
    - Started debug session and set breakpoint in `EditWidgetIcons::abortRequests()`
    - Opened an entry for editing, and click "Download favicon" button
    - Clicked "Ok" or "Cancel"
    - Verified that breakpoint was triggered,


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
