### PR TITLE
Hide yubikey gui labels if compiled without WITH_XC_YUBIKEY

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -80,6 +80,8 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
 
     connect(m_ui->buttonRedetectYubikey, SIGNAL(clicked()), SLOT(pollYubikey()));
 #else
+    m_ui->hardwareKeyLabel->setVisible(false);
+    m_ui->hardwareKeyLabelHelp->setVisible(false);
     m_ui->buttonRedetectYubikey->setVisible(false);
     m_ui->comboChallengeResponse->setVisible(false);
     m_ui->yubikeyProgress->setVisible(false);


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
The OpenDatabaseWidget has two labels that should not be visible when compiled without yubikey support.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/3578416/67575645-4a1d2300-f73d-11e9-9389-0d9ee2c89ecd.png)

After:
![image](https://user-images.githubusercontent.com/3578416/67575653-51443100-f73d-11e9-99fe-84898111d54f.png)

## Testing strategy
Manually, see screenshots.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All new and existing tests passed.
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON` (8807 bytes leaked in 127 allocation with and without my change -- no difference :stuck_out_tongue:).