### PR TITLE
Use QSharedPointer for CLI commands

### DIFF
--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -130,7 +130,7 @@ QSharedPointer<Command> Command::getCommand(const QString& commandName)
     if (commands.contains(commandName)) {
         return commands[commandName];
     }
-    return nullptr;
+    return {};
 }
 
 QList<QSharedPointer<Command>> Command::getCommands()

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -52,7 +52,7 @@ const QCommandLineOption Command::KeyFileOption = QCommandLineOption(QStringList
 const QCommandLineOption Command::NoPasswordOption =
     QCommandLineOption(QStringList() << "no-password", QObject::tr("Deactivate password key for the database."));
 
-QMap<QString, Command*> commands;
+QMap<QString, QSharedPointer<Command>> commands;
 
 Command::Command()
 {
@@ -107,24 +107,24 @@ QSharedPointer<QCommandLineParser> Command::getCommandLineParser(const QStringLi
 void populateCommands()
 {
     if (commands.isEmpty()) {
-        commands.insert(QString("add"), new Add());
-        commands.insert(QString("analyze"), new Analyze());
-        commands.insert(QString("clip"), new Clip());
-        commands.insert(QString("create"), new Create());
-        commands.insert(QString("diceware"), new Diceware());
-        commands.insert(QString("edit"), new Edit());
-        commands.insert(QString("estimate"), new Estimate());
-        commands.insert(QString("extract"), new Extract());
-        commands.insert(QString("generate"), new Generate());
-        commands.insert(QString("locate"), new Locate());
-        commands.insert(QString("ls"), new List());
-        commands.insert(QString("merge"), new Merge());
-        commands.insert(QString("rm"), new Remove());
-        commands.insert(QString("show"), new Show());
+        commands.insert(QString("add"), QSharedPointer<Command>(new Add()));
+        commands.insert(QString("analyze"), QSharedPointer<Command>(new Analyze()));
+        commands.insert(QString("clip"), QSharedPointer<Command>(new Clip()));
+        commands.insert(QString("create"), QSharedPointer<Command>(new Create()));
+        commands.insert(QString("diceware"), QSharedPointer<Command>(new Diceware()));
+        commands.insert(QString("edit"), QSharedPointer<Command>(new Edit()));
+        commands.insert(QString("estimate"), QSharedPointer<Command>(new Estimate()));
+        commands.insert(QString("extract"), QSharedPointer<Command>(new Extract()));
+        commands.insert(QString("generate"), QSharedPointer<Command>(new Generate()));
+        commands.insert(QString("locate"), QSharedPointer<Command>(new Locate()));
+        commands.insert(QString("ls"), QSharedPointer<Command>(new List()));
+        commands.insert(QString("merge"), QSharedPointer<Command>(new Merge()));
+        commands.insert(QString("rm"), QSharedPointer<Command>(new Remove()));
+        commands.insert(QString("show"), QSharedPointer<Command>(new Show()));
     }
 }
 
-Command* Command::getCommand(const QString& commandName)
+QSharedPointer<Command> Command::getCommand(const QString& commandName)
 {
     populateCommands();
     if (commands.contains(commandName)) {
@@ -133,7 +133,7 @@ Command* Command::getCommand(const QString& commandName)
     return nullptr;
 }
 
-QList<Command*> Command::getCommands()
+QList<QSharedPointer<Command>> Command::getCommands()
 {
     populateCommands();
     return commands.values();

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -50,8 +50,8 @@ public:
     QString getDescriptionLine();
     QSharedPointer<QCommandLineParser> getCommandLineParser(const QStringList& arguments);
 
-    static QList<Command*> getCommands();
-    static Command* getCommand(const QString& commandName);
+    static QList<QSharedPointer<Command>> getCommands();
+    static QSharedPointer<Command> getCommand(const QString& commandName);
 
     static const QCommandLineOption QuietOption;
     static const QCommandLineOption KeyFileOption;

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
 
     QString description("KeePassXC command line interface.");
     description = description.append(QObject::tr("\n\nAvailable commands:\n"));
-    for (Command* command : Command::getCommands()) {
+    for (QSharedPointer<Command> command : Command::getCommands()) {
         description = description.append(command->getDescriptionLine());
     }
     parser.setApplicationDescription(description);
@@ -84,7 +84,7 @@ int main(int argc, char** argv)
     }
 
     QString commandName = parser.positionalArguments().at(0);
-    Command* command = Command::getCommand(commandName);
+    QSharedPointer<Command> command = Command::getCommand(commandName);
 
     if (command == nullptr) {
         qCritical("Invalid command %s.", qPrintable(commandName));


### PR DESCRIPTION
This fixes most of the ASAN detected leaks when running
the CLI tests (and probably when running the CLI in general).

There's still some memory leaks detected, but they seem to be coming from `/lib/x86_64-linux-gnu/libdbus-1.so`

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)

## Testing strategy
unit tests.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
