### PR TITLE
Don't create default browser group

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -453,11 +453,6 @@ void BrowserService::addEntry(const QString& id,
         return;
     }
 
-    auto* addEntryGroup = findCreateAddEntryGroup(db);
-    if (!addEntryGroup) {
-        return;
-    }
-
     auto* entry = new Entry();
     entry->setUuid(QUuid::createUuid());
     entry->setTitle(QUrl(url).host());
@@ -465,16 +460,19 @@ void BrowserService::addEntry(const QString& id,
     entry->setIcon(KEEPASSXCBROWSER_DEFAULT_ICON);
     entry->setUsername(login);
     entry->setPassword(password);
-    entry->setGroup(addEntryGroup);
 
     // Select a group for the entry
     if (!group.isEmpty()) {
         if (db->rootGroup()) {
             auto selectedGroup = db->rootGroup()->findGroupByUuid(Tools::hexToUuid(groupUuid));
-            if (selectedGroup && selectedGroup->name() == group) {
+            if (selectedGroup) {
                 entry->setGroup(selectedGroup);
+            } else {
+                entry->setGroup(getDefaultEntryGroup(db));
             }
         }
+    } else {
+        entry->setGroup(getDefaultEntryGroup(db));
     }
 
     const QString host = QUrl(url).host();
@@ -855,7 +853,7 @@ BrowserService::checkAccess(const Entry* entry, const QString& host, const QStri
     return Unknown;
 }
 
-Group* BrowserService::findCreateAddEntryGroup(const QSharedPointer<Database>& selectedDb)
+Group* BrowserService::getDefaultEntryGroup(const QSharedPointer<Database>& selectedDb)
 {
     auto db = selectedDb ? selectedDb : getDatabase();
     if (!db) {
@@ -868,7 +866,7 @@ Group* BrowserService::findCreateAddEntryGroup(const QSharedPointer<Database>& s
     }
 
     const QString groupName =
-        QLatin1String(KEEPASSXCBROWSER_GROUP_NAME); // TODO: setting to decide where new keys are created
+        QLatin1String(KEEPASSXCBROWSER_GROUP_NAME);
 
     for (auto* g : rootGroup->groupsRecursive(true)) {
         if (g->name() == groupName && !g->isRecycled()) {

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -114,7 +114,7 @@ private:
                         const QString& realm);
     QJsonObject prepareEntry(const Entry* entry);
     Access checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm);
-    Group* findCreateAddEntryGroup(const QSharedPointer<Database>& selectedDb = {});
+    Group* getDefaultEntryGroup(const QSharedPointer<Database>& selectedDb = {});
     int
     sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
     bool matchUrlScheme(const QString& url);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
Default browser password group is not created if the group is set to something else.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes #3119.
A possible fix to the extension side is also needed because if Root group has not groups, the default group will be still generated.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
