### PR TITLE
Add open command, interactive CLI session support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - CLI: Add `-y --yubikey` option for YubiKey [#3416](https://github.com/keepassxreboot/keepassxc/issues/3416)
 - Add 'Monospaced font' option to the Notes field [#3321](https://github.com/keepassxreboot/keepassxc/issues/3321)
 - CLI: Add group commands (mv, mkdir and rmdir) [#3313].
+- CLI: Add interactive shell mode command `open` [#3224](https://github.com/keepassxreboot/keepassxc/issues/3224)
 - Add "Paper Backup" aka "Export to HTML file" to the "Database" menu [#3277](https://github.com/keepassxreboot/keepassxc/pull/3277)
 
 ### Changed

--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -1,0 +1,50 @@
+# Code copied from sethhall@github
+#
+# - Try to find readline include dirs and libraries
+#
+# Usage of this module as follows:
+#
+#     find_package(Readline)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  Readline_ROOT_DIR         Set this variable to the root installation of
+#                            readline if the module has problems finding the
+#                            proper installation path.
+#
+# Variables defined by this module:
+#
+#  READLINE_FOUND            System has readline, include and lib dirs found
+#  Readline_INCLUDE_DIR      The readline include directories.
+#  Readline_LIBRARY          The readline library.
+
+find_path(Readline_ROOT_DIR
+    NAMES include/readline/readline.h
+)
+
+find_path(Readline_INCLUDE_DIR
+    NAMES readline/readline.h
+    HINTS ${Readline_ROOT_DIR}/include
+)
+
+find_library(Readline_LIBRARY
+    NAMES readline
+    HINTS ${Readline_ROOT_DIR}/lib
+)
+
+if(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
+  set(READLINE_FOUND TRUE)
+else(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
+  find_library(Readline_LIBRARY NAMES readline)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Readline DEFAULT_MSG Readline_INCLUDE_DIR Readline_LIBRARY )
+  mark_as_advanced(Readline_INCLUDE_DIR Readline_LIBRARY)
+endif(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
+
+mark_as_advanced(
+    Readline_ROOT_DIR
+    Readline_INCLUDE_DIR
+    Readline_LIBRARY
+)
+

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -541,10 +541,7 @@ QString BrowserAction::getDatabaseHash()
 {
     QMutexLocker locker(&m_mutex);
     QByteArray hash =
-        QCryptographicHash::hash(
-            m_browserService.getDatabaseRootUuid().toUtf8(),
-            QCryptographicHash::Sha256)
-            .toHex();
+        QCryptographicHash::hash(m_browserService.getDatabaseRootUuid().toUtf8(), QCryptographicHash::Sha256).toHex();
     return QString(hash);
 }
 

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -45,7 +45,6 @@ const QCommandLineOption Add::GenerateOption = QCommandLineOption(QStringList() 
                                                                                 << "generate",
                                                                   QObject::tr("Generate a password for the entry."));
 
-
 Add::Add()
 {
     name = QString("add");

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -18,24 +18,35 @@ set(cli_SOURCES
         AddGroup.cpp
         Analyze.cpp
         Clip.cpp
+        Close.cpp
         Create.cpp
         Command.cpp
         DatabaseCommand.cpp
         Diceware.cpp
         Edit.cpp
         Estimate.cpp
+        Exit.cpp
         Export.cpp
         Generate.cpp
+        Help.cpp
         List.cpp
         Locate.cpp
         Merge.cpp
         Move.cpp
+        Open.cpp
         Remove.cpp
         RemoveGroup.cpp
         Show.cpp)
 
 add_library(cli STATIC ${cli_SOURCES})
 target_link_libraries(cli Qt5::Core Qt5::Widgets)
+
+find_package(Readline)
+
+if (READLINE_FOUND)
+    target_compile_definitions(cli PUBLIC USE_READLINE)
+    target_link_libraries(cli readline)
+endif()
 
 add_executable(keepassxc-cli keepassxc-cli.cpp)
 target_link_libraries(keepassxc-cli
@@ -52,6 +63,12 @@ target_link_libraries(keepassxc-cli
 install(TARGETS keepassxc-cli
         BUNDLE DESTINATION . COMPONENT Runtime
         RUNTIME DESTINATION ${CLI_INSTALL_DIR} COMPONENT Runtime)
+
+if(MINGW)
+    install(CODE "include(BundleUtilities)
+                  fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/keepassxc-cli.exe\" \"\" \"\")"
+            COMPONENT Runtime)
+endif()
 
 if(APPLE AND WITH_APP_BUNDLE)
     add_custom_command(TARGET keepassxc-cli

--- a/src/cli/Close.cpp
+++ b/src/cli/Close.cpp
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Close.h"
+
+#include <QCommandLineParser>
+#include <QtGlobal>
+
+#include "DatabaseCommand.h"
+#include "TextStream.h"
+#include "Utils.h"
+
+Close::Close()
+{
+    name = QString("close");
+    description = QObject::tr("Close the currently opened database.");
+}
+
+int Close::execute(const QStringList& arguments)
+{
+    Q_UNUSED(arguments)
+    currentDatabase.reset(nullptr);
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Close.h
+++ b/src/cli/Close.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_CLOSE_H
+#define KEEPASSXC_CLOSE_H
+
+#include <QStringList>
+
+#include "Command.h"
+
+class Close : public Command
+{
+public:
+    Close();
+    int execute(const QStringList& arguments) override;
+};
+
+#endif // KEEPASSXC_CLOSE_H

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -44,19 +44,27 @@ public:
     virtual int execute(const QStringList& arguments) = 0;
     QString name;
     QString description;
+    QSharedPointer<Database> currentDatabase;
     QList<CommandLineArgument> positionalArguments;
     QList<CommandLineArgument> optionalArguments;
     QList<QCommandLineOption> options;
+
     QString getDescriptionLine();
     QSharedPointer<QCommandLineParser> getCommandLineParser(const QStringList& arguments);
+    QString getHelpText();
 
-    static QList<Command*> getCommands();
-    static Command* getCommand(const QString& commandName);
-
+    static const QCommandLineOption HelpOption;
     static const QCommandLineOption QuietOption;
     static const QCommandLineOption KeyFileOption;
     static const QCommandLineOption NoPasswordOption;
     static const QCommandLineOption YubiKeyOption;
 };
+
+namespace Commands
+{
+    void setupCommands(bool interactive);
+    QList<QSharedPointer<Command>> getCommands();
+    QSharedPointer<Command> getCommand(const QString& commandName);
+} // namespace Commands
 
 #endif // KEEPASSXC_COMMAND_H

--- a/src/cli/Create.cpp
+++ b/src/cli/Create.cpp
@@ -93,16 +93,17 @@ int Create::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    Database db;
-    db.setKey(key);
+    QSharedPointer<Database> db(new Database);
+    db->setKey(key);
 
     QString errorMessage;
-    if (!db.save(databaseFilename, &errorMessage, true, false)) {
+    if (!db->save(databaseFilename, &errorMessage, true, false)) {
         err << QObject::tr("Failed to save the database: %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }
 
     out << QObject::tr("Successfully created new database.") << endl;
+    currentDatabase = db;
     return EXIT_SUCCESS;
 }
 

--- a/src/cli/DatabaseCommand.cpp
+++ b/src/cli/DatabaseCommand.cpp
@@ -31,20 +31,33 @@ DatabaseCommand::DatabaseCommand()
 
 int DatabaseCommand::execute(const QStringList& arguments)
 {
-    QSharedPointer<QCommandLineParser> parser = getCommandLineParser(arguments);
+    QStringList amendedArgs(arguments);
+    if (currentDatabase) {
+        amendedArgs.insert(1, currentDatabase->filePath());
+    }
+    QSharedPointer<QCommandLineParser> parser = getCommandLineParser(amendedArgs);
+
     if (parser.isNull()) {
         return EXIT_FAILURE;
     }
 
-    const QStringList args = parser->positionalArguments();
-    auto db = Utils::unlockDatabase(args.at(0),
-                                    !parser->isSet(Command::NoPasswordOption),
-                                    parser->value(Command::KeyFileOption),
-                                    parser->value(Command::YubiKeyOption),
-                                    parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
-                                    Utils::STDERR);
+    QStringList args = parser->positionalArguments();
+    auto db = currentDatabase;
     if (!db) {
-        return EXIT_FAILURE;
+        // It would be nice to update currentDatabase here, but the CLI tests frequently
+        // re-use Command objects to exercise non-interactive behavior. Updating the current
+        // database confuses these tests. Because of this, we leave it up to the interactive
+        // mode implementation in the main command loop to update currentDatabase
+        // (see keepassxc-cli.cpp).
+        db = Utils::unlockDatabase(args.at(0),
+                                   !parser->isSet(Command::NoPasswordOption),
+                                   parser->value(Command::KeyFileOption),
+                                   parser->value(Command::YubiKeyOption),
+                                   parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
+                                   Utils::STDERR);
+        if (!db) {
+            return EXIT_FAILURE;
+        }
     }
 
     return executeWithDatabase(db, parser);

--- a/src/cli/Exit.cpp
+++ b/src/cli/Exit.cpp
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Exit.h"
+
+#include <QCommandLineParser>
+#include <QObject>
+#include <QtGlobal>
+
+Exit::Exit(const QString& name)
+{
+    this->name = name;
+    description = QObject::tr("Exit interactive mode.");
+}
+
+int Exit::execute(const QStringList& arguments)
+{
+    Q_UNUSED(arguments)
+    // A placeholder only, behavior is implemented in keepassxc-cli.cpp.
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Exit.h
+++ b/src/cli/Exit.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_EXIT_H
+#define KEEPASSXC_EXIT_H
+
+#include <QString>
+#include <QStringList>
+
+#include "Command.h"
+
+class Exit : public Command
+{
+public:
+    Exit(const QString& name);
+    int execute(const QStringList& arguments) override;
+};
+
+#endif // KEEPASSXC_EXIT_H

--- a/src/cli/Export.cpp
+++ b/src/cli/Export.cpp
@@ -38,7 +38,6 @@ Export::Export()
     description = QObject::tr("Exports the content of a database to standard output in the specified format.");
 }
 
-
 int Export::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
 {
     TextStream outputTextStream(Utils::STDOUT, QIODevice::WriteOnly);

--- a/src/cli/Help.cpp
+++ b/src/cli/Help.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Help.h"
+
+#include "Command.h"
+#include "TextStream.h"
+#include "Utils.h"
+
+Help::Help()
+{
+    name = QString("help");
+    description = QObject::tr("Display command help.");
+}
+
+int Help::execute(const QStringList& arguments)
+{
+    TextStream out(Utils::STDERR, QIODevice::WriteOnly);
+    QSharedPointer<Command> command;
+    if (arguments.size() > 1 && (command = Commands::getCommand(arguments.at(1)))) {
+        out << command->getHelpText();
+    } else {
+        out << "\n\n" << QObject::tr("Available commands:") << "\n";
+        for (auto& cmd : Commands::getCommands()) {
+            out << cmd->getDescriptionLine();
+        }
+    }
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Help.h
+++ b/src/cli/Help.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_HELP_H
+#define KEEPASSXC_HELP_H
+
+#include "Command.h"
+
+class Help : public Command
+{
+public:
+    Help();
+    ~Help() override = default;
+    int execute(const QStringList& arguments) override;
+};
+
+#endif // KEEPASSXC_HELP_H

--- a/src/cli/Open.cpp
+++ b/src/cli/Open.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Open.h"
+
+#include <QCommandLineParser>
+
+#include "DatabaseCommand.h"
+#include "TextStream.h"
+#include "Utils.h"
+
+Open::Open()
+{
+    name = QString("open");
+    description = QObject::tr("Open a database.");
+}
+
+int Open::execute(const QStringList& arguments)
+{
+    currentDatabase.reset(nullptr);
+    return this->DatabaseCommand::execute(arguments);
+}
+
+int Open::executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser)
+{
+    Q_UNUSED(parser)
+    currentDatabase = db;
+    return EXIT_SUCCESS;
+}

--- a/src/cli/Open.h
+++ b/src/cli/Open.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_OPEN_H
+#define KEEPASSXC_OPEN_H
+
+#include "DatabaseCommand.h"
+
+class Open : public DatabaseCommand
+{
+public:
+    Open();
+    int execute(const QStringList& arguments) override;
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+};
+
+#endif // KEEPASSXC_OPEN_H

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -269,4 +269,42 @@ namespace Utils
         return clipProcess->exitCode();
     }
 
+    /**
+     * Splits the given QString into a QString list. For example:
+     *
+     * "hello world" -> ["hello", "world"]
+     * "hello    world" -> ["hello", "world"]
+     * "hello\\ world" -> ["hello world"] (i.e. backslash is an escape character
+     * "\"hello world\"" -> ["hello world"]
+     */
+    QStringList splitCommandString(const QString& command)
+    {
+        QStringList result;
+
+        bool insideQuotes = false;
+        QString cur;
+        for (int i = 0; i < command.size(); ++i) {
+            QChar c = command[i];
+            if (c == '\\' && i < command.size() - 1) {
+                cur.append(command[i + 1]);
+                ++i;
+            } else if (!insideQuotes && (c == ' ' || c == '\t')) {
+                if (!cur.isEmpty()) {
+                    result.append(cur);
+                    cur.clear();
+                }
+            } else if (c == '"' && (insideQuotes || i == 0 || command[i - 1].isSpace())) {
+                insideQuotes = !insideQuotes;
+            } else {
+                cur.append(c);
+            }
+        }
+
+        if (!cur.isEmpty()) {
+            result.append(cur);
+        }
+
+        return result;
+    }
+
 } // namespace Utils

--- a/src/cli/Utils.h
+++ b/src/cli/Utils.h
@@ -48,6 +48,8 @@ namespace Utils
                                             FILE* outputDescriptor = STDOUT,
                                             FILE* errorDescriptor = STDERR);
 
+    QStringList splitCommandString(const QString& command);
+
     namespace Test
     {
         void setNextPassword(const QString& password);

--- a/src/cli/keepassxc-cli.1
+++ b/src/cli/keepassxc-cli.1
@@ -18,16 +18,19 @@ Adds a new entry to a database. A password can be generated (\fI-g\fP option), o
 The same password generation options as documented for the generate command can be used when the \fI-g\fP option is set.
 
 .IP "analyze [options] <database>"
-Analyze passwords in a database for weaknesses.
+Analyzes passwords in a database for weaknesses.
 
 .IP "clip [options] <database> <entry> [timeout]"
 Copies the password or the current TOTP (\fI-t\fP option) of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
+
+.IP "close"
+In interactive mode, closes the currently opened database (see \fIopen\fP).
 
 .IP "create [options] <database>"
 Creates a new database with a key file and/or password. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
 
 .IP "diceware [options]"
-Generate a random diceware passphrase.
+Generates a random diceware passphrase.
 
 .IP "edit [options] <database> <entry>"
 Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
@@ -36,11 +39,17 @@ The same password generation options as documented for the generate command can 
 .IP "estimate [options] [password]"
 Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
 
+.IP "exit"
+Exits interactive mode. Synonymous with \fIquit\fP.
+
 .IP "export [options] <database>"
 Exports the content of a database to standard output in the specified format (defaults to XML).
 
 .IP "generate [options]"
-Generate a random password.
+Generates a random password.
+
+.IP "help [command]"
+Displays a list of available commands, or detailed information about the specified command.
 
 .IP "locate [options] <database> <term>"
 Locates all the entries that match a specific search term in a database.
@@ -56,6 +65,12 @@ Adds a new group to a database.
 
 .IP "mv [options] <database> <entry> <group>"
 Moves an entry to a new group.
+
+.IP "open [options] <database>"
+Opens the given database in a shell-style interactive mode. This is useful for performing multiple operations on a single database (e.g. \fIls\fP followed by \fIshow\fP).
+
+.IP "quit"
+Exits interactive mode. Synonymous with \fIexit\fP.
 
 .IP "rm [options] <database> <entry>"
 Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
@@ -74,16 +89,16 @@ Shows the title, username, password, URL and notes of a database entry. Can also
 Displays debugging information.
 
 .IP "-k, --key-file <path>"
-Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
+Specifies a path to a key file for unlocking the database. In a merge operation this option, is used to specify the key file path for the first database.
 
 .IP "--no-password"
-Deactivate password key for the database.
+Deactivates the password key for the database.
 
 .IP "-y, --yubikey <slot>"
 Specifies a yubikey slot for unlocking the database. In a merge operation this option is used to specify the yubikey slot for the first database.
 
 .IP "-q, --quiet <path>"
-Silence password prompt and other secondary outputs.
+Silences password prompt and other secondary outputs.
 
 .IP "-h, --help"
 Displays help information.
@@ -95,19 +110,19 @@ Displays the program version.
 .SS "Merge options"
 
 .IP "-d, --dry-run <path>"
-Only print the changes detected by the merge operation.
+Prints the changes detected by the merge operation without making any changes to the database.
 
 .IP "-f, --key-file-from <path>"
-Path of the key file for the second database.
+Sets the path of the key file for the second database.
 
 .IP "--no-password-from"
-Deactivate password key for the database to merge from.
+Deactivates password key for the database to merge from.
 
 .IP "--yubikey-from <slot>"
 Yubikey slot for the second database.
 
 .IP "-s, --same-credentials"
-Use the same credentials for unlocking both database.
+Uses the same credentials for unlocking both databases.
 
 
 .SS "Add and edit options"
@@ -115,34 +130,34 @@ The same password generation options as documented for the generate command can 
 with those 2 commands when the -g option is set.
 
 .IP "-u, --username <username>"
-Specify the username of the entry.
+Specifies the username of the entry.
 
 .IP "--url <url>"
-Specify the URL of the entry.
+Specifies the URL of the entry.
 
 .IP "-p, --password-prompt"
-Use a password prompt for the entry's password.
+Uses a password prompt for the entry's password.
 
 .IP "-g, --generate"
-Generate a new password for the entry.
+Generates a new password for the entry.
 
 
 .SS "Edit options"
 
 .IP "-t, --title <title>"
-Specify the title of the entry.
+Specifies the title of the entry.
 
 
 .SS "Estimate options"
 
 .IP "-a, --advanced"
-Perform advanced analysis on the password.
+Performs advanced analysis on the password.
 
 
 .SS "Analyze options"
 
 .IP "-H, --hibp <filename>"
-Check if any passwords have been publicly leaked, by comparing against the given
+Checks if any passwords have been publicly leaked, by comparing against the given
 list of password SHA-1 hashes, which must be in "Have I Been Pwned" format. Such
 files are available from https://haveibeenpwned.com/Passwords; note that they
 are large, and so this operation typically takes some time (minutes up to an
@@ -152,31 +167,31 @@ hour or so).
 .SS "Clip options"
 
 .IP "-t, --totp"
-Copy the current TOTP instead of current password to clipboard. Will report an error
-if no TOTP is configured for the entry.
+Copies the current TOTP instead of current password to clipboard. Will report
+an error if no TOTP is configured for the entry.
 
 
 .SS "Show options"
 
 .IP "-a, --attributes <attribute>..."
-Names of the attributes to show. This option can be specified more than once,
+Shows the named attributes. This option can be specified more than once,
 with each attribute shown one-per-line in the given order. If no attributes are
 specified and \fI-t\fP is not specified, a summary of the default attributes is given.
 
 .IP "-t, --totp"
-Also show the current TOTP. Will report an error if no TOTP is configured for the
-entry.
+Also shows the current TOTP, reporting an error if no TOTP is configured for
+the entry.
 
 
 .SS "Diceware options"
 
 .IP "-W, --words <count>"
-Desired number of words for the generated passphrase. [Default: 7]
+Sets the desired number of words for the generated passphrase. [Default: 7]
 
 .IP "-w, --word-list <path>"
-Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
-otherwise the program will fail. If the wordlist has < 4000 words a warning will
-be printed to STDERR.
+Sets the Path of the wordlist for the diceware generator. The wordlist must
+have > 1000 words, otherwise the program will fail. If the wordlist has < 4000
+words a warning will be printed to STDERR.
 
 
 .SS "Export options"
@@ -188,7 +203,7 @@ Format to use when exporting. Available choices are xml or csv. Defaults to xml.
 .SS "List options"
 
 .IP "-R, --recursive"
-Recursively list the elements of the group.
+Recursively lists the elements of the group.
 
 .IP "-f, --flatten"
 Flattens the output to single lines. When this option is enabled, subgroups and subentries will be displayed with a relative group path instead of indentation.
@@ -196,22 +211,22 @@ Flattens the output to single lines. When this option is enabled, subgroups and 
 .SS "Generate options"
 
 .IP "-L, --length <length>"
-Desired length for the generated password. [Default: 16]
+Sets the desired length for the generated password. [Default: 16]
 
 .IP "-l --lower"
-Use lowercase characters for the generated password. [Default: Enabled]
+Uses lowercase characters for the generated password. [Default: Enabled]
 
 .IP "-U --upper"
-Use uppercase characters for the generated password. [Default: Enabled]
+Uses uppercase characters for the generated password. [Default: Enabled]
 
 .IP "-n --numeric"
-Use numbers characters for the generated password. [Default: Enabled]
+Uses numbers characters for the generated password. [Default: Enabled]
 
 .IP "-s --special"
-Use special characters for the generated password. [Default: Disabled]
+Uses special characters for the generated password. [Default: Disabled]
 
 .IP "-e --extended"
-Use extended ASCII characters for the generated password. [Default: Disabled]
+Uses extended ASCII characters for the generated password. [Default: Disabled]
 
 .IP "-x --exclude <chars>"
 Comma-separated list of characters to exclude from the generated password. None is excluded by default.

--- a/src/keys/YkChallengeResponseKeyCLI.h
+++ b/src/keys/YkChallengeResponseKeyCLI.h
@@ -32,10 +32,7 @@ class YkChallengeResponseKeyCLI : public QObject, public ChallengeResponseKey
 public:
     static QUuid UUID;
 
-    explicit YkChallengeResponseKeyCLI(int slot,
-                                       bool blocking,
-                                       QString messageInteraction,
-                                       FILE* outputDescriptor);
+    explicit YkChallengeResponseKeyCLI(int slot, bool blocking, QString messageInteraction, FILE* outputDescriptor);
 
     QByteArray rawKey() const override;
     bool challenge(const QByteArray& challenge) override;

--- a/tests/TestCli.h
+++ b/tests/TestCli.h
@@ -43,11 +43,13 @@ private slots:
     void cleanup();
     void cleanupTestCase();
 
-    void testCommand();
+    void testBatchCommands();
     void testAdd();
     void testAddGroup();
     void testAnalyze();
     void testClip();
+    void testCommandParsing_data();
+    void testCommandParsing();
     void testCreate();
     void testDiceware();
     void testEdit();
@@ -58,10 +60,13 @@ private slots:
     void testGenerate();
     void testKeyFileOption();
     void testNoPasswordOption();
+    void testHelp();
+    void testInteractiveCommands();
     void testList();
     void testLocate();
     void testMerge();
     void testMove();
+    void testOpen();
     void testRemove();
     void testRemoveGroup();
     void testRemoveQuiet();

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -1214,7 +1214,6 @@ void TestMerge::testCustomData()
     QCOMPARE(dbDestination->metadata()->customData()->value("key3"),
              QString("newValue")); // Old value should be replaced
 
-
     // Merging again should not do anything if the values are the same.
     m_clock->advanceSecond(1);
     dbSource->metadata()->customData()->set("key3", "oldValue");
@@ -1222,7 +1221,6 @@ void TestMerge::testCustomData()
     Merger merger2(dbSource.data(), dbDestination.data());
     QStringList changes2 = merger2.merge();
     QVERIFY(changes2.isEmpty());
-
 
     Merger merger3(dbSource2.data(), dbDestination2.data());
     merger3.merge();

--- a/tests/gui/TestGuiBrowser.cpp
+++ b/tests/gui/TestGuiBrowser.cpp
@@ -26,8 +26,8 @@
 #include <QDialogButtonBox>
 #include <QLineEdit>
 #include <QPushButton>
-#include <QToolBar>
 #include <QTableView>
+#include <QToolBar>
 
 #include "config-keepassx-tests.h"
 #include "core/Bootstrap.h"
@@ -144,7 +144,7 @@ void TestGuiBrowser::testEntrySettings()
     QTest::mouseClick(entryEditWidget, Qt::LeftButton);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
-    
+
     // Switch to Properties page and select all rows from the custom data table
     editEntryWidget->setCurrentPage(4);
     auto customDataTableView = editEntryWidget->findChild<QTableView*>("customDataTable");
@@ -181,9 +181,9 @@ void TestGuiBrowser::triggerAction(const QString& name)
 }
 
 void TestGuiBrowser::clickIndex(const QModelIndex& index,
-                         QAbstractItemView* view,
-                         Qt::MouseButton button,
-                         Qt::KeyboardModifiers stateKey)
+                                QAbstractItemView* view,
+                                Qt::MouseButton button,
+                                Qt::KeyboardModifiers stateKey)
 {
     QTest::mouseClick(view->viewport(), button, stateKey, view->visualRect(index).center());
 }


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
This change adds an interactive mode to `keepassxc-cli`. For example:

```
$ ./src/cli/keepassxc-cli open ~/Downloads/passwords.kdbx
Insert password to unlock /home/whoever/Downloads/passwords.kdbx: <password>
Downloads/passwords.kdbx> ls /
General/
Windows/
Network/
Internet/
eMail/
Homebanking/
Recycle Bin/
Banking/
Downloads/passwords.kdbx> ls /Internet
Facebook
Twitter
Downloads/passwords.kdbx> show /Internet/Facebook
Title: Facebook
...
```

This change adds the following command: `open`. If `open` is invoked, the `keepassxc-cli` program attempts to open the database, then drops into interactive mode.

Interactive mode uses readline (falls back to just reading stdin if readline is not available). Each user command causes processing much like keepassxc-cli does today, except the command being invoked already has a database present, meaning the command should not attempt to open any database. I've changed the List and Show commands as examples.

Fixes #3224.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
 