### PR TITLE
Hotfix/#2820 more detailed share messages

### DIFF
--- a/src/keeshare/KeeShare.cpp
+++ b/src/keeshare/KeeShare.cpp
@@ -162,18 +162,32 @@ QString KeeShare::sharingLabel(const Group* group)
     }
 
     const auto reference = referenceOf(share);
+    if (!reference.isValid()) {
+        return tr("Invalid sharing reference");
+    }
+    QStringList messages;
     switch (reference.type) {
     case KeeShareSettings::Inactive:
-        return tr("Inactive share %1").arg(reference.path);
+        messages << tr("Inactive share %1").arg(reference.path);
+        break;
     case KeeShareSettings::ImportFrom:
-        return tr("Imported from %1").arg(reference.path);
+        messages << tr("Imported from %1").arg(reference.path);
+        break;
     case KeeShareSettings::ExportTo:
-        return tr("Exported to %1").arg(reference.path);
+        messages << tr("Exported to %1").arg(reference.path);
+        break;
     case KeeShareSettings::SynchronizeWith:
-        return tr("Synchronized with %1").arg(reference.path);
+        messages << tr("Synchronized with %1").arg(reference.path);
+        break;
     }
-
-    return {};
+    const auto active = KeeShare::active();
+    if (reference.isImporting() && !active.in) {
+        messages << tr("Import is disabled in settings");
+    }
+    if (reference.isExporting() && !active.out) {
+        messages << tr("Export is disabled in settings");
+    }
+    return messages.join("\n");
 }
 
 QPixmap KeeShare::indicatorBadge(const Group* group, QPixmap pixmap)

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -190,7 +190,6 @@ void ShareObserver::reinitialize()
         KeeShareSettings::Reference newReference;
     };
 
-    const auto active = KeeShare::active();
     QList<Update> updated;
     const QList<Group*> groups = m_db->rootGroup()->groupsRecursive(true);
     for (Group* group : groups) {
@@ -202,9 +201,7 @@ void ShareObserver::reinitialize()
         m_groupToReference.remove(couple.group);
         m_referenceToGroup.remove(couple.oldReference);
         m_shareToGroup.remove(couple.oldReference.path);
-        if (couple.newReference.isValid()
-            && ((active.in && couple.newReference.isImporting())
-                || (active.out && couple.newReference.isExporting()))) {
+        if (couple.newReference.isValid()) {
             m_groupToReference[couple.group] = couple.newReference;
             m_referenceToGroup[couple.newReference] = couple.group;
             m_shareToGroup[couple.newReference.path] = couple.group;


### PR DESCRIPTION
Introduced more detailed messages to show when a specific group cannot be shared (configuration error or disabled in settings).
Small change in `ShareObserver` which could cause an assertion in development mode and a warning in release mode when sharing export was disabled.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)

## Description and Context
Introduced detailed messages for sharing label. Since the error messages in the settings are created in a hierarchical fashion, I would refrain from showing when import/export was disabled as long as the settings themselves are invalid.

Found a small issue during debugging. The `ShareObserver` did filter out export shares when the export feature was disabled, but did try to find the export group. This led to warnings/assertions. Since the class does additional filtering of unneeded imports when reacting to the file change signal, I removed the filter of references for group - share associations.

"Fixes #2820"

## Screenshots
![Message](https://user-images.githubusercontent.com/16102996/55630485-133dea80-57b6-11e9-9cbb-123ee8784b58.png)

## Testing strategy
Manually tested.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ Related tests passed.
