### PR TITLE
FdoSecrets: only emit completed signal when the action actually finishes

### DIFF
--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -48,6 +48,14 @@ namespace FdoSecrets
         connect(backend, &DatabaseWidget::databaseUnlocked, this, &Collection::onDatabaseLockChanged);
         connect(backend, &DatabaseWidget::databaseLocked, this, &Collection::onDatabaseLockChanged);
 
+        // get notified whenever unlock db dialog finishes
+        connect(parent, &Service::doneUnlockDatabaseInDialog, this, [this](bool accepted, DatabaseWidget* dbWidget) {
+            if (!dbWidget || dbWidget != m_backend) {
+                return;
+            }
+            emit doneUnlockCollection(accepted);
+        });
+
         reloadBackend();
     }
 

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -71,6 +71,8 @@ namespace FdoSecrets
         void aliasAdded(const QString& alias);
         void aliasRemoved(const QString& alias);
 
+        void doneUnlockCollection(bool accepted);
+
     public:
         DBusReturn<void> setProperties(const QVariantMap& properties);
 

--- a/src/fdosecrets/objects/Prompt.h
+++ b/src/fdosecrets/objects/Prompt.h
@@ -98,8 +98,13 @@ namespace FdoSecrets
 
         DBusReturn<void> prompt(const QString& windowId) override;
 
+    private slots:
+        void collectionUnlockFinished(bool accepted);
+
     private:
         QList<QPointer<Collection>> m_collections;
+        QList<QDBusObjectPath> m_unlocked;
+        int m_numRejected = 0;
     };
 
     class Item;

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -47,6 +47,8 @@ namespace FdoSecrets
         , m_insdieEnsureDefaultAlias(false)
         , m_serviceWatcher(nullptr)
     {
+        connect(
+            m_databases, &DatabaseTabWidget::databaseUnlockDialogFinished, this, &Service::doneUnlockDatabaseInDialog);
     }
 
     Service::~Service()
@@ -447,9 +449,9 @@ namespace FdoSecrets
         return m_sessions;
     }
 
-    void Service::doCloseDatabase(DatabaseWidget* dbWidget)
+    bool Service::doCloseDatabase(DatabaseWidget* dbWidget)
     {
-        m_databases->closeDatabaseTab(dbWidget);
+        return m_databases->closeDatabaseTab(dbWidget);
     }
 
     Collection* Service::doNewDatabase()
@@ -472,11 +474,10 @@ namespace FdoSecrets
 
     void Service::doSwitchToChangeDatabaseSettings(DatabaseWidget* dbWidget)
     {
-        // switch selected to current
-        // unlock if needed
         if (dbWidget->isLocked()) {
-            m_databases->unlockDatabaseInDialog(dbWidget, DatabaseOpenDialog::Intent::None);
+            return;
         }
+        // switch selected to current
         m_databases->setCurrentWidget(dbWidget);
         m_databases->changeDatabaseSettings();
 

--- a/src/fdosecrets/objects/Service.h
+++ b/src/fdosecrets/objects/Service.h
@@ -88,6 +88,13 @@ namespace FdoSecrets
          */
         void error(const QString& msg);
 
+        /**
+         * Finish signal for async action doUnlockDatabaseInDialog
+         * @param accepted If false, the action is canceled by the user
+         * @param dbWidget The unlocked the dbWidget if succeed
+         */
+        void doneUnlockDatabaseInDialog(bool accepted, DatabaseWidget* dbWidget);
+
     public:
         /**
          * List of sessions
@@ -101,9 +108,14 @@ namespace FdoSecrets
         }
 
     public slots:
-        void doCloseDatabase(DatabaseWidget* dbWidget);
+        bool doCloseDatabase(DatabaseWidget* dbWidget);
         Collection* doNewDatabase();
         void doSwitchToChangeDatabaseSettings(DatabaseWidget* dbWidget);
+
+        /**
+         * Async, connect to signal doneUnlockDatabaseInDialog for finish notification
+         * @param dbWidget
+         */
         void doUnlockDatabaseInDialog(DatabaseWidget* dbWidget);
 
     private slots:

--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -51,7 +51,7 @@ void DatabaseOpenDialog::setTargetDatabaseWidget(DatabaseWidget* dbWidget)
         disconnect(this, nullptr, m_dbWidget, nullptr);
     }
     m_dbWidget = dbWidget;
-    connect(this, SIGNAL(dialogFinished(bool)), dbWidget, SLOT(unlockDatabase(bool)));
+    connect(this, &DatabaseOpenDialog::dialogFinished, dbWidget, &DatabaseWidget::unlockDatabase);
 }
 
 void DatabaseOpenDialog::setIntent(DatabaseOpenDialog::Intent intent)
@@ -90,6 +90,6 @@ void DatabaseOpenDialog::complete(bool accepted)
     } else {
         reject();
     }
-    emit dialogFinished(accepted);
+    emit dialogFinished(accepted, m_dbWidget);
     clearForms();
 }

--- a/src/gui/DatabaseOpenDialog.h
+++ b/src/gui/DatabaseOpenDialog.h
@@ -50,7 +50,7 @@ public:
     void clearForms();
 
 signals:
-    void dialogFinished(bool);
+    void dialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
 public slots:
     void complete(bool accepted);

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -63,6 +63,8 @@ DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
     connect(autoType(), SIGNAL(globalAutoTypeTriggered()), SLOT(performGlobalAutoType()));
     connect(autoType(), SIGNAL(autotypePerformed()), SLOT(relockPendingDatabase()));
     connect(autoType(), SIGNAL(autotypeRejected()), SLOT(relockPendingDatabase()));
+    connect(m_databaseOpenDialog.data(), &DatabaseOpenDialog::dialogFinished,
+            this, &DatabaseTabWidget::databaseUnlockDialogFinished);
     // clang-format on
 
 #ifdef Q_OS_MACOS

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -90,6 +90,7 @@ signals:
     void tabNameChanged();
     void messageGlobal(const QString&, MessageWidget::MessageType type);
     void messageDismissGlobal();
+    void databaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
 private slots:
     void toggleTabbar();


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
The `DatabaseTabWidget::unlockDatabaseInDialog` returns before the dialog is completed by the user. Previously the completed signal is emitted on DBus right after the method returns. This causes issues for clients using this signal assuming the database is already unlocked.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

1. lock the database
2. use secret-tool to create an entry
3. unlock in the pop up dialog

before:

4. secret-tool didn't create the entry and prints an error message

now:

4. the entry is created

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
