### PR TITLE
Bug fix: Never show recycled items in statistics

### DIFF
--- a/src/gui/dbsettings/DatabaseSettingsWidgetStatistics.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetStatistics.cpp
@@ -98,7 +98,7 @@ namespace
         {
             for (const auto* group : groups) {
                 // Don't count anything in the recycle bin
-                if (group == group->database()->metadata()->recycleBin()) {
+                if (group->isRecycled()) {
                     continue;
                 }
 


### PR DESCRIPTION
Previously, entries in the recycle bin would sometimes be included in the database statistics panel.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context

Recycled entries are not supposed to appear in DB statistics. Previously, entries in recycled groups would yet be counted for statistics.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

n/a

## Testing strategy

Tested manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
