### PR TITLE
Reduce default Argon2 memory and thread settings

### DIFF
--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
@@ -400,8 +400,10 @@ void DatabaseSettingsWidgetEncryption::updateFormatCompatibility(int index, bool
 
         if (kdf->uuid() == KeePass2::KDF_ARGON2) {
             auto argon2Kdf = kdf.staticCast<Argon2Kdf>();
-            argon2Kdf->setMemory(128 * 1024);
-            argon2Kdf->setParallelism(static_cast<quint32>(QThread::idealThreadCount()));
+            // Default to 64 MiB of memory and 2 threads
+            // these settings are safe for desktop and mobile devices
+            argon2Kdf->setMemory(1 << 16);
+            argon2Kdf->setParallelism(2);
         }
 
         activateChangeDecryptionTime();


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Fix #3550
* Default memory reduced to 64 MiB (from 128 MiB) and parallelism reduced to 2 threads. This allows for desktop and mobile device compatibility.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
