### PR TITLE
Remove hardcoded background color from search help widget

### DIFF
--- a/src/gui/SearchHelpWidget.ui
+++ b/src/gui/SearchHelpWidget.ui
@@ -16,9 +16,6 @@
   <property name="autoFillBackground">
    <bool>false</bool>
   </property>
-  <property name="styleSheet">
-   <string notr="true">#SearchHelpWidget { background-color: #ffffff }</string>
-  </property>
   <property name="frameShape">
    <enum>QFrame::Box</enum>
   </property>


### PR DESCRIPTION
The hardcoded background color was breaking the native dark mode background on macOS.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )


## Screenshots

### Before
![image](https://user-images.githubusercontent.com/107672/56082865-70f4b700-5df4-11e9-92df-8b0d563de527.png)

### After
![Screen Shot 2019-04-13 at 13 57 01](https://user-images.githubusercontent.com/107672/56082869-76ea9800-5df4-11e9-9ca6-006f8e969384.png)



## Testing strategy
Tested on Linux (ubuntu) and macOS, with and without dark mode.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**