### PR TITLE
Support key files with Auto Open feature

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -123,3 +123,15 @@ There is a simple overview of shared groups to keep track of your data.
 Sharing relies on the combination of file exports and imports as well as the synchronization mechanism provided by KeePassXC. Since the merge algorithm uses the history of entries to prevent data loss, this history must be enabled and have a sufficient size. Furthermore, the merge algorithm is location independend, therefore it does not matter if entries are moved outside of an import group. These entries will be updated none the less. Moving entries outside of export groups will prevent a further export of the entry, but it will not ensure that the already shared data will be removed from any client.
 
 KeeShare uses a custom certification mechanism to ensure that the source of the data is the expected one. This ensures that the data was exported by the signer but it is not possible to detect if someone replaced the data with an older version from a valid signer. To prevent this, the container could be placed at a location which is only writeable for valid signers.
+
+## Using Auto Open
+
+The Auto Open feature automatically loads and unlocks additional databases when you unlock your main database.
+In order to use this functionnality, do the following:
+
+1. Create a group called **AutoOpen** at the root of your main database.
+1. In this group, create a new entry for each database that should be opened automatically:
+    * Put the *password of the database* in the **Password** field
+    * Put the *path to the database's file* in the **URL** field* (it can be formatted either as **file://**, a **/path/to/the/file** form, or a relative file path.)
+    * If the extra database requires a keyfile to be unlocked, put the *path to the keyfile* in the **Username** field. The path options are the same as for the database's file in the URL field.
+1. The next time you unlock your database these databases will be opened and unlocked automatically.

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -201,8 +201,9 @@ void DatabaseTabWidget::addDatabaseTab(DatabaseWidget* dbWidget, bool inBackgrou
     }
 
     connect(dbWidget, SIGNAL(databaseFilePathChanged(QString, QString)), SLOT(updateTabName()));
-    connect(
-        dbWidget, SIGNAL(requestOpenDatabase(QString, bool, QString)), SLOT(addDatabaseTab(QString, bool, QString)));
+    connect(dbWidget,
+            SIGNAL(requestOpenDatabase(QString, bool, QString, QString)),
+            SLOT(addDatabaseTab(QString, bool, QString, QString)));
     connect(dbWidget, SIGNAL(closeRequest()), SLOT(closeDatabaseTabFromSender()));
     connect(dbWidget, SIGNAL(databaseModified()), SLOT(updateTabName()));
     connect(dbWidget, SIGNAL(databaseSaved()), SLOT(updateTabName()));

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -133,7 +133,8 @@ signals:
     void currentModeChanged(DatabaseWidget::Mode mode);
     void groupChanged();
     void entrySelectionChanged();
-    void requestOpenDatabase(const QString& filePath, bool inBackground, const QString& password);
+    void
+    requestOpenDatabase(const QString& filePath, bool inBackground, const QString& password, const QString& keyFile);
     void databaseMerged(QSharedPointer<Database> mergedDb);
     void groupContextMenuRequested(const QPoint& globalPos);
     void entryContextMenuRequested(const QPoint& globalPos);


### PR DESCRIPTION
Fixes #3495
Summary of changes:
* DatabaseWidget::processAutoOpen() looks for custom attribute KeyFile in
the AutoOpen's entry that should contain the path to a keyfile in the same
format as for the database file
* requestOpenDatabase and its call are updated to handle this extra parameter

- ✅ New feature (non-breaking change which adds functionality)

## Testing strategy
auto opening db with or without keyfile works (only tested on linux)


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
