### PR TITLE
Fix QuaZip find module on macOS and clean up code.

### DIFF
--- a/cmake/FindQuaZip.cmake
+++ b/cmake/FindQuaZip.cmake
@@ -1,41 +1,24 @@
-# QUAZIP_FOUND               - QuaZip library was found
-# QUAZIP_INCLUDE_DIR         - Path to QuaZip include dir
-# QUAZIP_INCLUDE_DIRS        - Path to QuaZip and zlib include dir (combined from QUAZIP_INCLUDE_DIR + ZLIB_INCLUDE_DIR)
-# QUAZIP_LIBRARIES           - List of QuaZip libraries
-# QUAZIP_ZLIB_INCLUDE_DIR    - The include dir of zlib headers
+# QUAZIP_FOUND                   - QuaZip library was found
+# QUAZIP_INCLUDE_DIR             - Path to QuaZip include dir
+# QUAZIP_INCLUDE_DIRS            - Path to QuaZip and zlib include dir (combined from QUAZIP_INCLUDE_DIR + ZLIB_INCLUDE_DIR)
+# QUAZIP_LIBRARIES               - List of QuaZip libraries
+# QUAZIP_ZLIB_INCLUDE_DIR        - The include dir of zlib headers
 
-IF(QUAZIP_INCLUDE_DIRS AND QUAZIP_LIBRARIES)
-  # in cache already
-  SET(QUAZIP_FOUND TRUE)
-ELSE(QUAZIP_INCLUDE_DIRS AND QUAZIP_LIBRARIES)
-    IF(Qt5Core_FOUND)
-        set(QUAZIP_LIB_VERSION_SUFFIX 5)
-    ENDIF()
-  IF(WIN32)
-    FIND_PATH(QUAZIP_LIBRARY_DIR
-      WIN32_DEBUG_POSTFIX d
-      NAMES libquazip${QUAZIP_LIB_VERSION_SUFFIX}.dll
-      HINTS "C:/Programme/" "C:/Program Files"
-      PATH_SUFFIXES QuaZip/lib
+if(MINGW)
+    find_library(QUAZIP_LIBRARIES libquazip5)
+    find_path(QUAZIP_INCLUDE_DIR quazip.h PATH_SUFFIXES quazip5)
+    find_path(QUAZIP_ZLIB_INCLUDE_DIR zlib.h)
+else()
+    find_library(QUAZIP_LIBRARIES
+        NAMES quazip5 quazip
+	PATHS /usr/lib /usr/lib64 /usr/local/lib
     )
-    FIND_LIBRARY(QUAZIP_LIBRARIES NAMES libquazip${QUAZIP_LIB_VERSION_SUFFIX}.dll HINTS ${QUAZIP_LIBRARY_DIR})
-    FIND_PATH(QUAZIP_INCLUDE_DIR NAMES quazip.h HINTS ${QUAZIP_LIBRARY_DIR}/../ PATH_SUFFIXES include/quazip5)
-    FIND_PATH(QUAZIP_ZLIB_INCLUDE_DIR NAMES zlib.h)
-  ELSE(WIN32)
-    FIND_PACKAGE(PkgConfig)
-    pkg_check_modules(PC_QUAZIP quazip)
-    FIND_LIBRARY(QUAZIP_LIBRARIES
-      WIN32_DEBUG_POSTFIX d
-      NAMES quazip${QUAZIP_LIB_VERSION_SUFFIX}
-      HINTS /usr/lib /usr/lib64
+    find_path(QUAZIP_INCLUDE_DIR quazip.h
+	PATHS /usr/include /usr/local/include
+        PATH_SUFFIXES quazip5 quazip
     )
-    FIND_PATH(QUAZIP_INCLUDE_DIR quazip.h
-      HINTS /usr/include /usr/local/include
-      PATH_SUFFIXES quazip${QUAZIP_LIB_VERSION_SUFFIX}
-    )
-    FIND_PATH(QUAZIP_ZLIB_INCLUDE_DIR zlib.h HINTS /usr/include /usr/local/include)
-  ENDIF(WIN32)
-  INCLUDE(FindPackageHandleStandardArgs)
-  SET(QUAZIP_INCLUDE_DIRS ${QUAZIP_INCLUDE_DIR} ${QUAZIP_ZLIB_INCLUDE_DIR})
-  find_package_handle_standard_args(QUAZIP DEFAULT_MSG  QUAZIP_LIBRARIES QUAZIP_INCLUDE_DIR QUAZIP_ZLIB_INCLUDE_DIR QUAZIP_INCLUDE_DIRS)
-ENDIF(QUAZIP_INCLUDE_DIRS AND QUAZIP_LIBRARIES)
+    find_path(QUAZIP_ZLIB_INCLUDE_DIR zlib.h PATHS /usr/include /usr/local/include)
+endif()
+include(FindPackageHandleStandardArgs)
+set(QUAZIP_INCLUDE_DIRS ${QUAZIP_INCLUDE_DIR} ${QUAZIP_ZLIB_INCLUDE_DIR})
+find_package_handle_standard_args(QUAZIP DEFAULT_MSG QUAZIP_LIBRARIES QUAZIP_INCLUDE_DIR QUAZIP_ZLIB_INCLUDE_DIR QUAZIP_INCLUDE_DIRS)

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -46,8 +46,8 @@
 #include <QStringBuilder>
 
 #if defined(WITH_XC_KEESHARE_SECURE)
-#include <quazip5/quazip.h>
-#include <quazip5/quazipfile.h>
+#include <quazip.h>
+#include <quazipfile.h>
 #endif
 
 namespace


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Finding libquazip failed on macOS due to path differences.

This patch also cleans up the find module's code, aligns it with the coding style of the other CMake files and removes clutter that is not needed for KeePassXC such as non-Msys builds on Windows.

## Testing Strategy:
CMake found QuaZip on macOS, Windows and Ubuntu.
KeeShare signature panel was available on macOS after compilation.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
