### PR TITLE
Prevent new entry loss on database file reload

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -585,13 +585,18 @@ QList<Entry*> Group::referencesRecursive(const Entry* entry) const
                                           [entry](const Entry* e) { return e->hasReferencesTo(entry->uuid()); });
 }
 
-Entry* Group::findEntryByUuid(const QUuid& uuid) const
+Entry* Group::findEntryByUuid(const QUuid& uuid, bool recursive) const
 {
     if (uuid.isNull()) {
         return nullptr;
     }
 
-    for (Entry* entry : entriesRecursive(false)) {
+    auto entries = m_entries;
+    if (recursive) {
+        entries = entriesRecursive(false);
+    }
+
+    for (auto entry : entries) {
         if (entry->uuid() == uuid) {
             return entry;
         }

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -114,7 +114,7 @@ public:
     static const QString RootAutoTypeSequence;
 
     Group* findChildByName(const QString& name);
-    Entry* findEntryByUuid(const QUuid& uuid) const;
+    Entry* findEntryByUuid(const QUuid& uuid, bool recursive = true) const;
     Entry* findEntryByPath(const QString& entryPath);
     Entry* findEntryBySearchTerm(const QString& term, EntryReferenceType referenceType);
     Group* findGroupByUuid(const QUuid& uuid);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Fix #3651

* Correct data loss when the database reloads due to a file change while creating a new entry. The issue occurred due to the "new parent group" pointer being invalid after the database is reloaded following merge.

* Also fix re-selecting entries following database file reload. If the entry was moved out of the current group it would result in an assert hit. This fix prevents recursively looking for the entry.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested through replication of the steps outlined in #3651

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
