### PR TITLE
Add enhancements to passphrase generator [feedback wanted]

### DIFF
--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -21,6 +21,8 @@
 #include <QFlags>
 #include <QString>
 #include <QVector>
+#include <QtCore/QScopedPointer>
+#include "PasswordGenerator.h"
 
 class PassphraseGenerator
 {
@@ -28,23 +30,36 @@ public:
     PassphraseGenerator();
     Q_DISABLE_COPY(PassphraseGenerator)
 
-    double calculateEntropy(const QString& passphrase);
+    double calculateEntropy(const QString& passphrase) const;
     void setWordCount(int wordCount);
     void setWordList(const QString& path);
     void setDefaultWordList();
     void setWordSeparator(const QString& separator);
+    void setWordSeparator(const PasswordGenerator::CharClasses& classes, const QString& exclude);
+    void setEnhancementChars(const PasswordGenerator::CharClasses& classes, const QString& exclude);
+    void setEnhancementCount(const int count);
     bool isValid() const;
 
-    QString generatePassphrase() const;
+    QString generatePassphrase();
 
     static constexpr int DefaultWordCount = 7;
     static const char* DefaultSeparator;
     static const char* DefaultWordList;
 
 private:
+    double calculateRawEntropy() const;
+
     int m_wordCount;
-    QString m_separator;
     QVector<QString> m_wordlist;
+
+    bool m_useSeparator = true;
+    QString m_separator;
+    const QScopedPointer<PasswordGenerator> m_separatorGenerator;
+
+    int m_enhancementCount = 0;
+    const QScopedPointer<PasswordGenerator> m_enhancementGenerator;
+
+    double m_lastEntropy = 0;
 };
 
 #endif // KEEPASSX_PASSPHRASEGENERATOR_H

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -22,6 +22,7 @@
 #include <QComboBox>
 #include <QLabel>
 #include <QWidget>
+#include <QtWidgets/QButtonGroup>
 
 #include "core/PassphraseGenerator.h"
 #include "core/PasswordGenerator.h"
@@ -72,8 +73,13 @@ private slots:
 
     void passwordSliderMoved();
     void passwordSpinBoxChanged();
+
+    void updateWordSeparator();
+    void updateEnhancement();
     void dicewareSliderMoved();
+    void enhancementSliderMoved();
     void dicewareSpinBoxChanged();
+    void enhancementSpinBoxChanged();
     void colorStrengthIndicator(double entropy);
 
     void updateGenerator();
@@ -88,6 +94,8 @@ private:
     const QScopedPointer<PasswordGenerator> m_passwordGenerator;
     const QScopedPointer<PassphraseGenerator> m_dicewareGenerator;
     const QScopedPointer<Ui::PasswordGeneratorWidget> m_ui;
+
+    QButtonGroup m_passphraseRadioButtons;
 
 protected:
     void keyPressEvent(QKeyEvent* e) override;

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -927,16 +927,40 @@ QProgressBar::chunk {
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="labelWordList">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
+             <item row="1" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordCount">
                <property name="text">
-                <string>Wordlist:</string>
+                <string>Word Co&amp;unt:</string>
+               </property>
+               <property name="buddy">
+                <cstring>spinBoxLength</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelEnhancement">
+               <property name="text">
+                <string>Enhance Phrase:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <spacer name="verticalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="2" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordSeparator">
+               <property name="text">
+                <string>Separate Words:</string>
                </property>
               </widget>
              </item>
@@ -947,16 +971,6 @@ QProgressBar::chunk {
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="labelWordCount">
-               <property name="text">
-                <string>Word Co&amp;unt:</string>
-               </property>
-               <property name="buddy">
-                <cstring>spinBoxLength</cstring>
                </property>
               </widget>
              </item>
@@ -1005,32 +1019,147 @@ QProgressBar::chunk {
                </item>
               </layout>
              </item>
-             <item row="2" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="labelWordSeparator">
+             <item row="0" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordList">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
                <property name="text">
-                <string>Word Separator:</string>
+                <string>Wordlist:</string>
                </property>
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QLineEdit" name="editWordSeparator">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
+              <layout class="QHBoxLayout" name="horizontalLayout_8">
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_9">
+                 <item>
+                  <widget class="QRadioButton" name="radioButtonWordSeparator">
+                   <property name="text">
+                    <string>Separator</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="editWordSeparator">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_10">
+                 <item>
+                  <widget class="QRadioButton" name="radioButtonRandomSeparator">
+                   <property name="text">
+                    <string>Random</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QToolButton" name="buttonNumbers">
+                   <property name="text">
+                    <string>0-9</string>
+                   </property>
+                   <property name="checkable">
+                    <bool>true</bool>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QToolButton" name="buttonSpecial">
+                   <property name="text">
+                    <string>/*_...</string>
+                   </property>
+                   <property name="checkable">
+                    <bool>true</bool>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelRandomSeparatorExclude">
+                   <property name="text">
+                    <string>Exclude:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="editRandomSeparatorExclude"/>
+                 </item>
+                </layout>
+               </item>
+              </layout>
              </item>
              <item row="3" column="1">
-              <spacer name="verticalSpacer_3">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
+              <layout class="QHBoxLayout" name="horizontalLayout_7">
+               <item>
+                <widget class="QSlider" name="sliderEnhancementCount">
+                 <property name="maximum">
+                  <number>20</number>
+                 </property>
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="spinBoxEnhancementCount">
+                 <property name="maximum">
+                  <number>100</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="buttonEnhancementNumbers">
+                 <property name="text">
+                  <string>0-9</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="buttonEnhancementSpecial">
+                 <property name="text">
+                  <string>/*_...</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="labelEnhancementExclude">
+                 <property name="text">
+                  <string>Exclude:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="editEnhancementExclude"/>
+               </item>
+              </layout>
              </item>
             </layout>
            </item>
@@ -1122,19 +1251,31 @@ QProgressBar::chunk {
   <tabstop>checkBoxPunctuation</tabstop>
   <tabstop>checkBoxMath</tabstop>
   <tabstop>checkBoxLogograms</tabstop>
+  <tabstop>checkBoxLowerAdv</tabstop>
   <tabstop>checkBoxBraces</tabstop>
   <tabstop>checkBoxQuotes</tabstop>
   <tabstop>checkBoxDashes</tabstop>
   <tabstop>checkBoxExtASCIIAdv</tabstop>
   <tabstop>editExcludedChars</tabstop>
-  <tabstop>buttonSimpleMode</tabstop>
+  <tabstop>buttonAddHex</tabstop>
   <tabstop>checkBoxExcludeAlike</tabstop>
   <tabstop>checkBoxEnsureEvery</tabstop>
+  <tabstop>buttonSimpleMode</tabstop>
   <tabstop>tabWidget</tabstop>
   <tabstop>comboBoxWordList</tabstop>
   <tabstop>sliderWordCount</tabstop>
   <tabstop>spinBoxWordCount</tabstop>
+  <tabstop>radioButtonWordSeparator</tabstop>
   <tabstop>editWordSeparator</tabstop>
+  <tabstop>radioButtonRandomSeparator</tabstop>
+  <tabstop>buttonNumbers</tabstop>
+  <tabstop>buttonSpecial</tabstop>
+  <tabstop>editRandomSeparatorExclude</tabstop>
+  <tabstop>sliderEnhancementCount</tabstop>
+  <tabstop>spinBoxEnhancementCount</tabstop>
+  <tabstop>buttonEnhancementNumbers</tabstop>
+  <tabstop>buttonEnhancementSpecial</tabstop>
+  <tabstop>editEnhancementExclude</tabstop>
   <tabstop>buttonGenerate</tabstop>
   <tabstop>buttonCopy</tabstop>
   <tabstop>buttonApply</tabstop>


### PR DESCRIPTION
Included more customizing options in the passphrase generator.
Only partially finished yet; I'm **looking for your feedback** before putting more effort in.

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Some issues request a more customizable.

I myself like to use passphrases with additional numbers and special characters added to them.
An example would be `shortcak6e sa0tirical amnes"ty flyover` (generated by my addition).
This is needed because some accounts enforce numbers and special characters in the password.

Issues like #1222 #1933 and #2133 are related and partially fixed by this.
I plan to add a combobox for camel case and upper case which resolves #1933 and #2133.

## TODOs before merge
* fix #1933 and #2133
* add testing
* extend CLI interface (?)

## Screenshots
![keepass](https://user-images.githubusercontent.com/3729858/57878890-65454780-781b-11e9-80f5-35957cd46980.png)

## Testing strategy
Only manual until now.

TODO


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- TODO ~~✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**~~
- TODO ~~✅ My change requires a change to the documentation, and I have updated it accordingly.~~
- TODO ~~✅ I have added tests to cover my changes.~~
