### PR TITLE
Fix syntax highlighting in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -121,11 +121,11 @@ For names made of only one word, the first letter should be lowercase.
 For names made of multiple concatenated words, the first letter of the whole is lowercase, and the first letter of each subsequent word is capitalized.
 
 #### Indention
-For **C++ files** (*.cpp .h*): 4 spaces  
+For **C++ files** (*.cpp .h*): 4 spaces
 For **Qt-UI files** (*.ui*): 2 spaces
 
 #### Includes
-```c
+```cpp
 // Class includes
 #include "MyWidget.h"
 #include "ui_MyWidget.h"
@@ -140,7 +140,7 @@ For **Qt-UI files** (*.ui*): 2 spaces
 ```
 
 #### Classes
-```c
+```cpp
 // Note: order is important, stay organized!
 class MyWidget : public QWidget
 {
@@ -174,13 +174,13 @@ MyWidget::MyWidget(QWidget* parent)
 ```
 
 #### Pointers / References
-```c
+```cpp
 int* count;
 const QString& string;
 ```
 
 #### Braces
-```c
+```cpp
 if (condition) {
     doSomething();
 } else {
@@ -194,7 +194,7 @@ void ExampleClass::exampleFunction()
 ```
 
 #### Switch statement
-```c
+```cpp
 // Note: avoid declaring variables in a switch statement
 switch (a) {
 case 1:


### PR DESCRIPTION
Just a minor fix. Code snippets were marked as `c` and caused incorrect highlighting when displayed by GitHub (see the `class` sample snippet, where it's more evident).