### PR TITLE
Add the name of the group to the results for browser extensions

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -859,6 +859,7 @@ QJsonObject BrowserService::prepareEntry(const Entry* entry)
     res["password"] = entry->resolveMultiplePlaceholders(entry->password());
     res["name"] = entry->resolveMultiplePlaceholders(entry->title());
     res["uuid"] = entry->resolveMultiplePlaceholders(entry->uuidToHex());
+    res["group"] = entry->resolveMultiplePlaceholders(entry->group()->name());
 
     if (entry->hasTotp()) {
         res["totp"] = entry->totp();


### PR DESCRIPTION
So it can be displayed in the autocomplete list when more than one login matches. 

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
For users that use groups and have similar names for multiple logins but they are organized in different groups.

Fixes https://github.com/keepassxreboot/keepassxc-browser/issues/466 together with https://github.com/keepassxreboot/keepassxc-browser/pull/739


## Testing strategy
Create multiple entries for the same URL in different groups.
Use the browser extension with the changes from https://github.com/keepassxreboot/keepassxc-browser/pull/739.
I also tested edge cases
* Older KeepassXC version without this change: Browser extension still works
* All entries being in the same group


I am not sure if the group can be null. Is it safe like this? At least I wasn't able to create a database without groups.


## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
