### PR TITLE
Fix entry clone modification time update

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -769,7 +769,6 @@ Entry* Entry::clone(CloneFlags flags) const
             entry->addHistoryItem(historyItemClone);
         }
     }
-    entry->setUpdateTimeinfo(true);
 
     if (flags & CloneResetTimeInfo) {
         QDateTime now = Clock::currentDateTimeUtc();
@@ -781,6 +780,8 @@ Entry* Entry::clone(CloneFlags flags) const
 
     if (flags & CloneRenameTitle)
         entry->setTitle(tr("%1 - Clone").arg(entry->title()));
+
+    entry->setUpdateTimeinfo(true);
 
     return entry;
 }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -762,7 +762,7 @@ Entry* Entry::clone(CloneFlags flags) const
     entry->m_autoTypeAssociations->copyDataFrom(m_autoTypeAssociations);
     if (flags & CloneIncludeHistory) {
         for (Entry* historyItem : m_history) {
-            Entry* historyItemClone = historyItem->clone(flags & ~CloneIncludeHistory & ~CloneNewUuid);
+            Entry* historyItemClone = historyItem->clone(flags & ~CloneIncludeHistory & ~CloneNewUuid & ~CloneResetTimeInfo);
             historyItemClone->setUpdateTimeinfo(false);
             historyItemClone->setUuid(entry->uuid());
             historyItemClone->setUpdateTimeinfo(true);

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -107,6 +107,16 @@ void TestEntry::testClone()
     QCOMPARE(entryCloneNewUuid->historyItems().size(), 0);
     QCOMPARE(entryCloneNewUuid->timeInfo().creationTime(), entryOrg->timeInfo().creationTime());
 
+    // Reset modification time
+    entryOrgTime.setLastModificationTime(Clock::datetimeUtc(60));
+    entryOrg->setTimeInfo(entryOrgTime);
+
+    QScopedPointer<Entry> entryCloneRename(entryOrg->clone(Entry::CloneRenameTitle));
+    QCOMPARE(entryCloneRename->uuid(), entryOrg->uuid());
+    QCOMPARE(entryCloneRename->title(), QString("New Title - Clone"));
+    // Cloning should not modify time info unless explicity requested
+    QCOMPARE(entryCloneRename->timeInfo(), entryOrg->timeInfo());
+
     QScopedPointer<Entry> entryCloneResetTime(entryOrg->clone(Entry::CloneResetTimeInfo));
     QCOMPARE(entryCloneResetTime->uuid(), entryOrg->uuid());
     QCOMPARE(entryCloneResetTime->title(), QString("New Title"));

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -113,12 +113,28 @@ void TestEntry::testClone()
     QCOMPARE(entryCloneResetTime->historyItems().size(), 0);
     QVERIFY(entryCloneResetTime->timeInfo().creationTime() != entryOrg->timeInfo().creationTime());
 
-    QScopedPointer<Entry> entryCloneHistory(entryOrg->clone(Entry::CloneIncludeHistory));
+    // Date back history of original entry
+    Entry * firstHistoryItem = entryOrg->historyItems()[0];
+    TimeInfo entryOrgHistoryTimeInfo = firstHistoryItem->timeInfo();
+    QDateTime datedBackEntryOrgModificationTime = entryOrgHistoryTimeInfo.lastModificationTime().addMSecs(-10);
+    entryOrgHistoryTimeInfo.setLastModificationTime(datedBackEntryOrgModificationTime);
+    entryOrgHistoryTimeInfo.setCreationTime(datedBackEntryOrgModificationTime);
+    firstHistoryItem->setTimeInfo(entryOrgHistoryTimeInfo);
+
+    QScopedPointer<Entry> entryCloneHistory(entryOrg->clone(Entry::CloneIncludeHistory | Entry::CloneResetTimeInfo));
     QCOMPARE(entryCloneHistory->uuid(), entryOrg->uuid());
     QCOMPARE(entryCloneHistory->title(), QString("New Title"));
-    QCOMPARE(entryCloneHistory->historyItems().size(), 1);
+    QCOMPARE(entryCloneHistory->historyItems().size(), entryOrg->historyItems().size());
     QCOMPARE(entryCloneHistory->historyItems().at(0)->title(), QString("Original Title"));
-    QCOMPARE(entryCloneHistory->timeInfo().creationTime(), entryOrg->timeInfo().creationTime());
+    QVERIFY(entryCloneHistory->timeInfo().creationTime() != entryOrg->timeInfo().creationTime());
+    // Timeinfo of history items should not be modified
+    QList<Entry*> entryOrgHistory = entryOrg->historyItems(), clonedHistory = entryCloneHistory->historyItems();
+    auto entryOrgHistoryItem = entryOrgHistory.constBegin();
+    for(auto entryCloneHistoryItem = clonedHistory.constBegin()
+            ;entryCloneHistoryItem != clonedHistory.constEnd()
+            ;++entryCloneHistoryItem, ++entryOrgHistoryItem) {
+        QCOMPARE((*entryOrgHistoryItem)->timeInfo(), (*entryCloneHistoryItem)->timeInfo());
+    }
 
     Database db;
     auto* entryOrgClone = entryOrg->clone(Entry::CloneNoFlags);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Fixes #3592.

Previously, cloning an entry with history would not preserve the modification times of items in the cloned entry's history. This was due to the CloneResetTimeInfo flag being set implicitly by CloneDialog.cpp and consequently being passed to the clone function of each entry in the cloned entry's history. This is mitigated by explicitly clearing the flag when calling clone() on a history entry.

Moreover, cloning an entry with the Rename flag set would update the modification time even when CloneResetTimeInfo was not set. In contrast, this does not happen when the Rename flag was not set, hence i assumed this to be a bug.

## Testing strategy
Extended TestEntry::testClone() to cover the cases outlined above.


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. 
- ✅ My code follows the code style of this project. 
- ✅ All new and existing tests passed. 
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`.
- ✅ I have added tests to cover my changes.
