### PR TITLE
SSH Agent: Refactor entry and agent key management

### DIFF
--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -112,6 +112,7 @@ private slots:
     void toggleHideNotes(bool visible);
     void pickColor();
 #ifdef WITH_XC_SSHAGENT
+    void toKeeAgentSettings(KeeAgentSettings& settings) const;
     void updateSSHAgent();
     void updateSSHAgentAttachment();
     void updateSSHAgentAttachments();
@@ -153,7 +154,6 @@ private:
     void updateEntryData(Entry* entry) const;
 #ifdef WITH_XC_SSHAGENT
     bool getOpenSSHKey(OpenSSHKey& key, bool decrypt = false);
-    void saveSSHAgentConfig();
 #endif
 
     void displayAttribute(QModelIndex index, bool showProtected);

--- a/src/sshagent/KeeAgentSettings.h
+++ b/src/sshagent/KeeAgentSettings.h
@@ -19,6 +19,8 @@
 #ifndef KEEAGENTSETTINGS_H
 #define KEEAGENTSETTINGS_H
 
+#include "core/Entry.h"
+#include "crypto/ssh/OpenSSHKey.h"
 #include <QXmlStreamReader>
 #include <QtCore>
 
@@ -27,12 +29,19 @@ class KeeAgentSettings
 public:
     KeeAgentSettings();
 
-    bool operator==(KeeAgentSettings& other);
-    bool operator!=(KeeAgentSettings& other);
-    bool isDefault();
+    bool operator==(const KeeAgentSettings& other) const;
+    bool operator!=(const KeeAgentSettings& other) const;
+    bool isDefault() const;
 
     bool fromXml(const QByteArray& ba);
-    QByteArray toXml();
+    QByteArray toXml() const;
+
+    bool fromEntry(const Entry* entry);
+    void toEntry(Entry* entry) const;
+    bool keyConfigured() const;
+    bool toOpenSSHKey(const Entry* entry, OpenSSHKey& key, bool decrypt);
+
+    const QString errorString() const;
 
     bool allowUseOfSshKey() const;
     bool addAtDatabaseOpen() const;
@@ -74,6 +83,7 @@ private:
     QString m_attachmentName;
     bool m_saveAttachmentToTempFile;
     QString m_fileName;
+    QString m_error;
 };
 
 #endif // KEEAGENTSETTINGS_H


### PR DESCRIPTION
 - Remove duplicate code to load a key (EditEntryWidget & SSHAgent)
 - Refactor all key loading and saving to KeeAgentSettings
 - Depend only on Entry to allow future CLI expansion

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)

## Description and Context
For future expansion and code duplication avoidance the KeeAgentSettings class has been made a complete pivot between an Entry and OpenSSHKey. It can load/save a key from an Entry without depending on GUI classes and configure OpenSSHKey. SSHAgent and EditEntryWidget have been updated to use this new style.

Future implementations may include context menu and hotkey based key management, cli support, global key management widget etc.

Compared to custom data expansions of KeePassXC, SSH Agent heavily depends on an attachment for compatibility reasons and since it's external to an Entry (it only knows about attachments in general) I thought it would be okay for KeeAgentSettings to manage an Entry instead of other way around which is used for TOTP et al.

## Testing strategy
Existing tests pass but the changes don't really touch code paths that hit them. Limited manual testing has been done on Linux.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
