### PR TITLE
Ask to delete recycle bin when disabled in database settings

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -702,8 +702,15 @@ void Database::setPublicCustomData(const QVariantMap& customData)
 void Database::createRecycleBin()
 {
     Q_ASSERT(!m_data.isReadOnly);
-    Group* recycleBin = Group::createRecycleBin();
+
+    auto recycleBin = new Group();
+    recycleBin->setUuid(QUuid::createUuid());
     recycleBin->setParent(rootGroup());
+    recycleBin->setName(tr("Recycle Bin"));
+    recycleBin->setIcon(Group::RecycleBinIconNumber);
+    recycleBin->setSearchingEnabled(Group::Disable);
+    recycleBin->setAutoTypeEnabled(Group::Disable);
+
     m_metadata->setRecycleBin(recycleBin);
 }
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -75,17 +75,6 @@ Group::~Group()
     cleanupParent();
 }
 
-Group* Group::createRecycleBin()
-{
-    Group* recycleBin = new Group();
-    recycleBin->setUuid(QUuid::createUuid());
-    recycleBin->setName(tr("Recycle Bin"));
-    recycleBin->setIcon(RecycleBinIconNumber);
-    recycleBin->setSearchingEnabled(Group::Disable);
-    recycleBin->setAutoTypeEnabled(Group::Disable);
-    return recycleBin;
-}
-
 template <class P, class V> inline bool Group::set(P& property, const V& value)
 {
     if (property != value) {
@@ -279,6 +268,11 @@ bool Group::isRecycled() const
 bool Group::isExpired() const
 {
     return m_data.timeInfo.expires() && m_data.timeInfo.expiryTime() < Clock::currentDateTimeUtc();
+}
+
+bool Group::isEmpty() const
+{
+    return !hasChildren() && m_entries.isEmpty();
 }
 
 CustomData* Group::customData()

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -80,8 +80,6 @@ public:
     Group();
     ~Group();
 
-    static Group* createRecycleBin();
-
     const QUuid& uuid() const;
     const QString uuidToHex() const;
     QString name() const;
@@ -103,6 +101,7 @@ public:
     Entry* lastTopVisibleEntry() const;
     bool isExpired() const;
     bool isRecycled() const;
+    bool isEmpty() const;
     CustomData* customData();
     const CustomData* customData() const;
 

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -799,7 +799,7 @@ void TestGroup::testAddEntryWithPath()
 void TestGroup::testIsRecycled()
 {
     Database* db = new Database();
-    db->rootGroup()->createRecycleBin();
+    db->metadata()->setRecycleBinEnabled(true);
 
     Group* group1 = new Group();
     group1->setName("group1");


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
  
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
- Fix issue [#3365](https://github.com/keepassxreboot/keepassxc/issues/3365).
- Makes it possible to empty the recycle bin if "Use recycle bin" is disabled in "Database settings".
## Testing strategy
Manually emptied recycle bin when "Use recycle bin" is enabled/disabled in Ubuntu 18.04.3 LTS, MacOS Mojave v10.14.6.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**