### PR TITLE
Always show search menu when icon clicked

### DIFF
--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -48,7 +48,8 @@ SearchWidget::SearchWidget(QWidget* parent)
     connect(m_ui->searchEdit, SIGNAL(textChanged(QString)), SLOT(startSearchTimer()));
     connect(m_ui->clearIcon, SIGNAL(triggered(bool)), m_ui->searchEdit, SLOT(clear()));
     connect(m_ui->helpIcon, SIGNAL(triggered()), SLOT(toggleHelp()));
-    connect(m_searchTimer, SIGNAL(timeout()), this, SLOT(startSearch()));
+    connect(m_ui->searchIcon, SIGNAL(triggered()), SLOT(showSearchMenu()));
+    connect(m_searchTimer, SIGNAL(timeout()), SLOT(startSearch()));
     connect(m_clearSearchTimer, SIGNAL(timeout()), m_ui->searchEdit, SLOT(clear()));
     connect(this, SIGNAL(escapePressed()), m_ui->searchEdit, SLOT(clear()));
 
@@ -59,18 +60,17 @@ SearchWidget::SearchWidget(QWidget* parent)
                                              .arg(QKeySequence(QKeySequence::Find).toString(QKeySequence::NativeText)));
     m_ui->searchEdit->installEventFilter(this);
 
-    QMenu* searchMenu = new QMenu();
-    m_actionCaseSensitive = searchMenu->addAction(tr("Case sensitive"), this, SLOT(updateCaseSensitive()));
+    m_searchMenu = new QMenu();
+    m_actionCaseSensitive = m_searchMenu->addAction(tr("Case sensitive"), this, SLOT(updateCaseSensitive()));
     m_actionCaseSensitive->setObjectName("actionSearchCaseSensitive");
     m_actionCaseSensitive->setCheckable(true);
 
-    m_actionLimitGroup = searchMenu->addAction(tr("Limit search to selected group"), this, SLOT(updateLimitGroup()));
+    m_actionLimitGroup = m_searchMenu->addAction(tr("Limit search to selected group"), this, SLOT(updateLimitGroup()));
     m_actionLimitGroup->setObjectName("actionSearchLimitGroup");
     m_actionLimitGroup->setCheckable(true);
     m_actionLimitGroup->setChecked(config()->get("SearchLimitGroup", false).toBool());
 
     m_ui->searchIcon->setIcon(filePath()->icon("actions", "system-search"));
-    m_ui->searchIcon->setMenu(searchMenu);
     m_ui->searchEdit->addAction(m_ui->searchIcon, QLineEdit::LeadingPosition);
 
     m_ui->helpIcon->setIcon(filePath()->icon("actions", "system-help"));
@@ -213,4 +213,9 @@ void SearchWidget::toggleHelp()
     } else {
         m_helpWidget->show();
     }
+}
+
+void SearchWidget::showSearchMenu()
+{
+    m_searchMenu->exec(m_ui->searchEdit->mapToGlobal(m_ui->searchEdit->rect().bottomLeft()));
 }

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -69,6 +69,7 @@ private slots:
     void updateLimitGroup();
     void searchFocus();
     void toggleHelp();
+    void showSearchMenu();
 
 private:
     const QScopedPointer<Ui::SearchWidget> m_ui;
@@ -77,6 +78,7 @@ private:
     QTimer* m_clearSearchTimer;
     QAction* m_actionCaseSensitive;
     QAction* m_actionLimitGroup;
+    QMenu* m_searchMenu;
 };
 
 #endif // SEARCHWIDGET_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Search menu icon only allowed the search menu to show when the right third of the icon was clicked, this was a Qt limitation.
* Fixes #3538

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
