### PR TITLE
Settings option to shush success KeeShare notifications

### DIFF
--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -100,6 +100,10 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
     m_generalUi->checkUpdatesSpacer->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
 #endif
 
+#ifndef WITH_XC_KEESHARE
+    m_generalUi->quietKeeShareSuccess->setVisible(false);
+#endif
+
 #ifndef WITH_XC_NETWORKING
     m_secUi->privacy->setVisible(false);
 #endif
@@ -182,6 +186,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->systrayDarkIconCheckBox->setChecked(config()->get("GUI/DarkTrayIcon").toBool());
     m_generalUi->systrayMinimizeToTrayCheckBox->setChecked(config()->get("GUI/MinimizeToTray").toBool());
     m_generalUi->minimizeOnCloseCheckBox->setChecked(config()->get("GUI/MinimizeOnClose").toBool());
+    m_generalUi->quietKeeShareSuccess->setChecked(config()->get("GUI/QuietKeeShareSuccess").toBool());
     m_generalUi->systrayMinimizeOnStartup->setChecked(config()->get("GUI/MinimizeOnStartup").toBool());
     m_generalUi->checkForUpdatesOnStartupCheckBox->setChecked(config()->get("GUI/CheckForUpdates").toBool());
     m_generalUi->checkForUpdatesIncludeBetasCheckBox->setChecked(
@@ -267,6 +272,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set("GUI/DarkTrayIcon", m_generalUi->systrayDarkIconCheckBox->isChecked());
     config()->set("GUI/MinimizeToTray", m_generalUi->systrayMinimizeToTrayCheckBox->isChecked());
     config()->set("GUI/MinimizeOnClose", m_generalUi->minimizeOnCloseCheckBox->isChecked());
+    config()->set("GUI/QuietKeeShareSuccess", m_generalUi->quietKeeShareSuccess->isChecked());
     config()->set("GUI/MinimizeOnStartup", m_generalUi->systrayMinimizeOnStartup->isChecked());
     config()->set("GUI/CheckForUpdates", m_generalUi->checkForUpdatesOnStartupCheckBox->isChecked());
     config()->set("GUI/CheckForUpdatesIncludeBetas", m_generalUi->checkForUpdatesIncludeBetasCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>684</width>
-    <height>881</height>
+    <height>1030</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -379,6 +379,13 @@
            <widget class="QCheckBox" name="minimizeOnCloseCheckBox">
             <property name="text">
              <string>Minimize instead of app exit</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="quietKeeShareSuccess">
+            <property name="text">
+             <string>Do not show success notifications for KeeShare, only warnings and errors</string>
             </property>
            </widget>
           </item>

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -261,18 +261,22 @@ void ShareObserver::reinitialize()
 
 void ShareObserver::notifyAbout(const QStringList& success, const QStringList& warning, const QStringList& error)
 {
-    if (error.isEmpty() && warning.isEmpty() && success.isEmpty()) {
-        return;
-    }
-
+    QStringList messages;
     MessageWidget::MessageType type = MessageWidget::Positive;
+    if (!(success.isEmpty() || config()->get("GUI/QuietKeeShareSuccess").toBool())) {
+        messages += success;
+    }
     if (!warning.isEmpty()) {
         type = MessageWidget::Warning;
+        messages += warning;
     }
     if (!error.isEmpty()) {
         type = MessageWidget::Error;
+        messages += error;
     }
-    emit sharingMessage((success + warning + error).join("\n"), type);
+    if (!messages.isEmpty()) {
+        emit sharingMessage(messages.join("\n"), type);
+    }
 }
 
 void ShareObserver::handleDatabaseChanged()


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
When using KeeShare, a lot of export and import notifications start showing up. The warnings and errors are important, but the success ones get on my nerve. Especially because the message slide in from the top, moving all my passwords down, making it hard to click the one I want. I propose a new option to shush the success notifications, disabled by default. I find this especially important when doing a demo of KeePassXC.

I will wait and see how the code review goes before looking into the translation tool.

## Testing
Feature seems to work, and persists across restart.

Though I doubt it's my fault, the following tests FAILED:
	  1 - testgroup (Failed)
	 16 - testopvaultreader (Failed)
I built on on arch Linux with: cmake -DWITH_XC_ALL=ON -DWITH_ASAN=ON ..
The sanitizer detected leaks.
"make format" touched more than the files I've touched.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- [NO] All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
