### PR TITLE
Ignore focus when checking toolbar state

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -30,6 +30,7 @@
 #include <QLineEdit>
 #include <QProcess>
 #include <QSplitter>
+#include <QTextEdit>
 
 #include "autotype/AutoType.h"
 #include "core/Config.h"
@@ -638,6 +639,14 @@ void DatabaseWidget::copyUsername()
 
 void DatabaseWidget::copyPassword()
 {
+    // QTextEdit does not properly trap Ctrl+C copy shortcut
+    // if a text edit has focus pass the copy operation to it
+    auto textEdit = qobject_cast<QTextEdit*>(focusWidget());
+    if (textEdit) {
+        textEdit->copy();
+        return;
+    }
+
     auto currentEntry = currentSelectedEntry();
     if (currentEntry) {
         setClipboardTextAndMinimize(currentEntry->resolveMultiplePlaceholders(currentEntry->password()));
@@ -1564,11 +1573,6 @@ void DatabaseWidget::restoreGroupEntryFocus(const QUuid& groupUuid, const QUuid&
 bool DatabaseWidget::isGroupSelected() const
 {
     return m_groupView->currentGroup();
-}
-
-bool DatabaseWidget::currentEntryHasFocus()
-{
-    return m_entryView->numberOfSelectedEntries() > 0 && m_entryView->hasFocus();
 }
 
 bool DatabaseWidget::currentEntryHasTitle()

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -104,7 +104,6 @@ public:
     bool isPasswordsHidden() const;
     void setPasswordsHidden(bool hide);
     void clearAllWidgets();
-    bool currentEntryHasFocus();
     bool currentEntryHasTitle();
     bool currentEntryHasUsername();
     bool currentEntryHasPassword();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -644,10 +644,8 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
 
         switch (mode) {
         case DatabaseWidget::Mode::ViewMode: {
-            bool hasFocus = m_contextMenuFocusLock || menuBar()->hasFocus() || m_searchWidget->hasFocus()
-                            || dbWidget->currentEntryHasFocus();
-            bool singleEntrySelected = dbWidget->numberOfSelectedEntries() == 1 && hasFocus;
-            bool entriesSelected = dbWidget->numberOfSelectedEntries() > 0 && hasFocus;
+            bool singleEntrySelected = dbWidget->numberOfSelectedEntries() == 1;
+            bool entriesSelected = dbWidget->numberOfSelectedEntries() > 0;
             bool groupSelected = dbWidget->isGroupSelected();
             bool currentGroupHasChildren = dbWidget->currentGroup()->hasChildren();
             bool currentGroupHasEntries = !dbWidget->currentGroup()->entries().isEmpty();
@@ -1192,7 +1190,7 @@ void MainWindow::showEntryContextMenu(const QPoint& globalPos)
     bool entrySelected = false;
     auto dbWidget = m_ui->tabWidget->currentDatabaseWidget();
     if (dbWidget) {
-        entrySelected = dbWidget->currentEntryHasFocus();
+        entrySelected = dbWidget->numberOfSelectedEntries() > 0;
     }
 
     if (entrySelected) {


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
Don't take the focus into account when setting certain menuitem's enabled / disabled state.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes https://github.com/keepassxreboot/keepassxc/issues/3770
I did not see any need to have the `hasFocus` condition. Without it, the application behaves intuitively: toolbar buttons are only disabled if an entry is visually unselected.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
* Manual test

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
