### PR TITLE
Display database path in root group tooltip

### DIFF
--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -142,6 +142,13 @@ QVariant GroupModel::data(const QModelIndex& index, int role) const
             font.setStrikeOut(true);
         }
         return font;
+    } else if (role == Qt::ToolTipRole) {
+        QString tooltip;
+        if (!group->parentGroup()) {
+            // only show a tooltip for the root group
+            tooltip = m_db->filePath();
+        }
+        return tooltip;
     } else {
         return QVariant();
     }


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Previous behavior: When only one database is open there is no display showing the opened database path and filename.
With this change, mousing over the root group entry will now display the database file path.
Fixes #4038

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![Screenshot_20200228_135052](https://user-images.githubusercontent.com/48535411/75579048-fb590000-5a32-11ea-9233-45bb702024b4.png)



## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual (on KDE)

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**