### PR TITLE
Issue a warning before adding large attachments

### DIFF
--- a/src/gui/entry/EntryAttachmentsWidget.cpp
+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
@@ -141,15 +141,17 @@ void EntryAttachmentsWidget::insertAttachments()
         defaultDirPath = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation).first();
     }
 
-    const QStringList filenames = fileDialog()->getOpenFileNames(this, tr("Select files"), defaultDirPath);
+    const auto filenames = fileDialog()->getOpenFileNames(this, tr("Select files"), defaultDirPath);
     if (filenames.isEmpty()) {
         return;
     }
-
+    const auto confirmedFileNames = confirmLargeAttachments(filenames);
+    if (confirmedFileNames.isEmpty()) {
+        return;
+    }
     config()->set(Config::LastAttachmentDir, QFileInfo(filenames.first()).absolutePath());
-
     QString errorMessage;
-    if (!insertAttachments(filenames, errorMessage)) {
+    if (!insertAttachments(confirmedFileNames, errorMessage)) {
         errorOccurred(errorMessage);
     }
     emit widgetUpdated();
@@ -351,6 +353,33 @@ bool EntryAttachmentsWidget::openAttachment(const QModelIndex& index, QString& e
     // take ownership of the tmpFile pointer
     tmpFile.take();
     return true;
+}
+
+QStringList EntryAttachmentsWidget::confirmLargeAttachments(const QStringList& filenames)
+{
+    const QString confirmation(tr("%1 is a big file (%2 MB).\nYour database may get very large and reduce "
+                                  "performance.\n\nAre you sure to add this file?"));
+    QStringList confirmedFileNames;
+    for (const auto& file : filenames) {
+        QFileInfo fileInfo(file);
+        double size = fileInfo.size() / (1024.0 * 1024.0);
+        // Ask for confirmation before adding files over 5 MB in size
+        if (size > 5.0) {
+            auto fileName = fileInfo.fileName();
+            auto result = MessageBox::question(this,
+                                               tr("Confirm Attachment"),
+                                               confirmation.arg(fileName, QString::number(size, 'f', 1)),
+                                               MessageBox::Yes | MessageBox::No,
+                                               MessageBox::No);
+            if (result == MessageBox::Yes) {
+                confirmedFileNames << file;
+            }
+        } else {
+            confirmedFileNames << file;
+        }
+    }
+
+    return confirmedFileNames;
 }
 
 bool EntryAttachmentsWidget::eventFilter(QObject* watched, QEvent* e)

--- a/src/gui/entry/EntryAttachmentsWidget.h
+++ b/src/gui/entry/EntryAttachmentsWidget.h
@@ -54,6 +54,8 @@ private:
     bool insertAttachments(const QStringList& fileNames, QString& errorMessage);
     bool openAttachment(const QModelIndex& index, QString& errorMessage);
 
+    QStringList confirmLargeAttachments(const QStringList& filenames);
+
     bool eventFilter(QObject* watched, QEvent* event) override;
 
     QScopedPointer<Ui::EntryAttachmentsWidget> m_ui;


### PR DESCRIPTION
The EntryAttachmentsWidget is changed such that a warning is issued to the user if he uploads one or more attachments that have size > 5MB. Added a function to EntryAttachmentsWidget.cpp that does the checking and issues warning.

Closes #3782

## Screenshots
**User tries to upload three files where two of them are >5MB.**
![save_1](https://user-images.githubusercontent.com/43716071/80115077-4e8e9100-8552-11ea-90a7-5deeef7371c2.PNG)
**User is issued a warning that two of them are large files.**
![save_2](https://user-images.githubusercontent.com/43716071/80115079-4f272780-8552-11ea-86d5-6f1fda31e142.PNG)
**The files are added to the widget.**
![save_3](https://user-images.githubusercontent.com/43716071/80115074-4e8e9100-8552-11ea-93a6-26d4451b8b4b.PNG)


## Testing strategy
All previous test pass.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)

