### PR TITLE
Add DB_DIR placeholder for autoopen urls

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -903,6 +903,10 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
             return url();
         }
         return resolveMultiplePlaceholdersRecursive(url(), maxDepth - 1);
+    case PlaceholderType::DbDir: {
+        QFileInfo fileInfo(database()->filePath());
+        return fileInfo.absoluteDir().absolutePath();
+    }
     case PlaceholderType::UrlWithoutScheme:
     case PlaceholderType::UrlScheme:
     case PlaceholderType::UrlHost:
@@ -1237,7 +1241,8 @@ Entry::PlaceholderType Entry::placeholderType(const QString& placeholder) const
         {QStringLiteral("{DT_UTC_DAY}"), PlaceholderType::DateTimeUtcDay},
         {QStringLiteral("{DT_UTC_HOUR}"), PlaceholderType::DateTimeUtcHour},
         {QStringLiteral("{DT_UTC_MINUTE}"), PlaceholderType::DateTimeUtcMinute},
-        {QStringLiteral("{DT_UTC_SECOND}"), PlaceholderType::DateTimeUtcSecond}};
+        {QStringLiteral("{DT_UTC_SECOND}"), PlaceholderType::DateTimeUtcSecond},
+        {QStringLiteral("{DB_DIR}"), PlaceholderType::DbDir}};
 
     return placeholders.value(placeholder.toUpper(), PlaceholderType::Unknown);
 }

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -205,7 +205,8 @@ public:
         DateTimeUtcDay,
         DateTimeUtcHour,
         DateTimeUtcMinute,
-        DateTimeUtcSecond
+        DateTimeUtcSecond,
+        DbDir
     };
 
     /**

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1973,15 +1973,16 @@ void DatabaseWidget::processAutoOpen()
         }
         QFileInfo filepath;
         QFileInfo keyfile;
+        QString databaseUrl = entry->resolveMultiplePlaceholders(entry->url());
 
-        if (entry->url().startsWith("file://")) {
-            QUrl url(entry->url());
+        if (databaseUrl.startsWith("file://")) {
+            QUrl url(databaseUrl);
             filepath.setFile(url.toLocalFile());
         } else {
-            filepath.setFile(entry->url());
+            filepath.setFile(databaseUrl);
             if (filepath.isRelative()) {
                 QFileInfo currentpath(m_db->filePath());
-                filepath.setFile(currentpath.absoluteDir(), entry->url());
+                filepath.setFile(currentpath.absoluteDir(), databaseUrl);
             }
         }
 


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Add placeholder `{DB_DIR}` for the url of the autoopen functionality

Adding placeholder for the url of the autoopen functionality would it make easier to sync a database with a child database on multiple devices via file sharing services.

e.g. `{DB_DIR}/passwords.kdbx`

Currently relative paths and absolute paths work in KeepassXC (https://github.com/keepassxreboot/keepassxc/pull/1053).
But relative paths do not work in Keepass2 or other clients i.e Keepass2Android, whereas path placeholders work in those clients.

Keepass placeholders:
https://keepass.info/help/base/placeholders.html

Fixes #3863 

## Testing strategy
created databases linked them to the parent database, using different url styles (relative path, `file:///`, and with `{DB_DIR}`)

built it with following settings:
`cmake -DWITH_TESTS=ON -DWITH_ASAN=ON -DCMAKE_BUILD_TYPE=Release ..`

I ran the `make test` and these tests failed (but I don't know what to do about it):
	  1 - testgroup (Failed)
	 15 - testopvaultreader (Failed)


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
   see testing section
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
