### PR TITLE
Fix stylesheet warnings introduced by 3b330ee2

### DIFF
--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -94,14 +94,14 @@ bool PasswordEdit::passwordsEqual() const
 
 void PasswordEdit::updateStylesheet()
 {
-    QString stylesheet("QLineEdit { background: %1; }");
+    const QString stylesheetTemplate("QLineEdit { background: %1; }");
 
     if (m_basePasswordEdit && !passwordsEqual()) {
         bool isCorrect = true;
         if (m_basePasswordEdit->text().startsWith(text())) {
-            stylesheet = stylesheet.arg(CorrectSoFarColor.name());
+            setStyleSheet(stylesheetTemplate.arg(CorrectSoFarColor.name()));
         } else {
-            stylesheet = stylesheet.arg(ErrorColor.name());
+            setStyleSheet(stylesheetTemplate.arg(ErrorColor.name()));
             isCorrect = false;
         }
         m_correctAction->setVisible(isCorrect);
@@ -109,9 +109,8 @@ void PasswordEdit::updateStylesheet()
     } else {
         m_correctAction->setVisible(false);
         m_errorAction->setVisible(false);
+        setStyleSheet("");
     }
-
-    setStyleSheet(stylesheet);
 }
 
 void PasswordEdit::autocompletePassword(const QString& password)


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Fixes regression introduced by 3b330ee2. The previous changes could add an invalid style sheet to PasswordEdit's QLineEdit.



## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
