### PR TITLE
Show application icon in Plasma Wayland sessions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: droidmonkey
+patreon: keepassxc
+liberapay: keepassxc
+custom: ["https://keepassxc.org/donate"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,7 +35,7 @@ Prepare the Building Environment
 
 * [Building Environment on Linux](https://github.com/keepassxreboot/keepassxc/wiki/Set-up-Build-Environment-on-Linux)
 * [Building Environment on Windows](https://github.com/keepassxreboot/keepassxc/wiki/Set-up-Build-Environment-on-Windows)
-* [Building Environment on MacOS](https://github.com/keepassxreboot/keepassxc/wiki/Set-up-Build-Environment-on-OS-X)
+* [Building Environment on MacOS](https://github.com/keepassxreboot/keepassxc/wiki/Set-up-Build-Environment-on-macOS)
 
 Build Steps
 ===========

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -49,7 +49,7 @@ Sharing allows you to share a subset of your credentials with others and vice ve
 
 ### Enable Sharing
 
-To use sharing, you need to enable for the application.
+To use sharing, you need to enable it for the application.
 
 1. Go to Tools &rarr; Settings.
 1. Select the category KeeShare.

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -177,7 +177,9 @@ namespace Utils
                 outputDescriptor));
             compositeKey->addChallengeResponseKey(key);
         }
-#endif
+#else
+        Q_UNUSED(yubiKeySlot);
+#endif // WITH_XC_YUBIKEY
 
         auto db = QSharedPointer<Database>::create();
         QString error;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,10 @@ int main(int argc, char** argv)
 #endif
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    QGuiApplication::setDesktopFileName("org.keepassxc.KeePassXC.desktop");
+#endif
+
     Application app(argc, argv);
     Application::setApplicationName("keepassxc");
     Application::setApplicationVersion(KEEPASSXC_VERSION);


### PR DESCRIPTION
This is required to show the keepassxc icon on Wayland windows in a
Plasma Wayland session.

kwin_wayland fetches application icons from .desktop files and it
expects the desktop filename to be set on the QGuiApplication instance.

Without this, kwin sets a generic Wayland icon as fallback.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing strategy
Start keepassxc on a Plasma Wayland session with/without this patch and check its window icon.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
