### PR TITLE
🛠 🛠 Repair build when YK disabled.

### DIFF
--- a/src/keys/drivers/YubiKeyStub.cpp
+++ b/src/keys/drivers/YubiKeyStub.cpp
@@ -61,6 +61,11 @@ bool YubiKey::getSerial(unsigned int& serial)
     return false;
 }
 
+QString YubiKey::getVendorName()
+{
+    return "YubiKeyStub";
+}
+
 YubiKey::ChallengeResult YubiKey::challenge(int slot, bool mayBlock, const QByteArray& chal, QByteArray& resp)
 {
     Q_UNUSED(slot);


### PR DESCRIPTION
I noticed in #3416 that the build was broken when the YubiKey flag was disabled.
This PR fixes the issue.

@droidmonkey so we're always testing with YK enabled during CI?

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
