### PR TITLE
SSH Agent: Track which database owns a key for remove-on-lock

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -221,8 +221,8 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
 
 #ifdef WITH_XC_SSHAGENT
     if (sshAgent()->isEnabled()) {
-        connect(this, SIGNAL(databaseLocked()), sshAgent(), SLOT(databaseModeChanged()));
-        connect(this, SIGNAL(databaseUnlocked()), sshAgent(), SLOT(databaseModeChanged()));
+        connect(this, SIGNAL(databaseLockRequested()), sshAgent(), SLOT(databaseLocked()));
+        connect(this, SIGNAL(databaseUnlocked()), sshAgent(), SLOT(databaseUnlocked()));
     }
 #endif
 
@@ -739,7 +739,7 @@ void DatabaseWidget::addToAgent()
 
     OpenSSHKey key;
     if (settings.toOpenSSHKey(currentEntry, key, true)) {
-        SSHAgent::instance()->addIdentity(key, settings);
+        SSHAgent::instance()->addIdentity(key, settings, database()->uuid());
     } else {
         m_messageWidget->showMessage(key.errorString(), MessageWidget::Error);
     }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -695,7 +695,7 @@ void EditEntryWidget::addKeyToAgent()
     KeeAgentSettings settings;
     toKeeAgentSettings(settings);
 
-    if (!sshAgent()->addIdentity(key, settings)) {
+    if (!sshAgent()->addIdentity(key, settings, m_db->uuid())) {
         showMessage(sshAgent()->errorString(), MessageWidget::Error);
         return;
     }

--- a/src/sshagent/SSHAgent.h
+++ b/src/sshagent/SSHAgent.h
@@ -47,9 +47,9 @@ public:
 
     const QString errorString() const;
     bool isAgentRunning() const;
-    bool addIdentity(OpenSSHKey& key, KeeAgentSettings& settings);
+    bool addIdentity(OpenSSHKey& key, const KeeAgentSettings& settings, const QUuid& databaseUuid);
     bool listIdentities(QList<QSharedPointer<OpenSSHKey>>& list);
-    bool checkIdentity(OpenSSHKey& key, bool& loaded);
+    bool checkIdentity(const OpenSSHKey& key, bool& loaded);
     bool removeIdentity(OpenSSHKey& key);
     void removeAllIdentities();
     void setAutoRemoveOnLock(const OpenSSHKey& key, bool autoRemove);
@@ -59,7 +59,8 @@ signals:
     void enabledChanged(bool enabled);
 
 public slots:
-    void databaseModeChanged();
+    void databaseLocked();
+    void databaseUnlocked();
 
 private:
     const quint8 SSH_AGENT_FAILURE = 5;
@@ -81,7 +82,7 @@ private:
     const quint32 AGENT_COPYDATA_ID = 0x804e50ba;
 #endif
 
-    QHash<OpenSSHKey, bool> m_addedKeys;
+    QHash<OpenSSHKey, QPair<QUuid, bool>> m_addedKeys;
     QString m_error;
 };
 

--- a/tests/TestSSHAgent.cpp
+++ b/tests/TestSSHAgent.cpp
@@ -119,8 +119,15 @@ void TestSSHAgent::testIdentity()
     bool keyInAgent;
 
     // test adding a key works
-    QVERIFY(agent.addIdentity(m_key, settings));
+    QVERIFY(agent.addIdentity(m_key, settings, m_uuid));
     QVERIFY(agent.checkIdentity(m_key, keyInAgent) && keyInAgent);
+
+    // test non-conflicting key ownership doesn't throw an error
+    QVERIFY(agent.addIdentity(m_key, settings, m_uuid));
+
+    // test conflicting key ownership throws an error
+    QUuid secondUuid("{11111111-1111-1111-1111-111111111111}");
+    QVERIFY(!agent.addIdentity(m_key, settings, secondUuid));
 
     // test removing a key works
     QVERIFY(agent.removeIdentity(m_key));
@@ -139,7 +146,7 @@ void TestSSHAgent::testRemoveOnClose()
     bool keyInAgent;
 
     settings.setRemoveAtDatabaseClose(true);
-    QVERIFY(agent.addIdentity(m_key, settings));
+    QVERIFY(agent.addIdentity(m_key, settings, m_uuid));
     QVERIFY(agent.checkIdentity(m_key, keyInAgent) && keyInAgent);
     agent.setEnabled(false);
     QVERIFY(agent.checkIdentity(m_key, keyInAgent) && !keyInAgent);
@@ -160,7 +167,7 @@ void TestSSHAgent::testLifetimeConstraint()
     settings.setLifetimeConstraintDuration(2); // two seconds
 
     // identity should be in agent immediately after adding
-    QVERIFY(agent.addIdentity(m_key, settings));
+    QVERIFY(agent.addIdentity(m_key, settings, m_uuid));
     QVERIFY(agent.checkIdentity(m_key, keyInAgent) && keyInAgent);
 
     QElapsedTimer timer;
@@ -193,7 +200,7 @@ void TestSSHAgent::testConfirmConstraint()
 
     settings.setUseConfirmConstraintWhenAdding(true);
 
-    QVERIFY(agent.addIdentity(m_key, settings));
+    QVERIFY(agent.addIdentity(m_key, settings, m_uuid));
 
     // we can't test confirmation itself is working but we can test the agent accepts the key
     QVERIFY(agent.checkIdentity(m_key, keyInAgent) && keyInAgent);

--- a/tests/TestSSHAgent.h
+++ b/tests/TestSSHAgent.h
@@ -41,6 +41,7 @@ private:
     QString m_agentSocketFileName;
     QProcess m_agentProcess;
     OpenSSHKey m_key;
+    QUuid m_uuid;
 };
 
 #endif // TESTSSHAGENT_H


### PR DESCRIPTION
We did not track which database "owned" what key so when any database is closed/locked all keys that had remove-on-lock set were cleared from the agent.

This change adds database UUID tracking when adding keys and outright refuses to add the same key from two different databases for simplicity. Null QUuid can be and is used for testing.

Signals and slots had to be refactored to use the `databaseLockRequested` signal to detect a lock request as `databaseLocked` was emitted after the Database object was cleared from data which also changed the UUID.

Additionally const'd some SSHAgent arguments.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes #4532

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added unit test works, manual testing by closing and opening databases by hand.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have added tests to cover my changes.
