### PR TITLE
Fix annoyances with access control dialog

### DIFF
--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -34,7 +34,6 @@ enum
     max_length = 16 * 1024
 };
 
-class DatabaseTabWidget;
 class DatabaseWidget;
 class BrowserHost;
 class BrowserAction;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Changes made:
- When "Search from all databases" is enabled, access control dialog is not executed when switching between open databases. Switching from locked to to open again, the dialog will be shown.
- Do not hide the application main window when switching databases when the access control dialog is visible. Switching to another tab rejects the dialog.

Fixes #4639.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
