### PR TITLE
Fix minimize on copy if running under KDE Plasma on Linux

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1433,6 +1433,19 @@ void MainWindow::hide()
 #endif
 }
 
+void MainWindow::minimizeWindow()
+{
+    if (QGuiApplication::platformName() == "xcb") {
+
+        // see https://bugreports.qt.io/browse/QTBUG-25727
+        setWindowState(windowState() | Qt::WindowMinimized);
+        QApplication::processEvents();
+        setWindowState(windowState() & ~Qt::WindowMinimized);
+    } else {
+        showMinimized();
+    }
+}
+
 void MainWindow::hideWindow()
 {
     saveWindowInformation();
@@ -1446,7 +1459,7 @@ void MainWindow::hideWindow()
         }
         hide();
     } else {
-        showMinimized();
+        minimizeWindow();
     }
 
     if (config()->get(Config::Security_LockDatabaseMinimize).toBool()) {
@@ -1459,7 +1472,7 @@ void MainWindow::minimizeOrHide()
     if (config()->get(Config::GUI_MinimizeToTray).toBool()) {
         hideWindow();
     } else {
-        showMinimized();
+        minimizeWindow();
     }
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -75,6 +75,7 @@ public slots:
     void hide();
     void show();
     void hideWindow();
+    void minimizeWindow();
     void minimizeOrHide();
     void toggleWindow();
     void bringToFront();


### PR DESCRIPTION
If keepassxs running on KDE "minimize on copy" works only once
After restoring window of keepassxs subsequent "minimize on copy" 
doesn't minimize window

This behavior related to old Qt bug https://bugreports.qt.io/browse/QTBUG-25727
fix is workaround for this bug
workaround was taken from description of QTBUG-25727

this bug only affect if keepassxs running on KDE from Arch like distros

Fixes #2793

## Testing strategy
Tested manually on 
OS: Manjaro 20.0.2 Lysia
Kernel: x86_64 Linux 5.6.15-1-MANJARO
Shell: zsh 5.8
Resolution: 2560x1440
DE: KDE 5.70.0 / Plasma 5.18.5
WM: KWin

tested modes:
"Drop to background"
"Minimize"
"Hide window to system tray when minimized" ON and OFF
"Show a system tray icon" ON and OFF

not tested on another Linux DEs (like GNOME, Xfce, etc)

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
