### PR TITLE
Fix "Minimise at startup" on Windows

### DIFF
--- a/src/core/Bootstrap.cpp
+++ b/src/core/Bootstrap.cpp
@@ -101,11 +101,7 @@ namespace Bootstrap
     {
         // start minimized if configured
         if (config()->get(Config::GUI_MinimizeOnStartup).toBool()) {
-#ifdef Q_OS_WIN
-            mainWindow.showMinimized();
-#else
             mainWindow.hideWindow();
-#endif
         } else {
             mainWindow.bringToFront();
         }


### PR DESCRIPTION
This option didn't work properly when "Hide window to system tray when minimised" was also enabled.

I don't see a particular reason why Windows shouldn't be calling hideWindow() like all other platforms. hideWindow() takes care of choosing the correct minimisation mode based on the user's settings.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested different combinations of tray and minimise settings, worked flawlessly.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
