### PR TITLE
Fix canceling cancel request in edited group

### DIFF
--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -227,6 +227,9 @@ void EditGroupWidget::cancel()
                                            tr("Entry has unsaved changes"),
                                            MessageBox::Cancel | MessageBox::Save | MessageBox::Discard,
                                            MessageBox::Cancel);
+        if (result == MessageBox::Cancel) {
+            return;
+        }
         if (result == MessageBox::Save) {
             apply();
             setModified(false);


### PR DESCRIPTION
In case of a modified group, pressing cancel in the confirmation dialog
of cancel led to discarding the changes instead of returning to the edit widget.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
When *Cancel* is pressed while editing a group (with chances), the following confirmation dialog will discard the changes instead of returning to the edit widget when *Cancel* is pressed again.

## Testing strategy
Manually tested.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
