### PR TITLE
Fix resolving placeholders in urls

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -696,7 +696,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
             }
         }
     } else {
-        QUrl url = QUrl::fromUserInput(entry->url());
+        QUrl url = QUrl::fromUserInput(entry->resolveMultiplePlaceholders(entry->url()));
         if (!url.isEmpty()) {
             QDesktopServices::openUrl(url);
         }

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -202,7 +202,7 @@ void EntryPreviewWidget::updateEntryGeneralTab()
     const QString url = m_currentEntry->url();
     if (!url.isEmpty()) {
         // URL is well formed and can be opened in a browser
-        m_ui->entryUrlLabel->setUrl(url);
+        m_ui->entryUrlLabel->setUrl(m_currentEntry->resolveMultiplePlaceholders(url));
         m_ui->entryUrlLabel->setCursor(Qt::PointingHandCursor);
         m_ui->entryUrlLabel->setOpenExternalLinks(false);
     } else {


### PR DESCRIPTION
I'm using placeholders heavily, so I've run into two bugs when trying to migrate to keepassxc:

1. Double-click on the URL field in the entry table passes URL to the framework as-is, with placeholders in place (see DatabaseWidget::openUrlForEntry). This may lead to QUrl parser failure and empty QUrl, so nothing is opened at all. Using four slashes instead of two after the scheme (related to https://github.com/keepassxreboot/keepassxc/issues/3219 ?) kind of "fixes" it for the QUrl parser, but the resulting URL still has placeholders in place of actual data, so it's not a valid workaround.

2. Copying URL from EntryPreviewWidget by right-clicking URL and choosing "copy" results in the same error, copied URL has placeholders instead of actual data.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
