### PR TITLE
Add back missing initializers to KeeAgentSettings

### DIFF
--- a/src/sshagent/KeeAgentSettings.cpp
+++ b/src/sshagent/KeeAgentSettings.cpp
@@ -19,12 +19,6 @@
 #include "KeeAgentSettings.h"
 #include "core/Tools.h"
 
-KeeAgentSettings::KeeAgentSettings()
-    : m_lifetimeConstraintDuration(600)
-    , m_selectedType(QString("file"))
-{
-}
-
 bool KeeAgentSettings::operator==(const KeeAgentSettings& other) const
 {
     // clang-format off

--- a/src/sshagent/KeeAgentSettings.h
+++ b/src/sshagent/KeeAgentSettings.h
@@ -27,8 +27,6 @@
 class KeeAgentSettings
 {
 public:
-    KeeAgentSettings();
-
     bool operator==(const KeeAgentSettings& other) const;
     bool operator!=(const KeeAgentSettings& other) const;
     bool isDefault() const;
@@ -72,17 +70,17 @@ private:
     bool readBool(QXmlStreamReader& reader);
     int readInt(QXmlStreamReader& reader);
 
-    bool m_allowUseOfSshKey;
-    bool m_addAtDatabaseOpen;
-    bool m_removeAtDatabaseClose;
-    bool m_useConfirmConstraintWhenAdding;
-    bool m_useLifetimeConstraintWhenAdding;
-    int m_lifetimeConstraintDuration;
+    bool m_allowUseOfSshKey = false;
+    bool m_addAtDatabaseOpen = false;
+    bool m_removeAtDatabaseClose = false;
+    bool m_useConfirmConstraintWhenAdding = false;
+    bool m_useLifetimeConstraintWhenAdding = false;
+    int m_lifetimeConstraintDuration = 600;
 
     // location
-    QString m_selectedType;
+    QString m_selectedType = QString("file");
     QString m_attachmentName;
-    bool m_saveAttachmentToTempFile;
+    bool m_saveAttachmentToTempFile = false;
     QString m_fileName;
     QString m_error;
 };


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )
Since #3833 was merged, `KeeAgentSettings` was not properly initialized and caused random _KeeAgent.settings_ attachments on every new entry.

Luckily @droidmonkey picked this up before even before any pre-release was made.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing strategy
Quick testing by hand.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
