### PR TITLE
Allow abbreviation of search field names

### DIFF
--- a/src/gui/SearchHelpWidget.ui
+++ b/src/gui/SearchHelpWidget.ui
@@ -237,21 +237,21 @@
         <item row="1" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
-           <string notr="true">username</string>
+           <string notr="true">username (u)</string>
           </property>
          </widget>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_11">
           <property name="text">
-           <string notr="true">password</string>
+           <string notr="true">password (p, pw)</string>
           </property>
          </widget>
         </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
-           <string notr="true">title</string>
+           <string notr="true">title (t)</string>
           </property>
          </widget>
         </item>
@@ -265,21 +265,21 @@
         <item row="0" column="1">
          <widget class="QLabel" name="label_5">
           <property name="text">
-           <string notr="true">notes</string>
+           <string notr="true">notes (n)</string>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
          <widget class="QLabel" name="label_12">
           <property name="text">
-           <string notr="true">attribute</string>
+           <string notr="true">attribute (attr)</string>
           </property>
          </widget>
         </item>
         <item row="2" column="1">
          <widget class="QLabel" name="label_14">
           <property name="text">
-           <string notr="true">attachment</string>
+           <string notr="true">attachment (attach)</string>
           </property>
          </widget>
         </item>

--- a/tests/TestEntrySearcher.cpp
+++ b/tests/TestEntrySearcher.cpp
@@ -96,7 +96,7 @@ void TestEntrySearcher::testSearch()
     e3->setGroup(group3);
 
     Entry* e3b = new Entry();
-    e3b->setTitle("test search test");
+    e3b->setTitle("test search test 123");
     e3b->setUsername("test@email.com");
     e3b->setPassword("realpass");
     e3b->setGroup(group3);
@@ -108,14 +108,29 @@ void TestEntrySearcher::testSearch()
     m_searchResult = m_entrySearcher.search("search term", m_rootGroup);
     QCOMPARE(m_searchResult.count(), 3);
 
+    m_searchResult = m_entrySearcher.search("123", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 2);
+
     m_searchResult = m_entrySearcher.search("search term", group211);
     QCOMPARE(m_searchResult.count(), 1);
 
     // Test advanced search terms
+    m_searchResult = m_entrySearcher.search("title:123", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 1);
+
+    m_searchResult = m_entrySearcher.search("t:123", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 1);
+
     m_searchResult = m_entrySearcher.search("password:testpass", m_rootGroup);
     QCOMPARE(m_searchResult.count(), 1);
 
+    m_searchResult = m_entrySearcher.search("pw:testpass", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 1);
+
     m_searchResult = m_entrySearcher.search("!user:email.com", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 5);
+
+    m_searchResult = m_entrySearcher.search("!u:email.com", m_rootGroup);
     QCOMPARE(m_searchResult.count(), 5);
 
     m_searchResult = m_entrySearcher.search("*user:\".*@.*\\.com\"", m_rootGroup);


### PR DESCRIPTION
I find the advanced search feature useful, but it's not always fun to have to type `title:word user:name` to narrow to the wanted results.  It'd be nice if you could search by just typing `t:word u:name`.

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context

This change allows `t:word` instead of `title:word` and `p:word` instead of `password:word`, and so on.  The rule is that an abbreviated name expands to the first field name that starts with it, with exceptions of `u:` expanding to `username:` instead of `url:` and `pw:` expanding to `password:`.

## Testing strategy
New test cases are added.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
