### PR TITLE
Fix URL matching with Browser Integration

### DIFF
--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -128,10 +128,10 @@ private:
     Group* getDefaultEntryGroup(const QSharedPointer<Database>& selectedDb = {});
     int
     sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
-    bool matchUrlScheme(const QString& url);
+    bool schemeFound(const QString& url);
     bool removeFirstDomain(QString& hostname);
     bool handleURL(const QString& entryUrl, const QString& hostname, const QString& url);
-    QString baseDomain(const QString& url) const;
+    QString baseDomain(const QString& hostname) const;
     QSharedPointer<Database> getDatabase();
     QSharedPointer<Database> selectedDatabase();
     QJsonArray getChildrenFromGroup(Group* group);

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -43,6 +43,8 @@ private slots:
     void testSearchEntries();
     void testSearchEntriesWithPort();
     void testSearchEntriesWithAdditionalURLs();
+    void testInvalidEntries();
+    void testSubdomainsAndPaths();
     void testSortEntries();
     void testGetDatabaseGroups();
 


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Ignores junk URL's, and fixes port matching. Also renames some functions and variables.

If scheme matching is enabled, entry URL's without a scheme will fallback to `https`.

Fixes #3751.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Previously an entry with URL `https:///example.com` was requested for all sites. Also, tests are included.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
