### PR TITLE
Fix setting and removing registy values for Browser Integration

### DIFF
--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -109,9 +109,7 @@ void HostInstaller::installBrowser(SupportedBrowsers browser,
 #ifdef Q_OS_WIN
         // Create a registry key
         QSettings settings(getTargetPath(browser), QSettings::NativeFormat);
-        if (!registryEntryFound(settings)) {
-            settings.setValue("Default", getPath(browser));
-        }
+        settings.setValue("Default", getPath(browser));
 #endif
         // Always create the script file
         QJsonObject script = constructFile(browser, proxy, location);
@@ -128,9 +126,7 @@ void HostInstaller::installBrowser(SupportedBrowsers browser,
 #ifdef Q_OS_WIN
         // Remove the registry entry
         QSettings settings(getTargetPath(browser), QSettings::NativeFormat);
-        if (registryEntryFound(settings)) {
-            settings.remove("Default");
-        }
+        settings.remove("Default");
 #endif
     }
 }


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
When updating KeePassXC portable, the Windows registry settings are pointing to the old location. The extra checking for existing registry folder is removed, and old values are always overridden.

Fixes #1817.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
NOT tested yet.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
