### PR TITLE
Deactivate read-only mode autodetection. Fixes #803.

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -120,11 +120,14 @@ bool Database::open(const QString& filePath, QSharedPointer<const CompositeKey> 
         return false;
     }
 
-    if (!readOnly && !dbFile.open(QIODevice::ReadWrite)) {
-        readOnly = true;
-    }
-
-    if (!dbFile.isOpen() && !dbFile.open(QIODevice::ReadOnly)) {
+    // Don't autodetect read-only mode, as it triggers an upstream bug.
+    // See https://github.com/keepassxreboot/keepassxc/issues/803
+    // if (!readOnly && !dbFile.open(QIODevice::ReadWrite)) {
+    //     readOnly = true;
+    // }
+    //
+    // if (!dbFile.isOpen() && !dbFile.open(QIODevice::ReadOnly)) {
+    if (!dbFile.open(QIODevice::ReadOnly)) {
         if (error) {
             *error = tr("Unable to open file %1.").arg(filePath);
         }


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
This removes read-only mode.

The underlying motivation is #803 (and maybe #1937), where a qt bug triggers keepassxc to always open in read-only mode on some filesystems. I am also guessing that read-only mode is vestigial, and may be removed to work around the bug.

As I explained [my comment on the issue](https://github.com/keepassxreboot/keepassxc/issues/803#issuecomment-605207384), read-only mode seems to not be fully functional. I can't find any documentation on read-only mode or its place in the vision of multi-user / multi-client support in KeePassXC; my inference is that read-only mode is part of an old "office-style" mandatory explicit locking mechanism, and KeeShare is the new mechanism.

If I got the vision wrong, please let me know. I find it's often easiest to start a conversation with a PR.

Fixes #803

## Testing strategy
I ran the existing unit tests and verified that I can open existing databases via gvfs and work with them normally, per #803.

## Checklist:
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ My change requires a change to the documentation, and I have updated it accordingly.
- ✅ I have added tests to cover my changes.