### PR TITLE
[RFC] fdosecrets: add optional confirmation to secret access

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -169,6 +169,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::FdoSecrets_Enabled, {QS("FdoSecrets/Enabled"), Roaming, false}},
     {Config::FdoSecrets_ShowNotification, {QS("FdoSecrets/ShowNotification"), Roaming, true}},
     {Config::FdoSecrets_NoConfirmDeleteItem, {QS("FdoSecrets/NoConfirmDeleteItem"), Roaming, false}},
+    {Config::FdoSecrets_ConfirmAccessItem, {QS("FdoSecrets/ConfirmAccessItem"), Roaming, true}},
 
     // KeeShare
     {Config::KeeShare_QuietSuccess, {QS("KeeShare/QuietSuccess"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -148,6 +148,7 @@ public:
         FdoSecrets_Enabled,
         FdoSecrets_ShowNotification,
         FdoSecrets_NoConfirmDeleteItem,
+        FdoSecrets_ConfirmAccessItem,
 
         KeeShare_QuietSuccess,
         KeeShare_Own,

--- a/src/fdosecrets/CMakeLists.txt
+++ b/src/fdosecrets/CMakeLists.txt
@@ -18,6 +18,7 @@ if(WITH_XC_FDOSECRETS)
         GcryptMPI.cpp
 
         # dbus objects
+        objects/Connection.cpp
         objects/DBusObject.cpp
         objects/Service.cpp
         objects/Session.cpp

--- a/src/fdosecrets/FdoSecretsSettings.cpp
+++ b/src/fdosecrets/FdoSecretsSettings.cpp
@@ -74,6 +74,16 @@ namespace FdoSecrets
         config()->set(Config::FdoSecrets_NoConfirmDeleteItem, noConfirm);
     }
 
+    bool FdoSecretsSettings::confirmAccessItem() const
+    {
+        return config()->get(Config::FdoSecrets_ConfirmAccessItem).toBool();
+    }
+
+    void FdoSecretsSettings::setConfirmAccessItem(bool confirmAccessItem)
+    {
+        config()->set(Config::FdoSecrets_ConfirmAccessItem, confirmAccessItem);
+    }
+
     QUuid FdoSecretsSettings::exposedGroup(const QSharedPointer<Database>& db) const
     {
         return exposedGroup(db.data());

--- a/src/fdosecrets/FdoSecretsSettings.h
+++ b/src/fdosecrets/FdoSecretsSettings.h
@@ -41,6 +41,9 @@ namespace FdoSecrets
         bool noConfirmDeleteItem() const;
         void setNoConfirmDeleteItem(bool noConfirm);
 
+        bool confirmAccessItem() const;
+        void setConfirmAccessItem(bool confirmAccessItem);
+
         // Per db settings
 
         QUuid exposedGroup(const QSharedPointer<Database>& db) const;

--- a/src/fdosecrets/objects/Connection.cpp
+++ b/src/fdosecrets/objects/Connection.cpp
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (C) 2020 Jan Klötzke <jan@kloetzke.net>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Connection.h"
+
+#include "fdosecrets/FdoSecretsSettings.h"
+#include "fdosecrets/objects/Service.h"
+#include "fdosecrets/objects/Session.h"
+
+namespace FdoSecrets
+{
+
+    Connection::Connection(Service* parent, const QString& peerName)
+        : QObject(parent)
+        , m_peerName(peerName)
+    {
+    }
+
+    Connection::~Connection()
+    {
+        disconnectDBus();
+        for (auto& sess : m_sessions) {
+            delete sess;
+        }
+    }
+
+    void Connection::addSession(Session* sess)
+    {
+        m_sessions.append(sess);
+        connect(sess, &Session::aboutToClose, this, [this, sess]() { m_sessions.removeAll(sess); });
+    }
+
+    bool Connection::authorized(const QUuid& uuid) const
+    {
+        if (!m_connected) {
+            return false;
+        }
+
+        if (!FdoSecrets::settings()->confirmAccessItem()) {
+            return true;
+        }
+
+        return m_authorizedAll || m_authorizedEntries.contains(uuid);
+    }
+
+    void Connection::setAuthorizedAll()
+    {
+        m_authorizedAll = true;
+    }
+
+    void Connection::setAuthorizedItem(const QUuid& uuid)
+    {
+        m_authorizedEntries.insert(uuid);
+    }
+
+    void Connection::disconnectDBus()
+    {
+        if (m_connected) {
+            m_connected = false;
+            emit disconnectedDBus();
+        }
+    }
+
+} // namespace FdoSecrets

--- a/src/fdosecrets/objects/Connection.h
+++ b/src/fdosecrets/objects/Connection.h
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (C) 2020 Jan Klötzke <jan@kloetzke.net>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_FDOSECRETS_CONNECTION_H
+#define KEEPASSXC_FDOSECRETS_CONNECTION_H
+
+#include <QList>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QUuid>
+
+namespace FdoSecrets
+{
+    class Service;
+    class Session;
+
+    /**
+     * Represent a client that has made requests to our service.
+     *
+     * The DBus model does not have any notion of a connection between client
+     * and service. This implies that we cannot disconnect a client but every
+     * request handler must check the connected() property if a request should
+     * be handled or not.
+     *
+     * A object of this class is created on the first request and destroyed
+     * when the client address vanishes from the bus. DBus guarantees that the
+     * client address is not reused.
+     */
+    class Connection : public QObject
+    {
+        Q_OBJECT
+    public:
+        explicit Connection(Service* parent, const QString& peerName);
+        ~Connection() override;
+
+        /**
+         * The human readable peer name.
+         */
+        QString peerName() const
+        {
+            return m_peerName;
+        }
+
+        /**
+         * Property signaling whether requests should be handled.
+         *
+         * If false a client request should be rejected.
+         */
+        bool connected() const
+        {
+            return m_connected;
+        }
+
+        /**
+         * Add Session object to the client state.
+         *
+         * Will take the ownership of the @a sess object.
+         */
+        void addSession(Session* sess);
+
+        /**
+         * Check if client may access item identified by @a uuid.
+         */
+        bool authorized(const QUuid& uuid) const;
+
+        /**
+         * Authorize client to access all items.
+         */
+        void setAuthorizedAll();
+
+        /**
+         * Authorize client to access item identified by @a uuid.
+         */
+        void setAuthorizedItem(const QUuid& uuid);
+
+    public slots:
+        /**
+         * Forcefully disconnect the client.
+         */
+        void disconnectDBus();
+
+    signals:
+        void disconnectedDBus();
+
+    private:
+        QString m_peerName;
+        bool m_connected{true};
+        bool m_authorizedAll{false};
+        QSet<QUuid> m_authorizedEntries{};
+        QList<Session*> m_sessions;
+    };
+
+} // namespace FdoSecrets
+
+#endif // KEEPASSXC_FDOSECRETS_CONNECTION_H

--- a/src/fdosecrets/objects/DBusObject.cpp
+++ b/src/fdosecrets/objects/DBusObject.cpp
@@ -19,6 +19,7 @@
 
 #include <QDBusAbstractAdaptor>
 #include <QFile>
+#include <QFileInfo>
 #include <QRegularExpression>
 #include <QTextStream>
 #include <QUrl>
@@ -44,15 +45,14 @@ namespace FdoSecrets
         Q_ASSERT(ok);
     }
 
-    QString DBusObject::callingPeerName() const
+    QString DBusObject::peerName(uint pid) const
     {
-        auto pid = callingPeerPid();
-        QFile proc(QStringLiteral("/proc/%1/comm").arg(pid));
-        if (!proc.open(QFile::ReadOnly)) {
-            return callingPeer();
+        QFileInfo info(QStringLiteral("/proc/%1/exe").arg(pid));
+        if (info.exists()) {
+            return info.canonicalFilePath();
+        } else {
+            return QStringLiteral("Unknown");
         }
-        QTextStream stream(&proc);
-        return stream.readAll().trimmed();
     }
 
     QString encodePath(const QString& value)

--- a/src/fdosecrets/objects/DBusObject.h
+++ b/src/fdosecrets/objects/DBusObject.h
@@ -66,6 +66,13 @@ namespace FdoSecrets
             m_objectPath.setPath(QStringLiteral("/"));
         }
 
+        uint peerPid(const QString& service) const
+        {
+            return connection().interface()->servicePid(service);
+        }
+
+        QString peerName(uint pid) const;
+
         QString callingPeer() const
         {
             Q_ASSERT(calledFromDBus());
@@ -74,10 +81,13 @@ namespace FdoSecrets
 
         uint callingPeerPid() const
         {
-            return connection().interface()->servicePid(callingPeer());
+            return peerPid(callingPeer());
         }
 
-        QString callingPeerName() const;
+        QString callingPeerName() const
+        {
+            return peerName(callingPeerPid());
+        }
 
         DBusObject* p() const
         {

--- a/src/fdosecrets/objects/Item.h
+++ b/src/fdosecrets/objects/Item.h
@@ -34,6 +34,7 @@ namespace FdoSecrets
         constexpr const auto PathKey = "Path";
     } // namespace ItemAttributes
 
+    class Connection;
     class Session;
     class Collection;
     class PromptBase;
@@ -45,6 +46,7 @@ namespace FdoSecrets
         explicit Item(Collection* parent, Entry* backend);
 
         DBusReturn<bool> locked() const;
+        DBusReturn<bool> locked(Connection* conn) const;
 
         DBusReturn<const StringStringMap> attributes() const;
         DBusReturn<void> setAttributes(const StringStringMap& attrs);
@@ -57,8 +59,8 @@ namespace FdoSecrets
         DBusReturn<qulonglong> modified() const;
 
         DBusReturn<PromptBase*> deleteItem();
-        DBusReturn<SecretStruct> getSecret(Session* session);
-        DBusReturn<void> setSecret(const SecretStruct& secret);
+        DBusReturn<SecretStruct> getSecret(Session* session, Connection* connection = nullptr);
+        DBusReturn<void> setSecret(const SecretStruct& secret, Connection* connection = nullptr);
 
     signals:
         void itemChanged();

--- a/src/fdosecrets/objects/Prompt.h
+++ b/src/fdosecrets/objects/Prompt.h
@@ -51,6 +51,8 @@ namespace FdoSecrets
     };
 
     class Collection;
+    class Item;
+    class Connection;
 
     class DeleteCollectionPrompt : public PromptBase
     {
@@ -97,7 +99,10 @@ namespace FdoSecrets
     {
         Q_OBJECT
     public:
-        explicit UnlockCollectionsPrompt(Service* parent, const QList<Collection*>& coll);
+        explicit UnlockCollectionsPrompt(Service* parent,
+                                         Connection* conn,
+                                         const QSet<Collection*>& colls,
+                                         const QSet<Item*>& items);
 
         DBusReturn<void> prompt(const QString& windowId) override;
         DBusReturn<void> dismiss() override;
@@ -106,7 +111,10 @@ namespace FdoSecrets
         void collectionUnlockFinished(bool accepted);
 
     private:
+        void unlockItems();
+        QPointer<Connection> m_conn;
         QList<QPointer<Collection>> m_collections;
+        QList<QPointer<Item>> m_items;
         QList<QDBusObjectPath> m_unlocked;
         int m_numRejected = 0;
     };
@@ -123,6 +131,25 @@ namespace FdoSecrets
 
     private:
         QPointer<Item> m_item;
+    };
+
+    class OverwritePrompt : public PromptBase
+    {
+        Q_OBJECT
+    public:
+        OverwritePrompt(Service* parent,
+                        Connection* conn,
+                        Item* item,
+                        const QVariantMap& properties,
+                        const SecretStruct& secret);
+
+        DBusReturn<void> prompt(const QString& windowId) override;
+
+    private:
+        QPointer<Connection> m_conn;
+        QPointer<Item> m_item;
+        QVariantMap m_properties;
+        SecretStruct m_secret;
     };
 
 } // namespace FdoSecrets

--- a/src/fdosecrets/objects/Service.h
+++ b/src/fdosecrets/objects/Service.h
@@ -39,6 +39,7 @@ namespace FdoSecrets
 {
 
     class Collection;
+    class Connection;
     class Item;
     class PromptBase;
     class ServiceAdaptor;
@@ -79,8 +80,8 @@ namespace FdoSecrets
         void collectionDeleted(Collection* collection);
         void collectionChanged(Collection* collection);
 
-        void sessionOpened(Session* sess);
-        void sessionClosed(Session* sess);
+        void connectionOpened(Connection* conn);
+        void connectionClosed(Connection* conn);
 
         /**
          * Report error message to the GUI
@@ -97,10 +98,18 @@ namespace FdoSecrets
 
     public:
         /**
-         * List of sessions
-         * @return
+         * Get connection state for a client.
+         *
+         * @param peer The DBus address of the peer
+         * @param create Create connection object if the peer is not known yet
+         * @return Connection object or nullptr if it does not exist and @a create is false
          */
-        const QList<Session*> sessions() const;
+        Connection* connection(const QString& peer, bool create = true);
+
+        /**
+         * Get all active connections.
+         */
+        const QList<Connection*> connections() const;
 
         FdoSecretsPlugin* plugin() const
         {
@@ -153,8 +162,7 @@ namespace FdoSecrets
         QList<Collection*> m_collections;
         QHash<const DatabaseWidget*, Collection*> m_dbToCollection;
 
-        QList<Session*> m_sessions;
-        QHash<QString, Session*> m_peerToSession;
+        QHash<QString, Connection*> m_connections;
 
         bool m_insdieEnsureDefaultAlias;
 

--- a/src/fdosecrets/objects/Session.cpp
+++ b/src/fdosecrets/objects/Session.cpp
@@ -23,8 +23,6 @@
 namespace FdoSecrets
 {
 
-    QHash<QString, QVariant> Session::negoniationState;
-
     Session::Session(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent)
         : DBusObject(parent)
         , m_cipher(std::move(cipher))
@@ -33,11 +31,6 @@ namespace FdoSecrets
     {
         registerWithPath(QStringLiteral(DBUS_PATH_TEMPLATE_SESSION).arg(p()->objectPath().path(), id()),
                          new SessionAdaptor(this));
-    }
-
-    void Session::CleanupNegotiation(const QString& peer)
-    {
-        negoniationState.remove(peer);
     }
 
     DBusReturn<void> Session::close()

--- a/src/fdosecrets/widgets/SettingsModels.h
+++ b/src/fdosecrets/widgets/SettingsModels.h
@@ -59,13 +59,13 @@ namespace FdoSecrets
     };
 
     class Service;
-    class Session;
+    class Connection;
 
-    class SettingsSessionModel : public QAbstractTableModel
+    class SettingsConnectionModel : public QAbstractTableModel
     {
         Q_OBJECT
     public:
-        explicit SettingsSessionModel(FdoSecretsPlugin* plugin, QObject* parent = nullptr);
+        explicit SettingsConnectionModel(FdoSecretsPlugin* plugin, QObject* parent = nullptr);
 
         int rowCount(const QModelIndex& parent) const override;
         int columnCount(const QModelIndex& parent) const override;
@@ -75,20 +75,20 @@ namespace FdoSecrets
     private:
         void setService(Service* service);
 
-        QVariant dataForApplication(Session* sess, int role) const;
-        QVariant dataForManage(Session* sess, int role) const;
+        QVariant dataForApplication(Connection* conn, int role) const;
+        QVariant dataForManage(Connection* conn, int role) const;
 
     private slots:
         void populateModel();
-        void sessionAdded(Session* sess, bool emitSignals);
-        void sessionRemoved(Session* sess);
+        void connectionAdded(Connection* conn, bool emitSignals);
+        void connectionRemoved(Connection* conn);
 
     private:
         // source
         QPointer<Service> m_service;
 
         // internal copy, so we can emit with changed index
-        QList<Session*> m_sessions;
+        QList<Connection*> m_connections;
     };
 
 } // namespace FdoSecrets

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.h
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.h
@@ -31,7 +31,7 @@ class QItemEditorFactory;
 namespace FdoSecrets
 {
 
-    class Session;
+    class Connection;
     class Collection;
 
 } // namespace FdoSecrets

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.ui
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.ui
@@ -54,6 +54,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="confirmAccessItem">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, any attempt to read a password must be confirmed. Otherwise, clients can read passwords without confirmation when the database is unlocked.&lt;/p&gt;&lt;p&gt;This option only covers the access to the password of an entry. Clients can always enumerate the items of exposed databases and query their attributes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Confirm when passwords are retrieved by clients</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="noConfirmDeleteItem">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If recycle bin is enabled for the database, entries will be moved to recycle bin directly. Otherwise, they will be deleted without confirmation.&lt;/p&gt;&lt;p&gt;You will still be prompted if any entries are referenced by others.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -120,7 +130,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QTableView" name="tableSessions">
+        <widget class="QTableView" name="tableConnections">
          <property name="focusPolicy">
           <enum>Qt::NoFocus</enum>
          </property>


### PR DESCRIPTION
This is a first rough implementation to confirm requests through the freedesktop.org DBus secret service API. It's current not fully polished but I wanted to get early feedback before wasting time. The confirmation is optional but enabled by default. This is implemented as a per-database setting.

The choice of the user is remembered for the client connection. The DBus specification guarantees that the client address is not reused during the lifetime of a DBus session. So as soon as the client process terminates a new confirmation will be required the next time. As long as the client service is alive it can be authorized for the whole session for all items by choosing "Yes to all". By choosing "Yes" the access is granted only for the currently requested item.

To improve the client identification the `/proc/$PID/exe` link is read. This is unforgeable by the application AFAICT. It's still weak and if the application does a `prctl(PR_SET_DUMPABLE, 0)` this link cannot be accessed. That's as good as it get's IMHO.

The implementation does not block the DBus handler (like the first attempt #3845) but relies on the prompt objects of the API. Unfortunately there is no way in QtDBus to know who reads a *property*. You can only get the caller identity on slot calls. This has the unfortunate consequence that we cannot honestly report the `Locked` property of the items. So even when an application has been given access to a certain item it will still read the `Locked` property as `true`. It also looks like that `seahorse` does not follow the spec because it assumes that all items are readable if the collection was unlocked.

Fixes #3837.

## Screenshots

There is a new knob in the FDO database settings to request confirmation:
![Screenshot_Settings](https://user-images.githubusercontent.com/234300/81735839-f2a29280-9495-11ea-9112-b311fb4dc105.png)

And this is the confirmation that the user sees per request:
![Screenshot_Confirmation](https://user-images.githubusercontent.com/234300/81735892-09e18000-9496-11ea-8bdd-a351dad86615.png)

## Testing strategy

Currently tested manually with `secret-tool`. It would be good to get some hints how to test such interactive things. The code documentation will be improvement.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)

## TODO
- [x] Refactor commit into smaller change sets
- [ ] Add tests
- [x] Document code