### PR TITLE
Fix a typo in EditGroupWidgetKeeShare

### DIFF
--- a/src/keeshare/KeeShare.cpp
+++ b/src/keeshare/KeeShare.cpp
@@ -164,13 +164,13 @@ QString KeeShare::sharingLabel(const Group* group)
     const auto reference = referenceOf(share);
     switch (reference.type) {
     case KeeShareSettings::Inactive:
-        return tr("Disabled share %1").arg(reference.path);
+        return tr("Inactive share %1").arg(reference.path);
     case KeeShareSettings::ImportFrom:
-        return tr("Import from share %1").arg(reference.path);
+        return tr("Imported from %1").arg(reference.path);
     case KeeShareSettings::ExportTo:
-        return tr("Export to share %1").arg(reference.path);
+        return tr("Exported to %1").arg(reference.path);
     case KeeShareSettings::SynchronizeWith:
-        return tr("Synchronize with share %1").arg(reference.path);
+        return tr("Synchronized with %1").arg(reference.path);
     }
 
     return {};
@@ -196,13 +196,13 @@ QString KeeShare::referenceTypeLabel(const KeeShareSettings::Reference& referenc
 {
     switch (reference.type) {
     case KeeShareSettings::Inactive:
-        return tr("Disabled share");
+        return tr("Inactive share");
     case KeeShareSettings::ImportFrom:
-        return tr("Import from");
+        return tr("Imported from");
     case KeeShareSettings::ExportTo:
-        return tr("Export to");
+        return tr("Exported to");
     case KeeShareSettings::SynchronizeWith:
-        return tr("Synchronize with");
+        return tr("Synchronized with");
     }
     return "";
 }

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -84,7 +84,7 @@ namespace
             key.openKey(QString());
             const auto signer = Signature();
             if (!signer.verify(data, sign.signature, key)) {
-                qCritical("Invalid signature for sharing container %s.", qPrintable(reference.path));
+                qCritical("Invalid signature for shared container %s.", qPrintable(reference.path));
                 return {Invalid, KeeShareSettings::Certificate()};
             }
 

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -160,7 +160,7 @@ void EditGroupWidgetKeeShare::showSharingState()
         }
         if (cycleImportExport) {
             m_ui->messageWidget->showMessage(
-                tr("The container %1 imported and export by different groups.").arg(reference.path),
+                tr("The container %1 imported and exported by different groups.").arg(reference.path),
                 MessageWidget::Warning);
             return;
         }

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -68,13 +68,13 @@ EditGroupWidgetKeeShare::EditGroupWidgetKeeShare(QWidget* parent)
             name = tr("Inactive");
             break;
         case KeeShareSettings::ImportFrom:
-            name = tr("Import from path");
+            name = tr("Import");
             break;
         case KeeShareSettings::ExportTo:
-            name = tr("Export to path");
+            name = tr("Export");
             break;
         case KeeShareSettings::SynchronizeWith:
-            name = tr("Synchronize with path");
+            name = tr("Synchronize");
             break;
         }
         m_ui->typeComboBox->insertItem(type, name, static_cast<int>(type));
@@ -124,10 +124,10 @@ void EditGroupWidgetKeeShare::showSharingState()
             }
         }
         if (!supported) {
-            m_ui->messageWidget->showMessage(
-                tr("Your KeePassXC version does not support sharing your container type. Please use %1.")
-                    .arg(supportedExtensions.join(", ")),
-                MessageWidget::Warning);
+            m_ui->messageWidget->showMessage(tr("Your KeePassXC version does not support sharing this container type.\n"
+                                                "Supported extensions are: %1.")
+                                                 .arg(supportedExtensions.join(", ")),
+                                             MessageWidget::Warning);
             return;
         }
 
@@ -149,18 +149,18 @@ void EditGroupWidgetKeeShare::showSharingState()
                 (other.isImporting() && reference.isExporting()) || (other.isExporting() && reference.isImporting());
         }
         if (conflictExport) {
-            m_ui->messageWidget->showMessage(tr("The export container %1 is already referenced.").arg(reference.path),
+            m_ui->messageWidget->showMessage(tr("%1 is already being exported by this database.").arg(reference.path),
                                              MessageWidget::Error);
             return;
         }
         if (multipleImport) {
-            m_ui->messageWidget->showMessage(tr("The import container %1 is already imported.").arg(reference.path),
+            m_ui->messageWidget->showMessage(tr("%1 is already being imported by this database.").arg(reference.path),
                                              MessageWidget::Warning);
             return;
         }
         if (cycleImportExport) {
             m_ui->messageWidget->showMessage(
-                tr("The container %1 imported and exported by different groups.").arg(reference.path),
+                tr("%1 is being imported and exported by different groups in this database.").arg(reference.path),
                 MessageWidget::Warning);
             return;
         }
@@ -169,15 +169,20 @@ void EditGroupWidgetKeeShare::showSharingState()
     }
     const auto active = KeeShare::active();
     if (!active.in && !active.out) {
-        m_ui->messageWidget->showMessage(tr("Database sharing is disabled"), MessageWidget::Information);
+        m_ui->messageWidget->showMessage(
+            tr("KeeShare is currently disabled. You can enable import/export in the application settings.",
+               "KeeShare is a proper noun"),
+            MessageWidget::Information);
         return;
     }
     if (active.in && !active.out) {
-        m_ui->messageWidget->showMessage(tr("Database export is disabled"), MessageWidget::Information);
+        m_ui->messageWidget->showMessage(tr("Database export is currently disabled by application settings."),
+                                         MessageWidget::Information);
         return;
     }
     if (!active.in && active.out) {
-        m_ui->messageWidget->showMessage(tr("Database import is disabled"), MessageWidget::Information);
+        m_ui->messageWidget->showMessage(tr("Database import is currently disabled by application settings."),
+                                         MessageWidget::Information);
         return;
     }
 }


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
During the translation of KeePassXC to Spanish and Russian I've encountered the following string: "The container %1 imported and export by different groups." I believe it should be "The container %1 imported and export**ed** by different groups." This PR fixes the typo. If I'm mistaken, then just close it.

## Testing strategy
Manual testing (well I've just fixed the typo).

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
