### PR TITLE
FdoSecrets: fix searching of entries with special characters in attributes

### DIFF
--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -30,6 +30,7 @@
 #include "gui/DatabaseWidget.h"
 
 #include <QFileInfo>
+#include <QRegularExpression>
 
 namespace FdoSecrets
 {
@@ -268,7 +269,7 @@ namespace FdoSecrets
         const auto useWildcards = false;
         const auto exactMatch = true;
         const auto caseSensitive = true;
-        term.regex = Tools::convertToRegex(value, useWildcards, exactMatch, caseSensitive);
+        term.regex = Tools::convertToRegex(QRegularExpression::escape(value), useWildcards, exactMatch, caseSensitive);
 
         return term;
     }

--- a/tests/TestFdoSecrets.cpp
+++ b/tests/TestFdoSecrets.cpp
@@ -112,3 +112,35 @@ void TestFdoSecrets::testCrazyAttributeKey()
     const auto res = EntrySearcher().search({term}, root.data());
     QCOMPARE(res.count(), 1);
 }
+
+void TestFdoSecrets::testSpecialCharsInAttributeValue()
+{
+    using FdoSecrets::Collection;
+    using FdoSecrets::Item;
+
+    const QScopedPointer<Group> root(new Group());
+    QScopedPointer<Entry> e1(new Entry());
+    e1->setGroup(root.data());
+
+    e1->setTitle("titleA");
+    e1->attributes()->set("testAttribute", "OAuth::[test.name@gmail.com]");
+
+    QScopedPointer<Entry> e2(new Entry());
+    e2->setGroup(root.data());
+    e2->setTitle("titleB");
+    e2->attributes()->set("testAttribute", "Abc:*+.-");
+
+    // search for custom entries via programatic API
+    {
+        const auto term = Collection::attributeToTerm("testAttribute", "OAuth::[test.name@gmail.com]");
+        const auto res = EntrySearcher().search({term}, root.data());
+        QCOMPARE(res.count(), 1);
+        QCOMPARE(res[0]->title(), QStringLiteral("titleA"));
+    }
+    {
+        const auto term = Collection::attributeToTerm("testAttribute", "Abc:*+.-");
+        const auto res = EntrySearcher().search({term}, root.data());
+        QCOMPARE(res.count(), 1);
+        QCOMPARE(res[0]->title(), QStringLiteral("titleB"));
+    }
+}

--- a/tests/TestFdoSecrets.h
+++ b/tests/TestFdoSecrets.h
@@ -31,6 +31,7 @@ private slots:
     void testGcryptMPI();
     void testDhIetf1024Sha256Aes128CbcPkcs7();
     void testCrazyAttributeKey();
+    void testSpecialCharsInAttributeValue();
 };
 
 #endif // KEEPASSXC_TESTFDOSECRETS_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

When constructing search terms for EntrySearcher, the attribute value should be escaped before passing to `Tools::convertToRegex`, otherwise special attribute value won't be searched.

This fixes #3955, because Evolution sets attribute `e-source-uid` to something like `OAuth::[user.name@gmail.com]`.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added unit test.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
