### PR TITLE
DatabaseWidget.cpp / m_shareLabel undefined

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1112,7 +1112,9 @@ void DatabaseWidget::search(const QString& searchtext)
     }
 
     m_searchingLabel->setVisible(true);
+#ifdef WITH_XC_KEESHARE
     m_shareLabel->setVisible(false);
+#endif
 
     emit searchModeActivated();
 }


### PR DESCRIPTION
Fix compilation when WITH_XC_KEESHARE isn't defined

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Fix compilation when WITH_XC_KEESHARE isn't defined

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
  cmake \
    -DCMAKE_INSTALL_PREFIX=/usr \
    -DCMAKE_BUILD_TYPE=Release \
    -DWITH_TESTS=OFF \
    -DWITH_XC_NETWORKING=ON \
    -DWITH_XC_BROWSER=ON \
    -DWITH_XC_YUBIKEY=OFF \
    -DWITH_XC_AUTOTYPE=ON \
    ..


## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed. 
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`.
