### PR TITLE
CLI: set decryption time on create.

### DIFF
--- a/share/docs/man/keepassxc-cli.1
+++ b/share/docs/man/keepassxc-cli.1
@@ -1,4 +1,4 @@
-.TH KEEPASSXC-CLI 1 "June 15, 2019"
+.TH KEEPASSXC-CLI 1 "Jan 04, 2020"
 
 .SH NAME
 keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
@@ -174,6 +174,12 @@ hour or so).
 .IP "\fB-t\fP, \fB--totp\fP"
 Copies the current TOTP instead of current password to clipboard. Will report
 an error if no TOTP is configured for the entry.
+
+
+.SS "Create options"
+
+.IP "\fB-t\fP, \fB--decryption-time\fP <time>"
+Target decryption time in MS for the database.
 
 
 .SS "Show options"

--- a/src/cli/Create.h
+++ b/src/cli/Create.h
@@ -28,6 +28,8 @@ public:
     Create();
     int execute(const QStringList& arguments) override;
 
+    static const QCommandLineOption DecryptionTimeOption;
+
 private:
     bool loadFileKey(const QString& path, QSharedPointer<FileKey>& fileKey);
 };

--- a/src/crypto/kdf/Kdf.h
+++ b/src/crypto/kdf/Kdf.h
@@ -46,6 +46,19 @@ public:
 
     int benchmark(int msec) const;
 
+    /*
+     * Default target encryption time, in MS.
+     */
+    static const int DEFAULT_ENCRYPTION_TIME = 1000;
+    /*
+     * Minimum target encryption time, in MS.
+     */
+    static const int MIN_ENCRYPTION_TIME = 100;
+    /*
+     * Maximum target encryption time, in MS.
+     */
+    static const int MAX_ENCRYPTION_TIME = 5000;
+
 protected:
     virtual int benchmarkImpl(int msec) const = 0;
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
@@ -45,8 +45,16 @@ DatabaseSettingsWidgetEncryption::DatabaseSettingsWidgetEncryption(QWidget* pare
 
     m_ui->compatibilitySelection->addItem(tr("KDBX 4.0 (recommended)"), KeePass2::KDF_ARGON2.toByteArray());
     m_ui->compatibilitySelection->addItem(tr("KDBX 3.1"), KeePass2::KDF_AES_KDBX3.toByteArray());
-    m_ui->decryptionTimeSlider->setValue(10);
+    m_ui->decryptionTimeSlider->setMinimum(Kdf::MIN_ENCRYPTION_TIME / 100);
+    m_ui->decryptionTimeSlider->setMaximum(Kdf::MAX_ENCRYPTION_TIME / 100);
+    m_ui->decryptionTimeSlider->setValue(Kdf::DEFAULT_ENCRYPTION_TIME / 100);
     updateDecryptionTime(m_ui->decryptionTimeSlider->value());
+
+    m_ui->transformBenchmarkButton->setText(
+        QObject::tr("Benchmark %1 delay")
+            .arg(DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(Kdf::DEFAULT_ENCRYPTION_TIME)));
+    m_ui->minTimeLabel->setText(DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(Kdf::MIN_ENCRYPTION_TIME));
+    m_ui->maxTimeLabel->setText(DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(Kdf::MAX_ENCRYPTION_TIME));
 
     connect(m_ui->activateChangeDecryptionTimeButton, SIGNAL(clicked()), SLOT(activateChangeDecryptionTime()));
     connect(m_ui->decryptionTimeSlider, SIGNAL(valueChanged(int)), SLOT(updateDecryptionTime(int)));
@@ -373,11 +381,7 @@ void DatabaseSettingsWidgetEncryption::setAdvancedMode(bool advanced)
 
 void DatabaseSettingsWidgetEncryption::updateDecryptionTime(int value)
 {
-    if (value < 10) {
-        m_ui->decryptionTimeValueLabel->setText(tr("%1 ms", "milliseconds", value * 100).arg(value * 100));
-    } else {
-        m_ui->decryptionTimeValueLabel->setText(tr("%1 s", "seconds", value / 10).arg(value / 10.0, 0, 'f', 1));
-    }
+    m_ui->decryptionTimeValueLabel->setText(DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(value * 100));
 }
 
 void DatabaseSettingsWidgetEncryption::updateFormatCompatibility(int index, bool retransform)
@@ -407,5 +411,14 @@ void DatabaseSettingsWidgetEncryption::updateFormatCompatibility(int index, bool
         }
 
         activateChangeDecryptionTime();
+    }
+}
+
+QString DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(int millisecs)
+{
+    if (millisecs < 1000) {
+        return QObject::tr("%1 ms", "milliseconds", millisecs).arg(millisecs);
+    } else {
+        return QObject::tr("%1 s", "seconds", millisecs / 1000).arg(millisecs / 1000.0, 0, 'f', 1);
     }
 }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.h
@@ -20,6 +20,8 @@
 
 #include "DatabaseSettingsWidget.h"
 
+#include "crypto/kdf/Kdf.h"
+
 #include <QPointer>
 #include <QScopedPointer>
 
@@ -49,11 +51,13 @@ public slots:
     void uninitialize() override;
     bool save() override;
 
+    static QString getTextualEncryptionTime(int millisecs);
+
 protected:
     void showEvent(QShowEvent* event) override;
 
 private slots:
-    void benchmarkTransformRounds(int millisecs = 1000);
+    void benchmarkTransformRounds(int millisecs = Kdf::DEFAULT_ENCRYPTION_TIME);
     void changeKdf(int index);
     void memoryChanged(int value);
     void parallelismChanged(int value);

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.ui
@@ -95,12 +95,6 @@
             <property name="accessibleName">
              <string>Decryption time in seconds</string>
             </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>50</number>
-            </property>
             <property name="singleStep">
              <number>1</number>
             </property>
@@ -124,9 +118,9 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
-             <widget class="QLabel" name="label_4">
+             <widget class="QLabel" name="minTimeLabel">
               <property name="text">
-               <string>100 ms</string>
+               <string>?? ms</string>
               </property>
              </widget>
             </item>
@@ -144,9 +138,9 @@
              </spacer>
             </item>
             <item>
-             <widget class="QLabel" name="label_3">
+             <widget class="QLabel" name="maxTimeLabel">
               <property name="text">
-               <string>5 s</string>
+               <string>? s</string>
               </property>
              </widget>
             </item>
@@ -325,9 +319,6 @@
           <widget class="QToolButton" name="transformBenchmarkButton">
            <property name="focusPolicy">
             <enum>Qt::WheelFocus</enum>
-           </property>
-           <property name="text">
-            <string>Benchmark 1-second delay</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Added an option to set the target decryption time on database creation
for the CLI create command. This required some refactoring, in
particular the extraction of the min, max and defaut decryption times in
the `Kdf` module. Some work was done to allow changing those constant
only in the `Kdf` module, should we ever want to change them.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
- ✅ New feature (non-breaking change which adds functionality)


## Testing strategy
Manual testing and new unit tests for the CLI option. I also tested when changing the defaults and everything works great as long as the values in MS are multiple of the slider's increment value (100).


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
