### PR TITLE
Use secure input entry to hide passwords from event taps on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -305,7 +305,7 @@ if(WITH_XC_KEESHARE)
 endif()
 
 if(APPLE)
-    target_link_libraries(keepassx_core "-framework Foundation -framework AppKit")
+    target_link_libraries(keepassx_core "-framework Foundation -framework AppKit -framework Carbon")
     if(Qt5MacExtras_FOUND)
         target_link_libraries(keepassx_core Qt5::MacExtras)
     endif()

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -54,7 +54,7 @@ void PasswordEdit::setShowPassword(bool show)
 {
     setEchoMode(show ? QLineEdit::Normal : QLineEdit::Password);
     if (hasFocus()) {
-        mac_secure_keyboard(!show);
+        secureInputEntry(!show);
     }
     // if I have a parent, I'm the child
     if (m_basePasswordEdit) {
@@ -109,7 +109,7 @@ void PasswordEdit::autocompletePassword(const QString& password)
     }
 }
 
-void PasswordEdit::mac_secure_keyboard(bool b)
+void PasswordEdit::secureInputEntry(bool b)
 {
     static bool secure = false;
     if (b != secure){
@@ -119,11 +119,11 @@ void PasswordEdit::mac_secure_keyboard(bool b)
 }
 
 void PasswordEdit::focusInEvent(QFocusEvent* e) {
-    mac_secure_keyboard(echoMode() == QLineEdit::Password);
+    secureInputEntry(echoMode() == QLineEdit::Password);
     QLineEdit::focusInEvent(e);
 }
 
 void PasswordEdit::focusOutEvent(QFocusEvent* e) {
-    mac_secure_keyboard(false);
+    secureInputEntry(false);
     QLineEdit::focusOutEvent(e);
 }

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -125,6 +125,10 @@ void PasswordEdit::autocompletePassword(const QString& password)
  * See the Apple Technical Note 2150:
  * https://developer.apple.com/library/archive/technotes/tn2150/_index.html
  *
+ * This functionality was adapted from the following Qt 4.8 source files:
+ *     src/gui/kernel/qkeymapper_mac.cpp
+ *     src/gui/widgets/qlineedit.cpp
+ *
  * @param enabled Status to set secure input entry to
  */
 void PasswordEdit::secureInputEntry(bool enabled)

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -111,11 +111,13 @@ void PasswordEdit::autocompletePassword(const QString& password)
 
 void PasswordEdit::secureInputEntry(bool b)
 {
+#ifdef Q_OS_MACOS
     static bool secure = false;
     if (b != secure){
         b ? EnableSecureEventInput() : DisableSecureEventInput();
         secure = b;
     }
+#endif
 }
 
 void PasswordEdit::focusInEvent(QFocusEvent* e) {

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -117,6 +117,8 @@ void PasswordEdit::secureInputEntry(bool b)
         b ? EnableSecureEventInput() : DisableSecureEventInput();
         secure = b;
     }
+#else
+    Q_UNUSED(b);
 #endif
 }
 

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -60,7 +60,7 @@ void PasswordEdit::setShowPassword(bool show)
     setEchoMode(show ? QLineEdit::Normal : QLineEdit::Password);
     // if the password is supposed to be hidden, hide it from event taps as well
     if (hasFocus()) {
-        secureInputEntry(!show);
+        setSecureEventInput(!show);
     }
     // if I have a parent, I'm the child
     if (m_basePasswordEdit) {
@@ -129,30 +129,30 @@ void PasswordEdit::autocompletePassword(const QString& password)
  *     src/gui/kernel/qkeymapper_mac.cpp
  *     src/gui/widgets/qlineedit.cpp
  *
- * @param enabled Status to set secure input entry to
+ * @param state Status to set secure input entry to
  */
-void PasswordEdit::secureInputEntry(bool enabled)
+void PasswordEdit::setSecureEventInput(bool state)
 {
 #ifdef Q_OS_MACOS
     // are we currently in secure input entry mode?
     static bool secure = false;
-    if (enabled != secure) {
-        enabled ? EnableSecureEventInput() : DisableSecureEventInput();
-        secure = enabled;
+    if (state != secure) {
+        state ? EnableSecureEventInput() : DisableSecureEventInput();
+        secure = state;
     }
 #else
     // mark the boolean as unused to avoid -Wunused-parameter warning
-    Q_UNUSED(enabled);
+    Q_UNUSED(state);
 #endif
 }
 
 void PasswordEdit::focusInEvent(QFocusEvent* event) {
     // if the password is supposed to be hidden, hide it from event taps as well
-    secureInputEntry(echoMode() == QLineEdit::Password);
+    setSecureEventInput(echoMode() == QLineEdit::Password);
     QLineEdit::focusInEvent(event);
 }
 
 void PasswordEdit::focusOutEvent(QFocusEvent* event) {
-    secureInputEntry(false);
+    setSecureEventInput(false);
     QLineEdit::focusOutEvent(event);
 }

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -125,30 +125,30 @@ void PasswordEdit::autocompletePassword(const QString& password)
  * See the Apple Technical Note 2150:
  * https://developer.apple.com/library/archive/technotes/tn2150/_index.html
  *
- * @param b Status to set secure input entry to
+ * @param enabled Status to set secure input entry to
  */
-void PasswordEdit::secureInputEntry(bool b)
+void PasswordEdit::secureInputEntry(bool enabled)
 {
 #ifdef Q_OS_MACOS
     // are we currently in secure input entry mode?
     static bool secure = false;
-    if (b != secure) {
-        b ? EnableSecureEventInput() : DisableSecureEventInput();
-        secure = b;
+    if (enabled != secure) {
+        enabled ? EnableSecureEventInput() : DisableSecureEventInput();
+        secure = enabled;
     }
 #else
     // mark the boolean as unused to avoid -Wunused-parameter warning
-    Q_UNUSED(b);
+    Q_UNUSED(enabled);
 #endif
 }
 
-void PasswordEdit::focusInEvent(QFocusEvent* e) {
+void PasswordEdit::focusInEvent(QFocusEvent* event) {
     // if the password is supposed to be hidden, hide it from event taps as well
     secureInputEntry(echoMode() == QLineEdit::Password);
-    QLineEdit::focusInEvent(e);
+    QLineEdit::focusInEvent(event);
 }
 
-void PasswordEdit::focusOutEvent(QFocusEvent* e) {
+void PasswordEdit::focusOutEvent(QFocusEvent* event) {
     secureInputEntry(false);
-    QLineEdit::focusOutEvent(e);
+    QLineEdit::focusOutEvent(event);
 }

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -53,6 +53,9 @@ void PasswordEdit::enableVerifyMode(PasswordEdit* basePasswordEdit)
 void PasswordEdit::setShowPassword(bool show)
 {
     setEchoMode(show ? QLineEdit::Normal : QLineEdit::Password);
+    if (hasFocus()) {
+        mac_secure_keyboard(!show);
+    }
     // if I have a parent, I'm the child
     if (m_basePasswordEdit) {
         if (config()->get("security/passwordsrepeat").toBool()) {
@@ -104,4 +107,23 @@ void PasswordEdit::autocompletePassword(const QString& password)
     if (config()->get("security/passwordsrepeat").toBool() && echoMode() == QLineEdit::Normal) {
         setText(password);
     }
+}
+
+void PasswordEdit::mac_secure_keyboard(bool b)
+{
+    static bool secure = false;
+    if (b != secure){
+        b ? EnableSecureEventInput() : DisableSecureEventInput();
+        secure = b;
+    }
+}
+
+void PasswordEdit::focusInEvent(QFocusEvent* e) {
+    mac_secure_keyboard(echoMode() == QLineEdit::Password);
+    QLineEdit::focusInEvent(e);
+}
+
+void PasswordEdit::focusOutEvent(QFocusEvent* e) {
+    mac_secure_keyboard(false);
+    QLineEdit::focusOutEvent(e);
 }

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -19,6 +19,7 @@
 #ifndef KEEPASSX_PASSWORDEDIT_H
 #define KEEPASSX_PASSWORDEDIT_H
 
+#include <Carbon/Carbon.h>
 #include <QLineEdit>
 #include <QPointer>
 
@@ -45,9 +46,15 @@ private slots:
     void autocompletePassword(const QString& password);
 
 private:
+    void mac_secure_keyboard(bool b);
     bool passwordsEqual() const;
 
+    bool secure;
     QPointer<PasswordEdit> m_basePasswordEdit;
+
+protected:
+    void focusInEvent(QFocusEvent* e);
+    void focusOutEvent(QFocusEvent* e);
 };
 
 #endif // KEEPASSX_PASSWORDEDIT_H

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -46,7 +46,7 @@ private slots:
     void autocompletePassword(const QString& password);
 
 private:
-    void mac_secure_keyboard(bool b);
+    void secureInputEntry(bool b);
     bool passwordsEqual() const;
 
     QPointer<PasswordEdit> m_basePasswordEdit;

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -19,9 +19,6 @@
 #ifndef KEEPASSX_PASSWORDEDIT_H
 #define KEEPASSX_PASSWORDEDIT_H
 
-#ifdef Q_OS_MACOS
-#include <Carbon/Carbon.h>
-#endif
 #include <QLineEdit>
 #include <QPointer>
 

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -19,7 +19,9 @@
 #ifndef KEEPASSX_PASSWORDEDIT_H
 #define KEEPASSX_PASSWORDEDIT_H
 
+#ifdef Q_OS_MACOS
 #include <Carbon/Carbon.h>
+#endif
 #include <QLineEdit>
 #include <QPointer>
 

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -49,7 +49,6 @@ private:
     void mac_secure_keyboard(bool b);
     bool passwordsEqual() const;
 
-    bool secure;
     QPointer<PasswordEdit> m_basePasswordEdit;
 
 protected:

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -44,15 +44,15 @@ private slots:
     void updateStylesheet();
     void autocompletePassword(const QString& password);
 
-private:
-    void secureInputEntry(bool enabled);
-    bool passwordsEqual() const;
-
-    QPointer<PasswordEdit> m_basePasswordEdit;
-
 protected:
     void focusInEvent(QFocusEvent* event);
     void focusOutEvent(QFocusEvent* event);
+
+private:
+    void setSecureEventInput(bool state);
+    bool passwordsEqual() const;
+
+    QPointer<PasswordEdit> m_basePasswordEdit;
 };
 
 #endif // KEEPASSX_PASSWORDEDIT_H

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -45,14 +45,14 @@ private slots:
     void autocompletePassword(const QString& password);
 
 private:
-    void secureInputEntry(bool b);
+    void secureInputEntry(bool enabled);
     bool passwordsEqual() const;
 
     QPointer<PasswordEdit> m_basePasswordEdit;
 
 protected:
-    void focusInEvent(QFocusEvent* e);
-    void focusOutEvent(QFocusEvent* e);
+    void focusInEvent(QFocusEvent* event);
+    void focusOutEvent(QFocusEvent* event);
 };
 
 #endif // KEEPASSX_PASSWORDEDIT_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

Fixes #3307

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

This change fixes #3307, by calling the Carbon APIs to enter and exit secure input entry when the user focuses and stops focusing on a `PasswordEdit` field which is not "visible". Visible password boxes are not affected.

This PR draws very heavily from similar functionality in Qt 4, which is licensed under GPL 2/3 so is compatible with KeePassXC licensing.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

N/A

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

This is very hard to test. I couldn't figure out how to create a regression test. Please help.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
