### PR TITLE
Windows: use winqtdeploy instead of DeplyQt4 from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,10 @@ project(KeePassXC)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
-            "Choose the type of build, options are: None Debug Release RelWithDebInfo Debug DebugFull Profile MinSizeRel."
+            "Choose the type of build, options are: Debug Release RelWithDebInfo Profile"
             FORCE)
 endif()
+string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -199,7 +200,7 @@ add_gcc_compiler_flags("-Wformat=2 -Wmissing-format-attribute")
 add_gcc_compiler_flags("-fvisibility=hidden")
 add_gcc_compiler_cxxflags("-fvisibility-inlines-hidden")
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
     add_gcc_compiler_flags("-Werror")
 endif()
 
@@ -230,7 +231,6 @@ if(WITH_ASAN)
 
 endif()
 
-string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 if(CMAKE_BUILD_TYPE_LOWER MATCHES "(release|relwithdebinfo|minsizerel)")
     add_gcc_compiler_flags("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2")
 endif()
@@ -276,7 +276,7 @@ if(MINGW)
     set(CMAKE_RC_COMPILER_INIT windres)
     enable_language(RC)
     set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> <FLAGS> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
-    if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
+    if(NOT (CMAKE_BUILD_TYPE_LOWER STREQUAL "debug" OR CMAKE_BUILD_TYPE_LOWER STREQUAL "relwithdebinfo"))
         # Enable DEP and ASLR
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--nxcompat -Wl,--dynamicbase")
         set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--nxcompat -Wl,--dynamicbase")
@@ -365,9 +365,16 @@ if(APPLE)
     set(CMAKE_MACOSX_RPATH TRUE)
     find_program(MACDEPLOYQT_EXE macdeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
     if(NOT MACDEPLOYQT_EXE)
-        message(FATAL_ERROR "macdeployqt is required to build in macOS")
+        message(FATAL_ERROR "macdeployqt is required to build on macOS")
     else()
         message(STATUS "Using macdeployqt: ${MACDEPLOYQT_EXE}")
+    endif()
+elseif(MINGW)
+    find_program(WINDEPLOYQT_EXE windeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
+    if(NOT WINDEPLOYQT_EXE)
+        message(FATAL_ERROR "windeployqt is required to build on Windows")
+    else()
+        message(STATUS "Using windeployqt: ${WINDEPLOYQT_EXE}")
     endif()
 endif()
 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -112,7 +112,7 @@ mark_as_advanced(
     CMAKE_EXE_LINKER_FLAGS_COVERAGE
     CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(NOT CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
     message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
 endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -410,25 +410,19 @@ if(MINGW)
 
     install(CODE "set(gp_tool \"objdump\")" COMPONENT Runtime)
 
-    include(DeployQt4)
-    install_qt4_executable(${PROGNAME}.exe)
+    # Deploy all 3rd party library dependencies first
+    install(CODE "include(BundleUtilities)
+                  fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${PROGNAME}.exe\" \"\" \"\")"
+            COMPONENT Runtime)
 
-    # install Qt5 plugins
-    set(PLUGINS_DIR ${Qt5_PREFIX}/share/qt5/plugins)
-    install(FILES
-            ${PLUGINS_DIR}/platforms/qwindows$<$<CONFIG:Debug>:d>.dll
-            ${PLUGINS_DIR}/platforms/qdirect2d$<$<CONFIG:Debug>:d>.dll
-            DESTINATION "platforms")
-    install(FILES ${PLUGINS_DIR}/styles/qwindowsvistastyle$<$<CONFIG:Debug>:d>.dll DESTINATION "styles")
-    install(FILES ${PLUGINS_DIR}/platforminputcontexts/qtvirtualkeyboardplugin$<$<CONFIG:Debug>:d>.dll DESTINATION "platforminputcontexts")
-    install(FILES ${PLUGINS_DIR}/iconengines/qsvgicon$<$<CONFIG:Debug>:d>.dll DESTINATION "iconengines")
-    install(FILES
-            ${PLUGINS_DIR}/imageformats/qgif$<$<CONFIG:Debug>:d>.dll
-            ${PLUGINS_DIR}/imageformats/qicns$<$<CONFIG:Debug>:d>.dll
-            ${PLUGINS_DIR}/imageformats/qico$<$<CONFIG:Debug>:d>.dll
-            ${PLUGINS_DIR}/imageformats/qjpeg$<$<CONFIG:Debug>:d>.dll
-            ${PLUGINS_DIR}/imageformats/qwebp$<$<CONFIG:Debug>:d>.dll
-            DESTINATION "imageformats")
+    # Use windeployqt.exe to setup Qt dependencies
+    set(WINDEPLOYQT_MODE "--release")
+    if(CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
+        set(WINDEPLOYQT_MODE "--debug")
+    endif()
+
+    install(CODE "execute_process(COMMAND ${WINDEPLOYQT_EXE} ${PROGNAME}.exe ${WINDEPLOYQT_MODE} WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX} OUTPUT_QUIET)"
+            COMPONENT Runtime)
 
     # install CA cert chains
     install(FILES ${Qt5_PREFIX}/ssl/certs/ca-bundle.crt DESTINATION "ssl/certs")


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Ensure Qt dlls find plugins in bundled directory
* Reduce complexity of deployment code
* Standardize use of CMAKE_BUILD_TYPE_LOWER for more robust comparisons

Fixes #3023
Fixes #1535

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows using CPack and make install.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
