### PR TITLE
Improve resilience against memory attacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ option(WITH_ASAN "Enable address sanitizer checks (Linux / macOS only)" OFF)
 option(WITH_COVERAGE "Use to build with coverage tests (GCC only)." OFF)
 option(WITH_APP_BUNDLE "Enable Application Bundle for macOS" ON)
 
-set(WITH_XC_ALL OFF CACHE BOOLEAN "Build in all available plugins")
+set(WITH_XC_ALL OFF CACHE BOOL "Build in all available plugins")
 
 option(WITH_XC_AUTOTYPE "Include Auto-Type." ON)
 option(WITH_XC_NETWORKING "Include networking code (e.g. for downlading website icons)." OFF)
@@ -163,11 +163,15 @@ if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
     set(IS_32BIT TRUE)
 endif()
 
-if("${CMAKE_C_COMPILER}" MATCHES "clang$" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+if("${CMAKE_C_COMPILER}" MATCHES "clang$"
+        OR "${CMAKE_EXTRA_GENERATOR_C_SYSTEM_DEFINED_MACROS}" MATCHES "__clang__"
+        OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_COMPILER_IS_CLANG 1)
 endif()
 
-if("${CMAKE_CXX_COMPILER}" MATCHES "clang(\\+\\+)?$" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if("${CMAKE_CXX_COMPILER}" MATCHES "clang(\\+\\+)?$"
+        OR "${CMAKE_EXTRA_GENERATOR_CXX_SYSTEM_DEFINED_MACROS}" MATCHES "__clang__"
+        OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_COMPILER_IS_CLANGXX 1)
 endif()
 
@@ -263,6 +267,11 @@ endif()
 
 add_gcc_compiler_cflags("-std=c99")
 add_gcc_compiler_cxxflags("-std=c++11")
+
+if((CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9.99) OR
+    (CMAKE_COMPILER_IS_CLANGXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.6.99))
+    add_gcc_compiler_cxxflags("-fsized-deallocation")
+endif()
 
 if(APPLE)
     add_gcc_compiler_cxxflags("-stdlib=libc++")
@@ -387,6 +396,7 @@ find_package(Gcrypt 1.7.0 REQUIRED)
 find_package(Argon2 REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(QREncode REQUIRED)
+find_package(sodium 1.0.12 REQUIRED)
 
 set(CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIR})
 
@@ -394,7 +404,7 @@ if(ZLIB_VERSION_STRING VERSION_LESS "1.2.0")
     message(FATAL_ERROR "zlib 1.2.0 or higher is required to use the gzip format")
 endif()
 
-include_directories(SYSTEM ${ARGON2_INCLUDE_DIR})
+include_directories(SYSTEM ${ARGON2_INCLUDE_DIR} ${sodium_INCLUDE_DIR})
 
 # Optional
 if(WITH_XC_KEESHARE)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,7 @@ The following libraries are required:
 * zlib
 * libmicrohttpd
 * libxi, libxtst, qtx11extras (optional for auto-type on X11)
-* libsodium (>= 1.0.12, optional for KeePassXC-Browser support)
+* libsodium (>= 1.0.12)
 * libargon2
 
 Prepare the Building Environment

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ if(NOT ZXCVBN_LIBRARIES)
 endif(NOT ZXCVBN_LIBRARIES)
 
 set(keepassx_SOURCES
+        core/Alloc.cpp
         core/AutoTypeAssociations.cpp
         core/AutoTypeMatch.cpp
         core/Compare.cpp
@@ -254,6 +255,8 @@ endif()
 
 if(WITH_XC_TOUCHID)
     list(APPEND keepassx_SOURCES touchid/TouchID.mm)
+    # TODO: Remove -Wno-error once deprecation warnings have been resolved.
+    set_source_files_properties(touchid/TouchID.mm PROPERTY COMPILE_FLAGS "-Wno-old-style-cast -Wno-error")
 endif()
 
 add_library(autotype STATIC ${autotype_SOURCES})
@@ -270,6 +273,7 @@ target_link_libraries(keepassx_core
         Qt5::Concurrent
         Qt5::Network
         Qt5::Widgets
+        ${sodium_LIBRARY_RELEASE}
         ${YUBIKEY_LIBRARIES}
         ${ZXCVBN_LIBRARIES}
         ${ARGON2_LIBRARIES}

--- a/src/browser/CMakeLists.txt
+++ b/src/browser/CMakeLists.txt
@@ -16,7 +16,6 @@
 
 if(WITH_XC_BROWSER)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-    find_package(sodium 1.0.12 REQUIRED)
 
     set(keepassxcbrowser_SOURCES
             BrowserAccessControlDialog.cpp
@@ -33,5 +32,5 @@ if(WITH_XC_BROWSER)
             Variant.cpp)
 
     add_library(keepassxcbrowser STATIC ${keepassxcbrowser_SOURCES})
-    target_link_libraries(keepassxcbrowser Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Network sodium)
+    target_link_libraries(keepassxcbrowser Qt5::Core Qt5::Concurrent Qt5::Widgets Qt5::Network ${sodium_LIBRARY_RELEASE})
 endif()

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(keepassxc-cli
         keepassx_core
         Qt5::Core
         ${GCRYPT_LIBRARIES}
+        ${sodium_LIBRARY_RELEASE}
         ${ARGON2_LIBRARIES}
         ${GPGERROR_LIBRARIES}
         ${ZLIB_LIBRARIES}

--- a/src/core/Alloc.cpp
+++ b/src/core/Alloc.cpp
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QtGlobal>
+#include <cstdint>
+#include <sodium.h>
+#ifdef Q_OS_MACOS
+#include <malloc/malloc.h>
+#else
+#include <malloc.h>
+#endif
+
+#if defined(NDEBUG) && !defined(__cpp_sized_deallocation)
+#warning "KeePassXC is being compiled without sized deallocation support. Deletes may be slow."
+#endif
+
+/**
+ * Custom sized delete operator which securely zeroes out allocated
+ * memory before freeing it (requires C++14 sized deallocation support).
+ */
+void operator delete(void* ptr, std::size_t size) noexcept
+{
+    if (!ptr) {
+        return;
+    }
+
+    sodium_memzero(ptr, size);
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t size) noexcept
+{
+    ::operator delete(ptr, size);
+}
+
+/**
+ * Custom delete operator which securely zeroes out
+ * allocated memory before freeing it.
+ */
+void operator delete(void* ptr) noexcept
+{
+    if (!ptr) {
+        return;
+    }
+
+#if defined(Q_OS_WIN)
+    ::operator delete(ptr, _msize(ptr));
+#elif defined(Q_OS_MACOS)
+    ::operator delete(ptr, malloc_size(ptr));
+#elif defined(Q_OS_UNIX)
+    ::operator delete(ptr, malloc_usable_size(ptr));
+#else
+    // whatever OS this is, give up and simply free stuff
+    std::free(ptr);
+#endif
+}
+
+void operator delete[](void* ptr) noexcept
+{
+    ::operator delete(ptr);
+}
+
+/**
+ * Custom insecure delete operator that does not zero out memory before
+ * freeing a buffer. Can be used for better performance.
+ */
+void operator delete(void* ptr, bool) noexcept
+{
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr, bool) noexcept
+{
+    ::operator delete(ptr, false);
+}

--- a/src/keys/FileKey.h
+++ b/src/keys/FileKey.h
@@ -40,6 +40,7 @@ public:
     };
 
     FileKey();
+    ~FileKey() override;
     bool load(QIODevice* device);
     bool load(const QString& fileName, QString* errorMsg = nullptr);
     QByteArray rawKey() const override;
@@ -48,6 +49,8 @@ public:
     static bool create(const QString& fileName, QString* errorMsg = nullptr, int size = 128);
 
 private:
+    static constexpr int SHA256_SIZE = 32;
+
     bool loadXml(QIODevice* device);
     bool loadXmlMeta(QXmlStreamReader& xmlReader);
     QByteArray loadXmlKey(QXmlStreamReader& xmlReader);
@@ -55,7 +58,7 @@ private:
     bool loadHex(QIODevice* device);
     bool loadHashed(QIODevice* device);
 
-    QByteArray m_key;
+    char* m_key = nullptr;
     Type m_type = None;
 };
 

--- a/src/keys/PasswordKey.cpp
+++ b/src/keys/PasswordKey.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,35 +16,51 @@
  */
 
 #include "PasswordKey.h"
+#include "core/Tools.h"
 
 #include "crypto/CryptoHash.h"
+#include <gcrypt.h>
+#include <algorithm>
+#include <cstring>
 
 QUuid PasswordKey::UUID("77e90411-303a-43f2-b773-853b05635ead");
 
+constexpr int PasswordKey::SHA256_SIZE;
+
 PasswordKey::PasswordKey()
     : Key(UUID)
+    , m_key(static_cast<char*>(gcry_malloc_secure(SHA256_SIZE)))
 {
 }
 
 PasswordKey::PasswordKey(const QString& password)
     : Key(UUID)
+    , m_key(static_cast<char*>(gcry_malloc_secure(SHA256_SIZE)))
 {
     setPassword(password);
+}
+
+PasswordKey::~PasswordKey()
+{
+    if (m_key) {
+        gcry_free(m_key);
+        m_key = nullptr;
+    }
 }
 
 QSharedPointer<PasswordKey> PasswordKey::fromRawKey(const QByteArray& rawKey)
 {
     auto result = QSharedPointer<PasswordKey>::create();
-    result->m_key = rawKey;
+    std::memcpy(result->m_key, rawKey.data(), std::min(SHA256_SIZE, rawKey.size()));
     return result;
 }
 
 QByteArray PasswordKey::rawKey() const
 {
-    return m_key;
+    return QByteArray::fromRawData(m_key, SHA256_SIZE);
 }
 
 void PasswordKey::setPassword(const QString& password)
 {
-    m_key = CryptoHash::hash(password.toUtf8(), CryptoHash::Sha256);
+    std::memcpy(m_key, CryptoHash::hash(password.toUtf8(), CryptoHash::Sha256).data(), SHA256_SIZE);
 }

--- a/src/keys/PasswordKey.h
+++ b/src/keys/PasswordKey.h
@@ -30,13 +30,16 @@ public:
 
     PasswordKey();
     explicit PasswordKey(const QString& password);
+    ~PasswordKey() override;
     QByteArray rawKey() const override;
     void setPassword(const QString& password);
 
     static QSharedPointer<PasswordKey> fromRawKey(const QByteArray& rawKey);
 
 private:
-    QByteArray m_key;
+    static constexpr int SHA256_SIZE = 32;
+
+    char* m_key = nullptr;
 };
 
 #endif // KEEPASSX_PASSWORDKEY_H

--- a/src/keys/YkChallengeResponseKey.h
+++ b/src/keys/YkChallengeResponseKey.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@ public:
     static QUuid UUID;
 
     explicit YkChallengeResponseKey(int slot = -1, bool blocking = false);
+    ~YkChallengeResponseKey() override;
 
     QByteArray rawKey() const override;
     bool challenge(const QByteArray& challenge) override;
@@ -52,7 +53,8 @@ signals:
     void userConfirmed();
 
 private:
-    QByteArray m_key;
+    char* m_key = nullptr;
+    std::size_t m_keySize = 0;
     int m_slot;
     bool m_blocking;
 };

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -18,12 +18,13 @@ if(WITH_XC_BROWSER)
     include_directories(${BROWSER_SOURCE_DIR})
 
     set(proxy_SOURCES
+        ../core/Alloc.cpp
         keepassxc-proxy.cpp
         ${BROWSER_SOURCE_DIR}/NativeMessagingBase.cpp
         NativeMessagingHost.cpp)
 
     add_library(proxy STATIC ${proxy_SOURCES})
-    target_link_libraries(proxy Qt5::Core Qt5::Network)
+    target_link_libraries(proxy Qt5::Core Qt5::Network ${sodium_LIBRARY_RELEASE})
     add_executable(keepassxc-proxy keepassxc-proxy.cpp)
     target_link_libraries(keepassxc-proxy proxy)
 

--- a/src/touchid/TouchID.mm
+++ b/src/touchid/TouchID.mm
@@ -15,6 +15,7 @@
 
 inline void debug(const char* message, ...)
 {
+    Q_UNUSED(message);
     // qWarning(...);
 }
 
@@ -258,6 +259,7 @@ bool TouchID::authenticate(const QString& message) const
         NSString* authMessage = msg.toNSString(); // autoreleased
         [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
                 localizedReason:authMessage reply:^(BOOL success, NSError* error) {
+                Q_UNUSED(error);
                 result = success ? kTouchIDResultAllowed : kTouchIDResultFailed;
                 CFRunLoopWakeUp(CFRunLoopGetCurrent());
             }];


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
To reduce residual fragments of secret data in memory after
deallocation, this patch replaces the global delete operator with a
version that zeros out previously allocated memory. It makes use of
the new C++14 sized deallocation, but provides an unsized fallback
with platform-specific size deductions.

This change is only a minor mitigation and cannot protect against
buffer reallocations by the operating system or non-C++ libraries.
Thus, we still cannot guarantee all memory to be wiped after free.

As a further improvement, this patch uses libgcrypt and libsodium
to write long-lived master key component hashes into a secure
memory area and wipe it afterwards.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Testing as a major part of 2.4.2

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
