### PR TITLE
Correctly initialize standalone PW generator mode

### DIFF
--- a/src/cli/Analyze.cpp
+++ b/src/cli/Analyze.cpp
@@ -55,7 +55,8 @@ int Analyze::executeWithDatabase(QSharedPointer<Database> database, QSharedPoint
         return EXIT_FAILURE;
     }
 
-    outputTextStream << QObject::tr("Evaluating database entries against HIBP file, this will take a while...");
+    outputTextStream << QObject::tr("Evaluating database entries against HIBP file, this will take a while...")
+                     << endl;
 
     QList<QPair<const Entry*, int>> findings;
     QString error;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -885,8 +885,8 @@ void MainWindow::switchToPasswordGen(bool enabled)
     if (enabled) {
         m_ui->passwordGeneratorWidget->loadSettings();
         m_ui->passwordGeneratorWidget->regeneratePassword();
-        m_ui->passwordGeneratorWidget->setStandaloneMode(true);
         m_ui->stackedWidget->setCurrentIndex(PasswordGeneratorScreen);
+        m_ui->passwordGeneratorWidget->setStandaloneMode(true);
     } else {
         m_ui->passwordGeneratorWidget->saveSettings();
         switchToDatabases();


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
The standalone mode on the password generator was set before the widget was made visible. The `showEvent` of `PasswordGeneratorWidget` resets its state and thus disables standalone mode.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes https://github.com/keepassxreboot/keepassxc/issues/953

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
* Manual test

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
