### PR TITLE
Make the purpose of the key file field clearer

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -65,6 +65,8 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
 
     m_ui->hardwareKeyLabelHelp->setIcon(filePath()->icon("actions", "system-help").pixmap(QSize(12, 12)));
     connect(m_ui->hardwareKeyLabelHelp, SIGNAL(clicked(bool)), SLOT(openHardwareKeyHelp()));
+    m_ui->keyFileLabelHelp->setIcon(filePath()->icon("actions", "system-help").pixmap(QSize(12, 12)));
+    connect(m_ui->keyFileLabelHelp, SIGNAL(clicked(bool)), SLOT(openKeyFileHelp()));
 
     connect(m_ui->comboKeyFile->lineEdit(), SIGNAL(textChanged(QString)), SLOT(handleKeyFileComboEdited()));
     connect(m_ui->comboKeyFile, SIGNAL(currentIndexChanged(int)), SLOT(handleKeyFileComboChanged()));
@@ -148,7 +150,7 @@ void DatabaseOpenWidget::load(const QString& filename)
     m_filename = filename;
     m_ui->fileNameLabel->setRawText(m_filename);
 
-    m_ui->comboKeyFile->addItem(tr("Select file..."), -1);
+    m_ui->comboKeyFile->addItem(tr("Select key file..."), -1);
     m_ui->comboKeyFile->setCurrentIndex(0);
     m_ui->keyFileClearIcon->setVisible(false);
     m_keyFileComboEdited = false;
@@ -365,6 +367,13 @@ void DatabaseOpenWidget::browseKeyFile()
     }
     QString filename = fileDialog()->getOpenFileName(this, tr("Select key file"), QString(), filters);
 
+    if (QFileInfo(filename).canonicalFilePath() == QFileInfo(m_filename).canonicalFilePath()) {
+        MessageBox::warning(this,  tr("Cannot use database file as key file"),
+            tr("You cannot use your database file as a key file.\nIf you do not have a key file, please leave the field empty."),
+            MessageBox::Button::Ok);
+        filename = "";
+    }
+
     if (!filename.isEmpty()) {
         m_ui->comboKeyFile->setCurrentIndex(-1);
         m_ui->comboKeyFile->setEditText(filename);
@@ -433,5 +442,10 @@ void DatabaseOpenWidget::noYubikeyFound()
 
 void DatabaseOpenWidget::openHardwareKeyHelp()
 {
-    QDesktopServices::openUrl(QUrl("https://keepassxc.org/docs#hwtoken"));
+    QDesktopServices::openUrl(QUrl("https://keepassxc.org/docs#faq-cat-yubikey"));
+}
+
+void DatabaseOpenWidget::openKeyFileHelp()
+{
+    QDesktopServices::openUrl(QUrl("https://keepassxc.org/docs#faq-cat-keyfile"));
 }

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -68,6 +68,7 @@ private slots:
     void yubikeyDetectComplete();
     void noYubikeyFound();
     void openHardwareKeyHelp();
+    void openKeyFileHelp();
 
 protected:
     const QScopedPointer<Ui::DatabaseOpenWidget> m_ui;

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>DatabaseOpenWidget</class>
  <widget class="QWidget" name="DatabaseOpenWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>592</width>
-    <height>462</height>
-   </rect>
-  </property>
   <property name="accessibleName">
    <string>Unlock KeePassXC Database</string>
   </property>
@@ -210,7 +202,7 @@
               <item>
                <widget class="QLabel" name="label_2">
                 <property name="text">
-                 <string>Enter Additional Credentials:</string>
+                 <string>Enter Additional Credentials (if any):</string>
                 </property>
                </widget>
               </item>
@@ -243,32 +235,6 @@
                   <property name="topMargin">
                    <number>3</number>
                   </property>
-                  <item row="0" column="3">
-                   <layout class="QGridLayout" name="gridLayout_2">
-                    <property name="verticalSpacing">
-                     <number>0</number>
-                    </property>
-                    <item row="0" column="1">
-                     <widget class="QComboBox" name="comboKeyFile">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="accessibleName">
-                       <string>Key file selection</string>
-                      </property>
-                      <property name="editable">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
                   <item row="1" column="3">
                    <layout class="QGridLayout" name="gridLayout">
                     <property name="spacing">
@@ -330,26 +296,36 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="4">
-                   <widget class="QPushButton" name="buttonRedetectYubikey">
-                    <property name="enabled">
-                     <bool>true</bool>
+                  <item row="0" column="3">
+                   <layout class="QGridLayout" name="gridLayout_2">
+                    <property name="verticalSpacing">
+                     <number>0</number>
                     </property>
-                    <property name="toolTip">
-                     <string>Refresh hardware tokens</string>
-                    </property>
-                    <property name="accessibleName">
-                     <string>Refresh hardware tokens</string>
-                    </property>
-                    <property name="text">
-                     <string>Refresh</string>
-                    </property>
-                   </widget>
+                    <item row="0" column="1">
+                     <widget class="QComboBox" name="comboKeyFile">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="accessibleName">
+                       <string>Key file selection</string>
+                      </property>
+                      <property name="editable">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
                   </item>
                   <item row="1" column="0">
                    <layout class="QHBoxLayout" name="horizontalLayout_6">
                     <property name="spacing">
-                     <number>0</number>
+                     <number>5</number>
                     </property>
                     <item>
                      <widget class="QLabel" name="hardwareKeyLabel">
@@ -368,16 +344,16 @@
                       </property>
                       <property name="toolTip">
                        <string>&lt;p&gt;You can use a hardware security key such as a &lt;strong&gt;YubiKey&lt;/strong&gt; or &lt;strong&gt;OnlyKey&lt;/strong&gt; with slots configured for HMAC-SHA1.&lt;/p&gt;
-                           &lt;p&gt;Click for more information...&lt;/p&gt;</string>
+&lt;p&gt;Click for more information...&lt;/p&gt;</string>
                       </property>
                       <property name="accessibleName">
                        <string>Hardware key help</string>
                       </property>
                       <property name="styleSheet">
                        <string notr="true">QToolButton {
-                           border: none;
-                           background: none;
-                           }</string>
+	border: none;
+	background: none;
+}</string>
                       </property>
                       <property name="text">
                        <string notr="true">?</string>
@@ -396,12 +372,66 @@
                    </layout>
                   </item>
                   <item row="0" column="0">
-                   <widget class="QLabel" name="keyFileLabel">
-                    <property name="text">
-                     <string>Key File:</string>
+                   <layout class="QHBoxLayout" name="horizontalLayout_4">
+                    <property name="spacing">
+                     <number>5</number>
                     </property>
-                    <property name="buddy">
-                     <cstring>comboKeyFile</cstring>
+                    <item>
+                     <widget class="QLabel" name="keyFileLabel">
+                      <property name="text">
+                       <string>Key File:</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>comboKeyFile</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QToolButton" name="keyFileLabelHelp">
+                      <property name="cursor">
+                       <cursorShape>PointingHandCursor</cursorShape>
+                      </property>
+                      <property name="toolTip">
+                       <string>&lt;p&gt;In addition to your master password, you can use a secret file to enhance the security of your database. Such a file can be generated in your database's security settings.&lt;/p&gt;&lt;p&gt;This is &lt;strong&gt;not&lt;/strong&gt; your *.kdbx database file!&lt;br&gt;If you do not have a key file, leave the field empty.&lt;/p&gt;&lt;p&gt;Click for more information...&lt;/p&gt;</string>
+                      </property>
+                      <property name="accessibleName">
+                       <string>Key file help</string>
+                      </property>
+                      <property name="styleSheet">
+                       <string notr="true">QToolButton {
+	border: none;
+	background: none;
+}</string>
+                      </property>
+                      <property name="text">
+                       <string>?</string>
+                      </property>
+                      <property name="iconSize">
+                       <size>
+                        <width>12</width>
+                        <height>12</height>
+                       </size>
+                      </property>
+                      <property name="popupMode">
+                       <enum>QToolButton::InstantPopup</enum>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="1" column="4">
+                   <widget class="QPushButton" name="buttonRedetectYubikey">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <property name="toolTip">
+                     <string>Refresh hardware tokens</string>
+                    </property>
+                    <property name="accessibleName">
+                     <string>Refresh hardware tokens</string>
+                    </property>
+                    <property name="text">
+                     <string>Refresh</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
The new unlock dialogue seems to confuse users as to what the purpose of the key file is. This
patch changes the generic "Select file..." affordance to the more explicit "Select key file (if any)..."
and prevents the user from using the KDBX file as a key file (since that would never work anyway).

The change breaks existing translations on purpose (instead of simply adjusting the en_US locale)
in order to force translators to update this string for their languages.

Resolves #3678

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
