### PR TITLE
Add option to launch KeePassXC at system startup

### DIFF
--- a/share/windows/KPXC_ExitDlg.wxs
+++ b/share/windows/KPXC_ExitDlg.wxs
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI>
+            <Dialog Id="KPXC_ExitDialog" Width="370" Height="270" Title="!(loc.ExitDialog_Title)">
+                <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="!(loc.WixUIFinish)" />
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUICancel)" />
+                <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="!(loc.ExitDialogBitmap)" />
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUIBack)" />
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+                <Control Id="Description" Type="Text" X="135" Y="70" Width="220" Height="40" Transparent="yes" NoPrefix="yes" Text="!(loc.ExitDialogDescription)" />
+                <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes" Text="!(loc.ExitDialogTitle)" />
+                <!-- Custom Controls for KPXC Installer -->
+                <Control Id="LaunchCheckBox" Type="CheckBox" X="80" Y="243" Width="100" Height="17" Property="LAUNCHAPPONEXIT" Hidden="yes" CheckBoxValue="1" Text="Launch KeePassXC">
+                    <Condition Action="show">NOT Installed</Condition>
+                </Control>
+            </Dialog>
+
+            <InstallUISequence>
+                <Show Dialog="KPXC_ExitDialog" OnExit="success" Overridable="yes" />
+            </InstallUISequence>
+
+            <AdminUISequence>
+                <Show Dialog="KPXC_ExitDialog" OnExit="success" Overridable="yes" />
+            </AdminUISequence>
+        </UI>
+    </Fragment>
+</Wix>

--- a/share/windows/KPXC_InstallDir.wxs
+++ b/share/windows/KPXC_InstallDir.wxs
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+
+<!--
+First-time install dialog sequence:
+ - WixUI_WelcomeDlg
+ - WixUI_LicenseAgreementDlg
+ - KPXC_InstallDirDlg
+ - WixUI_VerifyReadyDlg
+ - WixUI_DiskCostDlg
+
+Maintenance dialog sequence:
+ - WixUI_MaintenanceWelcomeDlg
+ - WixUI_MaintenanceTypeDlg
+ - KPXC_InstallDirDlg
+ - WixUI_VerifyReadyDlg
+
+Patch dialog sequence:
+ - WixUI_WelcomeDlg
+ - WixUI_VerifyReadyDlg
+
+-->
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI Id="KPXC_InstallDir">
+            <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
+            <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
+            <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
+
+            <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+            <Property Id="WixUI_Mode" Value="InstallDir" />
+
+            <DialogRef Id="BrowseDlg" />
+            <DialogRef Id="DiskCostDlg" />
+            <DialogRef Id="ErrorDlg" />
+            <DialogRef Id="FatalError" />
+            <DialogRef Id="FilesInUse" />
+            <DialogRef Id="MsiRMFilesInUse" />
+            <DialogRef Id="PrepareDlg" />
+            <DialogRef Id="ProgressDlg" />
+            <DialogRef Id="ResumeDlg" />
+            <DialogRef Id="UserExit" />
+            
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3">1</Publish>
+            <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+
+            <Publish Dialog="KPXC_ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
+
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT Installed</Publish>
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
+
+            <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
+            <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="KPXC_InstallDirDlg">LicenseAccepted = "1"</Publish>
+
+            <Publish Dialog="KPXC_InstallDirDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
+            <Publish Dialog="KPXC_InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
+            <Publish Dialog="KPXC_InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
+            <Publish Dialog="KPXC_InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+            <Publish Dialog="KPXC_InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+            <Publish Dialog="KPXC_InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
+            <Publish Dialog="KPXC_InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
+            
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="KPXC_InstallDirDlg" Order="1">NOT Installed</Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
+
+            <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
+
+            <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+            <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+            <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
+
+            <Property Id="ARPNOMODIFY" Value="1" />
+        </UI>
+
+        <UIRef Id="WixUI_Common" />
+    </Fragment>
+</Wix>

--- a/share/windows/KPXC_InstallDirDlg.wxs
+++ b/share/windows/KPXC_InstallDirDlg.wxs
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI>
+            <Dialog Id="KPXC_InstallDirDlg" Width="370" Height="270" Title="!(loc.InstallDirDlg_Title)">
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                    <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+                </Control>
+
+                <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.InstallDirDlgDescription)" />
+                <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.InstallDirDlgTitle)" />
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
+                <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+
+                <Control Id="FolderLabel" Type="Text" X="20" Y="60" Width="290" Height="30" NoPrefix="yes" Text="!(loc.InstallDirDlgFolderLabel)" />
+                <Control Id="Folder" Type="PathEdit" X="20" Y="100" Width="320" Height="18" Property="WIXUI_INSTALLDIR" Indirect="yes" />
+                <Control Id="ChangeFolder" Type="PushButton" X="20" Y="120" Width="56" Height="17" Text="!(loc.InstallDirDlgChange)" />
+                <!-- Custom Controls for KPXC Installer -->
+                <Control Id="DesktopShortcutCheckBox" Type="CheckBox" X="20" Y="150" Width="290" Height="17" Property="INSTALLDESKTOPSHORTCUT" CheckBoxValue="1" Text="Create a shortcut on the desktop" />
+                <Control Id="AutostartCheckBox" Type="CheckBox" X="20" Y="170" Width="290" Height="17" Property="AUTOSTARTPROGRAM" CheckBoxValue="1" Text="Autostart KeePassXC on login" />
+            </Dialog>
+        </UI>
+    </Fragment>
+</Wix>

--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -37,57 +37,75 @@
         <?ifdef CPACK_WIX_UI_DIALOG?>
         <WixVariable Id="WixUIDialogBmp" Value="$(var.CPACK_WIX_UI_DIALOG)"/>
         <?endif?>
-        
-        <FeatureRef Id="ProductFeature">
-            <ComponentRef Id="ApplicationShortcut" />
-        </FeatureRef>
 
         <UI>
             <UIRef Id="$(var.CPACK_WIX_UI_REF)" />
-            <Publish Dialog="ExitDialog" 
-                     Control="Finish" 
-                     Event="DoAction" 
-                     Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
+            <Publish Dialog="KPXC_ExitDialog" Control="Finish" Order="1" Event="DoAction" Value="LaunchApplication">LAUNCHAPPONEXIT</Publish>
         </UI>
 
         <?include "properties.wxi"?>
         <?include "product_fragment.wxi"?>
 
+        <!-- Autostart via registry (optional) -->
+        <Component Id="Autostart" Guid="*" Directory="INSTALL_ROOT">
+            <RegistryValue Id="Autostart.rst" Root="HKCU" Action="write"
+                    Key="Software\Microsoft\Windows\CurrentVersion\Run"
+                    Name="$(var.CPACK_PACKAGE_NAME)"
+                    Value="[#CM_FP_KeePassXC.exe]"
+                    Type="string" />
+            <Condition>AUTOSTARTPROGRAM</Condition>
+        </Component>
+
         <DirectoryRef Id="TARGETDIR">
+            <!-- Startmenu shortcut -->
             <Directory Id="ProgramMenuFolder">
-                <Directory Id="ApplicationProgramsFolder" Name="KeePassXC"/>
+                <Directory Id="ApplicationProgramsFolder" Name="KeePassXC">
+                    <Component Id="ApplicationShortcut" Guid="*">
+                        <Shortcut Id="ApplicationStartMenuShortcut" 
+                            Name="KeePassXC"
+                            Target="[#CM_FP_KeePassXC.exe]"
+                            WorkingDirectory="INSTALL_ROOT"/>
+                        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+                        <RegistryValue Root="HKCU" Key="Software\KeePassXC" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+                    </Component>
+                </Directory>
+            </Directory>
+
+            <!-- Desktop shortcut (optional) -->
+            <Directory Id="DesktopFolder" Name="Desktop">
+                <Component Id="DesktopShortcut" Guid="F8AFBA1C-296C-41AA-B968-60323A206665">
+                    <Condition>INSTALLDESKTOPSHORTCUT</Condition>
+                    <Shortcut Id="ApplicationDesktopShortcut"
+                        Directory="DesktopFolder"
+                        Name="KeePassXC"
+                        Target="[#CM_FP_KeePassXC.exe]"
+                        WorkingDirectory="INSTALL_ROOT" />
+                    <RegistryValue Root="HKCU" Key="Software\KeePassXC" Name="DesktopShortcut" Type="integer" Value="1" KeyPath="yes"/>
+                </Component>
             </Directory>
         </DirectoryRef>
 
-        <DirectoryRef Id="ApplicationProgramsFolder">
-            <Component Id="ApplicationShortcut" Guid="*">
-                <Shortcut Id="ApplicationStartMenuShortcut" 
-                    Name="KeePassXC"
-                    Target="[#CM_FP_KeePassXC.exe]"
-                    WorkingDirectory="INSTALL_ROOT"/>
-                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
-                <RegistryValue Root="HKCU" Key="Software\KeePassXC" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
-           </Component>
-        </DirectoryRef>
+        <Property Id="AUTOSTARTPROGRAM" Value="1" />
+        <Property Id="LAUNCHAPPONEXIT" Value="1" />
 
-        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
-        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch $(var.CPACK_PACKAGE_NAME)" />
+        <FeatureRef Id="ProductFeature">
+            <ComponentRef Id="ApplicationShortcut" />
+            <ComponentRef Id="Autostart" />
+            <ComponentRef Id="DesktopShortcut" />
+        </FeatureRef>
+
         <Property Id="WixShellExecTarget" Value="[#CM_FP_KeePassXC.exe]" />
         <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
         <Property Id="WixSilentExecCmdLine" Value='"Taskkill" /IM KeePassXC.exe' />
-        <CustomAction Id="KillKeePassXCInstall" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="ignore" />
-        <CustomAction Id="KillKeePassXCUninstall" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="ignore" />
+        <CustomAction Id="KillKeePassXC" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="ignore" />
 
         <Property Id="WixQuietExecCmdLine" Value='"Taskkill" /IM keepassxc-proxy.exe /F' />
-        <CustomAction Id="KillProxyInstall" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="ignore" />
-        <CustomAction Id="KillProxyUninstall" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="ignore" />
+        <CustomAction Id="KillProxy" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="ignore" />
 
         <InstallExecuteSequence>
-            <Custom Action="KillKeePassXCInstall" After="InstallInitialize" />
-            <Custom Action="KillProxyInstall" After="InstallInitialize" />
-            <Custom Action="KillKeePassXCUninstall" Before="InstallValidate">Installed</Custom>
-            <Custom Action="KillProxyUninstall" Before="InstallValidate">Installed</Custom>
+            <Custom Action="KillKeePassXC" Before="InstallValidate" />
+            <Custom Action="KillProxy" Before="InstallValidate" />
         </InstallExecuteSequence>
     </Product>
 </Wix>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -461,9 +461,14 @@ if(MINGW)
     set(CPACK_WIX_PRODUCT_ICON "${CMAKE_SOURCE_DIR}/share/windows/keepassxc.ico")
     set(CPACK_WIX_UI_BANNER "${CMAKE_SOURCE_DIR}/share/windows/wix-banner.bmp")
     set(CPACK_WIX_UI_DIALOG "${CMAKE_SOURCE_DIR}/share/windows/wix-dialog.bmp")
+    set(CPACK_WIX_UI_REF "KPXC_InstallDir")
     set(CPACK_WIX_TEMPLATE "${CMAKE_SOURCE_DIR}/share/windows/wix-template.xml")
     set(CPACK_WIX_PATCH_FILE "${CMAKE_SOURCE_DIR}/share/windows/wix-patch.xml")
-    set(CPACK_WIX_PROPERTY_ARPURLINFOABOUT "https://keepassxc.org")
+    set(CPACK_WIX_EXTRA_SOURCES
+            "${CMAKE_SOURCE_DIR}/share/windows/KPXC_InstallDir.wxs"
+            "${CMAKE_SOURCE_DIR}/share/windows/KPXC_InstallDirDlg.wxs"
+            "${CMAKE_SOURCE_DIR}/share/windows/KPXC_ExitDlg.wxs")
+    set(CPACK_WIX_PROPERTY_ARPURLINFOABOUT  "https://keepassxc.org")
     set(CPACK_WIX_EXTENSIONS "WixUtilExtension.dll")
     include(CPack)
 

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -27,6 +27,7 @@
 #include "core/Global.h"
 #include "core/Resources.h"
 #include "core/Translator.h"
+#include "gui/osutils/OSUtils.h"
 
 #include "MessageBox.h"
 #include "touchid/TouchID.h"
@@ -173,8 +174,10 @@ void ApplicationSettingsWidget::loadSettings()
 
 #ifdef QT_DEBUG
     m_generalUi->singleInstanceCheckBox->setEnabled(false);
+    m_generalUi->launchAtStartup->setEnabled(false);
 #endif
     m_generalUi->singleInstanceCheckBox->setChecked(config()->get(Config::SingleInstance).toBool());
+    m_generalUi->launchAtStartup->setChecked(osUtils->isLaunchAtStartupEnabled());
     m_generalUi->rememberLastDatabasesCheckBox->setChecked(config()->get(Config::RememberLastDatabases).toBool());
     m_generalUi->rememberLastKeyFilesCheckBox->setChecked(config()->get(Config::RememberLastKeyFiles).toBool());
     m_generalUi->openPreviousDatabasesOnStartupCheckBox->setChecked(
@@ -298,6 +301,10 @@ void ApplicationSettingsWidget::saveSettings()
         // the config file.
         return;
     }
+
+#ifndef QT_DEBUG
+    osUtils->setLaunchAtStartup(m_generalUi->launchAtStartup->isChecked());
+#endif
 
     config()->set(Config::SingleInstance, m_generalUi->singleInstanceCheckBox->isChecked());
     config()->set(Config::RememberLastDatabases, m_generalUi->rememberLastDatabasesCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -6,8 +6,6 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>499</width>
-    <height>1174</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -46,6 +44,13 @@
             </property>
             <property name="checked">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="launchAtStartup">
+            <property name="text">
+             <string>Automatically launch KeePassXC at system startup</string>
             </property>
            </widget>
           </item>

--- a/src/gui/osutils/OSUtilsBase.h
+++ b/src/gui/osutils/OSUtilsBase.h
@@ -30,7 +30,24 @@ class OSUtilsBase : public QObject
     Q_OBJECT
 
 public:
-    virtual bool isDarkMode() = 0;
+    /**
+     * @return OS dark mode enabled.
+     */
+    virtual bool isDarkMode() const = 0;
+
+    /**
+     * @return KeePassXC set to launch at system startup (autostart).
+     */
+    virtual bool isLaunchAtStartupEnabled() const = 0;
+
+    /**
+     * @param enable Add or remove KeePassXC from system autostart.
+     */
+    virtual void setLaunchAtStartup(bool enable) = 0;
+
+    /**
+     * @return OS caps lock enabled.
+     */
     virtual bool isCapslockEnabled() = 0;
 
 protected:

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -33,7 +33,9 @@ class MacUtils : public OSUtilsBase
 public:
     static MacUtils* instance();
 
-    bool isDarkMode() override;
+    bool isDarkMode() const override;
+    bool isLaunchAtStartupEnabled() const override;
+    void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
 
     WId activeWindow();
@@ -53,6 +55,8 @@ protected:
     ~MacUtils() override;
 
 private:
+    QString getLaunchAgentFilename() const;
+
     QScopedPointer<AppKit> m_appkit;
     static QPointer<MacUtils> m_instance;
 

--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -28,7 +28,9 @@ class NixUtils : public OSUtilsBase
 public:
     static NixUtils* instance();
 
-    bool isDarkMode() override;
+    bool isDarkMode() const override;
+    bool isLaunchAtStartupEnabled() const override;
+    void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
 
 private:
@@ -36,6 +38,8 @@ private:
     ~NixUtils() override;
 
 private:
+    QString getAutostartDesktopFilename(bool createDirs = false) const;
+
     static QPointer<NixUtils> m_instance;
 
     Q_DISABLE_COPY(NixUtils)

--- a/src/gui/osutils/winutils/WinUtils.cpp
+++ b/src/gui/osutils/winutils/WinUtils.cpp
@@ -77,11 +77,28 @@ bool WinUtils::DWMEventFilter::nativeEventFilter(const QByteArray& eventType, vo
     return false;
 }
 
-bool WinUtils::isDarkMode()
+bool WinUtils::isDarkMode() const
 {
     QSettings settings(R"(HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize)",
                        QSettings::NativeFormat);
     return settings.value("AppsUseLightTheme", 1).toInt() == 0;
+}
+
+bool WinUtils::isLaunchAtStartupEnabled() const
+{
+    return QSettings(R"(HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run)", QSettings::NativeFormat)
+        .contains(qAppName());
+    ;
+}
+
+void WinUtils::setLaunchAtStartup(bool enable)
+{
+    QSettings reg(R"(HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run)", QSettings::NativeFormat);
+    if (enable) {
+        reg.setValue(qAppName(), QApplication::applicationFilePath());
+    } else {
+        reg.remove(qAppName());
+    }
 }
 
 bool WinUtils::isCapslockEnabled()

--- a/src/gui/osutils/winutils/WinUtils.h
+++ b/src/gui/osutils/winutils/WinUtils.h
@@ -32,7 +32,9 @@ public:
     static WinUtils* instance();
     static void registerEventFilters();
 
-    bool isDarkMode() override;
+    bool isDarkMode() const override;
+    bool isLaunchAtStartupEnabled() const override;
+    void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
 
 protected:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,13 +53,13 @@ int main(int argc, char** argv)
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
-    QGuiApplication::setDesktopFileName("org.keepassxc.KeePassXC.desktop");
-#endif
-
     Application app(argc, argv);
     Application::setApplicationName("KeePassXC");
     Application::setApplicationVersion(KEEPASSXC_VERSION);
+    app.setProperty("KPXC_QUALIFIED_APPNAME", "org.keepassxc.KeePassXC");
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    QGuiApplication::setDesktopFileName(app.property("KPXC_QUALIFIED_APPNAME").toString() + QStringLiteral(".desktop"));
+#endif
 
     // don't set organizationName as that changes the return value of
     // QStandardPaths::writableLocation(QDesktopServices::DataLocation)


### PR DESCRIPTION
Adds autostart option on all platforms.

Works on all platforms, but macOS is a bit special. It doesn't show up in the user's login items, since we'd have to write a separate helper app for that whose only responsibility is to launch KeePassXC.

Fixes #1218

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
.desktop file is created at correct location and settings widget responds to its presence. Windows works perfectly, macOS works okay-ish (not user editable, because we are not using the overly complicated Service Management Framework or the equally complicated and deprecated shared file list API).

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)