### PR TITLE
Autocomplete usernames on typing based on existing ones

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -179,7 +179,6 @@ void Config::init(const QString& fileName)
     m_defaults.insert("SearchLimitGroup", false);
     m_defaults.insert("MinimizeOnCopy", false);
     m_defaults.insert("MinimizeOnOpenUrl", false);
-    m_defaults.insert("UseGroupIconOnEntryCreation", false);
     m_defaults.insert("AutoTypeEntryTitleMatch", true);
     m_defaults.insert("AutoTypeEntryURLMatch", true);
     m_defaults.insert("AutoTypeDelay", 25);

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -54,6 +54,7 @@ Database::Database()
 
     connect(m_metadata, SIGNAL(metadataModified()), this, SLOT(markAsModified()));
     connect(m_timer, SIGNAL(timeout()), SIGNAL(databaseModified()));
+    connect(this, SIGNAL(databaseSaved()), SLOT(updateCommonUsernames()));
 
     m_modified = false;
     m_emitModified = true;
@@ -148,6 +149,8 @@ bool Database::open(const QString& filePath, QSharedPointer<const CompositeKey> 
     setReadOnly(readOnly);
     setFilePath(filePath);
     dbFile.close();
+
+    updateCommonUsernames();
 
     setInitialized(ok);
     markAsClean();
@@ -523,6 +526,17 @@ void Database::addDeletedObject(const QUuid& uuid)
     delObj.uuid = uuid;
 
     addDeletedObject(delObj);
+}
+
+QList<QString> Database::commonUsernames()
+{
+    return m_commonUsernames;
+}
+
+void Database::updateCommonUsernames(int topN)
+{
+    m_commonUsernames.clear();
+    m_commonUsernames.append(rootGroup()->usernamesRecursive(topN));
 }
 
 const QUuid& Database::cipher() const

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -106,6 +106,8 @@ public:
     bool containsDeletedObject(const DeletedObject& uuid) const;
     void setDeletedObjects(const QList<DeletedObject>& delObjs);
 
+    QList<QString> commonUsernames();
+
     bool hasKey() const;
     QSharedPointer<const CompositeKey> key() const;
     bool setKey(const QSharedPointer<const CompositeKey>& key,
@@ -131,6 +133,7 @@ public:
 public slots:
     void markAsModified();
     void markAsClean();
+    void updateCommonUsernames(int topN = 10);
 
 signals:
     void filePathChanged(const QString& oldPath, const QString& newPath);
@@ -183,6 +186,8 @@ private:
     bool m_initialized = false;
     bool m_modified = false;
     bool m_emitModified;
+
+    QList<QString> m_commonUsernames;
 
     QUuid m_uuid;
     static QHash<QUuid, QPointer<Database>> s_uuidMap;

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -341,6 +341,11 @@ bool Entry::isExpired() const
     return m_data.timeInfo.expires() && m_data.timeInfo.expiryTime() < Clock::currentDateTimeUtc();
 }
 
+bool Entry::isAttributeReference(const QString& key) const
+{
+    return m_attributes->isReference(key);
+}
+
 bool Entry::isAttributeReferenceOf(const QString& key, const QUuid& uuid) const
 {
     if (!m_attributes->isReference(key)) {

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -111,6 +111,7 @@ public:
 
     bool hasTotp() const;
     bool isExpired() const;
+    bool isAttributeReference(const QString& key) const;
     bool isAttributeReferenceOf(const QString& key, const QUuid& uuid) const;
     void replaceReferencesWithValues(const Entry* other);
     bool hasReferences() const;

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -158,6 +158,7 @@ public:
     QList<const Group*> groupsRecursive(bool includeSelf) const;
     QList<Group*> groupsRecursive(bool includeSelf);
     QSet<QUuid> customIconsRecursive() const;
+    QList<QString> usernamesRecursive(int topN = -1) const;
 
     Group* clone(Entry::CloneFlags entryFlags = DefaultEntryCloneFlags,
                  CloneFlags groupFlags = DefaultCloneFlags) const;

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -20,6 +20,7 @@
 #define KEEPASSX_EDITENTRYWIDGET_H
 
 #include <QButtonGroup>
+#include <QCompleter>
 #include <QModelIndex>
 #include <QPointer>
 #include <QScopedPointer>
@@ -175,6 +176,8 @@ private:
     AutoTypeAssociationsModel* const m_autoTypeAssocModel;
     QButtonGroup* const m_autoTypeDefaultSequenceGroup;
     QButtonGroup* const m_autoTypeWindowSequenceGroup;
+    QCompleter* const m_usernameCompleter;
+    QStringListModel* const m_usernameCompleterModel;
 
     Q_DISABLE_COPY(EditEntryWidget)
 };

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -164,7 +164,7 @@
     <widget class="QLineEdit" name="titleEdit"/>
    </item>
    <item row="1" column="1">
-    <widget class="QLineEdit" name="usernameEdit"/>
+    <widget class="QComboBox" name="usernameComboBox"/>
    </item>
    <item row="7" column="0" alignment="Qt::AlignRight">
     <widget class="QCheckBox" name="expireCheck">
@@ -191,7 +191,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>titleEdit</tabstop>
-  <tabstop>usernameEdit</tabstop>
+  <tabstop>usernameComboBox</tabstop>
   <tabstop>passwordEdit</tabstop>
   <tabstop>passwordRepeatEdit</tabstop>
   <tabstop>togglePasswordButton</tabstop>

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -1181,3 +1181,29 @@ void TestGroup::testApplyGroupIconRecursively()
     QVERIFY(subsubgroup->iconNumber() == iconForGroups);
     QVERIFY(subsubgroupEntry->iconNumber() == iconForEntries);
 }
+
+void TestGroup::testUsernamesRecursive()
+{
+    Database* database = new Database();
+
+    // Create a subgroup
+    Group* subgroup = new Group();
+    subgroup->setName("Subgroup");
+    subgroup->setParent(database->rootGroup());
+
+    // Generate entries in the root group and the subgroup
+    Entry* rootGroupEntry = database->rootGroup()->addEntryWithPath("Root group entry");
+    rootGroupEntry->setUsername("Name1");
+
+    Entry* subgroupEntry = subgroup->addEntryWithPath("Subgroup entry");
+    subgroupEntry->setUsername("Name2");
+
+    Entry* subgroupEntryReusingUsername = subgroup->addEntryWithPath("Another subgroup entry");
+    subgroupEntryReusingUsername->setUsername("Name2");
+
+    QList<QString> usernames = database->rootGroup()->usernamesRecursive();
+    QCOMPARE(usernames.size(), 2);
+    QVERIFY(usernames.contains("Name1"));
+    QVERIFY(usernames.contains("Name2"));
+    QVERIFY(usernames.indexOf("Name2") < usernames.indexOf("Name1"));
+}

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -48,6 +48,7 @@ private slots:
     void testChildrenSort();
     void testHierarchy();
     void testApplyGroupIconRecursively();
+    void testUsernamesRecursive();
 };
 
 #endif // KEEPASSX_TESTGROUP_H

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -507,7 +507,7 @@ void TestGui::testEditEntry()
     QVERIFY(okButton);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
     titleEdit->setText("multiline\ntitle");
-    editEntryWidget->findChild<QLineEdit*>("usernameEdit")->setText("multiline\nusername");
+    editEntryWidget->findChild<QComboBox*>("usernameComboBox")->lineEdit()->setText("multiline\nusername");
     editEntryWidget->findChild<QLineEdit*>("passwordEdit")->setText("multiline\npassword");
     editEntryWidget->findChild<QLineEdit*>("passwordRepeatEdit")->setText("multiline\npassword");
     editEntryWidget->findChild<QLineEdit*>("urlEdit")->setText("multiline\nurl");
@@ -594,6 +594,10 @@ void TestGui::testAddEntry()
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
     auto* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
     QTest::keyClicks(titleEdit, "test");
+    auto* usernameComboBox = editEntryWidget->findChild<QComboBox*>("usernameComboBox");
+    QVERIFY(usernameComboBox);
+    QTest::mouseClick(usernameComboBox, Qt::LeftButton);
+    QTest::keyClicks(usernameComboBox, "AutocompletionUsername");
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
 
@@ -602,16 +606,30 @@ void TestGui::testAddEntry()
     Entry* entry = entryView->entryFromIndex(item);
 
     QCOMPARE(entry->title(), QString("test"));
+    QCOMPARE(entry->username(), QString("AutocompletionUsername"));
     QCOMPARE(entry->historyItems().size(), 0);
+
+    m_db->updateCommonUsernames();
 
     // Add entry "something 2"
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
     QTest::keyClicks(titleEdit, "something 2");
+    QTest::mouseClick(usernameComboBox, Qt::LeftButton);
+    QTest::keyClicks(usernameComboBox, "Auto");
+    QTest::keyPress(usernameComboBox, Qt::Key_Right);
     auto* passwordEdit = editEntryWidget->findChild<QLineEdit*>("passwordEdit");
     auto* passwordRepeatEdit = editEntryWidget->findChild<QLineEdit*>("passwordRepeatEdit");
     QTest::keyClicks(passwordEdit, "something 2");
     QTest::keyClicks(passwordRepeatEdit, "something 2");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
+    item = entryView->model()->index(1, 1);
+    entry = entryView->entryFromIndex(item);
+
+    QCOMPARE(entry->title(), QString("something 2"));
+    QCOMPARE(entry->username(), QString("AutocompletionUsername"));
+    QCOMPARE(entry->historyItems().size(), 0);
 
     // Add entry "something 5" but click cancel button (does NOT add entry)
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
@@ -1063,8 +1081,8 @@ void TestGui::testEntryPlaceholders()
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
     auto* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
     QTest::keyClicks(titleEdit, "test");
-    QLineEdit* usernameEdit = editEntryWidget->findChild<QLineEdit*>("usernameEdit");
-    QTest::keyClicks(usernameEdit, "john");
+    QComboBox* usernameComboBox = editEntryWidget->findChild<QComboBox*>("usernameComboBox");
+    QTest::keyClicks(usernameComboBox, "john");
     QLineEdit* urlEdit = editEntryWidget->findChild<QLineEdit*>("urlEdit");
     QTest::keyClicks(urlEdit, "{TITLE}.{USERNAME}");
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");


### PR DESCRIPTION
Fixes #3126

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
Autocompletion of usernames. 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Each time the EditEntryWidget opens, a set of existing usernames in the database is retrieved. If the user begins to enter a username, suggestions based on this set are made.

In case of a really large database, the current implementation would lead to a longer loading time of the EditEntryWidget. In this case, the user can disable autocompletion in the settings. Autocompletion in a database with 1000 entries had no noticeable effect on loading time.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![Screenshot from 2019-06-21 17-53-34](https://user-images.githubusercontent.com/51851447/59935225-a5689d00-944d-11e9-8480-1156b3b7036f.png)
![Screenshot from 2019-06-21 18-01-56](https://user-images.githubusercontent.com/51851447/59935717-b4038400-944e-11e9-9953-0381bacef9f1.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

1. Created a new test in TestGroup which tests a new method for retrieving the set of usernames in the database
2. Extended the existing testAddEntry test to make use of the autocompletion
3. Created a database with 1000 entries to check if the "New Entry" widget needs more time to load (not noticeable)

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.

## Annotations
The retrieving of existing usernames could be done in a different thread if large databases are a common use case.

If I set UsernameAutocompletion to false in testAddEntry from TestGui, the test still runs successfully. Normally, the test should fail now because of the missing autocompletion. The changed option seems to be ignored. Am I doing it wrong? The option seems to work as intended when tested manually.

(I also removed a duplicate `m_defaults.insert("UseGroupIconOnEntryCreation", false);` in Config.cpp.)