### PR TITLE
💻💻 CLI password generation options cleanup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@
 - 💥💥 CLI: The password length option `-l` for the CLI commands
   `Add` and `Edit` is now `-L` [#3275]
 - 💥💥 CLI: the `-u` shorthand for the `--upper` password generation option
-  has been removed [#3275]
+  has been renamed `-U` [#3275]
 - CLI: Add password generation options to `Add` and `Edit` commands [#3275]
 - Rework the Entry Preview panel [#3306]
 - Move notes to General tab on Group Preview Panel [#3336]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 =========================
 - Group sorting feature [#3282]
 - CLI: Add 'flatten' option to the 'ls' command [#3276]
+- 💥💥 CLI: The password length option `-l` for the CLI commands
+  `Add` and `Edit` is now `-L` [#3275]
+- 💥💥 CLI: the `-u` shorthand for the `--upper` password generation option
+  has been removed [#3275]
+- CLI: Add password generation options to `Add` and `Edit` commands [#3275]
 - Rework the Entry Preview panel [#3306]
 - Move notes to General tab on Group Preview Panel [#3336]
 - Add 'Monospaced font' option to the Notes field [#3321]

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -22,7 +22,6 @@
 
 #include "cli/TextStream.h"
 #include "cli/Utils.h"
-#include "core/PasswordGenerator.h"
 
 const QCommandLineOption Generate::PasswordLengthOption =
     QCommandLineOption(QStringList() << "L"
@@ -34,8 +33,7 @@ const QCommandLineOption Generate::LowerCaseOption = QCommandLineOption(QStringL
                                                                                       << "lower",
                                                                         QObject::tr("Use lowercase characters"));
 
-const QCommandLineOption Generate::UpperCaseOption = QCommandLineOption(QStringList() << "u"
-                                                                                      << "upper",
+const QCommandLineOption Generate::UpperCaseOption = QCommandLineOption(QStringList() << "upper",
                                                                         QObject::tr("Use uppercase characters"));
 
 const QCommandLineOption Generate::NumbersOption = QCommandLineOption(QStringList() << "n"
@@ -75,26 +73,22 @@ Generate::Generate()
     options.append(Generate::IncludeEveryGroupOption);
 }
 
-int Generate::execute(const QStringList& arguments)
+/**
+ * Creates a password generator instance using the command line options
+ * of the parser object.
+ */
+QSharedPointer<PasswordGenerator> Generate::createGenerator(QSharedPointer<QCommandLineParser> parser)
 {
-    QSharedPointer<QCommandLineParser> parser = getCommandLineParser(arguments);
-    if (parser.isNull()) {
-        return EXIT_FAILURE;
-    }
-    TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
     TextStream errorTextStream(Utils::STDERR, QIODevice::WriteOnly);
-
-    const QStringList args = parser->positionalArguments();
-
-    PasswordGenerator passwordGenerator;
+    QSharedPointer<PasswordGenerator> passwordGenerator = QSharedPointer<PasswordGenerator>(new PasswordGenerator());
     QString passwordLength = parser->value(Generate::PasswordLengthOption);
     if (passwordLength.isEmpty()) {
-        passwordGenerator.setLength(PasswordGenerator::DefaultLength);
+        passwordGenerator->setLength(PasswordGenerator::DefaultLength);
     } else if (passwordLength.toInt() <= 0) {
         errorTextStream << QObject::tr("Invalid password length %1").arg(passwordLength) << endl;
-        return EXIT_FAILURE;
+        return QSharedPointer<PasswordGenerator>(nullptr);
     } else {
-        passwordGenerator.setLength(passwordLength.toInt());
+        passwordGenerator->setLength(passwordLength.toInt());
     }
 
     PasswordGenerator::CharClasses classes = 0x0;
@@ -124,16 +118,34 @@ int Generate::execute(const QStringList& arguments)
         flags |= PasswordGenerator::CharFromEveryGroup;
     }
 
-    passwordGenerator.setCharClasses(classes);
-    passwordGenerator.setFlags(flags);
-    passwordGenerator.setExcludedChars(parser->value(Generate::ExcludeCharsOption));
+    // The default charset will be used if no explicit class
+    // option was set.
+    passwordGenerator->setCharClasses(classes);
+    passwordGenerator->setFlags(flags);
+    passwordGenerator->setExcludedChars(parser->value(Generate::ExcludeCharsOption));
 
-    if (!passwordGenerator.isValid()) {
+    if (!passwordGenerator->isValid()) {
         errorTextStream << QObject::tr("invalid password generator after applying all options") << endl;
+        return QSharedPointer<PasswordGenerator>(nullptr);
+    }
+
+    return passwordGenerator;
+}
+
+int Generate::execute(const QStringList& arguments)
+{
+    QSharedPointer<QCommandLineParser> parser = getCommandLineParser(arguments);
+    if (parser.isNull()) {
         return EXIT_FAILURE;
     }
 
-    QString password = passwordGenerator.generatePassword();
+    QSharedPointer<PasswordGenerator> passwordGenerator = Generate::createGenerator(parser);
+    if (passwordGenerator.isNull()) {
+        return EXIT_FAILURE;
+    }
+
+    TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);
+    QString password = passwordGenerator->generatePassword();
     outputTextStream << password << endl;
 
     return EXIT_SUCCESS;

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -33,7 +33,8 @@ const QCommandLineOption Generate::LowerCaseOption = QCommandLineOption(QStringL
                                                                                       << "lower",
                                                                         QObject::tr("Use lowercase characters"));
 
-const QCommandLineOption Generate::UpperCaseOption = QCommandLineOption(QStringList() << "upper",
+const QCommandLineOption Generate::UpperCaseOption = QCommandLineOption(QStringList() << "U"
+                                                                                      << "upper",
                                                                         QObject::tr("Use uppercase characters"));
 
 const QCommandLineOption Generate::NumbersOption = QCommandLineOption(QStringList() << "n"

--- a/src/cli/Generate.h
+++ b/src/cli/Generate.h
@@ -20,11 +20,15 @@
 
 #include "Command.h"
 
+#include "core/PasswordGenerator.h"
+
 class Generate : public Command
 {
 public:
     Generate();
     int execute(const QStringList& arguments) override;
+
+    static QSharedPointer<PasswordGenerator> createGenerator(QSharedPointer<QCommandLineParser> parser);
 
     static const QCommandLineOption PasswordLengthOption;
     static const QCommandLineOption LowerCaseOption;

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -180,7 +180,7 @@ Desired length for the generated password. [Default: 16]
 .IP "-l --lower"
 Use lowercase characters for the generated password. [Default: Enabled]
 
-.IP "--upper"
+.IP "-U --upper"
 Use uppercase characters for the generated password. [Default: Enabled]
 
 .IP "-n --numeric"

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -1,4 +1,4 @@
-.TH KEEPASSXC-CLI 1 "Nov 04, 2018"
+.TH KEEPASSXC-CLI 1 "June 15, 2019"
 
 .SH NAME
 keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
@@ -15,6 +15,7 @@ keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager
 
 .IP "add [options] <database> <entry>"
 Adds a new entry to a database. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+The same password generation options as documented for the generate command can be used when the \fI-g\fP option is set.
 
 .IP "analyze [options] <database>"
 Analyze passwords in a database for weaknesses.
@@ -30,6 +31,7 @@ Generate a random diceware passphrase.
 
 .IP "edit [options] <database> <entry>"
 Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+The same password generation options as documented for the generate command can be used when the \fI-g\fP option is set.
 
 .IP "estimate [options] [password]"
 Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
@@ -94,6 +96,8 @@ Use the same credentials for unlocking both database.
 
 
 .SS "Add and edit options"
+The same password generation options as documented for the generate command can be used
+with those 2 commands when the -g option is set.
 
 .IP "-u, --username <username>"
 Specify the username of the entry.
@@ -106,9 +110,6 @@ Use a password prompt for the entry's password.
 
 .IP "-g, --generate"
 Generate a new password for the entry.
-
-.IP "-l, --password-length"
-Specify the length of the password to generate.
 
 
 .SS "Edit options"
@@ -176,21 +177,29 @@ Flattens the output to single lines. When this option is enabled, subgroups and 
 .IP "-L, --length <length>"
 Desired length for the generated password. [Default: 16]
 
-.IP "-l"
+.IP "-l --lower"
 Use lowercase characters for the generated password. [Default: Enabled]
 
-.IP "-u"
+.IP "--upper"
 Use uppercase characters for the generated password. [Default: Enabled]
 
-.IP "-n"
+.IP "-n --numeric"
 Use numbers characters for the generated password. [Default: Enabled]
 
-.IP "-s"
+.IP "-s --special"
 Use special characters for the generated password. [Default: Disabled]
 
-.IP "-e"
+.IP "-e --extended"
 Use extended ASCII characters for the generated password. [Default: Disabled]
 
+.IP "-x --exclude <chars>"
+Comma-separated list of characters to exclude from the generated password. None is excluded by default.
+
+.IP "--exclude-similar"
+Exclude similar looking characters. [Default: Disabled]
+
+.IP "--every-group"
+Include characters from every selected group. [Default: Disabled]
 
 
 .SH REPORTING BUGS

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -280,7 +280,7 @@ void TestCli::testAdd()
                     "--every-group",
                     "-s",
                     "-n",
-                    "--upper",
+                    "-U",
                     "-l",
                     m_dbFile->fileName(),
                     "/newuser-entry4"});
@@ -795,9 +795,9 @@ void TestCli::testGenerate_data()
     QTest::newRow("numbers + lowercase + uppercase")
         << QStringList{"generate", "-L", "16", "-n", "--upper", "-l"} << "^[0-9a-zA-Z]{16}$";
     QTest::newRow("numbers + lowercase + uppercase (exclude)")
-        << QStringList{"generate", "-L", "500", "-n", "--upper", "-l", "-x", "abcdefg0123@"} << "^[^abcdefg0123@]{500}$";
+        << QStringList{"generate", "-L", "500", "-n", "-U", "-l", "-x", "abcdefg0123@"} << "^[^abcdefg0123@]{500}$";
     QTest::newRow("numbers + lowercase + uppercase (exclude similar)")
-        << QStringList{"generate", "-L", "200", "-n", "--upper", "-l", "--exclude-similar"} << "^[^l1IO0]{200}$";
+        << QStringList{"generate", "-L", "200", "-n", "-U", "-l", "--exclude-similar"} << "^[^l1IO0]{200}$";
     QTest::newRow("uppercase + lowercase (every)")
         << QStringList{"generate", "-L", "2", "--upper", "-l", "--every-group"} << "^[a-z][A-Z]|[A-Z][a-z]$";
     QTest::newRow("numbers + lowercase (every)")

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -193,7 +193,7 @@ void TestCli::testAdd()
                     "--url",
                     "https://example.com/",
                     "-g",
-                    "-l",
+                    "-L",
                     "20",
                     m_dbFile->fileName(),
                     "/newuser-entry"});
@@ -212,13 +212,17 @@ void TestCli::testAdd()
 
     // Quiet option
     qint64 pos = m_stdoutFile->pos();
+    qint64 posErr = m_stderrFile->pos();
     Utils::Test::setNextPassword("a");
-    addCmd.execute({"add", "-q", "-u", "newuser", "-g", "-l", "20", m_dbFile->fileName(), "/newentry-quiet"});
+    addCmd.execute({"add", "-q", "-u", "newuser", "-g", "-L", "20", m_dbFile->fileName(), "/newentry-quiet"});
     m_stdoutFile->seek(pos);
+    m_stderrFile->seek(posErr);
     QCOMPARE(m_stdoutFile->readAll(), QByteArray(""));
+    QCOMPARE(m_stderrFile->readAll(), QByteArray(""));
     db = readTestDatabase();
     entry = db->rootGroup()->findEntryByPath("/newentry-quiet");
     QVERIFY(entry);
+    QCOMPARE(entry->password().size(), 20);
 
     Utils::Test::setNextPassword("a");
     Utils::Test::setNextPassword("newpassword");
@@ -227,9 +231,6 @@ void TestCli::testAdd()
                     "newuser2",
                     "--url",
                     "https://example.net/",
-                    "-g",
-                    "-l",
-                    "20",
                     "-p",
                     m_dbFile->fileName(),
                     "/newuser-entry2"});
@@ -240,6 +241,61 @@ void TestCli::testAdd()
     QCOMPARE(entry->username(), QString("newuser2"));
     QCOMPARE(entry->url(), QString("https://example.net/"));
     QCOMPARE(entry->password(), QString("newpassword"));
+
+    // Password generation options
+    pos = m_stdoutFile->pos();
+    posErr = m_stderrFile->pos();
+    Utils::Test::setNextPassword("a");
+    addCmd.execute({"add",
+                    "-u",
+                    "newuser3",
+                    "-g",
+                    "-L",
+                    "34",
+                    m_dbFile->fileName(),
+                    "/newuser-entry3"});
+    m_stdoutFile->seek(pos);
+    m_stderrFile->seek(posErr);
+    m_stdoutFile->readLine(); // skip password prompt
+    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Successfully added entry newuser-entry3.\n"));
+    QCOMPARE(m_stderrFile->readAll(), QByteArray(""));
+
+    db = readTestDatabase();
+    entry = db->rootGroup()->findEntryByPath("/newuser-entry3");
+    QVERIFY(entry);
+    QCOMPARE(entry->username(), QString("newuser3"));
+    QCOMPARE(entry->password().size(), 34);
+    QRegularExpression defaultPasswordClassesRegex("^[a-zA-Z0-9]+$");
+    QVERIFY(defaultPasswordClassesRegex.match(entry->password()).hasMatch());
+
+    pos = m_stdoutFile->pos();
+    posErr = m_stderrFile->pos();
+    Utils::Test::setNextPassword("a");
+    addCmd.execute({"add",
+                    "-u",
+                    "newuser4",
+                    "-g",
+                    "-L",
+                    "20",
+                    "--every-group",
+                    "-s",
+                    "-n",
+                    "--upper",
+                    "-l",
+                    m_dbFile->fileName(),
+                    "/newuser-entry4"});
+    m_stdoutFile->seek(pos);
+    m_stderrFile->seek(posErr);
+    m_stdoutFile->readLine(); // skip password prompt
+    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Successfully added entry newuser-entry4.\n"));
+    QCOMPARE(m_stderrFile->readAll(), QByteArray(""));
+
+    db = readTestDatabase();
+    entry = db->rootGroup()->findEntryByPath("/newuser-entry4");
+    QVERIFY(entry);
+    QCOMPARE(entry->username(), QString("newuser4"));
+    QCOMPARE(entry->password().size(), 20);
+    QVERIFY(!defaultPasswordClassesRegex.match(entry->password()).hasMatch());
 }
 
 void TestCli::testAnalyze()
@@ -515,15 +571,18 @@ void TestCli::testEdit()
 
     // Quiet option
     qint64 pos = m_stdoutFile->pos();
+    qint64 posErr = m_stderrFile->pos();
     Utils::Test::setNextPassword("a");
-    editCmd.execute({"edit", m_dbFile->fileName(), "-q", "-t", "newtitle", "/Sample Entry"});
+    editCmd.execute({"edit", m_dbFile->fileName(), "-q", "-t", "newertitle", "/newtitle"});
     m_stdoutFile->seek(pos);
+    m_stderrFile->seek(posErr);
     QCOMPARE(m_stdoutFile->readAll(), QByteArray(""));
+    QCOMPARE(m_stderrFile->readAll(), QByteArray(""));
 
     Utils::Test::setNextPassword("a");
-    editCmd.execute({"edit", "-g", m_dbFile->fileName(), "/newtitle"});
+    editCmd.execute({"edit", "-g", m_dbFile->fileName(), "/newertitle"});
     db = readTestDatabase();
-    entry = db->rootGroup()->findEntryByPath("/newtitle");
+    entry = db->rootGroup()->findEntryByPath("/newertitle");
     QVERIFY(entry);
     QCOMPARE(entry->username(), QString("newuser"));
     QCOMPARE(entry->url(), QString("https://otherurl.example.com/"));
@@ -531,20 +590,48 @@ void TestCli::testEdit()
     QVERIFY(entry->password() != QString("Password"));
 
     Utils::Test::setNextPassword("a");
-    editCmd.execute({"edit", "-g", "-l", "34", "-t", "yet another title", m_dbFile->fileName(), "/newtitle"});
+    editCmd.execute({"edit", "-g", "-L", "34", "-t", "evennewertitle", m_dbFile->fileName(), "/newertitle"});
     db = readTestDatabase();
-    entry = db->rootGroup()->findEntryByPath("/yet another title");
+    entry = db->rootGroup()->findEntryByPath("/evennewertitle");
     QVERIFY(entry);
     QCOMPARE(entry->username(), QString("newuser"));
     QCOMPARE(entry->url(), QString("https://otherurl.example.com/"));
     QVERIFY(entry->password() != QString("Password"));
     QCOMPARE(entry->password().size(), 34);
+    QRegularExpression defaultPasswordClassesRegex("^[a-zA-Z0-9]+$");
+    QVERIFY(defaultPasswordClassesRegex.match(entry->password()).hasMatch());
+
+    pos = m_stdoutFile->pos();
+    posErr = m_stderrFile->pos();
+    Utils::Test::setNextPassword("a");
+    editCmd.execute({"edit",
+                     "-g",
+                     "-L",
+                     "20",
+                     "--every-group",
+                     "-s",
+                     "-n",
+                     "--upper",
+                     "-l",
+                     m_dbFile->fileName(),
+                     "/evennewertitle"});
+    m_stdoutFile->seek(pos);
+    m_stderrFile->seek(posErr);
+    m_stdoutFile->readLine(); // skip password prompt
+    QCOMPARE(m_stderrFile->readAll(), QByteArray(""));
+    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Successfully edited entry evennewertitle.\n"));
+
+    db = readTestDatabase();
+    entry = db->rootGroup()->findEntryByPath("/evennewertitle");
+    QVERIFY(entry);
+    QCOMPARE(entry->password().size(), 20);
+    QVERIFY(!defaultPasswordClassesRegex.match(entry->password()).hasMatch());
 
     Utils::Test::setNextPassword("a");
     Utils::Test::setNextPassword("newpassword");
-    editCmd.execute({"edit", "-p", m_dbFile->fileName(), "/yet another title"});
+    editCmd.execute({"edit", "-p", m_dbFile->fileName(), "/evennewertitle"});
     db = readTestDatabase();
-    entry = db->rootGroup()->findEntryByPath("/yet another title");
+    entry = db->rootGroup()->findEntryByPath("/evennewertitle");
     QVERIFY(entry);
     QCOMPARE(entry->password(), QString("newpassword"));
 }
@@ -697,7 +784,7 @@ void TestCli::testGenerate_data()
     QTest::newRow("default") << QStringList{"generate"} << "^[^\r\n]+$";
     QTest::newRow("length") << QStringList{"generate", "-L", "13"} << "^.{13}$";
     QTest::newRow("lowercase") << QStringList{"generate", "-L", "14", "-l"} << "^[a-z]{14}$";
-    QTest::newRow("uppercase") << QStringList{"generate", "-L", "15", "-u"} << "^[A-Z]{15}$";
+    QTest::newRow("uppercase") << QStringList{"generate", "-L", "15", "--upper"} << "^[A-Z]{15}$";
     QTest::newRow("numbers") << QStringList{"generate", "-L", "16", "-n"} << "^[0-9]{16}$";
     QTest::newRow("special") << QStringList{"generate", "-L", "200", "-s"}
                              << R"(^[\(\)\[\]\{\}\.\-*|\\,:;"'\/\_!+-<=>?#$%&^`@~]{200}$)";
@@ -706,13 +793,13 @@ void TestCli::testGenerate_data()
     QTest::newRow("extended") << QStringList{"generate", "-L", "50", "-e"}
                               << R"(^[^a-zA-Z0-9\(\)\[\]\{\}\.\-\*\|\\,:;"'\/\_!+-<=>?#$%&^`@~]{50}$)";
     QTest::newRow("numbers + lowercase + uppercase")
-        << QStringList{"generate", "-L", "16", "-n", "-u", "-l"} << "^[0-9a-zA-Z]{16}$";
+        << QStringList{"generate", "-L", "16", "-n", "--upper", "-l"} << "^[0-9a-zA-Z]{16}$";
     QTest::newRow("numbers + lowercase + uppercase (exclude)")
-        << QStringList{"generate", "-L", "500", "-n", "-u", "-l", "-x", "abcdefg0123@"} << "^[^abcdefg0123@]{500}$";
+        << QStringList{"generate", "-L", "500", "-n", "--upper", "-l", "-x", "abcdefg0123@"} << "^[^abcdefg0123@]{500}$";
     QTest::newRow("numbers + lowercase + uppercase (exclude similar)")
-        << QStringList{"generate", "-L", "200", "-n", "-u", "-l", "--exclude-similar"} << "^[^l1IO0]{200}$";
+        << QStringList{"generate", "-L", "200", "-n", "--upper", "-l", "--exclude-similar"} << "^[^l1IO0]{200}$";
     QTest::newRow("uppercase + lowercase (every)")
-        << QStringList{"generate", "-L", "2", "-u", "-l", "--every-group"} << "^[a-z][A-Z]|[A-Z][a-z]$";
+        << QStringList{"generate", "-L", "2", "--upper", "-l", "--every-group"} << "^[a-z][A-Z]|[A-Z][a-z]$";
     QTest::newRow("numbers + lowercase (every)")
         << QStringList{"generate", "-L", "2", "-n", "-l", "--every-group"} << "^[a-z][0-9]|[0-9][a-z]$";
 }

--- a/tests/TestCli.h
+++ b/tests/TestCli.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Summary of changes:
* extract function for creating password generator from options into
`Generate` command. This function is now reused in `Add` and `Edit`
commands.
* Updated manpage with missing password generation options.
* Updated manpage with missing longer forms of password generation options.
* Added unit tests for new password generation options in `Add` and
`Edit`.
* Handle case when `-g` and `-p` options are used at the same time.

This PR adds password generation functionalities while reducing
code duplication, but at the cost of 2 small breaking changes:
* the password generation option for `Add` and `Edit` for specifying
password length is now `-L` instead of `-l`, to not clash with the
`-l --lower` option.
* the `-u` shorthand for the `--upper` option had to be renamed to `-U`, to not
clash with the `-u --username` option.

@droidmonkey what about the  `CHANGELOG` file, should I update it with the breaking changes now, or do you wait before the releases to do that?

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix
- ✅ Refactor
- ✅ New feature
- ✅ Breaking change
- ✅ Documentation

## Testing strategy
existing + new unit tests.


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
