### PR TITLE
Validity period for automatic expiration management

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ set(keepassx_SOURCES
         core/TimeInfo.cpp
         core/Tools.cpp
         core/Translator.cpp
+        core/TriState.cpp
         cli/Utils.cpp
         cli/TextStream.cpp
         crypto/Crypto.cpp

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -642,9 +642,9 @@ QList<QString> AutoType::autoTypeSequences(const Entry* entry, const QString& wi
     }
 
     do {
-        if (group->autoTypeEnabled() == Group::Disable) {
+        if (group->autoTypeEnabled() == TriState::Disable) {
             return sequenceList;
-        } else if (group->autoTypeEnabled() == Group::Enable) {
+        } else if (group->autoTypeEnabled() == TriState::Enable) {
             break;
         }
         group = group->parentGroup();

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -790,8 +790,8 @@ void Database::createRecycleBin()
     recycleBin->setParent(rootGroup());
     recycleBin->setName(tr("Recycle Bin"));
     recycleBin->setIcon(Group::RecycleBinIconNumber);
-    recycleBin->setSearchingEnabled(Group::Disable);
-    recycleBin->setAutoTypeEnabled(Group::Disable);
+    recycleBin->setSearchingEnabled(TriState::Disable);
+    recycleBin->setAutoTypeEnabled(TriState::Disable);
 
     m_metadata->setRecycleBin(recycleBin);
 }

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -33,6 +33,7 @@
 #include "core/EntryAttributes.h"
 #include "core/Global.h"
 #include "core/TimeInfo.h"
+#include "core/TriState.h"
 
 class Database;
 class Group;
@@ -97,6 +98,10 @@ public:
     QString effectiveNewAutoTypeSequence() const;
     AutoTypeAssociations* autoTypeAssociations();
     const AutoTypeAssociations* autoTypeAssociations() const;
+    TriState::State validityPeriodEnabled() const;
+    int validityPeriod() const;
+    bool effectiveValidityPeriodEnabled() const;
+    int effectiveValidityPeriod() const;
     QString title() const;
     QString url() const;
     QString webUrl() const;
@@ -128,6 +133,8 @@ public:
     static const int ResolveMaximumDepth;
     static const QString AutoTypeSequenceUsername;
     static const QString AutoTypeSequencePassword;
+    static const QString ValidityPeriodEnabled;
+    static const QString ValidityPeriod;
 
     void setUuid(const QUuid& uuid);
     void setIcon(int iconNumber);
@@ -146,6 +153,8 @@ public:
     void setPassword(const QString& password);
     void setNotes(const QString& notes);
     void setDefaultAttribute(const QString& attribute, const QString& value);
+    void setValidityPeriodEnabled(const TriState::State state);
+    void setValidityPeriod(const int days);
     void setExpires(const bool& value);
     void setExpiryTime(const QDateTime& dateTime);
     void setTotp(QSharedPointer<Totp::Settings> settings);
@@ -239,6 +248,8 @@ public:
     Group* group();
     const Group* group() const;
     void setGroup(Group* group);
+    void setGroupUncommitted(Group* group);
+    void unsetUncommittedGroup();
     const Database* database() const;
     Database* database();
 
@@ -280,6 +291,7 @@ private:
     QScopedPointer<Entry> m_tmpHistoryItem;
     bool m_modifiedSinceBegin;
     QPointer<Group> m_group;
+    bool m_committedToGroup;
     bool m_updateTimeinfo;
 };
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -28,18 +28,13 @@
 #include "core/Entry.h"
 #include "core/Global.h"
 #include "core/TimeInfo.h"
+#include "core/TriState.h"
 
 class Group : public QObject
 {
     Q_OBJECT
 
 public:
-    enum TriState
-    {
-        Inherit,
-        Enable,
-        Disable
-    };
     enum MergeMode
     {
         Default, // Determine merge strategy from parent or fallback (Synchronize)
@@ -68,8 +63,8 @@ public:
         TimeInfo timeInfo;
         bool isExpanded;
         QString defaultAutoTypeSequence;
-        Group::TriState autoTypeEnabled;
-        Group::TriState searchingEnabled;
+        TriState::State autoTypeEnabled;
+        TriState::State searchingEnabled;
         Group::MergeMode mergeMode;
 
         bool operator==(const GroupData& other) const;
@@ -92,11 +87,15 @@ public:
     bool isExpanded() const;
     QString defaultAutoTypeSequence() const;
     QString effectiveAutoTypeSequence() const;
-    Group::TriState autoTypeEnabled() const;
-    Group::TriState searchingEnabled() const;
+    TriState::State autoTypeEnabled() const;
+    TriState::State searchingEnabled() const;
+    TriState::State defaultValidityPeriodEnabled() const;
+    int defaultValidityPeriod() const;
     Group::MergeMode mergeMode() const;
     bool resolveSearchingEnabled() const;
     bool resolveAutoTypeEnabled() const;
+    bool resolveDefaultValidityPeriodEnabled() const;
+    int resolveDefaultValidityPeriod() const;
     Entry* lastTopVisibleEntry() const;
     bool isExpired() const;
     bool isRecycled() const;
@@ -111,6 +110,8 @@ public:
     static CloneFlags DefaultCloneFlags;
     static Entry::CloneFlags DefaultEntryCloneFlags;
     static const QString RootAutoTypeSequence;
+    static const QString DefaultValidityPeriodEnabled;
+    static const QString DefaultValidityPeriod;
 
     Group* findChildByName(const QString& name);
     Entry* findEntryByUuid(const QUuid& uuid, bool recursive = true) const;
@@ -128,8 +129,10 @@ public:
     void setTimeInfo(const TimeInfo& timeInfo);
     void setExpanded(bool expanded);
     void setDefaultAutoTypeSequence(const QString& sequence);
-    void setAutoTypeEnabled(TriState enable);
-    void setSearchingEnabled(TriState enable);
+    void setAutoTypeEnabled(TriState::State enable);
+    void setSearchingEnabled(TriState::State enable);
+    void setDefaultValidityPeriodEnabled(TriState::State enable);
+    void setDefaultValidityPeriod(int days);
     void setLastTopVisibleEntry(Entry* entry);
     void setExpires(bool value);
     void setExpiryTime(const QDateTime& dateTime);

--- a/src/core/TimeDelta.cpp
+++ b/src/core/TimeDelta.cpp
@@ -67,3 +67,8 @@ int TimeDelta::getYears() const
 {
     return m_years;
 }
+
+int TimeDelta::getTotalDays() const
+{
+    return m_days + (365 * m_months / 12) + (m_years * 365);
+}

--- a/src/core/TimeDelta.h
+++ b/src/core/TimeDelta.h
@@ -39,6 +39,8 @@ public:
     int getMonths() const;
     int getYears() const;
 
+    int getTotalDays() const;
+
 private:
     int m_days;
     int m_months;

--- a/src/core/TriState.cpp
+++ b/src/core/TriState.cpp
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QObject>
+
+#include "TriState.h"
+
+bool TriState::isValidIndex(int index)
+{
+    return index >= 0 && index <= 2;
+}
+
+int TriState::indexFromTriState(TriState::State triState)
+{
+    switch (triState) {
+    case TriState::Inherit:
+        return 0;
+    case TriState::Enable:
+        return 1;
+    case TriState::Disable:
+        return 2;
+    default:
+        Q_ASSERT(false);
+        return 0;
+    }
+}
+
+TriState::State TriState::triStateFromIndex(int index)
+{
+    switch (index) {
+    case 0:
+        return TriState::Inherit;
+    case 1:
+        return TriState::Enable;
+    case 2:
+        return TriState::Disable;
+    default:
+        Q_ASSERT(false);
+        return TriState::Inherit;
+    }
+}

--- a/src/core/TriState.h
+++ b/src/core/TriState.h
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_TRISTATE_H
+#define KEEPASSX_TRISTATE_H
+
+class TriState : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum State
+    {
+        Inherit,
+        Enable,
+        Disable
+    };
+
+    static bool isValidIndex(int index);
+    static int indexFromTriState(State triState);
+    static State triStateFromIndex(int index);
+};
+
+#endif // KEEPASSX_TRISTATE_H

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -544,11 +544,11 @@ Group* KdbxXmlReader::parseGroup()
             QString str = readString();
 
             if (str.compare("null", Qt::CaseInsensitive) == 0) {
-                group->setAutoTypeEnabled(Group::Inherit);
+                group->setAutoTypeEnabled(TriState::Inherit);
             } else if (str.compare("true", Qt::CaseInsensitive) == 0) {
-                group->setAutoTypeEnabled(Group::Enable);
+                group->setAutoTypeEnabled(TriState::Enable);
             } else if (str.compare("false", Qt::CaseInsensitive) == 0) {
-                group->setAutoTypeEnabled(Group::Disable);
+                group->setAutoTypeEnabled(TriState::Disable);
             } else {
                 raiseError(tr("Invalid EnableAutoType value"));
             }
@@ -558,11 +558,11 @@ Group* KdbxXmlReader::parseGroup()
             QString str = readString();
 
             if (str.compare("null", Qt::CaseInsensitive) == 0) {
-                group->setSearchingEnabled(Group::Inherit);
+                group->setSearchingEnabled(TriState::Inherit);
             } else if (str.compare("true", Qt::CaseInsensitive) == 0) {
-                group->setSearchingEnabled(Group::Enable);
+                group->setSearchingEnabled(TriState::Enable);
             } else if (str.compare("false", Qt::CaseInsensitive) == 0) {
-                group->setSearchingEnabled(Group::Disable);
+                group->setSearchingEnabled(TriState::Disable);
             } else {
                 raiseError(tr("Invalid EnableSearching value"));
             }

--- a/src/format/KdbxXmlWriter.cpp
+++ b/src/format/KdbxXmlWriter.cpp
@@ -532,13 +532,13 @@ void KdbxXmlWriter::writeBinary(const QString& qualifiedName, const QByteArray& 
     writeString(qualifiedName, QString::fromLatin1(ba.toBase64()));
 }
 
-void KdbxXmlWriter::writeTriState(const QString& qualifiedName, Group::TriState triState)
+void KdbxXmlWriter::writeTriState(const QString& qualifiedName, TriState::State triState)
 {
     QString value;
 
-    if (triState == Group::Inherit) {
+    if (triState == TriState::Inherit) {
         value = "null";
-    } else if (triState == Group::Enable) {
+    } else if (triState == TriState::Enable) {
         value = "true";
     } else {
         value = "false";

--- a/src/format/KdbxXmlWriter.h
+++ b/src/format/KdbxXmlWriter.h
@@ -26,6 +26,7 @@
 #include "core/Entry.h"
 #include "core/Group.h"
 #include "core/TimeInfo.h"
+#include "core/TriState.h"
 
 class KeePass2RandomStream;
 class Metadata;
@@ -73,7 +74,7 @@ private:
     void writeUuid(const QString& qualifiedName, const Group* group);
     void writeUuid(const QString& qualifiedName, const Entry* entry);
     void writeBinary(const QString& qualifiedName, const QByteArray& ba);
-    void writeTriState(const QString& qualifiedName, Group::TriState triState);
+    void writeTriState(const QString& qualifiedName, TriState::State triState);
     QString colorPartToString(int value);
     QString stripInvalidXml10Chars(QString str);
 

--- a/src/format/KeePass1Reader.cpp
+++ b/src/format/KeePass1Reader.cpp
@@ -216,8 +216,8 @@ KeePass1Reader::readDatabase(QIODevice* device, const QString& password, QIODevi
     const QList<Group*> children = db->rootGroup()->children();
     for (Group* group : children) {
         if (group->name() == "Backup") {
-            group->setSearchingEnabled(Group::Disable);
-            group->setAutoTypeEnabled(Group::Disable);
+            group->setSearchingEnabled(TriState::Disable);
+            group->setAutoTypeEnabled(TriState::Disable);
         }
     }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1022,6 +1022,7 @@ void DatabaseWidget::switchToMainView(bool previousDialogAccepted)
 
         m_newParent = nullptr;
     } else if (m_newEntry) {
+        m_newEntry->unsetUncommittedGroup();
         if (previousDialogAccepted) {
             m_newEntry->setGroup(m_newParent);
             m_entryView->setFocus();
@@ -1068,6 +1069,7 @@ void DatabaseWidget::switchToEntryEdit(Entry* entry, bool create)
     Group* group;
     if (create) {
         group = currentGroup();
+        entry->setGroupUncommitted(currentGroup());
     } else {
         group = entry->group();
         // Ensure we have only this entry selected

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -20,7 +20,9 @@
 #define KEEPASSX_EDITENTRYWIDGET_H
 
 #include <QButtonGroup>
+#include <QComboBox>
 #include <QCompleter>
+#include <QMenu>
 #include <QModelIndex>
 #include <QPointer>
 #include <QScopedPointer>
@@ -108,6 +110,10 @@ private slots:
     void histEntryActivated(const QModelIndex& index);
     void updateHistoryButtons(const QModelIndex& current, const QModelIndex& previous);
     void useExpiryPreset(QAction* action);
+    void useValidityPeriodPreset(QAction* action);
+    void handleValidityPeriodTriState(int index);
+    void handleValidityPeriodChanged(int days);
+    void handleValidityPeriodOnPasswordChange();
     void toggleHideNotes(bool visible);
     void pickColor();
 #ifdef WITH_XC_SSHAGENT
@@ -152,6 +158,7 @@ private:
     void setForms(Entry* entry, bool restore = false);
     QMenu* createPresetsMenu();
     void updateEntryData(Entry* entry) const;
+    void addTriStateItems(QComboBox* comboBox, bool inheritValue);
 #ifdef WITH_XC_SSHAGENT
     bool getOpenSSHKey(OpenSSHKey& key, bool decrypt = false);
 #endif

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -29,8 +29,212 @@
    <property name="verticalSpacing">
     <number>8</number>
    </property>
-   <item row="6" column="1">
-    <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item row="2" column="0">
+    <widget class="QLabel" name="passwordLabel">
+     <property name="text">
+      <string>Password:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="usernameComboBox">
+     <property name="accessibleName">
+      <string>Username field</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="urlLabel">
+     <property name="text">
+      <string>URL:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="validityPeriodGroupBox">
+     <property name="title">
+      <string>Expiration Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="validityPeriodLayout">
+        <item>
+         <widget class="QLabel" name="validityPeriodLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Days until expiration:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="validityPeriodSpinBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string>Validity period length edit</string>
+          </property>
+          <property name="maximum">
+           <number>99999</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="validityPeriodPresets">
+          <property name="accessibleName">
+           <string>Validity period presets</string>
+          </property>
+          <property name="text">
+           <string>Presets</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="validityPeriodComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Default validity period toggle</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="validityPeriodEnabledLabel">
+        <property name="text">
+         <string>Validity period:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="expirationLayout">
+        <item>
+         <widget class="QDateTimeEdit" name="expireDatePicker">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="accessibleName">
+           <string>Expiration field</string>
+          </property>
+          <property name="calendarPopup">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="expirePresets">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Expiration Presets</string>
+          </property>
+          <property name="accessibleName">
+           <string>Expiration presets</string>
+          </property>
+          <property name="text">
+           <string>Presets</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="expireCheck">
+        <property name="text">
+         <string>Expires</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="titleLabel">
+     <property name="text">
+      <string>Title:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="PasswordEdit" name="passwordEdit">
+     <property name="accessibleName">
+      <string>Password field</string>
+     </property>
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QCheckBox" name="notesEnabled">
+       <property name="toolTip">
+        <string>Toggle notes visible</string>
+       </property>
+       <property name="accessibleName">
+        <string>Toggle notes visible</string>
+       </property>
+       <property name="text">
+        <string>Notes:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="1">
+    <layout class="QVBoxLayout" name="notesLayout">
      <item>
       <widget class="QPlainTextEdit" name="notesEdit">
        <property name="sizePolicy">
@@ -65,104 +269,15 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="usernameComboBox">
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="titleEdit">
      <property name="accessibleName">
-      <string>Username field</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QCheckBox" name="notesEnabled">
-       <property name="toolTip">
-        <string>Toggle notes visible</string>
-       </property>
-       <property name="accessibleName">
-        <string>Toggle notes visible</string>
-       </property>
-       <property name="text">
-        <string>Notes:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="5" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="spacing">
-      <number>8</number>
-     </property>
-     <item>
-      <widget class="QDateTimeEdit" name="expireDatePicker">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="accessibleName">
-        <string>Expiration field</string>
-       </property>
-       <property name="calendarPopup">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="expirePresets">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Expiration Presets</string>
-       </property>
-       <property name="accessibleName">
-        <string>Expiration presets</string>
-       </property>
-       <property name="text">
-        <string>Presets</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="passwordLabel">
-     <property name="text">
-      <string>Password:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="urlLabel">
-     <property name="text">
-      <string>URL:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <string>Title field</string>
      </property>
     </widget>
    </item>
    <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
+    <layout class="QHBoxLayout" name="fetchFaviconLayout">
      <property name="spacing">
       <number>8</number>
      </property>
@@ -188,23 +303,6 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="titleLabel">
-     <property name="text">
-      <string>Title:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="titleEdit">
-     <property name="accessibleName">
-      <string>Title field</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="usernameLabel">
      <property name="text">
@@ -214,36 +312,6 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="PasswordEdit" name="passwordEdit">
-     <property name="accessibleName">
-      <string>Password field</string>
-     </property>
-     <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QCheckBox" name="expireCheck">
-       <property name="toolTip">
-        <string>Toggle expiration</string>
-       </property>
-       <property name="accessibleName">
-        <string>Toggle expiration</string>
-       </property>
-       <property name="text">
-        <string>Expires:</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>
@@ -268,8 +336,6 @@
   <tabstop>urlEdit</tabstop>
   <tabstop>fetchFaviconButton</tabstop>
   <tabstop>expireCheck</tabstop>
-  <tabstop>expireDatePicker</tabstop>
-  <tabstop>expirePresets</tabstop>
   <tabstop>notesEnabled</tabstop>
   <tabstop>notesEdit</tabstop>
  </tabstops>

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -19,6 +19,7 @@
 #define KEEPASSX_EDITGROUPWIDGET_H
 
 #include <QComboBox>
+#include <QMenu>
 #include <QScopedPointer>
 
 #include "core/Group.h"
@@ -70,10 +71,13 @@ private slots:
     void save();
     void cancel();
 
+private slots:
+    void useValidityPeriodPreset(QAction* action);
+    void handleDefaultValidityPeriodTriState(int index);
+
 private:
     void addTriStateItems(QComboBox* comboBox, bool inheritValue);
-    int indexFromTriState(Group::TriState triState);
-    Group::TriState triStateFromIndex(int index);
+    QMenu* createPresetsMenu();
     void setupModifiedTracking();
 
     const QScopedPointer<Ui::EditGroupWidgetMain> m_mainUi;

--- a/src/gui/group/EditGroupWidgetMain.ui
+++ b/src/gui/group/EditGroupWidgetMain.ui
@@ -6,11 +6,11 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>410</width>
+    <width>483</width>
     <height>430</height>
    </rect>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,1" rowminimumheight="0,0,0,0,0,0,0,0,0,1">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -29,20 +29,56 @@
    <property name="verticalSpacing">
     <number>8</number>
    </property>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="expireCheck">
-     <property name="accessibleName">
-      <string>Toggle expiration</string>
-     </property>
-     <property name="text">
-      <string>Expires:</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
     <widget class="QLineEdit" name="editName">
      <property name="accessibleName">
       <string>Name field</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <layout class="QVBoxLayout" name="notesLayout">
+     <item>
+      <widget class="QLabel" name="notesLabel">
+       <property name="text">
+        <string>Notes:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="notesSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPlainTextEdit" name="editNotes">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>120</height>
+      </size>
+     </property>
+     <property name="accessibleName">
+      <string>Notes field</string>
      </property>
     </widget>
    </item>
@@ -59,24 +95,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QRadioButton" name="autoTypeSequenceInherit">
-     <property name="text">
-      <string>Use default Auto-Type sequence of parent group</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="autotypeLabel">
-     <property name="text">
-      <string>Auto-Type:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="searchLabel">
      <property name="text">
       <string>Search:</string>
@@ -86,44 +105,116 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="7" column="1">
     <widget class="QComboBox" name="autotypeComboBox">
      <property name="accessibleName">
       <string>Auto-Type toggle for this and sub groups</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
+   <item row="4" column="1">
+    <widget class="QComboBox" name="defaultValidityPeriodComboBox"/>
+   </item>
+   <item row="9" column="1">
+    <widget class="QRadioButton" name="autoTypeSequenceCustomRadio">
+     <property name="text">
+      <string>Set default Auto-Type sequence</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="defaultValidityPeriodLabel">
+     <property name="text">
+      <string>Default Period:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="expireCheck">
+     <property name="accessibleName">
+      <string>Toggle expiration</string>
+     </property>
+     <property name="text">
+      <string>Expires:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QRadioButton" name="autoTypeSequenceInherit">
+     <property name="text">
+      <string>Use default Auto-Type sequence of parent group</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <layout class="QHBoxLayout" name="defaultPeriodLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
      <item>
-      <widget class="QLabel" name="labelNotes">
-       <property name="text">
-        <string>Notes:</string>
+      <widget class="QLabel" name="defaultValidityPeriodDaysLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       <property name="text">
+        <string>Days until expiration:</string>
        </property>
       </widget>
      </item>
      <item>
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
+      <widget class="QSpinBox" name="defaultValidityPeriodSpinBox">
+       <property name="enabled">
+        <bool>false</bool>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>0</height>
-        </size>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-      </spacer>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="accessibleName">
+        <string>Days until expiration of contained entries</string>
+       </property>
+       <property name="maximum">
+        <number>36500</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="defaultValidityPeriodPresets">
+       <property name="toolTip">
+        <string>Default Expiration Presets</string>
+       </property>
+       <property name="accessibleName">
+        <string>Default expiration presets</string>
+       </property>
+       <property name="text">
+        <string>Presets</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
-   <item row="8" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+   <item row="6" column="1">
+    <widget class="QComboBox" name="searchComboBox">
+     <property name="accessibleName">
+      <string>Search toggle for this and sub groups</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <layout class="QHBoxLayout" name="autoTypeSequenceLayout">
      <item>
-      <spacer name="horizontalSpacer_2">
+      <spacer name="autoTypeSequenceSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -153,25 +244,6 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="1">
-    <widget class="QPlainTextEdit" name="editNotes">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>120</height>
-      </size>
-     </property>
-     <property name="accessibleName">
-      <string>Notes field</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="labelName">
      <property name="text">
@@ -182,22 +254,18 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <widget class="QRadioButton" name="autoTypeSequenceCustomRadio">
+   <item row="7" column="0">
+    <widget class="QLabel" name="autotypeLabel">
      <property name="text">
-      <string>Set default Auto-Type sequence</string>
+      <string>Auto-Type:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="searchComboBox">
-     <property name="accessibleName">
-      <string>Search toggle for this and sub groups</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <spacer name="verticalSpacer_4">
+   <item row="11" column="0">
+    <spacer name="widgetSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -342,7 +342,7 @@ void TestAutoType::testAutoTypeEffectiveSequences()
     // Group with autotype disabled and custom default sequence
     QPointer<Group> group3 = new Group();
     group3->setParent(group1);
-    group3->setAutoTypeEnabled(Group::Disable);
+    group3->setAutoTypeEnabled(TriState::Disable);
     group3->setDefaultAutoTypeSequence(sequenceG3);
 
     QCOMPARE(rootGroup->defaultAutoTypeSequence(), QString());

--- a/tests/TestEntrySearcher.cpp
+++ b/tests/TestEntrySearcher.cpp
@@ -62,7 +62,7 @@ void TestEntrySearcher::testSearch()
     group211->setParent(group21);
     group2111->setParent(group211);
 
-    group1->setSearchingEnabled(Group::Disable);
+    group1->setSearchingEnabled(TriState::Disable);
 
     Entry* eRoot = new Entry();
     eRoot->setTitle("test search term test");

--- a/tests/TestGlobal.h
+++ b/tests/TestGlobal.h
@@ -26,13 +26,13 @@
 namespace QTest
 {
 
-    template <> inline char* toString(const Group::TriState& triState)
+    template <> inline char* toString(const TriState::State& triState)
     {
         QString value;
 
-        if (triState == Group::Inherit) {
+        if (triState == TriState::Inherit) {
             value = "null";
-        } else if (triState == Group::Enable) {
+        } else if (triState == TriState::Enable) {
             value = "true";
         } else {
             value = "false";

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -146,8 +146,8 @@ void TestKeePass2Format::testXmlGroupRoot()
     QCOMPARE(ti.usageCount(), 52);
     QCOMPARE(ti.locationChanged(), MockClock::datetimeUtc(2010, 8, 8, 17, 24, 27));
     QCOMPARE(group->defaultAutoTypeSequence(), QString(""));
-    QCOMPARE(group->autoTypeEnabled(), Group::Inherit);
-    QCOMPARE(group->searchingEnabled(), Group::Inherit);
+    QCOMPARE(group->autoTypeEnabled(), TriState::Inherit);
+    QCOMPARE(group->searchingEnabled(), TriState::Inherit);
     QCOMPARE(group->lastTopVisibleEntry()->uuid(),
              QUuid::fromRfc4122(QByteArray::fromBase64("+wSUOv6qf0OzW8/ZHAs2sA==")));
     QCOMPARE(group->children().size(), 3);
@@ -167,8 +167,8 @@ void TestKeePass2Format::testXmlGroup1()
     QCOMPARE(group->iconUuid(), QUuid());
     QCOMPARE(group->isExpanded(), true);
     QCOMPARE(group->defaultAutoTypeSequence(), QString("{Password}{ENTER}"));
-    QCOMPARE(group->autoTypeEnabled(), Group::Enable);
-    QCOMPARE(group->searchingEnabled(), Group::Disable);
+    QCOMPARE(group->autoTypeEnabled(), TriState::Enable);
+    QCOMPARE(group->searchingEnabled(), TriState::Disable);
     QVERIFY(!group->lastTopVisibleEntry());
 }
 

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -53,6 +53,7 @@ private slots:
     void testAddEntry();
     void testPasswordEntryEntropy();
     void testDicewareEntryEntropy();
+    void testValidityPeriod();
     void testTotp();
     void testSearch();
     void testDeleteEntry();


### PR DESCRIPTION
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

Addresses #2612 and #2010.

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

It's recommended to change passwords regularly.
For this reason, expiry dates can be assigned to entries as a reminder to change
the password.
If a password is changed, the expiry date has to be updated manually.
The proposed changes intend to automate this step.

Quite similar to the AutoType sequence, "default validity periods" can be set
for entire groups as tristate ("Inherit" (standard), "Enable", "Disable").
If an entry inherits a default validity period from a parent group, the
expiry date is set based on it.
In case a policy for a single entry within a group differs, change it to enable and
set the desired validity period.
Disable the setting, to avoid automatic changes of the expiry date.

- A (default) validity period consists of two settings: "Default validity period
enabled" (tristate) and "Default validity period" (days)
- The current "expires" setting is not altered. If checked, the entry expires
at the given date/time, if unchecked, nothing happens. The validity period
settings only control the automatic updating of the expiry date, not the
expiration of the entry itself
- A validity period on group wide basis does not affect the group itself - it is
just the default validity period for child entries
- A validity period for an entry does only affect its own expiry date
- "Inherit" is the standard setting
- If the root group is set to "Inherit", it resolves to false
- Validity period is specified in days until expiration
- The expiry date will be set to `now + validity period` on password change if
enabled
- The expiry set will be reset if the password is reset to the current password
(only if not saved in the meantime)
- Tristate and validity period days are saved in customData
- The "expires" check box will be automatically checked on load, if the validity
period is enabled (either directly enabled or inherited from a parent group)
- The "expires" check can unchecked by the user with enabled validity period.
The entry will not expire. The next time the entry is opened, the settings is
rechecked again and the expiry date will be changed when the password is changed
- "Disable" or leave the root group on "Inherit" for the current behavior/to
disable setting the expiry date automatically

Since new entries do not know their future group on creation, a pointer to the
"temporary group" is introduced, which is set by the DatabaseWidget if a new
entry is created.
Temporary groups do not know the corresponding entry opposed to "normal" groups,
where the corresponding entry is contained in the entries list.
The temporary group will be unset when the creation of the entry is confirmed
or aborted.
For further details, see #3353.


## Screenshots
For example, set a default validity period in a group for child entries:
![Group](https://user-images.githubusercontent.com/51851447/71773793-fe200300-2f63-11ea-9128-d40a347eddc1.png)

The "expires" check box is automatically checked if enabled:
![Original](https://user-images.githubusercontent.com/51851447/71773795-01b38a00-2f64-11ea-883b-9c10d7430a92.png)

If the password is changed, the expiration time is updated if enabled:
![Changed](https://user-images.githubusercontent.com/51851447/71773797-05471100-2f64-11ea-8adc-0dc0fa8bd426.png)

If the password is changed back to the current one, the expiration time is reset:
![Changed back](https://user-images.githubusercontent.com/51851447/71773799-07a96b00-2f64-11ea-90ec-317004ae8950.png)


## Testing strategy
New test in TestGui (testValidityPeriod).

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
(On my machine, testCli() sometimes hangs until the timeout kills the test.)
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.



