### PR TITLE
Additional database file checks in cli/Utils.unlockDatabase

### DIFF
--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #endif
 
+#include <QFileInfo>
 #include <QProcess>
 #include <QScopedPointer>
 
@@ -107,6 +108,22 @@ namespace Utils
         auto compositeKey = QSharedPointer<CompositeKey>::create();
         TextStream out(outputDescriptor);
         TextStream err(errorDescriptor);
+
+        QFileInfo dbFileInfo(databaseFilename);
+        if (dbFileInfo.canonicalFilePath().isEmpty()) {
+            err << QObject::tr("Failed to open database file %1: not found").arg(databaseFilename) << endl;
+            return {};
+        }
+
+        if (!dbFileInfo.isFile()) {
+            err << QObject::tr("Failed to open database file %1: not a plain file").arg(databaseFilename) << endl;
+            return {};
+        }
+
+        if (!dbFileInfo.isReadable()) {
+            err << QObject::tr("Failed to open database file %1: not readable").arg(databaseFilename) << endl;
+            return {};
+        }
 
         if (isPasswordProtected) {
             out << QObject::tr("Insert password to unlock %1: ").arg(databaseFilename) << flush;

--- a/tests/TestCli.h
+++ b/tests/TestCli.h
@@ -63,6 +63,7 @@ private slots:
     void testRemove();
     void testRemoveQuiet();
     void testShow();
+    void testInvalidDbFiles();
 
 private:
     QByteArray m_dbData;


### PR DESCRIPTION


[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Avoids prompting the user for a password if unlocking is likely to fail
due to some problem with the database file (i.e. not found, not a file,
not readable).

## Testing strategy
Ran tests, tested manually.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
