### PR TITLE
Add "Size" column to entry view

### DIFF
--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -107,6 +107,7 @@ public:
     QString attribute(const QString& key) const;
     QString totp() const;
     QSharedPointer<Totp::Settings> totpSettings() const;
+    int size() const;
 
     bool hasTotp() const;
     bool isExpired() const;

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -129,7 +129,7 @@ int EntryModel::columnCount(const QModelIndex& parent) const
         return 0;
     }
 
-    return 13;
+    return 14;
 }
 
 QVariant EntryModel::data(const QModelIndex& index, int role) const
@@ -222,6 +222,22 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             }
             return result;
         }
+        case Size: {
+            const int unitsSize = 4;
+            QString units[unitsSize] = {"B", "KiB", "MiB", "GiB"};
+            float resultInt = entry->size();
+
+            for (int i = 0; i < unitsSize; i++) {
+                if (resultInt < 1024 || i == unitsSize - 1) {
+                    resultInt = qRound(resultInt * 100) / 100.0;
+                    result = QString::number(resultInt) + " " + units[i];
+                    break;
+                }
+                resultInt /= 1024.0;
+            }
+
+            return result;
+        }
         }
     } else if (role == Qt::UserRole) { // Qt::UserRole is used as sort role, see EntryView::EntryView()
         switch (index.column()) {
@@ -244,6 +260,8 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return !entry->attachments()->isEmpty();
         case Totp:
             return entry->hasTotp();
+        case Size:
+            return entry->size();
         default:
             // For all other columns, simply use data provided by Qt::Display-
             // Role for sorting
@@ -335,6 +353,8 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Accessed");
         case Attachments:
             return tr("Attachments");
+        case Size:
+            return tr("Size");
         }
 
     } else if (role == Qt::DecorationRole) {
@@ -368,6 +388,8 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Last access date");
         case Attachments:
             return tr("Attached files");
+        case Size:
+            return tr("Entry size");
         case Paperclip:
             return tr("Has attachments");
         case Totp:

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -230,7 +230,7 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             for (int i = 0; i < unitsSize; i++) {
                 if (resultInt < 1024 || i == unitsSize - 1) {
                     resultInt = qRound(resultInt * 100) / 100.0;
-                    result = QString::number(resultInt) + " " + units[i];
+                    result = QStringLiteral("%1 %2").arg(QString::number(resultInt), units[i]);
                     break;
                 }
                 resultInt /= 1024.0;

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -43,7 +43,8 @@ public:
         Accessed = 9,
         Paperclip = 10,
         Attachments = 11,
-        Totp = 12
+        Totp = 12,
+        Size = 13
     };
 
     explicit EntryModel(QObject* parent = nullptr);

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -72,7 +72,7 @@ EntryView::EntryView(QWidget* parent)
     resetViewToDefaults();
 
     // Actions to toggle column visibility, each carrying the corresponding
-    // colummn index as data
+    // column index as data
     m_columnActions = new QActionGroup(this);
     m_columnActions->setExclusive(false);
     for (int visualIndex = 1; visualIndex < header()->count(); ++visualIndex) {
@@ -451,6 +451,7 @@ void EntryView::resetViewToDefaults()
     header()->hideSection(EntryModel::Created);
     header()->hideSection(EntryModel::Accessed);
     header()->hideSection(EntryModel::Attachments);
+    header()->hideSection(EntryModel::Size);
 
     // Reset column order to logical indices
     for (int i = 0; i < header()->count(); ++i) {

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -295,7 +295,7 @@ void TestEntryModel::testProxyModel()
      */
     QSignalSpy spyColumnRemove(modelProxy, SIGNAL(columnsAboutToBeRemoved(QModelIndex, int, int)));
     modelProxy->hideColumn(0, true);
-    QCOMPARE(modelProxy->columnCount(), 12);
+    QCOMPARE(modelProxy->columnCount(), 13);
     QVERIFY(!spyColumnRemove.isEmpty());
 
     int oldSpyColumnRemoveSize = spyColumnRemove.size();
@@ -317,7 +317,7 @@ void TestEntryModel::testProxyModel()
      */
     QSignalSpy spyColumnInsert(modelProxy, SIGNAL(columnsAboutToBeInserted(QModelIndex, int, int)));
     modelProxy->hideColumn(0, false);
-    QCOMPARE(modelProxy->columnCount(), 13);
+    QCOMPARE(modelProxy->columnCount(), 14);
     QVERIFY(!spyColumnInsert.isEmpty());
 
     int oldSpyColumnInsertSize = spyColumnInsert.size();


### PR DESCRIPTION
## Type of change
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
Adds a size column to the entry view that displays the size of each entry in KiB

Closes #4101

## Screenshots
![sizecolumn](https://user-images.githubusercontent.com/20828023/79062506-04133780-7c69-11ea-8e58-0ebb99844e64.png)

## Testing strategy
Unit and Manual Testing

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
- ✅ I have modified tests to cover my changes.
