### PR TITLE
HTML Export (aka Paper Backup)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ set(keepassx_SOURCES
         crypto/kdf/AesKdf.cpp
         crypto/kdf/Argon2Kdf.cpp
         format/CsvExporter.cpp
+        format/HtmlExporter.cpp
         format/KeePass1Reader.cpp
         format/KeePass2.cpp
         format/KeePass2RandomStream.cpp

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -257,9 +257,9 @@ Entry* Group::lastTopVisibleEntry() const
     return m_lastTopVisibleEntry;
 }
 
-bool Group::isRecycled()
+bool Group::isRecycled() const
 {
-    Group* group = this;
+    auto group = this;
     if (!group->database()) {
         return false;
     }

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -102,7 +102,7 @@ public:
     bool resolveAutoTypeEnabled() const;
     Entry* lastTopVisibleEntry() const;
     bool isExpired() const;
-    bool isRecycled();
+    bool isRecycled() const;
     CustomData* customData();
     const CustomData* customData() const;
 

--- a/src/format/HtmlExporter.cpp
+++ b/src/format/HtmlExporter.cpp
@@ -1,0 +1,253 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "HtmlExporter.h"
+
+#include <QBuffer>
+#include <QFile>
+
+#include "core/Database.h"
+#include "core/Group.h"
+#include "core/Metadata.h"
+
+namespace
+{
+    QString PixmapToHTML(const QPixmap& pixmap)
+    {
+        if (pixmap.isNull())
+            return "";
+
+        // Based on https://stackoverflow.com/a/6621278
+        QByteArray a;
+        QBuffer buffer(&a);
+        pixmap.save(&buffer, "PNG");
+        return QString("<img src=\"data:image/png;base64,") + a.toBase64() + "\"/>";
+    }
+} // namespace
+
+bool HtmlExporter::exportDatabase(const QString& filename, const QSharedPointer<const Database>& db)
+{
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        m_error = file.errorString();
+        return false;
+    }
+    return exportDatabase(&file, db);
+}
+
+QString HtmlExporter::errorString() const
+{
+    return m_error;
+}
+
+bool HtmlExporter::exportDatabase(QIODevice* device, const QSharedPointer<const Database>& db)
+{
+    const auto meta = db->metadata();
+    if (!meta) {
+        m_error = "Internal error: metadata is NULL";
+        return false;
+    }
+
+    const auto header = QString("<html>"
+                                "<head>"
+                                "<meta charset=\"UTF-8\">"
+                                "<title>"
+                                + meta->name().toHtmlEscaped()
+                                + "</title>"
+                                  "<style>"
+                                  "body "
+                                  "{ font-family: \"Open Sans\", Helvetica, Arial, sans-serif; }"
+                                  "h3 "
+                                  "{ margin-left: 2em; }"
+                                  "table "
+                                  "{ margin-left: 4em; } "
+                                  "th, td "
+                                  "{ text-align: left; vertical-align: top; padding: 1px; }"
+                                  "th "
+                                  "{ min-width: 5em; } "
+                                  ".username, .password, .url, .attr "
+                                  "{ font-size: larger; font-family: monospace; } "
+                                  ".notes "
+                                  "{ font-size: medium; } "
+                                  "@media print {"
+                                  ".entry"
+                                  "{ page-break-inside: avoid; } "
+                                  "}"
+                                  "</style>"
+                                  "</head>\n"
+                                  "<body>"
+                                  "<h1>"
+                                + meta->name().toHtmlEscaped()
+                                + "</h1>"
+                                  "<p>"
+                                + meta->description().toHtmlEscaped().replace("\n", "<br>")
+                                + "</p>"
+                                  "<p><code>"
+                                + db->filePath().toHtmlEscaped() + "</code></p>");
+    const auto footer = QString("</body>"
+                                "</html>");
+
+    if (device->write(header.toUtf8()) == -1) {
+        m_error = device->errorString();
+        return false;
+    }
+
+    if (db->rootGroup()) {
+        if (!writeGroup(*device, *db->rootGroup())) {
+            return false;
+        }
+    }
+
+    if (device->write(footer.toUtf8()) == -1) {
+        m_error = device->errorString();
+        return false;
+    }
+
+    return true;
+}
+
+bool HtmlExporter::writeGroup(QIODevice& device, const Group& group, QString path)
+{
+    // Don't output the recycle bin
+    if (&group == group.database()->metadata()->recycleBin()) {
+        return true;
+    }
+
+    if (!path.isEmpty()) {
+        path.append(" &rarr; ");
+    }
+    path.append(group.name().toHtmlEscaped());
+
+    // Output the header for this group (but only if there are
+    // any notes or  entries in this group, otherwise we'd get
+    // a header with nothing after it, which looks stupid)
+    const auto& entries = group.entries();
+    const auto notes = group.notes();
+    if (!entries.empty() || !notes.isEmpty()) {
+
+        // Header line
+        auto header = QString("<hr><h2>");
+        header.append(PixmapToHTML(group.iconScaledPixmap()));
+        header.append("&nbsp;");
+        header.append(path);
+        header.append("</h2>\n");
+
+        // Group notes
+        if (!notes.isEmpty()) {
+            header.append("<p>");
+            header.append(notes.toHtmlEscaped().replace("\n", "<br>"));
+            header.append("</p>");
+        }
+
+        // Output it
+        if (device.write(header.toUtf8()) == -1) {
+            m_error = device.errorString();
+            return false;
+        }
+    }
+
+    // Output the entries in this  group
+    for (const auto entry : entries) {
+        auto item = QString("<div class=\"entry\"><h3>");
+
+        // Begin formatting this item into HTML
+        item.append(PixmapToHTML(entry->iconScaledPixmap()));
+        item.append("&nbsp;");
+        item.append(entry->title().toHtmlEscaped());
+        item.append("</h3>\n"
+                    "<table>");
+
+        // Output the fixed fields
+        const auto& u = entry->username();
+        if (!u.isEmpty()) {
+            item.append("<tr><th>");
+            item.append(QObject::tr("User name"));
+            item.append("</t><td class=\"username\">");
+            item.append(entry->username().toHtmlEscaped());
+            item.append("</td></tr>");
+        }
+
+        const auto& p = entry->password();
+        if (!p.isEmpty()) {
+            item.append("<tr><th>");
+            item.append(QObject::tr("Password"));
+            item.append("</th><td class=\"password\">");
+            item.append(entry->password().toHtmlEscaped());
+            item.append("</td></tr>");
+        }
+
+        const auto& r = entry->url();
+        if (!r.isEmpty()) {
+            item.append("<tr><th>");
+            item.append(QObject::tr("URL"));
+            item.append("</th><td class=\"url\"><a href=\"");
+            item.append(r.toHtmlEscaped());
+            item.append("\">");
+
+            // Restrict the length of what we display of the URL -
+            // even from a paper backup, nobody will every type in
+            // more than 100 characters of a URL
+            constexpr auto maxlen = 100;
+            if (r.size() <= maxlen) {
+                item.append(r.toHtmlEscaped());
+            } else {
+                item.append(r.mid(0, maxlen).toHtmlEscaped());
+                item.append("&hellip;");
+            }
+
+            item.append("</a></td></tr>");
+        }
+
+        const auto& n = entry->notes();
+        if (!n.isEmpty()) {
+            item.append("<tr><th>");
+            item.append(QObject::tr("Notes"));
+            item.append("</th><td class=\"notes\">");
+            item.append(entry->notes().toHtmlEscaped().replace("\n", "<br>"));
+            item.append("</td></tr>");
+        }
+
+        // Now add the attributes (if there are any)
+        const auto* const attr = entry->attributes();
+        if (attr && !attr->customKeys().isEmpty()) {
+            for (const auto& key : attr->customKeys()) {
+                item.append("<tr><th>");
+                item.append(key.toHtmlEscaped());
+                item.append("</th><td class=\"attr\">");
+                item.append(attr->value(key).toHtmlEscaped().replace("\n", "<br>"));
+                item.append("</td></tr>");
+            }
+        }
+
+        // Done with this entry
+        item.append("</table></div>\n");
+        if (device.write(item.toUtf8()) == -1) {
+            m_error = device.errorString();
+            return false;
+        }
+    }
+
+    // Recursively output the child groups
+    const auto& children = group.children();
+    for (const auto child : children) {
+        if (child && !writeGroup(device, *child, path)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/format/HtmlExporter.h
+++ b/src/format/HtmlExporter.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_HTMLEXPORTER_H
+#define KEEPASSX_HTMLEXPORTER_H
+
+#include <QSharedPointer>
+#include <QString>
+
+class Database;
+class Group;
+class QIODevice;
+
+class HtmlExporter
+{
+public:
+    bool exportDatabase(const QString& filename, const QSharedPointer<const Database>& db);
+    QString errorString() const;
+
+private:
+    bool exportDatabase(QIODevice* device, const QSharedPointer<const Database>& db);
+    bool writeGroup(QIODevice& device, const Group& group, QString path = QString());
+
+    QString m_error;
+};
+
+#endif // KEEPASSX_HTMLEXPORTER_H

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -30,6 +30,7 @@
 #include "core/Metadata.h"
 #include "core/Tools.h"
 #include "format/CsvExporter.h"
+#include "format/HtmlExporter.h"
 #include "gui/Clipboard.h"
 #include "gui/DatabaseOpenDialog.h"
 #include "gui/DatabaseWidget.h"
@@ -398,6 +399,32 @@ void DatabaseTabWidget::exportToCsv()
     CsvExporter csvExporter;
     if (!csvExporter.exportDatabase(fileName, db)) {
         emit messageGlobal(tr("Writing the CSV file failed.").append("\n").append(csvExporter.errorString()),
+                           MessageWidget::Error);
+    }
+}
+
+void DatabaseTabWidget::exportToHtml()
+{
+    auto db = databaseWidgetFromIndex(currentIndex())->database();
+    if (!db) {
+        Q_ASSERT(false);
+        return;
+    }
+
+    QString fileName = fileDialog()->getSaveFileName(this,
+                                                     tr("Export database to HTML file"),
+                                                     QString(),
+                                                     tr("HTML file").append(" (*.html)"),
+                                                     nullptr,
+                                                     nullptr,
+                                                     "html");
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    HtmlExporter htmlExporter;
+    if (!htmlExporter.exportDatabase(fileName, db)) {
+        emit messageGlobal(tr("Writing the HTML file failed.").append("\n").append(htmlExporter.errorString()),
                            MessageWidget::Error);
     }
 }

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -390,6 +390,10 @@ void DatabaseTabWidget::exportToCsv()
         return;
     }
 
+    if (!warnOnExport()) {
+        return;
+    }
+
     QString fileName = fileDialog()->getSaveFileName(
         this, tr("Export database to CSV file"), QString(), tr("CSV file").append(" (*.csv)"), nullptr, nullptr, "csv");
     if (fileName.isEmpty()) {
@@ -411,6 +415,10 @@ void DatabaseTabWidget::exportToHtml()
         return;
     }
 
+    if (!warnOnExport()) {
+        return;
+    }
+
     QString fileName = fileDialog()->getSaveFileName(this,
                                                      tr("Export database to HTML file"),
                                                      QString(),
@@ -427,6 +435,18 @@ void DatabaseTabWidget::exportToHtml()
         emit messageGlobal(tr("Writing the HTML file failed.").append("\n").append(htmlExporter.errorString()),
                            MessageWidget::Error);
     }
+}
+
+bool DatabaseTabWidget::warnOnExport()
+{
+    auto ans =
+        MessageBox::question(this,
+                             tr("Export Confirmation"),
+                             tr("You are about to export your database to an unencrypted file. This will leave your "
+                                "passwords and sensitive information vulnerable! Are you sure you want to continue?"),
+                             MessageBox::Yes | MessageBox::No,
+                             MessageBox::No);
+    return ans == MessageBox::Yes;
 }
 
 void DatabaseTabWidget::changeMasterKey()

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -99,6 +99,7 @@ private slots:
 private:
     QSharedPointer<Database> execNewDatabaseWizard();
     void updateLastDatabases(const QString& filename);
+    bool warnOnExport();
 
     QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
     QPointer<DatabaseWidget> m_dbWidgetPendingLock;

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -69,6 +69,7 @@ public slots:
     bool saveDatabase(int index = -1);
     bool saveDatabaseAs(int index = -1);
     void exportToCsv();
+    void exportToHtml();
 
     void lockDatabases();
     void closeDatabaseFromSender();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -355,6 +355,7 @@ MainWindow::MainWindow()
     connect(m_ui->actionImportKeePass1, SIGNAL(triggered()), m_ui->tabWidget, SLOT(importKeePass1Database()));
     connect(m_ui->actionImportOpVault, SIGNAL(triggered()), m_ui->tabWidget, SLOT(importOpVaultDatabase()));
     connect(m_ui->actionExportCsv, SIGNAL(triggered()), m_ui->tabWidget, SLOT(exportToCsv()));
+    connect(m_ui->actionExportHtml, SIGNAL(triggered()), m_ui->tabWidget, SLOT(exportToHtml()));
     connect(m_ui->actionLockDatabases, SIGNAL(triggered()), m_ui->tabWidget, SLOT(lockDatabases()));
     connect(m_ui->actionQuit, SIGNAL(triggered()), SLOT(appExit()));
 
@@ -606,7 +607,9 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->actionChangeDatabaseSettings->setEnabled(true);
             m_ui->actionDatabaseSave->setEnabled(m_ui->tabWidget->canSave());
             m_ui->actionDatabaseSaveAs->setEnabled(true);
+            m_ui->menuExport->setEnabled(true);
             m_ui->actionExportCsv->setEnabled(true);
+            m_ui->actionExportHtml->setEnabled(true);
             m_ui->actionDatabaseMerge->setEnabled(m_ui->tabWidget->currentIndex() != -1);
 
             m_searchWidgetAction->setEnabled(true);
@@ -630,7 +633,9 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->actionChangeDatabaseSettings->setEnabled(false);
             m_ui->actionDatabaseSave->setEnabled(false);
             m_ui->actionDatabaseSaveAs->setEnabled(false);
+            m_ui->menuExport->setEnabled(false);
             m_ui->actionExportCsv->setEnabled(false);
+            m_ui->actionExportHtml->setEnabled(false);
             m_ui->actionDatabaseMerge->setEnabled(false);
 
             m_searchWidgetAction->setEnabled(false);
@@ -656,7 +661,9 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
         m_ui->actionDatabaseSave->setEnabled(false);
         m_ui->actionDatabaseSaveAs->setEnabled(false);
         m_ui->actionDatabaseClose->setEnabled(false);
+        m_ui->menuExport->setEnabled(false);
         m_ui->actionExportCsv->setEnabled(false);
+        m_ui->actionExportHtml->setEnabled(false);
         m_ui->actionDatabaseMerge->setEnabled(false);
 
         m_searchWidgetAction->setEnabled(false);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -203,6 +203,13 @@
      <addaction name="actionImportOpVault"/>
      <addaction name="actionImportCsv"/>
     </widget>
+    <widget class="QMenu" name="menuExport">
+     <property name="title">
+      <string>&amp;Export</string>
+     </property>
+     <addaction name="actionExportCsv"/>
+     <addaction name="actionExportHtml"/>
+    </widget>
     <addaction name="actionDatabaseNew"/>
     <addaction name="actionDatabaseOpen"/>
     <addaction name="menuRecentDatabases"/>
@@ -215,7 +222,7 @@
     <addaction name="separator"/>
     <addaction name="actionDatabaseMerge"/>
     <addaction name="menuImport"/>
-    <addaction name="actionExportCsv"/>
+    <addaction name="menuExport"/>
     <addaction name="separator"/>
     <addaction name="actionQuit"/>
    </widget>
@@ -618,6 +625,14 @@
    </property>
    <property name="text">
     <string>&amp;Export to CSV file...</string>
+   </property>
+  </action>
+  <action name="actionExportHtml">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Export to HTML file...</string>
    </property>
   </action>
   <action name="actionImportKeePass1">


### PR DESCRIPTION
## Type of change

- ✅ New feature (non-breaking change which adds functionality)

## Description and Context

For users who want to back up their password database to paper, this feature
adds a "HTML Export" feature which creates a self-contained HTML with the
complete password database (all groups, all entries, all attributes, etc.), in
order to be printed using the web browser. I use to print using "4 pages per
sheet" mode which saves paper and is still not too small to be readable.

HTML Export is in menu "Database -> Export". This new menu also contains
"Export to CSV file" which existed before directly in the "Database" menu; I
moved it into the new "Database -> Export" menu for symmetry reasons
(since we already have "Database -> Import").

NOTE: Don't use this feature unless you trust your browser, printer driver, and printer.

Fixes #3277.

## Screenshots

Screenshot of HTML Export displayed in the Vivaldi browser, using the demo
database from #3294.

![paperbackup](https://user-images.githubusercontent.com/25565229/59978319-8566e400-95db-11e9-97a6-fc5848ff2977.png)

## Testing strategy

Tested manually.

## Checklist:

- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
