### PR TITLE
re-enable wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,13 +54,6 @@ int main(int argc, char** argv)
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 #endif
-#ifdef Q_OS_LINUX
-    if (qgetenv("XDG_SESSION_TYPE") == QByteArrayLiteral("wayland") && qgetenv("QT_QPA_PLATFORM").isEmpty()) {
-        qWarning() << "Warning: disregarding XDG_SESSION_TYPE=wayland";
-        qWarning() << "To use wayland anyway, please set QT_QPA_PLATFORM=wayland";
-        qunsetenv("XDG_SESSION_TYPE");
-    }
-#endif
 
     Application app(argc, argv);
     Application::setApplicationName("keepassxc");


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
(not sure what the appropriate type is)
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
This removes the unsetting of `XDG_SESSION_TYPE`, and thus restores QTs behaviour of choosing the platform backend according to OS and desktop used.

Rationale:
For one, the wayland backend of QT is quite stable nowadays, and with current QT, KPXC works fine under GNOME and sway (and probably KDE as well), file open dialog and clipboard included. Of course, auto-type does not work as with X, but that is an intentional limitation of wayland, and using KPXC under XWayland will not change this.
But even if there are distributions or desktops where QT-wayland does not work well, this problem will affect not only KPXC, but any other QT app as well (and it is likely that the user is using at least one other QT application). Thus, the user will have to override QTs backend anyway, to make all their other applications work. On the other hand, there is a big downside to setting `QT_QPA_PLATFORM` explicitly (which KPXC requires without this change): Forcing QT to one specific backend will not work when regularly switching between wayland and X11 desktops. But when `QT_QPA_PLATFORM` is unset, QT will choose the proper backend according to the desktop in use.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested this change with `GNOME Shell 3.32.2` and `sway version 1.2`, everything seems to be working (including file open dialogs and clipboard).


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ☐ All new and existing tests passed. **[REQUIRED]**
- ☐ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

Two tests fail because of memory leaks detected, but the tests also fail without my change.
