### PR TITLE
Fix CVE-2018-19358 by adding an authorization request to the feature …

### DIFF
--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -18,6 +18,7 @@
 #include "Item.h"
 
 #include "fdosecrets/FdoSecretsPlugin.h"
+#include "fdosecrets/FdoSecretsSettings.h"
 #include "fdosecrets/objects/Collection.h"
 #include "fdosecrets/objects/Prompt.h"
 #include "fdosecrets/objects/Service.h"
@@ -27,11 +28,13 @@
 #include "core/EntryAttributes.h"
 #include "core/Group.h"
 #include "core/Tools.h"
+#include "gui/MessageBox.h"
 
 #include <QMimeDatabase>
 #include <QRegularExpression>
 #include <QSet>
 #include <QTextCodec>
+#include <QMessageBox>
 
 namespace FdoSecrets
 {
@@ -238,6 +241,25 @@ namespace FdoSecrets
             service()->plugin()->emitRequestShowNotification(
                 tr(R"(Entry "%1" from database "%2" was used by %3)")
                     .arg(m_backend->title(), collection()->name(), callingPeerName()));
+			
+			if (FdoSecrets::settings()->showNotification()) {
+				QMessageBox msgBox;
+				msgBox.setIcon(QMessageBox::Question);
+				QPushButton *allowButton = msgBox.addButton(tr("Allow access"), QMessageBox::YesRole);
+				QPushButton *denyButton = msgBox.addButton(tr("Deny"), QMessageBox::NoRole);
+				msgBox.setDefaultButton(allowButton);
+				msgBox.setEscapeButton(denyButton);
+				msgBox.setWindowFlags(Qt::WindowStaysOnTopHint);
+				msgBox.setWindowTitle(tr("KeePassXC Request"));
+				msgBox.setText(
+						tr("\nKeepassXC Secret Service: new app request\n\nApplication: \n\n%3\n\nRequest entry: \n%1 \n\nFrom database: \n%2\n\n")
+							.arg(m_backend->title(), collection()->name(), callingPeerName()));	
+				msgBox.exec();
+				msgBox.raise();
+
+				if (msgBox.clickedButton() == allowButton) {return secret;}
+				return {};	
+			}
         }
         return secret;
     }

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -30,6 +30,7 @@
 #include <QDBusConnection>
 #include <QDBusServiceWatcher>
 #include <QDebug>
+#include <QMessageBox>
 
 namespace
 {
@@ -362,6 +363,25 @@ namespace FdoSecrets
             plugin()->emitRequestShowNotification(
                 tr(R"(%n Entry(s) was used by %1)", "%1 is the name of an application", res.size())
                     .arg(callingPeerName()));
+			
+			if (FdoSecrets::settings()->showNotification()) {
+				QMessageBox msgBox;
+				msgBox.setIcon(QMessageBox::Question);
+				QPushButton *allowButton = msgBox.addButton(tr("Allow access"), QMessageBox::YesRole);
+				QPushButton *denyButton = msgBox.addButton(tr("Deny"), QMessageBox::NoRole);
+				msgBox.setDefaultButton(allowButton);
+				msgBox.setEscapeButton(denyButton);
+				msgBox.setWindowFlags(Qt::WindowStaysOnTopHint);
+				msgBox.setWindowTitle(tr("KeePassXC Request"));
+				msgBox.setText(
+					tr("\nKeepassXC Secret Service: new app request\n\nApplication: \n\n%1\n\nRequesting %n entry\n\n","", res.size())
+					  .arg(callingPeerName()));
+				msgBox.exec();
+				msgBox.raise();
+
+				if (msgBox.clickedButton() == allowButton) {return res;}
+				return {};
+			}
         }
         return res;
     }


### PR DESCRIPTION
Fix CVE-2018-19358 by adding an authorization request to the feature show notification on access 
Following https://github.com/keepassxreboot/keepassxc/issues/3837

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
i updated my ugly patch after some tests... wont require a lot of time to add it properly with an additional settings entry... i can work on it in 1 week or so... right now this patch is bind to the feature "notify on access" 

Note that this is a quick implementation to fix the issue (where it always ask for confirmation if the feature is enabled), an other more elegant fix would be to add a system similar to the browser extension where the authorization choice would be saved to the data base... and may be add the elegant solution on top of this fix where if a user want to be asked anyway... (because app are not authenticated but just known by name)   

An advanced implementation could even limit an application to its passwords to avoid allowing an authorized application to get other passwords

## Testing strategy
- Enable the feature "Show notification when credentials are requested"
- Just access the secret service with seahorse or any other app using it 

## Note
Feel free to close this PR if not suitable ;)... 