### PR TITLE
Last round of fixes for 2.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,9 @@ endif()
 
 if(WITH_DEV_BUILD)
     add_definitions(-DQT_DEPRECATED_WARNINGS -DGCRYPT_NO_DEPRECATED)
+else()
+    add_definitions(-DQT_NO_DEPRECATED_WARNINGS)
+    add_gcc_compiler_cxxflags("-Wno-deprecated-declarations")
 endif()
 
 if(MINGW)

--- a/src/browser/BrowserOptionDialog.cpp
+++ b/src/browser/BrowserOptionDialog.cpp
@@ -128,6 +128,9 @@ void BrowserOptionDialog::loadSettings()
     m_ui->vivaldiSupport->setChecked(settings->vivaldiSupport());
     m_ui->torBrowserSupport->setChecked(settings->torBrowserSupport());
 #endif
+#ifndef Q_OS_LINUX
+    m_ui->snapWarningLabel->setVisible(false);
+#endif
 
 #if defined(KEEPASSXC_DIST_APPIMAGE)
     m_ui->supportBrowserProxy->setChecked(true);

--- a/src/format/OpVaultReaderSections.cpp
+++ b/src/format/OpVaultReaderSections.cpp
@@ -83,7 +83,7 @@ void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionNam
             }
             attrValue = query.toString(QUrl::FullyEncoded);
         }
-        entry->attributes()->set(Totp::ATTRIBUTE_SETTINGS, attrValue, true);
+        entry->setTotp(Totp::parseSettings(attrValue));
     } else if (attrName.startsWith("expir", Qt::CaseInsensitive)) {
         QDateTime expiry;
         if (kind == "date") {

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1770,7 +1770,7 @@ void DatabaseWidget::processAutoOpen()
     }
 
     for (const auto* entry : autoopenGroup->entries()) {
-        if (entry->url().isEmpty() || entry->password().isEmpty()) {
+        if (entry->url().isEmpty() || (entry->password().isEmpty() && entry->username().isEmpty())) {
             continue;
         }
         QFileInfo filepath;

--- a/src/gui/Font.cpp
+++ b/src/gui/Font.cpp
@@ -36,6 +36,11 @@ QFont Font::fixedFont()
         fixedFont = consolasFont;
     }
 #endif
+#ifdef Q_OS_MACOS
+    // Qt doesn't choose a monospace font correctly on macOS
+    const QFont defaultFont;
+    fixedFont = QFontDatabase().font("Menlo", defaultFont.styleName(), defaultFont.pointSize());
+#endif
 
     return fixedFont;
 }

--- a/src/gui/TotpDialog.cpp
+++ b/src/gui/TotpDialog.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
+ *  Copyright (C) 2017 Weslly Honorato <weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -42,7 +42,7 @@ TotpDialog::TotpDialog(QWidget* parent, Entry* entry)
     resetCounter();
     updateProgressBar();
 
-    connect(parent, SIGNAL(lockedDatabase()), SLOT(close()));
+    connect(parent, SIGNAL(databaseLocked()), SLOT(close()));
     connect(&m_totpUpdateTimer, SIGNAL(timeout()), this, SLOT(updateProgressBar()));
     connect(&m_totpUpdateTimer, SIGNAL(timeout()), this, SLOT(updateSeconds()));
     m_totpUpdateTimer.start(m_step * 10);

--- a/src/gui/masterkey/PasswordEditWidget.cpp
+++ b/src/gui/masterkey/PasswordEditWidget.cpp
@@ -95,8 +95,6 @@ void PasswordEditWidget::initComponentEditWidget(QWidget* widget)
 
 void PasswordEditWidget::hideEvent(QHideEvent* event)
 {
-    Q_ASSERT(m_compUi->enterPasswordEdit);
-
     if (!isVisible() && m_compUi->enterPasswordEdit) {
         m_compUi->enterPasswordEdit->setText("");
         m_compUi->repeatPasswordEdit->setText("");

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -79,6 +79,10 @@ static QString dbFileName = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/NewD
 
 void TestGui::initTestCase()
 {
+    Application::setApplicationName("KeePassXC");
+    Application::setApplicationVersion(KEEPASSXC_VERSION);
+    QApplication::setQuitOnLastWindowClosed(false);
+
     QVERIFY(Crypto::init());
     Config::createTempFileInstance();
     // Disable autosave so we can test the modified file indicator
@@ -91,11 +95,12 @@ void TestGui::initTestCase()
     // Disable the update check first time alert
     config()->set("UpdateCheckMessageShown", true);
 
-    m_mainWindow.reset(new MainWindow());
-    Bootstrap::restoreMainWindowState(*m_mainWindow);
     Bootstrap::bootstrapApplication();
+
+    m_mainWindow.reset(new MainWindow());
     m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
     m_mainWindow->show();
+    m_mainWindow->resize(1024, 768);
 }
 
 // Every test starts with opening the temp database
@@ -176,7 +181,7 @@ void TestGui::testSettingsDefaultTabOrder()
 
 void TestGui::testCreateDatabase()
 {
-    QTimer::singleShot(0, this, SLOT(createDatabaseCallback()));
+    QTimer::singleShot(50, this, SLOT(createDatabaseCallback()));
     triggerAction("actionDatabaseNew");
 
     // there is a new empty db
@@ -1435,8 +1440,9 @@ int TestGui::addCannedEntries()
 
 void TestGui::checkDatabase(QString dbFileName)
 {
-    if (dbFileName.isEmpty())
+    if (dbFileName.isEmpty()) {
         dbFileName = m_dbFilePath;
+    }
 
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Last bit of 2.5.2 bug fixes:

* Fix compiler issues with Qt 5.14
  * Remove deprecation warnings when not doing a DEV_BUILD. Qt 5.14 introduced several deprecation flags on basic function calls in QList and QSet that would require several #pragma ignores. Assuming this was in preparation to Qt 6.0.
  * Remove unnecessary assert in PasswordEditWidget that was hit in macOS debug builds.

* Choose a better monospace font on macOS (Fixes #1917)

* Hide snap browser warning label on non-Linux OS (Fixes #3707)

* Fix AutoOpen with key file only databases (Fixes #3931)

* Use new TOTP structure when importing 1Password Vault (Fixes #3999)

* Fix TOTP Dialog not closing on lock

* Improve GUI test reliability
  * Explicitly resize the window to improve testing on High DPI displays
  * Add additional bootstrap calls to mimic the actual application

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Ran all tests locally and on macOS

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
