### PR TITLE
 Change settings checkbox texts to positive phrasing, fixed merge conflicts

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -39,6 +39,14 @@ static const QMap<QString, QString> deprecationMap = {
     {QStringLiteral("GUI/DetailSplitterState"), QStringLiteral("GUI/PreviewSplitterState")},
     // >2.3.4
     {QStringLiteral("security/IconDownloadFallbackToGoogle"), QStringLiteral("security/IconDownloadFallback")},
+    // >x.x.x
+    {QStringLiteral("IgnoreGroupExpansion"), QStringLiteral("TrackNonDataChanges")},
+    // >x.x.x
+    {QStringLiteral("security/passwordsrepeat"), QStringLiteral("security/passwordsrepeatvisible")},
+    // >x.x.x
+    {QStringLiteral("security/passwordscleartext"), QStringLiteral("security/passwordshidden")},
+    // >x.x.x
+    {QStringLiteral("security/passwordemptynodots"), QStringLiteral("security/passwordemptyplaceholder")},
 };
 
 QPointer<Config> Config::m_instance(nullptr);
@@ -102,9 +110,18 @@ void Config::upgrade()
     for (const auto& setting : keys) {
         if (m_settings->contains(setting)) {
             if (!deprecationMap.value(setting).isEmpty()) {
-                // Add entry with new name and old entry's value
-                m_settings->setValue(deprecationMap.value(setting), m_settings->value(setting));
+                if (setting == QStringLiteral("IgnoreGroupExpansion")
+                    || setting == QStringLiteral("security/passwordsrepeat")
+                    || setting == QStringLiteral("security/passwordscleartext")
+                    || setting == QStringLiteral("security/passwordemptynodots")) {
+                    // Keep user's original setting for checkboxes whose meanings were reversed
+                    m_settings->setValue(deprecationMap.value(setting), !m_settings->value(setting).toBool());
+                } else {
+                    // Add entry with new name and old entry's value
+                    m_settings->setValue(deprecationMap.value(setting), m_settings->value(setting));
+                }
             }
+
             m_settings->remove(setting);
         }
     }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -201,7 +201,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("AutoTypeDelay", 25);
     m_defaults.insert("AutoTypeStartDelay", 500);
     m_defaults.insert("UseGroupIconOnEntryCreation", true);
-    m_defaults.insert("IgnoreGroupExpansion", true);
+    m_defaults.insert("TrackNonDataChanges", false);
     m_defaults.insert("FaviconDownloadTimeout", 10);
     m_defaults.insert("security/clearclipboard", true);
     m_defaults.insert("security/clearclipboardtimeout", 10);
@@ -211,9 +211,9 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/lockdatabaseidlesec", 240);
     m_defaults.insert("security/lockdatabaseminimize", false);
     m_defaults.insert("security/lockdatabasescreenlock", true);
-    m_defaults.insert("security/passwordsrepeat", false);
-    m_defaults.insert("security/passwordscleartext", false);
-    m_defaults.insert("security/passwordemptynodots", true);
+    m_defaults.insert("security/passwordsrepeatvisible", true);
+    m_defaults.insert("security/passwordshidden", true);
+    m_defaults.insert("security/passwordemptyplaceholder", false);
     m_defaults.insert("security/HidePasswordPreviewPanel", true);
     m_defaults.insert("security/autotypeask", true);
     m_defaults.insert("security/IconDownloadFallback", false);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -364,7 +364,7 @@ void Group::setExpanded(bool expanded)
 {
     if (m_data.isExpanded != expanded) {
         m_data.isExpanded = expanded;
-        if (config()->get("IgnoreGroupExpansion").toBool()) {
+        if (!config()->get("TrackNonDataChanges").toBool()) {
             updateTimeinfo();
             return;
         }

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -191,7 +191,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->useGroupIconOnEntryCreationCheckBox->setChecked(config()->get("UseGroupIconOnEntryCreation").toBool());
     m_generalUi->autoTypeEntryTitleMatchCheckBox->setChecked(config()->get("AutoTypeEntryTitleMatch").toBool());
     m_generalUi->autoTypeEntryURLMatchCheckBox->setChecked(config()->get("AutoTypeEntryURLMatch").toBool());
-    m_generalUi->ignoreGroupExpansionCheckBox->setChecked(config()->get("IgnoreGroupExpansion").toBool());
+    m_generalUi->trackNonDataChangesCheckBox->setChecked(config()->get("TrackNonDataChanges").toBool());
     m_generalUi->faviconTimeoutSpinBox->setValue(config()->get("FaviconDownloadTimeout").toInt());
 
     if (!m_generalUi->hideWindowOnCopyCheckBox->isChecked()) {
@@ -267,10 +267,10 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->relockDatabaseAutoTypeCheckBox->setChecked(config()->get("security/relockautotype").toBool());
     m_secUi->fallbackToSearch->setChecked(config()->get("security/IconDownloadFallback").toBool());
 
-    m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
-    m_secUi->passwordShowDotsCheckBox->setChecked(config()->get("security/passwordemptynodots").toBool());
+    m_secUi->passwordsHiddenCheckBox->setChecked(config()->get("security/passwordshidden").toBool());
+    m_secUi->passwordShowDotsCheckBox->setChecked(config()->get("security/passwordemptyplaceholder").toBool());
     m_secUi->passwordPreviewCleartextCheckBox->setChecked(config()->get("security/HidePasswordPreviewPanel").toBool());
-    m_secUi->passwordRepeatCheckBox->setChecked(config()->get("security/passwordsrepeat").toBool());
+    m_secUi->passwordsRepeatVisibleCheckBox->setChecked(config()->get("security/passwordsrepeatvisible").toBool());
     m_secUi->hideNotesCheckBox->setChecked(config()->get("security/hidenotes").toBool());
 
     m_secUi->touchIDResetCheckBox->setChecked(config()->get("security/resettouchid").toBool());
@@ -308,7 +308,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set("MinimizeOnCopy", m_generalUi->minimizeOnCopyRadioButton->isChecked());
     config()->set("DropToBackgroundOnCopy", m_generalUi->dropToBackgroundOnCopyRadioButton->isChecked());
     config()->set("UseGroupIconOnEntryCreation", m_generalUi->useGroupIconOnEntryCreationCheckBox->isChecked());
-    config()->set("IgnoreGroupExpansion", m_generalUi->ignoreGroupExpansionCheckBox->isChecked());
+    config()->set("TrackNonDataChanges", m_generalUi->trackNonDataChangesCheckBox->isChecked());
     config()->set("AutoTypeEntryTitleMatch", m_generalUi->autoTypeEntryTitleMatchCheckBox->isChecked());
     config()->set("AutoTypeEntryURLMatch", m_generalUi->autoTypeEntryURLMatchCheckBox->isChecked());
     config()->set("FaviconDownloadTimeout", m_generalUi->faviconTimeoutSpinBox->value());
@@ -353,11 +353,11 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set("security/relockautotype", m_secUi->relockDatabaseAutoTypeCheckBox->isChecked());
     config()->set("security/IconDownloadFallback", m_secUi->fallbackToSearch->isChecked());
 
-    config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
-    config()->set("security/passwordemptynodots", m_secUi->passwordShowDotsCheckBox->isChecked());
+    config()->set("security/passwordshidden", m_secUi->passwordsHiddenCheckBox->isChecked());
+    config()->set("security/passwordemptyplaceholder", m_secUi->passwordShowDotsCheckBox->isChecked());
 
     config()->set("security/HidePasswordPreviewPanel", m_secUi->passwordPreviewCleartextCheckBox->isChecked());
-    config()->set("security/passwordsrepeat", m_secUi->passwordRepeatCheckBox->isChecked());
+    config()->set("security/passwordsrepeatvisible", m_secUi->passwordsRepeatVisibleCheckBox->isChecked());
     config()->set("security/hidenotes", m_secUi->hideNotesCheckBox->isChecked());
 
     config()->set("security/resettouchid", m_secUi->touchIDResetCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -223,9 +223,9 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="ignoreGroupExpansionCheckBox">
+           <widget class="QCheckBox" name="trackNonDataChangesCheckBox">
             <property name="text">
-             <string>Don't mark database as modified for non-data changes (e.g., expanding groups)</string>
+             <string>Mark database as modified for non-data changes (e.g., expanding groups)</string>
             </property>
            </widget>
           </item>

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>595</width>
-    <height>541</height>
+    <height>567</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -223,23 +223,23 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="passwordRepeatCheckBox">
+       <widget class="QCheckBox" name="passwordsRepeatVisibleCheckBox">
         <property name="text">
-         <string>Don't require password repeat when it is visible</string>
+         <string>Require password repeat when it is visible</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="passwordCleartextCheckBox">
+       <widget class="QCheckBox" name="passwordsHiddenCheckBox">
         <property name="text">
-         <string>Don't hide passwords when editing them</string>
+         <string>Hide passwords when editing them</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="passwordShowDotsCheckBox">
         <property name="text">
-         <string>Don't use placeholder for empty password fields</string>
+         <string>Use placeholder for empty password fields</string>
         </property>
        </widget>
       </item>
@@ -302,8 +302,8 @@
   <tabstop>touchIDResetOnScreenLockCheckBox</tabstop>
   <tabstop>lockDatabaseMinimizeCheckBox</tabstop>
   <tabstop>relockDatabaseAutoTypeCheckBox</tabstop>
-  <tabstop>passwordRepeatCheckBox</tabstop>
-  <tabstop>passwordCleartextCheckBox</tabstop>
+  <tabstop>passwordsRepeatVisibleCheckBox</tabstop>
+  <tabstop>passwordsHiddenCheckBox</tabstop>
   <tabstop>passwordShowDotsCheckBox</tabstop>
   <tabstop>passwordPreviewCleartextCheckBox</tabstop>
   <tabstop>hideNotesCheckBox</tabstop>

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -186,7 +186,7 @@ void EntryPreviewWidget::setPasswordVisible(bool state)
     if (state) {
         m_ui->entryPasswordLabel->setText(password);
         m_ui->entryPasswordLabel->setCursorPosition(0);
-    } else if (password.isEmpty() && config()->get("security/passwordemptynodots").toBool()) {
+    } else if (password.isEmpty() && !config()->get("security/passwordemptyplaceholder").toBool()) {
         m_ui->entryPasswordLabel->setText("");
     } else {
         m_ui->entryPasswordLabel->setText(QString("\u25cf").repeated(6));

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -212,6 +212,8 @@ void EntryPreviewWidget::setNotesVisible(QTextEdit* notesWidget, const QString& 
     } else {
         if (!notes.isEmpty()) {
             notesWidget->setPlainText(QString("\u25cf").repeated(6));
+        } else {
+            notesWidget->clear();
         }
     }
 }
@@ -235,12 +237,12 @@ void EntryPreviewWidget::updateEntryGeneralTab()
     }
 
     if (config()->get("security/hidenotes").toBool()) {
-        setEntryNotesVisible(false);
-        m_ui->toggleEntryNotesButton->setVisible(!m_ui->entryNotesTextEdit->toPlainText().isEmpty());
+        m_ui->toggleEntryNotesButton->setVisible(!m_currentEntry->notes().isEmpty());
         m_ui->toggleEntryNotesButton->setChecked(false);
+        setEntryNotesVisible(false);
     } else {
-        setEntryNotesVisible(true);
         m_ui->toggleEntryNotesButton->setVisible(false);
+        setEntryNotesVisible(true);
     }
 
     if (config()->get("GUI/MonospaceNotes", false).toBool()) {
@@ -331,12 +333,12 @@ void EntryPreviewWidget::updateGroupGeneralTab()
     m_ui->groupExpirationLabel->setText(expiresText);
 
     if (config()->get("security/hidenotes").toBool()) {
-        setGroupNotesVisible(false);
-        m_ui->toggleGroupNotesButton->setVisible(!m_ui->groupNotesTextEdit->toPlainText().isEmpty());
+        m_ui->toggleGroupNotesButton->setVisible(!m_currentGroup->notes().isEmpty());
         m_ui->toggleGroupNotesButton->setChecked(false);
+        setGroupNotesVisible(false);
     } else {
-        setGroupNotesVisible(true);
         m_ui->toggleGroupNotesButton->setVisible(false);
+        setGroupNotesVisible(true);
     }
 
     if (config()->get("GUI/MonospaceNotes", false).toBool()) {

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -110,7 +110,7 @@ void PasswordEdit::setShowPassword(bool show)
 
     if (m_repeatPasswordEdit) {
         m_repeatPasswordEdit->setEchoMode(show ? QLineEdit::Normal : QLineEdit::Password);
-        if (config()->get("security/passwordsrepeat").toBool()) {
+        if (!config()->get("security/passwordsrepeatvisible").toBool()) {
             m_repeatPasswordEdit->setEnabled(!show);
             m_repeatPasswordEdit->setText(text());
         } else {
@@ -174,7 +174,7 @@ void PasswordEdit::updateRepeatStatus()
 
 void PasswordEdit::autocompletePassword(const QString& password)
 {
-    if (config()->get("security/passwordsrepeat").toBool() && echoMode() == QLineEdit::Normal) {
+    if (!config()->get("security/passwordsrepeatvisible").toBool() && echoMode() == QLineEdit::Normal) {
         setText(password);
     }
 }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -846,6 +846,7 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_mainUi->expireCheck->setChecked(entry->timeInfo().expires());
     m_mainUi->expireDatePicker->setDateTime(entry->timeInfo().expiryTime().toLocalTime());
     m_mainUi->expirePresets->setEnabled(!m_history);
+    m_mainUi->togglePasswordButton->setChecked(!config()->get("security/passwordshidden").toBool());
 
     QList<QString> commonUsernames = m_db->commonUsernames();
     m_usernameCompleterModel->setStringList(commonUsernames);

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -839,14 +839,13 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_mainUi->usernameComboBox->lineEdit()->setText(entry->username());
     m_mainUi->urlEdit->setText(entry->url());
     m_mainUi->passwordEdit->setText(entry->password());
-    m_mainUi->passwordEdit->setShowPassword(config()->get("security/passwordscleartext").toBool());
+    m_mainUi->passwordEdit->setShowPassword(!config()->get("security/passwordshidden").toBool());
     if (!m_history) {
         m_mainUi->passwordEdit->enablePasswordGenerator();
     }
     m_mainUi->expireCheck->setChecked(entry->timeInfo().expires());
     m_mainUi->expireDatePicker->setDateTime(entry->timeInfo().expiryTime().toLocalTime());
     m_mainUi->expirePresets->setEnabled(!m_history);
-    m_mainUi->togglePasswordButton->setChecked(!config()->get("security/passwordshidden").toBool());
 
     QList<QString> commonUsernames = m_db->commonUsernames();
     m_usernameCompleterModel->setStringList(commonUsernames);

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -174,7 +174,7 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             if (attr->isReference(EntryAttributes::PasswordKey)) {
                 result.prepend(tr("Ref: ", "Reference abbreviation"));
             }
-            if (entry->password().isEmpty() && config()->get("security/passwordemptynodots").toBool()) {
+            if (entry->password().isEmpty() && !config()->get("security/passwordemptyplaceholder").toBool()) {
                 result = "";
             }
             return result;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -221,6 +221,9 @@ add_unit_test(NAME testdatabase SOURCES TestDatabase.cpp
 
 add_unit_test(NAME testtools SOURCES TestTools.cpp
         LIBS ${TEST_LIBRARIES})
+        
+add_unit_test(NAME testconfig SOURCES TestConfig.cpp
+        LIBS testsupport ${TEST_LIBRARIES})
 
 if(WITH_XC_FDOSECRETS)
     add_unit_test(NAME testfdosecrets SOURCES TestFdoSecrets.cpp

--- a/tests/TestConfig.cpp
+++ b/tests/TestConfig.cpp
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestConfig.h"
+
+#include <QList>
+#include <QTest>
+
+#include "config-keepassx-tests.h"
+#include "core/Config.h"
+#include "gui/DatabaseWidgetStateSync.h"
+#include "util/TemporaryFile.h"
+
+QTEST_GUILESS_MAIN(TestConfig)
+
+const QString oldTrueConfigPath = QString(KEEPASSX_TEST_DATA_DIR).append("/OutdatedConfig.ini");
+
+// upgrade config file with deprecated settings set to non-default values
+void TestConfig::testUpgrade()
+{
+    TemporaryFile tempFile;
+
+    QVERIFY(tempFile.copyFromFile(oldTrueConfigPath));
+    Config::createConfigFromFile(tempFile.fileName());
+
+    QVERIFY(!config()->get("security/HidePasswordPreviewPanel").toBool());
+    QVERIFY(config()->get("GUI/HidePreviewPanel").toBool());
+    QVERIFY(config()->get("security/IconDownloadFallback").toBool());
+    QVERIFY(config()->get("TrackNonDataChanges").toBool());
+    QVERIFY(!config()->get("security/passwordsrepeatvisible").toBool());
+    QVERIFY(!config()->get("security/passwordshidden").toBool());
+    QVERIFY(config()->get("security/passwordemptyplaceholder").toBool());
+
+    QList<int> intList;
+    intList << 144 << 338;
+    QCOMPARE(variantToIntList(config()->get("GUI/PreviewSplitterState")), intList);
+
+    tempFile.remove();
+}
+
+QList<int> TestConfig::variantToIntList(const QVariant& variant)
+{
+    const QVariantList list = variant.toList();
+    QList<int> result;
+
+    for (const QVariant& var : list) {
+        bool ok;
+        int size = var.toInt(&ok);
+        if (ok) {
+            result.append(size);
+        } else {
+            result.clear();
+            break;
+        }
+    }
+
+    return result;
+}

--- a/tests/TestConfig.h
+++ b/tests/TestConfig.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_TESTCONFIG_H
+#define KEEPASSX_TESTCONFIG_H
+
+#include "core/Config.h"
+
+class TestConfig : public QObject
+{
+    Q_OBJECT
+private slots:
+    void testUpgrade();
+
+private:
+    QList<int> variantToIntList(const QVariant& variant);
+};
+
+#endif // KEEPASSX_TESTCONFIG_H

--- a/tests/data/OutdatedConfig.ini
+++ b/tests/data/OutdatedConfig.ini
@@ -1,0 +1,14 @@
+[General]
+IgnoreGroupExpansion=false
+
+[GUI]
+HideDetailsView=true
+DetailSplitterState=144, 338
+
+[security]
+hidepassworddetails=false
+IconDownloadFallbackToGoogle=true
+passwordemptynodots=false
+passwordscleartext=true
+passwordsrepeat=true
+


### PR DESCRIPTION
This PR fixes the merge conflicts in #4429, which in turn implements #3601. Credits for the actual work go to @ameyer0, I only merged develop into it and fixed the merge conflicts. Hopefully I didn't break anything; please have a good look at my changes, @ameyer0 and @droidmonkey!

I'm getting the following error in the unit tests:

```
$ tests/testcli -silent
Testing TestCli
FAIL!  : TestCli::testClip() Compared values are not the same
   Actual   (clipboard->text())  : ""
   Expected (QString("Password")): "Password"
   Loc: [/home/wolfram/src/keepassxc/tests/TestCli.cpp(485)]
Totals: 60 passed, 1 failed, 1 skipped, 0 blacklisted, 10674ms
```

but I'm not sure if it's related to the changes on this branch, could be something's wrong on my computer. Didn't check if the same error occurs on the original branch or on develop.