### PR TITLE
simplify wording of enabling browser integration

### DIFF
--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -35,7 +35,7 @@
       <string>This is required for accessing your databases with KeePassXC-Browser</string>
      </property>
      <property name="text">
-      <string>Enable KeepassXC browser integration</string>
+      <string>Enable browser integration</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
For user-facing UI elements, we use the following notation when
referring to the current, native browser:
  'KeePassXC-Browser'.

This commit irons out the last remaining formatting inconsistency,
which presented itself in the Browser Options dialog in an obvious
way since, after being enabled, a second instance of the string would
appear in close proximity to the first.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
#### Before
![KeepassXC browser vs KeePassXC-Browser](https://user-images.githubusercontent.com/2647660/57360693-12b0bf00-717b-11e9-9487-bc582cb74df7.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**