### PR TITLE
Add option to minimize after database unlock

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -193,6 +193,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("MinimizeOnOpenUrl", false);
     m_defaults.insert("HideWindowOnCopy", false);
     m_defaults.insert("MinimizeOnCopy", true);
+    m_defaults.insert("MinimizeAfterUnlock", false);
     m_defaults.insert("DropToBackgroundOnCopy", false);
     m_defaults.insert("UseGroupIconOnEntryCreation", false);
     m_defaults.insert("AutoTypeEntryTitleMatch", true);

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -183,6 +183,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->backupBeforeSaveCheckBox->setChecked(config()->get("BackupBeforeSave").toBool());
     m_generalUi->useAtomicSavesCheckBox->setChecked(config()->get("UseAtomicSaves").toBool());
     m_generalUi->autoReloadOnChangeCheckBox->setChecked(config()->get("AutoReloadOnChange").toBool());
+    m_generalUi->minimizeAfterUnlockCheckBox->setChecked(config()->get("MinimizeAfterUnlock").toBool());
     m_generalUi->minimizeOnOpenUrlCheckBox->setChecked(config()->get("MinimizeOnOpenUrl").toBool());
     m_generalUi->hideWindowOnCopyCheckBox->setChecked(config()->get("HideWindowOnCopy").toBool());
     m_generalUi->minimizeOnCopyRadioButton->setChecked(config()->get("MinimizeOnCopy").toBool());
@@ -293,6 +294,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set("BackupBeforeSave", m_generalUi->backupBeforeSaveCheckBox->isChecked());
     config()->set("UseAtomicSaves", m_generalUi->useAtomicSavesCheckBox->isChecked());
     config()->set("AutoReloadOnChange", m_generalUi->autoReloadOnChangeCheckBox->isChecked());
+    config()->set("MinimizeAfterUnlock", m_generalUi->minimizeAfterUnlockCheckBox->isChecked());
     config()->set("MinimizeOnOpenUrl", m_generalUi->minimizeOnOpenUrlCheckBox->isChecked());
     config()->set("HideWindowOnCopy", m_generalUi->hideWindowOnCopyCheckBox->isChecked());
     config()->set("MinimizeOnCopy", m_generalUi->minimizeOnCopyRadioButton->isChecked());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -57,6 +57,13 @@
            </widget>
           </item>
           <item>
+            <widget class="QCheckBox" name="minimizeAfterUnlockCheckBox">
+              <property name="text">
+                <string>Minimize window after unlocking database</string>
+              </property>
+            </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="rememberLastDatabasesCheckBox">
             <property name="text">
              <string>Remember previously used databases</string>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -911,6 +911,9 @@ void DatabaseWidget::loadDatabase(bool accepted)
         m_fileWatcher->restart();
         m_saveAttempts = 0;
         emit databaseUnlocked();
+        if (config()->get("MinimizeAfterUnlock").toBool()) {
+            window()->showMinimized();
+        }
     } else {
         m_fileWatcher->stop();
         if (m_databaseOpenWidget->database()) {


### PR DESCRIPTION
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Implements the feature request: Minimize after unlocking database (as separate option) #3118

Depending on a new Setting in the Config "MinimizeAfterUnlock" the Main window is minimized after unlocking the database. The already existing setting to minimize the main window after the application startup stays intact.
Fixes #3118 


## Screenshots
![Screenshot from 2019-08-11 16-37-54](https://user-images.githubusercontent.com/38611230/62835267-8c62b800-bc56-11e9-8329-8303258be560.png)


## Testing strategy
Ran unit tests
Tested if the new functionality works and is saved/loaded by trying it out
With -DWITH_ASAN=OFF all tests are successful. With -DWITH_ASAN=ON several tests fail. The same tests also fail on master though so I guess this is a problem that existed before? I would be happy about feedback on this.


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
