### PR TITLE
Fix start minimized to tray for unix...

### DIFF
--- a/src/core/Bootstrap.cpp
+++ b/src/core/Bootstrap.cpp
@@ -106,7 +106,11 @@ namespace Bootstrap
     {
         // start minimized if configured
         if (config()->get("GUI/MinimizeOnStartup").toBool()) {
+#ifdef Q_OS_WIN
             mainWindow.showMinimized();
+#else
+			mainWindow.hideWindow();
+#endif
         } else {
             mainWindow.bringToFront();
         }

--- a/src/core/Bootstrap.cpp
+++ b/src/core/Bootstrap.cpp
@@ -109,7 +109,7 @@ namespace Bootstrap
 #ifdef Q_OS_WIN
             mainWindow.showMinimized();
 #else
-			mainWindow.hideWindow();
+            mainWindow.hideWindow();
 #endif
         } else {
             mainWindow.bringToFront();


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
This permit to start the application minimized to system tray
If the system tray is disabled the application will start minimized to the taskbar

Fixes https://github.com/keepassxreboot/keepassxc/issues/2653
Fixes https://github.com/keepassxreboot/keepassxc/issues/3171

Related:
- https://github.com/keepassxreboot/keepassxc/issues/3797

## Current Behavior
 Keepassxc is started minimized to taskbar

## New Behavior
Keepassxc will start to system tray 
If system tray is disabled Keepassxc start minimized 

## Testing strategy
`mainWindow.hideWindow();` already check if system tray setting is enabled before hiding the window otherwise the window is minimized.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
