### PR TITLE
Read all database attachments even if duplicated

### DIFF
--- a/src/format/Kdbx4Reader.cpp
+++ b/src/format/Kdbx4Reader.cpp
@@ -35,7 +35,7 @@ bool Kdbx4Reader::readDatabaseImpl(QIODevice* device,
 {
     Q_ASSERT(m_kdbxVersion == KeePass2::FILE_VERSION_4);
 
-    m_binaryPoolInverse.clear();
+    m_binaryPool.clear();
 
     if (hasError()) {
         return false;
@@ -273,11 +273,7 @@ bool Kdbx4Reader::readInnerHeaderField(QIODevice* device)
             return false;
         }
         auto data = fieldData.mid(1);
-        if (m_binaryPoolInverse.contains(data)) {
-            qWarning("Skipping duplicate binary record");
-            break;
-        }
-        m_binaryPoolInverse.insert(data, QString::number(m_binaryPoolInverse.size()));
+        m_binaryPool.insert(QString::number(m_binaryPool.size()), data);
         break;
     }
     }
@@ -422,17 +418,5 @@ QVariantMap Kdbx4Reader::readVariantMap(QIODevice* device)
  */
 QHash<QString, QByteArray> Kdbx4Reader::binaryPool() const
 {
-    QHash<QString, QByteArray> binaryPool;
-    for (auto it = m_binaryPoolInverse.cbegin(); it != m_binaryPoolInverse.cend(); ++it) {
-        binaryPool.insert(it.value(), it.key());
-    }
-    return binaryPool;
-}
-
-/**
- * @return mapping from binary data to attachment keys
- */
-QHash<QByteArray, QString> Kdbx4Reader::binaryPoolInverse() const
-{
-    return m_binaryPoolInverse;
+    return m_binaryPool;
 }

--- a/src/format/Kdbx4Reader.h
+++ b/src/format/Kdbx4Reader.h
@@ -34,7 +34,6 @@ public:
                           const QByteArray& headerData,
                           QSharedPointer<const CompositeKey> key,
                           Database* db) override;
-    QHash<QByteArray, QString> binaryPoolInverse() const;
     QHash<QString, QByteArray> binaryPool() const;
 
 protected:
@@ -44,7 +43,7 @@ private:
     bool readInnerHeaderField(QIODevice* device);
     QVariantMap readVariantMap(QIODevice* device);
 
-    QHash<QByteArray, QString> m_binaryPoolInverse;
+    QHash<QString, QByteArray> m_binaryPool;
 };
 
 #endif // KEEPASSX_KDBX4READER_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Fixes #3048
* Certain programs that read/write KDBX4 files do not consolidate duplicate attachments into a single binary. This is against the KDBX4 specification. This change ensures KeePassXC will at least read the database in its entirety and not lose information. Upon saving the database in KeePassXC, the duplicate attachment binaries will be reduced to single binaries per the specification.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested with sample databases provided in issue 3048.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
