### PR TITLE
Wrap XML data into QString to fix encoding

### DIFF
--- a/src/cli/Export.cpp
+++ b/src/cli/Export.cpp
@@ -51,7 +51,7 @@ int Export::executeWithDatabase(QSharedPointer<Database> database, QSharedPointe
             errorTextStream << QObject::tr("Unable to export database to XML: %1").arg(errorMessage) << endl;
             return EXIT_FAILURE;
         }
-        outputTextStream << xmlData.constData() << endl;
+        outputTextStream.write(xmlData.constData());
     } else if (format.startsWith(QStringLiteral("csv"), Qt::CaseInsensitive)) {
         CsvExporter csvExporter;
         outputTextStream << csvExporter.exportDatabase(database);

--- a/src/cli/TextStream.cpp
+++ b/src/cli/TextStream.cpp
@@ -58,6 +58,15 @@ TextStream::TextStream(const QByteArray& array, QIODevice::OpenMode openMode)
     detectCodec();
 }
 
+void TextStream::write(const char* str)
+{
+    // Workaround for an issue with QTextStream. Its operator<<(const char *string) will encode the
+    // string with a non-UTF-8 encoding. We work around this by wrapping the input string into
+    // a QString, thus enforcing UTF-8. More info:
+    // https://code.qt.io/cgit/qt/qtbase.git/commit?id=cec8cdba4d1b856e17c8743ba8803349d42dc701
+    *this << QString(str);
+}
+
 void TextStream::detectCodec()
 {
     QString codecName = "UTF-8";

--- a/src/cli/TextStream.h
+++ b/src/cli/TextStream.h
@@ -43,6 +43,8 @@ public:
     explicit TextStream(QByteArray* array, QIODevice::OpenMode openMode = QIODevice::ReadWrite);
     explicit TextStream(const QByteArray& array, QIODevice::OpenMode openMode = QIODevice::ReadOnly);
 
+    void write(const char* str);
+
 private:
     void detectCodec();
 };


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
Fix encoding problem when exporting the database into XML format.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes https://github.com/keepassxreboot/keepassxc/issues/3900
Root case explained here: https://stackoverflow.com/questions/40318671/streaming-utf-8-literals-into-qtextstream
**Disclaimer**: I do not consider my change a proper fix. It works (correct XML is outputted), but I suspect the proper fix would be to overwrite the `<<` operator of the `TextStream` class, and wrap the output into a `QString` there. However, I am not 100% sure about the implications of this change, so I just did this small workaround to highlight the problem for you. It fixes the original issue that was raised, but does not address the underlying problem (explained in the stack overflow article).

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
* Manual test

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
