### PR TITLE
no "Share" tab without WITH_XC_KEESHARE

### DIFF
--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -72,6 +72,10 @@ EntryPreviewWidget::EntryPreviewWidget(QWidget* parent)
     m_ui->groupCloseButton->setIcon(filePath()->icon("actions", "dialog-close"));
     connect(m_ui->groupCloseButton, SIGNAL(clicked()), SLOT(hide()));
     connect(m_ui->groupTabWidget, SIGNAL(tabBarClicked(int)), SLOT(updateTabIndexes()), Qt::QueuedConnection);
+
+#if !defined(WITH_XC_KEESHARE)
+    removeTab(m_ui->groupTabWidget, m_ui->groupShareTab);
+#endif
 }
 
 EntryPreviewWidget::~EntryPreviewWidget()
@@ -374,6 +378,13 @@ void EntryPreviewWidget::openEntryUrl()
     if (m_currentEntry) {
         emit entryUrlActivated(m_currentEntry);
     }
+}
+
+void EntryPreviewWidget::removeTab(QTabWidget* tabWidget, QWidget* widget)
+{
+    const int tabIndex = tabWidget->indexOf(widget);
+    Q_ASSERT(tabIndex != -1);
+    tabWidget->removeTab(tabIndex);
 }
 
 void EntryPreviewWidget::setTabEnabled(QTabWidget* tabWidget, QWidget* widget, bool enabled)

--- a/src/gui/EntryPreviewWidget.h
+++ b/src/gui/EntryPreviewWidget.h
@@ -67,6 +67,7 @@ private slots:
     void openEntryUrl();
 
 private:
+    void removeTab(QTabWidget* tabWidget, QWidget* widget);
     void setTabEnabled(QTabWidget* tabWidget, QWidget* widget, bool enabled);
 
     static QPixmap preparePixmap(const QPixmap& pixmap, int size);


### PR DESCRIPTION
if KeePassXC is compiled with WITH_XC_KEESHARE=OFF, the "Share" tab of
the EntryPreviewWidget for groups is removed from the GUI completely.

closes #3619.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
The EntryPreviewWidget for groups should not display the "Shared" tab at all, if compiled with WITH_XC_KEESHARE=OFF.

## Screenshots
With KeeShare enabled:
![image](https://user-images.githubusercontent.com/3578416/67305585-d63d0980-f4f5-11e9-9d8b-abe2134f13f0.png)

With KeeShare disabled and without this change:
![image](https://user-images.githubusercontent.com/3578416/67305367-81998e80-f4f5-11e9-9ba3-45058369dc3e.png)

With KeeShare disabled and with this change:
![image](https://user-images.githubusercontent.com/3578416/67305436-99711280-f4f5-11e9-923c-773c54a2b673.png)

## Testing strategy
Manually, see screenshots.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed.
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`.