### PR TITLE
Fix menu menu spacing on low-DPI Windows

### DIFF
--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -107,7 +107,7 @@ namespace Phantom
         constexpr qreal MenuItem_LeftMarginFontRatio = 1.0 / 2.0;
         constexpr qreal MenuItem_RightMarginForTextFontRatio = 1.0 / 1.5;
         constexpr qreal MenuItem_RightMarginForArrowFontRatio = 1.0 / 4.0;
-        constexpr qreal MenuItem_VerticalMarginsFontRatio = 1.0 / 8.0;
+        constexpr qreal MenuItem_VerticalMarginsFontRatio = 1.0 / 5.0;
         // Number that's multiplied with a font's height to get the space between a
         // menu item's checkbox (or other sign) and its text (or icon).
         constexpr qreal MenuItem_CheckRightSpaceFontRatio = 1.0 / 4.0;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Menu spacing looked fine on most platforms and on high-DPI Windows, but was very crammed on low-DPI Windows.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Before:
![image](https://user-images.githubusercontent.com/911270/80922092-f4c06f00-8d7a-11ea-8b7d-167e803865f4.png)

After:
![image](https://user-images.githubusercontent.com/911270/80922098-fee26d80-8d7a-11ea-8de3-40690ad91db6.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on low- and high-DPI Windows and on Linux with KDE Plasma desktop.  1.0/4.0 is too much on all platforms except low-DPI Windows, whereas 1.0/6.0 and smaller is too little. 1.0/5.0 looks decent everywhere, probably due to rounding errors.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
