### PR TITLE
Don't mark entry edit as modified when attribute selection changes

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -285,7 +285,6 @@ void EditEntryWidget::setupEntryUpdate()
     connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), this, SLOT(updateFaviconButtonEnable(QString)));
 #endif
     connect(m_mainUi->expireCheck, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
-    connect(m_mainUi->notesEnabled, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
     connect(m_mainUi->expireDatePicker, SIGNAL(dateTimeChanged(QDateTime)), this, SLOT(setModified()));
     connect(m_mainUi->notesEdit, SIGNAL(textChanged()), this, SLOT(setModified()));
 
@@ -1111,8 +1110,9 @@ void EditEntryWidget::updateCurrentAttribute()
 
 void EditEntryWidget::displayAttribute(QModelIndex index, bool showProtected)
 {
-    // Block signals to prevent extra calls
+    // Block signals to prevent modified being set
     m_advancedUi->protectAttributeButton->blockSignals(true);
+    m_advancedUi->attributesEdit->blockSignals(true);
 
     if (index.isValid()) {
         QString key = m_attributesModel->keyByIndex(index);
@@ -1143,6 +1143,7 @@ void EditEntryWidget::displayAttribute(QModelIndex index, bool showProtected)
     }
 
     m_advancedUi->protectAttributeButton->blockSignals(false);
+    m_advancedUi->attributesEdit->blockSignals(false);
 }
 
 void EditEntryWidget::protectCurrentAttribute(bool state)


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* When selecting another attribute in the advanced tab, do not mark the entry as modified (nothing was changed)
* Also do not mark as modified when the notes checkbox is checked/unchecked (doesn't change entry)
* Fixes #3013

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
