### PR TITLE
FIX: Password generator skips special characters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 - Move notes to General tab on Group Preview Panel [#3336]
 - Add 'Monospaced font' option to the Notes field [#3321]
 - Drop to background when copy feature [#3253]
+- Fix password generator issues with special characters [#3303]
 
 2.4.3 (2019-06-12)
 =========================

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -92,11 +92,16 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     }
 
     loadSettings();
-    reset();
 }
 
 PasswordGeneratorWidget::~PasswordGeneratorWidget()
 {
+}
+
+void PasswordGeneratorWidget::showEvent(QShowEvent* event)
+{
+    QWidget::showEvent(event);
+    reset();
 }
 
 void PasswordGeneratorWidget::loadSettings()
@@ -107,6 +112,8 @@ void PasswordGeneratorWidget::loadSettings()
     m_ui->checkBoxUpper->setChecked(config()->get("generator/UpperCase", PasswordGenerator::DefaultUpper).toBool());
     m_ui->checkBoxUpperAdv->setChecked(config()->get("generator/UpperCase", PasswordGenerator::DefaultUpper).toBool());
     m_ui->checkBoxNumbers->setChecked(config()->get("generator/Numbers", PasswordGenerator::DefaultNumbers).toBool());
+    m_ui->checkBoxSpecialChars->setChecked(
+        config()->get("generator/SpecialChars", PasswordGenerator::DefaultSpecial).toBool());
     m_ui->checkBoxNumbersAdv->setChecked(
         config()->get("generator/Numbers", PasswordGenerator::DefaultNumbers).toBool());
     m_ui->advancedBar->setVisible(
@@ -119,6 +126,7 @@ void PasswordGeneratorWidget::loadSettings()
         config()->get("generator/AdvancedMode", PasswordGenerator::DefaultAdvancedMode).toBool());
     m_ui->editExcludedChars->setText(
         config()->get("generator/ExcludedChars", PasswordGenerator::DefaultExcludedChars).toString());
+
     m_ui->simpleBar->setVisible(
         !(config()->get("generator/AdvancedMode", PasswordGenerator::DefaultAdvancedMode).toBool()));
     m_ui->checkBoxBraces->setChecked(config()->get("generator/Braces", PasswordGenerator::DefaultBraces).toBool());
@@ -164,6 +172,7 @@ void PasswordGeneratorWidget::saveSettings()
         config()->set("generator/Numbers", m_ui->checkBoxNumbersAdv->isChecked());
         config()->set("generator/EASCII", m_ui->checkBoxExtASCIIAdv->isChecked());
     }
+    config()->set("generator/AdvancedMode", m_ui->advancedBar->isVisible());
     config()->set("generator/SpecialChars", m_ui->checkBoxSpecialChars->isChecked());
     config()->set("generator/Braces", m_ui->checkBoxBraces->isChecked());
     config()->set("generator/Punctuation", m_ui->checkBoxPunctuation->isChecked());
@@ -406,7 +415,6 @@ PasswordGenerator::CharClasses PasswordGeneratorWidget::charClasses()
     PasswordGenerator::CharClasses classes;
 
     if (m_ui->simpleBar->isVisible()) {
-
         if (m_ui->checkBoxLower->isChecked()) {
             classes |= PasswordGenerator::LowerLetters;
         }
@@ -426,9 +434,7 @@ PasswordGenerator::CharClasses PasswordGeneratorWidget::charClasses()
         if (m_ui->checkBoxExtASCII->isChecked()) {
             classes |= PasswordGenerator::EASCII;
         }
-
     } else {
-
         if (m_ui->checkBoxLowerAdv->isChecked()) {
             classes |= PasswordGenerator::LowerLetters;
         }

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -53,6 +53,9 @@ public:
     QString getGeneratedPassword();
     bool isPasswordVisible() const;
 
+protected:
+    void showEvent(QShowEvent* event) override;
+
 public slots:
     void regeneratePassword();
     void applyPassword();


### PR DESCRIPTION

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes #3064
Fixes #2749 
This issue was introduced by https://github.com/keepassxreboot/keepassxc/pull/1841. I found three problems with the code:
- Even though the `generator/SpecialChars` setting was saved properly, it was never loaded.
- The `generator/AdvancedMode` setting was never saved.
- The code that initializes the password generation options uses the `isVisible` method of a UI component to decide which initial character sets to include. When this code first runs (on application startup), the UI is not ready yet at all, therefore the correct code path never runs. Any subsequent action on the UI invokes this code again (this time the visibility check runs correctly), which fixes all settings, as reported in both issues.

I added both settings to the appropriate load/save functions. I also moved the password generator initialization logic to the proper event handler from the constructor.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
- Tested manually against the bugs reported in #3064 and #2479.
- Checked config file to verify that the `generator/SpecialChars` and `generator\AdvancedMode` setting is saved and loaded correctly.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

