### PR TITLE
Fix broken build with YubiKey disabled

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -80,7 +80,6 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
 
     connect(m_ui->buttonRedetectYubikey, SIGNAL(clicked()), SLOT(pollYubikey()));
 #else
-    m_ui->checkChallengeResponse->setVisible(false);
     m_ui->buttonRedetectYubikey->setVisible(false);
     m_ui->comboChallengeResponse->setVisible(false);
     m_ui->yubikeyProgress->setVisible(false);


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Remove reference to DatabaseOpenWidget::checkChallengeResponse that was removed in commit #3287.

## Testing strategy
Successfully built KeePassXC with YubiKey disabled.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code ~with `-DWITH_ASAN=ON`~. (it doesn't seem like a one-line removal should require ASAN) **[REQUIRED]**