### PR TITLE
Add CLI --dry-run option for merge

### DIFF
--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -66,9 +66,12 @@ int Merge::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer
 
     const QStringList args = parser->positionalArguments();
 
+    QString toDatabasePath = args.at(0);
+    QString fromDatabasePath = args.at(1);
+
     QSharedPointer<Database> db2;
     if (!parser->isSet(Merge::SameCredentialsOption)) {
-        db2 = Utils::unlockDatabase(args.at(1),
+        db2 = Utils::unlockDatabase(fromDatabasePath,
                                     !parser->isSet(Merge::NoPasswordFromOption),
                                     parser->value(Merge::KeyFileFromOption),
                                     parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
@@ -79,7 +82,7 @@ int Merge::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer
     } else {
         db2 = QSharedPointer<Database>::create();
         QString errorMessage;
-        if (!db2->open(args.at(1), database->key(), &errorMessage, false)) {
+        if (!db2->open(fromDatabasePath, database->key(), &errorMessage, false)) {
             errorTextStream << QObject::tr("Error reading merge file:\n%1").arg(errorMessage);
             return EXIT_FAILURE;
         }
@@ -94,13 +97,14 @@ int Merge::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer
 
     if (!changeList.isEmpty() && !parser->isSet(Merge::DryRunOption)) {
         QString errorMessage;
-        if (!database->save(args.at(0), &errorMessage, true, false)) {
+        if (!database->save(toDatabasePath, &errorMessage, true, false)) {
             errorTextStream << QObject::tr("Unable to save database to file : %1").arg(errorMessage) << endl;
             return EXIT_FAILURE;
         }
-        outputTextStream << "Successfully merged the database files." << endl;
+        outputTextStream << QObject::tr("Successfully merged %1 into %2.").arg(fromDatabasePath, toDatabasePath)
+                         << endl;
     } else {
-        outputTextStream << "Database was not modified by merge operation." << endl;
+        outputTextStream << QObject::tr("Database was not modified by merge operation.") << endl;
     }
 
     return EXIT_SUCCESS;

--- a/src/cli/Merge.h
+++ b/src/cli/Merge.h
@@ -31,6 +31,7 @@ public:
     static const QCommandLineOption SameCredentialsOption;
     static const QCommandLineOption KeyFileFromOption;
     static const QCommandLineOption NoPasswordFromOption;
+    static const QCommandLineOption DryRunOption;
 };
 
 #endif // KEEPASSXC_MERGE_H

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -77,6 +77,9 @@ Displays the program version.
 
 .SS "Merge options"
 
+.IP "-d, --dry-run <path>"
+Only print the changes detected by the merge operation.
+
 .IP "-f, --key-file-from <path>"
 Path of the key file for the second database.
 

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -60,7 +60,7 @@ void Merger::resetForcedMergeMode()
     m_mode = Group::Default;
 }
 
-bool Merger::merge()
+QStringList Merger::merge()
 {
     // Order of merge steps is important - it is possible that we
     // create some items before deleting them afterwards
@@ -74,9 +74,8 @@ bool Merger::merge()
     // At this point we have a list of changes we may want to show the user
     if (!changes.isEmpty()) {
         m_context.m_targetDb->markAsModified();
-        return true;
     }
-    return false;
+    return changes;
 }
 
 Merger::ChangeList Merger::mergeGroup(const MergeContext& context)

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -33,7 +33,7 @@ public:
     Merger(const Group* sourceGroup, Group* targetGroup);
     void setForcedMergeMode(Group::MergeMode mode);
     void resetForcedMergeMode();
-    bool merge();
+    QStringList merge();
 
 private:
     typedef QString Change;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -894,9 +894,9 @@ void DatabaseWidget::mergeDatabase(bool accepted)
         }
 
         Merger merger(srcDb.data(), m_db.data());
-        bool databaseChanged = merger.merge();
+        QStringList changeList = merger.merge();
 
-        if (databaseChanged) {
+        if (!changeList.isEmpty()) {
             showMessage(tr("Successfully merged the database files."), MessageWidget::Information);
         } else {
             showMessage(tr("Database was not modified by merge operation."), MessageWidget::Information);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -401,7 +401,6 @@ MainWindow::MainWindow()
     connect(m_ui->actionUserGuide, SIGNAL(triggered()), SLOT(openUserGuide()));
     connect(m_ui->actionOnlineHelp, SIGNAL(triggered()), SLOT(openOnlineHelp()));
 
-
 #ifdef Q_OS_MACOS
     setUnifiedTitleAndToolBarOnMac(true);
     if (macUtils()->isDarkMode()) {

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -409,8 +409,8 @@ ShareObserver::Result ShareObserver::importSingedContainerInto(const KeeShareSet
                    qPrintable(sourceDb->rootGroup()->name()));
             Merger merger(sourceDb->rootGroup(), targetGroup);
             merger.setForcedMergeMode(Group::Synchronize);
-            const bool changed = merger.merge();
-            if (changed) {
+            const QStringList changeList = merger.merge();
+            if (!changeList.isEmpty()) {
                 return {reference.path, Result::Success, tr("Successful signed import")};
             }
         }
@@ -425,8 +425,8 @@ ShareObserver::Result ShareObserver::importSingedContainerInto(const KeeShareSet
                qPrintable(sourceDb->rootGroup()->name()));
         Merger merger(sourceDb->rootGroup(), targetGroup);
         merger.setForcedMergeMode(Group::Synchronize);
-        const bool changed = merger.merge();
-        if (changed) {
+        const QStringList changeList = merger.merge();
+        if (!changeList.isEmpty()) {
             return {reference.path, Result::Success, tr("Successful signed import")};
         }
         return {};
@@ -496,8 +496,8 @@ ShareObserver::Result ShareObserver::importUnsignedContainerInto(const KeeShareS
                    qPrintable(sourceDb->rootGroup()->name()));
             Merger merger(sourceDb->rootGroup(), targetGroup);
             merger.setForcedMergeMode(Group::Synchronize);
-            const bool changed = merger.merge();
-            if (changed) {
+            const QStringList changeList = merger.merge();
+            if (!changeList.isEmpty()) {
                 return {reference.path, Result::Success, tr("Successful signed import")};
             }
         }
@@ -511,8 +511,8 @@ ShareObserver::Result ShareObserver::importUnsignedContainerInto(const KeeShareS
                qPrintable(sourceDb->rootGroup()->name()));
         Merger merger(sourceDb->rootGroup(), targetGroup);
         merger.setForcedMergeMode(Group::Synchronize);
-        const bool changed = merger.merge();
-        if (changed) {
+        const QStringList changeList = merger.merge();
+        if (!changeList.isEmpty()) {
             return {reference.path, Result::Success, tr("Successful unsigned import")};
         }
         return {};

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -1010,7 +1010,8 @@ void TestCli::testMerge()
     QList<QByteArray> outLines1 = m_stdoutFile->readAll().split('\n');
     QCOMPARE(outLines1.at(0).split('[').at(0), QByteArray("\tOverwriting Internet "));
     QCOMPARE(outLines1.at(1).split('[').at(0), QByteArray("\tCreating missing Some Website "));
-    QCOMPARE(outLines1.at(2), QByteArray("Successfully merged the database files."));
+    QCOMPARE(outLines1.at(2),
+             QString("Successfully merged %1 into %2.").arg(sourceFile.fileName(), targetFile1.fileName()).toUtf8());
 
     QFile readBack(targetFile1.fileName());
     readBack.open(QIODevice::ReadOnly);
@@ -1071,7 +1072,8 @@ void TestCli::testMerge()
     m_stdoutFile->readLine();
     m_stdoutFile->readLine();
     QList<QByteArray> outLines3 = m_stdoutFile->readAll().split('\n');
-    QCOMPARE(outLines3.at(2), QByteArray("Successfully merged the database files."));
+    QCOMPARE(outLines3.at(2),
+             QString("Successfully merged %1 into %2.").arg(sourceFile.fileName(), targetFile3.fileName()).toUtf8());
 
     readBack.setFileName(targetFile3.fileName());
     readBack.open(QIODevice::ReadOnly);

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -965,23 +965,27 @@ void TestCli::testMerge()
     Kdbx4Writer writer;
     Kdbx4Reader reader;
 
-    // load test database and save a copy
+    // load test database and save copies
     auto db = readTestDatabase();
     QVERIFY(db);
     TemporaryFile targetFile1;
     targetFile1.open();
     writer.writeDatabase(&targetFile1, db.data());
     targetFile1.close();
-
-    // save another copy with a different password
     TemporaryFile targetFile2;
     targetFile2.open();
+    writer.writeDatabase(&targetFile2, db.data());
+    targetFile2.close();
+
+    // save another copy with a different password
+    TemporaryFile targetFile3;
+    targetFile3.open();
     auto oldKey = db->key();
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("b"));
     db->setKey(key);
-    writer.writeDatabase(&targetFile2, db.data());
-    targetFile2.close();
+    writer.writeDatabase(&targetFile3, db.data());
+    targetFile3.close();
     db->setKey(oldKey);
 
     // then add a new entry to the in-memory database and save another copy
@@ -1003,7 +1007,10 @@ void TestCli::testMerge()
     m_stdoutFile->seek(pos);
     m_stdoutFile->readLine();
     m_stderrFile->reset();
-    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Successfully merged the database files.\n"));
+    QList<QByteArray> outLines1 = m_stdoutFile->readAll().split('\n');
+    QCOMPARE(outLines1.at(0).split('[').at(0), QByteArray("\tOverwriting Internet "));
+    QCOMPARE(outLines1.at(1).split('[').at(0), QByteArray("\tCreating missing Some Website "));
+    QCOMPARE(outLines1.at(2), QByteArray("Successfully merged the database files."));
 
     QFile readBack(targetFile1.fileName());
     readBack.open(QIODevice::ReadOnly);
@@ -1016,17 +1023,57 @@ void TestCli::testMerge()
     QCOMPARE(entry1->title(), QString("Some Website"));
     QCOMPARE(entry1->password(), QString("secretsecretsecret"));
 
+    // the dry run option should not modify the target database.
+    pos = m_stdoutFile->pos();
+    Utils::Test::setNextPassword("a");
+    mergeCmd.execute({"merge", "--dry-run", "-s", targetFile2.fileName(), sourceFile.fileName()});
+    m_stdoutFile->seek(pos);
+    m_stdoutFile->readLine();
+    m_stderrFile->reset();
+    QList<QByteArray> outLines2 = m_stdoutFile->readAll().split('\n');
+    QCOMPARE(outLines2.at(0).split('[').at(0), QByteArray("\tOverwriting Internet "));
+    QCOMPARE(outLines2.at(1).split('[').at(0), QByteArray("\tCreating missing Some Website "));
+    QCOMPARE(outLines2.at(2), QByteArray("Database was not modified by merge operation."));
+
+    QFile readBack2(targetFile2.fileName());
+    readBack2.open(QIODevice::ReadOnly);
+    mergedDb = QSharedPointer<Database>::create();
+    reader.readDatabase(&readBack2, oldKey, mergedDb.data());
+    readBack2.close();
+    QVERIFY(mergedDb);
+    entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
+    QVERIFY(!entry1);
+
+    // the dry run option can be used with the quiet option
+    pos = m_stdoutFile->pos();
+    Utils::Test::setNextPassword("a");
+    mergeCmd.execute({"merge", "--dry-run", "-s", "-q", targetFile2.fileName(), sourceFile.fileName()});
+    m_stdoutFile->seek(pos);
+    m_stdoutFile->readLine();
+    m_stderrFile->reset();
+    QCOMPARE(m_stdoutFile->readAll(), QByteArray(""));
+
+    readBack2.setFileName(targetFile2.fileName());
+    readBack2.open(QIODevice::ReadOnly);
+    mergedDb = QSharedPointer<Database>::create();
+    reader.readDatabase(&readBack2, oldKey, mergedDb.data());
+    readBack2.close();
+    QVERIFY(mergedDb);
+    entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
+    QVERIFY(!entry1);
+
     // try again with different passwords for both files
     pos = m_stdoutFile->pos();
     Utils::Test::setNextPassword("b");
     Utils::Test::setNextPassword("a");
-    mergeCmd.execute({"merge", targetFile2.fileName(), sourceFile.fileName()});
+    mergeCmd.execute({"merge", targetFile3.fileName(), sourceFile.fileName()});
     m_stdoutFile->seek(pos);
     m_stdoutFile->readLine();
     m_stdoutFile->readLine();
-    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Successfully merged the database files.\n"));
+    QList<QByteArray> outLines3 = m_stdoutFile->readAll().split('\n');
+    QCOMPARE(outLines3.at(2), QByteArray("Successfully merged the database files."));
 
-    readBack.setFileName(targetFile2.fileName());
+    readBack.setFileName(targetFile3.fileName());
     readBack.open(QIODevice::ReadOnly);
     mergedDb = QSharedPointer<Database>::create();
     reader.readDatabase(&readBack, key, mergedDb.data());


### PR DESCRIPTION
@droidmonkey This PR is rebased on top of https://github.com/keepassxreboot/keepassxc/pull/3210.
This shows how options can be added to CLI commands once the cleanup is merged.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor
- ✅ New feature
- ✅ Documentation

## Description and Context
Two changes in fact: I added the `--dry-run` option and the list of changes detected by the merge operation to the output. In the future, I'd also like to ask the user for confirmation before merging, after displaying the changes.

## Screenshots
```
$ keepassxc-cli merge -s --dry-run ~/test1.kdbx ~/test2.kdbx 
Insert password to unlock /home/louib/test1.kdbx: 
	Creating missing entry2 [06009d6280a741f88c4da6e4415d0aa5]
Database was not modified by merge operation.
$ keepassxc-cli merge -s ~/test1.kdbx ~/test2.kdbx 
Insert password to unlock /home/louib/test1.kdbx: 
	Creating missing entry2 [06009d6280a741f88c4da6e4415d0aa5]
Successfully merged the database files.
$ keepassxc-cli merge -s ~/test1.kdbx ~/test2.kdbx 
Insert password to unlock /home/louib/test1.kdbx: 
Database was not modified by merge operation.
$ keepassxc-cli merge -s --dry-run ~/test1.kdbx ~/test2.kdbx 
Insert password to unlock /home/louib/test1.kdbx: 
Database was not modified by merge operation.
```


## Testing strategy
unit test + CLI (see screenshot)


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
