### PR TITLE
Use unlock dialog when unlocking a database from browser extension

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -64,7 +64,6 @@ BrowserService::BrowserService()
     : QObject()
     , m_browserHost(new BrowserHost)
     , m_dialogActive(false)
-    , m_bringToFrontRequested(false)
     , m_prevWindowState(WindowState::Normal)
     , m_keepassBrowserUUID(Tools::hexToUuid("de887cc3036343b8974b5911b8816224"))
 {
@@ -110,8 +109,7 @@ bool BrowserService::openDatabase(bool triggerUnlock)
     }
 
     if (triggerUnlock) {
-        m_bringToFrontRequested = true;
-        raiseWindow(true);
+        emit requestUnlock();
     }
 
     return false;
@@ -1220,6 +1218,23 @@ void BrowserService::raiseWindow(const bool force)
 #endif
 }
 
+void BrowserService::updateWindowState()
+{
+    m_prevWindowState = WindowState::Normal;
+    if (getMainWindow()->isMinimized()) {
+        m_prevWindowState = WindowState::Minimized;
+    }
+#ifdef Q_OS_MACOS
+    if (macUtils()->isHidden()) {
+        m_prevWindowState = WindowState::Hidden;
+    }
+#else
+    if (getMainWindow()->isHidden()) {
+        m_prevWindowState = WindowState::Hidden;
+    }
+#endif
+}
+
 void BrowserService::databaseLocked(DatabaseWidget* dbWidget)
 {
     if (dbWidget) {
@@ -1232,11 +1247,6 @@ void BrowserService::databaseLocked(DatabaseWidget* dbWidget)
 void BrowserService::databaseUnlocked(DatabaseWidget* dbWidget)
 {
     if (dbWidget) {
-        if (m_bringToFrontRequested) {
-            hideWindow();
-            m_bringToFrontRequested = false;
-        }
-
         QJsonObject msg;
         msg["action"] = QString("database-unlocked");
         m_browserHost->sendClientMessage(msg);

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -91,6 +91,9 @@ public:
     static const QString OPTION_ONLY_HTTP_AUTH;
     static const QString ADDITIONAL_URL;
 
+signals:
+    void requestUnlock();
+
 public slots:
     void databaseLocked(DatabaseWidget* dbWidget);
     void databaseUnlocked(DatabaseWidget* dbWidget);
@@ -142,6 +145,7 @@ private:
 
     void hideWindow() const;
     void raiseWindow(const bool force = false);
+    void updateWindowState();
 
     static bool moveSettingsToCustomData(Entry* entry, const QString& name);
     static int moveKeysToCustomData(Entry* entry, QSharedPointer<Database> db);
@@ -150,7 +154,6 @@ private:
     QHash<QString, QSharedPointer<BrowserAction>> m_browserClients;
 
     bool m_dialogActive;
-    bool m_bringToFrontRequested;
     WindowState m_prevWindowState;
     QUuid m_keepassBrowserUUID;
 

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -755,3 +755,11 @@ void DatabaseTabWidget::performGlobalAutoType()
         unlockDatabaseInDialog(currentDatabaseWidget(), DatabaseOpenDialog::Intent::AutoType);
     }
 }
+
+void DatabaseTabWidget::performBrowserUnlock()
+{
+    auto dbWidget = currentDatabaseWidget();
+    if (dbWidget && dbWidget->isLocked()) {
+        unlockDatabaseInDialog(dbWidget, DatabaseOpenDialog::Intent::Browser);
+    }
+}

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -82,6 +82,7 @@ public slots:
     void changeReports();
     void changeDatabaseSettings();
     void performGlobalAutoType();
+    void performBrowserUnlock();
 
 signals:
     void databaseOpened(DatabaseWidget* dbWidget);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -144,6 +144,8 @@ MainWindow::MainWindow()
             &DatabaseTabWidget::activateDatabaseChanged,
             browserService(),
             &BrowserService::activeDatabaseChanged);
+    connect(
+        browserService(), &BrowserService::requestUnlock, m_ui->tabWidget, &DatabaseTabWidget::performBrowserUnlock);
 #endif
 
 #ifdef WITH_XC_SSHAGENT


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Instead of rising the KeePassXC window to the front, a separate unlock dialog is used.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
