### PR TITLE
Fix build broken by Qt

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -34,10 +34,10 @@
 
 #include "config-keepassx.h"
 
-#include <QSharedPointer>
-#include <QtConcurrentRun>
 #include <QDesktopServices>
 #include <QFont>
+#include <QSharedPointer>
+#include <QtConcurrentRun>
 
 DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     : DialogyWidget(parent)
@@ -311,8 +311,7 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::databaseKey()
             legacyWarning.setDefaultButton(QMessageBox::Ok);
             legacyWarning.setCheckBox(new QCheckBox(tr("Don't show this warning again")));
 
-            connect(legacyWarning.checkBox(), &QCheckBox::stateChanged, [](int state)
-            {
+            connect(legacyWarning.checkBox(), &QCheckBox::stateChanged, [](int state) {
                 config()->set("Messages/NoLegacyKeyFileWarning", state == Qt::CheckState::Checked);
             });
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -32,6 +32,7 @@
 #include <QSortFilterProxyModel>
 #include <QStackedLayout>
 #include <QStandardPaths>
+#include <QStringListModel>
 #include <QTemporaryFile>
 
 #include "autotype/AutoType.h"

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -41,6 +41,7 @@ class EntryHistoryModel;
 class QButtonGroup;
 class QMenu;
 class QSortFilterProxyModel;
+class QStringListModel;
 #ifdef WITH_XC_SSHAGENT
 #include "sshagent/KeeAgentSettings.h"
 class OpenSSHKey;


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Updating mingw-w64-x86_64-qt5 to version 5.12.4-2 caused EditEntryWidget to fail
building. Fixed that with proper includes. Also ran `make format` which revealed
one file in need of formatting.

## Testing strategy
Got a successful build.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ I have compiled and verified my code ~with `-DWITH_ASAN=ON`~. **[REQUIRED]**