### PR TITLE
CMakeLists.txt: Do not unconditionally use ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,6 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-# Use the Compiler Cache (ccache) if it is installed
-# (install with: sudo apt get ccache)
-find_program (CCACHE_FOUND ccache)
-if (CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-endif (CCACHE_FOUND)
-
 # Support Visual Studio Code
 include(CMakeToolsHelpers OPTIONAL)
 include(FeatureSummary)
@@ -48,6 +41,7 @@ option(WITH_DEV_BUILD "Use only for development. Disables/warns about deprecated
 option(WITH_ASAN "Enable address sanitizer checks (Linux / macOS only)" OFF)
 option(WITH_COVERAGE "Use to build with coverage tests (GCC only)." OFF)
 option(WITH_APP_BUNDLE "Enable Application Bundle for macOS" ON)
+option(WITH_CCACHE "Use ccache for build" OFF)
 
 set(WITH_XC_ALL OFF CACHE BOOL "Build in all available plugins")
 
@@ -63,6 +57,17 @@ if(UNIX AND NOT APPLE)
 endif()
 if(APPLE)
     option(WITH_XC_TOUCHID "Include TouchID support for macOS." OFF)
+endif()
+
+if(WITH_CCACHE)
+    # Use the Compiler Cache (ccache)
+    # (install with: sudo apt get ccache)
+    find_program (CCACHE_FOUND ccache)
+    if (CCACHE_FOUND)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    else()
+        message(FATAL_ERROR "ccache requested but cannot be found.")
+    endif (CCACHE_FOUND)
 endif()
 
 if(WITH_XC_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,14 +60,14 @@ if(APPLE)
 endif()
 
 if(WITH_CCACHE)
-    # Use the Compiler Cache (ccache)
+    # Use the Compiler Cache (ccache) program
     # (install with: sudo apt get ccache)
     find_program (CCACHE_FOUND ccache)
-    if (CCACHE_FOUND)
+    if(CCACHE_FOUND)
         set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
     else()
         message(FATAL_ERROR "ccache requested but cannot be found.")
-    endif (CCACHE_FOUND)
+    endif()
 endif()
 
 if(WITH_XC_ALL)


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
This causes build failures in Gentoo because we don't allow access to
ccache files if ccache is not enabled for build.
Fix this by adding a WITH_CCACHE cmake option and change behavior so that
cmake fails if WITH_CCACHE is enabled but ccache program cannot be found.

Gentoo-bug: https://bugs.gentoo.org/704560
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
