### PR TITLE
Multiple minor fixes to functionality

### DIFF
--- a/src/core/Global.h
+++ b/src/core/Global.h
@@ -36,6 +36,12 @@
 #define QUINT32_MAX 4294967295U
 #endif
 
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
+#define FILE_CASE_SENSITIVE Qt::CaseInsensitive
+#else
+#define FILE_CASE_SENSITIVE Qt::CaseSensitive
+#endif
+
 template <typename T> struct AddConst
 {
     typedef const T Type;

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -58,6 +58,7 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
 
     m_ui->buttonTogglePassword->setIcon(filePath()->onOffIcon("actions", "password-show"));
     connect(m_ui->buttonTogglePassword, SIGNAL(toggled(bool)), m_ui->editPassword, SLOT(setShowPassword(bool)));
+    connect(m_ui->buttonTogglePassword, SIGNAL(toggled(bool)), m_ui->editPassword, SLOT(setFocus()));
     connect(m_ui->buttonBrowseFile, SIGNAL(clicked()), SLOT(browseKeyFile()));
 
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(openDatabase()));
@@ -165,8 +166,6 @@ void DatabaseOpenWidget::load(const QString& filename)
 
     QHash<QString, QVariant> useTouchID = config()->get("UseTouchID").toHash();
     m_ui->checkTouchID->setChecked(useTouchID.value(m_filename, false).toBool());
-
-    m_ui->editPassword->setFocus();
 }
 
 void DatabaseOpenWidget::clearForms()
@@ -230,6 +229,9 @@ void DatabaseOpenWidget::openDatabase()
         }
         m_retryUnlockWithEmptyPassword = false;
         m_ui->messageWidget->showMessage(error, MessageWidget::MessageType::Error);
+        // Focus on the password field and select the input for easy retry
+        m_ui->editPassword->selectAll();
+        m_ui->editPassword->setFocus();
         return;
     }
 

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -156,6 +156,7 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
 {
     QFileInfo fileInfo(filePath);
     QString canonicalFilePath = fileInfo.canonicalFilePath();
+
     if (canonicalFilePath.isEmpty()) {
         emit messageGlobal(tr("Failed to open %1. It either does not exist or is not accessible.").arg(filePath),
                            MessageWidget::Error);
@@ -165,7 +166,7 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
     for (int i = 0, c = count(); i < c; ++i) {
         auto* dbWidget = databaseWidgetFromIndex(i);
         Q_ASSERT(dbWidget);
-        if (dbWidget && dbWidget->database()->canonicalFilePath() == canonicalFilePath) {
+        if (dbWidget && dbWidget->database()->canonicalFilePath().compare(canonicalFilePath, FILE_CASE_SENSITIVE) == 0) {
             dbWidget->performUnlockDatabase(password, keyfile);
             if (!inBackground) {
                 // switch to existing tab if file is already open

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -95,6 +95,8 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     , m_groupView(new GroupView(m_db.data(), m_mainSplitter))
     , m_saveAttempts(0)
 {
+    Q_ASSERT(m_db);
+
     m_messageWidget->setHidden(true);
 
     auto* mainLayout = new QVBoxLayout();
@@ -221,7 +223,11 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     KeeShare::instance()->connectDatabase(m_db, {});
 #endif
 
-    switchToMainView();
+    if (m_db->isInitialized()) {
+        switchToMainView();
+    } else {
+        switchToOpenDatabase();
+    }
 }
 
 DatabaseWidget::DatabaseWidget(const QString& filePath, QWidget* parent)

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -400,7 +400,6 @@ void DatabaseWidget::replaceDatabase(QSharedPointer<Database> db)
     m_db = std::move(db);
     connectDatabaseSignals();
     m_groupView->changeDatabase(m_db);
-    processAutoOpen();
 
     // Restore the new parent group pointer, if not found default to the root group
     // this prevents data loss when merging a database while creating a new entry
@@ -946,6 +945,7 @@ void DatabaseWidget::loadDatabase(bool accepted)
     if (accepted) {
         replaceDatabase(openWidget->database());
         switchToMainView();
+        processAutoOpen();
         m_saveAttempts = 0;
         emit databaseUnlocked();
         if (config()->get("MinimizeAfterUnlock").toBool()) {
@@ -1032,6 +1032,7 @@ void DatabaseWidget::unlockDatabase(bool accepted)
     m_entryBeforeLock = QUuid();
 
     switchToMainView();
+    processAutoOpen();
     emit databaseUnlocked();
 
     if (senderDialog && senderDialog->intent() == DatabaseOpenDialog::Intent::AutoType) {
@@ -1468,6 +1469,7 @@ void DatabaseWidget::reloadDatabaseFile()
         }
 
         replaceDatabase(db);
+        processAutoOpen();
         restoreGroupEntryFocus(groupBeforeReload, entryBeforeReload);
         m_blockAutoSave = false;
     } else {

--- a/src/gui/TotpSetupDialog.cpp
+++ b/src/gui/TotpSetupDialog.cpp
@@ -1,6 +1,5 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -46,9 +45,11 @@ TotpSetupDialog::~TotpSetupDialog()
 void TotpSetupDialog::saveSettings()
 {
     // Secret key sanity check
-    auto key = m_ui->seedEdit->text().toLatin1();
+    // Convert user input to all uppercase and remove '='
+    auto key = m_ui->seedEdit->text().toUpper().remove(" ").remove("=").toLatin1();
     auto sanitizedKey = Base32::sanitizeInput(key);
-    if (sanitizedKey != key) {
+    // Use startsWith to ignore added '=' for padding at the end
+    if (!sanitizedKey.startsWith(key)) {
         MessageBox::information(this,
                                 tr("Invalid TOTP Secret"),
                                 tr("You have entered an invalid secret key. The key must be in Base32 format.\n"
@@ -112,7 +113,9 @@ void TotpSetupDialog::init()
     // Read entry totp settings
     auto settings = m_entry->totpSettings();
     if (settings) {
-        m_ui->seedEdit->setText(settings->key);
+        auto key = settings->key;
+        m_ui->seedEdit->setText(key.remove("="));
+        m_ui->seedEdit->setCursorPosition(0);
         m_ui->stepSpinBox->setValue(settings->step);
 
         if (settings->encoder.shortName == Totp::STEAM_SHORTNAME) {

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -756,7 +756,8 @@ void TestGui::testTotp()
 
     QApplication::processEvents();
 
-    QString exampleSeed = "gezdgnbvgy3tqojqgezdgnbvgy3tqojq";
+    QString exampleSeed = "gezd gnbvgY 3tqojqGEZdgnb vgy3tqoJq===";
+    QString expectedFinalSeed = exampleSeed.toUpper().remove(" ").remove("=");
     auto* seedEdit = setupTotpDialog->findChild<QLineEdit*>("seedEdit");
     seedEdit->setText("");
     QTest::keyClicks(seedEdit, exampleSeed);
@@ -781,7 +782,7 @@ void TestGui::testTotp()
     editEntryWidget->setCurrentPage(1);
     auto* attrTextEdit = editEntryWidget->findChild<QPlainTextEdit*>("attributesEdit");
     QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("revealAttributeButton"), Qt::LeftButton);
-    QCOMPARE(attrTextEdit->toPlainText(), exampleSeed);
+    QCOMPARE(attrTextEdit->toPlainText(), expectedFinalSeed);
 
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Fix #3735 - Don't focus on OpenDatabaseWidget fields that are not visible; ensures password field is focused after database lock.

* Fix #3487 - Password input is selected after failed unlock.

* Fix #1938 - Password input is focused after toggling visibility using the keyboard

* Fix #3713 - DatabaseWidget starts in locked mode instead of view mode fixing tab names on launch.

* Fix #3334 - AutoOpen is now processed after the database widget is put into view mode to prevent infinite recursion of unlock attempts if two databases  auto open each other.

* Fix #3754 - Accept valid TOTP keys that require padding when converted to Base32.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
