### PR TITLE
Add setting for not displaying KeePassHTTP migration popup

### DIFF
--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -116,6 +116,7 @@ void BrowserOptionDialog::loadSettings()
     m_ui->httpAuthPermission->setChecked(settings->httpAuthPermission());
     m_ui->searchInAllDatabases->setChecked(settings->searchInAllDatabases());
     m_ui->supportKphFields->setChecked(settings->supportKphFields());
+    m_ui->noMigrationPrompt->setChecked(settings->noMigrationPrompt());
     m_ui->supportBrowserProxy->setChecked(settings->supportBrowserProxy());
     m_ui->useCustomProxy->setChecked(settings->useCustomProxy());
     m_ui->customProxyLocation->setText(settings->customProxyLocation());
@@ -183,6 +184,7 @@ void BrowserOptionDialog::saveSettings()
     settings->setHttpAuthPermission(m_ui->httpAuthPermission->isChecked());
     settings->setSearchInAllDatabases(m_ui->searchInAllDatabases->isChecked());
     settings->setSupportKphFields(m_ui->supportKphFields->isChecked());
+    settings->setNoMigrationPrompt(m_ui->noMigrationPrompt->isChecked());
 
     settings->setChromeSupport(m_ui->chromeSupport->isChecked());
     settings->setChromiumSupport(m_ui->chromiumSupport->isChecked());

--- a/src/browser/BrowserOptionDialog.ui
+++ b/src/browser/BrowserOptionDialog.ui
@@ -322,6 +322,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="noMigrationPrompt">
+         <property name="toolTip">
+          <string>Don't display the popup suggesting migration of legacy KeePassHTTP settings.</string>
+         </property>
+         <property name="text">
+          <string>&amp;Do not prompt for KeePassHTTP settings migration.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="updateBinaryPath">
          <property name="toolTip">
           <string>Updates KeePassXC or keepassxc-proxy binary path automatically to native messaging scripts on startup.</string>

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -151,6 +151,16 @@ void BrowserSettings::setSupportKphFields(bool supportKphFields)
     config()->set("Browser/SupportKphFields", supportKphFields);
 }
 
+bool BrowserSettings::noMigrationPrompt()
+{
+    return config()->get("Browser/NoMigrationPrompt", false).toBool();
+}
+
+void BrowserSettings::setNoMigrationPrompt(bool prompt)
+{
+    config()->set("Browser/NoMigrationPrompt", prompt);
+}
+
 bool BrowserSettings::supportBrowserProxy()
 {
     return config()->get("Browser/SupportBrowserProxy", true).toBool();

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -55,6 +55,8 @@ public:
     void setHttpAuthPermission(bool httpAuthPermission);
     bool supportKphFields();
     void setSupportKphFields(bool supportKphFields);
+    bool noMigrationPrompt();
+    void setNoMigrationPrompt(bool prompt);
 
     bool supportBrowserProxy();
     void setSupportBrowserProxy(bool enabled);

--- a/src/gui/MessageBox.cpp
+++ b/src/gui/MessageBox.cpp
@@ -19,6 +19,7 @@
 #include "MessageBox.h"
 
 #include <QWindow>
+#include <QCheckBox>
 
 QWindow* MessageBox::m_overrideParent(nullptr);
 
@@ -77,7 +78,8 @@ MessageBox::Button MessageBox::messageBox(QWidget* parent,
                                           const QString& text,
                                           MessageBox::Buttons buttons,
                                           MessageBox::Button defaultButton,
-                                          MessageBox::Action action)
+                                          MessageBox::Action action,
+                                          QCheckBox* checkbox)
 {
     if (m_nextAnswer == MessageBox::NoButton) {
         QMessageBox msgBox(parent);
@@ -110,6 +112,11 @@ MessageBox::Button MessageBox::messageBox(QWidget* parent,
             }
         }
 
+        if (checkbox) {
+            checkbox->setParent(&msgBox);
+            msgBox.setCheckBox(checkbox);
+        }
+
         if (action == MessageBox::Raise) {
             msgBox.setWindowFlags(Qt::WindowStaysOnTopHint);
             msgBox.activateWindow();
@@ -133,9 +140,10 @@ MessageBox::Button MessageBox::critical(QWidget* parent,
                                         const QString& text,
                                         MessageBox::Buttons buttons,
                                         MessageBox::Button defaultButton,
-                                        MessageBox::Action action)
+                                        MessageBox::Action action,
+                                        QCheckBox* checkbox)
 {
-    return messageBox(parent, QMessageBox::Critical, title, text, buttons, defaultButton, action);
+    return messageBox(parent, QMessageBox::Critical, title, text, buttons, defaultButton, action, checkbox);
 }
 
 MessageBox::Button MessageBox::information(QWidget* parent,
@@ -143,9 +151,10 @@ MessageBox::Button MessageBox::information(QWidget* parent,
                                            const QString& text,
                                            MessageBox::Buttons buttons,
                                            MessageBox::Button defaultButton,
-                                           MessageBox::Action action)
+                                           MessageBox::Action action,
+                                           QCheckBox* checkbox)
 {
-    return messageBox(parent, QMessageBox::Information, title, text, buttons, defaultButton, action);
+    return messageBox(parent, QMessageBox::Information, title, text, buttons, defaultButton, action, checkbox);
 }
 
 MessageBox::Button MessageBox::question(QWidget* parent,
@@ -153,9 +162,10 @@ MessageBox::Button MessageBox::question(QWidget* parent,
                                         const QString& text,
                                         MessageBox::Buttons buttons,
                                         MessageBox::Button defaultButton,
-                                        MessageBox::Action action)
+                                        MessageBox::Action action,
+                                        QCheckBox* checkbox)
 {
-    return messageBox(parent, QMessageBox::Question, title, text, buttons, defaultButton, action);
+    return messageBox(parent, QMessageBox::Question, title, text, buttons, defaultButton, action, checkbox);
 }
 
 MessageBox::Button MessageBox::warning(QWidget* parent,
@@ -163,9 +173,10 @@ MessageBox::Button MessageBox::warning(QWidget* parent,
                                        const QString& text,
                                        MessageBox::Buttons buttons,
                                        MessageBox::Button defaultButton,
-                                       MessageBox::Action action)
+                                       MessageBox::Action action,
+                                       QCheckBox* checkbox)
 {
-    return messageBox(parent, QMessageBox::Warning, title, text, buttons, defaultButton, action);
+    return messageBox(parent, QMessageBox::Warning, title, text, buttons, defaultButton, action, checkbox);
 }
 
 void MessageBox::setNextAnswer(MessageBox::Button button)

--- a/src/gui/MessageBox.h
+++ b/src/gui/MessageBox.h
@@ -81,25 +81,29 @@ public:
                            const QString& text,
                            Buttons buttons = MessageBox::Ok,
                            Button defaultButton = MessageBox::NoButton,
-                           Action action = MessageBox::None);
+                           Action action = MessageBox::None,
+                           QCheckBox* checkbox = nullptr);
     static Button information(QWidget* parent,
                               const QString& title,
                               const QString& text,
                               Buttons buttons = MessageBox::Ok,
                               Button defaultButton = MessageBox::NoButton,
-                              Action action = MessageBox::None);
+                              Action action = MessageBox::None,
+                              QCheckBox* checkbox = nullptr);
     static Button question(QWidget* parent,
                            const QString& title,
                            const QString& text,
                            Buttons buttons = MessageBox::Ok,
                            Button defaultButton = MessageBox::NoButton,
-                           Action action = MessageBox::None);
+                           Action action = MessageBox::None,
+                           QCheckBox* checkbox = nullptr);
     static Button warning(QWidget* parent,
                           const QString& title,
                           const QString& text,
                           Buttons buttons = MessageBox::Ok,
                           Button defaultButton = MessageBox::NoButton,
-                          Action action = MessageBox::None);
+                          Action action = MessageBox::None,
+                          QCheckBox* checkbox = nullptr);
 
     class OverrideParent
     {
@@ -123,7 +127,8 @@ private:
                              const QString& text,
                              Buttons buttons = MessageBox::Ok,
                              Button defaultButton = MessageBox::NoButton,
-                             Action action = MessageBox::None);
+                             Action action = MessageBox::None,
+                             QCheckBox* checkbox = nullptr);
 
     static QString stdButtonText(QMessageBox::StandardButton button);
 };


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Add an extra option for not displaying legacy KeePassHTTP setting popup. This is an add to the previous PR #3327.

Also extends the `MessageBox` class to include an optional checkbox.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![Screen Shot 2019-07-03 at 11 36 26](https://user-images.githubusercontent.com/24570482/60576833-d4084100-9d86-11e9-9c3b-2eaefbdeaa91.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
