### PR TITLE
Add option for returning expired credentials

### DIFF
--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -120,6 +120,7 @@ void BrowserOptionDialog::loadSettings()
     m_ui->useCustomProxy->setChecked(settings->useCustomProxy());
     m_ui->customProxyLocation->setText(settings->customProxyLocation());
     m_ui->updateBinaryPath->setChecked(settings->updateBinaryPath());
+    m_ui->allowExpiredCredentials->setChecked(settings->allowExpiredCredentials());
     m_ui->chromeSupport->setChecked(settings->chromeSupport());
     m_ui->chromiumSupport->setChecked(settings->chromiumSupport());
     m_ui->firefoxSupport->setChecked(settings->firefoxSupport());
@@ -176,6 +177,7 @@ void BrowserOptionDialog::saveSettings()
     settings->setCustomProxyLocation(m_ui->customProxyLocation->text());
 
     settings->setUpdateBinaryPath(m_ui->updateBinaryPath->isChecked());
+    settings->setAllowExpiredCredentials(m_ui->allowExpiredCredentials->isChecked());
     settings->setAlwaysAllowAccess(m_ui->alwaysAllowAccess->isChecked());
     settings->setAlwaysAllowUpdate(m_ui->alwaysAllowUpdate->isChecked());
     settings->setHttpAuthPermission(m_ui->httpAuthPermission->isChecked());

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -220,6 +220,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="allowExpiredCredentials">
+         <property name="toolTip">
+          <string>Returns expired credentials. String [expired] is added to the title.</string>
+         </property>
+         <property name="text">
+          <string>&amp;Allow returning expired credentials.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QRadioButton" name="sortByTitle">
          <property name="text">
           <string extracomment="Credentials mean login data requested via browser extension">Sort &amp;matching credentials by title</string>

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -818,6 +818,10 @@ QJsonObject BrowserService::prepareEntry(const Entry* entry)
         res["totp"] = entry->totp();
     }
 
+    if (entry->isExpired()) {
+        res["expired"] = "true";
+    }
+
     if (browserSettings()->supportKphFields()) {
         const EntryAttributes* attr = entry->attributes();
         QJsonArray stringFields;
@@ -841,7 +845,7 @@ BrowserService::checkAccess(const Entry* entry, const QString& host, const QStri
         return Unknown;
     }
     if (entry->isExpired()) {
-        return Denied;
+        return browserSettings()->allowExpiredCredentials() ? Allowed : Denied;
     }
     if ((config.isAllowed(host)) && (submitHost.isEmpty() || config.isAllowed(submitHost))) {
         return Allowed;

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -194,6 +194,16 @@ void BrowserSettings::setUpdateBinaryPath(bool enabled)
     config()->set("Browser/UpdateBinaryPath", enabled);
 }
 
+bool BrowserSettings::allowExpiredCredentials()
+{
+    return config()->get("Browser/AllowExpiredCredentials", false).toBool();
+}
+
+void BrowserSettings::setAllowExpiredCredentials(bool enabled)
+{
+    config()->set("Browser/AllowExpiredCredentials", enabled);
+}
+
 bool BrowserSettings::chromeSupport()
 {
     return m_hostInstaller.checkIfInstalled(HostInstaller::SupportedBrowsers::CHROME);

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -64,6 +64,8 @@ public:
     void setCustomProxyLocation(const QString& location);
     bool updateBinaryPath();
     void setUpdateBinaryPath(bool enabled);
+    bool allowExpiredCredentials();
+    void setAllowExpiredCredentials(bool enabled);
     bool chromeSupport();
     void setChromeSupport(bool enabled);
     bool chromiumSupport();


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
Allows returning expired credentials to the browser extension.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Allowing to retrieve expired credentials should still be allowed if the user wants to. In the extension side these credentials are marked with an extra "[Expired]" text appended to the end of the entry title.

Browser side support PR is here: https://github.com/keepassxreboot/keepassxc-browser/pull/537

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
