### PR TITLE
Add copy context-menu in AutoType dialog

### DIFF
--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -75,6 +75,7 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     connect(m_view, SIGNAL(clicked(QModelIndex)), SLOT(emitMatchActivated(QModelIndex)));
     connect(m_view->model(), SIGNAL(rowsRemoved(QModelIndex,int,int)), SLOT(matchRemoved()));
     connect(m_view, SIGNAL(rejected()), SLOT(reject()));
+    connect(m_view, SIGNAL(matchTextCopied()), SLOT(reject()));
     // clang-format on
 
     QSortFilterProxyModel* proxy = qobject_cast<QSortFilterProxyModel*>(m_view->model());

--- a/src/gui/entry/AutoTypeMatchView.cpp
+++ b/src/gui/entry/AutoTypeMatchView.cpp
@@ -18,8 +18,11 @@
 
 #include "AutoTypeMatchView.h"
 
+#include "core/Entry.h"
+#include "gui/Clipboard.h"
 #include "gui/SortFilterHideProxyModel.h"
 
+#include <QAction>
 #include <QHeaderView>
 #include <QKeyEvent>
 
@@ -42,11 +45,33 @@ AutoTypeMatchView::AutoTypeMatchView(QWidget* parent)
     setSelectionMode(QAbstractItemView::SingleSelection);
     header()->setDefaultSectionSize(150);
 
+    setContextMenuPolicy(Qt::ActionsContextMenu);
+    auto* copyUserNameAction = new QAction(tr("Copy &username"), this);
+    auto* copyPasswordAction = new QAction(tr("Copy &password"), this);
+    addAction(copyUserNameAction);
+    addAction(copyPasswordAction);
+
+    connect(copyUserNameAction, SIGNAL(triggered()), this, SLOT(userNameCopied()));
+    connect(copyPasswordAction, SIGNAL(triggered()), this, SLOT(passwordCopied()));
+
     connect(this, SIGNAL(doubleClicked(QModelIndex)), SLOT(emitMatchActivated(QModelIndex)));
     // clang-format off
-    connect(
-        selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)), SIGNAL(matchSelectionChanged()));
+    connect(selectionModel(),
+            SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
+            SIGNAL(matchSelectionChanged()));
     // clang-format on
+}
+
+void AutoTypeMatchView::userNameCopied()
+{
+    clipboard()->setText(currentMatch().entry->username());
+    emit matchTextCopied();
+}
+
+void AutoTypeMatchView::passwordCopied()
+{
+    clipboard()->setText(currentMatch().entry->password());
+    emit matchTextCopied();
 }
 
 void AutoTypeMatchView::keyPressEvent(QKeyEvent* event)

--- a/src/gui/entry/AutoTypeMatchView.h
+++ b/src/gui/entry/AutoTypeMatchView.h
@@ -42,12 +42,15 @@ public:
 signals:
     void matchActivated(AutoTypeMatch match);
     void matchSelectionChanged();
+    void matchTextCopied();
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
 
 private slots:
     void emitMatchActivated(const QModelIndex& index);
+    void userNameCopied();
+    void passwordCopied();
 
 private:
     AutoTypeMatchModel* const m_model;


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Sometimes when using AutoType the sequence does not match for various reasons 
(e.g. different login masks for the same service), and it is annoying to open KeePassXC manually.
Therefore it would be useful to have copy & paste of usernames and passwords available from the
AutoType dialog. This pull request adds a simple right-click context menu with both options. When
either a username or password is copied by the user the dialog automatically closes.

I was not quite sure why both _AutoTypeSelectView_ **and** _AutoTypeMatchView_ exist, so I chose
to go with the latter and added the context menu there. I also don't know how to handle the translation strings - both of them already exist within the translation context of the MainWindow, so I just
used `MainWindow::tr` for now. 
In the first commit there actually were shorcuts for copying just like in the main window, but the 
addition of the search box broke the behavior for Ctrl+C, since it takes focus by default and handles
this key combination; I removed them in the second commit. 

If you like this feature, I'd be happy to make any necessary changes to get this PR accepted. :)

## Screenshots
![autotype](https://user-images.githubusercontent.com/9140377/56434757-444e0d00-62d6-11e9-8dab-f03bf357c75b.png)

## Testing strategy
Manual testing on Linux.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**