### PR TITLE
Add integration with Brave browser (for Linux, OSX, and Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ so please check out your distribution's package list to see if KeePassXC is avai
 - Using website favicons as entry icons
 - Merging of databases
 - Automatic reload when the database changed on disk
-- Browser integration with KeePassXC-Browser using [native messaging](https://developer.chrome.com/extensions/nativeMessaging) for [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) and [Google Chrome or Chromium](https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk)
+- Browser integration with KeePassXC-Browser using [native messaging](https://developer.chrome.com/extensions/nativeMessaging) for [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) and [Google Chrome, Chromium, Vivaldi, or Brave](https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk)
 - Synchronize passwords using KeeShare. See [Using Sharing](./docs/QUICKSTART.md#using-sharing) for more details.
 - Many bug fixes
 

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -47,7 +47,7 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent)
         tr("KeePassXC-Browser is needed for the browser integration to work. <br />Download it for %1 and %2. %3")
             .arg("<a href=\"https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/\">Firefox</a>",
                  "<a href=\"https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">"
-                 "Google Chrome / Chromium / Vivaldi</a>",
+                 "Google Chrome / Chromium / Vivaldi / Brave</a>",
                  snapInstructions));
     // clang-format on
 
@@ -75,9 +75,11 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent)
     connect(m_ui->customProxyLocationBrowseButton, SIGNAL(clicked()), this, SLOT(showProxyLocationFileDialog()));
 
 #ifdef Q_OS_WIN
+    // Brave uses Chrome's registry settings
+    m_ui->braveSupport->setHidden(true);
     // Vivaldi uses Chrome's registry settings
     m_ui->vivaldiSupport->setHidden(true);
-    m_ui->chromeSupport->setText("Chrome and Vivaldi");
+    m_ui->chromeSupport->setText("Chrome, Vivaldi, and Brave");
     // Tor Browser uses Firefox's registry settings
     m_ui->torBrowserSupport->setHidden(true);
     m_ui->firefoxSupport->setText("Firefox and Tor Browser");
@@ -122,6 +124,7 @@ void BrowserOptionDialog::loadSettings()
     m_ui->chromiumSupport->setChecked(settings->chromiumSupport());
     m_ui->firefoxSupport->setChecked(settings->firefoxSupport());
 #ifndef Q_OS_WIN
+    m_ui->braveSupport->setChecked(settings->braveSupport());
     m_ui->vivaldiSupport->setChecked(settings->vivaldiSupport());
     m_ui->torBrowserSupport->setChecked(settings->torBrowserSupport());
 #endif
@@ -183,6 +186,7 @@ void BrowserOptionDialog::saveSettings()
     settings->setChromiumSupport(m_ui->chromiumSupport->isChecked());
     settings->setFirefoxSupport(m_ui->firefoxSupport->isChecked());
 #ifndef Q_OS_WIN
+    settings->setBraveSupport(m_ui->braveSupport->isChecked());
     settings->setVivaldiSupport(m_ui->vivaldiSupport->isChecked());
     settings->setTorBrowserSupport(m_ui->torBrowserSupport->isChecked());
 #endif

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -150,6 +150,16 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="braveSupport">
+            <property name="text">
+             <string>&amp;Brave</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -238,6 +238,17 @@ void BrowserSettings::setVivaldiSupport(bool enabled)
         HostInstaller::SupportedBrowsers::VIVALDI, enabled, supportBrowserProxy(), customProxyLocation());
 }
 
+bool BrowserSettings::braveSupport()
+{
+  return m_hostInstaller.checkIfInstalled(HostInstaller::SupportedBrowsers::BRAVE);
+}
+
+void BrowserSettings::setBraveSupport(bool enabled)
+{
+  m_hostInstaller.installBrowser(
+                                 HostInstaller::SupportedBrowsers::BRAVE, enabled, supportBrowserProxy(), customProxyLocation());
+}
+
 bool BrowserSettings::torBrowserSupport()
 {
     return m_hostInstaller.checkIfInstalled(HostInstaller::SupportedBrowsers::TOR_BROWSER);

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -72,6 +72,8 @@ public:
     void setFirefoxSupport(bool enabled);
     bool vivaldiSupport();
     void setVivaldiSupport(bool enabled);
+    bool braveSupport();
+    void setBraveSupport(bool enabled);
     bool torBrowserSupport();
     void setTorBrowserSupport(bool enabled);
 

--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -39,12 +39,14 @@ HostInstaller::HostInstaller()
     , TARGET_DIR_FIREFOX("/Library/Application Support/Mozilla/NativeMessagingHosts")
     , TARGET_DIR_VIVALDI("/Library/Application Support/Vivaldi/NativeMessagingHosts")
     , TARGET_DIR_TOR_BROWSER("/Library/Application Support/TorBrowser-Data/Browser/Mozilla/NativeMessagingHosts")
+    , TARGET_DIR_BRAVE("/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts")
 #elif defined(Q_OS_LINUX)
     , TARGET_DIR_CHROME("/.config/google-chrome/NativeMessagingHosts")
     , TARGET_DIR_CHROMIUM("/.config/chromium/NativeMessagingHosts")
     , TARGET_DIR_FIREFOX("/.mozilla/native-messaging-hosts")
     , TARGET_DIR_VIVALDI("/.config/vivaldi/NativeMessagingHosts")
     , TARGET_DIR_TOR_BROWSER("/.tor-browser/app/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts")
+    , TARGET_DIR_BRAVE("/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts")
 #elif defined(Q_OS_WIN)
     // clang-format off
     , TARGET_DIR_CHROME("HKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
@@ -53,6 +55,7 @@ HostInstaller::HostInstaller()
     , TARGET_DIR_FIREFOX("HKEY_CURRENT_USER\\Software\\Mozilla\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
     , TARGET_DIR_VIVALDI(TARGET_DIR_CHROME)
     , TARGET_DIR_TOR_BROWSER(TARGET_DIR_FIREFOX)
+    , TARGET_DIR_BRAVE(TARGET_DIR_CHROME)
 #endif
 {
 }
@@ -140,7 +143,8 @@ void HostInstaller::installBrowser(SupportedBrowsers browser,
  */
 void HostInstaller::updateBinaryPaths(const bool& proxy, const QString& location)
 {
-    for (int i = 0; i < 4; ++i) {
+    // Where 6 is the number of entries in the SupportedBrowsers enum declared in HostInstaller.h
+    for (int i = 0; i < 6; ++i) {
         if (checkIfInstalled(static_cast<SupportedBrowsers>(i))) {
             installBrowser(static_cast<SupportedBrowsers>(i), true, proxy, location);
         }
@@ -166,6 +170,8 @@ QString HostInstaller::getTargetPath(SupportedBrowsers browser) const
         return TARGET_DIR_VIVALDI;
     case SupportedBrowsers::TOR_BROWSER:
         return TARGET_DIR_TOR_BROWSER;
+    case SupportedBrowsers::BRAVE:
+      return TARGET_DIR_BRAVE;
     default:
         return QString();
     }
@@ -188,9 +194,11 @@ QString HostInstaller::getBrowserName(SupportedBrowsers browser) const
     case SupportedBrowsers::FIREFOX:
         return "firefox";
     case SupportedBrowsers::VIVALDI:
-        return "vivaldi";
+      return "vivaldi";
     case SupportedBrowsers::TOR_BROWSER:
         return "tor-browser";
+    case SupportedBrowsers::BRAVE:
+      return "brave";
     default:
         return QString();
     }

--- a/src/browser/HostInstaller.h
+++ b/src/browser/HostInstaller.h
@@ -34,7 +34,8 @@ public:
         CHROMIUM = 1,
         FIREFOX = 2,
         VIVALDI = 3,
-        TOR_BROWSER = 4
+        TOR_BROWSER = 4,
+        BRAVE = 5
     };
 
 public:
@@ -66,6 +67,7 @@ private:
     const QString TARGET_DIR_FIREFOX;
     const QString TARGET_DIR_VIVALDI;
     const QString TARGET_DIR_TOR_BROWSER;
+    const QString TARGET_DIR_BRAVE;
 };
 
 #endif // HOSTINSTALLER_H

--- a/utils/keepassxc-snap-helper.sh
+++ b/utils/keepassxc-snap-helper.sh
@@ -92,6 +92,11 @@ setupVivaldi() {
     INSTALL_DIR="${BASE_DIR}/.config/vivaldi/NativeMessagingHosts"
 }
 
+setupBrave() {
+    buildJson
+    INSTALL_DIR="${BASE_DIR}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+}
+
 setupTorBrowser() {
     buildJson "firefox"
     INSTALL_DIR="${BASE_DIR}/.tor-browser/app/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts"
@@ -109,9 +114,10 @@ BROWSER=$(whiptail \
             "2" "Chrome" \
             "3" "Chromium" \
             "4" "Vivaldi" \
-            "5" "Tor Browser" \
+            "5" "Brave" \
+            "6" "Tor Browser" \
             3>&1 1>&2 2>&3)
-            
+
 clear
 
 exitstatus=$?
@@ -122,16 +128,17 @@ if [ $exitstatus = 0 ]; then
         2) setupChrome ;;
         3) setupChromium ;;
         4) setupVivaldi ;;
-        5) setupTorBrowser ;;
+        5) setupBrave ;;
+        6) setupTorBrowser ;;
     esac
 
     # Install the JSON file
     cd ~
     mkdir -p "$INSTALL_DIR"
     echo "$JSON_OUT" > ${INSTALL_DIR}/${INSTALL_FILE}
-    
+
     $DEBUG && echo "Installed to: ${INSTALL_DIR}/${INSTALL_FILE}"
- 
+
     whiptail \
         --title "Installation Complete" \
         --msgbox "You will need to restart your browser in order to connect to KeePassXC" \
@@ -139,4 +146,3 @@ if [ $exitstatus = 0 ]; then
 else
     whiptail --title "Installation Canceled" --msgbox "No changes were made to your system" 8 50
 fi
-


### PR DESCRIPTION

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Fixes #2414

## Screenshots
![Screenshot from 2019-04-05 14-21-06](https://user-images.githubusercontent.com/131982/55657142-2351cc00-57ae-11e9-913e-614e10e8ea02.png)


## Testing strategy
* Ran unit tests and all 35 passed
* Tested with binary built from this branch:
  * Manually uninstalled KPXC config JSON from Brave .config dir
  * Started binary 
  * Checked the new "Brave" box in KPXC settings (see screenshot above)
  * Verified the config JSON was in Brave's `.config/NativeMessagingHosts` directory
  * Verified password auto-fill works in Brave

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**


