### PR TITLE
Merge custom data only when necessary

### DIFF
--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -1159,12 +1159,12 @@ void TestMerge::testMetadata()
 {
     QSKIP("Sophisticated merging for Metadata not implemented");
     // TODO HNH: I think a merge of recycle bins would be nice since duplicating them
-    //           is not realy a good solution - the one to use as final recycle bin
+    //           is not really a good solution - the one to use as final recycle bin
     //           is determined by the merge method - if only one has a bin, this one
     //           will be used - exception is the target has no recycle bin activated
 }
 
-void TestMerge::testCustomdata()
+void TestMerge::testCustomData()
 {
     QScopedPointer<Database> dbDestination(new Database());
     QScopedPointer<Database> dbSource(createTestDatabase());
@@ -1198,10 +1198,9 @@ void TestMerge::testCustomdata()
     m_clock->advanceSecond(1);
 
     Merger merger(dbSource.data(), dbDestination.data());
-    merger.merge();
+    QStringList changes = merger.merge();
 
-    Merger merger2(dbSource2.data(), dbDestination2.data());
-    merger2.merge();
+    QVERIFY(!changes.isEmpty());
 
     // Source is newer, data should be merged
     QVERIFY(!dbDestination->metadata()->customData()->isEmpty());
@@ -1214,6 +1213,19 @@ void TestMerge::testCustomdata()
     QCOMPARE(dbDestination->metadata()->customData()->value("Browser"), QString("n'8=3W@L^6d->d.]St_>]"));
     QCOMPARE(dbDestination->metadata()->customData()->value("key3"),
              QString("newValue")); // Old value should be replaced
+
+
+    // Merging again should not do anything if the values are the same.
+    m_clock->advanceSecond(1);
+    dbSource->metadata()->customData()->set("key3", "oldValue");
+    dbSource->metadata()->customData()->set("key3", "newValue");
+    Merger merger2(dbSource.data(), dbDestination.data());
+    QStringList changes2 = merger2.merge();
+    QVERIFY(changes2.isEmpty());
+
+
+    Merger merger3(dbSource2.data(), dbDestination2.data());
+    merger3.merge();
 
     // Target is newer, no data is merged
     QVERIFY(!dbDestination2->metadata()->customData()->isEmpty());

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -59,7 +59,7 @@ private slots:
     void testMergeCustomIcons();
     void testMergeDuplicateCustomIcons();
     void testMetadata();
-    void testCustomdata();
+    void testCustomData();
     void testDeletedEntry();
     void testDeletedGroup();
     void testDeletedRevertedEntry();


### PR DESCRIPTION
merge custom data only when new or changed. Also skipped the meta `LastModified` custom data.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
This was causing merge operation to repeatedly detect changes, even when the data and custom data didn't change.

## Testing strategy
unit tests

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
