### PR TITLE
Secret Service Integration: fix all exposed entries are returned if search with empty terms

### DIFF
--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -242,6 +242,11 @@ namespace FdoSecrets
             terms << attributeToTerm(it.key(), it.value());
         }
 
+        // empty terms causes EntrySearcher returns everything
+        if (terms.isEmpty()) {
+            return QList<Item*>{};
+        }
+
         QList<Item*> items;
         const auto foundEntries = EntrySearcher().search(terms, m_exposedGroup);
         items.reserve(foundEntries.size());


### PR DESCRIPTION


[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
When using `secret-tool` or any other client to search the database via secret service API, KeePassXC will return all exposed entries if the searching terms contain only `Password`.

Example: `secret-tool search --all Password abc`

The intended behavior is to not allow searching by password at all. Because the terms are passed in clear text which is insecure. In the implementation, any term matching `Password` is skipped. But if that is the only term, an empty term list is passed to `EntrySearcher`, which will return all entries.

This fix checks if the term list is empty and return not found if it is.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually by
```
secret-tool search --all Password abc
```

Nothing should be returned.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**