### PR TITLE
Ask user before allowing kdbx files as key files

### DIFF
--- a/src/gui/dbsettings/DatabaseSettingsWidget.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidget.cpp
@@ -43,3 +43,9 @@ void DatabaseSettingsWidget::load(QSharedPointer<Database> db)
     m_db = std::move(db);
     initialize();
 }
+
+const QSharedPointer<Database> DatabaseSettingsWidget::getDatabase() const
+{
+    return m_db;
+}
+

--- a/src/gui/dbsettings/DatabaseSettingsWidget.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidget.h
@@ -38,6 +38,8 @@ public:
 
     virtual void load(QSharedPointer<Database> db);
 
+    const QSharedPointer<Database> getDatabase() const;
+
 signals:
     /**
      * Can be emitted to indicate size changes and allow parents widgets to adjust properly.

--- a/src/gui/masterkey/KeyFileEditWidget.h
+++ b/src/gui/masterkey/KeyFileEditWidget.h
@@ -26,12 +26,15 @@ namespace Ui
     class KeyFileEditWidget;
 }
 
+class DatabaseSettingsWidget;
+
 class KeyFileEditWidget : public KeyComponentWidget
 {
     Q_OBJECT
 
+
 public:
-    explicit KeyFileEditWidget(QWidget* parent = nullptr);
+    explicit KeyFileEditWidget(DatabaseSettingsWidget* parent);
     Q_DISABLE_COPY(KeyFileEditWidget);
     ~KeyFileEditWidget() override;
 
@@ -49,6 +52,7 @@ private slots:
 private:
     const QScopedPointer<Ui::KeyFileEditWidget> m_compUi;
     QPointer<QWidget> m_compEditWidget;
+    const QPointer<DatabaseSettingsWidget> m_parent;
 };
 
 #endif // KEEPASSXC_KEYFILEEDITWIDGET_H

--- a/src/gui/masterkey/KeyFileEditWidget.ui
+++ b/src/gui/masterkey/KeyFileEditWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>364</width>
+    <width>370</width>
     <height>76</height>
    </rect>
   </property>
@@ -71,6 +71,21 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>Note: Do not use a file that may change as that will prevent you from unlocking your database!</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
When adding a keyfile, the selected file is checked:
- if it is a `*.kdbx` file, the user is warned that the file is not appropriate, but can ignore the warning. Maybe some users decided to give their keyfiles a kbdx extension and want to continue with this in the future.
- if it is the current database file, an error is shown. The database would be corrupted if it was used.

Strictly speaking, the change could be considered to be a breaking change. The user cannot pick the database as its own keyfile anymore. But practically this would corrupt the database anyway, so no ones "workflow" is breaking

This change might need new translations (I'm not sure how they work with Qt. Tested with English local only).

In issue #3611 @phoerious and @droidmonkey kind of referenced this feature

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Sorry for the missing window headers, my screenshot tool failed to grab them. They are (in both cases): "Database file as key file"
![image](https://user-images.githubusercontent.com/2809491/67128471-c22d9b00-f1c9-11e9-9c20-4586b0e99851.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Only manual test. This is a GUI change, there is not much to test here.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
