### PR TITLE
Add wordcase option (lower, upper, capital) when generating a passphrase

### DIFF
--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -26,10 +26,12 @@
 
 const char* PassphraseGenerator::DefaultSeparator = " ";
 const char* PassphraseGenerator::DefaultWordList = "eff_large.wordlist";
+const PassphraseGenerator::WordCaseOption PassphraseGenerator::DefaultCase = WordCaseOption::Lower;
 
 PassphraseGenerator::PassphraseGenerator()
     : m_wordCount(0)
     , m_separator(PassphraseGenerator::DefaultSeparator)
+    , m_wordcase(PassphraseGenerator::DefaultCase)
 {
 }
 
@@ -86,6 +88,11 @@ void PassphraseGenerator::setWordSeparator(const QString& separator)
     m_separator = separator;
 }
 
+void PassphraseGenerator::setWordCase(const WordCaseOption wordCase)
+{
+    m_wordcase = wordCase;
+}
+
 QString PassphraseGenerator::generatePassphrase() const
 {
     Q_ASSERT(isValid());
@@ -98,7 +105,18 @@ QString PassphraseGenerator::generatePassphrase() const
     QStringList words;
     for (int i = 0; i < m_wordCount; ++i) {
         int wordIndex = randomGen()->randomUInt(static_cast<quint32>(m_wordlist.length()));
-        words.append(m_wordlist.at(wordIndex));
+
+        QString currentWord = m_wordlist.at(wordIndex);
+
+        // Update case of word based on selected WordCaseOption
+        if (m_wordcase == WordCaseOption::Upper) {
+            currentWord = currentWord.toUpper();
+        } else if (m_wordcase == WordCaseOption::Capital) {
+            currentWord =  currentWord.replace(0,1,currentWord[0].toUpper());
+        }
+        // Nothing to do for lowercase
+
+        words.append(currentWord);
     }
 
     return words.join(m_separator);

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -21,6 +21,7 @@
 #include <QFlags>
 #include <QString>
 #include <QVector>
+#include <QMetaType>
 
 class PassphraseGenerator
 {
@@ -28,11 +29,19 @@ public:
     PassphraseGenerator();
     Q_DISABLE_COPY(PassphraseGenerator)
 
+    enum WordCaseOption
+    {
+        Lower,
+        Upper,
+        Capital
+    };
+
     double calculateEntropy(const QString& passphrase);
     void setWordCount(int wordCount);
     void setWordList(const QString& path);
     void setDefaultWordList();
     void setWordSeparator(const QString& separator);
+    void setWordCase(const WordCaseOption wordCase);
     bool isValid() const;
 
     QString generatePassphrase() const;
@@ -40,11 +49,16 @@ public:
     static constexpr int DefaultWordCount = 7;
     static const char* DefaultSeparator;
     static const char* DefaultWordList;
+    static const WordCaseOption DefaultCase;
 
 private:
     int m_wordCount;
     QString m_separator;
+    WordCaseOption m_wordcase;
     QVector<QString> m_wordlist;
 };
+
+// Declare as metatype so we can store it in the combo box item data
+Q_DECLARE_METATYPE(PassphraseGenerator::WordCaseOption)
 
 #endif // KEEPASSX_PASSPHRASEGENERATOR_H

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -57,6 +57,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     connect(m_ui->spinBoxWordCount, SIGNAL(valueChanged(int)), SLOT(dicewareSpinBoxChanged()));
 
     connect(m_ui->editWordSeparator, SIGNAL(textChanged(QString)), SLOT(updateGenerator()));
+    connect(m_ui->comboBoxWordCase, SIGNAL(currentIndexChanged(int)), SLOT(updateGenerator()));
     connect(m_ui->comboBoxWordList, SIGNAL(currentIndexChanged(int)), SLOT(updateGenerator()));
     connect(m_ui->optionButtons, SIGNAL(buttonClicked(int)), SLOT(updateGenerator()));
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(updateGenerator()));
@@ -139,6 +140,10 @@ void PasswordGeneratorWidget::loadSettings()
         config()->get("generator/WordSeparator", PassphraseGenerator::DefaultSeparator).toString());
     m_ui->comboBoxWordList->setCurrentText(
         config()->get("generator/WordList", PassphraseGenerator::DefaultWordList).toString());
+    m_ui->comboBoxWordCase->clear();
+    m_ui->comboBoxWordCase->addItem(tr("Lowercase"),QVariant::fromValue(PassphraseGenerator::WordCaseOption::Lower));
+    m_ui->comboBoxWordCase->addItem(tr("Uppercase"),QVariant::fromValue(PassphraseGenerator::WordCaseOption::Upper));
+    m_ui->comboBoxWordCase->addItem(tr("Capital case"),QVariant::fromValue(PassphraseGenerator::WordCaseOption::Capital));
 
     // Password or diceware?
     m_ui->tabWidget->setCurrentIndex(config()->get("generator/Type", 0).toInt());
@@ -565,6 +570,11 @@ void PasswordGeneratorWidget::updateGenerator()
             m_dicewareGenerator->setWordList(path);
         }
         m_dicewareGenerator->setWordSeparator(m_ui->editWordSeparator->text());
+
+	// Determine selected option for word case
+	int wordCaseSelectedIndex = m_ui->comboBoxWordCase->currentIndex();
+	QVariant selectedOption = m_ui->comboBoxWordCase->itemData(wordCaseSelectedIndex);
+	m_dicewareGenerator->setWordCase(selectedOption.value<PassphraseGenerator::WordCaseOption>());
 
         if (m_dicewareGenerator->isValid()) {
             m_ui->buttonGenerate->setEnabled(true);

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -1019,7 +1019,24 @@ QProgressBar::chunk {
                </property>
               </widget>
              </item>
+             <item row="3" column="0" alignment="Qt::AlignRight">
+              <widget class="QLabel" name="labelWordCase">
+               <property name="text">
+                <string>Word Case:</string>
+               </property>
+              </widget>
+             </item>
              <item row="3" column="1">
+              <widget class="QComboBox" name="comboBoxWordCase">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
               <spacer name="verticalSpacer_3">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -187,6 +187,9 @@ add_unit_test(NAME testmerge SOURCES TestMerge.cpp
 add_unit_test(NAME testpasswordgenerator SOURCES TestPasswordGenerator.cpp
         LIBS ${TEST_LIBRARIES})
 
+add_unit_test(NAME testpassphrasegenerator SOURCES TestPassphraseGenerator.cpp
+        LIBS ${TEST_LIBRARIES})
+
 add_unit_test(NAME testtotp SOURCES TestTotp.cpp
         LIBS ${TEST_LIBRARIES})
 

--- a/tests/TestPassphraseGenerator.cpp
+++ b/tests/TestPassphraseGenerator.cpp
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestPassphraseGenerator.h"
+#include "core/PassphraseGenerator.h"
+#include "crypto/Crypto.h"
+
+#include <QRegularExpression>
+#include <QTest>
+
+QTEST_GUILESS_MAIN(TestPassphraseGenerator)
+
+void TestPassphraseGenerator::initTestCase()
+{
+    QVERIFY(Crypto::init());
+}
+
+void TestPassphraseGenerator::testWordCaseOptions()
+{
+    PassphraseGenerator generator;
+    QString passphrase;
+    
+    // Basic test to confirm isValid
+    QVERIFY(!generator.isValid());
+    generator.setDefaultWordList();
+    generator.setWordCount(1);
+    QVERIFY(generator.isValid());
+
+    // Confirm we at least get something
+    QVERIFY(generator.generatePassphrase().size() > 0);
+
+    // By default we expect a lowercase passphrase
+    passphrase = generator.generatePassphrase();
+    QCOMPARE(passphrase, passphrase.toLower());
+
+    // Test upper case
+    generator.setWordCase(PassphraseGenerator::WordCaseOption::Upper);
+    passphrase = generator.generatePassphrase();
+    QCOMPARE(passphrase, passphrase.toUpper());
+    
+    // Test capital case - in this case we test for mixed case
+    generator.setWordCase(PassphraseGenerator::WordCaseOption::Capital);
+    passphrase = generator.generatePassphrase();
+    QVERIFY(!(passphrase == passphrase.toUpper()));
+    QVERIFY(!(passphrase == passphrase.toLower()));
+
+    // Test explicit lower case
+    generator.setWordCase(PassphraseGenerator::WordCaseOption::Lower);
+    passphrase = generator.generatePassphrase();
+    QCOMPARE(passphrase, passphrase.toLower());
+}

--- a/tests/TestPassphraseGenerator.h
+++ b/tests/TestPassphraseGenerator.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTPASSPHRASEGENERATOR_H
+#define KEEPASSXC_TESTPASSPHRASEGENERATOR_H
+
+#include <QObject>
+
+class TestPassphraseGenerator : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void testWordCaseOptions();
+};
+
+#endif // KEEPASSXC_TESTPASSPHRASEGENERATOR_H


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
This change introduces a single combo-box on the passphrase generation pane to allow some additional control of the letter case that is used for the generated passphrase.  The options added are:
* Lowercase: The current default for passphrases
* Uppercase: All letters in the passphrase are uppercase
* Capital case: The first letter of each word in the passphrase is uppercase

## Screenshots
![image](https://user-images.githubusercontent.com/42836473/61777760-cf442380-ae40-11e9-8bc5-a7811a36b524.png)

## Testing strategy
* Manually tested all options in the GUI
* Added new test class for testing the passphrase generator (currently only tests the new functionality added with this change)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
