### PR TITLE
Fix DatabaseUnlockDialog window sizing.

### DIFF
--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -31,6 +31,8 @@ DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::ForeignWindow);
 #endif
     connect(m_view, SIGNAL(dialogFinished(bool)), this, SLOT(complete(bool)));
+    setLayout(m_view->layout());
+    setMinimumWidth(700);
 }
 
 void DatabaseOpenDialog::setFilePath(const QString& filePath)


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes the default shrink-wrap and wonky upscaling behaviour of the DatabaseUnlockDialog window (must be a regression of something).

The explicit minimum width of 700 is because the minimum content size hints are not working properly. The widgets remain usable at the default window size, but are a bit too small to my taste (somebody please fix Qt layouting).

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Without the layout set, this is what the dialogue looks like:

![unlock1](https://user-images.githubusercontent.com/911270/68528887-b2046980-02f8-11ea-87f2-bd14dd13ab8c.png)

Scaling it up is pretty ugly as well (widget not centred and width is not scaling up to its preferred size):
![unlock2](https://user-images.githubusercontent.com/911270/68528892-b9c40e00-02f8-11ea-9fb1-60ba3ad12e36.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on KDE.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**