### PR TITLE
Cleanup welcome screen recent databases view

### DIFF
--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -105,3 +105,9 @@ void WelcomeWidget::keyPressEvent(QKeyEvent* event)
 
     QWidget::keyPressEvent(event);
 }
+
+void WelcomeWidget::showEvent(QShowEvent* event)
+{
+    refreshLastDatabases();
+    QWidget::showEvent(event);
+}

--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -98,7 +98,7 @@ void WelcomeWidget::keyPressEvent(QKeyEvent* event)
     if (m_ui->recentListWidget->hasFocus()) {
         if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
             openDatabaseFromFile(m_ui->recentListWidget->currentItem());
-        } else if (event->key() == Qt::Key_Delete) {
+        } else if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
             removeFromLastDatabases(m_ui->recentListWidget->currentItem());
         }
     }

--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -62,7 +62,7 @@ WelcomeWidget::~WelcomeWidget()
 
 void WelcomeWidget::openDatabaseFromFile(QListWidgetItem* item)
 {
-    if (item->text().isEmpty()) {
+    if (item == nullptr || item->text().isEmpty()) {
         return;
     }
     emit openDatabaseFile(item->text());
@@ -70,7 +70,7 @@ void WelcomeWidget::openDatabaseFromFile(QListWidgetItem* item)
 
 void WelcomeWidget::removeFromLastDatabases(QListWidgetItem* item)
 {
-    if (item->text().isEmpty()) {
+    if (item == nullptr || item->text().isEmpty()) {
         return;
     }
 

--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -40,11 +40,6 @@ WelcomeWidget::WelcomeWidget(QWidget* parent)
 
     refreshLastDatabases();
 
-    bool recent_visibility = (m_ui->recentListWidget->count() > 0);
-    m_ui->startLabel->setVisible(!recent_visibility);
-    m_ui->recentListWidget->setVisible(recent_visibility);
-    m_ui->recentLabel->setVisible(recent_visibility);
-
     connect(m_ui->buttonNewDatabase, SIGNAL(clicked()), SIGNAL(newDatabase()));
     connect(m_ui->buttonOpenDatabase, SIGNAL(clicked()), SIGNAL(openDatabase()));
     connect(m_ui->buttonImportKeePass1, SIGNAL(clicked()), SIGNAL(importKeePass1Database()));
@@ -91,6 +86,11 @@ void WelcomeWidget::refreshLastDatabases()
         itm->setText(database);
         m_ui->recentListWidget->addItem(itm);
     }
+
+    bool recent_visibility = (m_ui->recentListWidget->count() > 0);
+    m_ui->startLabel->setVisible(!recent_visibility);
+    m_ui->recentListWidget->setVisible(recent_visibility);
+    m_ui->recentLabel->setVisible(recent_visibility);
 }
 
 void WelcomeWidget::keyPressEvent(QKeyEvent* event)

--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -62,7 +62,7 @@ WelcomeWidget::~WelcomeWidget()
 
 void WelcomeWidget::openDatabaseFromFile(QListWidgetItem* item)
 {
-    if (item == nullptr || item->text().isEmpty()) {
+    if (!item || item->text().isEmpty()) {
         return;
     }
     emit openDatabaseFile(item->text());
@@ -70,7 +70,7 @@ void WelcomeWidget::openDatabaseFromFile(QListWidgetItem* item)
 
 void WelcomeWidget::removeFromLastDatabases(QListWidgetItem* item)
 {
-    if (item == nullptr || item->text().isEmpty()) {
+    if (!item || item->text().isEmpty()) {
         return;
     }
 

--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -68,6 +68,20 @@ void WelcomeWidget::openDatabaseFromFile(QListWidgetItem* item)
     emit openDatabaseFile(item->text());
 }
 
+void WelcomeWidget::removeFromLastDatabases(QListWidgetItem* item)
+{
+    if (item->text().isEmpty()) {
+        return;
+    }
+
+    if (config()->get(Config::RememberLastDatabases).toBool()) {
+        QStringList lastDatabases = config()->get(Config::LastDatabases).toStringList();
+        lastDatabases.removeOne(item->text());
+        config()->set(Config::LastDatabases, lastDatabases);
+    }
+    refreshLastDatabases();
+}
+
 void WelcomeWidget::refreshLastDatabases()
 {
     m_ui->recentListWidget->clear();
@@ -81,8 +95,12 @@ void WelcomeWidget::refreshLastDatabases()
 
 void WelcomeWidget::keyPressEvent(QKeyEvent* event)
 {
-    if (m_ui->recentListWidget->hasFocus() && (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)) {
-        openDatabaseFromFile(m_ui->recentListWidget->currentItem());
+    if (m_ui->recentListWidget->hasFocus()) {
+        if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+            openDatabaseFromFile(m_ui->recentListWidget->currentItem());
+        } else if (event->key() == Qt::Key_Delete) {
+            removeFromLastDatabases(m_ui->recentListWidget->currentItem());
+        }
     }
 
     QWidget::keyPressEvent(event);

--- a/src/gui/WelcomeWidget.h
+++ b/src/gui/WelcomeWidget.h
@@ -52,6 +52,7 @@ private slots:
 
 private:
     const QScopedPointer<Ui::WelcomeWidget> m_ui;
+    void removeFromLastDatabases(QListWidgetItem* item);
 };
 
 #endif // KEEPASSX_WELCOMEWIDGET_H

--- a/src/gui/WelcomeWidget.h
+++ b/src/gui/WelcomeWidget.h
@@ -46,6 +46,7 @@ signals:
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
+    void showEvent(QShowEvent* event) override;
 
 private slots:
     void openDatabaseFromFile(QListWidgetItem* item);


### PR DESCRIPTION
While a database in the "Recent databases" on the welcome screen is selected, pressing the "Delete" key will now cause that database to be removed from the recent databases list.
Fixes #4710 

Additionally, this fixes a segfault that occurs when a user presses Enter while the "Recent databases" widget is in focus but no database is selected.

## Screenshots

![clear-database](https://user-images.githubusercontent.com/9341692/83815779-e1c1f700-a6b8-11ea-876f-72f53615de28.gif)


## Testing strategy

I did some manual tests.  
I'm new to this so let me know if/how I should implement tests.

## Type of change
- ✅ New feature (change that adds functionality)
- ✅ Bug fix (non-breaking change that fixes an issue)
