### PR TITLE
Partial fix for building on Mac OS X < 10.12

### DIFF
--- a/src/gui/macutils/AppKitImpl.mm
+++ b/src/gui/macutils/AppKitImpl.mm
@@ -20,11 +20,6 @@
 
 #import <AppKit/NSWorkspace.h>
 #import <CoreVideo/CVPixelBuffer.h>
-#import <Availability.h>
-
-#if __MAC_OS_X_VERSION_MAX_ALLOWED < 101200
-static const NSEventMask NSEventMaskKeyDown = NSKeyDownMask;
-#endif
 
 @implementation AppKitImpl
 


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
This commit reverts #3357.

The previous PR is for the new symbol NSEventMaskKeyDown, which is
introduced in #3347. In #3794, #3347 is reverted, so the workaround
in #3357 is no longer needed. Furthermore, it causes build failures
on 10.11 (#3932) as the header file for type NSEventMask is removed
in #3794, too.

Note that this is not a complete fix. A complete patch can be found
at [1]. In MacPorts, the OS version for building a package is the same
as the OS that installs it, so #ifdef can be used to replace @available.
However, this is not always the case for other cases (e.g., official
KeePassXC builds for macOS), so I didn't include the full patch in this PR.
Here the latter language feature @available is not available until Xcode 9.

With the patch mentioned in the previous paragraph, KeePassXC 2.5.1
can be built on Mac OS X 10.9 or newer.

Ref: #2899

[1] https://github.com/macports/macports-ports/blob/de1bb703ad19c258ad27eb903cf510dc1930107c/security/KeePassXC/files/patch-old-mac.diff

## Screenshots
N/A - build fixes only

## Testing strategy
Build it!

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**