### PR TITLE
Hide window when performing entry auto-type on macOS

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -214,7 +214,7 @@ void AutoType::executeAutoTypeActions(const Entry* entry, QWidget* hideWindow, c
 
     if (hideWindow) {
 #if defined(Q_OS_MACOS)
-        m_plugin->raiseLastActiveWindow();
+        m_plugin->hideOwnWindow();
 #else
         hideWindow->showMinimized();
 #endif

--- a/src/autotype/AutoTypePlatformPlugin.h
+++ b/src/autotype/AutoTypePlatformPlugin.h
@@ -43,7 +43,7 @@ public:
     virtual AutoTypeExecutor* createExecutor() = 0;
 
 #if defined(Q_OS_MACOS)
-    virtual bool raiseLastActiveWindow() = 0;
+    virtual bool hideOwnWindow() = 0;
     virtual bool raiseOwnWindow() = 0;
 #endif
 

--- a/src/autotype/mac/AutoTypeMac.cpp
+++ b/src/autotype/mac/AutoTypeMac.cpp
@@ -165,9 +165,9 @@ bool AutoTypePlatformMac::raiseWindow(WId pid)
 //
 // Activate last active window
 //
-bool AutoTypePlatformMac::raiseLastActiveWindow()
+bool AutoTypePlatformMac::hideOwnWindow()
 {
-    return macUtils()->raiseLastActiveWindow();
+    return macUtils()->hideOwnWindow();
 }
 
 //

--- a/src/autotype/mac/AutoTypeMac.h
+++ b/src/autotype/mac/AutoTypeMac.h
@@ -44,7 +44,7 @@ public:
     bool raiseWindow(WId pid) override;
     AutoTypeExecutor* createExecutor() override;
 
-    bool raiseLastActiveWindow() override;
+    bool hideOwnWindow() override;
     bool raiseOwnWindow() override;
 
     void sendChar(const QChar& ch, bool isKeyDown);

--- a/src/autotype/test/AutoTypeTest.cpp
+++ b/src/autotype/test/AutoTypeTest.cpp
@@ -111,7 +111,7 @@ bool AutoTypePlatformTest::raiseWindow(WId window)
 }
 
 #if defined(Q_OS_MACOS)
-bool AutoTypePlatformTest::raiseLastActiveWindow()
+bool AutoTypePlatformTest::hideOwnWindow()
 {
     return false;
 }

--- a/src/autotype/test/AutoTypeTest.h
+++ b/src/autotype/test/AutoTypeTest.h
@@ -44,7 +44,7 @@ public:
     AutoTypeExecutor* createExecutor() override;
 
 #if defined(Q_OS_MACOS)
-    bool raiseLastActiveWindow() override;
+    bool hideOwnWindow() override;
     bool raiseOwnWindow() override;
 #endif
 


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Instead of choosing the last active window, always hide the current window (ie, KeePassXC)
* Fixes #2883

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on macOS

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
