### PR TITLE
don't change command.name on every execute()

### DIFF
--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -94,11 +94,11 @@ QSharedPointer<QCommandLineParser> Command::getCommandLineParser(const QStringLi
     parser->process(arguments);
 
     if (parser->positionalArguments().size() < positionalArguments.size()) {
-        errorTextStream << parser->helpText().replace("[options]", name.append(" [options]"));
+        errorTextStream << parser->helpText().replace("[options]", name + " [options]");
         return QSharedPointer<QCommandLineParser>(nullptr);
     }
     if (parser->positionalArguments().size() > (positionalArguments.size() + optionalArguments.size())) {
-        errorTextStream << parser->helpText().replace("[options]", name.append(" [options]"));
+        errorTextStream << parser->helpText().replace("[options]", name + " [options]");
         return QSharedPointer<QCommandLineParser>(nullptr);
     }
     return parser;


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Fixes mutation of command.name every time the command is executed, bug manifests in upcoming interactive mode.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
