### PR TITLE
Add xclip into snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ apps:
       DISABLE_WAYLAND: 1
   cli:
     command: keepassxc-cli
-    plugs: [gsettings, home, removable-media, raw-usb]
+    plugs: [x11, gsettings, home, removable-media, raw-usb]
   proxy:
     command: keepassxc-proxy
     plugs: [home]
@@ -87,6 +87,7 @@ parts:
       - qtwayland5
       - qt5-gtk-platformtheme # for theming, font settings, cursor and to use gtk3 file chooser
       - libqrencode3
+      - xclip
     override-build: |
       snapcraftctl build
       sed -i 's|Icon=keepassxc|Icon=${SNAP}/usr/share/icons/hicolor/256x256/apps/keepassxc.png|g' $SNAPCRAFT_PART_INSTALL/usr/share/applications/org.keepassxc.KeePassXC.desktop


### PR DESCRIPTION
Fixes #4663 by adding xclip into the snap and adding the x11 plug to keepass.cli


## Testing strategy
Used snapcraft on my machine with my changes and it solved the issue:
- Ran `snapcraft`
- Installed with ` sudo snap install --dangerous <pat_to_snap`
- Tested with `keepass.cli clip <db_path> <entry_path>`


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
