### PR TITLE
Allow manual editing of browser extension connection keys & add option for custom extension ID

### DIFF
--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -187,6 +187,18 @@ QString BrowserSettings::proxyLocation()
     return m_nativeMessageInstaller.getProxyPath();
 }
 
+#ifdef QT_DEBUG
+QString BrowserSettings::customExtensionId()
+{
+    return config()->get(Config::Browser_CustomExtensionId).toString();
+}
+
+void BrowserSettings::setCustomExtensionId(const QString& id)
+{
+    config()->set(Config::Browser_CustomExtensionId, id);
+}
+#endif
+
 bool BrowserSettings::updateBinaryPath()
 {
     return config()->get(Config::Browser_UpdateBinaryPath).toBool();

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -64,6 +64,10 @@ public:
     QString customProxyLocation();
     void setCustomProxyLocation(const QString& location);
     QString proxyLocation();
+#ifdef QT_DEBUG
+    QString customExtensionId();
+    void setCustomExtensionId(const QString& id);
+#endif
     bool updateBinaryPath();
     void setUpdateBinaryPath(bool enabled);
     bool allowExpiredCredentials();

--- a/src/browser/BrowserSettingsWidget.cpp
+++ b/src/browser/BrowserSettingsWidget.cpp
@@ -80,6 +80,11 @@ BrowserSettingsWidget::BrowserSettingsWidget(QWidget* parent)
     m_ui->firefoxSupport->setText("Firefox and Tor Browser");
 #endif
     m_ui->browserGlobalWarningWidget->setVisible(false);
+
+#ifndef QT_DEBUG
+    m_ui->customExtensionId->setVisible(false);
+    m_ui->customExtensionLabel->setVisible(false);
+#endif
 }
 
 BrowserSettingsWidget::~BrowserSettingsWidget()
@@ -152,6 +157,10 @@ void BrowserSettingsWidget::loadSettings()
     m_ui->browserGlobalWarningWidget->setAutoHideTimeout(-1);
 #endif
 
+#ifdef QT_DEBUG
+    m_ui->customExtensionId->setText(settings->customExtensionId());
+#endif
+
     validateCustomProxyLocation();
 }
 
@@ -189,6 +198,10 @@ void BrowserSettingsWidget::saveSettings()
     settings->setSearchInAllDatabases(m_ui->searchInAllDatabases->isChecked());
     settings->setSupportKphFields(m_ui->supportKphFields->isChecked());
     settings->setNoMigrationPrompt(m_ui->noMigrationPrompt->isChecked());
+
+#ifdef QT_DEBUG
+    settings->setCustomExtensionId(m_ui->customExtensionId->text());
+#endif
 
     settings->setBrowserSupport(BrowserShared::CHROME, m_ui->chromeSupport->isChecked());
     settings->setBrowserSupport(BrowserShared::CHROMIUM, m_ui->chromiumSupport->isChecked());

--- a/src/browser/BrowserSettingsWidget.ui
+++ b/src/browser/BrowserSettingsWidget.ui
@@ -379,6 +379,33 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="customExtensionBox">
+         <property name="topMargin">
+          <number>20</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="customExtensionLabel">
+           <property name="text">
+            <string>Custom extension ID:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="customExtensionId">
+           <property name="accessibleName">
+            <string>Custom extension ID</string>
+           </property>
+           <property name="maxLength">
+            <number>999</number>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_5">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -276,6 +276,12 @@ QJsonObject NativeMessageInstaller::constructFile(SupportedBrowsers browser)
         for (const QString& origin : ALLOWED_ORIGINS) {
             arr.append(origin);
         }
+#ifdef QT_DEBUG
+        auto customId = browserSettings()->customExtensionId();
+        if (!customId.isEmpty()) {
+            arr.append(QString("chrome-extension://%1/").arg(customId));
+        }
+#endif
         script["allowed_origins"] = arr;
     }
 

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -153,6 +153,9 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Browser_SearchInAllDatabases, {QS("Browser/SearchInAllDatabases"), Roaming, false}},
     {Config::Browser_SupportKphFields, {QS("Browser/SupportKphFields"), Roaming, true}},
     {Config::Browser_NoMigrationPrompt, {QS("Browser/NoMigrationPrompt"), Roaming, false}},
+#ifdef QT_DEBUG
+    {Config::Browser_CustomExtensionId, {QS("Browser/CustomExtensionId"), Local, {}}},
+#endif
 
     // SSHAgent
     {Config::SSHAgent_Enabled, {QS("SSHAgent/Enabled"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -134,6 +134,9 @@ public:
         Browser_SearchInAllDatabases,
         Browser_SupportKphFields,
         Browser_NoMigrationPrompt,
+#ifdef QT_DEBUG
+        Browser_CustomExtensionId,
+#endif
 
         SSHAgent_Enabled,
         SSHAgent_UseOpenSSH,

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.h
@@ -64,6 +64,8 @@ private slots:
     void removeStoredPermissions();
     void convertAttributesToCustomData();
     void refreshDatabaseID();
+    void editIndex(const QModelIndex& index);
+    void editFinished(QStandardItem* item);
 
 private:
     void updateModel();
@@ -77,6 +79,7 @@ protected:
 private:
     QPointer<CustomData> m_customData;
     QPointer<QStandardItemModel> m_customDataModel;
+    QString m_valueInEdit;
 };
 
 #endif // KEEPASSXC_DATABASESETTINGSWIDGETBROWSER_H


### PR DESCRIPTION
[TIP]:  # ( Provide a general summary of your changes in the title above ^^ )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (non-breaking change which adds functionality)

## Description and Context
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Describe the context of your change. Explain large code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" as necessary )
Allows editing the browser extension connection keys. Both key and identifier value can be changed. Editing "Created" timestamp is not allowed.

Editing works using double click on the mouse. A keyboard shortcut could be also added if needed.

Also adds an option to use a custom extension ID with debug builds.

Fixes #3819.

## Screenshots
![Screen Shot 2020-04-13 at 11 16 19](https://user-images.githubusercontent.com/24570482/79106374-0a91d400-7d7b-11ea-9e6e-0590e10e4a8f.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Checklist:
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Again, remove any lines which don't apply. )
[NOTE]: # ( Pull Requests that don't fulfill all [REQUIRED] requisites are likely )
[NOTE]: # ( to be sent back to you for correction or will be rejected.  )
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON`. **[REQUIRED]**
