### PR TITLE
Add functions to EntrySearcher accepting crazy terms for internal code use

### DIFF
--- a/src/core/EntrySearcher.h
+++ b/src/core/EntrySearcher.h
@@ -28,18 +28,6 @@ class Entry;
 class EntrySearcher
 {
 public:
-    explicit EntrySearcher(bool caseSensitive = false);
-
-    QList<Entry*> search(const QString& searchString, const Group* baseGroup, bool forceSearch = false);
-    QList<Entry*> repeat(const Group* baseGroup, bool forceSearch = false);
-
-    QList<Entry*> searchEntries(const QString& searchString, const QList<Entry*>& entries);
-    QList<Entry*> repeatEntries(const QList<Entry*>& entries);
-
-    void setCaseSensitive(bool state);
-    bool isCaseSensitive();
-
-private:
     enum class Field
     {
         Undefined,
@@ -48,7 +36,7 @@ private:
         Password,
         Url,
         Notes,
-        AttributeKey,
+        AttributeKV,
         Attachment,
         AttributeValue
     };
@@ -56,17 +44,32 @@ private:
     struct SearchTerm
     {
         Field field;
+        // only used when field == Field::AttributeValue
         QString word;
         QRegularExpression regex;
         bool exclude;
     };
 
+    explicit EntrySearcher(bool caseSensitive = false);
+
+    QList<Entry*> search(const QList<SearchTerm>& searchTerms, const Group* baseGroup, bool forceSearch = false);
+    QList<Entry*> search(const QString& searchString, const Group* baseGroup, bool forceSearch = false);
+    QList<Entry*> repeat(const Group* baseGroup, bool forceSearch = false);
+
+    QList<Entry*> searchEntries(const QList<SearchTerm>& searchTerms, const QList<Entry*>& entries);
+    QList<Entry*> searchEntries(const QString& searchString, const QList<Entry*>& entries);
+    QList<Entry*> repeatEntries(const QList<Entry*>& entries);
+
+    void setCaseSensitive(bool state);
+    bool isCaseSensitive();
+
+private:
     bool searchEntryImpl(Entry* entry);
     void parseSearchTerms(const QString& searchString);
 
     bool m_caseSensitive;
     QRegularExpression m_termParser;
-    QList<QSharedPointer<SearchTerm>> m_searchTerms;
+    QList<SearchTerm> m_searchTerms;
 
     friend class TestEntrySearcher;
 };

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -21,6 +21,7 @@
 #include "DBusObject.h"
 
 #include "adaptors/CollectionAdaptor.h"
+#include "core/EntrySearcher.h"
 
 #include <QPointer>
 #include <QSet>
@@ -89,6 +90,8 @@ namespace FdoSecrets
         Service* service() const;
         bool inRecycleBin(Group* group) const;
         bool inRecycleBin(Entry* entry) const;
+
+        static EntrySearcher::SearchTerm attributeToTerm(const QString& key, const QString& value);
 
     public slots:
         // expose some methods for Prmopt to use

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -99,10 +99,7 @@ namespace FdoSecrets
         // add custom attributes
         const auto customKeys = entryAttrs->customKeys();
         for (const auto& attr : customKeys) {
-            // decode attr key
-            auto decoded = decodeAttributeKey(attr);
-
-            attrs[decoded] = entryAttrs->value(attr);
+            attrs[attr] = entryAttrs->value(attr);
         }
 
         // add some informative and readonly attributes
@@ -134,8 +131,7 @@ namespace FdoSecrets
                 continue;
             }
 
-            auto encoded = encodeAttributeKey(it.key());
-            entryAttrs->set(encoded, it.value());
+            entryAttrs->set(it.key(), it.value());
         }
 
         m_backend->endUpdate();
@@ -352,16 +348,6 @@ namespace FdoSecrets
         pathComponents.prepend(QLatin1Literal(""));
 
         return pathComponents.join('/');
-    }
-
-    QString Item::encodeAttributeKey(const QString& key)
-    {
-        return QUrl::toPercentEncoding(key, "", "_:").replace('%', '_');
-    }
-
-    QString Item::decodeAttributeKey(const QString& key)
-    {
-        return QString::fromUtf8(QByteArray::fromPercentEncoding(key.toLatin1(), '_'));
     }
 
     void setEntrySecret(Entry* entry, const QByteArray& data, const QString& contentType)

--- a/src/fdosecrets/objects/Item.h
+++ b/src/fdosecrets/objects/Item.h
@@ -67,15 +67,6 @@ namespace FdoSecrets
     public:
         static const QSet<QString> ReadOnlyAttributes;
 
-        /**
-         * Due to the limitation in EntrySearcher, custom attr key cannot contain ':',
-         * Thus we encode the key when saving and decode it when returning.
-         * @param key
-         * @return
-         */
-        static QString encodeAttributeKey(const QString& key);
-        static QString decodeAttributeKey(const QString& key);
-
         DBusReturn<void> setProperties(const QVariantMap& properties);
 
         Entry* backend() const;

--- a/tests/TestEntrySearcher.cpp
+++ b/tests/TestEntrySearcher.cpp
@@ -197,22 +197,22 @@ void TestEntrySearcher::testSearchTermParser()
 
     QCOMPARE(terms.length(), 5);
 
-    QCOMPARE(terms[0]->field, EntrySearcher::Field::Undefined);
-    QCOMPARE(terms[0]->word, QString("test"));
-    QCOMPARE(terms[0]->exclude, true);
+    QCOMPARE(terms[0].field, EntrySearcher::Field::Undefined);
+    QCOMPARE(terms[0].word, QString("test"));
+    QCOMPARE(terms[0].exclude, true);
 
-    QCOMPARE(terms[1]->field, EntrySearcher::Field::Undefined);
-    QCOMPARE(terms[1]->word, QString("quoted \\\"string\\\""));
-    QCOMPARE(terms[1]->exclude, false);
+    QCOMPARE(terms[1].field, EntrySearcher::Field::Undefined);
+    QCOMPARE(terms[1].word, QString("quoted \\\"string\\\""));
+    QCOMPARE(terms[1].exclude, false);
 
-    QCOMPARE(terms[2]->field, EntrySearcher::Field::Username);
-    QCOMPARE(terms[2]->word, QString("user"));
+    QCOMPARE(terms[2].field, EntrySearcher::Field::Username);
+    QCOMPARE(terms[2].word, QString("user"));
 
-    QCOMPARE(terms[3]->field, EntrySearcher::Field::Password);
-    QCOMPARE(terms[3]->word, QString("test me"));
+    QCOMPARE(terms[3].field, EntrySearcher::Field::Password);
+    QCOMPARE(terms[3].word, QString("test me"));
 
-    QCOMPARE(terms[4]->field, EntrySearcher::Field::Undefined);
-    QCOMPARE(terms[4]->word, QString("noquote"));
+    QCOMPARE(terms[4].field, EntrySearcher::Field::Undefined);
+    QCOMPARE(terms[4].word, QString("noquote"));
 
     // Test wildcard and regex search terms
     m_entrySearcher.parseSearchTerms("+url:*.google.com *user:\\d+\\w{2}");
@@ -220,11 +220,11 @@ void TestEntrySearcher::testSearchTermParser()
 
     QCOMPARE(terms.length(), 2);
 
-    QCOMPARE(terms[0]->field, EntrySearcher::Field::Url);
-    QCOMPARE(terms[0]->regex.pattern(), QString("^.*\\.google\\.com$"));
+    QCOMPARE(terms[0].field, EntrySearcher::Field::Url);
+    QCOMPARE(terms[0].regex.pattern(), QString("^.*\\.google\\.com$"));
 
-    QCOMPARE(terms[1]->field, EntrySearcher::Field::Username);
-    QCOMPARE(terms[1]->regex.pattern(), QString("\\d+\\w{2}"));
+    QCOMPARE(terms[1].field, EntrySearcher::Field::Username);
+    QCOMPARE(terms[1].regex.pattern(), QString("\\d+\\w{2}"));
 
     // Test custom attribute search terms
     m_entrySearcher.parseSearchTerms("+_abc:efg _def:\"ddd\"");
@@ -232,13 +232,13 @@ void TestEntrySearcher::testSearchTermParser()
 
     QCOMPARE(terms.length(), 2);
 
-    QCOMPARE(terms[0]->field, EntrySearcher::Field::AttributeValue);
-    QCOMPARE(terms[0]->word, QString("abc"));
-    QCOMPARE(terms[0]->regex.pattern(), QString("^efg$"));
+    QCOMPARE(terms[0].field, EntrySearcher::Field::AttributeValue);
+    QCOMPARE(terms[0].word, QString("abc"));
+    QCOMPARE(terms[0].regex.pattern(), QString("^efg$"));
 
-    QCOMPARE(terms[1]->field, EntrySearcher::Field::AttributeValue);
-    QCOMPARE(terms[1]->word, QString("def"));
-    QCOMPARE(terms[1]->regex.pattern(), QString("ddd"));
+    QCOMPARE(terms[1].field, EntrySearcher::Field::AttributeValue);
+    QCOMPARE(terms[1].word, QString("def"));
+    QCOMPARE(terms[1].regex.pattern(), QString("ddd"));
 }
 
 void TestEntrySearcher::testCustomAttributesAreSearched()

--- a/tests/TestFdoSecrets.cpp
+++ b/tests/TestFdoSecrets.cpp
@@ -19,8 +19,11 @@
 
 #include "TestGlobal.h"
 
+#include "core/EntrySearcher.h"
 #include "fdosecrets/GcryptMPI.h"
 #include "fdosecrets/objects/SessionCipher.h"
+#include "fdosecrets/objects/Collection.h"
+#include "fdosecrets/objects/Item.h"
 
 #include "crypto/Crypto.h"
 
@@ -89,4 +92,23 @@ void TestFdoSecrets::testDhIetf1024Sha256Aes128CbcPkcs7()
     QVERIFY(cipher->isValid());
 
     QCOMPARE(cipher->m_aesKey.toHex(), QByteArrayLiteral("6b8f5ee55138eac37118508be21e7834"));
+}
+
+void TestFdoSecrets::testCrazyAttributeKey()
+{
+    using FdoSecrets::Item;
+    using FdoSecrets::Collection;
+
+    const QScopedPointer<Group> root(new Group());
+    const QScopedPointer<Entry> e1(new Entry());
+    e1->setGroup(root.data());
+
+    const QString key = "_a:bc&-+'-e%12df_d";
+    const QString value = "value";
+    e1->attributes()->set(key, value);
+
+    // search for custom entries
+    const auto term = Collection::attributeToTerm(key, value);
+    const auto res = EntrySearcher().search({term}, root.data());
+    QCOMPARE(res.count(), 1);
 }

--- a/tests/TestFdoSecrets.h
+++ b/tests/TestFdoSecrets.h
@@ -30,6 +30,7 @@ private slots:
 
     void testGcryptMPI();
     void testDhIetf1024Sha256Aes128CbcPkcs7();
+    void testCrazyAttributeKey();
 };
 
 #endif // KEEPASSXC_TESTFDOSECRETS_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
To properly fix #3729, we need a way to pass arbitrary terms to the entry searcher, bypassing the limitation of the search term minilanguage. I also removed `QSharedPointer` usage in search terms. These are not shared in multiple places and there's no benefit using `QSharedPointer` over using struct value directly.

- `EntrySearcher::SearchTerm` and `EntrySearcher::Field` are now public
- Add new overloads for `EntrySearcher::search` and `EntrySearcher::searchEntries` accepting search terms directly
- Remove `QSharedPointer` usage

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
- Add new test case in `testfdosecrets.cpp`
- Run both `testfdosecrets` and `testentrysearcher`

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
