### PR TITLE
Update legacy database hashes automatically

### DIFF
--- a/src/browser/BrowserAction.h
+++ b/src/browser/BrowserAction.h
@@ -75,6 +75,7 @@ private:
     QString getErrorMessage(const int errorCode) const;
     QString getReturnValue(const BrowserService::ReturnValue returnValue) const;
     QString getDatabaseHash();
+    QString getLegacyDatabaseHash();
 
     QString encryptMessage(const QJsonObject& message, const QString& nonce);
     QJsonObject decryptMessage(const QString& message, const QString& nonce);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
If any legacy database hashes are identified, `get-databasehash` response is written with an additional `oldHash` value. The hash is updated in the extension to a new format.

Reason for this: database hashes used with the extension are calculated using root group UUID + recycle bin UUID, which causes problems if any recycle bin related changes are made in the database. In these situations the extension thinks the connection has not been made to this database. Calculating the hash this way was introduced already in the KeePassHTTP implementation and it should've been modified earlier.

This way we can update the database hashes used in the extension without any need of users to reconnect the extension to all databases (which would cause a nice list of new issues).

Related KeePassXC-Browser PR: https://github.com/keepassxreboot/keepassxc-browser/pull/581

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
