### PR TITLE
Fix building on Mac OS X < 10.12

### DIFF
--- a/src/gui/macutils/AppKitImpl.mm
+++ b/src/gui/macutils/AppKitImpl.mm
@@ -19,6 +19,11 @@
 #import "AppKitImpl.h"
 
 #import <AppKit/NSWorkspace.h>
+#import <Availability.h>
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED < 101200
+static const NSEventMask NSEventMaskKeyDown = NSKeyDownMask;
+#endif
 
 @implementation AppKitImpl
 


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
This patch is inspired by a compatibility header in old WebKit. See
https://github.com/WebKit/webkit/blob/1262b1fbf85ae267aab0c946500527ef3b97bac8/Source/WTF/wtf/mac/AppKitCompatibilityDeclarations.h

Ref: https://github.com/keepassxreboot/keepassxc/issues/2899

## Screenshots
N/A - build fixes

## Testing strategy
Add this patch to MacPorts and build it on different versions of Mac OS X/macOS systems.

For Mac OS X < 10.8, builds fail as GitHub requires TLS 1.2 but old systems do not support that.
Build log for 10.9: https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/92138/steps/install-port/logs/stdio
For builders 10.10 and 10.11, KeePassXC is still in the queue.
For builders 10.12~10.14, KeePassXC is skipped as it already builds fine without this patch.

I've also tested the build manually with macOS 10.14.5 + Xcode 11 beta 1.

**I don't have old systems, so I didn't actually test global autotype shortcuts with built binaries.**

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- My change requires a change to the documentation, and I have updated it accordingly. N/A - build fixes
- I have added tests to cover my changes. N/A - build fixes
