### PR TITLE
Add support for entry related settings with Browser Integration

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -50,6 +50,9 @@ static int KEEPASSXCBROWSER_DEFAULT_ICON = 1;
 const char BrowserService::LEGACY_ASSOCIATE_KEY_PREFIX[] = "Public Key: ";
 static const char KEEPASSHTTP_NAME[] = "KeePassHttp Settings";
 static const char KEEPASSHTTP_GROUP_NAME[] = "KeePassHttp Passwords";
+// Extra entry related options saved in custom data
+const char BrowserService::OPTION_SKIP_AUTO_SUBMIT[] = "BrowserSkipAutoSubmit";
+const char BrowserService::OPTION_HIDE_ENTRY[] = "BrowserHideEntry";
 
 BrowserService::BrowserService(DatabaseTabWidget* parent)
     : m_dbTabWidget(parent)
@@ -375,6 +378,11 @@ QJsonArray BrowserService::findMatchingEntries(const QString& id,
     QList<Entry*> pwEntriesToConfirm;
     QList<Entry*> pwEntries;
     for (Entry* entry : searchEntries(url, keyList)) {
+        if (entry->customData()->contains(BrowserService::OPTION_HIDE_ENTRY) &&
+            entry->customData()->value(BrowserService::OPTION_HIDE_ENTRY) == "true") {
+            continue;
+        }
+
         // HTTP Basic Auth always needs a confirmation
         if (!ignoreHttpAuth && httpAuth) {
             pwEntriesToConfirm.append(entry);
@@ -826,6 +834,10 @@ QJsonObject BrowserService::prepareEntry(const Entry* entry)
 
     if (entry->isExpired()) {
         res["expired"] = "true";
+    }
+
+    if (entry->customData()->contains(BrowserService::OPTION_SKIP_AUTO_SUBMIT)) {
+        res["skipAutoSubmit"] = entry->customData()->value(BrowserService::OPTION_SKIP_AUTO_SUBMIT);
     }
 
     if (browserSettings()->supportKphFields()) {

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -72,6 +72,8 @@ public:
     static const char KEEPASSXCBROWSER_OLD_NAME[];
     static const char ASSOCIATE_KEY_PREFIX[];
     static const char LEGACY_ASSOCIATE_KEY_PREFIX[];
+    static const char OPTION_SKIP_AUTO_SUBMIT[];
+    static const char OPTION_HIDE_ENTRY[];
 
 public slots:
     QJsonArray findMatchingEntries(const QString& id,

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -51,6 +51,7 @@ namespace Ui
 {
     class EditEntryWidgetAdvanced;
     class EditEntryWidgetAutoType;
+    class EditEntryWidgetBrowser;
     class EditEntryWidgetSSHAgent;
     class EditEntryWidgetMain;
     class EditEntryWidgetHistory;
@@ -118,12 +119,18 @@ private slots:
     void decryptPrivateKey();
     void copyPublicKey();
 #endif
+#ifdef WITH_XC_BROWSER
+    void updateBrowser();
+#endif
 
 private:
     void setupMain();
     void setupAdvanced();
     void setupIcon();
     void setupAutoType();
+#ifdef WITH_XC_BROWSER
+    void setupBrowser();
+#endif
 #ifdef WITH_XC_SSHAGENT
     void setupSSHAgent();
 #endif
@@ -157,6 +164,7 @@ private:
     const QScopedPointer<Ui::EditEntryWidgetAutoType> m_autoTypeUi;
     const QScopedPointer<Ui::EditEntryWidgetSSHAgent> m_sshAgentUi;
     const QScopedPointer<Ui::EditEntryWidgetHistory> m_historyUi;
+    const QScopedPointer<Ui::EditEntryWidgetBrowser> m_browserUi;
     const QScopedPointer<CustomData> m_customData;
 
     QWidget* const m_mainWidget;
@@ -165,6 +173,9 @@ private:
     QWidget* const m_autoTypeWidget;
 #ifdef WITH_XC_SSHAGENT
     QWidget* const m_sshAgentWidget;
+#endif
+#ifdef WITH_XC_BROWSER
+    QWidget* const m_browserWidget;
 #endif
     EditWidgetProperties* const m_editWidgetProperties;
     QWidget* const m_historyWidget;

--- a/src/gui/entry/EditEntryWidgetBrowser.ui
+++ b/src/gui/entry/EditEntryWidgetBrowser.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EditEntryWidgetBrowser</class>
+ <widget class="QWidget" name="EditEntryWidgetBrowser">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>348</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_1">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>These settings affect to the entry's behaviour with the browser extension.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>General</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="skipAutoSubmitCheckbox">
+        <property name="text">
+         <string>Skip Auto-Submit for this entry</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="hideEntryCheckbox">
+        <property name="text">
+         <string>Hide this entry from the browser extension</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>skipAutoSubmitCheckbox</tabstop>
+  <tabstop>hideEntryCheckbox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Adds a new settings page "Browser Integration" when editing an entry.
The following options are added:
- Skip Auto-Submit for this entry
- Hide this entry from the browser extension

When **Skip Auto-Submit for this entry** is enabled, a new parameter `skipAutoSubmit` is returned with the credential.

In the future, other entry related Browser Integration settings can be added to the same page.

Related KeePassXC-Browser PR: https://github.com/keepassxreboot/keepassxc-browser/pull/592

## Screenshot
![Screen Shot 2019-08-28 at 11 02 19](https://user-images.githubusercontent.com/24570482/63837058-6aba3e00-c983-11e9-9e9b-69d9f0927170.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
