### PR TITLE
Improve memory hygiene

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -316,7 +316,11 @@ bool Database::writeDatabase(QIODevice* device, QString* error)
         return false;
     }
 
-    QByteArray oldTransformedKey = m_data.transformedMasterKey;
+    PasswordKey oldTransformedKey;
+    if (m_data.hasKey) {
+        oldTransformedKey.setHash(m_data.transformedMasterKey->rawKey());
+    }
+
     KeePass2Writer writer;
     setEmitModified(false);
     writer.writeDatabase(device, this);
@@ -329,9 +333,10 @@ bool Database::writeDatabase(QIODevice* device, QString* error)
         return false;
     }
 
-    Q_ASSERT(!m_data.transformedMasterKey.isEmpty());
-    Q_ASSERT(m_data.transformedMasterKey != oldTransformedKey);
-    if (m_data.transformedMasterKey.isEmpty() || m_data.transformedMasterKey == oldTransformedKey) {
+    QByteArray newKey = m_data.transformedMasterKey->rawKey();
+    Q_ASSERT(!newKey.isEmpty());
+    Q_ASSERT(newKey != oldTransformedKey.rawKey());
+    if (newKey.isEmpty() || newKey == oldTransformedKey.rawKey()) {
         if (error) {
             *error = tr("Key not transformed. This is a bug, please report it to the developers!");
         }
@@ -382,6 +387,7 @@ bool Database::import(const QString& xmlExportPath, QString* error)
  *
  * A previously reparented root group will not be freed.
  */
+
 void Database::releaseData()
 {
     s_uuidMap.remove(m_uuid);
@@ -391,7 +397,7 @@ void Database::releaseData()
         emit databaseDiscarded();
     }
 
-    m_data = DatabaseData();
+    m_data.clear();
 
     if (m_rootGroup && m_rootGroup->parent() == this) {
         delete m_rootGroup;
@@ -630,19 +636,24 @@ Database::CompressionAlgorithm Database::compressionAlgorithm() const
 
 QByteArray Database::transformedMasterKey() const
 {
-    return m_data.transformedMasterKey;
+    return m_data.transformedMasterKey->rawKey();
 }
 
 QByteArray Database::challengeResponseKey() const
 {
-    return m_data.challengeResponseKey;
+    return m_data.challengeResponseKey->rawKey();
 }
 
 bool Database::challengeMasterSeed(const QByteArray& masterSeed)
 {
     if (m_data.key) {
-        m_data.masterSeed = masterSeed;
-        return m_data.key->challenge(masterSeed, m_data.challengeResponseKey);
+        m_data.masterSeed->setHash(masterSeed);
+        QByteArray response;
+        bool ok = m_data.key->challenge(masterSeed, response);
+        if (ok && !response.isEmpty()) {
+            m_data.challengeResponseKey->setHash(response);
+        }
+        return ok;
     }
     return false;
 }
@@ -679,7 +690,7 @@ bool Database::setKey(const QSharedPointer<const CompositeKey>& key,
 
     if (!key) {
         m_data.key.reset();
-        m_data.transformedMasterKey = {};
+        m_data.transformedMasterKey.reset(new PasswordKey());
         m_data.hasKey = false;
         return true;
     }
@@ -689,22 +700,29 @@ bool Database::setKey(const QSharedPointer<const CompositeKey>& key,
         Q_ASSERT(!m_data.kdf->seed().isEmpty());
     }
 
-    QByteArray oldTransformedMasterKey = m_data.transformedMasterKey;
+    PasswordKey oldTransformedMasterKey;
+    if (m_data.hasKey) {
+        oldTransformedMasterKey.setHash(m_data.transformedMasterKey->rawKey());
+    }
+
     QByteArray transformedMasterKey;
+
     if (!transformKey) {
-        transformedMasterKey = oldTransformedMasterKey;
+        transformedMasterKey = QByteArray(oldTransformedMasterKey.rawKey());
     } else if (!key->transform(*m_data.kdf, transformedMasterKey)) {
         return false;
     }
 
     m_data.key = key;
-    m_data.transformedMasterKey = transformedMasterKey;
+    if (!transformedMasterKey.isEmpty()) {
+        m_data.transformedMasterKey->setHash(transformedMasterKey);
+    }
     m_data.hasKey = true;
     if (updateChangedTime) {
         m_metadata->setMasterKeyChanged(Clock::currentDateTimeUtc());
     }
 
-    if (oldTransformedMasterKey != m_data.transformedMasterKey) {
+    if (oldTransformedMasterKey.rawKey() != m_data.transformedMasterKey->rawKey()) {
         markAsModified();
     }
 
@@ -720,15 +738,15 @@ bool Database::verifyKey(const QSharedPointer<CompositeKey>& key) const
 {
     Q_ASSERT(hasKey());
 
-    if (!m_data.challengeResponseKey.isEmpty()) {
+    if (!m_data.challengeResponseKey->rawKey().isEmpty()) {
         QByteArray result;
 
-        if (!key->challenge(m_data.masterSeed, result)) {
+        if (!key->challenge(m_data.masterSeed->rawKey(), result)) {
             // challenge failed, (YubiKey?) removed?
             return false;
         }
 
-        if (m_data.challengeResponseKey != result) {
+        if (m_data.challengeResponseKey->rawKey() != result) {
             // wrong response from challenged device(s)
             return false;
         }
@@ -893,7 +911,7 @@ bool Database::changeKdf(const QSharedPointer<Kdf>& kdf)
     }
 
     setKdf(kdf);
-    m_data.transformedMasterKey = transformedMasterKey;
+    m_data.transformedMasterKey->setHash(transformedMasterKey);
     markAsModified();
 
     return true;

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -29,7 +29,6 @@
 #include "crypto/kdf/Kdf.h"
 #include "format/KeePass2.h"
 #include "keys/CompositeKey.h"
-
 class Entry;
 enum class EntryReferenceType;
 class FileWatcher;
@@ -75,6 +74,8 @@ public:
     bool saveAs(const QString& filePath, QString* error = nullptr, bool atomic = true, bool backup = false);
     bool extract(QByteArray&, QString* error = nullptr);
     bool import(const QString& xmlExportPath, QString* error = nullptr);
+
+    void releaseData();
 
     bool isInitialized() const;
     void setInitialized(bool initialized);
@@ -182,9 +183,9 @@ private:
     bool restoreDatabase(const QString& filePath);
     bool performSave(const QString& filePath, QString* error, bool atomic, bool backup);
 
-    Metadata* const m_metadata;
+    QPointer<Metadata> const m_metadata;
     DatabaseData m_data;
-    Group* m_rootGroup;
+    QPointer<Group> m_rootGroup;
     QList<DeletedObject> m_deletedObjects;
     QPointer<QTimer> m_timer;
     QPointer<FileWatcher> m_fileWatcher;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -413,6 +413,8 @@ void DatabaseWidget::replaceDatabase(QSharedPointer<Database> db)
     // Keep the instance active till the end of this function
     Q_UNUSED(oldDb);
 #endif
+
+    oldDb->releaseData();
 }
 
 void DatabaseWidget::cloneEntry()

--- a/src/keys/PasswordKey.h
+++ b/src/keys/PasswordKey.h
@@ -33,6 +33,7 @@ public:
     ~PasswordKey() override;
     QByteArray rawKey() const override;
     void setPassword(const QString& password);
+    void setHash(const QByteArray& hash);
 
     static QSharedPointer<PasswordKey> fromRawKey(const QByteArray& rawKey);
 
@@ -40,6 +41,7 @@ private:
     static constexpr int SHA256_SIZE = 32;
 
     char* m_key = nullptr;
+    bool m_isInitialized = false;
 };
 
 #endif // KEEPASSX_PASSWORDKEY_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
This patch improves KeePassXC's memory hygiene. It consists of two changes:

**1) Ensure database contents are released right away.**
When we lock a database, we reset the database pointer to free its resources. Since various other widgets besides the DatabaseWidget hold references to the shared pointer object, however, it cannot be guaranteed that the actual database object will be freed right away. This patch adds a `releaseData()` method which is called upon database lock to ensure all residual data is cleared without having to rely on the actual database object being cleaned up.

**2) Use PasswordKey for storing transformed secrets.**
The transformed secrets were stored in normal QByteArrays, which are at risk of being swapped out. We now use secure PasswordKey objects instead. There are still a few areas where QByteArrays are used for storing secrets, but since they are all temporary, they are less critical. It may be worth hunting those down as well, though.

Change 2) is the larger one and we should discuss if we want to include it in 2.5.1 or only merge a reduced version of it and defer the rest (together with the clean-up of the remaining uses of QByteArrays for temporary short-lived secrets) to 2.6.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
No functionality was added and all existing tests still pass.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
