### PR TITLE
Embed version information in AppImage

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -699,6 +699,10 @@ EOF
         appimage_name="KeePassXC-${RELEASE_NAME}-x86_64.AppImage"
     fi
 
+    # Allow appimagetool to insert version information into the AppImage to allow
+    # desktop integration tools to display that in app launchers
+    export VERSION="${RELEASE_NAME}"
+
     # Run appimagetool to package (and possibly sign) AppImage
     # --no-appstream is required, since it may crash on newer systems
     # see: https://github.com/AppImage/AppImageKit/issues/856


### PR DESCRIPTION
I've told some of your team members about that feature already, but it didn't make it into master yet, so I thought I'd show how it can be used.

appimagetool picks up a `$VERSION` environment variable and embeds that information into the AppImage in a way that allows desktop integration tools to display that in app launchers ("start menu" kind of things). That's *really* useful if you use more than one version, which might occur at updates, but is generally quite handy.

You could even get rid of the custom AppImage name picking, since appimagetool will also use `$VERSION` in the output filename, but that's for another day.