### PR TITLE
Use db-create as Create::name

### DIFF
--- a/src/cli/Create.cpp
+++ b/src/cli/Create.cpp
@@ -38,7 +38,7 @@ const QCommandLineOption Create::DecryptionTimeOption =
 
 Create::Create()
 {
-    name = QString("create");
+    name = QString("db-create");
     description = QObject::tr("Create a new database.");
     positionalArguments.append({QString("database"), QObject::tr("Path of the database."), QString("")});
     options.append(Command::KeyFileOption);


### PR DESCRIPTION
Fixes a name mismatch introduced in
b78ca924fdf2b6d5937d87bab65104cba629382f.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Currently, `db-create` is the correct invocation but `create` appears in all the runtime-generated documentation.

## Testing strategy
Tested manually. Unfortunately there are no tests that actually run the keepassxc-cli binary and simulate user input. Such a test would have caught this issue.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
