### PR TITLE
CLI: Use stderr for password prompt

### DIFF
--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -110,7 +110,7 @@ int Add::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<Q
         if (!parser->isSet(Command::QuietOption)) {
             outputTextStream << QObject::tr("Enter password for new entry: ") << flush;
         }
-        QString password = Utils::getPassword(parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT);
+        QString password = Utils::getPassword(parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDERR);
         entry->setPassword(password);
     } else if (parser->isSet(Add::GenerateOption)) {
         QString password = passwordGenerator->generatePassword();

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -115,7 +115,7 @@ int Edit::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
 
     if (prompt) {
         outputTextStream << QObject::tr("Enter new password for entry: ") << flush;
-        QString password = Utils::getPassword(parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT);
+        QString password = Utils::getPassword(parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDERR);
         entry->setPassword(password);
     } else if (generate) {
         QString password = passwordGenerator->generatePassword();

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -130,8 +130,8 @@ namespace Utils
         }
 
         if (isPasswordProtected) {
-            out << QObject::tr("Enter password to unlock %1: ").arg(databaseFilename) << flush;
-            QString line = Utils::getPassword(outputDescriptor);
+            err << QObject::tr("Enter password to unlock %1: ").arg(databaseFilename) << flush;
+            QString line = Utils::getPassword(errorDescriptor);
             auto passwordKey = QSharedPointer<PasswordKey>::create();
             passwordKey->setPassword(line);
             compositeKey->addKey(passwordKey);
@@ -232,9 +232,10 @@ namespace Utils
     {
         QSharedPointer<PasswordKey> passwordKey;
         QTextStream out(Utils::STDOUT, QIODevice::WriteOnly);
+        QTextStream err(Utils::STDERR, QIODevice::WriteOnly);
 
-        out << QObject::tr("Enter password to encrypt database (optional): ");
-        out.flush();
+        err << QObject::tr("Enter password to encrypt database (optional): ");
+        err.flush();
         auto password = Utils::getPassword();
 
         if (password.isEmpty()) {

--- a/src/cli/Utils.h
+++ b/src/cli/Utils.h
@@ -40,7 +40,7 @@ namespace Utils
     extern FILE* DEVNULL;
 
     void setStdinEcho(bool enable);
-    QString getPassword(FILE* outputDescriptor = STDOUT);
+    QString getPassword(FILE* outputDescriptor = STDERR);
     QSharedPointer<PasswordKey> getPasswordFromStdin();
     int clipText(const QString& text);
     QSharedPointer<Database> unlockDatabase(const QString& databaseFilename,


### PR DESCRIPTION
## Type of change

- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context

Output keepassxc-cli password prompts to stderr, so that it can be used as part of a pipeline or script.

Fixes #3398.

## Checklist:

- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
