### PR TITLE
Force app exit if session manager signals a shutdown.

### DIFF
--- a/src/core/OSEventFilter.cpp
+++ b/src/core/OSEventFilter.cpp
@@ -37,16 +37,8 @@ bool OSEventFilter::nativeEventFilter(const QByteArray& eventType, void* message
 #if defined(Q_OS_UNIX)
     if (eventType == QByteArrayLiteral("xcb_generic_event_t")) {
 #elif defined(Q_OS_WIN)
-    auto winmsg = static_cast<MSG*>(message);
-    if (winmsg->message == WM_QUERYENDSESSION) {
-        *result = 1;
-        return true;
-    } else if (winmsg->message == WM_ENDSESSION) {
-        getMainWindow()->appExit();
-        *result = 0;
-        return true;
-    } else if (eventType == QByteArrayLiteral("windows_generic_MSG")
-               || eventType == QByteArrayLiteral("windows_dispatcher_MSG")) {
+    if (eventType == QByteArrayLiteral("windows_generic_MSG")
+        || eventType == QByteArrayLiteral("windows_dispatcher_MSG")) {
 #endif
         return autoType()->callEventFilter(message) == 1;
     }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -144,24 +144,24 @@ private:
 
     const QScopedPointer<Ui::MainWindow> m_ui;
     SignalMultiplexer m_actionMultiplexer;
-    QAction* m_clearHistoryAction;
-    QAction* m_searchWidgetAction;
-    QMenu* m_entryContextMenu;
-    QActionGroup* m_lastDatabasesActions;
-    QActionGroup* m_copyAdditionalAttributeActions;
-    InactivityTimer* m_inactivityTimer;
-    InactivityTimer* m_touchIDinactivityTimer;
+    QPointer<QAction> m_clearHistoryAction;
+    QPointer<QAction> m_searchWidgetAction;
+    QPointer<QMenu> m_entryContextMenu;
+    QPointer<QActionGroup> m_lastDatabasesActions;
+    QPointer<QActionGroup> m_copyAdditionalAttributeActions;
+    QPointer<InactivityTimer> m_inactivityTimer;
+    QPointer<InactivityTimer> m_touchIDinactivityTimer;
     int m_countDefaultAttributes;
-    QSystemTrayIcon* m_trayIcon;
-    ScreenLockListener* m_screenLockListener;
+    QPointer<QSystemTrayIcon> m_trayIcon;
+    QPointer<ScreenLockListener> m_screenLockListener;
     QPointer<SearchWidget> m_searchWidget;
 
     Q_DISABLE_COPY(MainWindow)
 
-    bool m_appExitCalled;
-    bool m_appExiting;
-    bool m_contextMenuFocusLock;
-    uint m_lastFocusOutTime;
+    bool m_appExitCalled = false;
+    bool m_appExiting = false;
+    bool m_contextMenuFocusLock = false;
+    uint m_lastFocusOutTime = 0;
     QTimer m_trayIconTriggerTimer;
     QSystemTrayIcon::ActivationReason m_trayIconTriggerReason;
 };


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Force app exit if session manager signals a shutdown. Resolves #3410.

Additionally, "fix" main window toggling behaviour when clicking the tray icon while the window is visible, but not in focus (e.g. hidden by other windows). On platforms other than Windows, the window is now brought to the front if it does not already have focus or is toggled otherwise.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Since I cannot reliably reproduce shutdown issues on Linux, I could not really test if the change is effective. I did test all possible variants of hiding or toggling the window and exiting the app explicitly to avoid regressions.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**