### PR TITLE
Check include malloc.h and malloc_usable_size(3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,14 @@ if(UNIX)
     int main() { prctl(PR_SET_DUMPABLE, 0); return 0; }"
             HAVE_PR_SET_DUMPABLE)
 
+    check_cxx_source_compiles("#include <malloc.h>
+    int main() { return 0; }"
+            HAVE_MALLOC_H)
+
+    check_cxx_source_compiles("#include <malloc.h>
+    int main() { malloc_usable_size(NULL, 0); return 0; }"
+            HAVE_MALLOC_USABLE_SIZE)
+
     check_cxx_source_compiles("#include <sys/resource.h>
     int main() {
       struct rlimit limit;

--- a/src/core/Alloc.cpp
+++ b/src/core/Alloc.cpp
@@ -23,8 +23,10 @@
 #include <malloc/malloc.h>
 #elif defined(Q_OS_FREEBSD)
 #include <malloc_np.h>
-#else
+#elif defined(HAVE_MALLOC_H)
 #include <malloc.h>
+#else
+#include <stdlib.h>
 #endif
 
 #if defined(NDEBUG) && !defined(__cpp_sized_deallocation)
@@ -64,7 +66,7 @@ void operator delete(void* ptr) noexcept
     ::operator delete(ptr, _msize(ptr));
 #elif defined(Q_OS_MACOS)
     ::operator delete(ptr, malloc_size(ptr));
-#elif defined(Q_OS_UNIX)
+#elif defined(HAVE_MALLOC_USABLE_SIZE)
     ::operator delete(ptr, malloc_usable_size(ptr));
 #else
     // whatever OS this is, give up and simply free stuff


### PR DESCRIPTION
One some operating systems  malloc(3) is not in malloc.h nor in
malloc_np.h, instead it is in stdlib.h.

In addition, not all systems support malloc_usable_size(3). You could
argue it's not safe.

This patch tries to be portable and it fix the build on OpenBSD.