### PR TITLE
Allow setting group icons to children groups/entries

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -1080,6 +1080,21 @@ Entry* Group::addEntryWithPath(const QString& entryPath)
     return entry;
 }
 
+void Group::applyGroupIconOnCreateTo(Entry* entry)
+{
+    Q_ASSERT(entry);
+
+    if (!config()->get("UseGroupIconOnEntryCreation").toBool()) {
+        return;
+    }
+
+    if (iconNumber() == Group::DefaultIconNumber && iconUuid().isNull()) {
+        return;
+    }
+
+    applyGroupIconTo(entry);
+}
+
 void Group::applyGroupIconTo(Entry* entry)
 {
     Q_ASSERT(entry);
@@ -1095,21 +1110,24 @@ void Group::applyGroupIconTo(Group* other)
 {
     Q_ASSERT(other);
 
-    if (this->iconUuid().isNull()) {
-        other->setIcon(this->iconNumber());
+    if (iconUuid().isNull()) {
+        other->setIcon(iconNumber());
     } else {
-        other->setIcon(this->iconUuid());
+        other->setIcon(iconUuid());
     }
 }
 
-void Group::applyGroupIconRecursively()
+void Group::applyGroupIconToChildGroups()
 {
-    for (Group* recursiveChild : this->groupsRecursive(false)) {
-        this->applyGroupIconTo(recursiveChild);
+    for (Group* recursiveChild : groupsRecursive(false)) {
+        applyGroupIconTo(recursiveChild);
     }
+}
 
-    for (Entry* recursiveEntry : this->entriesRecursive(false)) {
-        this->applyGroupIconTo(recursiveEntry);
+void Group::applyGroupIconToChildEntries()
+{
+    for (Entry* recursiveEntry : entriesRecursive(false)) {
+        applyGroupIconTo(recursiveEntry);
     }
 }
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -1082,18 +1082,34 @@ Entry* Group::addEntryWithPath(const QString& entryPath)
 
 void Group::applyGroupIconTo(Entry* entry)
 {
-    if (!config()->get("UseGroupIconOnEntryCreation").toBool()) {
-        return;
-    }
-
-    if (iconNumber() == Group::DefaultIconNumber && iconUuid().isNull()) {
-        return;
-    }
+    Q_ASSERT(entry);
 
     if (iconUuid().isNull()) {
         entry->setIcon(iconNumber());
     } else {
         entry->setIcon(iconUuid());
+    }
+}
+
+void Group::applyGroupIconTo(Group* other)
+{
+    Q_ASSERT(other);
+
+    if (this->iconUuid().isNull()) {
+        other->setIcon(this->iconNumber());
+    } else {
+        other->setIcon(this->iconUuid());
+    }
+}
+
+void Group::applyGroupIconRecursively()
+{
+    for (Group* recursiveChild : this->groupsRecursive(false)) {
+        this->applyGroupIconTo(recursiveChild);
+    }
+
+    for (Entry* recursiveEntry : this->entriesRecursive(false)) {
+        this->applyGroupIconTo(recursiveEntry);
     }
 }
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -169,6 +169,8 @@ public:
     void removeEntry(Entry* entry);
 
     void applyGroupIconTo(Entry* entry);
+    void applyGroupIconTo(Group* other);
+    void applyGroupIconRecursively();
 
     void sortChildrenRecursively(bool reverse = false);
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -168,9 +168,11 @@ public:
     void addEntry(Entry* entry);
     void removeEntry(Entry* entry);
 
+    void applyGroupIconOnCreateTo(Entry* entry);
     void applyGroupIconTo(Entry* entry);
     void applyGroupIconTo(Group* other);
-    void applyGroupIconRecursively();
+    void applyGroupIconToChildGroups();
+    void applyGroupIconToChildEntries();
 
     void sortChildrenRecursively(bool reverse = false);
 

--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -308,7 +308,7 @@ namespace FdoSecrets
             entry->setUuid(QUuid::createUuid());
             entry->setTitle(itemName);
             entry->setUsername(m_backend->database()->metadata()->defaultUserName());
-            group->applyGroupIconTo(entry);
+            group->applyGroupIconOnCreateTo(entry);
 
             entry->setGroup(group);
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -368,7 +368,9 @@ void DatabaseWidget::createEntry()
     m_newEntry->setUuid(QUuid::createUuid());
     m_newEntry->setUsername(m_db->metadata()->defaultUserName());
     m_newParent = m_groupView->currentGroup();
-    m_newParent->applyGroupIconTo(m_newEntry.data());
+    if (config()->get("UseGroupIconOnEntryCreation").toBool()) {
+        m_newParent->applyGroupIconTo(m_newEntry.data());
+    }
     switchToEntryEdit(m_newEntry.data(), true);
 }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -368,9 +368,7 @@ void DatabaseWidget::createEntry()
     m_newEntry->setUuid(QUuid::createUuid());
     m_newEntry->setUsername(m_db->metadata()->defaultUserName());
     m_newParent = m_groupView->currentGroup();
-    if (config()->get("UseGroupIconOnEntryCreation").toBool()) {
-        m_newParent->applyGroupIconTo(m_newEntry.data());
-    }
+    m_newParent->applyGroupIconOnCreateTo(m_newEntry.data());
     switchToEntryEdit(m_newEntry.data(), true);
 }
 

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -65,6 +65,7 @@ EditWidgetIcons::EditWidgetIcons(QWidget* parent)
     connect(m_ui->addButton, SIGNAL(clicked()), SLOT(addCustomIconFromFile()));
     connect(m_ui->deleteButton, SIGNAL(clicked()), SLOT(removeCustomIcon()));
     connect(m_ui->faviconButton, SIGNAL(clicked()), SLOT(downloadFavicon()));
+    connect(m_ui->applyRecursivelyCheckBox, SIGNAL(toggled(bool)), SLOT(confirmApplyIconRecursively(bool)));
 
     connect(m_ui->defaultIconsRadio, SIGNAL(toggled(bool)), this, SIGNAL(widgetUpdated()));
     connect(m_ui->defaultIconsView->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
@@ -102,6 +103,11 @@ IconStruct EditWidgetIcons::state()
             iconStruct.number = -1;
         }
     }
+
+    iconStruct.applyRecursively = false;
+    if (m_ui->applyRecursivelyCheckBox->isChecked()) {
+        iconStruct.applyRecursively = true;
+    };
 
     return iconStruct;
 }
@@ -142,6 +148,8 @@ void EditWidgetIcons::load(const QUuid& currentUuid,
             m_ui->defaultIconsRadio->setChecked(true);
         }
     }
+
+    m_ui->applyRecursivelyCheckBox->setChecked(false);
 }
 
 void EditWidgetIcons::setUrl(const QString& url)
@@ -527,4 +535,24 @@ void EditWidgetIcons::updateRadioButtonDefaultIcons()
 void EditWidgetIcons::updateRadioButtonCustomIcons()
 {
     m_ui->customIconsRadio->setChecked(true);
+}
+
+void EditWidgetIcons::confirmApplyIconRecursively(bool checked)
+{
+    // Only show message box if checked
+    if (!checked) {
+        return;
+    }
+
+    auto result = MessageBox::question(this,
+                                       tr("Confirm Apply Icon Recursively"),
+                                       tr("This will overwrite the icon of every subgroup and "
+                                          "subentry. Are you sure you want to overwrite these?"),
+                                       MessageBox::Yes | MessageBox::No,
+                                       MessageBox::No);
+
+    if (result == MessageBox::No) {
+        // Uncheck the check box if not confirmed
+        this->m_ui->applyRecursivelyCheckBox->setChecked(false);
+    }
 }

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -153,18 +153,23 @@ void EditWidgetIcons::load(const QUuid& currentUuid,
     m_ui->applyIconToPushButton->menu()->defaultAction()->activate(QAction::Trigger);
 }
 
+void EditWidgetIcons::setShowApplyIconToButton(bool state)
+{
+    m_ui->applyIconToPushButton->setVisible(state);
+}
+
 QMenu* EditWidgetIcons::createApplyIconToMenu()
 {
     auto* applyIconToMenu = new QMenu(this);
-    QAction* defaultAction = applyIconToMenu->addAction(tr("Apply to this only", nullptr, 0));
+    QAction* defaultAction = applyIconToMenu->addAction(tr("Apply to this only"));
     defaultAction->setData(QVariant::fromValue(ApplyIconToOptions::THIS_ONLY));
     applyIconToMenu->setDefaultAction(defaultAction);
     applyIconToMenu->addSeparator();
-    applyIconToMenu->addAction(tr("Also apply to child groups", nullptr, 1))
+    applyIconToMenu->addAction(tr("Also apply to child groups"))
         ->setData(QVariant::fromValue(ApplyIconToOptions::CHILD_GROUPS));
-    applyIconToMenu->addAction(tr("Also apply to child entries", nullptr, 2))
+    applyIconToMenu->addAction(tr("Also apply to child entries"))
         ->setData(QVariant::fromValue(ApplyIconToOptions::CHILD_ENTRIES));
-    applyIconToMenu->addAction(tr("Also apply to all children", nullptr, 3))
+    applyIconToMenu->addAction(tr("Also apply to all children"))
         ->setData(QVariant::fromValue(ApplyIconToOptions::ALL_CHILDREN));
     return applyIconToMenu;
 }

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -160,11 +160,11 @@ QMenu* EditWidgetIcons::createApplyIconToMenu()
     defaultAction->setData(QVariant::fromValue(ApplyIconToOptions::THIS_ONLY));
     applyIconToMenu->setDefaultAction(defaultAction);
     applyIconToMenu->addSeparator();
-    applyIconToMenu->addAction(tr("Apply to child groups", nullptr, 1))
+    applyIconToMenu->addAction(tr("Also apply to child groups", nullptr, 1))
         ->setData(QVariant::fromValue(ApplyIconToOptions::CHILD_GROUPS));
-    applyIconToMenu->addAction(tr("Apply to child entries", nullptr, 2))
+    applyIconToMenu->addAction(tr("Also apply to child entries", nullptr, 2))
         ->setData(QVariant::fromValue(ApplyIconToOptions::CHILD_ENTRIES));
-    applyIconToMenu->addAction(tr("Apply to all children", nullptr, 3))
+    applyIconToMenu->addAction(tr("Also apply to all children", nullptr, 3))
         ->setData(QVariant::fromValue(ApplyIconToOptions::ALL_CHILDREN));
     return applyIconToMenu;
 }
@@ -556,28 +556,6 @@ void EditWidgetIcons::updateRadioButtonCustomIcons()
 
 void EditWidgetIcons::confirmApplyIconTo(QAction* action)
 {
-    ApplyIconToOptions selectedOption = action->data().value<ApplyIconToOptions>();
-    QAction* actualAction = action;
-
-    // If no other icons are to be overwritten, no popup is shown
-    if (selectedOption != ApplyIconToOptions::THIS_ONLY) {
-        auto result = MessageBox::question(this,
-                                           tr("Confirm Apply Icon to Children"),
-                                           tr("This will overwrite the icon of "
-                                              "every subgroup and subentry. "
-                                              "Are you sure you want to "
-                                              "overwrite these?"),
-                                           MessageBox::Yes | MessageBox::Abort,
-                                           MessageBox::Abort);
-
-        // If the user aborts, fall back to the default action which writes
-        // the icon only for the current element
-        if (result == MessageBox::Abort) {
-            selectedOption = ApplyIconToOptions::THIS_ONLY;
-            actualAction = m_ui->applyIconToPushButton->menu()->defaultAction();
-        }
-    }
-
-    m_applyIconTo = selectedOption;
-    m_ui->applyIconToPushButton->setText(actualAction->text());
+    m_applyIconTo = action->data().value<ApplyIconToOptions>();
+    m_ui->applyIconToPushButton->setText(action->text());
 }

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -74,8 +74,7 @@ public:
               const QSharedPointer<Database>& database,
               const IconStruct& iconStruct,
               const QString& url = "");
-
-    QMenu* createApplyIconToMenu();
+    void setShowApplyIconToButton(bool state);
 
 public slots:
     void setUrl(const QString& url);
@@ -101,6 +100,8 @@ private slots:
     void confirmApplyIconTo(QAction* action);
 
 private:
+    QMenu* createApplyIconToMenu();
+
     const QScopedPointer<Ui::EditWidgetIcons> m_ui;
     QSharedPointer<Database> m_db;
     QUuid m_currentUuid;

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -46,6 +46,7 @@ struct IconStruct
 
     QUuid uuid;
     int number;
+    bool applyRecursively;
 };
 
 class EditWidgetIcons : public QWidget
@@ -84,6 +85,7 @@ private slots:
     void updateWidgetsCustomIcons(bool checked);
     void updateRadioButtonDefaultIcons();
     void updateRadioButtonCustomIcons();
+    void confirmApplyIconRecursively(bool checked);
 
 private:
     const QScopedPointer<Ui::EditWidgetIcons> m_ui;

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -19,6 +19,7 @@
 #ifndef KEEPASSX_EDITWIDGETICONS_H
 #define KEEPASSX_EDITWIDGETICONS_H
 
+#include <QMenu>
 #include <QUrl>
 #include <QUuid>
 #include <QWidget>
@@ -40,13 +41,23 @@ namespace Ui
     class EditWidgetIcons;
 }
 
+enum ApplyIconToOptions
+{
+    THIS_ONLY = 0b00,
+    CHILD_GROUPS = 0b10,
+    CHILD_ENTRIES = 0b01,
+    ALL_CHILDREN = 0b11
+};
+
+Q_DECLARE_METATYPE(ApplyIconToOptions)
+
 struct IconStruct
 {
     IconStruct();
 
     QUuid uuid;
     int number;
-    bool applyRecursively;
+    ApplyIconToOptions applyTo;
 };
 
 class EditWidgetIcons : public QWidget
@@ -63,6 +74,8 @@ public:
               const QSharedPointer<Database>& database,
               const IconStruct& iconStruct,
               const QString& url = "");
+
+    QMenu* createApplyIconToMenu();
 
 public slots:
     void setUrl(const QString& url);
@@ -85,12 +98,13 @@ private slots:
     void updateWidgetsCustomIcons(bool checked);
     void updateRadioButtonDefaultIcons();
     void updateRadioButtonCustomIcons();
-    void confirmApplyIconRecursively(bool checked);
+    void confirmApplyIconTo(QAction* action);
 
 private:
     const QScopedPointer<Ui::EditWidgetIcons> m_ui;
     QSharedPointer<Database> m_db;
     QUuid m_currentUuid;
+    ApplyIconToOptions m_applyIconTo;
 #ifdef WITH_XC_NETWORKING
     QUrl m_url;
     QUrl m_fetchUrl;

--- a/src/gui/EditWidgetIcons.ui
+++ b/src/gui/EditWidgetIcons.ui
@@ -88,7 +88,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="customIconButtonsHorizontalLayout">
      <item>
       <widget class="QPushButton" name="addButton">
        <property name="text">
@@ -112,6 +112,24 @@
      </item>
     </layout>
    </item>
+   <item>
+   <layout class="QHBoxLayout" name="applyRecursivelyHorizontalLayout">
+    <item>
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QCheckBox" name="applyRecursivelyCheckBox">
+      <property name="text">
+       <string>Apply &amp;recursively</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+   </item>
   </layout>
  </widget>
  <tabstops>
@@ -121,6 +139,7 @@
   <tabstop>customIconsView</tabstop>
   <tabstop>addButton</tabstop>
   <tabstop>deleteButton</tabstop>
+  <tabstop>applyRecursivelyCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/gui/EditWidgetIcons.ui
+++ b/src/gui/EditWidgetIcons.ui
@@ -113,7 +113,7 @@
     </layout>
    </item>
    <item>
-   <layout class="QHBoxLayout" name="applyRecursivelyHorizontalLayout">
+   <layout class="QHBoxLayout" name="applyToChildrenHorizontalLayout">
     <item>
      <spacer name="horizontalSpacer">
       <property name="orientation">
@@ -122,9 +122,9 @@
      </spacer>
     </item>
     <item>
-     <widget class="QCheckBox" name="applyRecursivelyCheckBox">
+     <widget class="QPushButton" name="applyIconToPushButton">
       <property name="text">
-       <string>Apply &amp;recursively</string>
+       <string>Apply icon &amp;to ...</string>
       </property>
      </widget>
     </item>
@@ -139,7 +139,7 @@
   <tabstop>customIconsView</tabstop>
   <tabstop>addButton</tabstop>
   <tabstop>deleteButton</tabstop>
-  <tabstop>applyRecursivelyCheckBox</tabstop>
+  <tabstop>applyIconToPushButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/gui/EditWidgetIcons.ui
+++ b/src/gui/EditWidgetIcons.ui
@@ -113,22 +113,37 @@
     </layout>
    </item>
    <item>
-   <layout class="QHBoxLayout" name="applyToChildrenHorizontalLayout">
-    <item>
-     <spacer name="horizontalSpacer">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-     </spacer>
-    </item>
-    <item>
-     <widget class="QPushButton" name="applyIconToPushButton">
-      <property name="text">
-       <string>Apply icon &amp;to ...</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
+    <layout class="QHBoxLayout" name="applyToChildrenHorizontalLayout" stretch="0,0">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="applyIconToPushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">padding: 4px 10px</string>
+       </property>
+       <property name="text">
+        <string>Apply icon &amp;to ...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -188,6 +188,7 @@ void EditEntryWidget::setupAdvanced()
 
 void EditEntryWidget::setupIcon()
 {
+    m_iconsWidget->setShowApplyIconToButton(false);
     addPage(tr("Icon"), FilePath::instance()->icon("apps", "preferences-desktop-icons"), m_iconsWidget);
     connect(this, SIGNAL(accepted()), m_iconsWidget, SLOT(abortRequests()));
     connect(this, SIGNAL(rejected()), m_iconsWidget, SLOT(abortRequests()));

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -212,9 +212,15 @@ void EditGroupWidget::apply()
     // Icons add/remove are applied globally outside the transaction!
     m_group->copyDataFrom(m_temporaryGroup.data());
 
-    // Assign the icon recursively if selected
-    if (iconStruct.applyRecursively) {
-        m_group->applyGroupIconRecursively();
+    // Assign the icon to children if selected
+    if (iconStruct.applyTo == ApplyIconToOptions::CHILD_GROUPS
+        || iconStruct.applyTo == ApplyIconToOptions::ALL_CHILDREN) {
+        m_group->applyGroupIconToChildGroups();
+    }
+
+    if (iconStruct.applyTo == ApplyIconToOptions::CHILD_ENTRIES
+        || iconStruct.applyTo == ApplyIconToOptions::ALL_CHILDREN) {
+        m_group->applyGroupIconToChildEntries();
     }
 
     setModified(false);

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -212,6 +212,11 @@ void EditGroupWidget::apply()
     // Icons add/remove are applied globally outside the transaction!
     m_group->copyDataFrom(m_temporaryGroup.data());
 
+    // Assign the icon recursively if selected
+    if (iconStruct.applyRecursively) {
+        m_group->applyGroupIconRecursively();
+    }
+
     setModified(false);
 }
 

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -1110,7 +1110,8 @@ void TestGroup::testApplyGroupIconRecursively()
     const int rootIconNumber = 42;
     database->rootGroup()->setIcon(rootIconNumber);
     QVERIFY(database->rootGroup()->iconNumber() == rootIconNumber);
-    database->rootGroup()->applyGroupIconRecursively();
+    database->rootGroup()->applyGroupIconToChildGroups();
+    database->rootGroup()->applyGroupIconToChildEntries();
     QVERIFY(subgroup->iconNumber() == rootIconNumber);
     QVERIFY(subgroupEntry->iconNumber() == rootIconNumber);
     QVERIFY(subsubgroup->iconNumber() == rootIconNumber);
@@ -1121,7 +1122,8 @@ void TestGroup::testApplyGroupIconRecursively()
     const int subsubgroupIconNumber = 24;
     subsubgroup->setIcon(subsubgroupIconNumber);
     QVERIFY(subsubgroup->iconNumber() == subsubgroupIconNumber);
-    subsubgroup->applyGroupIconRecursively();
+    subsubgroup->applyGroupIconToChildGroups();
+    subsubgroup->applyGroupIconToChildEntries();
     QVERIFY(database->rootGroup()->iconNumber() == rootIconNumber);
     QVERIFY(subgroup->iconNumber() == rootIconNumber);
     QVERIFY(subgroupEntry->iconNumber() == rootIconNumber);
@@ -1135,7 +1137,8 @@ void TestGroup::testApplyGroupIconRecursively()
     subgroupIcon.setPixel(0, 0, qRgb(255, 0, 0));
     database->metadata()->addCustomIcon(subgroupIconUuid, subgroupIcon);
     subgroup->setIcon(subgroupIconUuid);
-    subgroup->applyGroupIconRecursively();
+    subgroup->applyGroupIconToChildGroups();
+    subgroup->applyGroupIconToChildEntries();
     QVERIFY(database->rootGroup()->iconNumber() == rootIconNumber);
     QCOMPARE(subgroup->iconUuid(), subgroupIconUuid);
     QCOMPARE(subgroup->icon(), subgroupIcon);
@@ -1145,4 +1148,36 @@ void TestGroup::testApplyGroupIconRecursively()
     QCOMPARE(subsubgroup->icon(), subgroupIcon);
     QCOMPARE(subsubgroupEntry->iconUuid(), subgroupIconUuid);
     QCOMPARE(subsubgroupEntry->icon(), subgroupIcon);
+
+    // Reset all icons to root icon
+    database->rootGroup()->setIcon(rootIconNumber);
+    QVERIFY(database->rootGroup()->iconNumber() == rootIconNumber);
+    database->rootGroup()->applyGroupIconToChildGroups();
+    database->rootGroup()->applyGroupIconToChildEntries();
+    QVERIFY(subgroup->iconNumber() == rootIconNumber);
+    QVERIFY(subgroupEntry->iconNumber() == rootIconNumber);
+    QVERIFY(subsubgroup->iconNumber() == rootIconNumber);
+    QVERIFY(subsubgroupEntry->iconNumber() == rootIconNumber);
+
+    // Apply only for child groups
+    const int iconForGroups = 10;
+    database->rootGroup()->setIcon(iconForGroups);
+    QVERIFY(database->rootGroup()->iconNumber() == iconForGroups);
+    database->rootGroup()->applyGroupIconToChildGroups();
+    QVERIFY(database->rootGroup()->iconNumber() == iconForGroups);
+    QVERIFY(subgroup->iconNumber() == iconForGroups);
+    QVERIFY(subgroupEntry->iconNumber() == rootIconNumber);
+    QVERIFY(subsubgroup->iconNumber() == iconForGroups);
+    QVERIFY(subsubgroupEntry->iconNumber() == rootIconNumber);
+
+    // Apply only for child entries
+    const int iconForEntries = 20;
+    database->rootGroup()->setIcon(iconForEntries);
+    QVERIFY(database->rootGroup()->iconNumber() == iconForEntries);
+    database->rootGroup()->applyGroupIconToChildEntries();
+    QVERIFY(database->rootGroup()->iconNumber() == iconForEntries);
+    QVERIFY(subgroup->iconNumber() == iconForGroups);
+    QVERIFY(subgroupEntry->iconNumber() == iconForEntries);
+    QVERIFY(subsubgroup->iconNumber() == iconForGroups);
+    QVERIFY(subsubgroupEntry->iconNumber() == iconForEntries);
 }

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -47,6 +47,7 @@ private slots:
     void testEquals();
     void testChildrenSort();
     void testHierarchy();
+    void testApplyGroupIconRecursively();
 };
 
 #endif // KEEPASSX_TESTGROUP_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
Set an icon for a group and automatically use it for subgroups and 
subentries. 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Applying icons recursively can be helpful if the database owner follows a policy
in which entries always have the same icon as their parent group (which also is
the standard setting for new entries).
After reorganization of the database, the icons keep their old icon which was
the icon of their old parent.
To avoid setting the icon of each entry individually, a new checkbox is
introduced in the "Icon" category of the EditGroupWidget.
Since the EditIconWidget is also used by the EditEntryWidget, the checkbox
also appears there but checking the box has no effect in this case.

The ApplyGroupIconTo(Entry*) is adjusted to be more generally applicable. Until now, the method was intended to be only run on entry creation (config checks).

Fixes #3228
Fixes #1314
Fixes #2361

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

After reorganization of the entries, the icons of the entries are mingled
wildly.

![Screenshot from 2019-06-13 22-49-19](https://user-images.githubusercontent.com/6493860/59532055-ec9fdc80-8ee7-11e9-9cf7-6f4e9876b2c6.png)

To match the icons of the entries to their new parent group, open the edit mode
of the parent and select the icon.


![Screenshot from 2019-06-13 22-50-37](https://user-images.githubusercontent.com/6493860/59532089-05a88d80-8ee8-11e9-8c05-2225d6130989.png)

To apply the icon recursively, check the box.
A message box requests confirmation to ensure that the option is checked
intentionally, to avoid accidental overwriting of icons.


![Screenshot from 2019-06-13 22-50-54](https://user-images.githubusercontent.com/6493860/59532093-07725100-8ee8-11e9-8f84-2cec64b6c8d2.png)
![Screenshot from 2019-06-13 22-51-05](https://user-images.githubusercontent.com/6493860/59532099-0a6d4180-8ee8-11e9-9e93-012c139c9f8c.png)
![Screenshot from 2019-06-13 22-51-13](https://user-images.githubusercontent.com/6493860/59532105-0e00c880-8ee8-11e9-9ab4-b8cc899e98b9.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

A new unit test is introduced in TestGroup which tests the new option with
a database which contains two nested subgroups in the root group.
Setting the icon by number as well as UUID is tested.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )

- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes. [x]
## Possible alternative
Another possible method would be to introduce an option in the context menu of
selected entries.

## Annotations
ASAN reports a memory leak if a custom icon is added or deleted (libglib).
This leak already existed in previous commits (and is not addressed by the
proposed changes).

Two new strings are introduced (checkbox and message box) and need to be
translated.
