### PR TITLE
Prevent proxy host from blocking application shutdown

### DIFF
--- a/src/browser/NativeMessagingBase.cpp
+++ b/src/browser/NativeMessagingBase.cpp
@@ -106,9 +106,9 @@ void NativeMessagingBase::readNativeMessages()
     quint32 length = 0;
     while (m_running.load() != 0 && !std::cin.eof()) {
         length = 0;
-        std::cin.read(reinterpret_cast<char*>(&length), 4);
+        std::cin.readsome(reinterpret_cast<char*>(&length), 4);
         readStdIn(length);
-        QThread::msleep(1);
+        QThread::msleep(100);
     }
 #endif
 }


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Fix #4079 - proxy host would get stuck trying to read characters from stdin. Switch to "readsome" which does not block if there are not enough characters to read. Added a longer delay to slow the checking loop down.

This may also address #4140, but that needs to be tested.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows 10 using the debugger. The CLion debugger refused to close KeePassXC when browser integration was turned on. Found out it was the stdin blocking. This is most likely the cause of hangs during shutdown.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
