### PR TITLE
Hide window and dock icon on macOS when tray enabled

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -141,7 +141,6 @@ private:
 
     static const QString BaseWindowTitle;
 
-    bool shouldHide();
     void saveWindowInformation();
     bool saveLastDatabases();
     void updateTrayIcon();

--- a/src/gui/osutils/macutils/AppKit.h
+++ b/src/gui/osutils/macutils/AppKit.h
@@ -39,6 +39,7 @@ public:
     bool isDarkMode();
     bool enableAccessibility();
     bool enableScreenRecording();
+    void toggleForegroundApp(bool foreground);
 
 signals:
     void lockDatabases();

--- a/src/gui/osutils/macutils/AppKitImpl.h
+++ b/src/gui/osutils/macutils/AppKitImpl.h
@@ -38,5 +38,6 @@
 - (void) userSwitchHandler:(NSNotification*) notification;
 - (bool) enableAccessibility;
 - (bool) enableScreenRecording;
+- (void) toggleForegroundApp:(bool) foreground;
 
 @end

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -154,6 +154,16 @@
     return YES;
 }
 
+- (void) toggleForegroundApp:(bool) foreground
+{
+    ProcessSerialNumber psn = {0, kCurrentProcess};
+    if (foreground) {
+        TransformProcessType(&psn, kProcessTransformToForegroundApplication);
+    } else {
+        TransformProcessType(&psn, kProcessTransformToUIElementApplication);
+    }
+}
+
 @end
 
 //
@@ -214,4 +224,9 @@ bool AppKit::enableAccessibility()
 bool AppKit::enableScreenRecording()
 {
     return [static_cast<id>(self) enableScreenRecording];
+}
+
+void AppKit::toggleForegroundApp(bool foreground)
+{
+    [static_cast<id>(self) toggleForegroundApp:foreground];
 }

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -123,3 +123,14 @@ bool MacUtils::isCapslockEnabled()
 {
     return (CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState) & kCGEventFlagMaskAlphaShift) != 0;
 }
+
+/**
+ * Toggle application state between foreground app and UIElement app.
+ * Foreground apps have dock icons, UIElement apps do not.
+ *
+ * @param foreground whether app is foreground app
+ */
+void MacUtils::toggleForegroundApp(bool foreground)
+{
+    m_appkit->toggleForegroundApp(foreground);
+}

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -46,6 +46,7 @@ public:
     bool isHidden();
     bool enableAccessibility();
     bool enableScreenRecording();
+    void toggleForegroundApp(bool foreground);
 
 signals:
     void lockDatabases();


### PR DESCRIPTION
Transforms application into a UIElement agent app when minimize to tray is enabled and the window is hidden. This hides the dock icon and removes the application from the Cmd+Tab listing. The changes work well together with macOS's inbuilt hide feature.

Also fixes the buggy tray icon context menu trigger behaviour. macOS triggers the tray context menu also on normal left click, which causes the window to toggle at the same time as the menu. To fix this, window toggling has been disabled altogether on macOS and users will be shown only the context menu from now on.

Fixes #1334

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)