### PR TITLE
Fix keepassxc-browser password entropy display

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -278,18 +278,18 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
 
 QJsonObject BrowserAction::handleGeneratePassword(const QJsonObject& json, const QString& action)
 {
-    const QString nonce = json.value("nonce").toString();
-    const QJsonObject password = browserSettings()->generatePassword();
+    auto nonce = json.value("nonce").toString();
+    auto password = browserSettings()->generatePassword();
 
     if (nonce.isEmpty() || password.isEmpty()) {
         return QJsonObject();
     }
 
+    // For backwards compatibility
+    password["login"] = password["entropy"];
+
     QJsonArray arr;
-    QJsonObject passwd = password;
-    // For backwards compatibility, "login" doesn't really make sense here
-    passwd["login"] = passwd["entropy"];
-    arr.append(passwd);
+    arr.append(password);
 
     const QString newNonce = incrementNonce(nonce);
 

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -279,16 +279,16 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
 QJsonObject BrowserAction::handleGeneratePassword(const QJsonObject& json, const QString& action)
 {
     const QString nonce = json.value("nonce").toString();
-    const QString password = browserSettings()->generatePassword();
+    const QJsonObject password = browserSettings()->generatePassword();
 
     if (nonce.isEmpty() || password.isEmpty()) {
         return QJsonObject();
     }
 
     QJsonArray arr;
-    QJsonObject passwd;
-    passwd["login"] = QString::number(password.length() * 8); // bits;
-    passwd["password"] = password;
+    QJsonObject passwd = password;
+    // For backwards compatibility, "login" doesn't really make sense here
+    passwd["login"] = passwd["entropy"];
     arr.append(passwd);
 
     const QString newNonce = incrementNonce(nonce);

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -525,7 +525,7 @@ QJsonObject BrowserSettings::generatePassword()
     } else {
         m_passPhraseGenerator.setWordCount(passPhraseWordCount());
         m_passPhraseGenerator.setWordSeparator(passPhraseWordSeparator());
-        password["entropy"] = m_passPhraseGenerator.getCurrentEntropy();
+        password["entropy"] = m_passPhraseGenerator.estimateEntropy();
         password["password"] = m_passPhraseGenerator.generatePassphrase();
     }
     return password;

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -512,18 +512,23 @@ PasswordGenerator::GeneratorFlags BrowserSettings::passwordGeneratorFlags()
     return flags;
 }
 
-QString BrowserSettings::generatePassword()
+QJsonObject BrowserSettings::generatePassword()
 {
+    QJsonObject password;
     if (generatorType() == 0) {
         m_passwordGenerator.setLength(passwordLength());
         m_passwordGenerator.setCharClasses(passwordCharClasses());
         m_passwordGenerator.setFlags(passwordGeneratorFlags());
-        return m_passwordGenerator.generatePassword();
+        const QString pw = m_passwordGenerator.generatePassword();
+        password["entropy"] = m_passwordGenerator.estimateEntropy(pw);
+        password["password"] = pw;
     } else {
         m_passPhraseGenerator.setWordCount(passPhraseWordCount());
         m_passPhraseGenerator.setWordSeparator(passPhraseWordSeparator());
-        return m_passPhraseGenerator.generatePassphrase();
+        password["entropy"] = m_passPhraseGenerator.getCurrentEntropy();
+        password["password"] = m_passPhraseGenerator.generatePassphrase();
     }
+    return password;
 }
 
 void BrowserSettings::updateBinaryPaths(const QString& customProxyLocation)

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -119,7 +119,7 @@ public:
     void setPasswordLength(int length);
     PasswordGenerator::CharClasses passwordCharClasses();
     PasswordGenerator::GeneratorFlags passwordGeneratorFlags();
-    QString generatePassword();
+    QJsonObject generatePassword();
     void updateBinaryPaths(const QString& customProxyLocation = QString());
     bool checkIfProxyExists(QString& path);
 

--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -35,13 +35,16 @@ PassphraseGenerator::PassphraseGenerator()
     setDefaultWordList();
 }
 
-double PassphraseGenerator::getCurrentEntropy()
+double PassphraseGenerator::estimateEntropy(int wordCount)
 {
     if (m_wordlist.isEmpty()) {
         return 0.0;
     }
+    if (wordCount < 1) {
+        wordCount = m_wordCount;
+    }
 
-    return std::log2(m_wordlist.size()) * m_wordCount;
+    return std::log2(m_wordlist.size()) * wordCount;
 }
 
 void PassphraseGenerator::setWordCount(int wordCount)

--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -35,10 +35,8 @@ PassphraseGenerator::PassphraseGenerator()
     setDefaultWordList();
 }
 
-double PassphraseGenerator::calculateEntropy(const QString& passphrase)
+double PassphraseGenerator::getCurrentEntropy()
 {
-    Q_UNUSED(passphrase);
-
     if (m_wordlist.isEmpty()) {
         return 0.0;
     }

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -35,7 +35,7 @@ public:
         TITLECASE
     };
 
-    double calculateEntropy(const QString& passphrase);
+    double getCurrentEntropy();
     void setWordCount(int wordCount);
     void setWordList(const QString& path);
     void setWordCase(PassphraseWordCase wordCase);

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -35,7 +35,7 @@ public:
         TITLECASE
     };
 
-    double getCurrentEntropy();
+    double estimateEntropy(int wordCount = 0);
     void setWordCount(int wordCount);
     void setWordList(const QString& path);
     void setWordCase(PassphraseWordCase wordCase);

--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -18,10 +18,6 @@
 
 #include "PasswordGenerator.h"
 
-#include <algorithm>
-#include <cmath>
-#include <numeric>
-
 #include "crypto/Random.h"
 #include <zxcvbn.h>
 
@@ -33,62 +29,6 @@ PasswordGenerator::PasswordGenerator()
     , m_flags(nullptr)
     , m_excluded(PasswordGenerator::DefaultExcludedChars)
 {
-}
-
-double PasswordGenerator::getCurrentEntropy()
-{
-    Q_ASSERT(isValid());
-
-    const QVector<PasswordGroup> groups = passwordGroups();
-
-    int totalSize = 0;
-    for (const PasswordGroup& group : groups) {
-        // Note: Character groups must be non-overlapping
-        totalSize += group.size();
-    }
-    if (!(m_flags & CharFromEveryGroup)) {
-        return std::log2(totalSize) * m_length;
-    }
-
-    // CharFromEveryGroup means all groups are required
-    QVector<int> requiredGroups(groups.size());
-    std::iota(requiredGroups.begin(), requiredGroups.end(), 0);
-
-    // Get all subsets of the set of required groups
-    // From https://stackoverflow.com/a/16310898 by Ronald Rey (https://stackoverflow.com/users/2175684/ronald-rey)
-    QVector<QVector<int>> subsets;
-    QVector<int> empty;
-    subsets.push_back(empty);
-    for (int i = 0; i < requiredGroups.size(); ++i) {
-        QVector<QVector<int>> subsetTemp = subsets;
-        for (int j = 0; j < subsetTemp.size(); ++j) {
-            subsetTemp[j].push_back(requiredGroups[i]);
-        }
-        for (int j = 0; j < subsetTemp.size(); ++j) {
-            subsets.push_back(subsetTemp[j]);
-        }
-    }
-
-    // Sort subsets by size ascending
-    std::sort(subsets.begin(), subsets.end(), [](const QVector<int>& a, const QVector<int>& b) -> bool {
-        return a.size() < b.size();
-    });
-
-    // Inclusion-exclusion
-    // Note: This depends on character groups being non-overlapping
-    double passwordSpace = 0;
-    int includeExclude = 1;
-    QVector<QVector<int>>::iterator subset = subsets.begin();
-    for (int i = 0; i < requiredGroups.size(); ++i, includeExclude *= -1) {
-        do {
-            int totalSubsetSize = 0;
-            for (int groupIndex : *subset) {
-                totalSubsetSize += groups[groupIndex].size();
-            }
-            passwordSpace += includeExclude * pow((totalSize - totalSubsetSize), m_length);
-        } while ((++subset)->size() == i);
-    }
-    return std::log2(passwordSpace);
 }
 
 double PasswordGenerator::estimateEntropy(const QString& password)

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -57,7 +57,6 @@ public:
 public:
     PasswordGenerator();
 
-    double getCurrentEntropy();
     double estimateEntropy(const QString& password);
     void setLength(int length);
     void setCharClasses(const CharClasses& classes);

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -57,7 +57,8 @@ public:
 public:
     PasswordGenerator();
 
-    double calculateEntropy(const QString& password);
+    double getCurrentEntropy();
+    double estimateEntropy(const QString& password);
     void setLength(int length);
     void setCharClasses(const CharClasses& classes);
     void setFlags(const GeneratorFlags& flags);

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -256,8 +256,7 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
     if (m_ui->tabWidget->currentIndex() == Password) {
         entropy = m_passwordGenerator->estimateEntropy(password);
     } else {
-        // TODO see issue #867
-        entropy = m_dicewareGenerator->getCurrentEntropy();
+        entropy = m_dicewareGenerator->estimateEntropy();
     }
 
     m_ui->entropyLabel->setText(tr("Entropy: %1 bit").arg(QString::number(entropy, 'f', 2)));

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -254,9 +254,10 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
 {
     double entropy = 0.0;
     if (m_ui->tabWidget->currentIndex() == Password) {
-        entropy = m_passwordGenerator->calculateEntropy(password);
+        entropy = m_passwordGenerator->estimateEntropy(password);
     } else {
-        entropy = m_dicewareGenerator->calculateEntropy(password);
+        // TODO see issue #867
+        entropy = m_dicewareGenerator->getCurrentEntropy();
     }
 
     m_ui->entropyLabel->setText(tr("Entropy: %1 bit").arg(QString::number(entropy, 'f', 2)));


### PR DESCRIPTION
Pass correct entropy amount to keepassxc-browser instead of amount of bits in password/passphrase.
Rename json key from "login" to "entropy" (keeping "login" key as well for backwards compatibility).

Also make some changes to entropy calculation methods:
  - Rename PassphraseGenerator::calculateEntropy to getCurrentEntropy
  - Rename PasswordGenerator::calculateEntropy to estimateEntropy
  - Implement PasswordGenerator::getCurrentEntropy

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context

### Fix incorrect entropy display in keepassxc-browser
Entropy was being calculated as the number of bits in the password, resulting in a notable overestimation for passwords and a ridiculous overestimation for passphrases. The calculation/estimation is now done with `PassphraseGenerator::getCurrentEntropy` and `PasswordGenerator::estimateEntropy(password)`.

### Rename PassphraseGenerator::calculateEntropy to getCurrentEntropy
`calculateEntropy(passphrase)` is a misleading, as it actually calculates the entropy a passphrase would have based on the current configuration. If someone were to generate a passphrase, change the configuration, then call `calculateEntropy(passphrase)` it would return the amount of entropy a new passphrase would have, rather than the amount of entropy in the passphrase passed to it.

### Rename PasswordGenerator::calculateEntropy to estimateEntropy
`estimateEntropy` more accurately describes what the function does.

### Implement PasswordGenerator::getCurrentEntropy
Implements an accurate entropy calculation based on the current generator configuration, analogous to `PassphraseGenerator::getCurrentEntropy`. If `CharFromEveryGroup` is set the calculation is based on the inclusion-exclusion principle. I also implemented it so that it would be easy to update the calculation to only require characters from certain groups by adding only those group indices to `requiredGroups`.

Currently unused, but I would be happy to add it to the gui and use it for the entropy amount sent to keepassxc-browser if a consensus is reached regarding #867 and #2061. Personally I would be in favor of having two labels, one for estimation and one for calculation. Upon generating a password both would be updated, but if the user changes the password the calculation label would be hidden. For keepassxc-browser I would prefer it always use the calculation.

This can also be moved to a separate pull request if required.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )


## Screenshots
Incorrect entropy count:
![keepass-browser-entropy](https://user-images.githubusercontent.com/7794502/57031393-40db4f80-6c0d-11e9-9730-aec263cadb85.png)

## Testing strategy
Manually tested keepassxc gui password generator and keepassxc-browser password generation.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
