### PR TITLE
Adding --dry-run option for merge.

### DIFF
--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -77,6 +77,9 @@ Displays the program version.
 
 .SS "Merge options"
 
+.IP "-d, --dry-run <path>"
+Only print the changes detected by the merge operation.
+
 .IP "-f, --key-file-from <path>"
 Path of the key file for the second database.
 

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -60,7 +60,7 @@ void Merger::resetForcedMergeMode()
     m_mode = Group::Default;
 }
 
-bool Merger::merge()
+QStringList Merger::merge()
 {
     // Order of merge steps is important - it is possible that we
     // create some items before deleting them afterwards
@@ -74,9 +74,8 @@ bool Merger::merge()
     // At this point we have a list of changes we may want to show the user
     if (!changes.isEmpty()) {
         m_context.m_targetDb->markAsModified();
-        return true;
     }
-    return false;
+    return changes;
 }
 
 Merger::ChangeList Merger::mergeGroup(const MergeContext& context)

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -33,7 +33,7 @@ public:
     Merger(const Group* sourceGroup, Group* targetGroup);
     void setForcedMergeMode(Group::MergeMode mode);
     void resetForcedMergeMode();
-    bool merge();
+    QStringList merge();
 
 private:
     typedef QString Change;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -894,9 +894,9 @@ void DatabaseWidget::mergeDatabase(bool accepted)
         }
 
         Merger merger(srcDb.data(), m_db.data());
-        bool databaseChanged = merger.merge();
+        QStringList changeList = merger.merge();
 
-        if (databaseChanged) {
+        if (!changeList.isEmpty()) {
             showMessage(tr("Successfully merged the database files."), MessageWidget::Information);
         } else {
             showMessage(tr("Database was not modified by merge operation."), MessageWidget::Information);

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -496,8 +496,8 @@ ShareObserver::Result ShareObserver::importUnsignedContainerInto(const KeeShareS
                    qPrintable(sourceDb->rootGroup()->name()));
             Merger merger(sourceDb->rootGroup(), targetGroup);
             merger.setForcedMergeMode(Group::Synchronize);
-            const bool changed = merger.merge();
-            if (changed) {
+            const QStringList changeList = merger.merge();
+            if (!changeList.isEmpty()) {
                 return {reference.path, Result::Success, tr("Successful signed import")};
             }
         }
@@ -511,8 +511,8 @@ ShareObserver::Result ShareObserver::importUnsignedContainerInto(const KeeShareS
                qPrintable(sourceDb->rootGroup()->name()));
         Merger merger(sourceDb->rootGroup(), targetGroup);
         merger.setForcedMergeMode(Group::Synchronize);
-        const bool changed = merger.merge();
-        if (changed) {
+        const QStringList changeList = merger.merge();
+        if (!changeList.isEmpty()) {
             return {reference.path, Result::Success, tr("Successful unsigned import")};
         }
         return {};

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -876,23 +876,27 @@ void TestCli::testMerge()
     Kdbx4Writer writer;
     Kdbx4Reader reader;
 
-    // load test database and save a copy
+    // load test database and save copies
     auto db = readTestDatabase();
     QVERIFY(db);
     TemporaryFile targetFile1;
     targetFile1.open();
     writer.writeDatabase(&targetFile1, db.data());
     targetFile1.close();
-
-    // save another copy with a different password
     TemporaryFile targetFile2;
     targetFile2.open();
+    writer.writeDatabase(&targetFile2, db.data());
+    targetFile2.close();
+
+    // save another copy with a different password
+    TemporaryFile targetFile3;
+    targetFile3.open();
     auto oldKey = db->key();
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("b"));
     db->setKey(key);
-    writer.writeDatabase(&targetFile2, db.data());
-    targetFile2.close();
+    writer.writeDatabase(&targetFile3, db.data());
+    targetFile3.close();
     db->setKey(oldKey);
 
     // then add a new entry to the in-memory database and save another copy
@@ -914,7 +918,10 @@ void TestCli::testMerge()
     m_stdoutFile->seek(pos);
     m_stdoutFile->readLine();
     m_stderrFile->reset();
-    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Successfully merged the database files.\n"));
+    QList<QByteArray> outLines1 = m_stdoutFile->readAll().split('\n');
+    QCOMPARE(outLines1.at(0).split('[').at(0), QByteArray("\tOverwriting Internet "));
+    QCOMPARE(outLines1.at(1).split('[').at(0), QByteArray("\tCreating missing Some Website "));
+    QCOMPARE(outLines1.at(2), QByteArray("Successfully merged the database files."));
 
     QFile readBack(targetFile1.fileName());
     readBack.open(QIODevice::ReadOnly);
@@ -927,17 +934,39 @@ void TestCli::testMerge()
     QCOMPARE(entry1->title(), QString("Some Website"));
     QCOMPARE(entry1->password(), QString("secretsecretsecret"));
 
+    // the dry run option should not modify the target database.
+    pos = m_stdoutFile->pos();
+    Utils::Test::setNextPassword("a");
+    mergeCmd.execute({"merge", "--dry-run", "-s", targetFile2.fileName(), sourceFile.fileName()});
+    m_stdoutFile->seek(pos);
+    m_stdoutFile->readLine();
+    m_stderrFile->reset();
+    QList<QByteArray> outLines2 = m_stdoutFile->readAll().split('\n');
+    QCOMPARE(outLines2.at(0).split('[').at(0), QByteArray("\tOverwriting Internet "));
+    QCOMPARE(outLines2.at(1).split('[').at(0), QByteArray("\tCreating missing Some Website "));
+    QCOMPARE(outLines2.at(2), QByteArray("Database was not modified by merge operation."));
+
+    QFile readBack2(targetFile2.fileName());
+    readBack2.open(QIODevice::ReadOnly);
+    mergedDb = QSharedPointer<Database>::create();
+    reader.readDatabase(&readBack2, oldKey, mergedDb.data());
+    readBack2.close();
+    QVERIFY(mergedDb);
+    entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
+    QVERIFY(!entry1);
+
     // try again with different passwords for both files
     pos = m_stdoutFile->pos();
     Utils::Test::setNextPassword("b");
     Utils::Test::setNextPassword("a");
-    mergeCmd.execute({"merge", targetFile2.fileName(), sourceFile.fileName()});
+    mergeCmd.execute({"merge", targetFile3.fileName(), sourceFile.fileName()});
     m_stdoutFile->seek(pos);
     m_stdoutFile->readLine();
     m_stdoutFile->readLine();
-    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Successfully merged the database files.\n"));
+    QList<QByteArray> outLines3 = m_stdoutFile->readAll().split('\n');
+    QCOMPARE(outLines3.at(2), QByteArray("Successfully merged the database files."));
 
-    readBack.setFileName(targetFile2.fileName());
+    readBack.setFileName(targetFile3.fileName());
     readBack.open(QIODevice::ReadOnly);
     mergedDb = QSharedPointer<Database>::create();
     reader.readDatabase(&readBack, key, mergedDb.data());


### PR DESCRIPTION
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor
- ✅ New feature
- ✅ Documentation

## Description and Context
Two changes in fact: I added the `--dry-run` option and the list of changes detected by the merge operation to the output. In the future, I'd also like to ask the user for confirmation before merging, after displaying the changes.

## Screenshots
```
$ keepassxc-cli merge -s --dry-run ~/test1.kdbx ~/test2.kdbx 
Insert password to unlock /home/louib/test1.kdbx: 
	Creating missing entry2 [06009d6280a741f88c4da6e4415d0aa5]
Database was not modified by merge operation.
$ keepassxc-cli merge -s ~/test1.kdbx ~/test2.kdbx 
Insert password to unlock /home/louib/test1.kdbx: 
	Creating missing entry2 [06009d6280a741f88c4da6e4415d0aa5]
Successfully merged the database files.
$ keepassxc-cli merge -s ~/test1.kdbx ~/test2.kdbx 
Insert password to unlock /home/louib/test1.kdbx: 
Database was not modified by merge operation.
$ keepassxc-cli merge -s --dry-run ~/test1.kdbx ~/test2.kdbx 
Insert password to unlock /home/louib/test1.kdbx: 
Database was not modified by merge operation.
```


## Testing strategy
unit test + CLI (see screenshot)


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
