### PR TITLE
Enable tab focus change in notes field.

### DIFF
--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -192,6 +192,9 @@
      <property name="accessibleName">
       <string>Notes field</string>
      </property>
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="9" column="1">


### PR DESCRIPTION
Previously, if focus landed inside the Notes field in the Entry editor,
hitting 'tab' would insert a literal tab character. This is problematic
for those using screen readers. Now, hitting tab goes to the next
widget in the focus list.

Fixes https://github.com/keepassxreboot/keepassxc/issues/4222.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing strategy
Tested manually.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
