### PR TITLE
May be the gcovr should be added to Build Dependencies section?

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@ The following tools must exist within your PATH:
 * make
 * cmake (>= 2.8.12)
 * g++ (>= 4.7) or clang++ (>= 3.0)
+* gcovr
 
 The following libraries are required:
 


### PR DESCRIPTION
I tried to compile but i got errors till i installed gcovr (`sudo apt-get install gcovr` at Ubuntu 18.04)
And please add this to wiki page too for `sudo apt-get install`
Thanks!
