### PR TITLE
Icon downloader button crash fix

### DIFF
--- a/src/core/IconDownloader.cpp
+++ b/src/core/IconDownloader.cpp
@@ -126,6 +126,10 @@ void IconDownloader::setUrl(const QString& entryUrl)
 
 void IconDownloader::download()
 {
+    if (m_urlsToTry.isEmpty()) {
+        return;
+    }
+
     if (!m_timeout.isActive()) {
         int timeout = config()->get("FaviconDownloadTimeout", 10).toInt();
         m_timeout.start(timeout * 1000);


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Adds a missing check for icon downloading. When editing an entry and using the Icon Download button with an invalid URL, the URL list for icon download is empty, and it's never checked.

Fixes https://github.com/keepassxreboot/keepassxc/issues/4352.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**