### PR TITLE
Enable browser-like DbTab (Alt + Num) experience across platforms with fixes

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -303,7 +303,6 @@ MainWindow::MainWindow()
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this, SLOT(selectPreviousDatabaseTab()));
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
 
-#ifdef Q_OS_MACOS
     auto shortcut = new QShortcut(Qt::CTRL + Qt::Key_1, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
     shortcut = new QShortcut(Qt::CTRL + Qt::Key_2, this);
@@ -321,8 +320,8 @@ MainWindow::MainWindow()
     shortcut = new QShortcut(Qt::CTRL + Qt::Key_8, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
     new QShortcut(Qt::CTRL + Qt::Key_9, this, SLOT(selectLastDatabaseTab()));
-#else
-    auto shortcut = new QShortcut(Qt::ALT + Qt::Key_1, this);
+#if defined(Q_OS_WIN) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    shortcut = new QShortcut(Qt::ALT + Qt::Key_1, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
     shortcut = new QShortcut(Qt::ALT + Qt::Key_2, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(2); });

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -322,7 +322,6 @@ MainWindow::MainWindow()
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
     new QShortcut(Qt::CTRL + Qt::Key_9, this, SLOT(selectLastDatabaseTab()));
 #else
-    
     auto shortcut = new QShortcut(Qt::ALT + Qt::Key_1, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
     shortcut = new QShortcut(Qt::ALT + Qt::Key_2, this);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -302,8 +302,29 @@ MainWindow::MainWindow()
     new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(selectNextDatabaseTab()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this, SLOT(selectPreviousDatabaseTab()));
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
-    new QShortcut(Qt::ALT + Qt::Key_0, this, SLOT(selectLastDatabaseTab()));
 
+#ifdef Q_OS_MACOS
+    new QShortcut(Qt::CTRL + Qt::Key_0, this, SLOT(selectLastDatabaseTab()));
+    auto shortcut = new QShortcut(Qt::CTRL + Qt::Key_1, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_2, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(2); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_3, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(3); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_4, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(4); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_5, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(5); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_6, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(6); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_7, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(7); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_8, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_9, this);
+    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(9); });
+#else
+    new QShortcut(Qt::ALT + Qt::Key_0, this, SLOT(selectLastDatabaseTab()));
     auto shortcut = new QShortcut(Qt::ALT + Qt::Key_1, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
     shortcut = new QShortcut(Qt::ALT + Qt::Key_2, this);
@@ -322,6 +343,7 @@ MainWindow::MainWindow()
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
     shortcut = new QShortcut(Qt::ALT + Qt::Key_9, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(9); });
+#endif
 
     // Toggle password and username visibility in entry view
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C, this, SLOT(togglePasswordsHidden()));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -303,6 +303,7 @@ MainWindow::MainWindow()
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this, SLOT(selectPreviousDatabaseTab()));
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
 
+    new QShortcut(Qt::CTRL + Qt::Key_9, this, SLOT(selectLastDatabaseTab()));
     auto shortcut = new QShortcut(Qt::CTRL + Qt::Key_1, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
     shortcut = new QShortcut(Qt::CTRL + Qt::Key_2, this);
@@ -319,8 +320,8 @@ MainWindow::MainWindow()
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(7); });
     shortcut = new QShortcut(Qt::CTRL + Qt::Key_8, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
-    new QShortcut(Qt::CTRL + Qt::Key_9, this, SLOT(selectLastDatabaseTab()));
 #if defined(Q_OS_WIN) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    new QShortcut(Qt::ALT + Qt::Key_9, this, SLOT(selectLastDatabaseTab()));
     shortcut = new QShortcut(Qt::ALT + Qt::Key_1, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
     shortcut = new QShortcut(Qt::ALT + Qt::Key_2, this);
@@ -337,7 +338,6 @@ MainWindow::MainWindow()
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(7); });
     shortcut = new QShortcut(Qt::ALT + Qt::Key_8, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
-    new QShortcut(Qt::ALT + Qt::Key_9, this, SLOT(selectLastDatabaseTab()));
 #endif
 
     // Toggle password and username visibility in entry view

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -304,7 +304,6 @@ MainWindow::MainWindow()
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
 
 #ifdef Q_OS_MACOS
-    new QShortcut(Qt::CTRL + Qt::Key_0, this, SLOT(selectLastDatabaseTab()));
     auto shortcut = new QShortcut(Qt::CTRL + Qt::Key_1, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
     shortcut = new QShortcut(Qt::CTRL + Qt::Key_2, this);
@@ -321,10 +320,9 @@ MainWindow::MainWindow()
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(7); });
     shortcut = new QShortcut(Qt::CTRL + Qt::Key_8, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
-    shortcut = new QShortcut(Qt::CTRL + Qt::Key_9, this);
-    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(9); });
+    new QShortcut(Qt::CTRL + Qt::Key_9, this, SLOT(selectLastDatabaseTab()));
 #else
-    new QShortcut(Qt::ALT + Qt::Key_0, this, SLOT(selectLastDatabaseTab()));
+    
     auto shortcut = new QShortcut(Qt::ALT + Qt::Key_1, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
     shortcut = new QShortcut(Qt::ALT + Qt::Key_2, this);
@@ -341,8 +339,7 @@ MainWindow::MainWindow()
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(7); });
     shortcut = new QShortcut(Qt::ALT + Qt::Key_8, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(8); });
-    shortcut = new QShortcut(Qt::ALT + Qt::Key_9, this);
-    connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(9); });
+    new QShortcut(Qt::ALT + Qt::Key_9, this, SLOT(selectLastDatabaseTab()));
 #endif
 
     // Toggle password and username visibility in entry view


### PR DESCRIPTION
Improvement of PR #4063 and apply of PR #4305 hotfix made by @varjolintu

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (significant modification to existing code

## Description and Context
Enable browser-like DbTab (Alt + Num) experience across platforms

This is follow up of:
 PR #4063 Enable browser-like DbTab experience (Alt + Nums)
 PR #4305 Fix browser-like DbTab experience with macOS
This commit introduces desired behaviour across platforms.
 On MacOS only Command key + Nums combination should be used. (on MacOS, ⌘Command is QT::CTRL)
 On Linux and Windows there are combinations with Ctrl and (Left) Alt. (code could be reused)

This is not breaking for various keyboard layout organization on MacOS because of @varjolintu fixes,
nor breaking on Linux or Windows because they use AltGr (Right Alt) as modkey.

edge case over common case   
Selecting last not use shortcut variable and is edge case here. This minimalize PR commit diff also.

Change Key_0 to Key_9
Fix browser-like DbTab experience with macOS
white space removal

## Testing strategy
not tested

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
