### PR TITLE
Ignore system icon theme, always use our own icons

### DIFF
--- a/src/core/FilePath.cpp
+++ b/src/core/FilePath.cpp
@@ -133,7 +133,7 @@ QIcon FilePath::trayIconUnlocked()
 #endif
 }
 
-QIcon FilePath::icon(const QString& category, const QString& name, bool fromTheme)
+QIcon FilePath::icon(const QString& category, const QString& name)
 {
     QString combinedName = category + "/" + name;
 
@@ -141,10 +141,6 @@ QIcon FilePath::icon(const QString& category, const QString& name, bool fromThem
 
     if (!icon.isNull()) {
         return icon;
-    }
-
-    if (fromTheme && !getenv("KEEPASSXC_IGNORE_ICON_THEME")) {
-        icon = QIcon::fromTheme(name);
     }
 
     if (icon.isNull()) {

--- a/src/core/FilePath.h
+++ b/src/core/FilePath.h
@@ -32,7 +32,7 @@ public:
     QIcon trayIcon();
     QIcon trayIconLocked();
     QIcon trayIconUnlocked();
-    QIcon icon(const QString& category, const QString& name, bool fromTheme = true);
+    QIcon icon(const QString& category, const QString& name);
     QIcon onOffIcon(const QString& category, const QString& name);
 
     static FilePath* instance();

--- a/src/fdosecrets/widgets/SettingsModels.cpp
+++ b/src/fdosecrets/widgets/SettingsModels.cpp
@@ -130,7 +130,7 @@ namespace FdoSecrets
             case Qt::DisplayRole:
                 return tr("Unlock to show");
             case Qt::DecorationRole:
-                return filePath()->icon(QStringLiteral("apps"), QStringLiteral("object-locked"), true);
+                return filePath()->icon(QStringLiteral("apps"), QStringLiteral("object-locked"));
             case Qt::FontRole: {
                 QFont font;
                 font.setItalic(true);
@@ -165,7 +165,7 @@ namespace FdoSecrets
             case Qt::DisplayRole:
                 return tr("None");
             case Qt::DecorationRole:
-                return filePath()->icon(QStringLiteral("apps"), QStringLiteral("paint-none"), true);
+                return filePath()->icon(QStringLiteral("apps"), QStringLiteral("paint-none"));
             default:
                 return {};
             }

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
@@ -75,7 +75,7 @@ namespace
 
             // unlock/lock
             m_lockAct = new QAction(tr("Unlock database"), this);
-            m_lockAct->setIcon(filePath()->icon(QStringLiteral("actions"), QStringLiteral("object-locked"), false));
+            m_lockAct->setIcon(filePath()->icon(QStringLiteral("actions"), QStringLiteral("object-locked")));
             m_lockAct->setToolTip(tr("Unlock database to show more information"));
             connect(m_lockAct, &QAction::triggered, this, [this]() {
                 if (!m_dbWidget) {
@@ -133,14 +133,13 @@ namespace
             }
             connect(m_dbWidget, &DatabaseWidget::databaseLocked, this, [this]() {
                 m_lockAct->setText(tr("Unlock database"));
-                m_lockAct->setIcon(filePath()->icon(QStringLiteral("actions"), QStringLiteral("object-locked"), false));
+                m_lockAct->setIcon(filePath()->icon(QStringLiteral("actions"), QStringLiteral("object-locked")));
                 m_lockAct->setToolTip(tr("Unlock database to show more information"));
                 m_dbSettingsAct->setEnabled(false);
             });
             connect(m_dbWidget, &DatabaseWidget::databaseUnlocked, this, [this]() {
                 m_lockAct->setText(tr("Lock database"));
-                m_lockAct->setIcon(
-                    filePath()->icon(QStringLiteral("actions"), QStringLiteral("object-unlocked"), false));
+                m_lockAct->setIcon(filePath()->icon(QStringLiteral("actions"), QStringLiteral("object-unlocked")));
                 m_lockAct->setToolTip(tr("Lock database"));
                 m_dbSettingsAct->setEnabled(true);
             });

--- a/src/gui/KMessageWidget.cpp
+++ b/src/gui/KMessageWidget.cpp
@@ -94,7 +94,7 @@ void KMessageWidgetPrivate::init(KMessageWidget *q_ptr)
     QAction *closeAction = new QAction(q);
     closeAction->setText(KMessageWidget::tr("&Close"));
     closeAction->setToolTip(KMessageWidget::tr("Close message"));
-    closeAction->setIcon(FilePath::instance()->icon("actions", "message-close", false));
+    closeAction->setIcon(FilePath::instance()->icon("actions", "message-close"));
 
     QObject::connect(closeAction, SIGNAL(triggered(bool)), q, SLOT(animatedHide()));
 

--- a/src/gui/LineEdit.cpp
+++ b/src/gui/LineEdit.cpp
@@ -33,16 +33,7 @@ LineEdit::LineEdit(QWidget* parent)
     QString iconNameDirected =
         QString("edit-clear-locationbar-").append((layoutDirection() == Qt::LeftToRight) ? "rtl" : "ltr");
 
-    QIcon icon;
-    if (!getenv("KEEPASSXC_IGNORE_ICON_THEME")) {
-        icon = QIcon::fromTheme(iconNameDirected);
-        if (icon.isNull()) {
-            icon = QIcon::fromTheme("edit-clear");
-        }
-    }
-    if (icon.isNull()) {
-        icon = filePath()->icon("actions", iconNameDirected);
-    }
+    const auto icon = filePath()->icon("actions", iconNameDirected);
 
     m_clearButton->setIcon(icon);
     m_clearButton->setCursor(Qt::ArrowCursor);

--- a/src/gui/masterkey/PasswordEditWidget.cpp
+++ b/src/gui/masterkey/PasswordEditWidget.cpp
@@ -74,7 +74,7 @@ QWidget* PasswordEditWidget::componentEditWidget()
     m_compEditWidget = new QWidget();
     m_compUi->setupUi(m_compEditWidget);
     m_compUi->togglePasswordButton->setIcon(filePath()->onOffIcon("actions", "password-show"));
-    m_compUi->passwordGeneratorButton->setIcon(filePath()->icon("actions", "password-generator", false));
+    m_compUi->passwordGeneratorButton->setIcon(filePath()->icon("actions", "password-generator"));
     m_compUi->repeatPasswordEdit->enableVerifyMode(m_compUi->enterPasswordEdit);
 
     connect(m_compUi->togglePasswordButton,

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -37,7 +37,7 @@ EditGroupWidgetKeeShare::EditGroupWidgetKeeShare(QWidget* parent)
     m_ui->setupUi(this);
 
     m_ui->togglePasswordButton->setIcon(filePath()->onOffIcon("actions", "password-show"));
-    m_ui->togglePasswordGeneratorButton->setIcon(filePath()->icon("actions", "password-generator", false));
+    m_ui->togglePasswordGeneratorButton->setIcon(filePath()->icon("actions", "password-generator"));
 
     m_ui->passwordGenerator->layout()->setContentsMargins(0, 0, 0, 0);
     m_ui->passwordGenerator->hide();

--- a/utils/makeicons.sh
+++ b/utils/makeicons.sh
@@ -32,12 +32,9 @@
 # 3. Create the icons:
 #       $ bash ../../utils/makeicons.sh ~/src/MaterialDesign
 #
-# 4. Re-build KeePassXC:
+# 4. Re-build and run KeePassXC:
 #       $ cd ~/keepassxc/build
-#       $ make keepassxc
-#
-# 5. Check icons by disabling the OS icon theme:
-#       $ KEEPASSXC_IGNORE_ICON_THEME=1 src/keepassxc
+#       $ make keepassxc && src/keepassxc
 #
 # Material icons: https://materialdesignicons.com/
 


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

In fact, it removes functionality.

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )

As requested in https://github.com/keepassxreboot/keepassxc/issues/475#issuecomment-573335843. With the Material Design icons (#475), any other icons brought in through the system icon theme will look inconsistent.


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![newicons](https://user-images.githubusercontent.com/25565229/72209312-4338bd80-34ad-11ea-8d2c-31858acf396a.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Tested manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**