### PR TITLE
Improve path handling when picking files with file dialogs

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -394,8 +394,8 @@ void DatabaseTabWidget::exportToCsv()
         return;
     }
 
-    QString fileName = fileDialog()->getSaveFileName(
-        this, tr("Export database to CSV file"), QString(), tr("CSV file").append(" (*.csv)"), nullptr, nullptr, "csv");
+    const QString fileName = fileDialog()->getSaveFileName(
+        this, tr("Export database to CSV file"), QString(), tr("CSV file").append(" (*.csv)"), nullptr, nullptr);
     if (fileName.isEmpty()) {
         return;
     }
@@ -419,13 +419,8 @@ void DatabaseTabWidget::exportToHtml()
         return;
     }
 
-    QString fileName = fileDialog()->getSaveFileName(this,
-                                                     tr("Export database to HTML file"),
-                                                     QString(),
-                                                     tr("HTML file").append(" (*.html)"),
-                                                     nullptr,
-                                                     nullptr,
-                                                     "html");
+    const QString fileName = fileDialog()->getSaveFileName(
+        this, tr("Export database to HTML file"), QString(), tr("HTML file").append(" (*.html)"), nullptr, nullptr);
     if (fileName.isEmpty()) {
         return;
     }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1656,13 +1656,8 @@ bool DatabaseWidget::saveAs()
             oldFilePath = QDir::toNativeSeparators(config()->get("LastDir", QDir::homePath()).toString() + "/"
                                                    + tr("Passwords").append(".kdbx"));
         }
-        QString newFilePath = fileDialog()->getSaveFileName(this,
-                                                            tr("Save database as"),
-                                                            oldFilePath,
-                                                            tr("KeePass 2 Database").append(" (*.kdbx)"),
-                                                            nullptr,
-                                                            nullptr,
-                                                            "kdbx");
+        const QString newFilePath = fileDialog()->getSaveFileName(
+            this, tr("Save database as"), oldFilePath, tr("KeePass 2 Database").append(" (*.kdbx)"), nullptr, nullptr);
 
         if (!newFilePath.isEmpty()) {
             // Ensure we don't recurse back into this function

--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -19,31 +19,32 @@
 
 #include "core/Config.h"
 
+#include <QDir>
+
 FileDialog* FileDialog::m_instance(nullptr);
 
 QString FileDialog::getOpenFileName(QWidget* parent,
                                     const QString& caption,
-                                    QString dir,
+                                    const QString& dir,
                                     const QString& filter,
                                     QString* selectedFilter,
-                                    QFileDialog::Options options)
+                                    const QFileDialog::Options options)
 {
     if (!m_nextFileName.isEmpty()) {
-        QString result = m_nextFileName;
+        const QString result = m_nextFileName;
         m_nextFileName.clear();
         return result;
     } else {
-        if (dir.isEmpty()) {
-            dir = config()->get("LastDir").toString();
-        }
+        const auto& workingDir = dir.isEmpty() ? config()->get("LastDir").toString() : dir;
+        const auto result = QDir::toNativeSeparators(
+            QFileDialog::getOpenFileName(parent, caption, workingDir, filter, selectedFilter, options));
 
-        QString result = QFileDialog::getOpenFileName(parent, caption, dir, filter, selectedFilter, options);
-
+#ifdef Q_OS_MACOS
         // on Mac OS X the focus is lost after closing the native dialog
         if (parent) {
             parent->activateWindow();
         }
-
+#endif
         saveLastDir(result);
         return result;
     }
@@ -51,27 +52,28 @@ QString FileDialog::getOpenFileName(QWidget* parent,
 
 QStringList FileDialog::getOpenFileNames(QWidget* parent,
                                          const QString& caption,
-                                         QString dir,
+                                         const QString& dir,
                                          const QString& filter,
                                          QString* selectedFilter,
-                                         QFileDialog::Options options)
+                                         const QFileDialog::Options options)
 {
     if (!m_nextFileNames.isEmpty()) {
-        QStringList results = m_nextFileNames;
+        const QStringList results = m_nextFileNames;
         m_nextFileNames.clear();
         return results;
     } else {
-        if (dir.isEmpty()) {
-            dir = config()->get("LastDir").toString();
-        }
+        const auto& workingDir = dir.isEmpty() ? config()->get("LastDir").toString() : dir;
+        auto results = QFileDialog::getOpenFileNames(parent, caption, workingDir, filter, selectedFilter, options);
 
-        QStringList results = QFileDialog::getOpenFileNames(parent, caption, dir, filter, selectedFilter, options);
+        for (auto& path : results)
+            path = QDir::toNativeSeparators(path);
 
+#ifdef Q_OS_MACOS
         // on Mac OS X the focus is lost after closing the native dialog
         if (parent) {
             parent->activateWindow();
         }
-
+#endif
         if (!results.isEmpty()) {
             saveLastDir(results[0]);
         }
@@ -81,57 +83,26 @@ QStringList FileDialog::getOpenFileNames(QWidget* parent,
 
 QString FileDialog::getFileName(QWidget* parent,
                                 const QString& caption,
-                                QString dir,
+                                const QString& dir,
                                 const QString& filter,
                                 QString* selectedFilter,
-                                QFileDialog::Options options,
-                                const QString& defaultExtension,
-                                const QString& defaultName)
+                                const QFileDialog::Options options)
 {
     if (!m_nextFileName.isEmpty()) {
-        QString result = m_nextFileName;
+        const QString result = m_nextFileName;
         m_nextFileName.clear();
         return result;
     } else {
-        if (dir.isEmpty()) {
-            dir = config()->get("LastDir").toString();
-        }
+        const auto& workingDir = dir.isEmpty() ? config()->get("LastDir").toString() : dir;
+        const auto result = QDir::toNativeSeparators(
+            QFileDialog::getSaveFileName(parent, caption, workingDir, filter, selectedFilter, options));
 
-        QString result;
-#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
-        Q_UNUSED(defaultName);
-        Q_UNUSED(defaultExtension);
-        // the native dialogs on these platforms already append the file extension
-        result = QFileDialog::getSaveFileName(parent, caption, dir, filter, selectedFilter, options);
-#else
-        QFileDialog dialog(parent, caption, dir, filter);
-        dialog.setFileMode(QFileDialog::AnyFile);
-        dialog.setAcceptMode(QFileDialog::AcceptSave);
-        if (selectedFilter) {
-            dialog.selectNameFilter(*selectedFilter);
-        }
-        if (!defaultName.isEmpty()) {
-            dialog.selectFile(defaultName);
-        }
-        dialog.setOptions(options);
-        if (!defaultExtension.isEmpty()) {
-            dialog.setDefaultSuffix(defaultExtension);
-        }
-        dialog.setLabelText(QFileDialog::Accept, QFileDialog::tr("Select"));
-        QStringList results;
-        if (dialog.exec()) {
-            results = dialog.selectedFiles();
-            if (!results.isEmpty()) {
-                result = results[0];
-            }
-        }
-#endif
-
+#ifdef Q_OS_MACOS
         // on Mac OS X the focus is lost after closing the native dialog
         if (parent) {
             parent->activateWindow();
         }
-
+#endif
         saveLastDir(result);
         return result;
     }
@@ -139,81 +110,53 @@ QString FileDialog::getFileName(QWidget* parent,
 
 QString FileDialog::getSaveFileName(QWidget* parent,
                                     const QString& caption,
-                                    QString dir,
+                                    const QString& dir,
                                     const QString& filter,
                                     QString* selectedFilter,
-                                    QFileDialog::Options options,
-                                    const QString& defaultExtension,
-                                    const QString& defaultName)
+                                    const QFileDialog::Options options)
 {
     if (!m_nextFileName.isEmpty()) {
-        QString result = m_nextFileName;
+        const QString result = m_nextFileName;
         m_nextFileName.clear();
         return result;
     } else {
-        if (dir.isEmpty()) {
-            dir = config()->get("LastDir").toString();
-        }
+        const auto& workingDir = dir.isEmpty() ? config()->get("LastDir").toString() : dir;
+        const auto result = QDir::toNativeSeparators(
+            QFileDialog::getSaveFileName(parent, caption, workingDir, filter, selectedFilter, options));
 
-        QString result;
-#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
-        Q_UNUSED(defaultName);
-        Q_UNUSED(defaultExtension);
-        // the native dialogs on these platforms already append the file extension
-        result = QFileDialog::getSaveFileName(parent, caption, dir, filter, selectedFilter, options);
-#else
-        QFileDialog dialog(parent, caption, dir, filter);
-        dialog.setAcceptMode(QFileDialog::AcceptSave);
-        dialog.setFileMode(QFileDialog::AnyFile);
-        if (selectedFilter) {
-            dialog.selectNameFilter(*selectedFilter);
-        }
-        if (!defaultName.isEmpty()) {
-            dialog.selectFile(defaultName);
-        }
-        dialog.setOptions(options);
-        dialog.setDefaultSuffix(defaultExtension);
-
-        QStringList results;
-        if (dialog.exec()) {
-            results = dialog.selectedFiles();
-            if (!results.isEmpty()) {
-                result = results[0];
-            }
-        }
-#endif
-
+#ifdef Q_OS_MACOS
         // on Mac OS X the focus is lost after closing the native dialog
         if (parent) {
             parent->activateWindow();
         }
-
+#endif
         saveLastDir(result);
         return result;
     }
 }
 
-QString
-FileDialog::getExistingDirectory(QWidget* parent, const QString& caption, QString dir, QFileDialog::Options options)
+QString FileDialog::getExistingDirectory(QWidget* parent,
+                                         const QString& caption,
+                                         const QString& dir,
+                                         const QFileDialog::Options options)
 {
     if (!m_nextDirName.isEmpty()) {
-        QString result = m_nextDirName;
+        const QString result = m_nextDirName;
         m_nextDirName.clear();
         return result;
     } else {
-        if (dir.isEmpty()) {
-            dir = config()->get("LastDir").toString();
-        }
+        const auto& workingDir = dir.isEmpty() ? config()->get("LastDir").toString() : dir;
+        const auto result =
+            QDir::toNativeSeparators(QFileDialog::getExistingDirectory(parent, caption, workingDir, options));
 
-        dir = QFileDialog::getExistingDirectory(parent, caption, dir, options);
-
+#ifdef Q_OS_MACOS
         // on Mac OS X the focus is lost after closing the native dialog
         if (parent) {
             parent->activateWindow();
         }
-
-        saveLastDir(dir);
-        return dir;
+#endif
+        saveLastDir(result);
+        return result;
     }
 }
 

--- a/src/gui/FileDialog.h
+++ b/src/gui/FileDialog.h
@@ -25,40 +25,36 @@ class FileDialog
 public:
     QString getOpenFileName(QWidget* parent = nullptr,
                             const QString& caption = QString(),
-                            QString dir = QString(),
+                            const QString& dir = QString(),
                             const QString& filter = QString(),
                             QString* selectedFilter = nullptr,
-                            QFileDialog::Options options = 0);
+                            const QFileDialog::Options options = {});
 
     QStringList getOpenFileNames(QWidget* parent = nullptr,
                                  const QString& caption = QString(),
-                                 QString dir = QString(),
+                                 const QString& dir = QString(),
                                  const QString& filter = QString(),
                                  QString* selectedFilter = nullptr,
-                                 QFileDialog::Options options = 0);
+                                 const QFileDialog::Options options = {});
 
     QString getFileName(QWidget* parent = nullptr,
                         const QString& caption = QString(),
-                        QString dir = QString(),
+                        const QString& dir = QString(),
                         const QString& filter = QString(),
                         QString* selectedFilter = nullptr,
-                        QFileDialog::Options options = 0,
-                        const QString& defaultExtension = QString(),
-                        const QString& defaultName = QString());
+                        const QFileDialog::Options options = {});
 
     QString getSaveFileName(QWidget* parent = nullptr,
                             const QString& caption = QString(),
-                            QString dir = QString(),
+                            const QString& dir = QString(),
                             const QString& filter = QString(),
                             QString* selectedFilter = nullptr,
-                            QFileDialog::Options options = 0,
-                            const QString& defaultExtension = QString(),
-                            const QString& defaultName = QString());
+                            const QFileDialog::Options options = {});
 
     QString getExistingDirectory(QWidget* parent = nullptr,
                                  const QString& caption = QString(),
-                                 QString dir = QString(),
-                                 QFileDialog::Options options = QFileDialog::ShowDirsOnly);
+                                 const QString& dir = QString(),
+                                 const QFileDialog::Options options = QFileDialog::ShowDirsOnly);
 
     void setNextForgetDialog();
     /**

--- a/src/keeshare/SettingsWidgetKeeShare.cpp
+++ b/src/keeshare/SettingsWidgetKeeShare.cpp
@@ -187,7 +187,7 @@ void SettingsWidgetKeeShare::exportCertificate()
     const auto filters = QString("%1 (*." + filetype + ");;%2 (*)").arg(tr("KeeShare key file"), tr("All files"));
     QString filename = QString("%1.%2").arg(m_own.certificate.signer).arg(filetype);
     filename = fileDialog()->getSaveFileName(
-        this, tr("Select path"), defaultDirPath, filters, nullptr, QFileDialog::Options(0), filetype, filename);
+        this, tr("Select path"), defaultDirPath, filters, nullptr, QFileDialog::Options(0));
     if (filename.isEmpty()) {
         return;
     }

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -284,35 +284,17 @@ void EditGroupWidgetKeeShare::launchPathSelectionDialog()
     }
     switch (reference.type) {
     case KeeShareSettings::ImportFrom:
-        filename = fileDialog()->getFileName(this,
-                                             tr("Select import source"),
-                                             defaultDirPath,
-                                             filters,
-                                             nullptr,
-                                             QFileDialog::DontConfirmOverwrite,
-                                             defaultFiletype,
-                                             filename);
+        filename = fileDialog()->getFileName(
+            this, tr("Select import source"), defaultDirPath, filters, nullptr, QFileDialog::DontConfirmOverwrite);
         break;
     case KeeShareSettings::ExportTo:
-        filename = fileDialog()->getFileName(this,
-                                             tr("Select export target"),
-                                             defaultDirPath,
-                                             filters,
-                                             nullptr,
-                                             QFileDialog::Option(0),
-                                             defaultFiletype,
-                                             filename);
+        filename = fileDialog()->getFileName(
+            this, tr("Select export target"), defaultDirPath, filters, nullptr, QFileDialog::Option(0));
         break;
     case KeeShareSettings::SynchronizeWith:
     case KeeShareSettings::Inactive:
-        filename = fileDialog()->getFileName(this,
-                                             tr("Select import/export file"),
-                                             defaultDirPath,
-                                             filters,
-                                             nullptr,
-                                             QFileDialog::Option(0),
-                                             defaultFiletype,
-                                             filename);
+        filename = fileDialog()->getFileName(
+            this, tr("Select import/export file"), defaultDirPath, filters, nullptr, QFileDialog::Option(0));
         break;
     }
 


### PR DESCRIPTION
This PR aims at the portions of code that handle picking files from the file systems.
It also improves the overall code style of those portions.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)

## Description and Context
- **Convert UNIX paths to native paths**
This commit fixes #3454. On Windows, `QFileDialog`s return paths with a UNIX-style path separator whereas when a `.kdbx` file is double-clicked in Explorer, it is passed to the KeepassXC process with Windows-style path separators. This caused the same file to be registered as two different files by KeepassXC depending on whether it was opened from the context menu or the file explorer. `QDir::toNativeSeparators` will adjust the path separator depending on the platform.
- **Let the window focus fix compile only on MacOS**
I saw the comment saying that MacOS needs additional code because the parent window looses focus after the file picker shows up so I just wrapped that code in an `#ifdef` statement so that it doesn't end up in the binary on platforms that don't need it.
- **Improve const correctness**
It just fixes a few variables that weren't marked as `const` (sorry, I'm kind of obsessed with const correctness! 😂)
- **Avoid imposing file extension on Linux**
I understand that this may be a bit controversial but that's why I made it as a separate commit so that I can easily discard it in case it's not a welcome change. Extensions on a Linux file system are essentially meaningless and extensions carry no information about a particular file. The OS treats files without extensions just as well as files that have one. Actually, files with no extension are very common on Linux. I saw that, on Linux, picking files for a save operation adds much more code than for the other two platforms: a `QFileDialog` instance was created from scratch instead of using the `QFileDialog::getSaveFileName()` convenience method because, according to the comment, the file picker doesn't automatically append the extension. I just felt like it was a bit "hacky" and, more importantly, it tried to forcibly change a behavior that's intended by the OS. Also, I tried to reproduce this thing and, on KDE, I get a checkbox in the file picker saying "Automatically append file extension (.kdbx)" which prevents me from saving files without the intended extension. If I leave it unchecked, I can of course save files without an extension. I'm sure other file pickers from other desktop environment also have this option. If I run the `file` command on a database saved without extension, it has no problem recognizing it; nor does KeepassXC have any kind of issue opening it and working with it. Anyways, _my point is that it must be the user's choice whether a file must have an extension or not, instead of being imposed by the program_.
```sh
$ file new_copy
new_copy: Keepass password database 2.x KDBX
```
- **Improve code style**
This commit improves (arguably small) things about the code style, such as const correctness, initialization of enum types with `0` which were flagged by clang-tidy as a pointer initialization with `0` for some reason but it's still good practice to use `{}` instead of `0` (which is technically an implicit conversion from `int`) and the `dir` variable which was passed by non-const value just to be reused inside the function as a local. It was kind of an ugly usage, in my opinion, so I made `dir` become a const-reference to some string from the outside and used a ternary operator + a reference to achieve the exact same thing as before but without unnecessary copies (it's easier in code than in words 😊).

P.S. Some function calls are now formatted differently than before because Clang Format decided to change the formatting, with fewer parameters. I set it to run on Save.

## Testing strategy
I tested my changes manually and I ran all the tests (both on Linux and Windows). They all pass on Linux while only one fails on Windows, but so it did before I touched the code so it's unrelated to my changes.


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
