### PR TITLE
Fix tabbar separator visibility

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -407,14 +407,15 @@ MainWindow::MainWindow()
     connect(m_ui->tabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), m_searchWidget, SLOT(databaseChanged()));
 
     connect(m_ui->tabWidget, SIGNAL(tabNameChanged()), SLOT(updateWindowTitle()));
-    connect(m_ui->tabWidget, SIGNAL(tabVisibilityChanged(bool)), SLOT(adjustToTabVisibilityChange(bool)));
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(updateWindowTitle()));
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(databaseTabChanged(int)));
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(setMenuActionState()));
     connect(m_ui->tabWidget, SIGNAL(databaseLocked(DatabaseWidget*)), SLOT(databaseStatusChanged(DatabaseWidget*)));
     connect(m_ui->tabWidget, SIGNAL(databaseUnlocked(DatabaseWidget*)), SLOT(databaseStatusChanged(DatabaseWidget*)));
+    connect(m_ui->tabWidget, SIGNAL(tabVisibilityChanged(bool)), SLOT(updateToolbarSeparatorVisibility()));
     connect(m_ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(setMenuActionState()));
     connect(m_ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(updateWindowTitle()));
+    connect(m_ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(updateToolbarSeparatorVisibility()));
     connect(m_ui->settingsWidget, SIGNAL(accepted()), SLOT(applySettingsChanges()));
     connect(m_ui->settingsWidget, SIGNAL(settingsReset()), SLOT(applySettingsChanges()));
     connect(m_ui->settingsWidget, SIGNAL(accepted()), SLOT(switchToDatabases()));
@@ -647,12 +648,6 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
     m_ui->menuImport->setEnabled(inDatabaseTabWidgetOrWelcomeWidget);
     m_ui->actionLockDatabases->setEnabled(m_ui->tabWidget->hasLockableDatabases());
 
-    if (m_showToolbarSeparator) {
-        m_ui->toolbarSeparator->setVisible(
-            (!inWelcomeWidget && inDatabaseTabWidget && !m_ui->tabWidget->tabBar()->isVisible())
-            || currentIndex == SettingsScreen);
-    }
-
     if (inDatabaseTabWidget && m_ui->tabWidget->currentIndex() != -1) {
         DatabaseWidget* dbWidget = m_ui->tabWidget->currentDatabaseWidget();
         Q_ASSERT(dbWidget);
@@ -809,10 +804,24 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
     }
 }
 
-void MainWindow::adjustToTabVisibilityChange(bool tabsVisible)
+void MainWindow::updateToolbarSeparatorVisibility()
 {
-    m_ui->toolbarSeparator->setVisible(m_showToolbarSeparator && !tabsVisible
-                                       && m_ui->stackedWidget->currentIndex() == DatabaseTabScreen);
+    if (!m_showToolbarSeparator) {
+        m_ui->toolbarSeparator->setVisible(false);
+        return;
+    }
+
+    switch (m_ui->stackedWidget->currentIndex()) {
+    case DatabaseTabScreen:
+        m_ui->toolbarSeparator->setVisible(!m_ui->tabWidget->tabBar()->isVisible()
+                                           && m_ui->tabWidget->tabBar()->count() == 1);
+        break;
+    case SettingsScreen:
+        m_ui->toolbarSeparator->setVisible(true);
+        break;
+    default:
+        m_ui->toolbarSeparator->setVisible(false);
+    }
 }
 
 void MainWindow::updateWindowTitle()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -86,7 +86,7 @@ protected:
 
 private slots:
     void setMenuActionState(DatabaseWidget::Mode mode = DatabaseWidget::Mode::None);
-    void adjustToTabVisibilityChange(bool tabsVisible);
+    void updateToolbarSeparatorVisibility();
     void updateWindowTitle();
     void showAboutDialog();
     void showUpdateCheckStartup();


### PR DESCRIPTION
Fixes separator being visible despite multiple tabs being active when KeePassXC started hidden in the tray.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tabbar hidden as expected when starting in the tray with multiple tabs open. Also tested all other combinations of tabs being visible or not and different stacked widget pages.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
