### PR TITLE
Show database name when doing association

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -304,9 +304,9 @@ QString BrowserService::storeKey(const QString& key)
         QInputDialog keyDialog;
         connect(m_dbTabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), &keyDialog, SLOT(reject()));
         keyDialog.setWindowTitle(tr("KeePassXC: New key association request"));
-        keyDialog.setLabelText(tr("You have received an association request for the above key.\n\n"
-                                  "If you would like to allow it access to your KeePassXC database,\n"
-                                  "give it a unique name to identify and accept it."));
+        keyDialog.setLabelText(tr("You have received an association request for the following database:\n%1\n\n"
+                                  "Give the connection a unique name or ID, for example:\nchrome-laptop.")
+                                   .arg(db->metadata()->name().toHtmlEscaped()));
         keyDialog.setOkButtonText(tr("Save and allow access"));
         keyDialog.setWindowFlags(keyDialog.windowFlags() | Qt::WindowStaysOnTopHint);
         raiseWindow();


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
When extension associates KeePassXC with a database, a popup window is shown. The text is not informative and haven't been updated for a while. The fix shows the database name in the popup.

Fixes #838.
Fixes #3626.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![Screen Shot 2019-10-19 at 14 23 35](https://user-images.githubusercontent.com/24570482/67144135-33c62180-f27c-11e9-8405-806094c059f2.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
