### PR TITLE
Allow system to shutdown on Linux

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -887,7 +887,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     }
 
     if (config()->get("GUI/MinimizeOnClose").toBool() && !m_appExitCalled) {
-        event->ignore();
+        event->accept();
         hideWindow();
         return;
     }


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Fixes #2692. With "Minimize instead of app exit" enabled, this change allows the application to close when a system shutdown or logout is initiated. Otherwise, the close event will be ignored by the application, thereby inhibiting shutdown/logout.

## Testing strategy
When selecting Logout, Shutdown, or Reboot from the KDE application launcher, the action will be prevented by KeePassXC if "Minimize instead of app exit" is enabled. After making this change, when I select either logout, shutdown, or reboot from the menu, the app is able to close normally, and subsequently the system can logout/shutdown/reboot without issue.


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**