### PR TITLE
Disable remember checkbox with Basic HTTP Auth

### DIFF
--- a/src/browser/BrowserAccessControlDialog.cpp
+++ b/src/browser/BrowserAccessControlDialog.cpp
@@ -59,3 +59,8 @@ void BrowserAccessControlDialog::setRemember(bool r)
 {
     m_ui->rememberDecisionCheckBox->setChecked(r);
 }
+
+void BrowserAccessControlDialog::setHTTPAuth(bool httpAuth)
+{
+    m_ui->rememberDecisionCheckBox->setVisible(!httpAuth);
+}

--- a/src/browser/BrowserAccessControlDialog.h
+++ b/src/browser/BrowserAccessControlDialog.h
@@ -41,6 +41,7 @@ public:
     void setItems(const QList<Entry*>& items);
     bool remember() const;
     void setRemember(bool r);
+    void setHTTPAuth(bool httpAuth);
 
 private:
     QScopedPointer<Ui::BrowserAccessControlDialog> m_ui;

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -400,7 +400,7 @@ QJsonArray BrowserService::findMatchingEntries(const QString& id,
     }
 
     // Confirm entries
-    if (confirmEntries(pwEntriesToConfirm, url, host, submitHost, realm)) {
+    if (confirmEntries(pwEntriesToConfirm, url, host, submitHost, realm, httpAuth)) {
         pwEntries.append(pwEntriesToConfirm);
     }
 
@@ -764,7 +764,8 @@ bool BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
                                     const QString& url,
                                     const QString& host,
                                     const QString& submitHost,
-                                    const QString& realm)
+                                    const QString& realm,
+                                    const bool httpAuth)
 {
     if (pwEntriesToConfirm.isEmpty() || m_dialogActive) {
         return false;
@@ -775,6 +776,7 @@ bool BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
     connect(m_dbTabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), &accessControlDialog, SLOT(reject()));
     accessControlDialog.setUrl(url);
     accessControlDialog.setItems(pwEntriesToConfirm);
+    accessControlDialog.setHTTPAuth(httpAuth);
 
     raiseWindow();
     accessControlDialog.show();

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -118,7 +118,8 @@ private:
                         const QString& url,
                         const QString& host,
                         const QString& submitHost,
-                        const QString& realm);
+                        const QString& realm,
+                        const bool httpAuth);
     QJsonObject prepareEntry(const Entry* entry);
     Access checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm);
     Group* getDefaultEntryGroup(const QSharedPointer<Database>& selectedDb = {});


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Disables the remember checkbox when requesting access to credentials with HTTP Basic Auth. Because a global setting exists for showing the HTTP Basic Auth permissions, this checkbox actually does nothing.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
