### PR TITLE
Adding OnlyKey support

### DIFF
--- a/src/keys/YkChallengeResponseKey.cpp
+++ b/src/keys/YkChallengeResponseKey.cpp
@@ -106,12 +106,14 @@ bool YkChallengeResponseKey::challenge(const QByteArray& challenge, unsigned int
 QString YkChallengeResponseKey::getName() const
 {
     unsigned int serial;
-    QString fmt(QObject::tr("YubiKey[%1] Challenge Response - Slot %2 - %3"));
+    QString fmt(QObject::tr("%1[%2] Challenge Response - Slot %3 - %4"));
 
     YubiKey::instance()->getSerial(serial);
 
-    return fmt.arg(
-        QString::number(serial), QString::number(m_slot), (m_blocking) ? QObject::tr("Press") : QObject::tr("Passive"));
+    return fmt.arg(YubiKey::instance()->getVendorName(),
+                   QString::number(serial),
+                   QString::number(m_slot),
+                   (m_blocking) ? QObject::tr("Press") : QObject::tr("Passive"));
 }
 
 bool YkChallengeResponseKey::isBlocking() const

--- a/src/keys/drivers/YubiKey.h
+++ b/src/keys/drivers/YubiKey.h
@@ -80,6 +80,12 @@ public:
     bool getSerial(unsigned int& serial);
 
     /**
+     * @brief YubiKey::getVendorName - vendor name of token
+     * @return vendor name
+     */
+    QString getVendorName();
+
+    /**
      * @brief YubiKey::detect - probe for attached YubiKeys
      */
     void detect();
@@ -110,6 +116,7 @@ private:
     // Create void ptr here to avoid ifdef header include mess
     void* m_yk_void;
     void* m_ykds_void;
+    bool m_onlyKey;
 
     QMutex m_mutex;
 


### PR DESCRIPTION
This PR is for the better way I mentioned here - https://github.com/keepassxreboot/keepassxc/pull/2754#issuecomment-506768000

This adds support for OnlyKey, this requires yubikey-personalization library greater than 1.19.3. Good news, yubikey-personalization library v1.20.0 was just released today! The function yk_open_key_vid_pid was added to yubikey-personalization in version 1.20.0 

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
- ✅ Documentation (non-code change)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
