### PR TITLE
CLI: Add UUID as attribute and make searchable

### DIFF
--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -20,6 +20,8 @@
 #include "Utils.h"
 #include "core/Group.h"
 
+#include <quuid.h>
+
 const QCommandLineOption Show::TotpOption = QCommandLineOption(QStringList() << "t"
                                                                              << "totp",
                                                                QObject::tr("Show the entry's current TOTP."));

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -99,6 +99,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
             out << "PROTECTED" << endl;
         } else if (attributeName.compare("Uuid") == 0) {
             out << entry->uuid().toString() << endl;
+            outputTextStream << entry->uuid().toString().remove((QRegExp("[{}]"))) << endl;
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << endl;
         }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -97,6 +97,8 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         }
         if (entry->attributes()->isProtected(canonicalName) && showDefaultAttributes && !showProtectedAttributes) {
             out << "PROTECTED" << endl;
+        } else if (attributeName.compare("Uuid") == 0) {
+            out << entry->uuid().toString() << endl;
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << endl;
         }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -20,8 +20,6 @@
 #include "Utils.h"
 #include "core/Group.h"
 
-#include <quuid.h>
-
 const QCommandLineOption Show::TotpOption = QCommandLineOption(QStringList() << "t"
                                                                              << "totp",
                                                                QObject::tr("Show the entry's current TOTP."));
@@ -104,7 +102,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         if (entry->attributes()->isProtected(canonicalName) && showDefaultAttributes && !showProtectedAttributes) {
             out << "PROTECTED" << endl;
         } else if (attributeName.compare("Uuid") == 0) {
-            out << entry->uuid().toString(QUuid::WithoutBraces) << endl;
+            out << entry->uuid().toString(static_cast<QUuid::StringFormat>(1)) << endl;
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << endl;
         }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -64,8 +64,12 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
 
     Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
-        err << QObject::tr("Could not find entry with path %1.").arg(entryPath) << endl;
-        return EXIT_FAILURE;
+        // If no entry found try find by entry UUID.
+        entry = database->rootGroup()->findEntryByUuid(entryPath);
+        if (!entry) {
+            errorTextStream << QObject::tr("Could not find entry with path or uuid %1.").arg(entryPath) << endl;
+            return EXIT_FAILURE;
+        }
     }
 
     if (showTotp && !entry->hasTotp()) {

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -14,11 +14,12 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 #include "Show.h"
 
 #include "Utils.h"
 #include "core/Group.h"
+
+#include <QUuid>
 
 const QCommandLineOption Show::TotpOption = QCommandLineOption(QStringList() << "t"
                                                                              << "totp",
@@ -102,7 +103,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         if (entry->attributes()->isProtected(canonicalName) && showDefaultAttributes && !showProtectedAttributes) {
             out << "PROTECTED" << endl;
         } else if (attributeName.compare("Uuid") == 0) {
-            out << entry->uuid().toString(static_cast<QUuid::StringFormat>(1)) << endl;
+            out << entry->uuid().toString(QUuid::WithoutBraces) << endl;
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << endl;
         }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -21,6 +21,7 @@
 #include "core/Group.h"
 
 #include <quuid.h>
+#include <QUuid>
 
 const QCommandLineOption Show::TotpOption = QCommandLineOption(QStringList() << "t"
                                                                              << "totp",

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -21,7 +21,6 @@
 #include "core/Group.h"
 
 #include <quuid.h>
-#include <QUuid>
 
 const QCommandLineOption Show::TotpOption = QCommandLineOption(QStringList() << "t"
                                                                              << "totp",
@@ -67,7 +66,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         // If no entry found try find by entry UUID.
         entry = database->rootGroup()->findEntryByUuid(entryPath);
         if (!entry) {
-            errorTextStream << QObject::tr("Could not find entry with path or uuid %1.").arg(entryPath) << endl;
+            err << QObject::tr("Could not find entry with path or uuid %1.").arg(entryPath) << endl;
             return EXIT_FAILURE;
         }
     }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -19,8 +19,6 @@
 #include "Utils.h"
 #include "core/Group.h"
 
-#include <QUuid>
-
 const QCommandLineOption Show::TotpOption = QCommandLineOption(QStringList() << "t"
                                                                              << "totp",
                                                                QObject::tr("Show the entry's current TOTP."));
@@ -103,7 +101,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         if (entry->attributes()->isProtected(canonicalName) && showDefaultAttributes && !showProtectedAttributes) {
             out << "PROTECTED" << endl;
         } else if (attributeName.compare("Uuid") == 0) {
-            out << entry->uuid().toString(QUuid::WithoutBraces) << endl;
+            out << entry->uuid().toString(QUuid::Id128) << endl;
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << endl;
         }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -101,7 +101,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         if (entry->attributes()->isProtected(canonicalName) && showDefaultAttributes && !showProtectedAttributes) {
             out << "PROTECTED" << endl;
         } else if (attributeName.compare("Uuid") == 0) {
-            out << entry->uuid().toString(QUuid::Id128) << endl;
+            out << entry->uuid().toString().remove((QRegExp("[{}]"))) << endl;
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << endl;
         }

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -98,8 +98,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         if (entry->attributes()->isProtected(canonicalName) && showDefaultAttributes && !showProtectedAttributes) {
             out << "PROTECTED" << endl;
         } else if (attributeName.compare("Uuid") == 0) {
-            out << entry->uuid().toString() << endl;
-            outputTextStream << entry->uuid().toString().remove((QRegExp("[{}]"))) << endl;
+            out << entry->uuid().toString(QUuid::WithoutBraces) << endl;
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << endl;
         }

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -25,8 +25,9 @@ const QString EntryAttributes::UserNameKey = "UserName";
 const QString EntryAttributes::PasswordKey = "Password";
 const QString EntryAttributes::URLKey = "URL";
 const QString EntryAttributes::NotesKey = "Notes";
-const QStringList EntryAttributes::DefaultAttributes(QStringList()
-                                                     << TitleKey << UserNameKey << PasswordKey << URLKey << NotesKey);
+const QString EntryAttributes::UuidKey = "Uuid";
+const QStringList EntryAttributes::DefaultAttributes(QStringList() << TitleKey << UserNameKey << PasswordKey << URLKey
+                                                     << UuidKey << NotesKey);
 
 const QString EntryAttributes::WantedFieldGroupName = "WantedField";
 const QString EntryAttributes::SearchInGroupName = "SearchIn";

--- a/src/core/EntryAttributes.cpp
+++ b/src/core/EntryAttributes.cpp
@@ -27,7 +27,7 @@ const QString EntryAttributes::URLKey = "URL";
 const QString EntryAttributes::NotesKey = "Notes";
 const QString EntryAttributes::UuidKey = "Uuid";
 const QStringList EntryAttributes::DefaultAttributes(QStringList() << TitleKey << UserNameKey << PasswordKey << URLKey
-                                                     << UuidKey << NotesKey);
+                                                                   << UuidKey << NotesKey);
 
 const QString EntryAttributes::WantedFieldGroupName = "WantedField";
 const QString EntryAttributes::SearchInGroupName = "SearchIn";

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -60,6 +60,7 @@ public:
     static const QString PasswordKey;
     static const QString URLKey;
     static const QString NotesKey;
+    static const QString UuidKey;
     static const QStringList DefaultAttributes;
     static const QString RememberCmdExecAttr;
     static bool isDefaultAttribute(const QString& key);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -30,8 +30,8 @@
 #include "keeshare/KeeShare.h"
 #endif
 
-#include <QtConcurrent>
 #include <QUuid>
+#include <QtConcurrent>
 
 const int Group::DefaultIconNumber = 48;
 const int Group::RecycleBinIconNumber = 43;
@@ -588,24 +588,6 @@ Entry* Group::findEntryByUuid(const QUuid& uuid, bool recursive) const
 
     for (auto entry : entries) {
         if (entry->uuid() == uuid) {
-            return entry;
-        }
-    }
-
-    return nullptr;
-}
-
-Entry* Group::findEntryByUuid(const QString& uuid) const
-{
-    if (uuid.isEmpty()) {
-        return nullptr;
-    }
-
-    auto entries = m_entries;
-    entries = entriesRecursive(false);
-
-    for (auto entry : entries) {
-        if (entry->uuid().toString(QUuid::Id128) == uuid) {
             return entry;
         }
     }

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -666,6 +666,11 @@ Entry* Group::findEntryByPathRecursive(const QString& entryPath, const QString& 
             || (!entryPath.startsWith("/") && entry->title() == entryPath)) {
             return entry;
         }
+        bool found = false;
+        found = entry->uuid() == QUuid::fromRfc4122(QByteArray::fromHex(entry->uuid().toString().toLatin1()));
+        if (found) {
+            return entry;
+        }
         // clang-format on
     }
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -595,6 +595,24 @@ Entry* Group::findEntryByUuid(const QUuid& uuid, bool recursive) const
     return nullptr;
 }
 
+Entry* Group::findEntryByUuid(const QString& uuid) const
+{
+    if (uuid.isEmpty()) {
+        return nullptr;
+    }
+
+    auto entries = m_entries;
+    entries = entriesRecursive(false);
+
+    for (auto entry : entries) {
+        if (entry->uuid().toString(QUuid::Id128) == uuid) {
+            return entry;
+        }
+    }
+
+    return nullptr;
+}
+
 Entry* Group::findEntryByPath(const QString& entryPath)
 {
     if (entryPath.isEmpty()) {
@@ -665,9 +683,6 @@ Entry* Group::findEntryByPathRecursive(const QString& entryPath, const QString& 
         // clang-format off
         if (entryPath == (basePath + entry->title())
             || (!entryPath.startsWith("/") && entry->title() == entryPath)) {
-            return entry;
-        }
-        if (entryPath == entry->uuid().toString(QUuid::Id128)) {
             return entry;
         }
         // clang-format on

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <QtConcurrent>
+#include <quuid.h>
 
 const int Group::DefaultIconNumber = 48;
 const int Group::RecycleBinIconNumber = 43;

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -31,7 +31,7 @@
 #endif
 
 #include <QtConcurrent>
-#include <quuid.h>
+#include <QUuid>
 
 const int Group::DefaultIconNumber = 48;
 const int Group::RecycleBinIconNumber = 43;

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -666,9 +666,7 @@ Entry* Group::findEntryByPathRecursive(const QString& entryPath, const QString& 
             || (!entryPath.startsWith("/") && entry->title() == entryPath)) {
             return entry;
         }
-        bool found = false;
-        found = entry->uuid() == QUuid::fromRfc4122(QByteArray::fromHex(entry->uuid().toString().toLatin1()));
-        if (found) {
+        if (entryPath == entry->uuid().toString(QUuid::Id128)) {
             return entry;
         }
         // clang-format on

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -113,6 +113,7 @@ public:
 
     Group* findChildByName(const QString& name);
     Entry* findEntryByUuid(const QUuid& uuid, bool recursive = true) const;
+    Entry* findEntryByUuid(const QString& uuid) const;
     Entry* findEntryByPath(const QString& entryPath);
     Entry* findEntryBySearchTerm(const QString& term, EntryReferenceType referenceType);
     Group* findGroupByUuid(const QUuid& uuid);

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -113,7 +113,6 @@ public:
 
     Group* findChildByName(const QString& name);
     Entry* findEntryByUuid(const QUuid& uuid, bool recursive = true) const;
-    Entry* findEntryByUuid(const QString& uuid) const;
     Entry* findEntryByPath(const QString& entryPath);
     Entry* findEntryBySearchTerm(const QString& term, EntryReferenceType referenceType);
     Group* findGroupByUuid(const QUuid& uuid);

--- a/tests/TestKdbx4.cpp
+++ b/tests/TestKdbx4.cpp
@@ -139,7 +139,7 @@ void TestKdbx4Argon2::testFormat400()
 
     QCOMPARE(entry->title(), QString("Format400"));
     QCOMPARE(entry->username(), QString("Format400"));
-    QCOMPARE(entry->attributes()->keys().size(), 6);
+    QCOMPARE(entry->attributes()->keys().size(), 7);
     QCOMPARE(entry->attributes()->value("Format400"), QString("Format400"));
     QCOMPARE(entry->attachments()->keys().size(), 1);
     QCOMPARE(entry->attachments()->value("Format400"), QByteArray("Format400\n"));

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -230,6 +230,7 @@ void TestKeePass2Format::testXmlEntry1()
     QCOMPARE(entry->attributes()->value("UserName"), QString("User Name"));
     QVERIFY(entry->attributes()->isProtected("UserName"));
     QVERIFY(attrs.removeOne("UserName"));
+    QVERIFY(attrs.removeOne("Uuid"));
     QVERIFY(attrs.isEmpty());
 
     QCOMPARE(entry->title(), entry->attributes()->value("Title"));
@@ -285,6 +286,7 @@ void TestKeePass2Format::testXmlEntry2()
     QVERIFY(attrs.removeOne("URL"));
     QCOMPARE(entry->attributes()->value("UserName"), QString("notDEFUSERNAME"));
     QVERIFY(attrs.removeOne("UserName"));
+    QVERIFY(attrs.removeOne("Uuid"));
     QVERIFY(attrs.isEmpty());
 
     QCOMPARE(entry->attachments()->keys().size(), 1);


### PR DESCRIPTION
Add UUID as an attribute when using keepassxc-cli show. Also makes this a searchable attribute.

Fixes #4112 and fixes #4113.

Testing is validated by running the command and searching by the UUID and seeing UUID in the output:
`keepassxc-cli show ~/Documents/PasswordsTest.kdbx '076b5698-5ad7-4c47-97a7-c5e373efa0b3'`

> Title: Cool Site
> UserName: derp
> Password: PROTECTED
> URL: punny.xyz
> Uuid: 076b5698-5ad7-4c47-97a7-c5e373efa0b3
> Notes: 
 