### PR TITLE
Fix permissions changing on database save

### DIFF
--- a/src/keys/FileKey.cpp
+++ b/src/keys/FileKey.cpp
@@ -200,6 +200,7 @@ bool FileKey::create(const QString& fileName, QString* errorMsg, int size)
     }
     create(&file, size);
     file.close();
+    file.setPermissions(QFile::ReadUser);
 
     if (file.error()) {
         if (errorMsg) {

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -680,7 +680,7 @@ void TestGuiFdoSecrets::testCollectionCreate()
 
         QCOMPARE(spyCollectionCreated.count(), 1);
         {
-            auto args = spyCollectionCreated.takeFirst();
+            args = spyCollectionCreated.takeFirst();
             QCOMPARE(args.size(), 1);
             QCOMPARE(args.at(0).value<Collection*>(), coll);
         }
@@ -754,7 +754,7 @@ void TestGuiFdoSecrets::testCollectionDelete()
 
     QCOMPARE(spyCollectionDeleted.count(), 1);
     {
-        auto args = spyCollectionDeleted.takeFirst();
+        args = spyCollectionDeleted.takeFirst();
         QCOMPARE(args.size(), 1);
         QCOMPARE(args.at(0).value<Collection*>(), rawColl);
     }
@@ -977,7 +977,7 @@ void TestGuiFdoSecrets::testItemDelete()
 
     QCOMPARE(spyItemDeleted.count(), 1);
     {
-        auto args = spyItemDeleted.takeFirst();
+        args = spyItemDeleted.takeFirst();
         QCOMPARE(args.size(), 1);
         QCOMPARE(args.at(0).value<Item*>(), rawItem);
     }


### PR DESCRIPTION
* Saving a database in unsafe mode retains the existing permissions on the kdbx file
* New databases (save as, save backup, new database) and new key files are saved with 0600 permissions (user read/write), fixes #2575

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on all platforms, these changes really only apply to *nix systems. Windows by default inherits folder permissions and changes to permissions on individual files is ignored by Qt.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
