### PR TITLE
Removing QColor (from Qt::Widgets) from core modules.

### DIFF
--- a/src/core/Compare.cpp
+++ b/src/core/Compare.cpp
@@ -15,24 +15,3 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "Compare.h"
-
-#include <QColor>
-
-bool operator<(const QColor& lhs, const QColor& rhs)
-{
-    const QColor adaptedLhs = lhs.toCmyk();
-    const QColor adaptedRhs = rhs.toCmyk();
-    const int iCyan = compare(adaptedLhs.cyanF(), adaptedRhs.cyanF());
-    if (iCyan != 0) {
-        return iCyan;
-    }
-    const int iMagenta = compare(adaptedLhs.magentaF(), adaptedRhs.magentaF());
-    if (iMagenta != 0) {
-        return iMagenta;
-    }
-    const int iYellow = compare(adaptedLhs.yellowF(), adaptedRhs.yellowF());
-    if (iYellow != 0) {
-        return iYellow;
-    }
-    return compare(adaptedLhs.blackF(), adaptedRhs.blackF()) < 0;
-}

--- a/src/core/Compare.h
+++ b/src/core/Compare.h
@@ -34,14 +34,6 @@ enum CompareItemOption
 Q_DECLARE_FLAGS(CompareItemOptions, CompareItemOption)
 Q_DECLARE_OPERATORS_FOR_FLAGS(CompareItemOptions)
 
-class QColor;
-/*!
- * \return true when both color match
- *
- * Comparison converts both into the cmyk-model
- */
-bool operator<(const QColor& lhs, const QColor& rhs);
-
 template <typename Type> inline short compareGeneric(const Type& lhs, const Type& rhs, CompareItemOptions)
 {
     if (lhs != rhs) {

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -208,12 +208,12 @@ const QUuid& Entry::iconUuid() const
     return m_data.customIcon;
 }
 
-QColor Entry::foregroundColor() const
+QString Entry::foregroundColor() const
 {
     return m_data.foregroundColor;
 }
 
-QColor Entry::backgroundColor() const
+QString Entry::backgroundColor() const
 {
     return m_data.backgroundColor;
 }
@@ -508,14 +508,14 @@ void Entry::setIcon(const QUuid& uuid)
     }
 }
 
-void Entry::setForegroundColor(const QColor& color)
+void Entry::setForegroundColor(const QString& colorStr)
 {
-    set(m_data.foregroundColor, color);
+    set(m_data.foregroundColor, colorStr);
 }
 
-void Entry::setBackgroundColor(const QColor& color)
+void Entry::setBackgroundColor(const QString& colorStr)
 {
-    set(m_data.backgroundColor, color);
+    set(m_data.backgroundColor, colorStr);
 }
 
 void Entry::setOverrideUrl(const QString& url)

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -19,7 +19,6 @@
 #ifndef KEEPASSX_ENTRY_H
 #define KEEPASSX_ENTRY_H
 
-#include <QColor>
 #include <QImage>
 #include <QMap>
 #include <QPixmap>
@@ -57,8 +56,8 @@ struct EntryData
 {
     int iconNumber;
     QUuid customIcon;
-    QColor foregroundColor;
-    QColor backgroundColor;
+    QString foregroundColor;
+    QString backgroundColor;
     QString overrideUrl;
     QString tags;
     bool autoTypeEnabled;
@@ -86,8 +85,8 @@ public:
     QPixmap iconScaledPixmap() const;
     int iconNumber() const;
     const QUuid& iconUuid() const;
-    QColor foregroundColor() const;
-    QColor backgroundColor() const;
+    QString foregroundColor() const;
+    QString backgroundColor() const;
     QString overrideUrl() const;
     QString tags() const;
     const TimeInfo& timeInfo() const;
@@ -132,8 +131,8 @@ public:
     void setUuid(const QUuid& uuid);
     void setIcon(int iconNumber);
     void setIcon(const QUuid& uuid);
-    void setForegroundColor(const QColor& color);
-    void setBackgroundColor(const QColor& color);
+    void setForegroundColor(const QString& color);
+    void setBackgroundColor(const QString& color);
     void setOverrideUrl(const QString& url);
     void setTags(const QString& tags);
     void setTimeInfo(const TimeInfo& timeInfo);

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -131,7 +131,7 @@ int Metadata::maintenanceHistoryDays() const
     return m_data.maintenanceHistoryDays;
 }
 
-QColor Metadata::color() const
+QString Metadata::color() const
 {
     return m_data.color;
 }
@@ -347,7 +347,7 @@ void Metadata::setMaintenanceHistoryDays(int value)
     set(m_data.maintenanceHistoryDays, value);
 }
 
-void Metadata::setColor(const QColor& value)
+void Metadata::setColor(const QString& value)
 {
     set(m_data.color, value);
 }

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -18,7 +18,6 @@
 #ifndef KEEPASSX_METADATA_H
 #define KEEPASSX_METADATA_H
 
-#include <QColor>
 #include <QDateTime>
 #include <QHash>
 #include <QImage>
@@ -49,7 +48,7 @@ public:
         QString defaultUserName;
         QDateTime defaultUserNameChanged;
         int maintenanceHistoryDays;
-        QColor color;
+        QString color;
         bool recycleBinEnabled;
         int historyMaxItems;
         int historyMaxSize;
@@ -72,7 +71,7 @@ public:
     QDateTime defaultUserNameChanged() const;
     QDateTime settingsChanged() const;
     int maintenanceHistoryDays() const;
-    QColor color() const;
+    QString color() const;
     bool protectTitle() const;
     bool protectUsername() const;
     bool protectPassword() const;
@@ -113,7 +112,7 @@ public:
     void setDefaultUserNameChanged(const QDateTime& value);
     void setSettingsChanged(const QDateTime& value);
     void setMaintenanceHistoryDays(int value);
-    void setColor(const QColor& value);
+    void setColor(const QString& value);
     void setProtectTitle(bool value);
     void setProtectUsername(bool value);
     void setProtectPassword(bool value);

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -1047,22 +1047,21 @@ QDateTime KdbxXmlReader::readDateTime()
     return Clock::currentDateTimeUtc();
 }
 
-QColor KdbxXmlReader::readColor()
+QString KdbxXmlReader::readColor()
 {
     QString colorStr = readString();
 
     if (colorStr.isEmpty()) {
-        return {};
+        return colorStr;
     }
 
     if (colorStr.length() != 7 || colorStr[0] != '#') {
         if (m_strictMode) {
             raiseError(tr("Invalid color value"));
         }
-        return {};
+        return colorStr;
     }
 
-    QColor color;
     for (int i = 0; i <= 2; ++i) {
         QString rgbPartStr = colorStr.mid(1 + 2 * i, 2);
         bool ok;
@@ -1071,19 +1070,11 @@ QColor KdbxXmlReader::readColor()
             if (m_strictMode) {
                 raiseError(tr("Invalid color rgb part"));
             }
-            return {};
-        }
-
-        if (i == 0) {
-            color.setRed(rgbPart);
-        } else if (i == 1) {
-            color.setGreen(rgbPart);
-        } else {
-            color.setBlue(rgbPart);
+            return colorStr;
         }
     }
 
-    return color;
+    return colorStr;
 }
 
 int KdbxXmlReader::readNumber()

--- a/src/format/KdbxXmlReader.h
+++ b/src/format/KdbxXmlReader.h
@@ -83,7 +83,7 @@ protected:
     virtual QString readString(bool& isProtected, bool& protectInMemory);
     virtual bool readBool();
     virtual QDateTime readDateTime();
-    virtual QColor readColor();
+    virtual QString readColor();
     virtual int readNumber();
     virtual QUuid readUuid();
     virtual QByteArray readBinary();

--- a/src/format/KdbxXmlWriter.cpp
+++ b/src/format/KdbxXmlWriter.cpp
@@ -111,7 +111,7 @@ void KdbxXmlWriter::writeMetadata()
     writeString("DefaultUserName", m_meta->defaultUserName());
     writeDateTime("DefaultUserNameChanged", m_meta->defaultUserNameChanged());
     writeNumber("MaintenanceHistoryDays", m_meta->maintenanceHistoryDays());
-    writeColor("Color", m_meta->color());
+    writeString("Color", m_meta->color());
     writeDateTime("MasterKeyChanged", m_meta->masterKeyChanged());
     writeNumber("MasterKeyChangeRec", m_meta->masterKeyChangeRec());
     writeNumber("MasterKeyChangeForce", m_meta->masterKeyChangeForce());
@@ -346,8 +346,8 @@ void KdbxXmlWriter::writeEntry(const Entry* entry)
     if (!entry->iconUuid().isNull()) {
         writeUuid("CustomIconUUID", entry->iconUuid());
     }
-    writeColor("ForegroundColor", entry->foregroundColor());
-    writeColor("BackgroundColor", entry->backgroundColor());
+    writeString("ForegroundColor", entry->foregroundColor());
+    writeString("BackgroundColor", entry->backgroundColor());
     writeString("OverrideURL", entry->overrideUrl());
     writeString("Tags", entry->tags());
     writeTimes(entry->timeInfo());
@@ -530,18 +530,6 @@ void KdbxXmlWriter::writeUuid(const QString& qualifiedName, const Entry* entry)
 void KdbxXmlWriter::writeBinary(const QString& qualifiedName, const QByteArray& ba)
 {
     writeString(qualifiedName, QString::fromLatin1(ba.toBase64()));
-}
-
-void KdbxXmlWriter::writeColor(const QString& qualifiedName, const QColor& color)
-{
-    QString colorStr;
-
-    if (color.isValid()) {
-        colorStr = QString("#%1%2%3").arg(
-            colorPartToString(color.red()), colorPartToString(color.green()), colorPartToString(color.blue()));
-    }
-
-    writeString(qualifiedName, colorStr);
 }
 
 void KdbxXmlWriter::writeTriState(const QString& qualifiedName, Group::TriState triState)

--- a/src/format/KdbxXmlWriter.h
+++ b/src/format/KdbxXmlWriter.h
@@ -18,7 +18,6 @@
 #ifndef KEEPASSX_KDBXXMLWRITER_H
 #define KEEPASSX_KDBXXMLWRITER_H
 
-#include <QColor>
 #include <QDateTime>
 #include <QImage>
 #include <QXmlStreamWriter>
@@ -74,7 +73,6 @@ private:
     void writeUuid(const QString& qualifiedName, const Group* group);
     void writeUuid(const QString& qualifiedName, const Entry* entry);
     void writeBinary(const QString& qualifiedName, const QByteArray& ba);
-    void writeColor(const QString& qualifiedName, const QColor& color);
     void writeTriState(const QString& qualifiedName, Group::TriState triState);
     QString colorPartToString(int value);
     QString stripInvalidXml10Chars(QString str);

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1123,15 +1123,15 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
     entry->setNotes(m_mainUi->notesEdit->toPlainText());
 
     if (m_advancedUi->fgColorCheckBox->isChecked() && m_advancedUi->fgColorButton->property("color").isValid()) {
-        entry->setForegroundColor(QColor(m_advancedUi->fgColorButton->property("color").toString()));
+        entry->setForegroundColor(m_advancedUi->fgColorButton->property("color").toString());
     } else {
-        entry->setForegroundColor(QColor());
+        entry->setForegroundColor(QString());
     }
 
     if (m_advancedUi->bgColorCheckBox->isChecked() && m_advancedUi->bgColorButton->property("color").isValid()) {
-        entry->setBackgroundColor(QColor(m_advancedUi->bgColorButton->property("color").toString()));
+        entry->setBackgroundColor(m_advancedUi->bgColorButton->property("color").toString());
     } else {
-        entry->setBackgroundColor(QColor());
+        entry->setBackgroundColor(QString());
     }
 
     IconStruct iconStruct = m_iconsWidget->state();

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -271,7 +271,8 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
         }
         return font;
     } else if (role == Qt::ForegroundRole) {
-        QColor foregroundColor = EntryModel::getColorFromString(entry->foregroundColor());
+        QColor foregroundColor;
+        foregroundColor.setNamedColor(entry->foregroundColor());
         if (entry->hasReferences()) {
             QPalette p;
 #ifdef Q_OS_MACOS
@@ -284,7 +285,8 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return QVariant(foregroundColor);
         }
     } else if (role == Qt::BackgroundRole) {
-        QColor backgroundColor = EntryModel::getColorFromString(entry->backgroundColor());
+        QColor backgroundColor;
+        backgroundColor.setNamedColor(entry->backgroundColor());
         if (backgroundColor.isValid()) {
             return QVariant(backgroundColor);
         }
@@ -295,18 +297,6 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
     }
 
     return QVariant();
-}
-
-QColor EntryModel::getColorFromString(QString colorStr)
-{
-    QColor color;
-    QString redPart = colorStr.mid(1, 2);
-    QString greenPart = colorStr.mid(3, 2);
-    QString bluePart = colorStr.mid(5, 2);
-    color.setRed(redPart.toInt(NULL, 16));
-    color.setGreen(greenPart.toInt(NULL, 16));
-    color.setBlue(bluePart.toInt(NULL, 16));
-    return color;
 }
 
 QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int role) const

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -271,6 +271,7 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
         }
         return font;
     } else if (role == Qt::ForegroundRole) {
+        QColor foregroundColor = EntryModel::getColorFromString(entry->foregroundColor());
         if (entry->hasReferences()) {
             QPalette p;
 #ifdef Q_OS_MACOS
@@ -279,12 +280,13 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             }
 #endif
             return QVariant(p.color(QPalette::Active, QPalette::Mid));
-        } else if (entry->foregroundColor().isValid()) {
-            return QVariant(entry->foregroundColor());
+        } else if (foregroundColor.isValid()) {
+            return QVariant(foregroundColor);
         }
     } else if (role == Qt::BackgroundRole) {
-        if (entry->backgroundColor().isValid()) {
-            return QVariant(entry->backgroundColor());
+        QColor backgroundColor = EntryModel::getColorFromString(entry->backgroundColor());
+        if (backgroundColor.isValid()) {
+            return QVariant(backgroundColor);
         }
     } else if (role == Qt::TextAlignmentRole) {
         if (index.column() == Paperclip) {
@@ -293,6 +295,18 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
     }
 
     return QVariant();
+}
+
+QColor EntryModel::getColorFromString(QString colorStr)
+{
+    QColor color;
+    QString redPart = colorStr.mid(1, 2);
+    QString greenPart = colorStr.mid(3, 2);
+    QString bluePart = colorStr.mid(5, 2);
+    color.setRed(redPart.toInt(NULL, 16));
+    color.setGreen(greenPart.toInt(NULL, 16));
+    color.setBlue(bluePart.toInt(NULL, 16));
+    return color;
 }
 
 QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int role) const

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -97,7 +97,6 @@ private:
 
     const QString HiddenContentDisplay;
     const Qt::DateFormat DateFormat;
-    static QColor getColorFromString(QString colorStr);
 };
 
 #endif // KEEPASSX_ENTRYMODEL_H

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -97,6 +97,7 @@ private:
 
     const QString HiddenContentDisplay;
     const Qt::DateFormat DateFormat;
+    static QColor getColorFromString(QString colorStr);
 };
 
 #endif // KEEPASSX_ENTRYMODEL_H

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -86,7 +86,7 @@ void TestKeePass2Format::testXmlMetadata()
     QCOMPARE(m_xmlDb->metadata()->defaultUserName(), QString("DEFUSERNAME"));
     QCOMPARE(m_xmlDb->metadata()->defaultUserNameChanged(), MockClock::datetimeUtc(2010, 8, 8, 17, 27, 45));
     QCOMPARE(m_xmlDb->metadata()->maintenanceHistoryDays(), 127);
-    QCOMPARE(m_xmlDb->metadata()->color(), QColor(0xff, 0xef, 0x00));
+    QCOMPARE(m_xmlDb->metadata()->color(), QString("#FFEF00"));
     QCOMPARE(m_xmlDb->metadata()->masterKeyChanged(), MockClock::datetimeUtc(2012, 4, 5, 17, 9, 34));
     QCOMPARE(m_xmlDb->metadata()->masterKeyChangeRec(), 101);
     QCOMPARE(m_xmlDb->metadata()->masterKeyChangeForce(), -1);
@@ -200,8 +200,8 @@ void TestKeePass2Format::testXmlEntry1()
     QCOMPARE(entry->historyItems().size(), 2);
     QCOMPARE(entry->iconNumber(), 0);
     QCOMPARE(entry->iconUuid(), QUuid());
-    QVERIFY(!entry->foregroundColor().isValid());
-    QVERIFY(!entry->backgroundColor().isValid());
+    QVERIFY(entry->foregroundColor().isEmpty());
+    QVERIFY(entry->backgroundColor().isEmpty());
     QCOMPARE(entry->overrideUrl(), QString(""));
     QCOMPARE(entry->tags(), QString("a b c"));
 
@@ -262,8 +262,8 @@ void TestKeePass2Format::testXmlEntry2()
     QCOMPARE(entry->iconNumber(), 0);
     QCOMPARE(entry->iconUuid(), QUuid::fromRfc4122(QByteArray::fromBase64("++vyI+daLk6omox4a6kQGA==")));
     // TODO: test entry->icon()
-    QCOMPARE(entry->foregroundColor(), QColor(255, 0, 0));
-    QCOMPARE(entry->backgroundColor(), QColor(255, 255, 0));
+    QCOMPARE(entry->foregroundColor(), QString("#FF0000"));
+    QCOMPARE(entry->backgroundColor(), QString("#FFFF00"));
     QCOMPARE(entry->overrideUrl(), QString("http://override.net/"));
     QCOMPARE(entry->tags(), QString(""));
 

--- a/tests/TestModified.cpp
+++ b/tests/TestModified.cpp
@@ -309,13 +309,13 @@ void TestModified::testEntrySets()
     entry->setDefaultAutoTypeSequence(entry->defaultAutoTypeSequence());
     QTRY_COMPARE(spyModified.count(), spyCount);
 
-    entry->setForegroundColor(Qt::red);
+    entry->setForegroundColor(QString("#FF0000"));
     ++spyCount;
     QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setForegroundColor(entry->foregroundColor());
     QTRY_COMPARE(spyModified.count(), spyCount);
 
-    entry->setBackgroundColor(Qt::red);
+    entry->setBackgroundColor(QString("#FF0000"));
     ++spyCount;
     QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setBackgroundColor(entry->backgroundColor());

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -432,8 +432,8 @@ void TestGui::testEditEntry()
 
     // Test entry colors (simulate choosing a color)
     editEntryWidget->setCurrentPage(1);
-    auto fgColor = QColor(Qt::red);
-    auto bgColor = QColor(Qt::blue);
+    auto fgColor = QString("#FF0000");
+    auto bgColor = QString("#0000FF");
     // Set foreground color
     auto colorButton = editEntryWidget->findChild<QPushButton*>("fgColorButton");
     auto colorCheckBox = editEntryWidget->findChild<QCheckBox*>("fgColorCheckBox");


### PR DESCRIPTION
Opening this one as a draft PR since it's not ready to be merged, but I'd like some early review. This is a first step to remove the `Qt:Widgets` dependency for the core modules (and thus the CLI). Basically instead of storing `QColor`s in the entries, we store the RGB `QString` and convert it to `QColor` in the gui code only. After `QColor` I think the only Widgets module remaining in the core module is `QImage`, but I'm not 100% sure.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)

## Description and Context
https://github.com/keepassxreboot/keepassxc/issues/1714

## Testing strategy
Unit tests and manual testing. Let me know if you'd like new unit tests.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**