### PR TITLE
Fix minor UX issues with DB Open Widget

### DIFF
--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -20,6 +20,7 @@
 #define KEEPASSX_DATABASEOPENWIDGET_H
 
 #include <QScopedPointer>
+#include <QTimer>
 
 #include "gui/DialogyWidget.h"
 #include "keys/CompositeKey.h"
@@ -53,30 +54,28 @@ protected:
     void hideEvent(QHideEvent* event) override;
     QSharedPointer<CompositeKey> databaseKey();
 
+    const QScopedPointer<Ui::DatabaseOpenWidget> m_ui;
+    QSharedPointer<Database> m_db;
+    QString m_filename;
+    bool m_retryUnlockWithEmptyPassword = false;
+
 protected slots:
     virtual void openDatabase();
     void reject();
 
 private slots:
     void browseKeyFile();
-    void clearKeyFileEdit();
-    void handleKeyFileComboEdited();
-    void handleKeyFileComboChanged();
+    void clearKeyFileText();
+    void keyFileTextChanged();
     void pollHardwareKey();
     void hardwareKeyResponse(bool found);
     void openHardwareKeyHelp();
     void openKeyFileHelp();
 
-protected:
-    const QScopedPointer<Ui::DatabaseOpenWidget> m_ui;
-    QSharedPointer<Database> m_db;
-    QString m_filename;
-    bool m_retryUnlockWithEmptyPassword = false;
-
 private:
     bool m_pollingHardwareKey = false;
-    bool m_keyFileComboEdited = false;
-    bool m_isOpeningDatabase = false;
+    QTimer m_hideTimer;
+
     Q_DISABLE_COPY(DatabaseOpenWidget)
 };
 

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -237,7 +237,7 @@
                        <string>Key File:</string>
                       </property>
                       <property name="buddy">
-                       <cstring>comboKeyFile</cstring>
+                       <cstring>keyFileLineEdit</cstring>
                       </property>
                      </widget>
                     </item>
@@ -406,10 +406,7 @@
                      <number>0</number>
                     </property>
                     <item row="0" column="1">
-                     <widget class="QComboBox" name="comboKeyFile">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
+                     <widget class="QLineEdit" name="keyFileLineEdit">
                       <property name="sizePolicy">
                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                         <horstretch>0</horstretch>
@@ -417,10 +414,7 @@
                        </sizepolicy>
                       </property>
                       <property name="accessibleName">
-                       <string>Key file selection</string>
-                      </property>
-                      <property name="editable">
-                       <bool>true</bool>
+                       <string>Key file to unlock the database</string>
                       </property>
                      </widget>
                     </item>
@@ -610,7 +604,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>editPassword</tabstop>
-  <tabstop>comboKeyFile</tabstop>
+  <tabstop>keyFileLineEdit</tabstop>
   <tabstop>buttonBrowseFile</tabstop>
   <tabstop>challengeResponseCombo</tabstop>
   <tabstop>buttonRedetectYubikey</tabstop>

--- a/src/gui/KeePass1OpenWidget.cpp
+++ b/src/gui/KeePass1OpenWidget.cpp
@@ -37,14 +37,10 @@ void KeePass1OpenWidget::openDatabase()
     KeePass1Reader reader;
 
     QString password;
-    QString keyFileName;
+    QString keyFileName = m_ui->keyFileLineEdit->text();
 
     if (!m_ui->editPassword->text().isEmpty() || m_retryUnlockWithEmptyPassword) {
         password = m_ui->editPassword->text();
-    }
-
-    if (!m_ui->comboKeyFile->currentText().isEmpty() && m_ui->comboKeyFile->currentData() != -1) {
-        keyFileName = m_ui->comboKeyFile->currentText();
     }
 
     QFile file(m_filename);


### PR DESCRIPTION
* Only clear password field when switching tabs or minimizing. This prevents the setting "Remember Key Files and Hardware Keys" from being useless with multiple databases.
* Convert key file field to Line Edit, simplifies usage. Fix clear field button as well.
* Removed need for clearForms to check if the database is being opened (was a solution to tab switching while unlocking, no longer a problem).

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested multiple ways manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
