### PR TITLE
Improve parsing of Urls in the Open Url feature

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -696,7 +696,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
             }
         }
     } else {
-        QUrl url = QUrl(entry->url());
+        QUrl url = QUrl::fromUserInput(entry->url());
         if (!url.isEmpty()) {
             QDesktopServices::openUrl(url);
         }


### PR DESCRIPTION
Fix #3259 

Use [QUrl::fromUserInput](https://doc.qt.io/qt-5/qurl.html#fromUserInput) to parse a url with scheme, if one is not provided

Related to https://github.com/keepassxreboot/keepassxc/pull/3153

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

Signed-off-by: sohamg <sohamg2@gmail.com>
