### PR TITLE
WIP: Automated sample screenshots from GUI tests

### DIFF
--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1594,15 +1594,13 @@ bool TestGui::screenshot(const QString& baseName)
     }
 
     QScreen* screen = QGuiApplication::screens()[QApplication::desktop()->screenNumber()];
-    QRect geometry = m_mainWindow->geometry();
-    QRect frameGeometry = m_mainWindow->frameGeometry();
 
     QPixmap pixmap = screen->grabWindow(
-            m_mainWindow->winId(),
-            frameGeometry.x() - geometry.x(),
-            frameGeometry.y() - geometry.y(),
-            frameGeometry.width(),
-            frameGeometry.height());
+            0,
+            m_mainWindow->x(),
+            m_mainWindow->y(),
+            m_mainWindow->frameGeometry().width(),
+            m_mainWindow->frameGeometry().height());
 
     qDebug() << "Saving screenshot as " << screenshotFile;
 

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -48,6 +48,7 @@ private slots:
     void cleanup();
     void cleanupTestCase();
 
+    void testWelcomeScreen();
     void testSettingsDefaultTabOrder();
     void testCreateDatabase();
     void testMergeDatabase();
@@ -88,6 +89,7 @@ private:
                     QAbstractItemView* view,
                     Qt::MouseButton button,
                     Qt::KeyboardModifiers stateKey = 0);
+    bool screenshot(const QString& baseName);
 
     QScopedPointer<MainWindow> m_mainWindow;
     QPointer<DatabaseTabWidget> m_tabWidget;


### PR DESCRIPTION
While we are converting the documentation from a static PDF into AsciiDoc it would be *really* nice to have automated screenshots from the program that are taken during GUI tests and slapped in the documentation. It will help us a lot during the release process and to keep the screenshots in the documentation up-to-date.

In this WIP PR I have cobbled together some screenshots automatically to get a feeling if this is feasible. It is possible to use headless Xvfb and any window decorator to get a consistent style we are looking for.

This way we can generate most generic screenshots, some platform specific ones need to be updated manually.

Taking screenshots is conditional behind _GUI_SCREENSHOT_DIR_ environment variable so it doesn't affect normal automated test runs.

As an added bonus this forces the creation of GUI tests for features that need screenshots :tada:

Example snippet of a test run with _GUI_SCREENSHOT_DIR_ set.
```
QDEBUG : TestGui::testCreateDatabase() Grabbing screenshot in a second...
QDEBUG : TestGui::testCreateDatabase() Saving screenshot as  "/home/hifi/work/keepassxc/build/create-database.png"
QDEBUG : TestGui::testCreateDatabase() Grabbing screenshot in a second...
QDEBUG : TestGui::testCreateDatabase() Saving screenshot as  "/home/hifi/work/keepassxc/build/create-database-encryption.png"
QDEBUG : TestGui::testCreateDatabase() Grabbing screenshot in a second...
QDEBUG : TestGui::testCreateDatabase() Saving screenshot as  "/home/hifi/work/keepassxc/build/create-database-encryption-advanced.png"
QDEBUG : TestGui::testCreateDatabase() Grabbing screenshot in a second...
QDEBUG : TestGui::testCreateDatabase() Saving screenshot as  "/home/hifi/work/keepassxc/build/create-database-keys.png"
QDEBUG : TestGui::testCreateDatabase() Grabbing screenshot in a second...
QDEBUG : TestGui::testCreateDatabase() Saving screenshot as  "/home/hifi/work/keepassxc/build/create-database-keys-additional.png"
```
The actual changes to GUI tests to have a clean welcome screen and database creation flow are a bit hacky but the overall changes are very minimal.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Screenshots
Sample test run on Xfce4 with Numix theme:

![image](https://user-images.githubusercontent.com/106598/77843539-d2996700-71a6-11ea-9634-77ce3e15f835.png)
![image](https://user-images.githubusercontent.com/106598/77843542-d88f4800-71a6-11ea-9858-f03fe6f73192.png)
![image](https://user-images.githubusercontent.com/106598/77843543-ddec9280-71a6-11ea-90c8-36285a6e231a.png)
![image](https://user-images.githubusercontent.com/106598/77843546-dfb65600-71a6-11ea-9007-1d9acdcd4c50.png)
![image](https://user-images.githubusercontent.com/106598/77843548-e3e27380-71a6-11ea-9462-48fcdbdc448e.png)
![image](https://user-images.githubusercontent.com/106598/77843562-05435f80-71a7-11ea-8694-48d183ec5213.png)
![image](https://user-images.githubusercontent.com/106598/77843553-f0ff6280-71a6-11ea-999b-1929d06c0c31.png)
![image](https://user-images.githubusercontent.com/106598/77843554-f2c92600-71a6-11ea-8fe5-007ce71756c3.png)



## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
