### PR TITLE
Add empty path to URL when needed

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -935,6 +935,12 @@ int BrowserService::sortPriority(const Entry* entry,
     if (url.scheme().isEmpty()) {
         url.setScheme("https");
     }
+
+    // Add the empty path to the URL if it's missing
+    if (url.path().isEmpty() && !url.hasFragment() && !url.hasQuery()) {
+        url.setPath("/");
+    }
+
     const QString entryURL = url.toString(QUrl::StripTrailingSlash);
     const QString baseEntryURL =
         url.toString(QUrl::StripTrailingSlash | QUrl::RemovePath | QUrl::RemoveQuery | QUrl::RemoveFragment);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Add's an empty path to URL's when needed. Otherwise URL's `https://example.com`  and `https://example.com/` will have a different sorting priority which causes the latter one to be choosed when "Return only best-matching credentials" is enabled.

Fixes #4109.

## Testing strategy
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
