### PR TITLE
On Unix, copy to clipboard using wl-clipboard if xclip is not available

### DIFF
--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -473,6 +473,10 @@ void TestCli::testClip()
     m_stdoutFile->reset();
     QString errorOutput(m_stderrFile->readAll());
 
+    if (QProcessEnvironment::systemEnvironment().contains("WAYLAND_DISPLAY")) {
+        QSKIP("Clip test skipped due to QClipboard and Wayland issues");
+    }
+
     if (errorOutput.contains("Unable to start program")
         || errorOutput.contains("No program defined for clipboard manipulation")) {
         QSKIP("Clip test skipped due to missing clipboard tool");


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
This fix allows copying passwords on Wayland, where xclip does not work. I've also slightly changed the code so that other clipboard tools could be easily added in the future.  #3812 

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
