### PR TITLE
Snap: improve cursor theme

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,6 +9,12 @@ description: |
 confinement: strict
 base: core18
 
+plugs:
+  icon-themes: # fix mouse cursor theme
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+
 apps:
   keepassxc:
     command: desktop-launch keepassxc
@@ -67,6 +73,7 @@ parts:
       - libquazip5-1
       - libusb-1.0-0
       - qtwayland5
+      - qt5-style-plugins # for mouse cursor theme fix
     override-build: |
       snapcraftctl build
       sed -i 's|Icon=keepassxc|Icon=${SNAP}/usr/share/icons/hicolor/256x256/apps/keepassxc.png|g' $SNAPCRAFT_PART_INSTALL/usr/share/applications/org.keepassxc.KeePassXC.desktop


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
One issue with Qt snaps is the default cursor theme, which is a fallback theme and quite ugly. I propose the following changes to the snapcraft.yaml file to use the system cursor theme when available. Please see the following thread on the snapcraft forum for more background info and limitations of this: https://forum.snapcraft.io/t/qt-apps-and-gtk-themes-an-investigation-with-partial-success/10513

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

To use the system cursor theme, the snap needs to connect to the appropriate plug (icon theme plug). In addition, a new stage package is required (qt5 style plugins).
Please see screenshots below for the result.

## Screenshots
Before:
![ugly](https://user-images.githubusercontent.com/12795018/54790390-3f922c80-4c36-11e9-9095-1d05e580967b.png)

After:
![fix](https://user-images.githubusercontent.com/12795018/54790392-43be4a00-4c36-11e9-84a9-8c84c291cc1f.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on a few different distros. Please see the forum thread above for details.
It works for example with Ubuntu and elementaryOS. Distros that don't support this will keep using the fallback cursor theme, so for them nothing changes, it has only advantages.


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
