### PR TITLE
Fix clearing clipboad on Gnome

### DIFF
--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -44,20 +44,22 @@ Clipboard::Clipboard(QObject* parent)
     connect(qApp, SIGNAL(aboutToQuit()), SLOT(clearCopiedText()));
 }
 
-void Clipboard::setText(const QString& text)
+void Clipboard::setText(const QString& text, bool clear)
 {
-    QClipboard* clipboard = QApplication::clipboard();
+    auto* clipboard = QApplication::clipboard();
+    if (!clipboard) {
+        qWarning("Unable to access the clipboard.");
+        return;
+    }
 
-    QMimeData* mime = new QMimeData;
+    auto* mime = new QMimeData;
 #ifdef Q_OS_MACOS
     mime->setText(text);
     mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());
     clipboard->setMimeData(mime, QClipboard::Clipboard);
 #else
-    const QString secretStr = "secret";
-    QByteArray secretBa = secretStr.toUtf8();
     mime->setText(text);
-    mime->setData("x-kde-passwordManagerHint", secretBa);
+    mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
     clipboard->setMimeData(mime, QClipboard::Clipboard);
 
     if (clipboard->supportsSelection()) {
@@ -65,7 +67,7 @@ void Clipboard::setText(const QString& text)
     }
 #endif
 
-    if (config()->get("security/clearclipboard").toBool()) {
+    if (clear && config()->get("security/clearclipboard").toBool()) {
         int timeout = config()->get("security/clearclipboardtimeout").toInt();
         if (timeout > 0) {
             m_lastCopied = text;
@@ -84,19 +86,15 @@ void Clipboard::clearCopiedText()
 
 void Clipboard::clearClipboard()
 {
-    QClipboard* clipboard = QApplication::clipboard();
-
+    auto* clipboard = QApplication::clipboard();
     if (!clipboard) {
         qWarning("Unable to access the clipboard.");
         return;
     }
 
-    if (clipboard->text(QClipboard::Clipboard) == m_lastCopied) {
-        clipboard->clear(QClipboard::Clipboard);
-    }
-
-    if (clipboard->supportsSelection() && (clipboard->text(QClipboard::Selection) == m_lastCopied)) {
-        clipboard->clear(QClipboard::Selection);
+    if (m_lastCopied == clipboard->text(QClipboard::Clipboard)
+        || m_lastCopied == clipboard->text(QClipboard::Selection)) {
+        setText("", false);
     }
 
     m_lastCopied.clear();

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -32,7 +32,7 @@ class Clipboard : public QObject
     Q_OBJECT
 
 public:
-    void setText(const QString& text);
+    void setText(const QString& text, bool clear = true);
 
     static Clipboard* instance();
 


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
* Prefer clearing clipboard by explicitly setting the clipboard
to an empty string. Qt's QClipboard::clear() method is unreliable
under X11 environment.

* Fixes #4126

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Gnome and Windows 10.

Needs to be tested on:
- [x] KDE
- [x] XFCE
- [x] macOS

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
