### PR TITLE
Stop file checksum compare when stop is called

### DIFF
--- a/src/core/FileWatcher.cpp
+++ b/src/core/FileWatcher.cpp
@@ -87,6 +87,7 @@ void FileWatcher::stop()
     }
     m_filePath.clear();
     m_fileChecksum.clear();
+    m_fileChecksumTimer.stop();
     m_fileChangeDelayTimer.stop();
 }
 


### PR DESCRIPTION
* When FileWatcher::stop() is called, also stop the timer that checks the file checksum every 30 seconds.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
