### PR TITLE
Add a -n (--notes) option to keepassxc-cli `add` and `edit` commands

### DIFF
--- a/docs/man/keepassxc-cli.1.adoc
+++ b/docs/man/keepassxc-cli.1.adoc
@@ -176,6 +176,9 @@ The same password generation options as documented for the generate command can 
 *--url* <__url__>::
   Specifies the URL of the entry.
 
+*-n*, *--notes* <__notes__>::
+  Specifies the notes of the entry.
+
 *-p*, *--password-prompt*::
   Uses a password prompt for the entry's password.
 

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -36,6 +36,11 @@ const QCommandLineOption Add::UsernameOption = QCommandLineOption(QStringList() 
 const QCommandLineOption Add::UrlOption =
     QCommandLineOption(QStringList() << "url", QObject::tr("URL for the entry."), QObject::tr("URL"));
 
+const QCommandLineOption Add::NotesOption = QCommandLineOption(QStringList() << "n"
+                                                                            << "notes",
+                                                              QObject::tr("Notes for the entry."),
+                                                              QObject::tr("Notes"));
+
 const QCommandLineOption Add::PasswordPromptOption =
     QCommandLineOption(QStringList() << "p"
                                      << "password-prompt",
@@ -51,6 +56,7 @@ Add::Add()
     description = QObject::tr("Add a new entry to a database.");
     options.append(Add::UsernameOption);
     options.append(Add::UrlOption);
+    options.append(Add::NotesOption);
     options.append(Add::PasswordPromptOption);
     positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to add."), QString("")});
 
@@ -103,6 +109,10 @@ int Add::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<Q
 
     if (!parser->value(Add::UrlOption).isEmpty()) {
         entry->setUrl(parser->value(Add::UrlOption));
+    }
+
+    if (!parser->value(Add::NotesOption).isEmpty()) {
+        entry->setNotes(parser->value(Add::NotesOption).replace("\\n", "\n"));
     }
 
     if (parser->isSet(Add::PasswordPromptOption)) {

--- a/src/cli/Add.h
+++ b/src/cli/Add.h
@@ -29,6 +29,7 @@ public:
 
     static const QCommandLineOption UsernameOption;
     static const QCommandLineOption UrlOption;
+    static const QCommandLineOption NotesOption;
     static const QCommandLineOption PasswordPromptOption;
     static const QCommandLineOption GenerateOption;
     static const QCommandLineOption PasswordLengthOption;

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -41,6 +41,7 @@ Edit::Edit()
     // Using some of the options from the Add command since they are the same.
     options.append(Add::UsernameOption);
     options.append(Add::UrlOption);
+    options.append(Add::NotesOption);
     options.append(Add::PasswordPromptOption);
     options.append(Edit::TitleOption);
     positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to edit."), QString("")});
@@ -91,9 +92,10 @@ int Edit::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
 
     QString username = parser->value(Add::UsernameOption);
     QString url = parser->value(Add::UrlOption);
+    QString notes = parser->value(Add::NotesOption);
     QString title = parser->value(Edit::TitleOption);
     bool prompt = parser->isSet(Add::PasswordPromptOption);
-    if (username.isEmpty() && url.isEmpty() && title.isEmpty() && !prompt && !generate) {
+    if (username.isEmpty() && url.isEmpty() && notes.isEmpty() && title.isEmpty() && !prompt && !generate) {
         err << QObject::tr("Not changing any field for entry %1.").arg(entryPath) << endl;
         return EXIT_FAILURE;
     }
@@ -106,6 +108,10 @@ int Edit::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
 
     if (!username.isEmpty()) {
         entry->setUsername(username);
+    }
+
+    if (!notes.isEmpty()) {
+        entry->setNotes(notes.replace("\\n", "\n"));
     }
 
     if (!url.isEmpty()) {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
Was working on exporting my data from Bitwarden where I use notes to KeePass and noticed the keepassxc-cli was missing notes as an option for adding and editing records. Looked easy enough to plug in so figured I would give it a go. Hopefully it is to taste!

## Screenshots
![edit_add](https://user-images.githubusercontent.com/19330133/80016954-bc43aa00-84cb-11ea-91db-c9fb2a89f4ad.jpeg)
![help](https://user-images.githubusercontent.com/19330133/80016992-c796d580-84cb-11ea-8fd8-76102345d582.jpeg)
![man](https://user-images.githubusercontent.com/19330133/80017014-cf567a00-84cb-11ea-91df-8e62f6bb976e.jpeg)

## Testing strategy
Manual testing performed with existing and newly created databases through the develop branch version. Changes show to be reflected correctly in the databases.


## Type of change
- ✅ New feature (change that adds functionality)
