### PR TITLE
Implement SSH key file path env substitution

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -324,6 +324,29 @@ namespace Tools
         return QUuid::fromRfc4122(QByteArray::fromHex(uuid.toLatin1()));
     }
 
+    QString envSubstitute(const QString& filepath, QProcessEnvironment environment)
+    {
+        QString subbed = filepath;
+
+#if defined(Q_OS_WIN)
+        QRegularExpression varRe("\\%([A-Za-z][A-Za-z0-9_]*)\\%");
+#else
+        QRegularExpression varRe("\\$([A-Za-z][A-Za-z0-9_]*)");
+        subbed.replace("~", environment.value("HOME"));
+#endif
+
+        QRegularExpressionMatch match;
+
+        do {
+            match = varRe.match(subbed);
+            if (match.hasMatch()) {
+                subbed.replace(match.capturedStart(), match.capturedLength(), environment.value(match.captured(1)));
+            }
+        } while (match.hasMatch());
+
+        return subbed;
+    }
+
     Buffer::Buffer()
         : raw(nullptr)
         , size(0)

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -22,6 +22,7 @@
 #include "core/Global.h"
 
 #include <QObject>
+#include <QProcessEnvironment>
 #include <QString>
 #include <QUuid>
 
@@ -48,6 +49,8 @@ namespace Tools
                                       bool useWildcards = false,
                                       bool exactMatch = false,
                                       bool caseSensitive = false);
+    QString envSubstitute(const QString& filepath,
+                          QProcessEnvironment environment = QProcessEnvironment::systemEnvironment());
 
     template <typename RandomAccessIterator, typename T>
     RandomAccessIterator binaryFind(RandomAccessIterator begin, RandomAccessIterator end, const T& value)

--- a/src/sshagent/KeeAgentSettings.cpp
+++ b/src/sshagent/KeeAgentSettings.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "KeeAgentSettings.h"
+#include "core/Tools.h"
 
 KeeAgentSettings::KeeAgentSettings()
     : m_lifetimeConstraintDuration(600)
@@ -113,6 +114,11 @@ bool KeeAgentSettings::saveAttachmentToTempFile() const
 const QString KeeAgentSettings::fileName() const
 {
     return m_fileName;
+}
+
+const QString KeeAgentSettings::fileNameEnvSubst(QProcessEnvironment environment) const
+{
+    return Tools::envSubstitute(m_fileName, environment);
 }
 
 void KeeAgentSettings::setAllowUseOfSshKey(bool allowUseOfSshKey)
@@ -361,7 +367,7 @@ bool KeeAgentSettings::toOpenSSHKey(const Entry* entry, OpenSSHKey& key, bool de
         fileName = m_attachmentName;
         privateKeyData = entry->attachments()->value(fileName);
     } else {
-        QFile localFile(m_fileName);
+        QFile localFile(fileNameEnvSubst());
         QFileInfo localFileInfo(localFile);
         fileName = localFileInfo.fileName();
 

--- a/src/sshagent/KeeAgentSettings.h
+++ b/src/sshagent/KeeAgentSettings.h
@@ -54,6 +54,7 @@ public:
     const QString attachmentName() const;
     bool saveAttachmentToTempFile() const;
     const QString fileName() const;
+    const QString fileNameEnvSubst(QProcessEnvironment environment = QProcessEnvironment::systemEnvironment()) const;
 
     void setAllowUseOfSshKey(bool allowUseOfSshKey);
     void setAddAtDatabaseOpen(bool addAtDatabaseOpen);

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -64,3 +64,24 @@ void TestTools::testIsBase64()
     QVERIFY(not Tools::isBase64(QByteArray("abc_")));
     QVERIFY(not Tools::isBase64(QByteArray("123")));
 }
+
+void TestTools::testEnvSubstitute()
+{
+    QProcessEnvironment environment;
+
+#if defined(Q_OS_WIN)
+    environment.insert("HOMEDRIVE", "C:");
+    environment.insert("HOMEPATH", "\\Users\\User");
+
+    QCOMPARE(Tools::envSubstitute("%HOMEDRIVE%%HOMEPATH%\\.ssh\\id_rsa", environment),
+             QString("C:\\Users\\User\\.ssh\\id_rsa"));
+    QCOMPARE(Tools::envSubstitute("start%EMPTY%%EMPTY%%%HOMEDRIVE%%end", environment), QString("start%C:%end"));
+#else
+    environment.insert("HOME", QString("/home/user"));
+    environment.insert("USER", QString("user"));
+
+    QCOMPARE(Tools::envSubstitute("~/.ssh/id_rsa", environment), QString("/home/user/.ssh/id_rsa"));
+    QCOMPARE(Tools::envSubstitute("$HOME/.ssh/id_rsa", environment), QString("/home/user/.ssh/id_rsa"));
+    QCOMPARE(Tools::envSubstitute("start/$EMPTY$$EMPTY$HOME/end", environment), QString("start/$/home/user/end"));
+#endif
+}

--- a/tests/TestTools.h
+++ b/tests/TestTools.h
@@ -27,6 +27,7 @@ private slots:
     void testHumanReadableFileSize();
     void testIsHex();
     void testIsBase64();
+    void testEnvSubstitute();
 };
 
 #endif // KEEPASSX_TESTTOOLS_H


### PR DESCRIPTION
People usually want their SSH key file path to be relative to `$HOME` which helps transferring database between multiple systems with different local users. Automatic path pickup will use an absolute path but you can manually change it to use a tilde or any combination of environment variables.

For example the following key file paths work on Linux/Mac/BSD:
- `~/.ssh/id_rsa`
- `$HOME/.ssh/id_rsa`

Following hypothetical path should work on Windows:
- `%HOMEDRIVE%%HOMEPATH%\.ssh\id_rsa`

This work has been kindly supported by my employer, Vincit.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Fixes #3523

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tests are implemented for env substition. Manually tested with the GUI on Linux.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
