### PR TITLE
Skip the Wayland warning if QT_QPA_PLATFORM already set

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 #ifdef Q_OS_LINUX
-    if (qgetenv("XDG_SESSION_TYPE") == QByteArrayLiteral("wayland")) {
+    if (qgetenv("XDG_SESSION_TYPE") == QByteArrayLiteral("wayland") && qgetenv("QT_QPA_PLATFORM").isEmpty()) {
         qWarning() << "Warning: disregarding XDG_SESSION_TYPE=wayland";
         qWarning() << "To use wayland anyway, please set QT_QPA_PLATFORM=wayland";
         qunsetenv("XDG_SESSION_TYPE");


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
I use Wayland without an XWayland server. In such a case fallback to the Qt xcb plugin does not work, so I explicitly set QT_QPA_PLATFORM=wayland to use Qt's Wayland plugin. The Wayland warning no longer matters and floods the terminal (or log files).

## Screenshots
Less warnings on Wayland:
```
$ keepassxc
qt.qpa.wayland: Wayland does not support QWindow::requestActivate()
qt.qpa.wayland: Wayland does not support QWindow::requestActivate()
QObject::startTimer: Timers cannot have negative intervals
```

## Testing strategy
Run KeePassXC on Wayfire 0.2 with `export QT_QPA_PLATFORM=wayland`.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- I have added tests to cover my changes.
  Currently GUI tests are run on X. I don't know if there is a headless Wayland server for testing.
