### PR TITLE
Minor fixes for 2.4.1

### DIFF
--- a/src/format/Kdbx3Reader.cpp
+++ b/src/format/Kdbx3Reader.cpp
@@ -78,7 +78,8 @@ bool Kdbx3Reader::readDatabaseImpl(QIODevice* device,
     QByteArray realStart = cipherStream.read(32);
 
     if (realStart != m_streamStartBytes) {
-        raiseError(tr("Wrong key or database file is corrupt."));
+        raiseError(tr("Invalid credentials were provided, please try again.\n"
+                      "If this reoccurs, then your database file may be corrupt."));
         return false;
     }
 

--- a/src/format/Kdbx4Reader.cpp
+++ b/src/format/Kdbx4Reader.cpp
@@ -71,7 +71,8 @@ bool Kdbx4Reader::readDatabaseImpl(QIODevice* device,
     // clang-format off
     QByteArray hmacKey = KeePass2::hmacKey(m_masterSeed, db->transformedMasterKey());
     if (headerHmac != CryptoHash::hmac(headerData, HmacBlockStream::getHmacKey(UINT64_MAX, hmacKey), CryptoHash::Sha256)) {
-        raiseError(tr("Wrong key or database file is corrupt. (HMAC mismatch)"));
+        raiseError(tr("Invalid credentials were provided, please try again.\n"
+                      "If this reoccurs, then your database file may be corrupt.") + " " + tr("(HMAC mismatch)"));
         return false;
     }
     HmacBlockStream hmacStream(device, hmacKey);

--- a/src/format/KeePass1Reader.cpp
+++ b/src/format/KeePass1Reader.cpp
@@ -372,7 +372,8 @@ KeePass1Reader::testKeys(const QString& password, const QByteArray& keyfileData,
     }
 
     if (!cipherStream) {
-        raiseError(tr("Wrong key or database file is corrupt."));
+        raiseError(tr("Invalid credentials were provided, please try again.\n"
+                      "If this reoccurs, then your database file may be corrupt."));
     }
 
     return cipherStream.take();

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -470,7 +470,7 @@
             <item alignment="Qt::AlignRight">
              <widget class="QLabel" name="languageLabel_2">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
@@ -487,6 +487,13 @@
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="languageLabel_3">
+              <property name="text">
+               <string>(restart program to activate)</string>
               </property>
              </widget>
             </item>

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -194,8 +194,7 @@ void DatabaseOpenWidget::openDatabase()
     bool ok = m_db->open(m_filename, masterKey, &error, false);
     QApplication::restoreOverrideCursor();
     if (!ok) {
-        m_ui->messageWidget->showMessage(tr("Unable to open the database:\n%1").arg(error),
-                                         MessageWidget::MessageType::Error);
+        m_ui->messageWidget->showMessage(error, MessageWidget::MessageType::Error);
         return;
     }
 
@@ -223,7 +222,7 @@ void DatabaseOpenWidget::openDatabase()
         }
         emit dialogFinished(true);
     } else {
-        m_ui->messageWidget->showMessage(tr("Unable to open the database:\n%1").arg(error), MessageWidget::Error);
+        m_ui->messageWidget->showMessage(error, MessageWidget::Error);
         m_ui->editPassword->setText("");
 
 #ifdef WITH_XC_TOUCHID
@@ -268,7 +267,7 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::databaseKey()
         QString keyFilename = m_ui->comboKeyFile->currentText();
         QString errorMsg;
         if (!key->load(keyFilename, &errorMsg)) {
-            m_ui->messageWidget->showMessage(tr("Can't open key file:\n%1").arg(errorMsg), MessageWidget::Error);
+            m_ui->messageWidget->showMessage(tr("Failed to open key file: %1").arg(errorMsg), MessageWidget::Error);
             return {};
         }
         if (key->type() != FileKey::Hashed && !config()->get("Messages/NoLegacyKeyFileWarning").toBool()) {

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -260,12 +260,11 @@ bool DatabaseWidget::isSearchActive() const
 bool DatabaseWidget::isEditWidgetModified() const
 {
     if (currentWidget() == m_editEntryWidget) {
-        return m_editEntryWidget->hasBeenModified();
-    } else {
-        // other edit widget don't have a hasBeenModified() method yet
-        // assume that they already have been modified
-        return true;
+        return m_editEntryWidget->isModified();
+    } else if (currentWidget() == m_editGroupWidget) {
+        return m_editGroupWidget->isModified();
     }
+    return false;
 }
 
 QList<int> DatabaseWidget::mainSplitterSizes() const
@@ -1247,7 +1246,7 @@ bool DatabaseWidget::lock()
 
     clipboard()->clearCopiedText();
 
-    if (currentMode() == DatabaseWidget::Mode::EditMode) {
+    if (isEditWidgetModified()) {
         auto result = MessageBox::question(this,
                                            tr("Lock Database?"),
                                            tr("You are editing an entry. Discard changes and lock anyway?"),

--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -30,6 +30,7 @@ EditWidget::EditWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
     setReadOnly(false);
+    setModified(false);
 
     m_ui->messageWidget->setHidden(true);
 
@@ -43,6 +44,7 @@ EditWidget::EditWidget(QWidget* parent)
 
     connect(m_ui->buttonBox, SIGNAL(accepted()), SIGNAL(accepted()));
     connect(m_ui->buttonBox, SIGNAL(rejected()), SIGNAL(rejected()));
+    connect(m_ui->buttonBox, SIGNAL(clicked(QAbstractButton*)), SLOT(buttonClicked(QAbstractButton*)));
 }
 
 EditWidget::~EditWidget()
@@ -106,9 +108,6 @@ void EditWidget::setReadOnly(bool readOnly)
         m_ui->buttonBox->setStandardButtons(QDialogButtonBox::Close);
     } else {
         m_ui->buttonBox->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Apply);
-        // Find and connect the apply button
-        QPushButton* applyButton = m_ui->buttonBox->button(QDialogButtonBox::Apply);
-        connect(applyButton, SIGNAL(clicked()), SIGNAL(apply()));
     }
 }
 
@@ -117,11 +116,43 @@ bool EditWidget::readOnly() const
     return m_readOnly;
 }
 
+void EditWidget::setModified(bool state)
+{
+    m_modified = state;
+    enableApplyButton(state);
+}
+
+bool EditWidget::isModified() const
+{
+    return m_modified;
+}
+
 void EditWidget::enableApplyButton(bool enabled)
 {
     QPushButton* applyButton = m_ui->buttonBox->button(QDialogButtonBox::Apply);
     if (applyButton) {
         applyButton->setEnabled(enabled);
+    }
+}
+
+void EditWidget::showApplyButton(bool state)
+{
+    if (!m_readOnly) {
+        auto buttons = m_ui->buttonBox->standardButtons();
+        if (state) {
+            buttons |= QDialogButtonBox::Apply;
+        } else {
+            buttons &= ~QDialogButtonBox::Apply;
+        }
+        m_ui->buttonBox->setStandardButtons(buttons);
+    }
+}
+
+void EditWidget::buttonClicked(QAbstractButton* button)
+{
+    auto stdButton = m_ui->buttonBox->standardButton(button);
+    if (stdButton == QDialogButtonBox::Apply) {
+        emit apply();
     }
 }
 

--- a/src/gui/EditWidget.h
+++ b/src/gui/EditWidget.h
@@ -49,6 +49,8 @@ public:
     void setReadOnly(bool readOnly);
     bool readOnly() const;
     void enableApplyButton(bool enabled);
+    void showApplyButton(bool state);
+    virtual bool isModified() const;
 
 signals:
     void apply();
@@ -58,10 +60,13 @@ signals:
 protected slots:
     void showMessage(const QString& text, MessageWidget::MessageType type);
     void hideMessage();
+    void setModified(bool state = true);
+    void buttonClicked(QAbstractButton* button);
 
 private:
     const QScopedPointer<Ui::EditWidget> m_ui;
     bool m_readOnly;
+    bool m_modified;
 
     Q_DISABLE_COPY(EditWidget)
 };

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -1,5 +1,4 @@
 /*
- *  Copyright (C) 2016 Jonathan White <support@dmapps.us>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -97,6 +96,13 @@ bool SearchWidget::eventFilter(QObject* obj, QEvent* event)
         if (keyEvent->key() == Qt::Key_Escape) {
             emit escapePressed();
             return true;
+        } else if (keyEvent->matches(QKeySequence::Copy)) {
+            // If Control+C is pressed in the search edit when no text
+            // is selected, copy the password of the current entry.
+            if (!m_ui->searchEdit->hasSelectedText()) {
+                emit copyPressed();
+                return true;
+            }
         } else if (keyEvent->matches(QKeySequence::MoveToNextLine)) {
             if (m_ui->searchEdit->cursorPosition() == m_ui->searchEdit->text().length()) {
                 // If down is pressed at EOL, move the focus to the entry view

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -276,55 +276,54 @@ void EditEntryWidget::setupHistory()
 void EditEntryWidget::setupEntryUpdate()
 {
     // Entry tab
-    connect(m_mainUi->titleEdit, SIGNAL(textChanged(QString)), this, SLOT(setUnsavedChanges()));
-    connect(m_mainUi->usernameEdit, SIGNAL(textChanged(QString)), this, SLOT(setUnsavedChanges()));
-    connect(m_mainUi->passwordEdit, SIGNAL(textChanged(QString)), this, SLOT(setUnsavedChanges()));
-    connect(m_mainUi->passwordRepeatEdit, SIGNAL(textChanged(QString)), this, SLOT(setUnsavedChanges()));
-    connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), this, SLOT(setUnsavedChanges()));
+    connect(m_mainUi->titleEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
+    connect(m_mainUi->usernameEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
+    connect(m_mainUi->passwordEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
+    connect(m_mainUi->passwordRepeatEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
+    connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
 #ifdef WITH_XC_NETWORKING
     connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), this, SLOT(updateFaviconButtonEnable(QString)));
 #endif
-    connect(m_mainUi->expireCheck, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-    connect(m_mainUi->notesEnabled, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-    connect(m_mainUi->expireDatePicker, SIGNAL(dateTimeChanged(QDateTime)), this, SLOT(setUnsavedChanges()));
-    connect(m_mainUi->notesEdit, SIGNAL(textChanged()), this, SLOT(setUnsavedChanges()));
+    connect(m_mainUi->expireCheck, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+    connect(m_mainUi->notesEnabled, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+    connect(m_mainUi->expireDatePicker, SIGNAL(dateTimeChanged(QDateTime)), this, SLOT(setModified()));
+    connect(m_mainUi->notesEdit, SIGNAL(textChanged()), this, SLOT(setModified()));
 
     // Advanced tab
-    connect(m_advancedUi->attributesEdit, SIGNAL(textChanged()), this, SLOT(setUnsavedChanges()));
-    connect(m_advancedUi->protectAttributeButton, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-    connect(m_advancedUi->fgColorCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-    connect(m_advancedUi->bgColorCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-    connect(m_advancedUi->attachmentsWidget, SIGNAL(widgetUpdated()), this, SLOT(setUnsavedChanges()));
+    connect(m_advancedUi->attributesEdit, SIGNAL(textChanged()), this, SLOT(setModified()));
+    connect(m_advancedUi->protectAttributeButton, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+    connect(m_advancedUi->fgColorCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+    connect(m_advancedUi->bgColorCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+    connect(m_advancedUi->attachmentsWidget, SIGNAL(widgetUpdated()), this, SLOT(setModified()));
 
     // Icon tab
-    connect(m_iconsWidget, SIGNAL(widgetUpdated()), this, SLOT(setUnsavedChanges()));
+    connect(m_iconsWidget, SIGNAL(widgetUpdated()), this, SLOT(setModified()));
 
     // Auto-Type tab
-    connect(m_autoTypeUi->enableButton, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-    connect(m_autoTypeUi->customWindowSequenceButton, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-    connect(m_autoTypeUi->inheritSequenceButton, SIGNAL(toggled(bool)), this, SLOT(setUnsavedChanges()));
-    connect(m_autoTypeUi->customSequenceButton, SIGNAL(toggled(bool)), this, SLOT(setUnsavedChanges()));
-    connect(m_autoTypeUi->windowSequenceEdit, SIGNAL(textChanged(QString)), this, SLOT(setUnsavedChanges()));
-    connect(m_autoTypeUi->sequenceEdit, SIGNAL(textChanged(QString)), this, SLOT(setUnsavedChanges()));
-    connect(m_autoTypeUi->windowTitleCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(setUnsavedChanges()));
-    connect(m_autoTypeUi->windowTitleCombo, SIGNAL(editTextChanged(QString)), this, SLOT(setUnsavedChanges()));
+    connect(m_autoTypeUi->enableButton, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+    connect(m_autoTypeUi->customWindowSequenceButton, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+    connect(m_autoTypeUi->inheritSequenceButton, SIGNAL(toggled(bool)), this, SLOT(setModified()));
+    connect(m_autoTypeUi->customSequenceButton, SIGNAL(toggled(bool)), this, SLOT(setModified()));
+    connect(m_autoTypeUi->windowSequenceEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
+    connect(m_autoTypeUi->sequenceEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
+    connect(m_autoTypeUi->windowTitleCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(setModified()));
+    connect(m_autoTypeUi->windowTitleCombo, SIGNAL(editTextChanged(QString)), this, SLOT(setModified()));
 
     // Properties and History tabs don't need extra connections
 
 #ifdef WITH_XC_SSHAGENT
     // SSH Agent tab
     if (config()->get("SSHAgent", false).toBool()) {
-        connect(m_sshAgentUi->attachmentRadioButton, SIGNAL(toggled(bool)), this, SLOT(setUnsavedChanges()));
-        connect(m_sshAgentUi->externalFileRadioButton, SIGNAL(toggled(bool)), this, SLOT(setUnsavedChanges()));
-        connect(m_sshAgentUi->attachmentComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(setUnsavedChanges()));
-        connect(m_sshAgentUi->attachmentComboBox, SIGNAL(editTextChanged(QString)), this, SLOT(setUnsavedChanges()));
-        connect(m_sshAgentUi->externalFileEdit, SIGNAL(textChanged(QString)), this, SLOT(setUnsavedChanges()));
-        connect(m_sshAgentUi->addKeyToAgentCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-        connect(m_sshAgentUi->removeKeyFromAgentCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-        connect(
-            m_sshAgentUi->requireUserConfirmationCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-        connect(m_sshAgentUi->lifetimeCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setUnsavedChanges()));
-        connect(m_sshAgentUi->lifetimeSpinBox, SIGNAL(valueChanged(int)), this, SLOT(setUnsavedChanges()));
+        connect(m_sshAgentUi->attachmentRadioButton, SIGNAL(toggled(bool)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->externalFileRadioButton, SIGNAL(toggled(bool)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->attachmentComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->attachmentComboBox, SIGNAL(editTextChanged(QString)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->externalFileEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->addKeyToAgentCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->removeKeyFromAgentCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->requireUserConfirmationCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->lifetimeCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+        connect(m_sshAgentUi->lifetimeSpinBox, SIGNAL(valueChanged(int)), this, SLOT(setModified()));
     }
 #endif
 }
@@ -703,8 +702,10 @@ void EditEntryWidget::loadEntry(Entry* entry,
     setCurrentPage(0);
     setPageHidden(m_historyWidget, m_history || m_entry->historyItems().count() < 1);
 
-    // Force the user to Save/Apply/Discard new entries
-    setUnsavedChanges(m_create);
+    // Force the user to Save/Discard new entries
+    showApplyButton(!m_create);
+
+    setModified(false);
 }
 
 void EditEntryWidget::setForms(Entry* entry, bool restore)
@@ -881,7 +882,6 @@ bool EditEntryWidget::commitEntry()
     }
 
     updateEntryData(m_entry);
-    setUnsavedChanges(false);
 
     if (!m_create) {
         m_entry->endUpdate();
@@ -896,6 +896,7 @@ bool EditEntryWidget::commitEntry()
     m_historyModel->setEntries(m_entry->historyItems());
 
     showMessage(tr("Entry updated successfully."), MessageWidget::Positive);
+    setModified(false);
     return true;
 }
 
@@ -968,7 +969,7 @@ void EditEntryWidget::cancel()
         m_entry->setIcon(Entry::DefaultIconNumber);
     }
 
-    if (!m_saved) {
+    if (isModified()) {
         auto result = MessageBox::question(this,
                                            QString(),
                                            tr("Entry has unsaved changes"),
@@ -980,13 +981,13 @@ void EditEntryWidget::cancel()
         }
         if (result == MessageBox::Save) {
             commitEntry();
-            m_saved = true;
+            setModified(false);
         }
     }
 
     clear();
 
-    emit editFinished(m_saved);
+    emit editFinished(!isModified());
 }
 
 void EditEntryWidget::clear()
@@ -1006,22 +1007,6 @@ void EditEntryWidget::clear()
     m_historyModel->clear();
     m_iconsWidget->reset();
     hideMessage();
-}
-
-bool EditEntryWidget::hasBeenModified() const
-{
-    // entry has been modified if a history item is to be deleted
-    if (!m_historyModel->deletedEntries().isEmpty()) {
-        return true;
-    }
-
-    // check if updating the entry would modify it
-    auto* entry = new Entry();
-    entry->copyDataFrom(m_entry.data());
-
-    entry->beginUpdate();
-    updateEntryData(entry);
-    return entry->endUpdate();
 }
 
 void EditEntryWidget::togglePasswordGeneratorButton(bool checked)
@@ -1070,7 +1055,7 @@ void EditEntryWidget::insertAttribute()
     m_advancedUi->attributesView->setCurrentIndex(index);
     m_advancedUi->attributesView->edit(index);
 
-    setUnsavedChanges(true);
+    setModified(true);
 }
 
 void EditEntryWidget::editCurrentAttribute()
@@ -1081,7 +1066,7 @@ void EditEntryWidget::editCurrentAttribute()
 
     if (index.isValid()) {
         m_advancedUi->attributesView->edit(index);
-        setUnsavedChanges(true);
+        setModified(true);
     }
 }
 
@@ -1101,7 +1086,7 @@ void EditEntryWidget::removeCurrentAttribute()
 
         if (result == MessageBox::Remove) {
             m_entryAttributes->remove(m_attributesModel->keyByIndex(index));
-            setUnsavedChanges(true);
+            setModified(true);
         }
     }
 }
@@ -1223,7 +1208,7 @@ void EditEntryWidget::insertAutoTypeAssoc()
     m_autoTypeUi->assocView->setCurrentIndex(newIndex);
     loadCurrentAssoc(newIndex);
     m_autoTypeUi->windowTitleCombo->setFocus();
-    setUnsavedChanges(true);
+    setModified(true);
 }
 
 void EditEntryWidget::removeAutoTypeAssoc()
@@ -1232,7 +1217,7 @@ void EditEntryWidget::removeAutoTypeAssoc()
 
     if (currentIndex.isValid()) {
         m_autoTypeAssoc->remove(currentIndex.row());
-        setUnsavedChanges(true);
+        setModified(true);
     }
 }
 
@@ -1295,7 +1280,7 @@ void EditEntryWidget::restoreHistoryEntry()
     QModelIndex index = m_sortModel->mapToSource(m_historyUi->historyView->currentIndex());
     if (index.isValid()) {
         setForms(m_historyModel->entryFromIndex(index), true);
-        setUnsavedChanges(true);
+        setModified(true);
     }
 }
 
@@ -1309,7 +1294,7 @@ void EditEntryWidget::deleteHistoryEntry()
         } else {
             m_historyUi->deleteAllButton->setEnabled(false);
         }
-        setUnsavedChanges(true);
+        setModified(true);
     }
 }
 
@@ -1317,7 +1302,7 @@ void EditEntryWidget::deleteAllHistoryEntries()
 {
     m_historyModel->deleteAll();
     m_historyUi->deleteAllButton->setEnabled(m_historyModel->rowCount() > 0);
-    setUnsavedChanges(true);
+    setModified(true);
 }
 
 QMenu* EditEntryWidget::createPresetsMenu()
@@ -1370,12 +1355,6 @@ void EditEntryWidget::pickColor()
     QColor newColor = QColorDialog::getColor(oldColor);
     if (newColor.isValid()) {
         setupColorButton(isForeground, newColor);
-        setUnsavedChanges(true);
+        setModified(true);
     }
-}
-
-void EditEntryWidget::setUnsavedChanges(bool hasUnsaved)
-{
-    m_saved = !hasUnsaved;
-    enableApplyButton(hasUnsaved);
 }

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -68,7 +68,6 @@ public:
 
     QString entryTitle() const;
     void clear();
-    bool hasBeenModified() const;
 
 signals:
     void editFinished(bool accepted);
@@ -106,7 +105,6 @@ private slots:
     void useExpiryPreset(QAction* action);
     void toggleHideNotes(bool visible);
     void pickColor();
-    void setUnsavedChanges(bool hasUnsaved = true);
 #ifdef WITH_XC_SSHAGENT
     void updateSSHAgent();
     void updateSSHAgentAttachment();
@@ -148,7 +146,6 @@ private:
 
     bool m_create;
     bool m_history;
-    bool m_saved;
 #ifdef WITH_XC_SSHAGENT
     bool m_sshAgentEnabled;
     KeeAgentSettings m_sshAgentSettings;

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -74,6 +74,7 @@ private:
     void addTriStateItems(QComboBox* comboBox, bool inheritValue);
     int indexFromTriState(Group::TriState triState);
     Group::TriState triStateFromIndex(int index);
+    void setupModifiedTracking();
 
     const QScopedPointer<Ui::EditGroupWidgetMain> m_mainUi;
 

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -702,8 +702,7 @@ void TestCli::testKeyFileOption()
     m_stdoutFile->readLine(); // skip password prompt
     m_stderrFile->seek(posErr);
     QCOMPARE(m_stdoutFile->readAll(), QByteArray(""));
-    QCOMPARE(m_stderrFile->readAll(),
-             QByteArray("Error while reading the database: Wrong key or database file is corrupt. (HMAC mismatch)\n"));
+    QVERIFY(m_stderrFile->readAll().contains("Invalid credentials were provided"));
 
     // Should raise an error if key file path is invalid.
     pos = m_stdoutFile->pos();
@@ -736,8 +735,7 @@ void TestCli::testNoPasswordOption()
     m_stdoutFile->readLine(); // skip password prompt
     m_stderrFile->seek(posErr);
     QCOMPARE(m_stdoutFile->readAll(), QByteArray(""));
-    QCOMPARE(m_stderrFile->readAll(),
-             QByteArray("Error while reading the database: Wrong key or database file is corrupt. (HMAC mismatch)\n"));
+    QVERIFY(m_stderrFile->readAll().contains("Invalid credentials were provided"));
 }
 
 void TestCli::testList()

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -429,13 +429,20 @@ void TestGui::testEditEntry()
     auto* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
     QTest::keyClicks(titleEdit, "_test");
 
-    // Apply the edit
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
     QVERIFY(editEntryWidgetButtonBox);
-    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Apply), Qt::LeftButton);
+    auto* okButton = editEntryWidgetButtonBox->button(QDialogButtonBox::Ok);
+    QVERIFY(okButton);
+    auto* applyButton = editEntryWidgetButtonBox->button(QDialogButtonBox::Apply);
+    QVERIFY(applyButton);
+
+    // Apply the edit
+    QTRY_VERIFY(applyButton->isEnabled());
+    QTest::mouseClick(applyButton, Qt::LeftButton);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
     QCOMPARE(entry->title(), QString("Sample Entry_test"));
     QCOMPARE(entry->historyItems().size(), ++editCount);
+    QVERIFY(!applyButton->isEnabled());
 
     // Test entry colors (simulate choosing a color)
     editEntryWidget->setCurrentPage(1);
@@ -451,7 +458,7 @@ void TestGui::testEditEntry()
     colorCheckBox = editEntryWidget->findChild<QCheckBox*>("bgColorCheckBox");
     colorButton->setProperty("color", bgColor);
     colorCheckBox->setChecked(true);
-    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Apply), Qt::LeftButton);
+    QTest::mouseClick(applyButton, Qt::LeftButton);
     QCOMPARE(entry->historyItems().size(), ++editCount);
 
     // Test protected attributes
@@ -471,7 +478,7 @@ void TestGui::testEditEntry()
     auto* passwordEdit = editEntryWidget->findChild<QLineEdit*>("passwordEdit");
     QString originalPassword = passwordEdit->text();
     passwordEdit->setText("newpass");
-    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    QTest::mouseClick(okButton, Qt::LeftButton);
     auto* messageWiget = editEntryWidget->findChild<MessageWidget*>("messageWidget");
     QTRY_VERIFY(messageWiget->isVisible());
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
@@ -479,7 +486,7 @@ void TestGui::testEditEntry()
     passwordEdit->setText(originalPassword);
 
     // Save the edit (press OK)
-    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    QTest::mouseClick(okButton, Qt::LeftButton);
     QApplication::processEvents();
 
     // Confirm edit was made
@@ -496,13 +503,15 @@ void TestGui::testEditEntry()
 
     // Test copy & paste newline sanitization
     QTest::mouseClick(entryEditWidget, Qt::LeftButton);
+    okButton = editEntryWidgetButtonBox->button(QDialogButtonBox::Ok);
+    QVERIFY(okButton);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
     titleEdit->setText("multiline\ntitle");
     editEntryWidget->findChild<QLineEdit*>("usernameEdit")->setText("multiline\nusername");
     editEntryWidget->findChild<QLineEdit*>("passwordEdit")->setText("multiline\npassword");
     editEntryWidget->findChild<QLineEdit*>("passwordRepeatEdit")->setText("multiline\npassword");
     editEntryWidget->findChild<QLineEdit*>("urlEdit")->setText("multiline\nurl");
-    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    QTest::mouseClick(okButton, Qt::LeftButton);
 
     QCOMPARE(entry->title(), QString("multiline title"));
     QCOMPARE(entry->username(), QString("multiline username"));


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

Improved error messages when opening database
* Reduced wording and confusion
* Streamlined delivery format
* Fix #813

Add note to restart after changing language
* Fix #2713

Allow copying passwords directly from searching
* Reverts removal of previously implemented feature
* Fix #2630

Correct issues with apply button
* Don't show apply button when creating new entries or groups (Fix #2191)
* Don't mark entry/group as dirty when first creating a new one (prevents unnecessary discard dialog on cancel)
* Properly enable/disable apply button when changes are made to entries and groups
* Don't show discard change warning when locking database unless their are actual changes made

NOTE: Extra pages in the group edit widget are not watched for changes yet. Requires a major refactor.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/55634567-c4c82600-578c-11e9-95fe-4330efba578c.png)

![image](https://user-images.githubusercontent.com/2809491/55634575-c7c31680-578c-11e9-9bdd-8077c150105b.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added tests to ensure copy from search worked.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
