### PR TITLE
Fix loading of tray icon appearance setting

### DIFF
--- a/src/core/Resources.cpp
+++ b/src/core/Resources.cpp
@@ -32,7 +32,7 @@
 
 Resources* Resources::m_instance(nullptr);
 
-QString Resources::dataPath(const QString& name)
+QString Resources::dataPath(const QString& name) const
 {
     if (name.isEmpty() || name.startsWith('/')) {
         return m_dataPath + name;
@@ -40,7 +40,7 @@ QString Resources::dataPath(const QString& name)
     return m_dataPath + "/" + name;
 }
 
-QString Resources::pluginPath(const QString& name)
+QString Resources::pluginPath(const QString& name) const
 {
     QStringList pluginPaths;
 
@@ -91,7 +91,7 @@ QString Resources::pluginPath(const QString& name)
     return {};
 }
 
-QString Resources::wordlistPath(const QString& name)
+QString Resources::wordlistPath(const QString& name) const
 {
     return dataPath(QStringLiteral("wordlists/%1").arg(name));
 }
@@ -101,7 +101,7 @@ QIcon Resources::applicationIcon()
     return icon("keepassxc", false);
 }
 
-QString Resources::getTrayIconAppearance() const
+QString Resources::trayIconAppearance() const
 {
     auto iconAppearance = config()->get(Config::GUI_TrayIconAppearance).toString();
     if (iconAppearance.isNull()) {
@@ -121,7 +121,7 @@ QIcon Resources::trayIcon()
 
 QIcon Resources::trayIconLocked()
 {
-    auto iconApperance = getTrayIconAppearance();
+    auto iconApperance = trayIconAppearance();
 
     if (iconApperance == "monochrome-light") {
         return icon("keepassxc-monochrome-light-locked", false);
@@ -134,7 +134,7 @@ QIcon Resources::trayIconLocked()
 
 QIcon Resources::trayIconUnlocked()
 {
-    auto iconApperance = getTrayIconAppearance();
+    auto iconApperance = trayIconAppearance();
 
     if (iconApperance == "monochrome-light") {
         return icon("keepassxc-monochrome-light", false);

--- a/src/core/Resources.h
+++ b/src/core/Resources.h
@@ -27,20 +27,20 @@
 class Resources
 {
 public:
-    QString dataPath(const QString& name);
-    QString pluginPath(const QString& name);
-    QString wordlistPath(const QString& name);
+    QString dataPath(const QString& name) const;
+    QString pluginPath(const QString& name) const;
+    QString wordlistPath(const QString& name) const;
     QIcon applicationIcon();
     QIcon trayIcon();
     QIcon trayIconLocked();
     QIcon trayIconUnlocked();
+    QString trayIconAppearance() const;
     QIcon icon(const QString& name, bool recolor = true, const QColor& overrideColor = QColor::Invalid);
     QIcon onOffIcon(const QString& name, bool recolor = true);
 
     static Resources* instance();
 
 private:
-    QString getTrayIconAppearance() const;
     Resources();
     bool testResourceDir(const QString& dir);
 

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -217,10 +217,10 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->monospaceNotesCheckBox->setChecked(config()->get(Config::GUI_MonospaceNotes).toBool());
 
     m_generalUi->appThemeSelection->clear();
-    m_generalUi->appThemeSelection->addItem(tr("Automatic"), QStringLiteral("auto"));
-    m_generalUi->appThemeSelection->addItem(tr("Light"), QStringLiteral("light"));
-    m_generalUi->appThemeSelection->addItem(tr("Dark"), QStringLiteral("dark"));
-    m_generalUi->appThemeSelection->addItem(tr("Classic (Platform-native)"), QStringLiteral("classic"));
+    m_generalUi->appThemeSelection->addItem(tr("Automatic"), "auto");
+    m_generalUi->appThemeSelection->addItem(tr("Light"), "light");
+    m_generalUi->appThemeSelection->addItem(tr("Dark"), "dark");
+    m_generalUi->appThemeSelection->addItem(tr("Classic (Platform-native)"), "classic");
     m_generalUi->appThemeSelection->setCurrentIndex(
         m_generalUi->appThemeSelection->findData(config()->get(Config::GUI_ApplicationTheme).toString()));
 
@@ -261,10 +261,10 @@ void ApplicationSettingsWidget::loadSettings()
     }
 
     m_generalUi->trayIconAppearance->clear();
-    m_generalUi->trayIconAppearance->addItem(tr("Monochrome (light)"), QStringLiteral("monochrome-light"));
-    m_generalUi->trayIconAppearance->addItem(tr("Monochrome (dark)"), QStringLiteral("monochrome-dark"));
-    m_generalUi->trayIconAppearance->addItem(tr("Colored"), QStringLiteral("colored"));
-    int trayIconIndex = m_generalUi->trayIconAppearance->findData(config()->get(Config::GUI_TrayIconAppearance));
+    m_generalUi->trayIconAppearance->addItem(tr("Monochrome (light)"), "monochrome-light");
+    m_generalUi->trayIconAppearance->addItem(tr("Monochrome (dark)"), "monochrome-dark");
+    m_generalUi->trayIconAppearance->addItem(tr("Colorful"), "colorful");
+    int trayIconIndex = m_generalUi->trayIconAppearance->findData(resources()->trayIconAppearance());
     if (trayIconIndex > 0) {
         m_generalUi->trayIconAppearance->setCurrentIndex(trayIconIndex);
     }


### PR DESCRIPTION
The tray icon appearance setting is null by default, since we do not
want to include OSUtils into Config. As a result, we must take special
care to preselect the correct combo box entry on the settings page.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)