### PR TITLE
SSH Agent: Add SSH_AUTH_SOCK override and connection test

### DIFF
--- a/src/sshagent/AgentSettingsWidget.ui
+++ b/src/sshagent/AgentSettingsWidget.ui
@@ -38,6 +38,59 @@
     </widget>
    </item>
    <item>
+    <widget class="QWidget" name="sshAuthSockWidget" native="true">
+     <layout class="QGridLayout" name="sshAuthSockOverrideLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="4" column="0">
+       <widget class="QLabel" name="sshAuthSockValueLabel">
+        <property name="text">
+         <string>SSH_AUTH_SOCK value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="sshAuthSockLabel">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>(empty)</string>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="sshAuthSockOverrideLabel">
+        <property name="text">
+         <string>SSH_AUTH_SOCK override</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLineEdit" name="sshAuthSockOverrideEdit"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="MessageWidget" name="sshAuthSockMessageWidget" native="true"/>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -52,6 +105,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MessageWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/MessageWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/sshagent/SSHAgent.h
+++ b/src/sshagent/SSHAgent.h
@@ -37,6 +37,7 @@ public:
 
     const QString errorString() const;
     bool isAgentRunning() const;
+    bool testConnection();
     bool addIdentity(OpenSSHKey& key, KeeAgentSettings& settings);
     bool removeIdentity(OpenSSHKey& key);
     void setAutoRemoveOnLock(const OpenSSHKey& key, bool autoRemove);


### PR DESCRIPTION
In issue #3683 and many others, the agent socket path environment variable is either missing or wrong in KeePassXC. Added a view to current effective environment variable and an override field to set a static path if so desired.

This work has been kindly supported by my employer, Vincit.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes #3795

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/106598/68239565-dff55f80-0013-11ea-82d2-528ae1b879f2.png)


## Testing strategy
Manual testing on Linux. Manual testing of agent connection test on Windows against Pageant and OpenSSH for Windows. Possibly needs to be tested on macOS but it should be fine.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
