### PR TITLE
Add option to use entry only for HTTP Basic Auth

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -42,7 +42,7 @@ QJsonObject BrowserAction::readResponse(const QJsonObject& json)
 
     bool triggerUnlock = false;
     const QString trigger = json.value("triggerUnlock").toString();
-    if (!trigger.isEmpty() && trigger.compare("true", Qt::CaseSensitive) == 0) {
+    if (!trigger.isEmpty() && trigger.compare(TRUE_STR, Qt::CaseSensitive) == 0) {
         triggerUnlock = true;
     }
 
@@ -268,7 +268,7 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
     const QString id = decrypted.value("id").toString();
     const QString submit = decrypted.value("submitUrl").toString();
     const QString auth = decrypted.value("httpAuth").toString();
-    const bool httpAuth = auth.compare("true", Qt::CaseSensitive) == 0 ? true : false;
+    const bool httpAuth = auth.compare(TRUE_STR, Qt::CaseSensitive) == 0 ? true : false;
     const QJsonArray users = m_browserService.findMatchingEntries(id, url, submit, "", keyList, httpAuth);
 
     if (users.isEmpty()) {
@@ -469,7 +469,7 @@ QJsonObject BrowserAction::buildMessage(const QString& nonce) const
 {
     QJsonObject message;
     message["version"] = KEEPASSXC_VERSION;
-    message["success"] = "true";
+    message["success"] = TRUE_STR;
     message["nonce"] = nonce;
     return message;
 }

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -54,6 +54,7 @@ static const QString KEEPASSHTTP_GROUP_NAME = QStringLiteral("KeePassHttp Passwo
 // Extra entry related options saved in custom data
 const QString BrowserService::OPTION_SKIP_AUTO_SUBMIT = QStringLiteral("BrowserSkipAutoSubmit");
 const QString BrowserService::OPTION_HIDE_ENTRY = QStringLiteral("BrowserHideEntry");
+const QString BrowserService::OPTION_ONLY_HTTP_AUTH = QStringLiteral("BrowserOnlyHttpAuth");
 // Multiple URL's
 const QString BrowserService::ADDITIONAL_URL = QStringLiteral("KP2A_URL");
 
@@ -382,7 +383,12 @@ QJsonArray BrowserService::findMatchingEntries(const QString& id,
     QList<Entry*> pwEntries;
     for (auto* entry : searchEntries(url, submitUrl, keyList)) {
         if (entry->customData()->contains(BrowserService::OPTION_HIDE_ENTRY)
-            && entry->customData()->value(BrowserService::OPTION_HIDE_ENTRY) == "true") {
+            && entry->customData()->value(BrowserService::OPTION_HIDE_ENTRY) == TRUE_STR) {
+            continue;
+        }
+
+        if (!httpAuth && entry->customData()->contains(BrowserService::OPTION_ONLY_HTTP_AUTH)
+            && entry->customData()->value(BrowserService::OPTION_ONLY_HTTP_AUTH) == TRUE_STR) {
             continue;
         }
 
@@ -850,7 +856,7 @@ QJsonObject BrowserService::prepareEntry(const Entry* entry)
     }
 
     if (entry->isExpired()) {
-        res["expired"] = "true";
+        res["expired"] = TRUE_STR;
     }
 
     if (entry->customData()->contains(BrowserService::OPTION_SKIP_AUTO_SUBMIT)) {

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -74,6 +74,7 @@ public:
     static const QString LEGACY_ASSOCIATE_KEY_PREFIX;
     static const QString OPTION_SKIP_AUTO_SUBMIT;
     static const QString OPTION_HIDE_ENTRY;
+    static const QString OPTION_ONLY_HTTP_AUTH;
     static const QString ADDITIONAL_URL;
 
 public slots:

--- a/src/core/Global.h
+++ b/src/core/Global.h
@@ -20,6 +20,7 @@
 #ifndef KEEPASSX_GLOBAL_H
 #define KEEPASSX_GLOBAL_H
 
+#include <QString>
 #include <QtGlobal>
 
 #if defined(Q_OS_WIN)
@@ -41,6 +42,9 @@
 #else
 #define FILE_CASE_SENSITIVE Qt::CaseSensitive
 #endif
+
+static const auto TRUE_STR = QStringLiteral("true");
+static const auto FALSE_STR = QStringLiteral("false");
 
 template <typename T> struct AddConst
 {

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -279,6 +279,7 @@ void EditEntryWidget::setupBrowser()
         // clang-format off
         connect(m_browserUi->skipAutoSubmitCheckbox, SIGNAL(toggled(bool)), SLOT(updateBrowserModified()));
         connect(m_browserUi->hideEntryCheckbox, SIGNAL(toggled(bool)), SLOT(updateBrowserModified()));
+        connect(m_browserUi->onlyHttpAuthCheckbox, SIGNAL(toggled(bool)), SLOT(updateBrowserModified()));
         connect(m_browserUi->addURLButton, SIGNAL(clicked()), SLOT(insertURL()));
         connect(m_browserUi->removeURLButton, SIGNAL(clicked()), SLOT(removeCurrentURL()));
         connect(m_browserUi->editURLButton, SIGNAL(clicked()), SLOT(editCurrentURL()));
@@ -305,8 +306,10 @@ void EditEntryWidget::updateBrowser()
 
     auto skip = m_browserUi->skipAutoSubmitCheckbox->isChecked();
     auto hide = m_browserUi->hideEntryCheckbox->isChecked();
-    m_customData->set(BrowserService::OPTION_SKIP_AUTO_SUBMIT, (skip ? QString("true") : QString("false")));
-    m_customData->set(BrowserService::OPTION_HIDE_ENTRY, (hide ? QString("true") : QString("false")));
+    auto onlyHttpAuth = m_browserUi->onlyHttpAuthCheckbox->isChecked();
+    m_customData->set(BrowserService::OPTION_SKIP_AUTO_SUBMIT, (skip ? TRUE_STR : FALSE_STR));
+    m_customData->set(BrowserService::OPTION_HIDE_ENTRY, (hide ? TRUE_STR : FALSE_STR));
+    m_customData->set(BrowserService::OPTION_ONLY_HTTP_AUTH, (onlyHttpAuth ? TRUE_STR : FALSE_STR));
 }
 
 void EditEntryWidget::insertURL()
@@ -470,6 +473,7 @@ void EditEntryWidget::setupEntryUpdate()
     if (config()->get("Browser/Enabled", false).toBool()) {
         connect(m_browserUi->skipAutoSubmitCheckbox, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->hideEntryCheckbox, SIGNAL(toggled(bool)), SLOT(setModified()));
+        connect(m_browserUi->onlyHttpAuthCheckbox, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->addURLButton, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->removeURLButton, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->editURLButton, SIGNAL(toggled(bool)), SLOT(setModified()));
@@ -964,16 +968,23 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
 #ifdef WITH_XC_BROWSER
     if (m_customData->contains(BrowserService::OPTION_SKIP_AUTO_SUBMIT)) {
         // clang-format off
-        m_browserUi->skipAutoSubmitCheckbox->setChecked(m_customData->value(BrowserService::OPTION_SKIP_AUTO_SUBMIT) == "true");
+        m_browserUi->skipAutoSubmitCheckbox->setChecked(m_customData->value(BrowserService::OPTION_SKIP_AUTO_SUBMIT) == TRUE_STR);
         // clang-format on
     } else {
         m_browserUi->skipAutoSubmitCheckbox->setChecked(false);
     }
 
     if (m_customData->contains(BrowserService::OPTION_HIDE_ENTRY)) {
-        m_browserUi->hideEntryCheckbox->setChecked(m_customData->value(BrowserService::OPTION_HIDE_ENTRY) == "true");
+        m_browserUi->hideEntryCheckbox->setChecked(m_customData->value(BrowserService::OPTION_HIDE_ENTRY) == TRUE_STR);
     } else {
         m_browserUi->hideEntryCheckbox->setChecked(false);
+    }
+
+    if (m_customData->contains(BrowserService::OPTION_ONLY_HTTP_AUTH)) {
+        m_browserUi->onlyHttpAuthCheckbox->setChecked(m_customData->value(BrowserService::OPTION_ONLY_HTTP_AUTH)
+                                                      == TRUE_STR);
+    } else {
+        m_browserUi->onlyHttpAuthCheckbox->setChecked(false);
     }
 
     m_browserUi->addURLButton->setEnabled(!m_history);

--- a/src/gui/entry/EditEntryWidgetBrowser.ui
+++ b/src/gui/entry/EditEntryWidgetBrowser.ui
@@ -50,6 +50,16 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="onlyHttpAuthCheckbox">
+        <property name="toolTip">
+         <string>Only send this setting to the browser for HTTP Auth dialogs. If enabled, normal login forms will not show this entry for selection.</string>
+        </property>
+        <property name="text">
+         <string>Use this entry only with HTTP Basic Auth</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -130,6 +140,7 @@
  <tabstops>
   <tabstop>skipAutoSubmitCheckbox</tabstop>
   <tabstop>hideEntryCheckbox</tabstop>
+  <tabstop>onlyHttpAuthCheckbox</tabstop>
   <tabstop>additionalURLsView</tabstop>
   <tabstop>addURLButton</tabstop>
   <tabstop>removeURLButton</tabstop>

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -57,7 +57,7 @@ void TestBrowser::testChangePublicKeys()
     auto response = m_browserAction->handleAction(json);
     QCOMPARE(response["action"].toString(), QString("change-public-keys"));
     QCOMPARE(response["publicKey"].toString() == PUBLICKEY, false);
-    QCOMPARE(response["success"].toString(), QString("true"));
+    QCOMPARE(response["success"].toString(), TRUE_STR);
 }
 
 void TestBrowser::testEncryptMessage()


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Adds a new option to use entry only with HTTP Basic Auth. If an entry uses additional URL's, the option will be enabled for them also.

Fixes #3925.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![Screen Shot 2019-11-24 at 18 01 02](https://user-images.githubusercontent.com/24570482/69497447-dc077f80-0ee5-11ea-89b6-a22009ad1a17.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
