### PR TITLE
Add setting for search results timeout (#3400)

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -197,6 +197,8 @@ void Config::init(const QString& fileName)
     m_defaults.insert("FaviconDownloadTimeout", 10);
     m_defaults.insert("security/clearclipboard", true);
     m_defaults.insert("security/clearclipboardtimeout", 10);
+    m_defaults.insert("security/clearsearch", true);
+    m_defaults.insert("security/clearsearchtimeout", 300);
     m_defaults.insert("security/lockdatabaseidle", false);
     m_defaults.insert("security/lockdatabaseidlesec", 240);
     m_defaults.insert("security/lockdatabaseminimize", false);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -198,7 +198,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/clearclipboard", true);
     m_defaults.insert("security/clearclipboardtimeout", 10);
     m_defaults.insert("security/clearsearch", true);
-    m_defaults.insert("security/clearsearchtimeout", 300);
+    m_defaults.insert("security/clearsearchtimeout", 5);
     m_defaults.insert("security/lockdatabaseidle", false);
     m_defaults.insert("security/lockdatabaseidlesec", 240);
     m_defaults.insert("security/lockdatabaseminimize", false);

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -87,6 +87,8 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
 
     connect(m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)),
             m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));
+    connect(m_secUi->clearSearchCheckBox, SIGNAL(toggled(bool)),
+            m_secUi->clearSearchSpinBox, SLOT(setEnabled(bool)));
     connect(m_secUi->lockDatabaseIdleCheckBox, SIGNAL(toggled(bool)),
             m_secUi->lockDatabaseIdleSpinBox, SLOT(setEnabled(bool)));
     connect(m_secUi->touchIDResetCheckBox, SIGNAL(toggled(bool)),
@@ -215,6 +217,9 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->clearClipboardCheckBox->setChecked(config()->get("security/clearclipboard").toBool());
     m_secUi->clearClipboardSpinBox->setValue(config()->get("security/clearclipboardtimeout").toInt());
 
+    m_secUi->clearSearchCheckBox->setChecked(config()->get("security/clearsearch").toBool());
+    m_secUi->clearSearchSpinBox->setValue(config()->get("security/clearsearchtimeout").toInt());
+
     m_secUi->lockDatabaseIdleCheckBox->setChecked(config()->get("security/lockdatabaseidle").toBool());
     m_secUi->lockDatabaseIdleSpinBox->setValue(config()->get("security/lockdatabaseidlesec").toInt());
     m_secUi->lockDatabaseMinimizeCheckBox->setChecked(config()->get("security/lockdatabaseminimize").toBool());
@@ -298,6 +303,9 @@ void ApplicationSettingsWidget::saveSettings()
     }
     config()->set("security/clearclipboard", m_secUi->clearClipboardCheckBox->isChecked());
     config()->set("security/clearclipboardtimeout", m_secUi->clearClipboardSpinBox->value());
+
+    config()->set("security/clearsearch", m_secUi->clearSearchCheckBox->isChecked());
+    config()->set("security/clearsearchtimeout", m_secUi->clearSearchSpinBox->value());
 
     config()->set("security/lockdatabaseidle", m_secUi->lockDatabaseIdleCheckBox->isChecked());
     config()->set("security/lockdatabaseidlesec", m_secUi->lockDatabaseIdleSpinBox->value());

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>595</width>
-    <height>478</height>
+    <height>510</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -61,6 +61,41 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="clearSearchCheckBox">
+        <property name="text">
+         <string>Clear search query after</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="clearSearchSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="suffix">
+         <string comment="Seconds"> sec</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>999</number>
+        </property>
+        <property name="value">
+         <number>300</number>
+        </property>
+        <property name="displayIntegerBase">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QCheckBox" name="lockDatabaseIdleCheckBox">
         <property name="sizePolicy">
@@ -99,6 +134,13 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="touchIDResetCheckBox">
+        <property name="text">
+         <string>Forget TouchID after inactivity of</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="1">
        <widget class="QSpinBox" name="touchIDResetSpinBox">
         <property name="enabled">
@@ -118,13 +160,6 @@
         </property>
         <property name="value">
          <number>30</number>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="touchIDResetCheckBox">
-        <property name="text">
-         <string>Forget TouchID after inactivity of</string>
         </property>
        </widget>
       </item>

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>595</width>
-    <height>510</height>
+    <height>541</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -80,16 +80,16 @@
          </sizepolicy>
         </property>
         <property name="suffix">
-         <string comment="Seconds"> sec</string>
+         <string comment="Minutes"> min</string>
         </property>
         <property name="minimum">
          <number>1</number>
         </property>
         <property name="maximum">
-         <number>999</number>
+         <number>1440</number>
         </property>
         <property name="value">
-         <number>300</number>
+         <number>5</number>
         </property>
         <property name="displayIntegerBase">
          <number>10</number>

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -116,8 +116,13 @@ bool SearchWidget::eventFilter(QObject* obj, QEvent* event)
             }
         }
     } else if (event->type() == QEvent::FocusOut) {
-        // Auto-clear search after 5 minutes
-        m_clearSearchTimer->start(300000);
+        if (config()->get("security/clearsearch").toBool()) {
+            int timeout = config()->get("security/clearsearchtimeout").toInt();
+            if (timeout > 0) {
+                // Auto-clear search after set timeout (5 minutes by default)
+                m_clearSearchTimer->start(timeout * 1000);
+            }
+        }
     } else if (event->type() == QEvent::FocusIn) {
         m_clearSearchTimer->stop();
     }

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -120,7 +120,7 @@ bool SearchWidget::eventFilter(QObject* obj, QEvent* event)
             int timeout = config()->get("security/clearsearchtimeout").toInt();
             if (timeout > 0) {
                 // Auto-clear search after set timeout (5 minutes by default)
-                m_clearSearchTimer->start(timeout * 1000);
+                m_clearSearchTimer->start(timeout * 60000); // 60 sec * 1000 ms
             }
         }
     } else if (event->type() == QEvent::FocusIn) {


### PR DESCRIPTION
Add setting to control search results timeout.

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
KeepassXC has a hard-coded 5 minute timeout when searching the database. This adds an option in security settings to control the timeout. (Resolves #3400)


## Screenshots
![KeepassXC Timeouts](https://user-images.githubusercontent.com/1549806/62013025-57853a00-b15b-11e9-88c1-ff10727002ee.png)


## Testing strategy
Tested changing the timeout setting and observing results.


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**


Forgive me if I missed something, this is my first pull request/open-source contribution. Edit: Oops, I think my branch name should've been feature/#3400 instead of hotfix. I'm not sure how the branch naming works; if it's meant for my repo or the main keepassxc repo.