### PR TITLE
CLI: Cleanup create options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Changed
 - Renamed CLI create command to db-create [#4231]
+- Added --set-password option for CLI db-create command
+- Added --set-key-file option for CLI db-create command (replacing --key-file option)
 
 ## 2.5.3 (2020-01-19)
 

--- a/share/docs/man/keepassxc-cli.1
+++ b/share/docs/man/keepassxc-cli.1
@@ -29,7 +29,7 @@ Copies an attribute or the current TOTP (if the \fI-t\fP option is specified) of
 In interactive mode, closes the currently opened database (see \fIopen\fP).
 
 .IP "\fBdb-create\fP [options] <database>"
-Creates a new database with a key file and/or password. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
+Creates a new database with a password and/or a key file. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
 
 .IP "\fBdb-info\fP [options] <database>"
 Show a database's information.
@@ -184,6 +184,12 @@ Copies the current TOTP instead of the specified attribute to the clipboard.
 Will report an error if no TOTP is configured for the entry.
 
 .SS "Create options"
+
+.IP "\fB-k\fP, \fB--set-key-file\fP <path>"
+Set the key file for the database.
+
+.IP "\fB-p\fP, \fB--set-password\fP"
+Set a password for the database.
 
 .IP "\fB-t\fP, \fB--decryption-time\fP <time>"
 Target decryption time in MS for the database.

--- a/src/cli/Create.cpp
+++ b/src/cli/Create.cpp
@@ -111,9 +111,11 @@ int Create::execute(const QStringList& arguments)
 
     if (parser->isSet(Create::SetPasswordOption)) {
         auto passwordKey = Utils::getPasswordFromStdin();
-        if (!passwordKey.isNull()) {
-            key->addKey(passwordKey);
+        if (passwordKey.isNull()) {
+            err << QObject::tr("Failed to set database password.") << endl;
+            return EXIT_FAILURE;
         }
+        key->addKey(passwordKey);
     }
 
     if (parser->isSet(Create::SetKeyFileOption)) {

--- a/src/cli/Create.cpp
+++ b/src/cli/Create.cpp
@@ -110,9 +110,9 @@ int Create::execute(const QStringList& arguments)
     auto key = QSharedPointer<CompositeKey>::create();
 
     if (parser->isSet(Create::SetPasswordOption)) {
-        auto password = Utils::getPasswordFromStdin();
-        if (!password.isNull()) {
-            key->addKey(password);
+        auto passwordKey = Utils::getPasswordFromStdin();
+        if (!passwordKey.isNull()) {
+            key->addKey(passwordKey);
         }
     }
 

--- a/src/cli/Create.h
+++ b/src/cli/Create.h
@@ -28,6 +28,8 @@ public:
     Create();
     int execute(const QStringList& arguments) override;
 
+    static const QCommandLineOption SetKeyFileOption;
+    static const QCommandLineOption SetPasswordOption;
     static const QCommandLineOption DecryptionTimeOption;
 
 private:

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -70,9 +70,9 @@ int Import::execute(const QStringList& arguments)
 
     auto key = QSharedPointer<CompositeKey>::create();
 
-    auto password = Utils::getPasswordFromStdin();
-    if (!password.isNull()) {
-        key->addKey(password);
+    auto passwordKey = Utils::getPasswordFromStdin();
+    if (!passwordKey.isNull()) {
+        key->addKey(passwordKey);
     }
 
     if (key->isEmpty()) {

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -71,9 +71,11 @@ int Import::execute(const QStringList& arguments)
     auto key = QSharedPointer<CompositeKey>::create();
 
     auto passwordKey = Utils::getPasswordFromStdin();
-    if (!passwordKey.isNull()) {
-        key->addKey(passwordKey);
+    if (passwordKey.isNull()) {
+        errorTextStream << QObject::tr("Failed to set database password.") << endl;
+        return EXIT_FAILURE;
     }
+    key->addKey(passwordKey);
 
     if (key->isEmpty()) {
         errorTextStream << QObject::tr("No key is set. Aborting database creation.") << endl;

--- a/src/cli/Utils.h
+++ b/src/cli/Utils.h
@@ -62,7 +62,7 @@ namespace Utils
 
     namespace Test
     {
-        void setNextPassword(const QString& password);
+        void setNextPassword(const QString& password, bool repeat = false);
     }
 }; // namespace Utils
 


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc/issues/4307

This makes sure that there's no clash between the database opening options (`--no-password` and `--key-file`) and the database creation/modification options, which start by `--set`. The main consequence is that setting the password on creation must be done explicitly, but I feel like it's ok to be explicit when creating the  db. 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
- ✅ Documentation (non-code change)


## Testing strategy
unit tests.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
