### PR TITLE
Support for RFC-compliant TOTP hashes

### DIFF
--- a/src/gui/TotpSetupDialog.cpp
+++ b/src/gui/TotpSetupDialog.cpp
@@ -59,7 +59,8 @@ void TotpSetupDialog::saveSettings()
         }
     }
 
-    auto settings = Totp::createSettings(m_ui->seedEdit->text(), digits, step, encShortName, m_entry->totpSettings());
+    auto settings = Totp::createSettings(
+        m_ui->seedEdit->text(), digits, step, encShortName, Totp::HashType::Sha1, m_entry->totpSettings());
     m_entry->setTotp(settings);
     emit totpUpdated();
     close();

--- a/src/totp/totp.h
+++ b/src/totp/totp.h
@@ -39,9 +39,17 @@ namespace Totp
         bool reverse;
     };
 
+    enum HashType
+    {
+        Sha1,
+        Sha256,
+        Sha512,
+    };
+
     struct Settings
     {
         Totp::Encoder encoder;
+        Totp::HashType hashType;
         QString key;
         bool otpUrl;
         bool keeOtp;
@@ -53,6 +61,7 @@ namespace Totp
     constexpr uint DEFAULT_STEP = 30u;
     constexpr uint DEFAULT_DIGITS = 6u;
     constexpr uint STEAM_DIGITS = 5u;
+    constexpr Totp::HashType DEFAULT_HASHTYPE = Sha1;
     static const QString STEAM_SHORTNAME = "S";
 
     static const QString ATTRIBUTE_OTP = "otp";
@@ -64,6 +73,7 @@ namespace Totp
                                                   const uint digits,
                                                   const uint step,
                                                   const QString& encoderShortName = {},
+                                                  const Totp::HashType hashType = DEFAULT_HASHTYPE,
                                                   QSharedPointer<Totp::Settings> prevSettings = {});
     QString writeSettings(const QSharedPointer<Totp::Settings>& settings,
                           const QString& title = {},

--- a/tests/TestTotp.cpp
+++ b/tests/TestTotp.cpp
@@ -41,15 +41,29 @@ void TestTotp::testParseSecret()
     QCOMPARE(settings->custom, false);
     QCOMPARE(settings->digits, 6u);
     QCOMPARE(settings->step, 30u);
+    QCOMPARE(settings->hashType, Totp::HashType::Sha1);
+
+    // OTP URL with non-default hash type
+    secret = "otpauth://totp/"
+             "ACME%20Co:john@example.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm="
+             "SHA512&digits=6&period=30";
+    settings = Totp::parseSettings(secret);
+    QVERIFY(!settings.isNull());
+    QCOMPARE(settings->key, QString("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
+    QCOMPARE(settings->custom, false);
+    QCOMPARE(settings->digits, 6u);
+    QCOMPARE(settings->step, 30u);
+    QCOMPARE(settings->hashType, Totp::HashType::Sha512);
 
     // KeeOTP Parsing
-    secret = "key=HXDMVJECJJWSRBY%3d&step=25&size=8";
+    secret = "key=HXDMVJECJJWSRBY%3d&step=25&size=8&otpHashMode=Sha256";
     settings = Totp::parseSettings(secret);
     QVERIFY(!settings.isNull());
     QCOMPARE(settings->key, QString("HXDMVJECJJWSRBY="));
     QCOMPARE(settings->custom, true);
     QCOMPARE(settings->digits, 8u);
     QCOMPARE(settings->step, 25u);
+    QCOMPARE(settings->hashType, Totp::HashType::Sha256);
 
     // Semi-colon delineated "TOTP Settings"
     secret = "gezdgnbvgy3tqojqgezdgnbvgy3tqojq";
@@ -59,6 +73,7 @@ void TestTotp::testParseSecret()
     QCOMPARE(settings->custom, true);
     QCOMPARE(settings->digits, 8u);
     QCOMPARE(settings->step, 30u);
+    QCOMPARE(settings->hashType, Totp::HashType::Sha1);
 
     // Bare secret (no "TOTP Settings" attribute)
     secret = "gezdgnbvgy3tqojqgezdgnbvgy3tqojq";
@@ -68,6 +83,7 @@ void TestTotp::testParseSecret()
     QCOMPARE(settings->custom, false);
     QCOMPARE(settings->digits, 6u);
     QCOMPARE(settings->step, 30u);
+    QCOMPARE(settings->hashType, Totp::HashType::Sha1);
 }
 
 void TestTotp::testTotpCode()


### PR DESCRIPTION
This implements support for SHA-256 and SHA-512 hash algorithms when
generating TOTP codes. These algorithms are specified by RFC6238. The
implementation is compatible with Google's OTP URL format, as well as
with the KeeOTP plugin for KeePass.

The implementation is not wired into the GUI, as the main project
developer expressed strong negative sentiment about adding more
options there. It is possible to configure codes by putting the
appropriate string into the entry's otp property, or using another
program with a less opinionated UI and a compatible on-disk format.

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Description above.

Fixes #873
Fixes #1566

## Testing strategy
Built modified binary. Launched with existing database file containing a mix of SHA1 and SHA512 TOTPs from KeeOTP. Compared generated TOTP codes for both algorithms using "show OTP" with KeeOTP on one side and KeepassXC on the other. Ran OTP->"Show QR Code" and verified correct URL creation. Wrote and ran unit tests.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]** - there is none, so I don't know what this is. But I've read every one that's in this repo.
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
