### PR TITLE
Fix mixed translations for keepassxc-cli

### DIFF
--- a/share/translations/CMakeLists.txt
+++ b/share/translations/CMakeLists.txt
@@ -33,5 +33,6 @@ endif()
 set(QM_FILES ${QM_FILES} ${QTBASE_TRANSLATIONS})
 
 install(FILES ${QM_FILES} DESTINATION ${DATA_INSTALL_DIR}/translations)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/keepassx_en_US.qm DESTINATION ${DATA_INSTALL_DIR}/translations RENAME keepassx_en.qm)
 add_custom_target(translations DEPENDS ${QM_FILES})
 add_dependencies(${PROGNAME} translations)


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context

Currently, `keepassxc-cli` doesn't respect primary/secondary languages in macOS (and most likely other OS) when there's an uncommon locale (e.g. en-DE/ru-DE, en-AT/de-AT, etc). It also ends up being mixed if the translation is incomplete.

Since there's no `keepassx_en_DE.qm` nor `keepassx_ru_DE.qm` or similar, QT tries to find `keepassx_en.qm` (no success) and eventually falls back to a secondary language, which doesn't have any region in the name.

In order to fix it and fallback to a proper language, we need to have `keepassx_en.qm` in Resources folder, that will be used for all unusual locale combinations. As per recommendation from @droidmonkey, we will explicitly create a copy of `keepassx_en_US.qm` as `keepassx_en.qm` on install in cmake.

This is related to #3202

## Screenshots
Issue:
<img width="798" alt="image" src="https://user-images.githubusercontent.com/18210256/67854901-97b8d780-fb11-11e9-8118-90e533e4704e.png">


## Testing strategy
To test changes in CMakeLists.txt we need to build and install the app from scratch. Once `keepassx_en.qm` is in Resources folder, fallback order works properly, so we use English as a primary language.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**