### PR TITLE
Fix DatabaseTabWidget::lockDatabases returns false even when all tabs are locked

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -627,7 +627,8 @@ DatabaseWidget* DatabaseTabWidget::currentDatabaseWidget()
 bool DatabaseTabWidget::lockDatabases()
 {
     int numLocked = 0;
-    for (int i = 0, c = count(); i < c; ++i) {
+    int c = count();
+    for (int i = 0; i < c; ++i) {
         auto dbWidget = databaseWidgetFromIndex(i);
         if (dbWidget->lock()) {
             ++numLocked;
@@ -638,7 +639,7 @@ bool DatabaseTabWidget::lockDatabases()
         }
     }
 
-    return numLocked == count();
+    return numLocked == c;
 }
 
 /**


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
`count()` will change if some tabs without a file were closed because of locking. So `numLocked` will be different from `count()`. I found this while working on some gui tests, which marks every tab clean and close them all.

The fix is to simply save the count at the beginning.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
* create a new database
* mark it as clean
* call `lockDatabases`

It should return `true` rather than `false`.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
