### PR TITLE
Adjust matching with best-matching credentials enabled

### DIFF
--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -119,7 +119,8 @@ private:
 
     QList<Entry*> searchEntries(const QSharedPointer<Database>& db, const QString& url, const QString& submitUrl);
     QList<Entry*> searchEntries(const QString& url, const QString& submitUrl, const StringPairList& keyList);
-    QList<Entry*> sortEntries(QList<Entry*>& pwEntries, const QString& host, const QString& submitUrl);
+    QList<Entry*>
+    sortEntries(QList<Entry*>& pwEntries, const QString& host, const QString& submitUrl, const QString& fullUrl);
     QList<Entry*> confirmEntries(QList<Entry*>& pwEntriesToConfirm,
                                  const QString& url,
                                  const QString& host,
@@ -130,8 +131,11 @@ private:
     QJsonArray getChildrenFromGroup(Group* group);
     Access checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm);
     Group* getDefaultEntryGroup(const QSharedPointer<Database>& selectedDb = {});
-    int
-    sortPriority(const Entry* entry, const QString& host, const QString& submitUrl, const QString& baseSubmitUrl) const;
+    int sortPriority(const Entry* entry,
+                     const QString& host,
+                     const QString& submitUrl,
+                     const QString& baseSubmitUrl,
+                     const QString& fullUrl) const;
     bool schemeFound(const QString& url);
     bool removeFirstDomain(QString& hostname);
     bool handleURL(const QString& entryUrl, const QString& url, const QString& submitUrl);

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -47,6 +47,7 @@ private slots:
     void testSubdomainsAndPaths();
     void testSortEntries();
     void testValidURLs();
+    void testBestMatchingCredentials();
 
 private:
     QList<Entry*> createEntries(QStringList& urls, Group* root) const;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
When _Return only best-matching credentials_ is enabled matching is also done based to subdomain and URL path.

This requires https://github.com/keepassxreboot/keepassxc-browser/pull/904 for full support so let's include this to 2.6.1 so the extension can be upgraded before the release. Otherwise the best-matching feature will not work properly.

Fixes https://github.com/keepassxreboot/keepassxc/issues/4734.
Fixes https://github.com/keepassxreboot/keepassxc/issues/4754.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Tests are also included

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Breaking change (causes existing functionality to change)
