### PR TITLE
Explicitly set parallelism suffix to correct grammar

### DIFF
--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
@@ -355,7 +355,11 @@ void DatabaseSettingsWidgetEncryption::memoryChanged(int value)
  */
 void DatabaseSettingsWidgetEncryption::parallelismChanged(int value)
 {
-    m_ui->parallelismSpinBox->setSuffix(tr(" thread(s)", "Threads for parallel execution (KDF settings)", value));
+    if (value == 1) {
+        m_ui->parallelismSpinBox->setSuffix(tr(" thread", "Threads for parallel execution (KDF settings)", value));
+    } else {
+        m_ui->parallelismSpinBox->setSuffix(tr(" threads", "Threads for parallel execution (KDF settings)", value));
+    }
 }
 
 void DatabaseSettingsWidgetEncryption::setAdvancedMode(bool advanced)


### PR DESCRIPTION
(**super** nitpick PR, I know)

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

(It's not _really_ a bug, but it's the closest option)

## Description and Context

Remove the "(s)" suffix, so the grammar is always correct. 

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
