### PR TITLE
Add integration with Dissenter browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ so please check out your distribution's package list to see if KeePassXC is avai
 - Using website favicons as entry icons
 - Merging of databases
 - Automatic reload when the database changed on disk
-- Browser integration with KeePassXC-Browser using [native messaging](https://developer.chrome.com/extensions/nativeMessaging) for [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) and [Google Chrome, Chromium, Vivaldi, or Brave](https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk)
+- Browser integration with KeePassXC-Browser using [native messaging](https://developer.chrome.com/extensions/nativeMessaging) for [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/) and [Google Chrome, Chromium, Vivaldi, Brave, or Dissenter](https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk)
 - Synchronize passwords using KeeShare. See [Using Sharing](./docs/QUICKSTART.md#using-sharing) for more details.
 - Many bug fixes
 

--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -632,6 +632,10 @@ Please select the correct database for saving credentials.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Dissenter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Returns expired credentials. String [expired] is added to the title.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -47,7 +47,7 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent)
         tr("KeePassXC-Browser is needed for the browser integration to work. <br />Download it for %1 and %2. %3")
             .arg("<a href=\"https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser/\">Firefox</a>",
                  "<a href=\"https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">"
-                 "Google Chrome / Chromium / Vivaldi / Brave</a>",
+                 "Google Chrome / Chromium / Vivaldi / Brave / Dissenter</a>",
                  snapInstructions));
     // clang-format on
 
@@ -77,9 +77,11 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent)
 #ifdef Q_OS_WIN
     // Brave uses Chrome's registry settings
     m_ui->braveSupport->setHidden(true);
+    // Dissenter uses Chrome's registry settings
+    m_ui->dissenterSupport->setHidden(true);
     // Vivaldi uses Chrome's registry settings
     m_ui->vivaldiSupport->setHidden(true);
-    m_ui->chromeSupport->setText("Chrome, Vivaldi, and Brave");
+    m_ui->chromeSupport->setText("Chrome, Vivaldi, Brave, and Dissenter");
     // Tor Browser uses Firefox's registry settings
     m_ui->torBrowserSupport->setHidden(true);
     m_ui->firefoxSupport->setText("Firefox and Tor Browser");
@@ -126,6 +128,7 @@ void BrowserOptionDialog::loadSettings()
     m_ui->firefoxSupport->setChecked(settings->firefoxSupport());
 #ifndef Q_OS_WIN
     m_ui->braveSupport->setChecked(settings->braveSupport());
+    m_ui->dissenterSupport->setChecked(settings->dissenterSupport());
     m_ui->vivaldiSupport->setChecked(settings->vivaldiSupport());
     m_ui->torBrowserSupport->setChecked(settings->torBrowserSupport());
 #endif
@@ -189,6 +192,7 @@ void BrowserOptionDialog::saveSettings()
     settings->setFirefoxSupport(m_ui->firefoxSupport->isChecked());
 #ifndef Q_OS_WIN
     settings->setBraveSupport(m_ui->braveSupport->isChecked());
+    settings->setDissenterSupport(m_ui->dissenterSupport->isChecked());
     settings->setVivaldiSupport(m_ui->vivaldiSupport->isChecked());
     settings->setTorBrowserSupport(m_ui->torBrowserSupport->isChecked());
 #endif

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -167,6 +167,16 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="3">
+           <widget class="QCheckBox" name="dissenterSupport">
+            <property name="text">
+             <string>&amp;Dissenter</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -259,6 +259,17 @@ void BrowserSettings::setBraveSupport(bool enabled)
         HostInstaller::SupportedBrowsers::BRAVE, enabled, supportBrowserProxy(), customProxyLocation());
 }
 
+bool BrowserSettings::dissenterSupport()
+{
+    return m_hostInstaller.checkIfInstalled(HostInstaller::SupportedBrowsers::DISSENTER);
+}
+
+void BrowserSettings::setDissenterSupport(bool enabled)
+{
+    m_hostInstaller.installBrowser(
+        HostInstaller::SupportedBrowsers::DISSENTER, enabled, supportBrowserProxy(), customProxyLocation());
+}
+
 bool BrowserSettings::torBrowserSupport()
 {
     return m_hostInstaller.checkIfInstalled(HostInstaller::SupportedBrowsers::TOR_BROWSER);

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -76,6 +76,8 @@ public:
     void setVivaldiSupport(bool enabled);
     bool braveSupport();
     void setBraveSupport(bool enabled);
+    bool dissenterSupport();
+    void setDissenterSupport(bool enabled);
     bool torBrowserSupport();
     void setTorBrowserSupport(bool enabled);
 

--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -40,6 +40,7 @@ HostInstaller::HostInstaller()
     , TARGET_DIR_VIVALDI("/Library/Application Support/Vivaldi/NativeMessagingHosts")
     , TARGET_DIR_TOR_BROWSER("/Library/Application Support/TorBrowser-Data/Browser/Mozilla/NativeMessagingHosts")
     , TARGET_DIR_BRAVE("/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts")
+    , TARGET_DIR_DISSENTER("/Library/Application Support/GabAI/Dissenter/NativeMessagingHosts")
 #elif defined(Q_OS_WIN)
     // clang-format off
     , TARGET_DIR_CHROME("HKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser")
@@ -49,6 +50,7 @@ HostInstaller::HostInstaller()
     , TARGET_DIR_VIVALDI(TARGET_DIR_CHROME)
     , TARGET_DIR_TOR_BROWSER(TARGET_DIR_FIREFOX)
     , TARGET_DIR_BRAVE(TARGET_DIR_CHROME)
+    , TARGET_DIR_DISSENTER(TARGET_DIR_CHROME)
 #else
     , TARGET_DIR_CHROME("/.config/google-chrome/NativeMessagingHosts")
     , TARGET_DIR_CHROMIUM("/.config/chromium/NativeMessagingHosts")
@@ -56,6 +58,7 @@ HostInstaller::HostInstaller()
     , TARGET_DIR_VIVALDI("/.config/vivaldi/NativeMessagingHosts")
     , TARGET_DIR_TOR_BROWSER("/.tor-browser/app/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts")
     , TARGET_DIR_BRAVE("/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts")
+    , TARGET_DIR_DISSENTER("/.config/GabAI/Dissenter/NativeMessagingHosts")
 #endif
 {
 }
@@ -172,6 +175,8 @@ QString HostInstaller::getTargetPath(SupportedBrowsers browser) const
         return TARGET_DIR_TOR_BROWSER;
     case SupportedBrowsers::BRAVE:
         return TARGET_DIR_BRAVE;
+    case SupportedBrowsers::DISSENTER:
+        return TARGET_DIR_DISSENTER;
     default:
         return QString();
     }
@@ -199,6 +204,8 @@ QString HostInstaller::getBrowserName(SupportedBrowsers browser) const
         return "tor-browser";
     case SupportedBrowsers::BRAVE:
         return "brave";
+    case SupportedBrowsers::DISSENTER:
+        return "dissenter";
     default:
         return QString();
     }

--- a/src/browser/HostInstaller.h
+++ b/src/browser/HostInstaller.h
@@ -35,7 +35,8 @@ public:
         FIREFOX = 2,
         VIVALDI = 3,
         TOR_BROWSER = 4,
-        BRAVE = 5
+        BRAVE = 5,
+        DISSENTER = 6
     };
 
 public:
@@ -68,6 +69,7 @@ private:
     const QString TARGET_DIR_VIVALDI;
     const QString TARGET_DIR_TOR_BROWSER;
     const QString TARGET_DIR_BRAVE;
+    const QString TARGET_DIR_DISSENTER;
 };
 
 #endif // HOSTINSTALLER_H

--- a/utils/keepassxc-snap-helper.sh
+++ b/utils/keepassxc-snap-helper.sh
@@ -97,6 +97,11 @@ setupBrave() {
     INSTALL_DIR="${BASE_DIR}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
 }
 
+setupDissenter() {
+    buildJson
+    INSTALL_DIR="${BASE_DIR}/.config/GabAI/Dissenter/NativeMessagingHosts"
+}
+
 setupTorBrowser() {
     buildJson "firefox"
     INSTALL_DIR="${BASE_DIR}/.tor-browser/app/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts"
@@ -115,7 +120,8 @@ BROWSER=$(whiptail \
             "3" "Chromium" \
             "4" "Vivaldi" \
             "5" "Brave" \
-            "6" "Tor Browser" \
+            "6" "Dissenter" \
+            "7" "Tor Browser" \
             3>&1 1>&2 2>&3)
 
 clear
@@ -129,7 +135,8 @@ if [ $exitstatus = 0 ]; then
         3) setupChromium ;;
         4) setupVivaldi ;;
         5) setupBrave ;;
-        6) setupTorBrowser ;;
+        6) setupDissenter ;;
+        7) setupTorBrowser ;;
     esac
 
     # Install the JSON file


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation (non-code change)

## Description and Context
This pull requests adds integration for the [Dissenter browser](https://dissenter.com/download) to KeePassXC, so that when the KeePassXC-Browser extension is installed, you can access and auto-fill your passwords while using the browser. Since the browser is based off of Brave (which is itself based off of Chromium), it was pretty simple to add integration. I'm thinking about making another pull request to add Waterfox integration if this one gets merged.

## Screenshots
![image](https://user-images.githubusercontent.com/19592990/59154051-6559f100-8a2f-11e9-839c-b73a30af019f.png)

## Testing strategy
I tested to see if my fork was able to connect to the KeePassXC-Browser extension when using the Dissenter browser. I was able to confirm that the added functionality works on both Linux and Windows 10. It should also work just fine on macOS, though I am unable to test on that platform.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

I built the app on Linux. Four tests (1, 16, 37, and 38), did not pass, but these tests also do not pass on the `develop` branch, so they appear to be either the fault of a prior commit or an issue with a build dependency used by KeePassXC, and not related to this pull request.

LeakSanitizer also detects some memory leaks, but these also occur on the `develop` branch and so appear to be unrelated to this PR.

The latest merged PR as of right now mentions these same issues: https://github.com/keepassxreboot/keepassxc/pull/3236

Also, apparently `release-tool` requires Python to be installed, which was not mentioned in this repo's build instructions.

Aside from the aforementioned issues, I was able to build and use the app on Windows 10 without any problems.

- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.