### PR TITLE
Add extension ID for unpacked browser extension

### DIFF
--- a/src/browser/HostInstaller.cpp
+++ b/src/browser/HostInstaller.cpp
@@ -32,7 +32,8 @@ HostInstaller::HostInstaller()
     : HOST_NAME("org.keepassxc.keepassxc_browser")
     , ALLOWED_EXTENSIONS(QStringList() << "keepassxc-browser@keepassxc.org")
     , ALLOWED_ORIGINS(QStringList() << "chrome-extension://pdffhmdngciaglkoonimfcmckehcpafo/"
-                                    << "chrome-extension://oboonakemofpalcgghocfoadofidjkkk/")
+                                    << "chrome-extension://oboonakemofpalcgghocfoadofidjkkk/"
+                                    << "chrome-extension://dfjfhjeobapondnkcplfgoccllgobobb/")
 #if defined(Q_OS_MACOS)
     , TARGET_DIR_CHROME("/Library/Application Support/Google/Chrome/NativeMessagingHosts")
     , TARGET_DIR_CHROMIUM("/Library/Application Support/Chromium/NativeMessagingHosts")


### PR DESCRIPTION
This allows the browser extension to function correctly under Chromium
when it is loaded as an unpacked extension. This ID was generated for a
directory name of keepassxc by the Linux version of it. It may work for
other ports of Chromium but I have no way to test this right now.

## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**

