### PR TITLE
CLI: do not display protected fields by default.

### DIFF
--- a/share/docs/man/keepassxc-cli.1
+++ b/share/docs/man/keepassxc-cli.1
@@ -182,6 +182,10 @@ an error if no TOTP is configured for the entry.
 Shows the named attributes. This option can be specified more than once,
 with each attribute shown one-per-line in the given order. If no attributes are
 specified and \fI-t\fP is not specified, a summary of the default attributes is given.
+Protected attributes will be displayed in clear text if specified explicitly by this option.
+
+.IP "-s, --show-protected"
+Shows the protected attributes in clear text.
 
 .IP "-t, --totp"
 Also shows the current TOTP, reporting an error if no TOTP is configured for

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -29,6 +29,7 @@ public:
 
     static const QCommandLineOption TotpOption;
     static const QCommandLineOption AttributesOption;
+    static const QCommandLineOption ProtectedAttributesOption;
 };
 
 #endif // KEEPASSXC_SHOW_H

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -1682,14 +1682,15 @@ void TestCli::testShow()
     QCOMPARE(m_stdoutFile->readAll(),
              QByteArray("Title: Sample Entry\n"
                         "UserName: User Name\n"
-                        "Password: Password\n"
+                        "Password: PROTECTED\n"
                         "URL: http://www.somesite.com/\n"
                         "Notes: Notes\n"));
 
     qint64 pos = m_stdoutFile->pos();
     Utils::Test::setNextPassword("a");
-    showCmd.execute({"show", m_dbFile->fileName(), "-q", "/Sample Entry"});
+    showCmd.execute({"show", "-s", m_dbFile->fileName(), "/Sample Entry"});
     m_stdoutFile->seek(pos);
+    m_stdoutFile->readLine(); // skip password prompt
     QCOMPARE(m_stdoutFile->readAll(),
              QByteArray("Title: Sample Entry\n"
                         "UserName: User Name\n"
@@ -1699,10 +1700,28 @@ void TestCli::testShow()
 
     pos = m_stdoutFile->pos();
     Utils::Test::setNextPassword("a");
+    showCmd.execute({"show", m_dbFile->fileName(), "-q", "/Sample Entry"});
+    m_stdoutFile->seek(pos);
+    QCOMPARE(m_stdoutFile->readAll(),
+             QByteArray("Title: Sample Entry\n"
+                        "UserName: User Name\n"
+                        "Password: PROTECTED\n"
+                        "URL: http://www.somesite.com/\n"
+                        "Notes: Notes\n"));
+
+    pos = m_stdoutFile->pos();
+    Utils::Test::setNextPassword("a");
     showCmd.execute({"show", "-a", "Title", m_dbFile->fileName(), "/Sample Entry"});
     m_stdoutFile->seek(pos);
     m_stdoutFile->readLine(); // skip password prompt
     QCOMPARE(m_stdoutFile->readAll(), QByteArray("Sample Entry\n"));
+
+    pos = m_stdoutFile->pos();
+    Utils::Test::setNextPassword("a");
+    showCmd.execute({"show", "-a", "Password", m_dbFile->fileName(), "/Sample Entry"});
+    m_stdoutFile->seek(pos);
+    m_stdoutFile->readLine(); // skip password prompt
+    QCOMPARE(m_stdoutFile->readAll(), QByteArray("Password\n"));
 
     pos = m_stdoutFile->pos();
     Utils::Test::setNextPassword("a");


### PR DESCRIPTION
Realized this might be a problem while using the interactive session with `open`.
Added an option to reveal the protected fields, but otherwise I'd say it's better not to display it by default.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
- ✅ Documentation (non-code change)


## Testing strategy
existing and new unit tests.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
