### PR TITLE
Add free text filter to Auto-Type dialog

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,6 +231,7 @@ set(autotype_SOURCES
         core/Tools.cpp
         autotype/AutoType.cpp
         autotype/AutoTypeAction.cpp
+        autotype/AutoTypeFilterLineEdit.cpp
         autotype/AutoTypeSelectDialog.cpp
         autotype/AutoTypeSelectView.cpp
         autotype/ShortcutWidget.cpp

--- a/src/autotype/AutoTypeFilterLineEdit.cpp
+++ b/src/autotype/AutoTypeFilterLineEdit.cpp
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AutoTypeFilterLineEdit.h"
+#include <QKeyEvent>
+
+void AutoTypeFilterLineEdit::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Up) {
+        emit keyUpPressed();
+    } else if (event->key() == Qt::Key_Down) {
+        emit keyDownPressed();
+    } else {
+        QLineEdit::keyPressEvent(event);
+    }
+}
+
+void AutoTypeFilterLineEdit::keyReleaseEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Escape) {
+        emit escapeReleased();
+    } else {
+        QLineEdit::keyReleaseEvent(event);
+    }
+}

--- a/src/autotype/AutoTypeFilterLineEdit.h
+++ b/src/autotype/AutoTypeFilterLineEdit.h
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_AUTOTYPEFILTERLINEEDIT_H
+#define KEEPASSX_AUTOTYPEFILTERLINEEDIT_H
+
+#include <QLineEdit>
+
+class AutoTypeFilterLineEdit : public QLineEdit
+{
+    Q_OBJECT
+
+public:
+    AutoTypeFilterLineEdit(QWidget* widget) : QLineEdit(widget) {}
+protected:
+    virtual void keyPressEvent(QKeyEvent *event);
+    virtual void keyReleaseEvent(QKeyEvent *event);
+signals:
+    void keyUpPressed();
+    void keyDownPressed();
+    void escapeReleased();
+};
+
+#endif // KEEPASSX_AUTOTYPEFILTERLINEEDIT_H

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -28,6 +28,8 @@
 #include <QHeaderView>
 #include <QLabel>
 #include <QVBoxLayout>
+#include <QLineEdit>
+#include <QSortFilterProxyModel>
 
 #include "autotype/AutoTypeSelectView.h"
 #include "core/AutoTypeMatch.h"
@@ -38,6 +40,7 @@
 AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     : QDialog(parent)
     , m_view(new AutoTypeSelectView(this))
+    , m_filterLineEdit(new AutoTypeFilterLineEdit(this))
     , m_matchActivatedEmitted(false)
     , m_rejected(false)
 {
@@ -76,9 +79,20 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
 
     layout->addWidget(m_view);
 
+    connect(m_filterLineEdit, SIGNAL(textChanged(QString)), SLOT(filterList(QString)));
+    connect(m_filterLineEdit, SIGNAL(returnPressed()), SLOT(selectCurrentMatch()));
+    connect(m_filterLineEdit, SIGNAL(keyUpPressed()), SLOT(moveSelectionUp()));
+    connect(m_filterLineEdit, SIGNAL(keyDownPressed()), SLOT(moveSelectionDown()));
+    connect(m_filterLineEdit, SIGNAL(escapeReleased()), SLOT(reject()));
+
+    m_filterLineEdit->setPlaceholderText(tr("Search..."));
+    layout->addWidget(m_filterLineEdit);
+
     QDialogButtonBox* buttonBox = new QDialogButtonBox(QDialogButtonBox::Cancel, Qt::Horizontal, this);
     connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
     layout->addWidget(buttonBox);
+
+    m_filterLineEdit->setFocus();
 }
 
 void AutoTypeSelectDialog::setMatchList(const QList<AutoTypeMatch>& matchList)
@@ -121,7 +135,49 @@ void AutoTypeSelectDialog::matchRemoved()
         return;
     }
 
-    if (m_view->model()->rowCount() == 0) {
+    if (m_view->model()->rowCount() == 0 && m_filterLineEdit->text().isEmpty()) {
         reject();
     }
+}
+
+
+void AutoTypeSelectDialog::filterList(QString filterString)
+{
+    QSortFilterProxyModel *proxy = qobject_cast<QSortFilterProxyModel*>(m_view->model());
+    if (proxy) {
+        proxy->setFilterKeyColumn(-1);
+        proxy->setFilterWildcard(filterString);
+    }
+}
+
+void AutoTypeSelectDialog::moveSelectionUp()
+{
+    auto current = m_view->currentIndex();
+    auto previous = current.siblingAtRow(current.row() - 1);
+
+    if (previous.isValid()) {
+        m_view->setCurrentIndex(previous);
+    }
+}
+
+void AutoTypeSelectDialog::moveSelectionDown()
+{
+    auto current = m_view->currentIndex();
+    auto next = current.siblingAtRow(current.row() + 1);
+
+    if (next.isValid()) {
+        m_view->setCurrentIndex(next);
+    }
+}
+
+void AutoTypeSelectDialog::selectCurrentMatch()
+{
+    if (m_matchActivatedEmitted) {
+        return;
+    }
+    m_matchActivatedEmitted = true;
+
+    AutoTypeMatch match = m_view->currentMatch();
+    accept();
+    emit matchActivated(match);
 }

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -77,6 +77,12 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     connect(m_view, SIGNAL(rejected()), SLOT(reject()));
     // clang-format on
 
+    QSortFilterProxyModel *proxy = qobject_cast<QSortFilterProxyModel*>(m_view->model());
+    if (proxy) {
+        proxy->setFilterKeyColumn(-1);
+        proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
+    }
+
     layout->addWidget(m_view);
 
     connect(m_filterLineEdit, SIGNAL(textChanged(QString)), SLOT(filterList(QString)));
@@ -145,8 +151,6 @@ void AutoTypeSelectDialog::filterList(QString filterString)
 {
     QSortFilterProxyModel *proxy = qobject_cast<QSortFilterProxyModel*>(m_view->model());
     if (proxy) {
-        proxy->setFilterKeyColumn(-1);
-        proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
         proxy->setFilterWildcard(filterString);
         if (!m_view->currentIndex().isValid()) {
             m_view->setCurrentIndex(m_view->model()->index(0, 0));

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -153,7 +153,7 @@ void AutoTypeSelectDialog::filterList(QString filterString)
 void AutoTypeSelectDialog::moveSelectionUp()
 {
     auto current = m_view->currentIndex();
-    auto previous = current.siblingAtRow(current.row() - 1);
+    auto previous = current.sibling(current.row() - 1, 0);
 
     if (previous.isValid()) {
         m_view->setCurrentIndex(previous);
@@ -163,7 +163,7 @@ void AutoTypeSelectDialog::moveSelectionUp()
 void AutoTypeSelectDialog::moveSelectionDown()
 {
     auto current = m_view->currentIndex();
-    auto next = current.siblingAtRow(current.row() + 1);
+    auto next = current.sibling(current.row() + 1, 0);
 
     if (next.isValid()) {
         m_view->setCurrentIndex(next);

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -146,7 +146,11 @@ void AutoTypeSelectDialog::filterList(QString filterString)
     QSortFilterProxyModel *proxy = qobject_cast<QSortFilterProxyModel*>(m_view->model());
     if (proxy) {
         proxy->setFilterKeyColumn(-1);
+        proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
         proxy->setFilterWildcard(filterString);
+        if (!m_view->currentIndex().isValid()) {
+            m_view->setCurrentIndex(m_view->model()->index(0, 0));
+        }
     }
 }
 

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -80,7 +80,7 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     layout->addWidget(m_view);
 
     connect(m_filterLineEdit, SIGNAL(textChanged(QString)), SLOT(filterList(QString)));
-    connect(m_filterLineEdit, SIGNAL(returnPressed()), SLOT(selectCurrentMatch()));
+    connect(m_filterLineEdit, SIGNAL(returnPressed()), SLOT(activateCurrentIndex()));
     connect(m_filterLineEdit, SIGNAL(keyUpPressed()), SLOT(moveSelectionUp()));
     connect(m_filterLineEdit, SIGNAL(keyDownPressed()), SLOT(moveSelectionDown()));
     connect(m_filterLineEdit, SIGNAL(escapeReleased()), SLOT(reject()));
@@ -170,14 +170,7 @@ void AutoTypeSelectDialog::moveSelectionDown()
     }
 }
 
-void AutoTypeSelectDialog::selectCurrentMatch()
+void AutoTypeSelectDialog::activateCurrentIndex()
 {
-    if (m_matchActivatedEmitted) {
-        return;
-    }
-    m_matchActivatedEmitted = true;
-
-    AutoTypeMatch match = m_view->currentMatch();
-    accept();
-    emit matchActivated(match);
+    emitMatchActivated(m_view->currentIndex());
 }

--- a/src/autotype/AutoTypeSelectDialog.h
+++ b/src/autotype/AutoTypeSelectDialog.h
@@ -22,6 +22,7 @@
 #include <QDialog>
 #include <QHash>
 
+#include "autotype/AutoTypeFilterLineEdit.h"
 #include "core/AutoTypeMatch.h"
 
 class AutoTypeSelectView;
@@ -44,9 +45,14 @@ public slots:
 private slots:
     void emitMatchActivated(const QModelIndex& index);
     void matchRemoved();
+    void filterList(QString filterString);
+    void moveSelectionUp();
+    void moveSelectionDown();
+    void selectCurrentMatch();
 
 private:
     AutoTypeSelectView* const m_view;
+    AutoTypeFilterLineEdit* const m_filterLineEdit;
     bool m_matchActivatedEmitted;
     bool m_rejected;
 };

--- a/src/autotype/AutoTypeSelectDialog.h
+++ b/src/autotype/AutoTypeSelectDialog.h
@@ -48,7 +48,7 @@ private slots:
     void filterList(QString filterString);
     void moveSelectionUp();
     void moveSelectionDown();
-    void selectCurrentMatch();
+    void activateCurrentIndex();
 
 private:
     AutoTypeSelectView* const m_view;


### PR DESCRIPTION
When you have a lot of Auto-Type matches for the same window title, some quick search is helpful.

The input field has default focus and up/down arrow keys are captured which move the selection in the list. To make this a bit better, it would work with multiple words split into separate filters that narrow down the list.

Note: This does not yet pass the code quality requirements. The existing view model filter is pulled with a `qobject_cast<>()` which may be a bit hacky.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Implements #2944.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/106598/55670104-ead2f080-5888-11e9-961c-22e4413ef76a.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual tests on Linux.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
