### PR TITLE
Compile with Compiler Cache (ccache) if it's installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,13 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+# Use the Compiler Cache (ccache) if it is installed
+# (install with: sudo apt get ccache)
+find_program (CCACHE_FOUND ccache)
+if (CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+endif (CCACHE_FOUND)
+
 # Support Visual Studio Code
 include(CMakeToolsHelpers OPTIONAL)
 


### PR DESCRIPTION
Install ccache with `sudo apt install ccache`.
About ccache: https://en.wikipedia.org/wiki/Ccache

Makes building a huge lot faster, especially after switching branches.
Nothing happens if ccache is not installed. if you don't like it, just `sudo
apt remove ccache` and all is as before.

Example: (measured on my laptop)

```
$ ccache -C # clear the cache
$ rm -fr build
$ cd build
$ cmake -DWITH_XC_ALL=ON -DCMAKE_BUILD_TYPE=Release ..
$ time make -j4
...
real	5m8,817s
user	16m47,107s
sys	1m38,808s

$ rm -fr ../build/*
$ cmake -DWITH_XC_ALL=ON -DCMAKE_BUILD_TYPE=Release ..
$ time make -j4
...
real	0m32,571s
user	1m0,253s
sys	0m24,069s
```

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code) - affects the build process only, not the actual program.

## Testing strategy
Built and tested several times.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
