### PR TITLE
Last minute fixes for 2.4.2

### DIFF
--- a/src/crypto/kdf/Argon2Kdf.cpp
+++ b/src/crypto/kdf/Argon2Kdf.cpp
@@ -35,7 +35,7 @@ Argon2Kdf::Argon2Kdf()
     , m_memory(1 << 16)
     , m_parallelism(static_cast<quint32>(QThread::idealThreadCount()))
 {
-    m_rounds = 1;
+    m_rounds = 10;
 }
 
 quint32 Argon2Kdf::version() const

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -787,6 +787,9 @@ void DatabaseWidget::switchToMainView(bool previousDialogAccepted)
         }
 
         m_newParent = nullptr;
+    } else {
+        // Workaround: ensure entries are focused so search doesn't reset
+        m_entryView->setFocus();
     }
 
     setCurrentWidget(m_mainWidget);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -874,7 +874,9 @@ void MainWindow::closeEvent(QCloseEvent* event)
         return;
     }
 
-    if (config()->get("GUI/MinimizeOnClose").toBool() && !m_appExitCalled) {
+    // Don't ignore close event when the app is hidden to tray.
+    // This can occur when the OS issues close events on shutdown.
+    if (config()->get("GUI/MinimizeOnClose").toBool() && !isHidden() && !m_appExitCalled) {
         event->ignore();
         hideWindow();
         return;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -253,6 +253,9 @@ MainWindow::MainWindow()
     m_ui->actionEntryCopyURL->setShortcutVisibleInContextMenu(true);
 #endif
 
+    connect(m_ui->menuEntries, SIGNAL(aboutToHide()), SLOT(releaseContextFocusLock()));
+    connect(m_ui->menuGroups, SIGNAL(aboutToHide()), SLOT(releaseContextFocusLock()));
+
     // Control window state
     new QShortcut(Qt::CTRL + Qt::Key_M, this, SLOT(showMinimized()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_M, this, SLOT(hideWindow()));
@@ -543,8 +546,8 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
         switch (mode) {
         case DatabaseWidget::Mode::ViewMode: {
             // bool inSearch = dbWidget->isInSearchMode();
-            bool singleEntrySelected = dbWidget->numberOfSelectedEntries() == 1 && dbWidget->currentEntryHasFocus();
-            bool entriesSelected = dbWidget->numberOfSelectedEntries() > 0 && dbWidget->currentEntryHasFocus();
+            bool singleEntrySelected = dbWidget->numberOfSelectedEntries() == 1 && (m_contextMenuFocusLock || dbWidget->currentEntryHasFocus());
+            bool entriesSelected = dbWidget->numberOfSelectedEntries() > 0 && (m_contextMenuFocusLock || dbWidget->currentEntryHasFocus());
             bool groupSelected = dbWidget->isGroupSelected();
             bool recycleBinSelected = dbWidget->isRecycleBinSelected();
 
@@ -985,13 +988,20 @@ void MainWindow::updateTrayIcon()
     }
 }
 
+void MainWindow::releaseContextFocusLock()
+{
+    m_contextMenuFocusLock = false;
+}
+
 void MainWindow::showEntryContextMenu(const QPoint& globalPos)
 {
+    m_contextMenuFocusLock = true;
     m_ui->menuEntries->popup(globalPos);
 }
 
 void MainWindow::showGroupContextMenu(const QPoint& globalPos)
 {
+    m_contextMenuFocusLock = true;
     m_ui->menuGroups->popup(globalPos);
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -117,6 +117,7 @@ private slots:
     void selectPreviousDatabaseTab();
     void togglePasswordsHidden();
     void toggleUsernamesHidden();
+    void releaseContextFocusLock();
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);
@@ -148,6 +149,7 @@ private:
 
     bool m_appExitCalled;
     bool m_appExiting;
+    bool m_contextMenuFocusLock;
     uint m_lastFocusOutTime;
     QTimer m_trayIconTriggerTimer;
     QSystemTrayIcon::ActivationReason m_trayIconTriggerReason;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -962,6 +962,7 @@ void EditEntryWidget::cancel()
         m_entry->setIcon(Entry::DefaultIconNumber);
     }
 
+    bool accepted = false;
     if (isModified()) {
         auto result = MessageBox::question(this,
                                            QString(),
@@ -969,18 +970,17 @@ void EditEntryWidget::cancel()
                                            MessageBox::Cancel | MessageBox::Save | MessageBox::Discard,
                                            MessageBox::Cancel);
         if (result == MessageBox::Cancel) {
-            m_mainUi->passwordGenerator->reset();
             return;
-        }
-        if (result == MessageBox::Save) {
-            commitEntry();
-            setModified(false);
+        } else if (result == MessageBox::Save) {
+            accepted = true;
+            if (!commitEntry()) {
+                return;
+            }
         }
     }
 
     clear();
-
-    emit editFinished(!isModified());
+    emit editFinished(accepted);
 }
 
 void EditEntryWidget::clear()

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -139,17 +139,18 @@ void EntryView::keyPressEvent(QKeyEvent* event)
     }
 
     int last = m_model->rowCount() - 1;
+    if (last > 0) {
+        if (event->key() == Qt::Key_Up && currentIndex().row() == 0) {
+            QModelIndex index = m_sortModel->mapToSource(m_sortModel->index(last, 0));
+            setCurrentEntry(m_model->entryFromIndex(index));
+            return;
+        }
 
-    if (event->key() == Qt::Key_Up && currentIndex().row() == 0) {
-        QModelIndex index = m_sortModel->mapToSource(m_sortModel->index(last, 0));
-        setCurrentEntry(m_model->entryFromIndex(index));
-        return;
-    }
-
-    if (event->key() == Qt::Key_Down && currentIndex().row() == last) {
-        QModelIndex index = m_sortModel->mapToSource(m_sortModel->index(0, 0));
-        setCurrentEntry(m_model->entryFromIndex(index));
-        return;
+        if (event->key() == Qt::Key_Down && currentIndex().row() == last) {
+            QModelIndex index = m_sortModel->mapToSource(m_sortModel->index(0, 0));
+            setCurrentEntry(m_model->entryFromIndex(index));
+            return;
+        }
     }
 
     QTreeView::keyPressEvent(event);

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -72,6 +72,12 @@ void GroupView::dragMoveEvent(QDragMoveEvent* event)
     }
 }
 
+void GroupView::focusInEvent(QFocusEvent* event)
+{
+    emitGroupChanged();
+    QTreeView::focusInEvent(event);
+}
+
 Group* GroupView::currentGroup()
 {
     if (currentIndex() == QModelIndex()) {

--- a/src/gui/group/GroupView.h
+++ b/src/gui/group/GroupView.h
@@ -47,6 +47,7 @@ private slots:
 
 protected:
     void dragMoveEvent(QDragMoveEvent* event) override;
+    void focusInEvent(QFocusEvent* event) override;
 
 private:
     void recInitExpanded(Group* group);

--- a/src/totp/totp.cpp
+++ b/src/totp/totp.cpp
@@ -128,9 +128,9 @@ QString Totp::writeSettings(const QSharedPointer<Totp::Settings>& settings,
         auto urlstring = QString("otpauth://totp/%1:%2?secret=%3&period=%4&digits=%5&issuer=%1")
                              .arg(title.isEmpty() ? "KeePassXC" : QString(QUrl::toPercentEncoding(title)),
                                   username.isEmpty() ? "none" : QString(QUrl::toPercentEncoding(username)),
-                                  QString(Base32::sanitizeInput(settings->key.toLatin1())))
-                             .arg(settings->step)
-                             .arg(settings->digits);
+                                  QString(Base32::sanitizeInput(settings->key.toLatin1())),
+                                  QString::number(settings->step),
+                                  QString::number(settings->digits));
 
         if (!settings->encoder.name.isEmpty()) {
             urlstring.append("&encoder=").append(settings->encoder.name);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

* Prevent context menu options from disabling with keyboard navigation
  * Fixes #2838
  * When navigating the entry context menu with up/down arrow the options would disable due to losing focus on the EntryView. This change preserves the "focus" during this event.

* Update Group in Preview Widget when focused
  * Fixes #3129
  * Also fix out of bounds access when no entries are present in EntryView and up/down arrow pressed

* Fix argument parsing for OTP TOTP URL's
  * Fixes #2915

* Exit when receiving OS Close Message when in tray
  * Fixes #2692
  * KeePassXC was ignoring OS close messages on shutdown or logoff when minimize to tray on close was enabled. This change causes a second close message (when KeePassXC is hidden to the tray) to actually exit the application.

* Set default Argon2 transform rounds to 10
  * Fixes #2806

* Fix behavior when saving after canceling entry edit
  * Fixes #3141
  * Clearing the entry edit widget prior to emitting the editFinished signal caused the widget to be marked modified and prevent new entries from being created. Use an explicit boolean to notify commit success.
  * Don't clear password generator on canceling a cancel
  * Don't discard changes if saving from a cancel produces an error

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested Manually

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
