### PR TITLE
Add DateTime placeholders to AutoType feature

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -684,7 +684,7 @@ bool AutoType::checkSyntax(const QString& string)
     QString allowRepetition = "(?:\\s\\d+)?";
     // the ":" allows custom commands with syntax S:Field
     // exclude BEEP otherwise will be checked as valid
-    QString normalCommands = "(?!BEEP\\s)[A-Z:]*" + allowRepetition;
+    QString normalCommands = "(?!BEEP\\s)[A-Z:_]*" + allowRepetition;
     QString specialLiterals = "[\\^\\%\\(\\)~\\{\\}\\[\\]\\+]" + allowRepetition;
     QString functionKeys = "(?:F[1-9]" + allowRepetition + "|F1[0-2])" + allowRepetition;
     QString numpad = "NUMPAD\\d" + allowRepetition;

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -29,8 +29,8 @@
 
 #include <QDir>
 #include <QRegularExpression>
-#include <utility>
 #include <ctime>
+#include <utility>
 
 const int Entry::DefaultIconNumber = 0;
 const int Entry::ResolveMaximumDepth = 10;
@@ -1228,8 +1228,7 @@ Entry::PlaceholderType Entry::placeholderType(const QString& placeholder) const
         {QStringLiteral("{DT_UTC_DAY}"), PlaceholderType::DateTimeUtcDay},
         {QStringLiteral("{DT_UTC_HOUR}"), PlaceholderType::DateTimeUtcHour},
         {QStringLiteral("{DT_UTC_MINUTE}"), PlaceholderType::DateTimeUtcMinute},
-        {QStringLiteral("{DT_UTC_SECOND}"), PlaceholderType::DateTimeUtcSecond}
-    };
+        {QStringLiteral("{DT_UTC_SECOND}"), PlaceholderType::DateTimeUtcSecond}};
 
     return placeholders.value(placeholder.toUpper(), PlaceholderType::Unknown);
 }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -30,6 +30,7 @@
 #include <QDir>
 #include <QRegularExpression>
 #include <utility>
+#include <ctime>
 
 const int Entry::DefaultIconNumber = 0;
 const int Entry::ResolveMaximumDepth = 10;
@@ -916,9 +917,82 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
     }
     case PlaceholderType::Reference:
         return resolveReferencePlaceholderRecursive(placeholder, maxDepth);
+    case PlaceholderType::DateTimeSimple:
+    case PlaceholderType::DateTimeYear:
+    case PlaceholderType::DateTimeMonth:
+    case PlaceholderType::DateTimeDay:
+    case PlaceholderType::DateTimeHour:
+    case PlaceholderType::DateTimeMinute:
+    case PlaceholderType::DateTimeSecond:
+    case PlaceholderType::DateTimeUtcSimple:
+    case PlaceholderType::DateTimeUtcYear:
+    case PlaceholderType::DateTimeUtcMonth:
+    case PlaceholderType::DateTimeUtcDay:
+    case PlaceholderType::DateTimeUtcHour:
+    case PlaceholderType::DateTimeUtcMinute:
+    case PlaceholderType::DateTimeUtcSecond:
+        return resolveMultiplePlaceholdersRecursive(resolveDateTimePlaceholder(typeOfPlaceholder), maxDepth - 1);
     }
 
     return placeholder;
+}
+
+QString Entry::resolveDateTimePlaceholder(Entry::PlaceholderType placeholderType) const
+{
+    time_t time = std::time(NULL);
+    char date_simple_formatted[50] {};
+    char date_part_formatted[50] {};
+
+    switch (placeholderType) {
+    case PlaceholderType::DateTimeSimple:
+        std::strftime(date_simple_formatted, sizeof(date_simple_formatted), "%Y%m%d%H%M", localtime(&time));
+        break;
+    case PlaceholderType::DateTimeYear:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%Y", localtime(&time));
+        break;
+    case PlaceholderType::DateTimeMonth:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%m", localtime(&time));
+        break;
+    case PlaceholderType::DateTimeDay:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%d", localtime(&time));
+        break;
+    case PlaceholderType::DateTimeHour:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%H", localtime(&time));
+        break;
+    case PlaceholderType::DateTimeMinute:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%M", localtime(&time));
+        break;
+    case PlaceholderType::DateTimeSecond:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%S", localtime(&time));
+        break;
+    case PlaceholderType::DateTimeUtcSimple:
+        std::strftime(date_simple_formatted, sizeof(date_simple_formatted), "%Y%m%d%H%M", gmtime(&time));
+        break;
+    case PlaceholderType::DateTimeUtcYear:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%Y", gmtime(&time));
+        break;
+    case PlaceholderType::DateTimeUtcMonth:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%m", gmtime(&time));
+        break;
+    case PlaceholderType::DateTimeUtcDay:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%d", gmtime(&time));
+        break;
+    case PlaceholderType::DateTimeUtcHour:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%H", gmtime(&time));
+        break;
+    case PlaceholderType::DateTimeUtcMinute:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%M", gmtime(&time));
+        break;
+    case PlaceholderType::DateTimeUtcSecond:
+        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%S", gmtime(&time));
+        break;
+    default: {
+        Q_ASSERT_X(false, "Entry::resolveDateTimePlaceholder", "Bad DateTime placeholder type");
+        break;
+    }
+    }
+
+    return date_simple_formatted[0] == 0x0 ? QString(date_part_formatted) : QString(date_simple_formatted);
 }
 
 QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, int maxDepth) const
@@ -1141,7 +1215,22 @@ Entry::PlaceholderType Entry::placeholderType(const QString& placeholder) const
         {QStringLiteral("{URL:FRAGMENT}"), PlaceholderType::UrlFragment},
         {QStringLiteral("{URL:USERINFO}"), PlaceholderType::UrlUserInfo},
         {QStringLiteral("{URL:USERNAME}"), PlaceholderType::UrlUserName},
-        {QStringLiteral("{URL:PASSWORD}"), PlaceholderType::UrlPassword}};
+        {QStringLiteral("{URL:PASSWORD}"), PlaceholderType::UrlPassword},
+        {QStringLiteral("{DT_SIMPLE}"), PlaceholderType::DateTimeSimple},
+        {QStringLiteral("{DT_YEAR}"), PlaceholderType::DateTimeYear},
+        {QStringLiteral("{DT_MONTH}"), PlaceholderType::DateTimeMonth},
+        {QStringLiteral("{DT_DAY}"), PlaceholderType::DateTimeDay},
+        {QStringLiteral("{DT_HOUR}"), PlaceholderType::DateTimeHour},
+        {QStringLiteral("{DT_MINUTE}"), PlaceholderType::DateTimeMinute},
+        {QStringLiteral("{DT_SECOND}"), PlaceholderType::DateTimeSecond},
+        {QStringLiteral("{DT_UTC_SIMPLE}"), PlaceholderType::DateTimeUtcSimple},
+        {QStringLiteral("{DT_UTC_YEAR}"), PlaceholderType::DateTimeUtcYear},
+        {QStringLiteral("{DT_UTC_MONTH}"), PlaceholderType::DateTimeUtcMonth},
+        {QStringLiteral("{DT_UTC_DAY}"), PlaceholderType::DateTimeUtcDay},
+        {QStringLiteral("{DT_UTC_HOUR}"), PlaceholderType::DateTimeUtcHour},
+        {QStringLiteral("{DT_UTC_MINUTE}"), PlaceholderType::DateTimeUtcMinute},
+        {QStringLiteral("{DT_UTC_SECOND}"), PlaceholderType::DateTimeUtcSecond}
+    };
 
     return placeholders.value(placeholder.toUpper(), PlaceholderType::Unknown);
 }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -940,51 +940,50 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
 QString Entry::resolveDateTimePlaceholder(Entry::PlaceholderType placeholderType) const
 {
     time_t time = std::time(NULL);
-    char date_simple_formatted[50] {};
-    char date_part_formatted[50] {};
+    char date_formatted[50]{};
 
     switch (placeholderType) {
     case PlaceholderType::DateTimeSimple:
-        std::strftime(date_simple_formatted, sizeof(date_simple_formatted), "%Y%m%d%H%M", localtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%Y%m%d%H%M", localtime(&time));
         break;
     case PlaceholderType::DateTimeYear:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%Y", localtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%Y", localtime(&time));
         break;
     case PlaceholderType::DateTimeMonth:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%m", localtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%m", localtime(&time));
         break;
     case PlaceholderType::DateTimeDay:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%d", localtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%d", localtime(&time));
         break;
     case PlaceholderType::DateTimeHour:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%H", localtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%H", localtime(&time));
         break;
     case PlaceholderType::DateTimeMinute:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%M", localtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%M", localtime(&time));
         break;
     case PlaceholderType::DateTimeSecond:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%S", localtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%S", localtime(&time));
         break;
     case PlaceholderType::DateTimeUtcSimple:
-        std::strftime(date_simple_formatted, sizeof(date_simple_formatted), "%Y%m%d%H%M", gmtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%Y%m%d%H%M", gmtime(&time));
         break;
     case PlaceholderType::DateTimeUtcYear:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%Y", gmtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%Y", gmtime(&time));
         break;
     case PlaceholderType::DateTimeUtcMonth:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%m", gmtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%m", gmtime(&time));
         break;
     case PlaceholderType::DateTimeUtcDay:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%d", gmtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%d", gmtime(&time));
         break;
     case PlaceholderType::DateTimeUtcHour:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%H", gmtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%H", gmtime(&time));
         break;
     case PlaceholderType::DateTimeUtcMinute:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%M", gmtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%M", gmtime(&time));
         break;
     case PlaceholderType::DateTimeUtcSecond:
-        std::strftime(date_part_formatted, sizeof(date_part_formatted), "%S", gmtime(&time));
+        std::strftime(date_formatted, sizeof(date_formatted), "%S", gmtime(&time));
         break;
     default: {
         Q_ASSERT_X(false, "Entry::resolveDateTimePlaceholder", "Bad DateTime placeholder type");
@@ -992,7 +991,7 @@ QString Entry::resolveDateTimePlaceholder(Entry::PlaceholderType placeholderType
     }
     }
 
-    return date_simple_formatted[0] == 0x0 ? QString(date_part_formatted) : QString(date_simple_formatted);
+    return QString(date_formatted);
 }
 
 QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, int maxDepth) const

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -29,7 +29,6 @@
 
 #include <QDir>
 #include <QRegularExpression>
-#include <ctime>
 #include <utility>
 
 const int Entry::DefaultIconNumber = 0;
@@ -939,51 +938,52 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
 
 QString Entry::resolveDateTimePlaceholder(Entry::PlaceholderType placeholderType) const
 {
-    time_t time = std::time(NULL);
-    char date_formatted[50]{};
+    QDateTime time = Clock::currentDateTime();
+    QDateTime time_utc = Clock::currentDateTimeUtc();
+    QString date_formatted{};
 
     switch (placeholderType) {
     case PlaceholderType::DateTimeSimple:
-        std::strftime(date_formatted, sizeof(date_formatted), "%Y%m%d%H%M", localtime(&time));
+        date_formatted = time.toString("yyyyMMddhhmmss");
         break;
     case PlaceholderType::DateTimeYear:
-        std::strftime(date_formatted, sizeof(date_formatted), "%Y", localtime(&time));
+        date_formatted = time.toString("yyyy");
         break;
     case PlaceholderType::DateTimeMonth:
-        std::strftime(date_formatted, sizeof(date_formatted), "%m", localtime(&time));
+        date_formatted = time.toString("MM");
         break;
     case PlaceholderType::DateTimeDay:
-        std::strftime(date_formatted, sizeof(date_formatted), "%d", localtime(&time));
+        date_formatted = time.toString("dd");
         break;
     case PlaceholderType::DateTimeHour:
-        std::strftime(date_formatted, sizeof(date_formatted), "%H", localtime(&time));
+        date_formatted = time.toString("hh");
         break;
     case PlaceholderType::DateTimeMinute:
-        std::strftime(date_formatted, sizeof(date_formatted), "%M", localtime(&time));
+        date_formatted = time.toString("mm");
         break;
     case PlaceholderType::DateTimeSecond:
-        std::strftime(date_formatted, sizeof(date_formatted), "%S", localtime(&time));
+        date_formatted = time.toString("ss");
         break;
     case PlaceholderType::DateTimeUtcSimple:
-        std::strftime(date_formatted, sizeof(date_formatted), "%Y%m%d%H%M", gmtime(&time));
+        date_formatted = time_utc.toString("yyyyMMddhhmmss");
         break;
     case PlaceholderType::DateTimeUtcYear:
-        std::strftime(date_formatted, sizeof(date_formatted), "%Y", gmtime(&time));
+        date_formatted = time_utc.toString("yyyy");
         break;
     case PlaceholderType::DateTimeUtcMonth:
-        std::strftime(date_formatted, sizeof(date_formatted), "%m", gmtime(&time));
+        date_formatted = time_utc.toString("MM");
         break;
     case PlaceholderType::DateTimeUtcDay:
-        std::strftime(date_formatted, sizeof(date_formatted), "%d", gmtime(&time));
+        date_formatted = time_utc.toString("dd");
         break;
     case PlaceholderType::DateTimeUtcHour:
-        std::strftime(date_formatted, sizeof(date_formatted), "%H", gmtime(&time));
+        date_formatted = time_utc.toString("hh");
         break;
     case PlaceholderType::DateTimeUtcMinute:
-        std::strftime(date_formatted, sizeof(date_formatted), "%M", gmtime(&time));
+        date_formatted = time_utc.toString("mm");
         break;
     case PlaceholderType::DateTimeUtcSecond:
-        std::strftime(date_formatted, sizeof(date_formatted), "%S", gmtime(&time));
+        date_formatted = time_utc.toString("ss");
         break;
     default: {
         Q_ASSERT_X(false, "Entry::resolveDateTimePlaceholder", "Bad DateTime placeholder type");
@@ -991,7 +991,7 @@ QString Entry::resolveDateTimePlaceholder(Entry::PlaceholderType placeholderType
     }
     }
 
-    return QString(date_formatted);
+    return date_formatted;
 }
 
 QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, int maxDepth) const

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -190,7 +190,21 @@ public:
         UrlUserName,
         UrlPassword,
         Reference,
-        CustomAttribute
+        CustomAttribute,
+        DateTimeSimple,
+        DateTimeYear,
+        DateTimeMonth,
+        DateTimeDay,
+        DateTimeHour,
+        DateTimeMinute,
+        DateTimeSecond,
+        DateTimeUtcSimple,
+        DateTimeUtcYear,
+        DateTimeUtcMonth,
+        DateTimeUtcDay,
+        DateTimeUtcHour,
+        DateTimeUtcMinute,
+        DateTimeUtcSecond
     };
 
     /**
@@ -206,6 +220,7 @@ public:
     QString resolveMultiplePlaceholders(const QString& str) const;
     QString resolvePlaceholder(const QString& str) const;
     QString resolveUrlPlaceholder(const QString& str, PlaceholderType placeholderType) const;
+    QString resolveDateTimePlaceholder(PlaceholderType placeholderType) const;
     PlaceholderType placeholderType(const QString& placeholder) const;
     QString resolveUrl(const QString& url) const;
 


### PR DESCRIPTION
This PR adds support for AutoType DateTime placeholders, in the same way KeePass2 has it.

https://keepass.info/help/base/placeholders.html

PS: This is my first contribution to a C++ project in general and KeePassXC specifically :)

## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
I used DateTime placeholders in KeePass2 all the time, but switched to KeePassXC. So i added the following AutoType placeholders.

Placeholder | Is Replaced By
-- | --
{DT_SIMPLE} | Current local date/time as a simple, sortable string. For example, for 2012-07-25 17:05:34 the value is 20120725170534.
{DT_YEAR} | Year component of the current local date/time.
{DT_MONTH} | Month component of the current local date/time.
{DT_DAY} | Day component of the current local date/time.
{DT_HOUR} | Hour component of the current local date/time.
{DT_MINUTE} | Minute component of the current local date/time.
{DT_SECOND} | Seconds component of the current local date/time.
{DT_UTC_SIMPLE} | Current UTC date/time as a simple, sortable string.
{DT_UTC_YEAR} | Year component of the current UTC date/time.
{DT_UTC_MONTH} | Month component of the current UTC date/time.
{DT_UTC_DAY} | Day component of the current UTC date/time.
{DT_UTC_HOUR} | Hour component of the current UTC date/time.
{DT_UTC_MINUTE} | Minute component of the current UTC date/time.
{DT_UTC_SECOND} | Seconds component of the current UTC date/time.


## Screenshots
- None


## Testing strategy
1. Create a new Database
2. Add a new Entry
3. Add Auto-Type Window Assosiation
    Title: `* - Notepad`
    Use a specific sequence for this assosiation: `DT_SIMPLE: {DT_SIMPLE}{ENTER}DT_YEAR: {DT_YEAR}{ENTER}DT_MONTH: {DT_MONTH}{ENTER}DT_DAY: {DT_DAY}{ENTER}DT_HOUR: {DT_HOUR}{ENTER}DT_MINUTE: {DT_MINUTE}{ENTER}DT_SECOND: {DT_SECOND}{ENTER}DT_UTC_SIMPLE: {DT_UTC_SIMPLE}{ENTER}DT_UTC_YEAR: {DT_UTC_YEAR}{ENTER}DT_UTC_MONTH: {DT_UTC_MONTH}{ENTER}DT_UTC_DAY: {DT_UTC_DAY}{ENTER}DT_UTC_HOUR: {DT_UTC_HOUR}{ENTER}DT_UTC_MINUTE: {DT_UTC_MINUTE}{ENTER}DT_UTC_SECOND: {DT_UTC_SECOND}`
4. Enable Global Auto-Type
5. Define Global Auto-Type shortcut
6. Open Notepad
7. Perform Auto-Type via Global Auto-Type shortcut

Expected (example) result, for DateTime `Sun, 08 Mar 2020 18:11:43 GMT` and local timezone UTC +0100:
```
DT_SIMPLE: 20200308191143
DT_YEAR: 2020
DT_MONTH: 03
DT_DAY: 08
DT_HOUR: 19
DT_MINUTE: 11
DT_SECOND: 43
DT_UTC_SIMPLE: 20200308181143
DT_UTC_YEAR: 2020
DT_UTC_MONTH: 03
DT_UTC_DAY: 08
DT_UTC_HOUR: 18
DT_UTC_MINUTE: 11
DT_UTC_SECOND: 43
```

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
