### PR TITLE
add Lock Databases option to tray icon menu

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -936,6 +936,8 @@ void MainWindow::updateTrayIcon()
             QAction* actionToggle = new QAction(tr("Toggle window"), menu);
             menu->addAction(actionToggle);
 
+            menu->addAction(m_ui->actionLockDatabases);
+
 #ifdef Q_OS_MACOS
             QAction* actionQuit = new QAction(tr("Quit KeePassXC"), menu);
             menu->addAction(actionQuit);


### PR DESCRIPTION
This is useful when keepassxc is minimized/hidden to the tray, and all
the plumbing is already in place from the lock icon button in the main
window UI.

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Add a shortcut to lock all databases to the tray icon's menu without having to
open the full GUI. This feature was shockingly trivial to add, thanks to the magic
of Qt.

## Screenshots
![image](https://user-images.githubusercontent.com/11742669/55120262-96cb4d80-50cb-11e9-9892-7cf986d6c335.png)
![image](https://user-images.githubusercontent.com/11742669/55120271-a054b580-50cb-11e9-9ba3-2fa8b3a4ab0d.png)
(ignore the weird transparency, it doesn't look like that for real, only when taking a screenshot on my system)

## Testing strategy
* All functionality is pulled in through the Lock Databases menu bar button that's already in MainWindow
* I tested on Linux (Arch with Gnome 3.32 and the "Kstatusnotifieritem/appindicator support" Gnome shell extension)
* Databases can be locked whether the main window is open or closed (hidden to tray)
* Menu option is greyed out when databases are already locked

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
  - Note: the "testgroup" test fails with a few asan indirect leaks on my machine with or without this PR's changes.
-  [n/a] My change requires a change to the documentation, and I have updated it accordingly.
-  [n/a] I have added tests to cover my changes.
