### PR TITLE
Show application icon in Plasma Wayland sessions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,10 @@ int main(int argc, char** argv)
 #endif
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    QGuiApplication::setDesktopFileName("org.keepassxc.KeePassXC.desktop");
+#endif
+
     Application app(argc, argv);
     Application::setApplicationName("keepassxc");
     Application::setApplicationVersion(KEEPASSXC_VERSION);


### PR DESCRIPTION
This is required to show the keepassxc icon on Wayland windows in a
Plasma Wayland session.

kwin_wayland fetches application icons from .desktop files and it
expects the desktop filename to be set on the QGuiApplication instance.

Without this, kwin sets a generic Wayland icon as fallback.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing strategy
Start keepassxc on a Plasma Wayland session with/without this patch and check its window icon.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
