### PR TITLE
Fix unused variable error when building without WITH_XC_YUBIKEY.

### DIFF
--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -177,7 +177,9 @@ namespace Utils
                 outputDescriptor));
             compositeKey->addChallengeResponseKey(key);
         }
-#endif
+#else
+        Q_UNUSED(yubiKeySlot);
+#endif // WITH_XC_YUBIKEY
 
         auto db = QSharedPointer<Database>::create();
         QString error;


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Fixes an unused variable error when building with `-Werror=unused-parameter`.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
