### PR TITLE
Mention Nextcloud in addition to Dropbox

### DIFF
--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -194,7 +194,7 @@
           <item>
            <widget class="QCheckBox" name="useAtomicSavesCheckBox">
             <property name="text">
-             <string>Safely save database files (may be incompatible with Dropbox, etc)</string>
+             <string>Safely save database files (may be incompatible with Dropbox, Nextcloud, etc.)</string>
             </property>
             <property name="checked">
              <bool>true</bool>


### PR DESCRIPTION
Mention Nextcloud in addition to Dropbox in the warning message about the "Safely save database files" checkbox in the application settings dialog.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context

In the application settings dialog, the "Safely save database files" checkbox warns that it may be incompatible with "Dropbox etc". Since KeePassXC is all about privacy and open source, and as a nod to a fellow open source project, this commit adds Nextcloud to the warning message. The reason is that privacy-minded people, and thus the main target group of KeePassXC, tend to switch away from proprietary services like Dropbox and seek open source alternatives, of which Nextcloud seems to be among the most popular. If a commercial system like Dropbox has reason to me mentioned in this place, the same reason applies to Nextcloud as well. (Also, I've used KeePassXC with Nextcloud long enough to confirm that the option in question actually supports it perfectly well.)

## Screenshots

![mention_nextcloud](https://user-images.githubusercontent.com/25565229/66136163-4cd39f00-e5fb-11e9-9778-ac679d789883.png)

## Testing strategy

Tested manually.

## Checklist:

- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
