### PR TITLE
Properly encode trailing equal signs for base32 encoded TOTP

### DIFF
--- a/src/totp/totp.cpp
+++ b/src/totp/totp.cpp
@@ -152,7 +152,7 @@ QString Totp::writeSettings(const QSharedPointer<Totp::Settings>& settings,
         auto urlstring = QString("otpauth://totp/%1:%2?secret=%3&period=%4&digits=%5&issuer=%1")
                              .arg(title.isEmpty() ? "KeePassXC" : QString(QUrl::toPercentEncoding(title)),
                                   username.isEmpty() ? "none" : QString(QUrl::toPercentEncoding(username)),
-                                  QString(Base32::sanitizeInput(settings->key.toLatin1())),
+                                  QString(QUrl::toPercentEncoding(Base32::sanitizeInput(settings->key.toLatin1()))),
                                   QString::number(settings->step),
                                   QString::number(settings->digits));
 


### PR DESCRIPTION
Allows for proper export of TOTP settings via QR code

Fixes https://github.com/keepassxreboot/keepassxc/issues/3255