### PR TITLE
Improve handling of read-only files

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -204,7 +204,7 @@ bool Database::save(const QString& filePath, QString* error, bool atomic, bool b
 {
     // Disallow saving to the same file if read-only
     if (m_data.isReadOnly && filePath == m_data.filePath) {
-        Q_ASSERT(false);
+        Q_ASSERT_X(false, "Database::save", "Could not save, database file is read-only.");
         if (error) {
             *error = tr("Could not save, database file is read-only.");
         }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -202,8 +202,12 @@ bool Database::save(QString* error, bool atomic, bool backup)
  */
 bool Database::save(const QString& filePath, QString* error, bool atomic, bool backup)
 {
-    Q_ASSERT(!m_data.isReadOnly);
-    if (m_data.isReadOnly) {
+    // Disallow saving to the same file if read-only
+    if (m_data.isReadOnly && filePath == m_data.filePath) {
+        Q_ASSERT(false);
+        if (error) {
+            *error = tr("Could not save, database file is read-only.");
+        }
         return false;
     }
 
@@ -741,10 +745,6 @@ bool Database::isModified() const
 
 void Database::markAsModified()
 {
-    if (isReadOnly()) {
-        return;
-    }
-
     m_modified = true;
     if (m_emitModified) {
         startModifiedTimer();
@@ -780,8 +780,6 @@ Database* Database::databaseByFilePath(const QString& filePath)
 
 void Database::startModifiedTimer()
 {
-    Q_ASSERT(!m_data.isReadOnly);
-
     if (!m_emitModified) {
         return;
     }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -984,7 +984,10 @@ void DatabaseWidget::unlockDatabase(bool accepted)
     }
     replaceDatabase(db);
     if (db->isReadOnly()) {
-        showMessage(tr("File opened in read only mode."), MessageWidget::Warning, false, -1);
+        showMessage(tr("This database is opened in read only mode. Auto-save has been disabled."),
+                    MessageWidget::Warning,
+                    false,
+                    -1);
     }
 
     restoreGroupEntryFocus(m_groupBeforeLock, m_entryBeforeLock);
@@ -1225,7 +1228,7 @@ void DatabaseWidget::onGroupChanged(Group* group)
 
 void DatabaseWidget::onDatabaseModified()
 {
-    if (!m_blockAutoSave && config()->get("AutoSaveAfterEveryChange").toBool()) {
+    if (!m_blockAutoSave && config()->get("AutoSaveAfterEveryChange").toBool() && !m_db->isReadOnly()) {
         save();
     } else {
         // Only block once, then reset

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -984,7 +984,7 @@ void DatabaseWidget::unlockDatabase(bool accepted)
     }
     replaceDatabase(db);
     if (db->isReadOnly()) {
-        showMessage(tr("This database is opened in read only mode. Auto-save has been disabled."),
+        showMessage(tr("This database is opened in read-only mode. Autosave is disabled."),
                     MessageWidget::Warning,
                     false,
                     -1);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Fix #3407
* Read-only files now disable auto-save and show as modified correctly. This allows the GUI to prompt to "save-as" instead of silently discarding changes when the read-only database is locked or closed.

_Note: The assert changes in Database.cpp are never hit due to correct handling of files in DatabaseWidget.cpp. These are in place in case of future invalid handling of read-only files._

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested using read-only directory on Windows 10.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
