### PR TITLE
Fix toolbar text color on macOS when in dark mode

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -41,6 +41,10 @@
 #include "keys/FileKey.h"
 #include "keys/PasswordKey.h"
 
+#ifdef Q_OS_MACOS
+#include "macutils/MacUtils.h"
+#endif
+
 #ifdef WITH_XC_UPDATECHECK
 #include "gui/MessageBox.h"
 #include "gui/UpdateCheckDialog.h"
@@ -370,6 +374,9 @@ MainWindow::MainWindow()
 
 #ifdef Q_OS_MACOS
     setUnifiedTitleAndToolBarOnMac(true);
+    if (macUtils()->isDarkMode()) {
+        setStyleSheet("QToolButton {color:white;}");
+    }
 #endif
 
 #ifdef WITH_XC_UPDATECHECK


### PR DESCRIPTION
# Fix toolbar action color macOS 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
The text for the action icons in toolbar was not readable in macOS, changed to white text color.

## Screenshots

### Before
<img width="442" alt="screenshot-before" src="https://user-images.githubusercontent.com/10264942/56080681-49a5e600-5e04-11e9-8963-471046da5c2e.png">

### After
<img width="462" alt="screenshot" src="https://user-images.githubusercontent.com/10264942/56080649-ec119980-5e03-11e9-889c-bb3d937c0b22.png">

## Testing strategy
Local Release Build with Tests

