### PR TITLE
Fix base64 check missing '/' as valid character

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -205,7 +205,7 @@ namespace Tools
 
     bool isBase64(const QByteArray& ba)
     {
-        constexpr auto pattern = R"(^(?:[a-z0-9+]{4})*(?:[a-z0-9+]{3}=|[a-z0-9+]{2}==)?$)";
+        constexpr auto pattern = R"(^(?:[a-z0-9+/]{4})*(?:[a-z0-9+/]{3}=|[a-z0-9+/]{2}==)?$)";
         QRegExp regexp(pattern, Qt::CaseInsensitive, QRegExp::RegExp2);
 
         QString base64 = QString::fromLatin1(ba.constData(), ba.size());

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -59,6 +59,7 @@ void TestTools::testIsBase64()
     QVERIFY(Tools::isBase64(QByteArray("12==")));
     QVERIFY(Tools::isBase64(QByteArray("abcd9876MN==")));
     QVERIFY(Tools::isBase64(QByteArray("abcd9876DEFGhijkMNO=")));
+    QVERIFY(Tools::isBase64(QByteArray("abcd987/DEFGh+jk/NO=")));
     QVERIFY(not Tools::isBase64(QByteArray("abcd123==")));
     QVERIFY(not Tools::isBase64(QByteArray("abc_")));
     QVERIFY(not Tools::isBase64(QByteArray("123")));


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Issue introduced in 558cb3d
* Corrects loading of legacy KeePass Key Files that included a '/' in their data section. Fix #2863 and Fix #2834

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
* Added base64 unit test for '+' and '/' characters
* Used test database provided by @vpav to confirm functionality

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
