### PR TITLE
Hide notes in entry view when hidden in preview panel

### DIFF
--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -185,8 +185,12 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             }
             return result;
         case Notes:
-            // Display only first line of notes in simplified format
-            result = entry->notes().section("\n", 0, 0).simplified();
+            // Display only first line of notes in simplified format if not hidden
+            if (config()->get("security/hidenotes").toBool()) {
+                result = EntryModel::HiddenContentDisplay;
+            } else {
+                result = entry->notes().section("\n", 0, 0).simplified();
+            }
             if (attr->isReference(EntryAttributes::NotesKey)) {
                 result.prepend(tr("Ref: ", "Reference abbreviation"));
             }


### PR DESCRIPTION
## Type of change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
- Notes are hidden in preview panel when set to mask on default, but not in the entry view. This checks if notes are set to be hidden and masks them in the entry view if so.

- Fixes #4412 

## Screenshots
![beforehidden](https://user-images.githubusercontent.com/20828023/78422953-02c28900-7631-11ea-8fc6-35a2b0bf7233.png)

![afterhidden](https://user-images.githubusercontent.com/20828023/78422960-0c4bf100-7631-11ea-9177-58b263700ecd.png)

## Testing strategy
Unit and manual testing

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
