### PR TITLE
Correct multiple issues with database saving

### DIFF
--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -21,9 +21,9 @@
 
 #include <QDateTime>
 #include <QHash>
-#include <QObject>
 #include <QPointer>
 #include <QScopedPointer>
+#include <QTimer>
 
 #include "config-keepassx.h"
 #include "crypto/kdf/AesKdf.h"
@@ -37,7 +37,6 @@ enum class EntryReferenceType;
 class FileWatcher;
 class Group;
 class Metadata;
-class QTimer;
 class QIODevice;
 
 struct DeletedObject
@@ -155,9 +154,6 @@ signals:
     void databaseDiscarded();
     void databaseFileChanged();
 
-private slots:
-    void startModifiedTimer();
-
 private:
     struct DatabaseData
     {
@@ -211,7 +207,7 @@ private:
     DatabaseData m_data;
     QPointer<Group> m_rootGroup;
     QList<DeletedObject> m_deletedObjects;
-    QPointer<QTimer> m_timer;
+    QTimer m_modifiedTimer;
     QPointer<FileWatcher> m_fileWatcher;
     bool m_initialized = false;
     bool m_modified = false;

--- a/src/core/FileWatcher.h
+++ b/src/core/FileWatcher.h
@@ -43,8 +43,7 @@ public slots:
     void resume();
 
 private slots:
-    void onWatchedFileChanged();
-    void checkFileChecksum();
+    void checkFileChanged();
 
 private:
     QByteArray calculateChecksum();
@@ -56,8 +55,8 @@ private:
     QTimer m_fileChangeDelayTimer;
     QTimer m_fileIgnoreDelayTimer;
     QTimer m_fileChecksumTimer;
-    int m_fileChecksumSizeBytes;
-    bool m_ignoreFileChange;
+    int m_fileChecksumSizeBytes = -1;
+    bool m_ignoreFileChange = false;
 };
 
 class BulkFileWatcher : public QObject

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1370,7 +1370,7 @@ bool DatabaseWidget::lock()
     if (m_db->isModified()) {
         bool saved = false;
         // Attempt to save on exit, but don't block locking if it fails
-        if (config()->get("AutoSaveOnExit").toBool()) {
+        if (config()->get("AutoSaveOnExit").toBool() || config()->get("AutoSaveAfterEveryChange").toBool()) {
             saved = save();
         }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -275,6 +275,11 @@ bool DatabaseWidget::isEntryEditActive() const
     return currentWidget() == m_editEntryWidget;
 }
 
+bool DatabaseWidget::isGroupEditActive() const
+{
+    return currentWidget() == m_editGroupWidget;
+}
+
 bool DatabaseWidget::isEditWidgetModified() const
 {
     if (currentWidget() == m_editEntryWidget) {
@@ -387,6 +392,8 @@ void DatabaseWidget::createEntry()
 
 void DatabaseWidget::replaceDatabase(QSharedPointer<Database> db)
 {
+    Q_ASSERT(!isEntryEditActive() && !isGroupEditActive());
+
     // Save off new parent UUID which will be valid when creating a new entry
     QUuid newParentUuid;
     if (m_newParent) {
@@ -1421,7 +1428,8 @@ bool DatabaseWidget::lock()
 
 void DatabaseWidget::reloadDatabaseFile()
 {
-    if (!m_db || isLocked()) {
+    // Ignore reload if we are locked or currently editing an entry or group
+    if (!m_db || isLocked() || isEntryEditActive() || isGroupEditActive()) {
         return;
     }
 
@@ -1440,6 +1448,11 @@ void DatabaseWidget::reloadDatabaseFile()
             return;
         }
     }
+
+    // Lock out interactions
+    m_entryView->setDisabled(true);
+    m_groupView->setDisabled(true);
+    QApplication::processEvents();
 
     QString error;
     auto db = QSharedPointer<Database>::create(m_db->filePath());
@@ -1480,6 +1493,10 @@ void DatabaseWidget::reloadDatabaseFile()
         // Mark db as modified since existing data may differ from file or file was deleted
         m_db->markAsModified();
     }
+
+    // Return control
+    m_entryView->setDisabled(false);
+    m_groupView->setDisabled(false);
 }
 
 int DatabaseWidget::numberOfSelectedEntries() const
@@ -1620,10 +1637,19 @@ bool DatabaseWidget::save()
     m_blockAutoSave = true;
     ++m_saveAttempts;
 
-    // TODO: Make this async, but lock out the database widget to prevent re-entrance
+    // TODO: Make this async
+    // Lock out interactions
+    m_entryView->setDisabled(true);
+    m_groupView->setDisabled(true);
+    QApplication::processEvents();
+
     bool useAtomicSaves = config()->get("UseAtomicSaves", true).toBool();
     QString errorMessage;
     bool ok = m_db->save(&errorMessage, useAtomicSaves, config()->get("BackupBeforeSave").toBool());
+
+    // Return control
+    m_entryView->setDisabled(false);
+    m_groupView->setDisabled(false);
 
     if (ok) {
         m_saveAttempts = 0;

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -81,6 +81,7 @@ public:
     bool isLocked() const;
     bool isSearchActive() const;
     bool isEntryEditActive() const;
+    bool isGroupEditActive() const;
 
     QString getCurrentSearch();
     void refreshSearch();

--- a/src/gui/widgets/ElidedLabel.cpp
+++ b/src/gui/widgets/ElidedLabel.cpp
@@ -105,7 +105,7 @@ void ElidedLabel::updateElidedText()
         const QFontMetrics metrix(font());
         displayText = metrix.elidedText(m_rawText, m_elideMode, width() - 2);
     }
-    
+
     bool hasUrl = !m_url.isEmpty();
     setText(hasUrl ? htmlLinkTemplate.arg(m_url.toHtmlEscaped(), displayText) : displayText);
     setOpenExternalLinks(!hasUrl);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Mark the database as clean after fully completing the file save operation INSTEAD of when merely writing the database to a file.

* Stop the modified timer when marking the database as clean, this prevents latent erroneous modified signals from being emitted.

* Do not restart the modified timer after a new change is detected while it is still running.

* Fix #3933 and  fix #3857. Interaction with entries and groups is disabled while the database is being reloaded or saved to prevent changes from occurring. Prevent the database from being reloading if an entry or group is currently being edited.

* Fix #3941 - Only notify components when the database file actually changes (determined by checksum). This prevents spurious merge requests when the file is merely touched by another service (e.g., DropBox).

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Currently testing on all platforms to confirm the above bugs are fixed.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
