### PR TITLE
add warning for large collective attachment size

### DIFF
--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -150,6 +150,7 @@ private:
     void setForms(Entry* entry, bool restore = false);
     QMenu* createPresetsMenu();
     void updateEntryData(Entry* entry) const;
+    bool checkLargeDbSize();
 #ifdef WITH_XC_SSHAGENT
     bool getOpenSSHKey(OpenSSHKey& key, bool decrypt = false);
 #endif


### PR DESCRIPTION
The EditEntryWidget is changed such that if total attachment size for the current entry is > 50, a warning is issued which warns the user if they want to continue with such large total attachment size.
The warning will also show the total size of all the attachments from database and only continues if the user presses yes.
Complements pull request #4651 to address Issue -#3782

## Screenshots
**User selects a file such that collective size for current entry becomes >50.**
![select-1](https://user-images.githubusercontent.com/43716071/80779430-9c4e5f00-8b39-11ea-9cc4-7d78fab2dc9c.PNG)
**User given warning and only continues if user selects Yes.**
![question](https://user-images.githubusercontent.com/43716071/80779477-c142d200-8b39-11ea-9892-09371716fc85.PNG)

## Testing strategy
Manually.

## Type of change

- ✅ New feature (change that adds functionality)

