### PR TITLE
Fix broken safe saves across file systems

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -241,20 +241,16 @@ bool Database::save(const QString& filePath, QString* error, bool atomic, bool b
 
             // Delete the original db and move the temp file in place
             QFile::remove(filePath);
-#ifdef Q_OS_LINUX
-            // workaround to make this workaround work, see: https://bugreports.qt.io/browse/QTBUG-64008
-            if (tempFile.copy(filePath)) {
-                // successfully saved database file
-                return true;
-            }
-#else
-            if (tempFile.rename(filePath)) {
+
+            // Note: call into the QFile rename instead of QTemporaryFile
+            // due to an undocumented difference in how the function handles
+            // errors. This prevents errors when saving across file systems.
+            if (tempFile.QFile::rename(filePath)) {
                 // successfully saved database file
                 tempFile.setAutoRemove(false);
                 setFilePath(filePath);
                 return true;
             }
-#endif
         }
         if (error) {
             *error = tempFile.errorString();

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -172,6 +172,7 @@ private:
 
     bool writeDatabase(QIODevice* device, QString* error = nullptr);
     bool backupDatabase(const QString& filePath);
+    bool restoreDatabase(const QString& filePath);
 
     Metadata* const m_metadata;
     DatabaseData m_data;

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -150,7 +150,8 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
     QFileInfo fileInfo(filePath);
     QString canonicalFilePath = fileInfo.canonicalFilePath();
     if (canonicalFilePath.isEmpty()) {
-        emit messageGlobal(tr("The database file does not exist or is not accessible."), MessageWidget::Error);
+        emit messageGlobal(tr("Failed to open %1. It either does not exist or is not accessible.").arg(filePath),
+                           MessageWidget::Error);
         return;
     }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -89,6 +89,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     , m_databaseOpenWidget(new DatabaseOpenWidget(this))
     , m_keepass1OpenWidget(new KeePass1OpenWidget(this))
     , m_groupView(new GroupView(m_db.data(), m_mainSplitter))
+    , m_saveAttempts(0)
     , m_fileWatcher(new DelayingFileWatcher(this))
 {
     m_messageWidget->setHidden(true);
@@ -859,6 +860,7 @@ void DatabaseWidget::loadDatabase(bool accepted)
         replaceDatabase(openWidget->database());
         switchToMainView();
         m_fileWatcher->restart();
+        m_saveAttempts = 0;
         emit databaseUnlocked();
     } else {
         m_fileWatcher->stop();
@@ -1512,7 +1514,7 @@ EntryView* DatabaseWidget::entryView()
  * @param attempt current save attempt or -1 to disable attempts
  * @return true on success
  */
-bool DatabaseWidget::save(int attempt)
+bool DatabaseWidget::save()
 {
     // Never allow saving a locked database; it causes corruption
     Q_ASSERT(!isLocked());
@@ -1527,6 +1529,8 @@ bool DatabaseWidget::save(int attempt)
     }
 
     blockAutoReload(true);
+    ++m_saveAttempts;
+
     // TODO: Make this async, but lock out the database widget to prevent re-entrance
     bool useAtomicSaves = config()->get("UseAtomicSaves", true).toBool();
     QString errorMessage;
@@ -1534,14 +1538,11 @@ bool DatabaseWidget::save(int attempt)
     blockAutoReload(false);
 
     if (ok) {
+        m_saveAttempts = 0;
         return true;
     }
 
-    if (attempt >= 0 && attempt <= 2) {
-        return save(attempt + 1);
-    }
-
-    if (attempt > 2 && useAtomicSaves) {
+    if (m_saveAttempts > 2 && useAtomicSaves) {
         // Saving failed 3 times, issue a warning and attempt to resolve
         auto result = MessageBox::question(this,
                                            tr("Disable safe saves?"),
@@ -1552,11 +1553,15 @@ bool DatabaseWidget::save(int attempt)
                                            MessageBox::Disable);
         if (result == MessageBox::Disable) {
             config()->set("UseAtomicSaves", false);
-            return save(attempt + 1);
+            return save();
         }
     }
 
-    showMessage(tr("Writing the database failed.\n%1").arg(errorMessage), MessageWidget::Error);
+    showMessage(tr("Writing the database failed: %1").arg(errorMessage),
+                MessageWidget::Error,
+                true,
+                MessageWidget::LongAutoHideTimeout);
+
     return false;
 }
 
@@ -1585,8 +1590,9 @@ bool DatabaseWidget::saveAs()
             // Ensure we don't recurse back into this function
             m_db->setReadOnly(false);
             m_db->setFilePath(newFilePath);
+            m_saveAttempts = 0;
 
-            if (!save(-1)) {
+            if (!save()) {
                 // Failed to save, try again
                 continue;
             }

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -144,7 +144,7 @@ signals:
 
 public slots:
     bool lock();
-    bool save(int attempt = 0);
+    bool save();
     bool saveAs();
 
     void replaceDatabase(QSharedPointer<Database> db);
@@ -254,6 +254,8 @@ private:
 
     QUuid m_groupBeforeLock;
     QUuid m_entryBeforeLock;
+
+    int m_saveAttempts;
 
     // Search state
     EntrySearcher* m_EntrySearcher;

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -23,6 +23,7 @@
 #include <QUrl>
 
 const int MessageWidget::DefaultAutoHideTimeout = 6000;
+const int MessageWidget::LongAutoHideTimeout = 15000;
 const int MessageWidget::DisableAutoHide = -1;
 
 MessageWidget::MessageWidget(QWidget* parent)

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -33,6 +33,7 @@ public:
     int autoHideTimeout() const;
 
     static const int DefaultAutoHideTimeout;
+    static const int LongAutoHideTimeout;
     static const int DisableAutoHide;
 
 signals:


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Fix #2888
* Qt has an undocumented rename implementation for QTemporaryFile that does not fallback to the copy implementation. Forcing the use of QFile::rename(...) allows for this fallback and protects against cross-device link errors.

* Improve behaviors when the database fails to save properly.
  * Mark database dirty if saving fails
  * Restore database file from backup if unsafe save fails between deleting database file and copying temporary file into place
  * Improve error message display for opening and saving database files
  * Do not automatically retry saving after failure. This prevents deletion of the backup database file and improves user awareness of issues.

This was tested against databases with various extensions and forced failure modes.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
