### PR TITLE
Use Segoe UI font on Windows.

### DIFF
--- a/src/core/Bootstrap.cpp
+++ b/src/core/Bootstrap.cpp
@@ -73,7 +73,6 @@ namespace Bootstrap
 
         setupSearchPaths();
         applyEarlyQNetworkAccessManagerWorkaround();
-        Translator::installTranslators();
     }
 
     /**
@@ -84,6 +83,15 @@ namespace Bootstrap
     void bootstrapApplication()
     {
         bootstrap();
+        Translator::installTranslators();
+
+#ifdef Q_OS_WIN
+        // Qt on Windows uses "MS Shell Dlg 2" as the default font for many widgets, which resolves
+        // to Tahoma 8pt, whereas the correct font would be "Segoe UI" 9pt.
+        // Apparently, some widgets are already using the correct font. Thanks, MuseScore for this neat fix!
+        QApplication::setFont(QApplication::font("QMessageBox"));
+#endif
+
         MessageBox::initializeButtonDefs();
 
 #ifdef Q_OS_MACOS


### PR DESCRIPTION
Qt uses "MS Shell Dlg 2" as the default font, which resolves to Tahoma and not Segoe UI, which is the actual Windows 10 default font.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Before:
![tahoma](https://user-images.githubusercontent.com/911270/82558389-ceb60f80-9b6d-11ea-9ef5-18eb41ccc172.png)

After:
![segoe](https://user-images.githubusercontent.com/911270/82558398-d1186980-9b6d-11ea-9db0-7f22d8d199f8.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
I checked the exact pixel dimensions of the font at various font scaling settings. The application still doesn't react immediately when you change the "Make text bigger" setting, but at least it does react at all now (after a restart).

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
