### PR TITLE
Enforce ShareObserver to resolve relative paths

### DIFF
--- a/src/keeshare/ShareObserver.h
+++ b/src/keeshare/ShareObserver.h
@@ -79,12 +79,20 @@ private:
     static void resolveReferenceAttributes(Entry* targetEntry, const Database* sourceDb);
 
     static Database* exportIntoContainer(const KeeShareSettings::Reference& reference, const Group* sourceRoot);
-    static Result exportIntoReferenceUnsignedContainer(const KeeShareSettings::Reference& reference,
+    static Result exportIntoReferenceUnsignedContainer(const QString& realPath,
+                                                       const KeeShareSettings::Reference& reference,
                                                        Database* targetDb);
-    static Result exportIntoReferenceSignedContainer(const KeeShareSettings::Reference& reference, Database* targetDb);
-    static Result importSingedContainerInto(const KeeShareSettings::Reference& reference, Group* targetGroup);
-    static Result importUnsignedContainerInto(const KeeShareSettings::Reference& reference, Group* targetGroup);
-    static Result importContainerInto(const KeeShareSettings::Reference& reference, Group* targetGroup);
+    static Result exportIntoReferenceSignedContainer(const QString& realPath,
+                                                     const KeeShareSettings::Reference& reference,
+                                                     Database* targetDb);
+    static Result importSignedContainerInto(const QString& realPath,
+                                            const KeeShareSettings::Reference& reference,
+                                            Group* targetGroup);
+    static Result importUnsignedContainerInto(const QString& realPath,
+                                              const KeeShareSettings::Reference& reference,
+                                              Group* targetGroup);
+    static Result
+    importContainerInto(const QString& realPath, const KeeShareSettings::Reference& reference, Group* targetGroup);
     static Result importDatabaseInto();
 
     Result importFromReferenceContainer(const QString& path);


### PR DESCRIPTION
Introduce a path resolver to allow to specify shares relative to the database (#2799). 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
`ShareObserver` now tracks the location of shares using their path translated relative to the share defining database. This means absolute paths (which are still default using the file dialog) will work, but manually defined share location using relatives path should work now to.

A second pr is #3029 which is based on these changes and improves the separation of concerns of the `ShareObserver`.

## Testing strategy
Manually tested.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
