### PR TITLE
Clear combo box before adding elements. Fixes #4321.

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -142,6 +142,7 @@ void DatabaseOpenWidget::hideEvent(QHideEvent* event)
 
 void DatabaseOpenWidget::load(const QString& filename)
 {
+	clearForms();
     m_filename = filename;
     m_ui->fileNameLabel->setRawText(m_filename);
 


### PR DESCRIPTION
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Clear the combo box of key file before adding elements. 
The reason of #4321 comes from several sources. In the application initialization phase, the following code
```c++
if (m_db->isInitialized()) {
        switchToMainView();
    } else {
        switchToOpenDatabase();
    }
```
from DatabaseWidget constructor calls switchToOpenDatabase() to load last key file from configuration file. Straight after the calling, the member function DatabaseWidget::showEvent calls switchToOpenDatabase() again, which causes duplicated entries in Key File dropdown. I saw the above code in constructor is introduced to fix the issue 3713. 

But this is not the only one reason for #4321. If there are more than two unlocked database tabs, once I click the locker to lock all of them, the member function DatabaseWidget::lock() will be called, which fills Key File dropdown entries for all of the database tabs. For the current tab, everything is fine, once I switch to another tab, the member function DatabaseWidget::showEvent will be called, consequently fills the dropdown entries for the newly shown tab again. As a result, the dropdown entries of Key File are duplicated.

For solving the problem, the easiest way is to simply clear the form before fill it.

Fixes #4321.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
