### PR TITLE
Browser access control dialog shows submitUrl when found

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -410,7 +410,7 @@ QJsonArray BrowserService::findMatchingEntries(const QString& id,
     }
 
     // Confirm entries
-    if (confirmEntries(pwEntriesToConfirm, url, host, submitHost, realm, httpAuth)) {
+    if (confirmEntries(pwEntriesToConfirm, url, host, submitUrl, realm, httpAuth)) {
         pwEntries.append(pwEntriesToConfirm);
     }
 
@@ -786,7 +786,7 @@ QList<Entry*> BrowserService::sortEntries(QList<Entry*>& pwEntries, const QStrin
 bool BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
                                     const QString& url,
                                     const QString& host,
-                                    const QString& submitHost,
+                                    const QString& submitUrl,
                                     const QString& realm,
                                     const bool httpAuth)
 {
@@ -797,7 +797,7 @@ bool BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
     m_dialogActive = true;
     BrowserAccessControlDialog accessControlDialog;
     connect(m_dbTabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), &accessControlDialog, SLOT(reject()));
-    accessControlDialog.setUrl(url);
+    accessControlDialog.setUrl(!submitUrl.isEmpty() ? submitUrl : url);
     accessControlDialog.setItems(pwEntriesToConfirm);
     accessControlDialog.setHTTPAuth(httpAuth);
 
@@ -806,6 +806,7 @@ bool BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
     accessControlDialog.activateWindow();
     accessControlDialog.raise();
 
+    const QString submitHost = QUrl(submitUrl).host();
     int res = accessControlDialog.exec();
     if (accessControlDialog.remember()) {
         for (auto* entry : pwEntriesToConfirm) {

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -120,7 +120,7 @@ private:
     bool confirmEntries(QList<Entry*>& pwEntriesToConfirm,
                         const QString& url,
                         const QString& host,
-                        const QString& submitHost,
+                        const QString& submitUrl,
                         const QString& realm,
                         const bool httpAuth);
     QJsonObject prepareEntry(const Entry* entry);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
- ✅ Documentation (non-code change)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
When requesting access to a credential, the `submitUrl` received from the extension is not shown at all. At worst cases the `submitUrl` can be a totally different site. Now, when `submitUrl` is provided, it will be shown as a access requester.

Fixes #2788.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
