### PR TITLE
Retrieve login1 session object from manager

### DIFF
--- a/src/core/ScreenLockListenerDBus.h
+++ b/src/core/ScreenLockListenerDBus.h
@@ -18,6 +18,7 @@
 #ifndef SCREENLOCKLISTENERDBUS_H
 #define SCREENLOCKLISTENERDBUS_H
 #include "ScreenLockListenerPrivate.h"
+#include <QDBusMessage>
 #include <QObject>
 #include <QWidget>
 
@@ -32,6 +33,7 @@ private slots:
     void logindPrepareForSleep(bool beforeSleep);
     void unityLocked();
     void freedesktopScreenSaver(bool status);
+    void login1SessionObjectReceived(QDBusMessage);
 };
 
 #endif // SCREENLOCKLISTENERDBUS_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Issue #3339 shows issues with some screen locker setups where the database is not locked. The ObjectPath of the `org.freedesktop.login1.Session` object is created from `$XDG_SESSION_ID`, which does not necessarily correspond to the correct path. With this PR, the ObjectPath is retrieved with a call to `org.freedesktop.login1.Manager.GetSession` (introduced in systemd/systemd@bef422ae1e7cbe77ad72dcbfe44798b0fe5e2931, systemd v30).

Fixes #3339

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
