### PR TITLE
Enable browser-like DbTab experience (Alt + Nums)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -302,6 +302,27 @@ MainWindow::MainWindow()
     new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(selectNextDatabaseTab()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this, SLOT(selectPreviousDatabaseTab()));
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
+    new QShortcut(Qt::ALT + Qt::Key_0, this, SLOT(selectLastDatabaseTab()));
+
+    auto shortcut = new QShortcut(Qt::ALT + Qt::Key_1, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_2, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(2); });
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_3, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(3); });
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_4, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(4); });
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_5, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(5); });
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_6, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(6); });
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_7, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(7); });
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_8, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_9, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(9); });
+
     // Toggle password and username visibility in entry view
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C, this, SLOT(togglePasswordsHidden()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_B, this, SLOT(toggleUsernamesHidden()));
@@ -971,6 +992,23 @@ void MainWindow::selectPreviousDatabaseTab()
         } else {
             m_ui->tabWidget->setCurrentIndex(index);
         }
+    }
+}
+
+void MainWindow::selectDatabaseTab(int tabIndex)
+{
+    if (m_ui->stackedWidget->currentIndex() == DatabaseTabScreen) {
+        if (tabIndex <= m_ui->tabWidget->count()) {
+            m_ui->tabWidget->setCurrentIndex(--tabIndex);
+        }
+    }
+}
+
+void MainWindow::selectLastDatabaseTab()
+{
+    if (m_ui->stackedWidget->currentIndex() == DatabaseTabScreen) {
+        int index = m_ui->tabWidget->count() - 1;
+        m_ui->tabWidget->setCurrentIndex(index);
     }
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -122,6 +122,8 @@ private slots:
     void showErrorMessage(const QString& message);
     void selectNextDatabaseTab();
     void selectPreviousDatabaseTab();
+    void selectDatabaseTab(int tabIndex);
+    void selectLastDatabaseTab();
     void togglePasswordsHidden();
     void toggleUsernamesHidden();
     void obtainContextFocusLock();


### PR DESCRIPTION
1-9 goes to 1-9 tab; 0 - goes to the last one

Please read Testing strategy, thanks!

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
In browsers we could not only use CTRL + PgDn/PgUp and CTRL (+ SHIFT) + TAB to switch tabs.
There is also ALT + <Number> which have various types of work. 1-9 operates on tabs from 1st to 9th one, and (on Chrome?) the 0 goes to last one.
On the another similar to KPXC application found this kind of feature. ;)

## Screenshots
N/A

## Testing strategy
This is WIP, I wonder if this code could be (bc of less complexity) or should change to functor or some Signal mapper.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
Not yet: - ✅ My change requires a change to the documentation, and I have updated it accordingly.
Not yet: - ✅ I have added tests to cover my changes.
