### PR TITLE
Add possibility to get login by its UUID

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -66,6 +66,7 @@ QJsonObject BrowserAction::processClientMessage(const QJsonObject& json)
     }
 
     const QString action = json.value("action").toString();
+    qDebug() << "BrowserAction: '" << action << "'";
     if (action.isEmpty()) {
         return getErrorReply(action, ERROR_KEEPASS_INCORRECT_ACTION);
     }

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -332,9 +332,6 @@ QJsonObject BrowserAction::handleGetLoginExact(const QJsonObject& json, const QS
     }
 
     const QString id = decrypted.value("id").toString();
-    const QString submit = decrypted.value("submitUrl").toString();
-    const QString auth = decrypted.value("httpAuth").toString();
-    const bool httpAuth = auth.compare(TRUE_STR, Qt::CaseSensitive) == 0 ? true : false;
     const QJsonObject entry = browserService()->findEntry(id, uuidHex);
 
     if (entry.isEmpty()) {

--- a/src/browser/BrowserAction.h
+++ b/src/browser/BrowserAction.h
@@ -36,6 +36,7 @@ private:
     QJsonObject handleAssociate(const QJsonObject& json, const QString& action);
     QJsonObject handleTestAssociate(const QJsonObject& json, const QString& action);
     QJsonObject handleGetLogins(const QJsonObject& json, const QString& action);
+    QJsonObject handleGetLoginExact(const QJsonObject& json, const QString& action);
     QJsonObject handleGeneratePassword(const QJsonObject& json, const QString& action);
     QJsonObject handleSetLogin(const QJsonObject& json, const QString& action);
     QJsonObject handleLockDatabase(const QJsonObject& json, const QString& action);

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -562,7 +562,7 @@ Entry* BrowserService::searchEntry(const QSharedPointer<Database>& db, const QUu
 {
     auto* rootGroup = db->rootGroup();
     if (!rootGroup) {
-        return NULL;
+        return nullptr;
     }
 
     for (const auto& group : rootGroup->groupsRecursive(true)) {
@@ -581,7 +581,7 @@ Entry* BrowserService::searchEntry(const QSharedPointer<Database>& db, const QUu
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 QList<Entry*>

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -558,8 +558,7 @@ bool BrowserService::updateEntry(const QString& dbid,
     return result;
 }
 
-Entry*
-BrowserService::searchEntry(const QSharedPointer<Database>& db, const QUuid& uuid)
+Entry* BrowserService::searchEntry(const QSharedPointer<Database>& db, const QUuid& uuid)
 {
     auto* rootGroup = db->rootGroup();
     if (!rootGroup) {

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -81,6 +81,7 @@ public:
                                    const QString& realm,
                                    const StringPairList& keyList,
                                    const bool httpAuth = false);
+    QJsonObject findEntry(const QString& dbid, const QString& uuidHex);
 
     static void convertAttributesToCustomData(QSharedPointer<Database> db);
 
@@ -114,6 +115,7 @@ private:
         Hidden
     };
 
+    Entry* searchEntry(const QSharedPointer<Database>& db, const QUuid& uuid);
     QList<Entry*> searchEntries(const QSharedPointer<Database>& db, const QString& url, const QString& submitUrl);
     QList<Entry*> searchEntries(const QString& url, const QString& submitUrl, const StringPairList& keyList);
     QList<Entry*> sortEntries(QList<Entry*>& pwEntries, const QString& host, const QString& submitUrl);

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -259,11 +259,13 @@ void TestBrowser::testSearchEntryByUUID()
     auto* root = db->rootGroup();
 
     /* Create some dummy entries */
-    QStringList urls = {"https://github.com/login_page",
-                        "https://github.com/login",
-                        "https://github.com/",
-                        "http://github.com",
-                        "http://github.com/login",};
+    QStringList urls = {
+        "https://github.com/login_page",
+        "https://github.com/login",
+        "https://github.com/",
+        "http://github.com",
+        "http://github.com/login",
+    };
     auto entries = createEntries(urls, root);
 
     for (Entry* entry : entries) {
@@ -271,7 +273,7 @@ void TestBrowser::testSearchEntryByUUID()
         auto result = m_browserService->searchEntry(db, entry.uuidToHex());
         QCOMPARE(result, entry);
     }
-    
+
     /* Test for entries that don't exist */
     QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000000"), NULL);
     QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000001"), NULL);

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -253,6 +253,34 @@ void TestBrowser::testSearchEntriesWithAdditionalURLs()
     QCOMPARE(additionalResult[0]->url(), QString("https://github.com/"));
 }
 
+void TestBrowser::testSearchEntryByUUID()
+{
+    auto db = QSharedPointer<Database>::create();
+    auto* root = db->rootGroup();
+
+    /* Create some dummy entries */
+    QStringList urls = {"https://github.com/login_page",
+                        "https://github.com/login",
+                        "https://github.com/",
+                        "http://github.com",
+                        "http://github.com/login",};
+    auto entries = createEntries(urls, root);
+
+    for (Entry* entry : entries) {
+        /* Look for an entry with that UUID */
+        auto result = m_browserService->searchEntry(db, entry.uuidToHex());
+        QCOMPARE(result, entry);
+    }
+    
+    /* Test for entries that don't exist */
+    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000000"), NULL);
+    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000001"), NULL);
+    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000002"), NULL);
+    /* Test for invalid UUIDs */
+    QCOMPARE(m_browserService->searchEntry(db, "invalid uuid"), NULL);
+    QCOMPARE(m_browserService->searchEntry(db, "000000000000000000000000000000000000000"), NULL);
+}
+
 void TestBrowser::testInvalidEntries()
 {
     auto db = QSharedPointer<Database>::create();

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -270,17 +270,18 @@ void TestBrowser::testSearchEntryByUUID()
 
     for (Entry* entry : entries) {
         /* Look for an entry with that UUID */
-        auto result = m_browserService->searchEntry(db, entry.uuidToHex());
+        auto result = m_browserService->searchEntry(db, entry->uuidToHex());
         QCOMPARE(result, entry);
     }
 
     /* Test for entries that don't exist */
-    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000000"), NULL);
-    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000001"), NULL);
-    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000002"), NULL);
+    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000000"), static_cast<Entry*>(nullptr));
+    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000001"), static_cast<Entry*>(nullptr));
+    QCOMPARE(m_browserService->searchEntry(db, "00000000000000000000000000000002"), static_cast<Entry*>(nullptr));
     /* Test for invalid UUIDs */
-    QCOMPARE(m_browserService->searchEntry(db, "invalid uuid"), NULL);
-    QCOMPARE(m_browserService->searchEntry(db, "000000000000000000000000000000000000000"), NULL);
+    QCOMPARE(m_browserService->searchEntry(db, "invalid uuid"), static_cast<Entry*>(nullptr));
+    QCOMPARE(m_browserService->searchEntry(db, "000000000000000000000000000000000000000"),
+             static_cast<Entry*>(nullptr));
 }
 
 void TestBrowser::testInvalidEntries()

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -43,6 +43,7 @@ private slots:
     void testSearchEntries();
     void testSearchEntriesWithPort();
     void testSearchEntriesWithAdditionalURLs();
+    void testSearchEntryByUUID();
     void testInvalidEntries();
     void testSubdomainsAndPaths();
     void testSortEntries();


### PR DESCRIPTION
This is an attempt to implement: https://github.com/keepassxreboot/keepassxc-browser/issues/533 .

I'm new to Keepass and copy-pasted my way around to get what I want, but I may need some help.

- First of all, the code doesn't work, as issuing a `get-exact-login` command will resond with an `Incorrect action` error.
- Also, how do I turn the `qdebug` messages on? `KEEPASSXC_BUILD_TYPE=Debug` doesn't seem to work.
- ~~When I add a test, do I need to "register" it somewhere or will it be run automatically?~~
- I'm not really happy about any of the names (both for methods and the new action itself), suggestions are welcome.
- Any of the security-related stuff isn't implemented yet. I'll deal with it once the code actually works.
- How can I make that `QCOMPARE(result, entry);` uses `equals` and not a shallow pointer comparison?

## Testing strategy

I added tests for `searchEntry` but not for the actual `BrowserAction` that uses it.

## Type of change
- ✅ New feature (change that adds functionality)
