### PR TITLE
Use stderr for help text on error.

### DIFF
--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -189,6 +189,7 @@ int main(int argc, char** argv)
     Commands::setupCommands(false);
 
     TextStream out(stdout);
+    TextStream err(stderr);
     QStringList arguments;
     for (int i = 0; i < argc; ++i) {
         arguments << QString(argv[i]);
@@ -223,6 +224,7 @@ int main(int argc, char** argv)
             out << debugInfo << endl;
             return EXIT_SUCCESS;
         }
+        // showHelp exits the application immediately.
         parser.showHelp();
     }
 
@@ -234,10 +236,9 @@ int main(int argc, char** argv)
 
     auto command = Commands::getCommand(commandName);
     if (!command) {
-        qCritical("Invalid command %s.", qPrintable(commandName));
-        // showHelp exits the application immediately, so we need to set the
-        // exit code here.
-        parser.showHelp(EXIT_FAILURE);
+        err << QObject::tr("Invalid command %1.").arg(commandName) << endl;
+        err << parser.helpText();
+        return EXIT_FAILURE;
     }
 
     // Removing the first argument (keepassxc).


### PR DESCRIPTION
Also not sure why `qCritical` was used instead of an `stderr` output
stream. Added translation on the invalid command string.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code)

## Testing strategy
Tested locally. `showHelp` will log to `stdout` whatever the status code we pass, so doing the logging to `stderr` directly.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
