### PR TITLE
Support returning a message for canceled operation

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -329,10 +329,11 @@ QJsonObject BrowserAction::handleSetLogin(const QJsonObject& json, const QString
     const QString groupUuid = decrypted.value("groupUuid").toString();
     const QString realm;
 
+    BrowserService::ReturnValue result = BrowserService::ReturnValue::Success;
     if (uuid.isEmpty()) {
         m_browserService.addEntry(id, login, password, url, submitUrl, realm, group, groupUuid);
     } else {
-        m_browserService.updateEntry(id, uuid, login, password, url, submitUrl);
+        result = m_browserService.updateEntry(id, uuid, login, password, url, submitUrl);
     }
 
     const QString newNonce = incrementNonce(nonce);
@@ -340,7 +341,7 @@ QJsonObject BrowserAction::handleSetLogin(const QJsonObject& json, const QString
     QJsonObject message = buildMessage(newNonce);
     message["count"] = QJsonValue::Null;
     message["entries"] = QJsonValue::Null;
-    message["error"] = QString("");
+    message["error"] = getReturnValue(result);
     message["hash"] = hash;
 
     return buildResponse(action, message, newNonce);
@@ -511,6 +512,19 @@ QString BrowserAction::getErrorMessage(const int errorCode) const
     default:
         return QObject::tr("Unknown error");
     }
+}
+
+QString BrowserAction::getReturnValue(const BrowserService::ReturnValue returnValue) const
+{
+    switch(returnValue) {
+        case BrowserService::ReturnValue::Success:
+            return QString("success");
+        case BrowserService::ReturnValue::Error:
+            return QString("error");
+        case BrowserService::ReturnValue::Canceled:
+            return QString("canceled");
+    }
+    return QString("error");
 }
 
 QString BrowserAction::getDatabaseHash()

--- a/src/browser/BrowserAction.h
+++ b/src/browser/BrowserAction.h
@@ -73,6 +73,7 @@ private:
     QJsonObject buildResponse(const QString& action, const QJsonObject& message, const QString& nonce);
     QJsonObject getErrorReply(const QString& action, const int errorCode) const;
     QString getErrorMessage(const int errorCode) const;
+    QString getReturnValue(const BrowserService::ReturnValue returnValue) const;
     QString getDatabaseHash();
 
     QString encryptMessage(const QJsonObject& message, const QString& nonce);

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -38,6 +38,13 @@ class BrowserService : public QObject
     Q_OBJECT
 
 public:
+    enum ReturnValue
+    {
+        Success,
+        Error,
+        Canceled
+    };
+
     explicit BrowserService(DatabaseTabWidget* parent);
 
     bool isDatabaseOpened() const;
@@ -74,12 +81,12 @@ public slots:
                                    const StringPairList& keyList,
                                    const bool httpAuth = false);
     QString storeKey(const QString& key);
-    void updateEntry(const QString& id,
-                     const QString& uuid,
-                     const QString& login,
-                     const QString& password,
-                     const QString& url,
-                     const QString& submitUrl);
+    ReturnValue updateEntry(const QString& id,
+                            const QString& uuid,
+                            const QString& login,
+                            const QString& password,
+                            const QString& url,
+                            const QString& submitUrl);
     void databaseLocked(DatabaseWidget* dbWidget);
     void databaseUnlocked(DatabaseWidget* dbWidget);
     void activateDatabaseChanged(DatabaseWidget* dbWidget);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Adds support for returning a proper state based on the user interaction. These states are `success`, `error` and `canceled`. Previously even a canceled operation (when updating a credentials from the browser extension) returned only a message for a successful operation.

This is needed for the extension to identify a correct user interaction.

Related browser extension PR: https://github.com/keepassxreboot/keepassxc-browser/pull/351.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
