### PR TITLE
✨✨ CLI Command cleanup ✨✨

### DIFF
--- a/src/cli/Add.h
+++ b/src/cli/Add.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,14 +18,21 @@
 #ifndef KEEPASSXC_ADD_H
 #define KEEPASSXC_ADD_H
 
-#include "Command.h"
+#include "DatabaseCommand.h"
 
-class Add : public Command
+class Add : public DatabaseCommand
 {
 public:
     Add();
     ~Add();
-    int execute(const QStringList& arguments) override;
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+
+    static const QCommandLineOption UsernameOption;
+    static const QCommandLineOption UrlOption;
+    static const QCommandLineOption PasswordPromptOption;
+    static const QCommandLineOption GenerateOption;
+    static const QCommandLineOption PasswordLengthOption;
 };
 
 #endif // KEEPASSXC_ADD_H

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017 KeePassXC Team
+#  Copyright (C) 2019 KeePassXC Team
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@ set(cli_SOURCES
         Clip.cpp
         Create.cpp
         Command.cpp
+        DatabaseCommand.cpp
         Diceware.cpp
         Edit.cpp
         Estimate.cpp

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,19 +18,17 @@
 #ifndef KEEPASSXC_CLIP_H
 #define KEEPASSXC_CLIP_H
 
-#include "Command.h"
+#include "DatabaseCommand.h"
 
-class Clip : public Command
+class Clip : public DatabaseCommand
 {
 public:
     Clip();
     ~Clip();
-    int execute(const QStringList& arguments) override;
-    int clipEntry(const QSharedPointer<Database>& database,
-                  const QString& entryPath,
-                  const QString& timeout,
-                  bool clipTotp,
-                  bool silent);
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+
+    static const QCommandLineOption TotpOption;
 };
 
 #endif // KEEPASSXC_CLIP_H

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 #define KEEPASSXC_COMMAND_H
 
 #include <QCommandLineOption>
+#include <QCommandLineParser>
 #include <QList>
 #include <QObject>
 #include <QString>
@@ -26,14 +27,28 @@
 
 #include "core/Database.h"
 
+// At the moment, there's no QT class for the positional arguments
+// like there is for the options (QCommandLineOption).
+struct CommandLineArgument
+{
+    QString name;
+    QString description;
+    QString syntax;
+};
+
 class Command
 {
 public:
+    Command();
     virtual ~Command();
     virtual int execute(const QStringList& arguments) = 0;
     QString name;
     QString description;
+    QList<CommandLineArgument> positionalArguments;
+    QList<CommandLineArgument> optionalArguments;
+    QList<QCommandLineOption> options;
     QString getDescriptionLine();
+    QSharedPointer<QCommandLineParser> getCommandLineParser(const QStringList& arguments);
 
     static QList<Command*> getCommands();
     static Command* getCommand(const QString& commandName);

--- a/src/cli/DatabaseCommand.cpp
+++ b/src/cli/DatabaseCommand.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DatabaseCommand.h"
+
+#include "Utils.h"
+
+DatabaseCommand::DatabaseCommand()
+{
+    positionalArguments.append({QString("database"), QObject::tr("Path of the database."), QString("")});
+    options.append(Command::KeyFileOption);
+    options.append(Command::NoPasswordOption);
+}
+
+int DatabaseCommand::execute(const QStringList& arguments)
+{
+    QSharedPointer<QCommandLineParser> parser = getCommandLineParser(arguments);
+    if (parser.isNull()) {
+        return EXIT_FAILURE;
+    }
+
+    const QStringList args = parser->positionalArguments();
+    auto db = Utils::unlockDatabase(args.at(0),
+                                    !parser->isSet(Command::NoPasswordOption),
+                                    parser->value(Command::KeyFileOption),
+                                    parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    Utils::STDERR);
+    if (!db) {
+        return EXIT_FAILURE;
+    }
+
+    return executeWithDatabase(db, parser);
+}

--- a/src/cli/DatabaseCommand.h
+++ b/src/cli/DatabaseCommand.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,18 +15,21 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSXC_REMOVE_H
-#define KEEPASSXC_REMOVE_H
+#ifndef KEEPASSXC_DATABASECOMMAND_H
+#define KEEPASSXC_DATABASECOMMAND_H
 
-#include "DatabaseCommand.h"
+#include <QCommandLineOption>
 
-class Remove : public DatabaseCommand
+#include "Command.h"
+#include "Utils.h"
+#include "core/Database.h"
+
+class DatabaseCommand : public Command
 {
 public:
-    Remove();
-    ~Remove();
-
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+    DatabaseCommand();
+    int execute(const QStringList& arguments) override;
+    virtual int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) = 0;
 };
 
-#endif // KEEPASSXC_REMOVE_H
+#endif // KEEPASSXC_DATABASECOMMAND_H

--- a/src/cli/Diceware.h
+++ b/src/cli/Diceware.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,11 @@ class Diceware : public Command
 public:
     Diceware();
     ~Diceware();
-    int execute(const QStringList& arguments) override;
+
+    int execute(const QStringList& arguments);
+
+    static const QCommandLineOption WordCountOption;
+    static const QCommandLineOption WordListOption;
 };
 
 #endif // KEEPASSXC_DICEWARE_H

--- a/src/cli/Edit.h
+++ b/src/cli/Edit.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,14 +18,16 @@
 #ifndef KEEPASSXC_EDIT_H
 #define KEEPASSXC_EDIT_H
 
-#include "Command.h"
+#include "DatabaseCommand.h"
 
-class Edit : public Command
+class Edit : public DatabaseCommand
 {
 public:
     Edit();
     ~Edit();
-    int execute(const QStringList& arguments) override;
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+
+    static const QCommandLineOption TitleOption;
 };
 
 #endif // KEEPASSXC_EDIT_H

--- a/src/cli/Estimate.h
+++ b/src/cli/Estimate.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,6 +26,8 @@ public:
     Estimate();
     ~Estimate();
     int execute(const QStringList& arguments) override;
+
+    static const QCommandLineOption AdvancedOption;
 };
 
 #endif // KEEPASSXC_ESTIMATE_H

--- a/src/cli/Extract.h
+++ b/src/cli/Extract.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,14 +18,15 @@
 #ifndef KEEPASSXC_EXTRACT_H
 #define KEEPASSXC_EXTRACT_H
 
-#include "Command.h"
+#include "DatabaseCommand.h"
 
-class Extract : public Command
+class Extract : public DatabaseCommand
 {
 public:
     Extract();
     ~Extract();
-    int execute(const QStringList& arguments) override;
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
 };
 
 #endif // KEEPASSXC_EXTRACT_H

--- a/src/cli/Generate.h
+++ b/src/cli/Generate.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,6 +26,16 @@ public:
     Generate();
     ~Generate();
     int execute(const QStringList& arguments) override;
+
+    static const QCommandLineOption PasswordLengthOption;
+    static const QCommandLineOption LowerCaseOption;
+    static const QCommandLineOption UpperCaseOption;
+    static const QCommandLineOption NumbersOption;
+    static const QCommandLineOption SpecialCharsOption;
+    static const QCommandLineOption ExtendedAsciiOption;
+    static const QCommandLineOption ExcludeCharsOption;
+    static const QCommandLineOption ExcludeSimilarCharsOption;
+    static const QCommandLineOption IncludeEveryGroupOption;
 };
 
 #endif // KEEPASSXC_GENERATE_H

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,75 +21,44 @@
 #include "List.h"
 #include "cli/Utils.h"
 
-#include <QCommandLineParser>
-
 #include "cli/TextStream.h"
 #include "core/Database.h"
 #include "core/Entry.h"
 #include "core/Group.h"
 
+const QCommandLineOption List::RecursiveOption =
+    QCommandLineOption(QStringList() << "R"
+                                     << "recursive",
+                       QObject::tr("Recursively list the elements of the group."));
+
 List::List()
 {
     name = QString("ls");
     description = QObject::tr("List database entries.");
+    options.append(List::RecursiveOption);
+    optionalArguments.append(
+        {QString("group"), QObject::tr("Path of the group to list. Default is /"), QString("[group]")});
 }
 
 List::~List()
 {
 }
 
-int List::execute(const QStringList& arguments)
-{
-    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
-
-    QCommandLineParser parser;
-    parser.setApplicationDescription(description);
-    parser.addPositionalArgument("database", QObject::tr("Path of the database."));
-    parser.addPositionalArgument("group", QObject::tr("Path of the group to list. Default is /"), "[group]");
-    parser.addOption(Command::QuietOption);
-    parser.addOption(Command::KeyFileOption);
-    parser.addOption(Command::NoPasswordOption);
-
-    QCommandLineOption recursiveOption(QStringList() << "R"
-                                                     << "recursive",
-                                       QObject::tr("Recursively list the elements of the group."));
-    parser.addOption(recursiveOption);
-    parser.addHelpOption();
-    parser.process(arguments);
-
-    const QStringList args = parser.positionalArguments();
-    if (args.size() != 1 && args.size() != 2) {
-        errorTextStream << parser.helpText().replace("[options]", "ls [options]");
-        return EXIT_FAILURE;
-    }
-
-    bool recursive = parser.isSet(recursiveOption);
-
-    auto db = Utils::unlockDatabase(args.at(0),
-                                    !parser.isSet(Command::NoPasswordOption),
-                                    parser.value(Command::KeyFileOption),
-                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                    Utils::STDERR);
-    if (!db) {
-        return EXIT_FAILURE;
-    }
-
-    if (args.size() == 2) {
-        return listGroup(db.data(), recursive, args.at(1));
-    }
-    return listGroup(db.data(), recursive);
-}
-
-int List::listGroup(Database* database, bool recursive, const QString& groupPath)
+int List::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
 {
     TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
     TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
-    if (groupPath.isEmpty()) {
+    const QStringList args = parser->positionalArguments();
+    bool recursive = parser->isSet(List::RecursiveOption);
+
+    // No group provided, defaulting to root group.
+    if (args.size() == 1) {
         outputTextStream << database->rootGroup()->print(recursive) << flush;
         return EXIT_SUCCESS;
     }
 
+    QString groupPath = args.at(1);
     Group* group = database->rootGroup()->findGroupByPath(groupPath);
     if (!group) {
         errorTextStream << QObject::tr("Cannot find group %1.").arg(groupPath) << endl;

--- a/src/cli/List.h
+++ b/src/cli/List.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,15 +18,17 @@
 #ifndef KEEPASSXC_LIST_H
 #define KEEPASSXC_LIST_H
 
-#include "Command.h"
+#include "DatabaseCommand.h"
 
-class List : public Command
+class List : public DatabaseCommand
 {
 public:
     List();
     ~List();
-    int execute(const QStringList& arguments) override;
-    int listGroup(Database* database, bool recursive, const QString& groupPath = {});
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+
+    static const QCommandLineOption RecursiveOption;
 };
 
 #endif // KEEPASSXC_LIST_H

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 
 #include "Locate.h"
 
-#include <QCommandLineParser>
 #include <QStringList>
 
 #include "cli/TextStream.h"
@@ -34,46 +33,18 @@ Locate::Locate()
 {
     name = QString("locate");
     description = QObject::tr("Find entries quickly.");
+    positionalArguments.append({QString("term"), QObject::tr("Search term."), QString("")});
 }
 
 Locate::~Locate()
 {
 }
 
-int Locate::execute(const QStringList& arguments)
+int Locate::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
 {
-    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
-    QCommandLineParser parser;
-    parser.setApplicationDescription(description);
-    parser.addPositionalArgument("database", QObject::tr("Path of the database."));
-    parser.addPositionalArgument("term", QObject::tr("Search term."));
-    parser.addOption(Command::QuietOption);
-    parser.addOption(Command::KeyFileOption);
-    parser.addOption(Command::NoPasswordOption);
-    parser.addHelpOption();
-    parser.process(arguments);
-
-    const QStringList args = parser.positionalArguments();
-    if (args.size() != 2) {
-        errorTextStream << parser.helpText().replace("[options]", "locate [options]");
-        return EXIT_FAILURE;
-    }
-
-    auto db = Utils::unlockDatabase(args.at(0),
-                                    !parser.isSet(Command::NoPasswordOption),
-                                    parser.value(Command::KeyFileOption),
-                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                    Utils::STDERR);
-    if (!db) {
-        return EXIT_FAILURE;
-    }
-
-    return locateEntry(db.data(), args.at(1));
-}
-
-int Locate::locateEntry(Database* database, const QString& searchTerm)
-{
+    const QStringList args = parser->positionalArguments();
+    QString searchTerm = args.at(1);
     TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
     TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 

--- a/src/cli/Locate.h
+++ b/src/cli/Locate.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,15 +18,15 @@
 #ifndef KEEPASSXC_LOCATE_H
 #define KEEPASSXC_LOCATE_H
 
-#include "Command.h"
+#include "DatabaseCommand.h"
 
-class Locate : public Command
+class Locate : public DatabaseCommand
 {
 public:
     Locate();
     ~Locate();
-    int execute(const QStringList& arguments) override;
-    int locateEntry(Database* database, const QString& searchTerm);
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
 };
 
 #endif // KEEPASSXC_LOCATE_H

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,79 +15,57 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Merge.h"
+#include <cstdlib>
 
-#include <QCommandLineParser>
+#include "Merge.h"
 
 #include "cli/TextStream.h"
 #include "cli/Utils.h"
 #include "core/Database.h"
 #include "core/Merger.h"
 
-#include <cstdlib>
+const QCommandLineOption Merge::SameCredentialsOption =
+    QCommandLineOption(QStringList() << "s"
+                                     << "same-credentials",
+                       QObject::tr("Use the same credentials for both database files."));
+
+const QCommandLineOption Merge::KeyFileFromOption =
+    QCommandLineOption(QStringList() << "k"
+                                     << "key-file-from",
+                       QObject::tr("Key file of the database to merge from."),
+                       QObject::tr("path"));
+
+const QCommandLineOption Merge::NoPasswordFromOption =
+    QCommandLineOption(QStringList() << "no-password-from",
+                       QObject::tr("Deactivate password key for the database to merge from."));
 
 Merge::Merge()
 {
     name = QString("merge");
     description = QObject::tr("Merge two databases.");
+    options.append(Merge::SameCredentialsOption);
+    options.append(Merge::KeyFileFromOption);
+    options.append(Merge::NoPasswordFromOption);
+    positionalArguments.append({QString("database2"), QObject::tr("Path of the database to merge from."), QString("")});
 }
 
 Merge::~Merge()
 {
 }
 
-int Merge::execute(const QStringList& arguments)
+int Merge::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
 {
     TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
     TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
 
-    QCommandLineParser parser;
-    parser.setApplicationDescription(description);
-    parser.addPositionalArgument("database1", QObject::tr("Path of the database to merge into."));
-    parser.addPositionalArgument("database2", QObject::tr("Path of the database to merge from."));
-    parser.addOption(Command::QuietOption);
-
-    QCommandLineOption samePasswordOption(QStringList() << "s"
-                                                        << "same-credentials",
-                                          QObject::tr("Use the same credentials for both database files."));
-    parser.addOption(samePasswordOption);
-    parser.addOption(Command::KeyFileOption);
-    parser.addOption(Command::NoPasswordOption);
-
-    QCommandLineOption keyFileFromOption(QStringList() << "f"
-                                                       << "key-file-from",
-                                         QObject::tr("Key file of the database to merge from."),
-                                         QObject::tr("path"));
-    parser.addOption(keyFileFromOption);
-
-    QCommandLineOption noPasswordFromOption(QStringList() << "no-password-from",
-                                            QObject::tr("Deactivate password key for the database to merge from."));
-    parser.addOption(noPasswordFromOption);
-
-    parser.addHelpOption();
-    parser.process(arguments);
-
-    const QStringList args = parser.positionalArguments();
-    if (args.size() != 2) {
-        errorTextStream << parser.helpText().replace("[options]", "merge [options]");
-        return EXIT_FAILURE;
-    }
-
-    auto db1 = Utils::unlockDatabase(args.at(0),
-                                     !parser.isSet(Command::NoPasswordOption),
-                                     parser.value(Command::KeyFileOption),
-                                     parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                     Utils::STDERR);
-    if (!db1) {
-        return EXIT_FAILURE;
-    }
+    const QStringList args = parser->positionalArguments();
 
     QSharedPointer<Database> db2;
-    if (!parser.isSet("same-credentials")) {
+    if (!parser->isSet(Merge::SameCredentialsOption)) {
         db2 = Utils::unlockDatabase(args.at(1),
-                                    !parser.isSet(noPasswordFromOption),
-                                    parser.value(keyFileFromOption),
-                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                    !parser->isSet(Merge::NoPasswordFromOption),
+                                    parser->value(Merge::KeyFileFromOption),
+                                    parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                     Utils::STDERR);
         if (!db2) {
             return EXIT_FAILURE;
@@ -95,25 +73,25 @@ int Merge::execute(const QStringList& arguments)
     } else {
         db2 = QSharedPointer<Database>::create();
         QString errorMessage;
-        if (!db2->open(args.at(1), db1->key(), &errorMessage, false)) {
+        if (!db2->open(args.at(1), database->key(), &errorMessage, false)) {
             errorTextStream << QObject::tr("Error reading merge file:\n%1").arg(errorMessage);
             return EXIT_FAILURE;
         }
     }
 
-    Merger merger(db2.data(), db1.data());
+    Merger merger(db2.data(), database.data());
     bool databaseChanged = merger.merge();
 
     if (databaseChanged) {
         QString errorMessage;
-        if (!db1->save(args.at(0), &errorMessage, true, false)) {
+        if (!database->save(args.at(0), &errorMessage, true, false)) {
             errorTextStream << QObject::tr("Unable to save database to file : %1").arg(errorMessage) << endl;
             return EXIT_FAILURE;
         }
-        if (!parser.isSet(Command::QuietOption)) {
+        if (!parser->isSet(Command::QuietOption)) {
             outputTextStream << "Successfully merged the database files." << endl;
         }
-    } else if (!parser.isSet(Command::QuietOption)) {
+    } else if (!parser->isSet(Command::QuietOption)) {
         outputTextStream << "Database was not modified by merge operation." << endl;
     }
 

--- a/src/cli/Merge.h
+++ b/src/cli/Merge.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,14 +18,19 @@
 #ifndef KEEPASSXC_MERGE_H
 #define KEEPASSXC_MERGE_H
 
-#include "Command.h"
+#include "DatabaseCommand.h"
 
-class Merge : public Command
+class Merge : public DatabaseCommand
 {
 public:
     Merge();
     ~Merge();
-    int execute(const QStringList& arguments) override;
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+
+    static const QCommandLineOption SameCredentialsOption;
+    static const QCommandLineOption KeyFileFromOption;
+    static const QCommandLineOption NoPasswordFromOption;
 };
 
 #endif // KEEPASSXC_MERGE_H

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,8 +20,6 @@
 #include <cstdlib>
 #include <stdio.h>
 
-#include <QCommandLineParser>
-
 #include "Utils.h"
 #include "cli/TextStream.h"
 #include "core/Database.h"
@@ -29,66 +27,41 @@
 #include "core/Global.h"
 #include "core/Group.h"
 
+const QCommandLineOption Show::TotpOption = QCommandLineOption(QStringList() << "t"
+                                                                             << "totp",
+                                                               QObject::tr("Show the entry's current TOTP."));
+
+const QCommandLineOption Show::AttributesOption = QCommandLineOption(
+    QStringList() << "a"
+                  << "attributes",
+    QObject::tr(
+        "Names of the attributes to show. "
+        "This option can be specified more than once, with each attribute shown one-per-line in the given order. "
+        "If no attributes are specified, a summary of the default attributes is given."),
+    QObject::tr("attribute"));
+
 Show::Show()
 {
     name = QString("show");
     description = QObject::tr("Show an entry's information.");
+    options.append(Show::TotpOption);
+    options.append(Show::AttributesOption);
+    positionalArguments.append({QString("entry"), QObject::tr("Name of the entry to show."), QString("")});
 }
 
 Show::~Show()
 {
 }
 
-int Show::execute(const QStringList& arguments)
-{
-    TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
-
-    QCommandLineParser parser;
-    parser.setApplicationDescription(description);
-    parser.addPositionalArgument("database", QObject::tr("Path of the database."));
-    parser.addOption(Command::QuietOption);
-    parser.addOption(Command::KeyFileOption);
-    parser.addOption(Command::NoPasswordOption);
-
-    QCommandLineOption totp(QStringList() << "t"
-                                          << "totp",
-                            QObject::tr("Show the entry's current TOTP."));
-    parser.addOption(totp);
-    QCommandLineOption attributes(
-        QStringList() << "a"
-                      << "attributes",
-        QObject::tr(
-            "Names of the attributes to show. "
-            "This option can be specified more than once, with each attribute shown one-per-line in the given order. "
-            "If no attributes are specified, a summary of the default attributes is given."),
-        QObject::tr("attribute"));
-    parser.addOption(attributes);
-    parser.addPositionalArgument("entry", QObject::tr("Name of the entry to show."));
-    parser.addHelpOption();
-    parser.process(arguments);
-
-    const QStringList args = parser.positionalArguments();
-    if (args.size() != 2) {
-        errorTextStream << parser.helpText().replace("[options]", "show [options]");
-        return EXIT_FAILURE;
-    }
-
-    auto db = Utils::unlockDatabase(args.at(0),
-                                    !parser.isSet(Command::NoPasswordOption),
-                                    parser.value(Command::KeyFileOption),
-                                    parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                    Utils::STDERR);
-    if (!db) {
-        return EXIT_FAILURE;
-    }
-
-    return showEntry(db.data(), parser.values(attributes), parser.isSet(totp), args.at(1));
-}
-
-int Show::showEntry(Database* database, QStringList attributes, bool showTotp, const QString& entryPath)
+int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
 {
     TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
     TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
+
+    const QStringList args = parser->positionalArguments();
+    const QString& entryPath = args.at(1);
+    bool showTotp = parser->isSet(Show::TotpOption);
+    QStringList attributes = parser->values(Show::AttributesOption);
 
     Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
     if (!entry) {

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,15 +18,18 @@
 #ifndef KEEPASSXC_SHOW_H
 #define KEEPASSXC_SHOW_H
 
-#include "Command.h"
+#include "DatabaseCommand.h"
 
-class Show : public Command
+class Show : public DatabaseCommand
 {
 public:
     Show();
     ~Show();
-    int execute(const QStringList& arguments) override;
-    int showEntry(Database* database, QStringList attributes, bool showTotp, const QString& entryPath);
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+
+    static const QCommandLineOption TotpOption;
+    static const QCommandLineOption AttributesOption;
 };
 
 #endif // KEEPASSXC_SHOW_H


### PR DESCRIPTION
This PR cleans up the `Command` classes in the CLI, introducing a
`DatabaseCommand` class for the commands operating on a database,
and a `getCommandLineParser` command to centralize the arguments
parsing and validation.

The opening of the database based on the CLI arguments and options
is now centralized in `DatabaseCommand.execute`, making it easy to
add new database opening features (like YubiKey support for the CLI).

Also a couple of bugs fixed:
  * `Create` was still using `stdout` for some error messages.
  * `Diceware` and `Generate` were not validating that the word count was an integer.
  * `Diceware` was also using `stdout` for some error messages.

@droidmonkey let me know what you think! I believe with this PR merged, adding new commands or new database opening features will be faster and safer.

@phoerious can you take a look at how I'm using the `QSharedPointer` for the `QCommandLineParser`?? It's my first time using anything other than "vanilla" pointers.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)


## Testing strategy
* existing unit tests
* some new unit tests
* tested locally with most of the commands

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
