### PR TITLE
Connect ShareObserver to group signals

### DIFF
--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -113,10 +113,12 @@ void ShareObserver::reinitialize()
         }
         if (update.newReference.isExporting()) {
             exported[update.newReference.path] << update.group->name();
+            // export is only on save
         }
 
         if (update.newReference.isImporting()) {
             imported[update.newReference.path] << update.group->name();
+            // import has to occur immediately
             const auto result = this->importShare(update.newReference.path);
             if (!result.isValid()) {
                 // tolerable result - blocked import or missing source

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -41,6 +41,10 @@ ShareObserver::ShareObserver(QSharedPointer<Database> db, QObject* parent)
 {
     connect(KeeShare::instance(), SIGNAL(activeChanged()), SLOT(handleDatabaseChanged()));
 
+    connect(m_db.data(), SIGNAL(groupDataChanged(Group*)), SLOT(handleDatabaseChanged()));
+    connect(m_db.data(), SIGNAL(groupAdded()), SLOT(handleDatabaseChanged()));
+    connect(m_db.data(), SIGNAL(groupRemoved()), SLOT(handleDatabaseChanged()));
+
     connect(m_db.data(), SIGNAL(databaseModified()), SLOT(handleDatabaseChanged()));
     connect(m_db.data(), SIGNAL(databaseSaved()), SLOT(handleDatabaseSaved()));
 


### PR DESCRIPTION
Connected ShareObserver to allow to import from a share before an export happens.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context

Fixes #3286 by correcting the order of import and exports handled during database changes and database saves.

The problem seems to be the order of slot calls for `Database::databaseModified()` and `Database::databaseSaved()`. The current solution is more or less a workaround. I think listening to the `Database::groupAdded()`. `Database::groupDataChanged()` and `Database::groupRemoved()` signals should be replaced by some proper ordering of the signal handlers for database slot calls.

## Testing strategy
Currently only manually tested - possibly we need a GUI-Test which exercises the save chain.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
-  ❓ All new and existing tests passed. **[REQUIRED]**
-  ❓ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
-  ❓ I have added tests to cover my changes.
