### PR TITLE
Add word case option to passphrase generator

### DIFF
--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -510,7 +510,6 @@ QString BrowserSettings::generatePassword()
         m_passwordGenerator.setFlags(passwordGeneratorFlags());
         return m_passwordGenerator.generatePassword();
     } else {
-        m_passPhraseGenerator.setDefaultWordList();
         m_passPhraseGenerator.setWordCount(passPhraseWordCount());
         m_passPhraseGenerator.setWordSeparator(passPhraseWordSeparator());
         return m_passPhraseGenerator.generatePassphrase();

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -73,8 +73,6 @@ int Diceware::execute(const QStringList& arguments)
 
     if (!parser.value(wordlistFile).isEmpty()) {
         dicewareGenerator.setWordList(parser.value(wordlistFile));
-    } else {
-        dicewareGenerator.setDefaultWordList();
     }
 
     if (!dicewareGenerator.isValid()) {

--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -54,6 +54,16 @@ void PassphraseGenerator::setWordCount(int wordCount)
     }
 }
 
+void PassphraseGenerator::setWordCase(int wordCase)
+{
+    if (wordCase >= 0 && wordCase <= 2) {
+        m_wordCase = wordCase;
+    } else {
+        // safe default (lowercase) if something goes wrong
+        m_wordCase = 0;
+    }
+}
+
 void PassphraseGenerator::setWordList(const QString& path)
 {
     m_wordlist.clear();
@@ -88,6 +98,7 @@ void PassphraseGenerator::setWordSeparator(const QString& separator)
 
 QString PassphraseGenerator::generatePassphrase() const
 {
+    QString tmpWord;
     Q_ASSERT(isValid());
 
     // In case there was an error loading the wordlist
@@ -98,7 +109,23 @@ QString PassphraseGenerator::generatePassphrase() const
     QStringList words;
     for (int i = 0; i < m_wordCount; ++i) {
         int wordIndex = randomGen()->randomUInt(static_cast<quint32>(m_wordlist.length()));
-        words.append(m_wordlist.at(wordIndex));
+        tmpWord = m_wordlist.at(wordIndex);
+
+        //convert case
+        switch (m_wordCase) {
+        case 0 : // lower case
+            tmpWord = tmpWord.toLower();
+            break;
+        case 1 : // UPPER CASE
+            tmpWord = tmpWord.toUpper();
+            break;
+        case 2 : // Title Case
+            tmpWord = tmpWord.replace(0,1,tmpWord.left(1).toUpper());
+            break;
+        default :
+            break;
+        }
+        words.append(tmpWord);
     }
 
     return words.join(m_separator);

--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -56,7 +56,7 @@ void PassphraseGenerator::setWordCount(int wordCount)
 
 void PassphraseGenerator::setWordCase(int wordCase)
 {
-    if (wordCase >= 0 && wordCase <= 2) {
+    if (wordCase >= PassphraseGenerator::MIN_VALUE && wordCase <= PassphraseGenerator::MAX_VALUE ) {
         m_wordCase = wordCase;
     } else {
         // safe default (lowercase) if something goes wrong
@@ -113,16 +113,15 @@ QString PassphraseGenerator::generatePassphrase() const
 
         //convert case
         switch (m_wordCase) {
-        case 0 : // lower case
-            tmpWord = tmpWord.toLower();
-            break;
-        case 1 : // UPPER CASE
+        case PassphraseGenerator::UPPERCASE :
             tmpWord = tmpWord.toUpper();
             break;
-        case 2 : // Title Case
+        case PassphraseGenerator::TITLECASE :
             tmpWord = tmpWord.replace(0,1,tmpWord.left(1).toUpper());
             break;
+        case PassphraseGenerator::LOWERCASE :
         default :
+            tmpWord = tmpWord.toLower();
             break;
         }
         words.append(tmpWord);

--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -28,9 +28,11 @@ const char* PassphraseGenerator::DefaultSeparator = " ";
 const char* PassphraseGenerator::DefaultWordList = "eff_large.wordlist";
 
 PassphraseGenerator::PassphraseGenerator()
-    : m_wordCount(0)
-    , m_separator(PassphraseGenerator::DefaultSeparator)
+    : m_wordCount(DefaultWordCount)
+    , m_wordCase(LOWERCASE)
+    , m_separator(DefaultSeparator)
 {
+    setDefaultWordList();
 }
 
 double PassphraseGenerator::calculateEntropy(const QString& passphrase)
@@ -46,22 +48,12 @@ double PassphraseGenerator::calculateEntropy(const QString& passphrase)
 
 void PassphraseGenerator::setWordCount(int wordCount)
 {
-    if (wordCount > 0) {
-        m_wordCount = wordCount;
-    } else {
-        // safe default if something goes wrong
-        m_wordCount = DefaultWordCount;
-    }
+    m_wordCount = qMax(1, wordCount);
 }
 
-void PassphraseGenerator::setWordCase(int wordCase)
+void PassphraseGenerator::setWordCase(PassphraseWordCase wordCase)
 {
-    if (wordCase >= PassphraseGenerator::MIN_VALUE && wordCase <= PassphraseGenerator::MAX_VALUE ) {
-        m_wordCase = wordCase;
-    } else {
-        // safe default (lowercase) if something goes wrong
-        m_wordCase = 0;
-    }
+    m_wordCase = wordCase;
 }
 
 void PassphraseGenerator::setWordList(const QString& path)
@@ -111,16 +103,16 @@ QString PassphraseGenerator::generatePassphrase() const
         int wordIndex = randomGen()->randomUInt(static_cast<quint32>(m_wordlist.length()));
         tmpWord = m_wordlist.at(wordIndex);
 
-        //convert case
+        // convert case
         switch (m_wordCase) {
-        case PassphraseGenerator::UPPERCASE :
+        case UPPERCASE:
             tmpWord = tmpWord.toUpper();
             break;
-        case PassphraseGenerator::TITLECASE :
-            tmpWord = tmpWord.replace(0,1,tmpWord.left(1).toUpper());
+        case TITLECASE:
+            tmpWord = tmpWord.replace(0, 1, tmpWord.left(1).toUpper());
             break;
-        case PassphraseGenerator::LOWERCASE :
-        default :
+        case LOWERCASE:
+        default:
             tmpWord = tmpWord.toLower();
             break;
         }

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -31,6 +31,7 @@ public:
     double calculateEntropy(const QString& passphrase);
     void setWordCount(int wordCount);
     void setWordList(const QString& path);
+    void setWordCase(int wordCase);
     void setDefaultWordList();
     void setWordSeparator(const QString& separator);
     bool isValid() const;
@@ -38,11 +39,13 @@ public:
     QString generatePassphrase() const;
 
     static constexpr int DefaultWordCount = 7;
+    static constexpr int DefaultWordCase = 0; // 0 = lower
     static const char* DefaultSeparator;
     static const char* DefaultWordList;
 
 private:
     int m_wordCount;
+    int m_wordCase; // 0 = lower, 1 = upper, 2 = title
     QString m_separator;
     QVector<QString> m_wordlist;
 };

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -28,27 +28,30 @@ public:
     PassphraseGenerator();
     Q_DISABLE_COPY(PassphraseGenerator)
 
+    enum PassphraseWordCase
+    {
+        LOWERCASE,
+        UPPERCASE,
+        TITLECASE
+    };
+
     double calculateEntropy(const QString& passphrase);
     void setWordCount(int wordCount);
     void setWordList(const QString& path);
-    void setWordCase(int wordCase);
+    void setWordCase(PassphraseWordCase wordCase);
     void setDefaultWordList();
     void setWordSeparator(const QString& separator);
     bool isValid() const;
 
     QString generatePassphrase() const;
 
-    enum PassphraseWordCase { LOWERCASE = 0, UPPERCASE = 1, TITLECASE = 2, MIN_VALUE = LOWERCASE, MAX_VALUE = TITLECASE };
-    Q_DECLARE_FLAGS(PassphraseWordCases, PassphraseWordCase)
-
     static constexpr int DefaultWordCount = 7;
-    static constexpr int DefaultWordCase = PassphraseGenerator::LOWERCASE;
     static const char* DefaultSeparator;
     static const char* DefaultWordList;
 
 private:
     int m_wordCount;
-    int m_wordCase;
+    PassphraseWordCase m_wordCase;
     QString m_separator;
     QVector<QString> m_wordlist;
 };

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -38,14 +38,17 @@ public:
 
     QString generatePassphrase() const;
 
+    enum PassphraseWordCase { LOWERCASE = 0, UPPERCASE = 1, TITLECASE = 2, MIN_VALUE = LOWERCASE, MAX_VALUE = TITLECASE };
+    Q_DECLARE_FLAGS(PassphraseWordCases, PassphraseWordCase)
+
     static constexpr int DefaultWordCount = 7;
-    static constexpr int DefaultWordCase = 0; // 0 = lower
+    static constexpr int DefaultWordCase = PassphraseGenerator::LOWERCASE;
     static const char* DefaultSeparator;
     static const char* DefaultWordList;
 
 private:
     int m_wordCount;
-    int m_wordCase; // 0 = lower, 1 = upper, 2 = title
+    int m_wordCase;
     QString m_separator;
     QVector<QString> m_wordlist;
 };

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -60,6 +60,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     connect(m_ui->comboBoxWordList, SIGNAL(currentIndexChanged(int)), SLOT(updateGenerator()));
     connect(m_ui->optionButtons, SIGNAL(buttonClicked(int)), SLOT(updateGenerator()));
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(updateGenerator()));
+    connect(m_ui->wordCaseButtonGroup, SIGNAL(buttonClicked(int)), SLOT(updateGenerator()));
 
     // set font size of password quality and entropy labels dynamically to 80% of
     // the default font size, but make it no smaller than 8pt
@@ -73,6 +74,14 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
 
     // set default separator to Space
     m_ui->editWordSeparator->setText(PassphraseGenerator::DefaultSeparator);
+
+    // set the ids of the radiobuttons
+    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseLowerRadioButton, 0);
+    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseUpperRadioButton, 1);
+    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseTitleRadioButton, 2);
+
+    // set word case to lowercase (default)
+    m_ui->wordCaseButtonGroup->button(0)->isChecked();
 
     QDir path(filePath()->wordlistPath(""));
     QStringList files = path.entryList(QDir::Files);
@@ -139,6 +148,8 @@ void PasswordGeneratorWidget::loadSettings()
         config()->get("generator/WordSeparator", PassphraseGenerator::DefaultSeparator).toString());
     m_ui->comboBoxWordList->setCurrentText(
         config()->get("generator/WordList", PassphraseGenerator::DefaultWordList).toString());
+    m_ui->wordCaseButtonGroup->button(
+        config()->get("generator/WordCase", PassphraseGenerator::DefaultWordCase).toInt())->isChecked();
 
     // Password or diceware?
     m_ui->tabWidget->setCurrentIndex(config()->get("generator/Type", 0).toInt());
@@ -174,6 +185,7 @@ void PasswordGeneratorWidget::saveSettings()
     config()->set("generator/WordCount", m_ui->spinBoxWordCount->value());
     config()->set("generator/WordSeparator", m_ui->editWordSeparator->text());
     config()->set("generator/WordList", m_ui->comboBoxWordList->currentText());
+    config()->set("generator/WordCase", m_ui->wordCaseButtonGroup->checkedId());
 
     // Password or diceware?
     config()->set("generator/Type", m_ui->tabWidget->currentIndex());
@@ -555,6 +567,8 @@ void PasswordGeneratorWidget::updateGenerator()
             m_ui->sliderWordCount->setValue(minWordCount);
             m_updatingSpinBox = false;
         }
+
+        m_dicewareGenerator->setWordCase(m_ui->wordCaseButtonGroup->checkedId());
 
         m_ui->spinBoxWordCount->setMinimum(minWordCount);
         m_ui->sliderWordCount->setMinimum(minWordCount);

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -60,7 +60,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     connect(m_ui->comboBoxWordList, SIGNAL(currentIndexChanged(int)), SLOT(updateGenerator()));
     connect(m_ui->optionButtons, SIGNAL(buttonClicked(int)), SLOT(updateGenerator()));
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(updateGenerator()));
-    connect(m_ui->wordCaseButtonGroup, SIGNAL(buttonClicked(int)), SLOT(updateGenerator()));
+    connect(m_ui->wordCaseComboBox, SIGNAL(currentIndexChanged(int)), SLOT(updateGenerator()));
 
     // set font size of password quality and entropy labels dynamically to 80% of
     // the default font size, but make it no smaller than 8pt
@@ -75,13 +75,10 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     // set default separator to Space
     m_ui->editWordSeparator->setText(PassphraseGenerator::DefaultSeparator);
 
-    // set the ids of the radiobuttons
-    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseLowerRadioButton, PassphraseGenerator::LOWERCASE);
-    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseUpperRadioButton, PassphraseGenerator::UPPERCASE);
-    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseTitleRadioButton, PassphraseGenerator::TITLECASE);
-
-    // set word case to lowercase (default)
-    m_ui->wordCaseButtonGroup->button(PassphraseGenerator::LOWERCASE)->isChecked();
+    // add passphrase generator case options
+    m_ui->wordCaseComboBox->addItem(tr("lower case"), PassphraseGenerator::LOWERCASE);
+    m_ui->wordCaseComboBox->addItem(tr("UPPER CASE"), PassphraseGenerator::UPPERCASE);
+    m_ui->wordCaseComboBox->addItem(tr("Title Case"), PassphraseGenerator::TITLECASE);
 
     QDir path(filePath()->wordlistPath(""));
     QStringList files = path.entryList(QDir::Files);
@@ -94,7 +91,6 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
         m_ui->labelWordList->setVisible(false);
     }
 
-    m_dicewareGenerator->setDefaultWordList();
     loadSettings();
     reset();
 }
@@ -148,8 +144,7 @@ void PasswordGeneratorWidget::loadSettings()
         config()->get("generator/WordSeparator", PassphraseGenerator::DefaultSeparator).toString());
     m_ui->comboBoxWordList->setCurrentText(
         config()->get("generator/WordList", PassphraseGenerator::DefaultWordList).toString());
-    m_ui->wordCaseButtonGroup->button(
-        config()->get("generator/WordCase", PassphraseGenerator::DefaultWordCase).toInt())->isChecked();
+    m_ui->wordCaseComboBox->setCurrentIndex(config()->get("generator/WordCase", 0).toInt());
 
     // Password or diceware?
     m_ui->tabWidget->setCurrentIndex(config()->get("generator/Type", 0).toInt());
@@ -185,7 +180,7 @@ void PasswordGeneratorWidget::saveSettings()
     config()->set("generator/WordCount", m_ui->spinBoxWordCount->value());
     config()->set("generator/WordSeparator", m_ui->editWordSeparator->text());
     config()->set("generator/WordList", m_ui->comboBoxWordList->currentText());
-    config()->set("generator/WordCase", m_ui->wordCaseButtonGroup->checkedId());
+    config()->set("generator/WordCase", m_ui->wordCaseComboBox->currentIndex());
 
     // Password or diceware?
     config()->set("generator/Type", m_ui->tabWidget->currentIndex());
@@ -568,7 +563,8 @@ void PasswordGeneratorWidget::updateGenerator()
             m_updatingSpinBox = false;
         }
 
-        m_dicewareGenerator->setWordCase(m_ui->wordCaseButtonGroup->checkedId());
+        m_dicewareGenerator->setWordCase(
+            static_cast<PassphraseGenerator::PassphraseWordCase>(m_ui->wordCaseComboBox->currentData().toInt()));
 
         m_ui->spinBoxWordCount->setMinimum(minWordCount);
         m_ui->sliderWordCount->setMinimum(minWordCount);

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -76,12 +76,12 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     m_ui->editWordSeparator->setText(PassphraseGenerator::DefaultSeparator);
 
     // set the ids of the radiobuttons
-    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseLowerRadioButton, 0);
-    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseUpperRadioButton, 1);
-    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseTitleRadioButton, 2);
+    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseLowerRadioButton, PassphraseGenerator::LOWERCASE);
+    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseUpperRadioButton, PassphraseGenerator::UPPERCASE);
+    m_ui->wordCaseButtonGroup->setId(m_ui->wordCaseTitleRadioButton, PassphraseGenerator::TITLECASE);
 
     // set word case to lowercase (default)
-    m_ui->wordCaseButtonGroup->button(0)->isChecked();
+    m_ui->wordCaseButtonGroup->button(PassphraseGenerator::LOWERCASE)->isChecked();
 
     QDir path(filePath()->wordlistPath(""));
     QStringList files = path.entryList(QDir::Files);

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -927,15 +927,55 @@ QProgressBar::chunk {
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <layout class="QGridLayout" name="gridLayout_3">
-             <item row="1" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="labelWordCount">
+             <item row="3" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="wordCaseLabel">
                <property name="text">
-                <string>Word Co&amp;unt:</string>
-               </property>
-               <property name="buddy">
-                <cstring>spinBoxLength</cstring>
+                <string>Word Case:</string>
                </property>
               </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="comboBoxWordList">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordSeparator">
+               <property name="text">
+                <string>Word Separator:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordList">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Wordlist:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <spacer name="verticalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
              </item>
              <item row="1" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -982,28 +1022,15 @@ QProgressBar::chunk {
                </item>
               </layout>
              </item>
-             <item row="0" column="1">
-              <widget class="QComboBox" name="comboBoxWordList">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="1" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordCount">
+               <property name="text">
+                <string>Word Co&amp;unt:</string>
+               </property>
+               <property name="buddy">
+                <cstring>spinBoxLength</cstring>
                </property>
               </widget>
-             </item>
-             <item row="4" column="1">
-              <spacer name="verticalSpacer_3">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
              </item>
              <item row="2" column="1">
               <widget class="QLineEdit" name="editWordSeparator">
@@ -1012,69 +1039,25 @@ QProgressBar::chunk {
                </property>
               </widget>
              </item>
-             <item row="0" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="labelWordList">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Wordlist:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="wordCaseLabel">
-               <property name="text">
-                <string>Word Case:</string>
-               </property>
-              </widget>
-             </item>
              <item row="3" column="1">
-              <layout class="QHBoxLayout" name="horizontalLayoutWordCase">
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
                <item>
-                <widget class="QRadioButton" name="wordCaseLowerRadioButton">
-                 <property name="text">
-                  <string>lower case (default)</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                 <attribute name="buttonGroup">
-                  <string notr="true">wordCaseButtonGroup</string>
-                 </attribute>
-                </widget>
+                <widget class="QComboBox" name="wordCaseComboBox"/>
                </item>
                <item>
-                <widget class="QRadioButton" name="wordCaseUpperRadioButton">
-                 <property name="text">
-                  <string>UPPER CASE</string>
+                <spacer name="horizontalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
-                 <attribute name="buttonGroup">
-                  <string notr="true">wordCaseButtonGroup</string>
-                 </attribute>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="wordCaseTitleRadioButton">
-                 <property name="text">
-                  <string>Title Case</string>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
                  </property>
-                 <attribute name="buttonGroup">
-                  <string notr="true">wordCaseButtonGroup</string>
-                 </attribute>
-                </widget>
+                </spacer>
                </item>
               </layout>
-             </item>
-             <item row="2" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="labelWordSeparator">
-               <property name="text">
-                <string>Word Separator:</string>
-               </property>
-              </widget>
              </item>
             </layout>
            </item>
@@ -1179,9 +1162,6 @@ QProgressBar::chunk {
   <tabstop>sliderWordCount</tabstop>
   <tabstop>spinBoxWordCount</tabstop>
   <tabstop>editWordSeparator</tabstop>
-  <tabstop>wordCaseLowerRadioButton</tabstop>
-  <tabstop>wordCaseUpperRadioButton</tabstop>
-  <tabstop>wordCaseTitleRadioButton</tabstop>
   <tabstop>buttonGenerate</tabstop>
   <tabstop>buttonCopy</tabstop>
   <tabstop>buttonApply</tabstop>
@@ -1189,11 +1169,6 @@ QProgressBar::chunk {
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="wordCaseButtonGroup">
-   <property name="exclusive">
-    <bool>true</bool>
-   </property>
-  </buttongroup>
   <buttongroup name="optionButtons">
    <property name="exclusive">
     <bool>false</bool>

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -927,29 +927,6 @@ QProgressBar::chunk {
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="labelWordList">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Wordlist:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QComboBox" name="comboBoxWordList">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="0" alignment="Qt::AlignRight">
               <widget class="QLabel" name="labelWordCount">
                <property name="text">
@@ -1005,21 +982,17 @@ QProgressBar::chunk {
                </item>
               </layout>
              </item>
-             <item row="2" column="0" alignment="Qt::AlignRight">
-              <widget class="QLabel" name="labelWordSeparator">
-               <property name="text">
-                <string>Word Separator:</string>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="comboBoxWordList">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
-              <widget class="QLineEdit" name="editWordSeparator">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
+             <item row="4" column="1">
               <spacer name="verticalSpacer_3">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
@@ -1031,6 +1004,77 @@ QProgressBar::chunk {
                 </size>
                </property>
               </spacer>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLineEdit" name="editWordSeparator">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordList">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Wordlist:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="wordCaseLabel">
+               <property name="text">
+                <string>Word Case:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <layout class="QHBoxLayout" name="horizontalLayoutWordCase">
+               <item>
+                <widget class="QRadioButton" name="wordCaseLowerRadioButton">
+                 <property name="text">
+                  <string>lower case (default)</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">wordCaseButtonGroup</string>
+                 </attribute>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="wordCaseUpperRadioButton">
+                 <property name="text">
+                  <string>UPPER CASE</string>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">wordCaseButtonGroup</string>
+                 </attribute>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="wordCaseTitleRadioButton">
+                 <property name="text">
+                  <string>Title Case</string>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">wordCaseButtonGroup</string>
+                 </attribute>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="2" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordSeparator">
+               <property name="text">
+                <string>Word Separator:</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>
@@ -1135,6 +1179,9 @@ QProgressBar::chunk {
   <tabstop>sliderWordCount</tabstop>
   <tabstop>spinBoxWordCount</tabstop>
   <tabstop>editWordSeparator</tabstop>
+  <tabstop>wordCaseLowerRadioButton</tabstop>
+  <tabstop>wordCaseUpperRadioButton</tabstop>
+  <tabstop>wordCaseTitleRadioButton</tabstop>
   <tabstop>buttonGenerate</tabstop>
   <tabstop>buttonCopy</tabstop>
   <tabstop>buttonApply</tabstop>
@@ -1142,6 +1189,11 @@ QProgressBar::chunk {
  <resources/>
  <connections/>
  <buttongroups>
+  <buttongroup name="wordCaseButtonGroup">
+   <property name="exclusive">
+    <bool>true</bool>
+   </property>
+  </buttongroup>
   <buttongroup name="optionButtons">
    <property name="exclusive">
     <bool>false</bool>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -190,6 +190,9 @@ add_unit_test(NAME testmerge SOURCES TestMerge.cpp
 add_unit_test(NAME testpasswordgenerator SOURCES TestPasswordGenerator.cpp
         LIBS ${TEST_LIBRARIES})
 
+add_unit_test(NAME testpassphrasegenerator SOURCES TestPassphraseGenerator.cpp
+        LIBS ${TEST_LIBRARIES})
+
 add_unit_test(NAME testtotp SOURCES TestTotp.cpp
         LIBS ${TEST_LIBRARIES})
 

--- a/tests/TestPassphraseGenerator.cpp
+++ b/tests/TestPassphraseGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018-2019 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,35 +32,23 @@ void TestPassphraseGenerator::initTestCase()
 void TestPassphraseGenerator::testWordCase()
 {
     PassphraseGenerator generator;
-
-    generator.setWordCount(1);
-    generator.setWordCase(-3); // invalid - should default to lowercase
+    generator.setWordSeparator(" ");
     QVERIFY(generator.isValid());
-    QString password = generator.generatePassword();
-    QVERIFY(password.isLower());
 
-    generator.setWordCount(1);
-    generator.setWordCase(99); // invalid - should default to lowercase
-    QVERIFY(generator.isValid());
-    QString password = generator.generatePassword();
-    QVERIFY(password.isLower());
+    QString passphrase;
+    passphrase = generator.generatePassphrase();
+    QCOMPARE(passphrase, passphrase.toLower());
 
-    generator.setWordCount(1);
     generator.setWordCase(PassphraseGenerator::LOWERCASE);
-    QVERIFY(generator.isValid());
-    QString password = generator.generatePassword();
-    QVERIFY(password.isLower());
+    passphrase = generator.generatePassphrase();
+    QCOMPARE(passphrase, passphrase.toLower());
 
-    generator.setWordCount(1);
     generator.setWordCase(PassphraseGenerator::UPPERCASE);
-    QVERIFY(generator.isValid());
-    QString password = generator.generatePassword();
-    QVERIFY(password.isUpper());
+    passphrase = generator.generatePassphrase();
+    QCOMPARE(passphrase, passphrase.toUpper());
 
-    generator.setWordCount(1);
     generator.setWordCase(PassphraseGenerator::TITLECASE);
-    QVERIFY(generator.isValid());
-    QString password = generator.generatePassword();
-    QRegularExpression regex("^[A-Z][a-z]*+$");
-    QVERIFY(regex.match(password).hasMatch());
+    passphrase = generator.generatePassphrase();
+    QRegularExpression regex("^([A-Z][a-z]* ?)+$");
+    QVERIFY(regex.match(passphrase).hasMatch());
 }

--- a/tests/TestPassphraseGenerator.cpp
+++ b/tests/TestPassphraseGenerator.cpp
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2018-2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestPassphraseGenerator.h"
+#include "core/PassphraseGenerator.h"
+#include "crypto/Crypto.h"
+
+#include <QRegularExpression>
+#include <QTest>
+
+QTEST_GUILESS_MAIN(TestPassphraseGenerator)
+
+void TestPassphraseGenerator::initTestCase()
+{
+    QVERIFY(Crypto::init());
+}
+
+void TestPassphraseGenerator::testWordCase()
+{
+    PassphraseGenerator generator;
+
+    generator.setWordCount(1);
+    generator.setWordCase(-3); // invalid - should default to lowercase
+    QVERIFY(generator.isValid());
+    QString password = generator.generatePassword();
+    QVERIFY(password.isLower());
+
+    generator.setWordCount(1);
+    generator.setWordCase(99); // invalid - should default to lowercase
+    QVERIFY(generator.isValid());
+    QString password = generator.generatePassword();
+    QVERIFY(password.isLower());
+
+    generator.setWordCount(1);
+    generator.setWordCase(PassphraseGenerator::LOWERCASE);
+    QVERIFY(generator.isValid());
+    QString password = generator.generatePassword();
+    QVERIFY(password.isLower());
+
+    generator.setWordCount(1);
+    generator.setWordCase(PassphraseGenerator::UPPERCASE);
+    QVERIFY(generator.isValid());
+    QString password = generator.generatePassword();
+    QVERIFY(password.isUpper());
+
+    generator.setWordCount(1);
+    generator.setWordCase(PassphraseGenerator::TITLECASE);
+    QVERIFY(generator.isValid());
+    QString password = generator.generatePassword();
+    QRegularExpression regex("^[A-Z][a-z]*+$");
+    QVERIFY(regex.match(password).hasMatch());
+}

--- a/tests/TestPassphraseGenerator.h
+++ b/tests/TestPassphraseGenerator.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018-2019 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tests/TestPassphraseGenerator.h
+++ b/tests/TestPassphraseGenerator.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2018-2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTPASSPHRASEGENERATOR_H
+#define KEEPASSXC_TESTPASSPHRASEGENERATOR_H
+
+#include <QObject>
+
+class TestPassphraseGenerator : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void testWordCase();
+};
+
+#endif // KEEPASSXC_TESTPASSPHRASEGENERATOR_H


### PR DESCRIPTION
adds lower, upper, and title case options to passphrase (diceware) generation

Adds an option to have passphrases generated in lower, UPPER, or title case. Adds this option to the saved configuration.

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
No large changes, ads a small step in teh gerenation of passphrases that modifies the word selected form the word list based on desired capitalization

fixes #1933

## Screenshots
![image](https://user-images.githubusercontent.com/158361/58110655-34636a80-7bad-11e9-9bf6-7f48c3195d00.png)

## Testing strategy
Manual testing only. I ran the compiled executable and generated a new passphrase with the new options. The passphrases were all generated with the correct case based on the selected option. 

I opened the executable multiple time and the case option was saved between sessions.

Repeated all manual tests with the standalone password generator.

No major documentation changes required - added comments for 0 = lower, 1 = UPPER, and 2 = Title in several locations in the code to make the values clear. Considered an enum but decided to go with numbers. 

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
I built using the release tool - is this accomplished with the release tool or do I have to do a manual step?

- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
I did not find any tests that needed to be updated and I am not certain if any need to be added. I am open to creating new tests if necessary I just need some guidance as to what is required. 

