### PR TITLE
SSH Agent: Fix attachment data not updating before apply

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -673,7 +673,11 @@ bool EditEntryWidget::getOpenSSHKey(OpenSSHKey& key, bool decrypt)
         return false;
     }
 
-    if (!settings.toOpenSSHKey(m_entry, key, decrypt)) {
+    if (!settings.toOpenSSHKey(m_mainUi->usernameComboBox->lineEdit()->text(),
+                               m_mainUi->passwordEdit->text(),
+                               m_advancedUi->attachmentsWidget->entryAttachments(),
+                               key,
+                               decrypt)) {
         showMessage(settings.errorString(), MessageWidget::Error);
         return false;
     }

--- a/src/sshagent/KeeAgentSettings.h
+++ b/src/sshagent/KeeAgentSettings.h
@@ -20,6 +20,7 @@
 #define KEEAGENTSETTINGS_H
 
 #include "core/Entry.h"
+#include "core/EntryAttachments.h"
 #include "crypto/ssh/OpenSSHKey.h"
 #include <QXmlStreamReader>
 #include <QtCore>
@@ -39,6 +40,11 @@ public:
     void toEntry(Entry* entry) const;
     bool keyConfigured() const;
     bool toOpenSSHKey(const Entry* entry, OpenSSHKey& key, bool decrypt);
+    bool toOpenSSHKey(const QString& username,
+                      const QString& password,
+                      const EntryAttachments* attachments,
+                      OpenSSHKey& key,
+                      bool decrypt);
 
     const QString errorString() const;
 


### PR DESCRIPTION
Entry attachments are updated only after apply and the refactored agent code depended on Entry. This fix introduces the least amount of dependencies to KeeAgentSettings while keeping the functionality identical.

[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change which fixes an issue)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Fixes regression since #3833 was merged

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual clicking through entry settings

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
