### PR TITLE
Improve YubiKey/OnlyKey detection with more than 2 keys

### DIFF
--- a/src/keys/drivers/YubiKey.cpp
+++ b/src/keys/drivers/YubiKey.cpp
@@ -203,6 +203,8 @@ void YubiKey::findValidKeys()
 
                 ykds_free(st);
                 closeKey(yk_key);
+
+                Tools::wait(100);
             } else {
                 // No more keys are connected
                 break;


### PR DESCRIPTION
Add a small delay between key polling to let the hardware interface settle. Prevents invalid serial numbers from being pulled messing up the KeePassXC workflow.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)