### PR TITLE
Fix building on Mac OS X 10.11 or older

### DIFF
--- a/src/core/Alloc.cpp
+++ b/src/core/Alloc.cpp
@@ -17,6 +17,7 @@
 
 #include <QtGlobal>
 #include <cstdint>
+#include <cstdlib>
 #include <sodium.h>
 #if defined(Q_OS_MACOS)
 #include <malloc/malloc.h>

--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -149,8 +149,7 @@ namespace
             KeeShareSettings::Sign sign;
             auto sshKey = own.key.sshKey();
             sshKey.openKey(QString());
-            const Signature signer;
-            sign.signature = signer.create(bytes, sshKey);
+            sign.signature = Signature::create(bytes, sshKey);
             sign.certificate = own.certificate;
             stream << KeeShareSettings::Sign::serialize(sign);
             stream.flush();


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

* Add a missing include in src/core/Alloc.cpp

On Mac OS X 10.11 with Xcode 8.2.1, building fails with
```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC-devel/work/keepassxc-f726d7501ff7e8a66ae974719042f23010716595/src/core/Alloc.cpp:44:10: error: no type named 'free' in namespace 'std'
    std::free(ptr);
    ~~~~~^
```
Per [1], `std::free()` needs `#include <cstdlib>`. That file is included
indirectly on newer systems.

* Avoid const Signature object in src/keeshare/ShareExport.cpp

After the above issue is resolved, building fails at
```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC-devel/work/keepassxc-f726d7501ff7e8a66ae974719042f23010716595/src/keeshare/ShareExport.cpp:152:29: error: default initialization of an object of const type 'const Signature' without a user-provided default constructor
            const Signature signer;
                            ^
```
Apparently this is related to C++ defect 253 [2]. From the code,
creating a Signature is not needed as all methods in Signature are
static, so just call the method.

[1] https://en.cppreference.com/w/cpp/memory/c/free
[2] https://stackoverflow.com/a/47368753

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
N/A

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Build it! Some logs from build servers of MacPorts:

https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/103349/steps/install-port/logs/stdio (Mac OS X 10.9)
https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/100565/steps/install-port/logs/stdio (Mac OS X 10.10)

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- My change requires a change to the documentation, and I have updated it accordingly.
- I have added tests to cover my changes.
