### PR TITLE
Fix memory leak in test

### DIFF
--- a/tests/TestOpVaultReader.cpp
+++ b/tests/TestOpVaultReader.cpp
@@ -68,7 +68,7 @@ void TestOpVaultReader::testReadIntoDatabase()
     QDir opVaultDir(m_opVaultPath);
 
     OpVaultReader reader;
-    auto db = reader.readDatabase(opVaultDir, "a");
+    QScopedPointer<Database> db(reader.readDatabase(opVaultDir, "a"));
     QVERIFY(db);
     QVERIFY2(!reader.hasError(), qPrintable(reader.errorString()));
 


### PR DESCRIPTION
Just a simple lost pointer in a test case.

I think the `QScopedPointer` in `OpVaultReader::readDatabase` gave a false sense of security.

## Testing strategy
`valgrind build/tests/testopvaultreader` no longer shows leaked memory

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
