### PR TITLE
Add hyperlinks to EntryPreviewWidget notes field

### DIFF
--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -168,13 +168,12 @@ void EntryPreviewWidget::updateEntryTotp()
 void EntryPreviewWidget::setPasswordVisible(bool state)
 {
     const QString password = m_currentEntry->resolveMultiplePlaceholders(m_currentEntry->password());
-    auto flags = m_ui->entryPasswordLabel->textInteractionFlags();
     if (state) {
         m_ui->entryPasswordLabel->setRawText(password);
         m_ui->entryPasswordLabel->setToolTip(password);
-        m_ui->entryPasswordLabel->setTextInteractionFlags(flags | Qt::TextSelectableByMouse);
+        m_ui->entryPasswordLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
     } else {
-        m_ui->entryPasswordLabel->setTextInteractionFlags(flags & ~Qt::TextSelectableByMouse);
+        m_ui->entryPasswordLabel->setTextInteractionFlags(Qt::NoTextInteraction);
         m_ui->entryPasswordLabel->setToolTip({});
         if (password.isEmpty() && config()->get("security/passwordemptynodots").toBool()) {
             m_ui->entryPasswordLabel->setRawText("");
@@ -194,21 +193,20 @@ void EntryPreviewWidget::setGroupNotesVisible(bool state)
     setNotesVisible(m_ui->groupNotesLabel, m_currentGroup->notes(), state);
 }
 
-void EntryPreviewWidget::setNotesVisible(QLabel* notesLabel, const QString notes, bool state)
+void EntryPreviewWidget::setNotesVisible(QLabel* notesLabel, const QString& notes, bool state)
 {
-    auto flags = notesLabel->textInteractionFlags();
     if (state) {
-        notesLabel->setText(notes);
-        notesLabel->setToolTip(notes);
-        notesLabel->setTextInteractionFlags(flags | Qt::TextSelectableByMouse);
+        // Add html hyperlinks to notes that start with XXXX://
+        QString hyperlinkNotes = notes;
+        notesLabel->setText(hyperlinkNotes.replace(QRegExp("(\\w+:\\/\\/\\S+)"), "<a href=\"\\1\">\\1</a>"));
+        notesLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
     } else {
         if (notes.isEmpty()) {
             notesLabel->setText("");
         } else {
             notesLabel->setText(QString("\u25cf").repeated(6));
         }
-        notesLabel->setToolTip({});
-        notesLabel->setTextInteractionFlags(flags & ~Qt::TextSelectableByMouse);
+        notesLabel->setTextInteractionFlags(Qt::NoTextInteraction);
     }
 }
 

--- a/src/gui/EntryPreviewWidget.h
+++ b/src/gui/EntryPreviewWidget.h
@@ -54,7 +54,7 @@ private slots:
     void setPasswordVisible(bool state);
     void setEntryNotesVisible(bool state);
     void setGroupNotesVisible(bool state);
-    void setNotesVisible(QLabel* notesLabel, const QString notes, bool state);
+    void setNotesVisible(QLabel* notesLabel, const QString& notes, bool state);
 
     void updateGroupHeaderLine();
     void updateGroupGeneralTab();

--- a/src/gui/EntryPreviewWidget.ui
+++ b/src/gui/EntryPreviewWidget.ui
@@ -463,7 +463,7 @@
                  <string>Notes</string>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignTop|Qt::AlignRight</set>
+                 <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
                 </property>
                </widget>
               </item>
@@ -502,11 +502,20 @@
                   <property name="text">
                    <string notr="true">notes</string>
                   </property>
+                  <property name="textFormat">
+                   <enum>Qt::RichText</enum>
+                  </property>
                   <property name="alignment">
                    <set>Qt::AlignTop</set>
                   </property>
                   <property name="wordWrap">
                    <bool>true</bool>
+                  </property>
+                  <property name="openExternalLinks">
+                   <bool>true</bool>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::NoTextInteraction</set>
                   </property>
                  </widget>
                 </item>
@@ -828,7 +837,7 @@
           <layout class="QVBoxLayout" name="verticalLayout_8">
            <item>
             <widget class="QWidget" name="groupGeneralWidget" native="true">
-             <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
+             <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
               <property name="leftMargin">
                <number>0</number>
               </property>
@@ -971,7 +980,7 @@
                  <string>Notes</string>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignTop|Qt::AlignRight</set>
+                 <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Fixes #3511 
This change adds support for hyperlinks in the notes field of the
EntryPreviewWidget. This is done by enabling the
`openExternalLinks` property of `QLabel`, and modifying the
value of the content of this field so that links are wrapped
with `<a>` tags.

Links are assumed to use the format: `protocol://path`, since
assumptions cannot/shoudn't be made about the specific format of
a link. The text of the label uses the modified notes value.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![image](https://user-images.githubusercontent.com/16418643/66022198-03bc0780-e4a2-11e9-9276-11c8e09e16b6.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Has been tested manually, and unit tests were added in d1fb773bfcd42cd3da860bb7a2a878d0213a4b96 to test around the regex pattern.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes. d1fb773bfcd42cd3da860bb7a2a878d0213a4b96
