### PR TITLE
Fix window hiding right after being shown on X11, fix window not minimizing in X11

### DIFF
--- a/src/core/Clock.cpp
+++ b/src/core/Clock.cpp
@@ -34,6 +34,11 @@ uint Clock::currentSecondsSinceEpoch()
     return instance().currentDateTimeImpl().toTime_t();
 }
 
+qint64 Clock::currentMilliSecondsSinceEpoch()
+{
+    return instance().currentDateTimeImpl().toMSecsSinceEpoch();
+}
+
 QDateTime Clock::serialized(const QDateTime& dateTime)
 {
     auto time = dateTime.time();

--- a/src/core/Clock.h
+++ b/src/core/Clock.h
@@ -28,6 +28,7 @@ public:
     static QDateTime currentDateTime();
 
     static uint currentSecondsSinceEpoch();
+    static qint64 currentMilliSecondsSinceEpoch();
 
     static QDateTime serialized(const QDateTime& dateTime);
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -49,6 +49,7 @@
 #include "gui/EntryPreviewWidget.h"
 #include "gui/FileDialog.h"
 #include "gui/KeePass1OpenWidget.h"
+#include "gui/MainWindow.h"
 #include "gui/MessageBox.h"
 #include "gui/OpVaultOpenWidget.h"
 #include "gui/TotpDialog.h"
@@ -677,7 +678,7 @@ void DatabaseWidget::setClipboardTextAndMinimize(const QString& text)
     clipboard()->setText(text);
     if (config()->get("HideWindowOnCopy").toBool()) {
         if (config()->get("MinimizeOnCopy").toBool()) {
-            window()->showMinimized();
+            getMainWindow()->minimizeOrHide();
         } else if (config()->get("DropToBackgroundOnCopy").toBool()) {
             window()->lower();
         }
@@ -782,7 +783,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
             QProcess::startDetached(cmdString.mid(6));
 
             if (config()->get("MinimizeOnOpenUrl").toBool()) {
-                window()->showMinimized();
+                getMainWindow()->minimizeOrHide();
             }
         }
     } else {
@@ -791,7 +792,7 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
             QDesktopServices::openUrl(url);
 
             if (config()->get("MinimizeOnOpenUrl").toBool()) {
-                window()->showMinimized();
+                getMainWindow()->minimizeOrHide();
             }
         }
     }
@@ -972,7 +973,7 @@ void DatabaseWidget::loadDatabase(bool accepted)
         m_saveAttempts = 0;
         emit databaseUnlocked();
         if (config()->get("MinimizeAfterUnlock").toBool()) {
-            window()->showMinimized();
+            getMainWindow()->minimizeOrHide();
         }
     } else {
         if (m_databaseOpenWidget->database()) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -70,7 +70,10 @@ public slots:
     void hideGlobalMessage();
     void showYubiKeyPopup();
     void hideYubiKeyPopup();
+    void hide();
+    void show();
     void hideWindow();
+    void minimizeOrHide();
     void toggleWindow();
     void bringToFront();
     void closeAllDatabases();
@@ -133,6 +136,7 @@ private:
 
     static const QString BaseWindowTitle;
 
+    bool shouldHide();
     void saveWindowInformation();
     bool saveLastDatabases();
     void updateTrayIcon();
@@ -163,7 +167,8 @@ private:
     bool m_appExitCalled = false;
     bool m_appExiting = false;
     bool m_contextMenuFocusLock = false;
-    uint m_lastFocusOutTime = 0;
+    qint64 m_lastFocusOutTime = 0;
+    qint64 m_lastShowTime = 0;
     QTimer m_trayIconTriggerTimer;
     QSystemTrayIcon::ActivationReason m_trayIconTriggerReason;
 };

--- a/src/gui/TotpDialog.cpp
+++ b/src/gui/TotpDialog.cpp
@@ -67,7 +67,7 @@ void TotpDialog::copyToClipboard()
     clipboard()->setText(m_entry->totp());
     if (config()->get("HideWindowOnCopy").toBool()) {
         if (config()->get("MinimizeOnCopy").toBool()) {
-            getMainWindow()->showMinimized();
+            getMainWindow()->minimizeOrHide();
         } else if (config()->get("DropToBackgroundOnCopy").toBool()) {
             getMainWindow()->lower();
             window()->lower();

--- a/src/gui/TotpExportSettingsDialog.cpp
+++ b/src/gui/TotpExportSettingsDialog.cpp
@@ -105,7 +105,7 @@ void TotpExportSettingsDialog::copyToClipboard()
     clipboard()->setText(m_totpUri);
     if (config()->get("HideWindowOnCopy").toBool()) {
         if (config()->get("MinimizeOnCopy").toBool()) {
-            getMainWindow()->showMinimized();
+            getMainWindow()->minimizeOrHide();
         } else if (config()->get("DropToBackgroundOnCopy").toBool()) {
             getMainWindow()->lower();
             window()->lower();


### PR DESCRIPTION
* Bug with window both minimized and hidden is reported in XFCE/LXDE - that is X11 desktops. You can run a X11 desktop on any platform - X11 is portable. Detect running X11 rather than the OS.

* Sometimes the main window hides just after clicking the tray icon to show it.
Add a timer to not hide window immediately after it is shown.

* The workaround for window hiding after shown breaks Windows tests for some reason. Don't apply it on windows. 

* The main window fails to minimize in X11 in some WMs that don't support minimization (in olden days some WMs did not support minimization but minimized windows were simply lost). There is an option for hiding the window in tray instead of minimizing. Honor it.

## Type of change
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

## Testing strategy
This is a race condition in the main window event handling code. No idea how to test. Not reproducible reliably. Sometimes reproduction ratio is like 90% and sometimes like 10%.

## Checklist:
Automated tests pass. Needs some real use testing to see if the issue is gone.