### PR TITLE
FdoSecrets: fix crash when enabling the plugin on a non-exposed database

### DIFF
--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -74,6 +74,10 @@ namespace FdoSecrets
     public:
         DBusReturn<void> setProperties(const QVariantMap& properties);
 
+        bool isValid() const {
+            return backend();
+        }
+
         DBusReturn<void> removeAlias(QString alias);
         DBusReturn<void> addAlias(QString alias);
         const QSet<QString> aliases() const;
@@ -106,6 +110,7 @@ namespace FdoSecrets
     private slots:
         void onDatabaseLockChanged();
         void onDatabaseExposedGroupChanged();
+        // force reload info from backend, potentially delete self
         void reloadBackend();
 
     private:


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
While reproducing #3861, I found this crash. This may or may not be the crash reported in the issue.

When the user enabling the Secret Service Integration plugin, the plugin tries to create a `default` alias for the currently opened database. But if the database is not exposed, the creation will fail. The code didn't handle this.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually, the program no longer crashes.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
