### PR TITLE
FindQuaZip: Only look for Qt 5 build

### DIFF
--- a/cmake/FindQuaZip.cmake
+++ b/cmake/FindQuaZip.cmake
@@ -10,12 +10,12 @@ if(MINGW)
     find_path(QUAZIP_ZLIB_INCLUDE_DIR zlib.h)
 else()
     find_library(QUAZIP_LIBRARIES
-        NAMES quazip5 quazip
+        quazip5
 	PATHS /usr/lib /usr/lib64 /usr/local/lib
     )
     find_path(QUAZIP_INCLUDE_DIR quazip.h
 	PATHS /usr/include /usr/local/include
-        PATH_SUFFIXES quazip5 quazip
+        PATH_SUFFIXES quazip5
     )
     find_path(QUAZIP_ZLIB_INCLUDE_DIR zlib.h PATHS /usr/include /usr/local/include)
 endif()


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
As can be seen at
https://github.com/stachenov/quazip/blob/bae3aa762a37c894f8a8ce21db83fe7d5c7b7489/CMakeLists.txt#L19,
the resulting so for Qt 5 will have the suffix “5”.

Looking up the unsuffixed variant can lead to the end binary being
linked to both Qt 4 and 5, which would subsequently lead to crashes:
https://bugzilla.redhat.com/show_bug.cgi?id=1753325

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
(In Fedora) Install quazip-devel, but not quazip-qt5-devel, build the binary (with KeeShare support enabled) and run it. It will segfault.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ My code follows the code style of this project. **[REQUIRED]**
