### PR TITLE
Add a new line after in Analyze command

### DIFF
--- a/src/cli/Analyze.cpp
+++ b/src/cli/Analyze.cpp
@@ -55,7 +55,8 @@ int Analyze::executeWithDatabase(QSharedPointer<Database> database, QSharedPoint
         return EXIT_FAILURE;
     }
 
-    outputTextStream << QObject::tr("Evaluating database entries against HIBP file, this will take a while...");
+    outputTextStream << QObject::tr("Evaluating database entries against HIBP file, this will take a while...")
+                     << endl;
 
     QList<QPair<const Entry*, int>> findings;
     QString error;


### PR DESCRIPTION
Adding a new line after the message "Evaluating database entries against HIBP file, this will take a while..." helps to separate a report and the comment.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
The output of the analyze command looks like

> % keepassxc-cli analyze db.kdbx --hibp  pwned-passwords-sha1-ordered-by-count-v5.txt
> Enter password to unlock db.kdbx: 
> Evaluating database entries against HIBP file, this will take a while...Password for '<1>' has been leaked 1161 times!
> Password for '<2>' has been leaked 891 times!
> Password for '<3>' has been leaked 27 times!

The comment "take a while..." and the first line of the report are molded together.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
