### PR TITLE
Return keyboard focus after saving database edits

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1671,6 +1671,8 @@ bool DatabaseWidget::save()
     m_entryView->setDisabled(false);
     m_groupView->setDisabled(false);
 
+    m_entryView->setFocus();
+
     if (ok) {
         m_saveAttempts = 0;
         m_blockAutoSave = false;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1657,6 +1657,8 @@ bool DatabaseWidget::save()
     m_blockAutoSave = true;
     ++m_saveAttempts;
 
+    auto focusWidget = qApp->focusWidget();
+
     // TODO: Make this async
     // Lock out interactions
     m_entryView->setDisabled(true);
@@ -1671,7 +1673,9 @@ bool DatabaseWidget::save()
     m_entryView->setDisabled(false);
     m_groupView->setDisabled(false);
 
-    m_entryView->setFocus();
+    if (focusWidget) {
+        focusWidget->setFocus();
+    }
 
     if (ok) {
         m_saveAttempts = 0;


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
Prior to when a database is saved after an edit, the Group and Entry Views are disabled which causes a loss in keyboard focus. This change sets the focus to Entry View after the views are re-enabled.

Fixes #4157 

## Testing strategy
All unit tests as well as manual testing.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
