### PR TITLE
Don't show a warning when opening a database without WITH_XC_YUBIKEY.

### DIFF
--- a/src/cli/DatabaseCommand.cpp
+++ b/src/cli/DatabaseCommand.cpp
@@ -52,7 +52,11 @@ int DatabaseCommand::execute(const QStringList& arguments)
         db = Utils::unlockDatabase(args.at(0),
                                    !parser->isSet(Command::NoPasswordOption),
                                    parser->value(Command::KeyFileOption),
+#ifdef WITH_XC_YUBIKEY
                                    parser->value(Command::YubiKeyOption),
+#else
+                                   "",
+#endif
                                    parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT,
                                    Utils::STDERR);
         if (!db) {


### PR DESCRIPTION
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Fixes the following warning when opening a database with `keepassxc-cli` when `WITH_XC_YUBIKEY` is not set:

```
QCommandLineParser: option not defined: "y"
```

## Testing strategy
Tested manually.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
