### PR TITLE
Fix icon scaling for HiDPI displays

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,9 @@ int main(int argc, char** argv)
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#ifdef Q_OS_LINUX
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 #endif
 #ifdef Q_OS_LINUX
     if (qgetenv("XDG_SESSION_TYPE") == QByteArrayLiteral("wayland")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,7 @@ int main(int argc, char** argv)
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 #ifdef Q_OS_LINUX
     if (qgetenv("XDG_SESSION_TYPE") == QByteArrayLiteral("wayland")) {


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
This PR fixes the way icons are scaled for displays with a scale level >1 according to the method described in https://andrewcrouthamel.wordpress.com/2018/10/03/making-plasma-superb-in-hidpi/. Before, icons displayed severe scaling artifacts (see screenshots below)

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
The top image is taken from this PR with fixed scaling. (Open in fullscreen view/zoom in to see the change better!)
![image](https://user-images.githubusercontent.com/3987560/60306631-34d7e980-9941-11e9-8fdf-51b481710bfd.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested with scale factor 1, no change from upstream. Tested with scale factor >1, fix works as expected.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
