### PR TITLE
Make 'show/hide passwords' toggle temporary

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -98,7 +98,6 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_MinimizeOnStartup, {QS("GUI/MinimizeOnStartup"), Roaming, false}},
     {Config::GUI_MinimizeOnClose, {QS("GUI/MinimizeOnClose"), Roaming, false}},
     {Config::GUI_HideUsernames, {QS("GUI/HideUsernames"), Roaming, false}},
-    {Config::GUI_HidePasswords, {QS("GUI/HidePasswords"), Roaming, true}},
     {Config::GUI_AdvancedSettings, {QS("GUI/AdvancedSettings"), Roaming, false}},
     {Config::GUI_MonospaceNotes, {QS("GUI/MonospaceNotes"), Roaming, false}},
     {Config::GUI_ApplicationTheme, {QS("GUI/ApplicationTheme"), Roaming, QS("auto")}},
@@ -342,7 +341,8 @@ static const QHash<QString, Config::ConfigKey> deprecationMap = {
     {QS("generator/WordList"), Config::PasswordGenerator_WordList},
     {QS("generator/WordCase"), Config::PasswordGenerator_WordCase},
     {QS("generator/Type"), Config::PasswordGenerator_Type},
-    {QS("QtErrorMessageShown"), Config::Messages_Qt55CompatibilityWarning}};
+    {QS("QtErrorMessageShown"), Config::Messages_Qt55CompatibilityWarning},
+    {QS("GUI/HidePasswords"), Config::Deleted}};
 
 /**
  * Migrate settings from previous versions.
@@ -381,13 +381,14 @@ void Config::migrate()
     }
 
     // Move local settings to separate file
-    if (m_localSettings)
+    if (m_localSettings) {
         for (const auto& setting : asConst(configStrings)) {
             if (setting.type == Local && m_settings->contains(setting.name)) {
                 m_localSettings->setValue(setting.name, m_settings->value(setting.name));
                 m_settings->remove(setting.name);
             }
         }
+    }
 
     // Detailed version migrations
 

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -81,7 +81,6 @@ public:
         GUI_MinimizeOnStartup,
         GUI_MinimizeOnClose,
         GUI_HideUsernames,
-        GUI_HidePasswords,
         GUI_AdvancedSettings,
         GUI_MonospaceNotes,
         GUI_ApplicationTheme,

--- a/src/gui/DatabaseWidgetStateSync.cpp
+++ b/src/gui/DatabaseWidgetStateSync.cpp
@@ -30,7 +30,7 @@ DatabaseWidgetStateSync::DatabaseWidgetStateSync(QObject* parent)
     m_mainSplitterSizes = variantToIntList(config()->get(Config::GUI_SplitterState));
     m_previewSplitterSizes = variantToIntList(config()->get(Config::GUI_PreviewSplitterState));
     m_hideUsernames = config()->get(Config::GUI_HideUsernames).toBool();
-    m_hidePasswords = config()->get(Config::GUI_HidePasswords).toBool();
+    m_hidePasswords = true;
     m_listViewState = config()->get(Config::GUI_ListViewState).toByteArray();
     m_searchViewState = config()->get(Config::GUI_SearchViewState).toByteArray();
 
@@ -49,7 +49,6 @@ void DatabaseWidgetStateSync::sync()
     config()->set(Config::GUI_SplitterState, intListToVariant(m_mainSplitterSizes));
     config()->set(Config::GUI_PreviewSplitterState, intListToVariant(m_previewSplitterSizes));
     config()->set(Config::GUI_HideUsernames, m_hideUsernames);
-    config()->set(Config::GUI_HidePasswords, m_hidePasswords);
     config()->set(Config::GUI_ListViewState, m_listViewState);
     config()->set(Config::GUI_SearchViewState, m_searchViewState);
     config()->sync();


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Changes the behavior of the "Hide Passwords" setting in entry view so it no longer persists across runs.

It is easy to accidentally activate the keyboard shortcut for this setting without an obvious way to change it back (see #4378). Since it's possible for a user to unintentionally switch to less secure behavior, either the switch should be temporary or it should be harder to accidentally trigger (remove the keyboard shortcut). Making it temporary is probably the less disruptive change between those options.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Breaking change (causes existing functionality to change)