### PR TITLE
Fix clicking tray icon to toggle window on Linux

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -25,6 +25,7 @@
 #include <QMimeData>
 #include <QShortcut>
 #include <QTimer>
+#include <QWindow>
 
 #include "config-keepassx.h"
 
@@ -1088,9 +1089,16 @@ void MainWindow::processTrayIconTrigger()
         toggleWindow();
     } else if (m_trayIconTriggerReason == QSystemTrayIcon::Trigger
                || m_trayIconTriggerReason == QSystemTrayIcon::MiddleClick) {
-        // On single/middle click focus the window if it is not hidden
-        // and did not have focus less than a second ago, otherwise toggle
-        if (isHidden() || (Clock::currentSecondsSinceEpoch() - m_lastFocusOutTime) <= 1) {
+        // Toggle window if hidden
+        // If on windows, check if focus switched within the last second because
+        // clicking the tray icon removes focus from main window
+        // If on Linux or macOS, check if the window is active
+        if (isHidden()
+#ifdef Q_OS_WIN
+            || (Clock::currentSecondsSinceEpoch() - m_lastFocusOutTime) <= 1) {
+#else
+            || windowHandle()->isActive()) {
+#endif
             toggleWindow();
         } else {
             bringToFront();


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* KDE does not take focus from the current active window when the tray icon is clicked. This prevented toggling the window (always called bringToFront). Checking if the window is active corrects this issue.
* Fixes #3256 and Fixes #3214 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Ubuntu 19.04 KDE. Unity/Gnome does not support click activation of the tray icon (the context menu is always shown).

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
