### PR TITLE
Browser service search for entries by UUID

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -597,7 +597,7 @@ BrowserService::searchEntries(const QSharedPointer<Database>& db, const QString&
                 }
             }
 
-            if (!handleURL(entry->url(), url, submitUrl)) {
+            if (!handleEntry(entry, url, submitUrl)) {
                 continue;
             }
 
@@ -1004,6 +1004,17 @@ bool BrowserService::removeFirstDomain(QString& hostname)
     return false;
 }
 
+/* Test if a search URL matches a custom entry. If the URL has the schema "keepassxc", some special checks will be made.
+ * Otherwise, this simply delegates to handleURL(). */
+bool BrowserService::handleEntry(Entry* entry, const QString& url, const QString& submitUrl)
+{
+    // Use this special scheme to find entries by UUID
+    if (url.startsWith("keepassxc://")) {
+        return ("keepassxc://by-uuid/" + entry->uuidToHex()) == url;
+    }
+    return handleURL(entry->url(), url, submitUrl);
+}
+
 bool BrowserService::handleURL(const QString& entryUrl, const QString& url, const QString& submitUrl)
 {
     if (entryUrl.isEmpty()) {
@@ -1022,7 +1033,7 @@ bool BrowserService::handleURL(const QString& entryUrl, const QString& url, cons
     }
 
     // Make a direct compare if a local file is used
-    if (url.contains("file://")) {
+    if (url.startsWith("file://")) {
         return entryUrl == submitUrl;
     }
 

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -139,6 +139,7 @@ private:
                      const QString& fullUrl) const;
     bool schemeFound(const QString& url);
     bool removeFirstDomain(QString& hostname);
+    bool handleEntry(Entry* entry, const QString& url, const QString& submitUrl);
     bool handleURL(const QString& entryUrl, const QString& url, const QString& submitUrl);
     QString baseDomain(const QString& hostname) const;
     QSharedPointer<Database> getDatabase();

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -41,6 +41,7 @@ private slots:
     void testBaseDomain();
     void testSortPriority();
     void testSearchEntries();
+    void testSearchEntriesByUUID();
     void testSearchEntriesWithPort();
     void testSearchEntriesWithAdditionalURLs();
     void testInvalidEntries();


### PR DESCRIPTION
This is my second take on implementing https://github.com/keepassxreboot/keepassxc-browser/issues/533 .

The idea is to add custom handling for URLs that start with `keepassxc://`. If a search URL matches `keepassxc://by-uuid/<uuid>` and an entry with that UUID exists, it will be returned.

This concept could be extended to search for entries using other attributes or more complex search queries, but I don't plan on doing that.

## Testing strategy

Successful dogfooding for multiple months (:

## Type of change

- ✅ New feature (change that adds functionality)
