### PR TITLE
Ensure challenge-response key buffer is properly cleared.

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -651,6 +651,9 @@ bool Database::challengeMasterSeed(const QByteArray& masterSeed)
         bool ok = m_data.key->challenge(masterSeed, response);
         if (ok && !response.isEmpty()) {
             m_data.challengeResponseKey->setHash(response);
+        } else if (ok && response.isEmpty()) {
+            // no CR key present, make sure buffer is empty
+            m_data.challengeResponseKey.reset(new PasswordKey);
         }
         return ok;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,7 +104,7 @@ add_unit_test(NAME testgroup SOURCES TestGroup.cpp
 add_unit_test(NAME testkdbx2 SOURCES TestKdbx2.cpp
         LIBS ${TEST_LIBRARIES})
 
-add_unit_test(NAME testkdbx3 SOURCES TestKeePass2Format.cpp FailDevice.cpp TestKdbx3.cpp
+add_unit_test(NAME testkdbx3 SOURCES TestKeePass2Format.cpp FailDevice.cpp mock/MockChallengeResponseKey.cpp TestKdbx3.cpp
         LIBS testsupport ${TEST_LIBRARIES})
 
 add_unit_test(NAME testkdbx4 SOURCES TestKeePass2Format.cpp FailDevice.cpp mock/MockChallengeResponseKey.cpp TestKdbx4.cpp

--- a/tests/TestKdbx3.cpp
+++ b/tests/TestKdbx3.cpp
@@ -31,6 +31,8 @@ QTEST_GUILESS_MAIN(TestKdbx3)
 
 void TestKdbx3::initTestCaseImpl()
 {
+    m_xmlDb->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_AES_KDBX3)));
+    m_kdbxSourceDb->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_AES_KDBX3)));
 }
 
 QSharedPointer<Database> TestKdbx3::readXml(const QString& path, bool strictMode, bool& hasError, QString& errorString)

--- a/tests/TestKdbx4.h
+++ b/tests/TestKdbx4.h
@@ -20,7 +20,7 @@
 
 #include "TestKeePass2Format.h"
 
-class TestKdbx4 : public TestKeePass2Format
+class TestKdbx4Argon2 : public TestKeePass2Format
 {
     Q_OBJECT
 
@@ -51,8 +51,14 @@ protected:
                   bool& hasError,
                   QString& errorString) override;
     void writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString) override;
+};
 
-    QSharedPointer<Kdf> fastKdf(QSharedPointer<Kdf> kdf);
+class TestKdbx4AesKdf : public TestKdbx4Argon2
+{
+    Q_OBJECT
+
+protected:
+    void initTestCaseImpl() override;
 };
 
 #endif // KEEPASSXC_TEST_KDBX4_H

--- a/tests/TestKeePass2Format.h
+++ b/tests/TestKeePass2Format.h
@@ -62,6 +62,8 @@ private slots:
     void testKdbxAttachments();
     void testKdbxNonAsciiPasswords();
     void testKdbxDeviceFailure();
+    void testKdbxKeyChange();
+    void testKdbxKeyChange_data();
     void testDuplicateAttachments();
 
 protected:
@@ -83,6 +85,8 @@ protected:
                           bool& hasError,
                           QString& errorString) = 0;
     virtual void writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString) = 0;
+
+    QSharedPointer<Kdf> fastKdf(QSharedPointer<Kdf> kdf) const;
 
     QSharedPointer<Database> m_xmlDb;
     QSharedPointer<Database> m_kdbxSourceDb;


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

The challenge-response key buffer is explicitly cleared before the key transformation if no such key is configured to ensure one is never injected into the hash even if the database had a challenge-response key previously.

This patch also adds extensive tests for verifying that a key change will not add any expired key material to the hash.

Fixes #4146
Fixes #4041

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Removing a YubiKey from a KDBX 3.1 database caused the old response to be injected into the new master key. KDBX 4.0 was unaffected due to different CR key handling.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
New tests were added that test various key change scenarios to detect such problems. I verified that removing this fixes triggers a test failure. 

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
