### PR TITLE
FdoSecrets: fix double deletion

### DIFF
--- a/src/fdosecrets/FdoSecretsPlugin.cpp
+++ b/src/fdosecrets/FdoSecretsPlugin.cpp
@@ -31,8 +31,7 @@
 using FdoSecrets::Service;
 
 FdoSecretsPlugin::FdoSecretsPlugin(DatabaseTabWidget* tabWidget)
-    : QObject(tabWidget)
-    , m_dbTabs(tabWidget)
+    : m_dbTabs(tabWidget)
 {
     FdoSecrets::registerDBusTypes();
 }


### PR DESCRIPTION
FdoSecretsPlugin is added to m_extraPages in ApplicationSettingsWidget
via addSettingsPage(). m_extraPages holds QSharedPointer's to added
pages, so those pages are freed when ApplicationSettingsWidget is freed.
If FdoSecretsPlugin also declares tabWidget as parent, double deletion
will occur and may cause crashes:
```
==1472== Invalid read of size 8
==1472==    at 0x1CCF38: QtSharedPointer::CustomDeleter<ISettingsPage, QtSharedPointer::NormalDeleter>::execute() (qsharedpointer_impl.h:186)
==1472==    by 0x1CCCEC: QtSharedPointer::ExternalRefCountWithCustomDeleter<ISettingsPage, QtSharedPointer::NormalDeleter>::deleter(QtSharedPointer::ExternalRefCountData*) (qsharedpointer_impl.h:204)
==1472==    by 0x18F6F4: QtSharedPointer::ExternalRefCountData::destroy() (qsharedpointer_impl.h:148)
==1472==    by 0x1CCDED: QSharedPointer<ISettingsPage>::deref(QtSharedPointer::ExternalRefCountData*) (qsharedpointer_impl.h:456)
==1472==    by 0x1CCA43: QSharedPointer<ISettingsPage>::deref() (qsharedpointer_impl.h:451)
==1472==    by 0x1CC6EB: QSharedPointer<ISettingsPage>::~QSharedPointer() (qsharedpointer_impl.h:309)
==1472==    by 0x1CC5F9: ApplicationSettingsWidget::ExtraPage::~ExtraPage() (ApplicationSettingsWidget.cpp:35)
==1472==    by 0x1CCE5B: QList<ApplicationSettingsWidget::ExtraPage>::node_destruct(QList<ApplicationSettingsWidget::ExtraPage>::Node*, QList<ApplicationSettingsWidget::ExtraPage>::Node*) (qlist.h:524)
==1472==    by 0x1CCAF2: QList<ApplicationSettingsWidget::ExtraPage>::dealloc(QListData::Data*) (qlist.h:921)
==1472==    by 0x1CC7DB: QList<ApplicationSettingsWidget::ExtraPage>::~QList() (qlist.h:874)
==1472==    by 0x1C0845: ApplicationSettingsWidget::~ApplicationSettingsWidget() (ApplicationSettingsWidget.cpp:157)
==1472==    by 0x1C0893: ApplicationSettingsWidget::~ApplicationSettingsWidget() (ApplicationSettingsWidget.cpp:159)
==1472==  Address 0xdea4210 is 16 bytes inside a block of size 48 free'd
==1472==    at 0x483B08B: operator delete(void*, unsigned long) (vg_replace_malloc.c:593)
==1472==    by 0x39363E: FdoSecretsPlugin::~FdoSecretsPlugin() (FdoSecretsPlugin.h:39)
==1472==    by 0x5BE4C3D: QObjectPrivate::deleteChildren() (in /usr/lib/libQt5Core.so.5.15.0)
==1472==    by 0x4C7C1DD: QWidget::~QWidget() (in /usr/lib/libQt5Widgets.so.5.15.0)
==1472==    by 0x293EFF: DatabaseTabWidget::~DatabaseTabWidget() (DatabaseTabWidget.cpp:75)
==1472==    by 0x293F21: DatabaseTabWidget::~DatabaseTabWidget() (DatabaseTabWidget.cpp:77)
==1472==    by 0x5BE4C3D: QObjectPrivate::deleteChildren() (in /usr/lib/libQt5Core.so.5.15.0)
==1472==    by 0x4C7C1DD: QWidget::~QWidget() (in /usr/lib/libQt5Widgets.so.5.15.0)
==1472==    by 0x4C7C559: QWidget::~QWidget() (in /usr/lib/libQt5Widgets.so.5.15.0)
==1472==    by 0x5BE4C3D: QObjectPrivate::deleteChildren() (in /usr/lib/libQt5Core.so.5.15.0)
==1472==    by 0x4C7C1DD: QWidget::~QWidget() (in /usr/lib/libQt5Widgets.so.5.15.0)
==1472==    by 0x4DF0069: QStackedWidget::~QStackedWidget() (in /usr/lib/libQt5Widgets.so.5.15.0)
==1472==  Block was alloc'd at
==1472==    at 0x4839DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==1472==    by 0x199DC5: MainWindow::MainWindow() (MainWindow.cpp:179)
==1472==    by 0x1794B7: main (main.cpp:132)
==1472==
==1472== Jump to the invalid address stated on the next line
==1472==    at 0x0: ???
==1472==    by 0x1CCCEC: QtSharedPointer::ExternalRefCountWithCustomDeleter<ISettingsPage, QtSharedPointer::NormalDeleter>::deleter(QtSharedPointer::ExternalRefCountData*) (qsharedpointer_impl.h:204)
==1472==    by 0x18F6F4: QtSharedPointer::ExternalRefCountData::destroy() (qsharedpointer_impl.h:148)
==1472==    by 0x1CCDED: QSharedPointer<ISettingsPage>::deref(QtSharedPointer::ExternalRefCountData*) (qsharedpointer_impl.h:456)
==1472==    by 0x1CCA43: QSharedPointer<ISettingsPage>::deref() (qsharedpointer_impl.h:451)
==1472==    by 0x1CC6EB: QSharedPointer<ISettingsPage>::~QSharedPointer() (qsharedpointer_impl.h:309)
==1472==    by 0x1CC5F9: ApplicationSettingsWidget::ExtraPage::~ExtraPage() (ApplicationSettingsWidget.cpp:35)
==1472==    by 0x1CCE5B: QList<ApplicationSettingsWidget::ExtraPage>::node_destruct(QList<ApplicationSettingsWidget::ExtraPage>::Node*, QList<ApplicationSettingsWidget::ExtraPage>::Node*) (qlist.h:524)
==1472==    by 0x1CCAF2: QList<ApplicationSettingsWidget::ExtraPage>::dealloc(QListData::Data*) (qlist.h:921)
==1472==    by 0x1CC7DB: QList<ApplicationSettingsWidget::ExtraPage>::~QList() (qlist.h:874)
==1472==    by 0x1C0845: ApplicationSettingsWidget::~ApplicationSettingsWidget() (ApplicationSettingsWidget.cpp:157)
==1472==    by 0x1C0893: ApplicationSettingsWidget::~ApplicationSettingsWidget() (ApplicationSettingsWidget.cpp:159)
==1472==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==1472==
==1472==
==1472== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==1472==  Bad permissions for mapped region at address 0x0
==1472==    at 0x0: ???
==1472==    by 0x1CCCEC: QtSharedPointer::ExternalRefCountWithCustomDeleter<ISettingsPage, QtSharedPointer::NormalDeleter>::deleter(QtSharedPointer::ExternalRefCountData*) (qsharedpointer_impl.h:204)
==1472==    by 0x18F6F4: QtSharedPointer::ExternalRefCountData::destroy() (qsharedpointer_impl.h:148)
==1472==    by 0x1CCDED: QSharedPointer<ISettingsPage>::deref(QtSharedPointer::ExternalRefCountData*) (qsharedpointer_impl.h:456)
==1472==    by 0x1CCA43: QSharedPointer<ISettingsPage>::deref() (qsharedpointer_impl.h:451)
==1472==    by 0x1CC6EB: QSharedPointer<ISettingsPage>::~QSharedPointer() (qsharedpointer_impl.h:309)
==1472==    by 0x1CC5F9: ApplicationSettingsWidget::ExtraPage::~ExtraPage() (ApplicationSettingsWidget.cpp:35)
==1472==    by 0x1CCE5B: QList<ApplicationSettingsWidget::ExtraPage>::node_destruct(QList<ApplicationSettingsWidget::ExtraPage>::Node*, QList<ApplicationSettingsWidget::ExtraPage>::Node*) (qlist.h:524)
==1472==    by 0x1CCAF2: QList<ApplicationSettingsWidget::ExtraPage>::dealloc(QListData::Data*) (qlist.h:921)
==1472==    by 0x1CC7DB: QList<ApplicationSettingsWidget::ExtraPage>::~QList() (qlist.h:874)
==1472==    by 0x1C0845: ApplicationSettingsWidget::~ApplicationSettingsWidget() (ApplicationSettingsWidget.cpp:157)
==1472==    by 0x1C0893: ApplicationSettingsWidget::~ApplicationSettingsWidget() (ApplicationSettingsWidget.cpp:159)
```
Fixes #4877

As a record, the changed line appeared in #4232.

## Screenshots
N/A

## Testing strategy
No more crashes, and no memory leaks related to FdoSecretsPlugin with GCC's ASAN library and valgrind.

<summary>

ASAN logs:

<details>

```
=================================================================
==5278==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 256 byte(s) in 1 object(s) allocated from:
    #0 0x7efdff4f1459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7efdf7b635b5  (/usr/lib/libfontconfig.so.1+0x215b5)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7efdff4f1639 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7efdf7b63c09  (/usr/lib/libfontconfig.so.1+0x21c09)

Indirect leak of 14 byte(s) in 1 object(s) allocated from:
    #0 0x7efdff499a69 in __interceptor_strdup /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:452
    #1 0x7efdf7b62e45 in FcValueSave (/usr/lib/libfontconfig.so.1+0x20e45)

SUMMARY: AddressSanitizer: 302 byte(s) leaked in 3 allocation(s).
```

</details>

</summary>

<summary>

Valgrind logs:

<details>

```
==6522== 16 bytes in 1 blocks are possibly lost in loss record 1,015 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02CFB7: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6CF: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A755: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 16 bytes in 1 blocks are possibly lost in loss record 1,016 of 7,058
==6522==    at 0x48396AF: malloc (vg_replace_malloc.c:306)
==6522==    by 0x733D728: g_realloc (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02CF3D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6CF: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A755: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 16 bytes in 1 blocks are possibly lost in loss record 1,017 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02CFB7: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6CF: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A7B4: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 16 bytes in 1 blocks are possibly lost in loss record 1,018 of 7,058
==6522==    at 0x48396AF: malloc (vg_replace_malloc.c:306)
==6522==    by 0x733D728: g_realloc (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02CF3D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6CF: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A7B4: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 16 bytes in 1 blocks are possibly lost in loss record 1,019 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02CFB7: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6CF: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A87C: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 16 bytes in 1 blocks are possibly lost in loss record 1,020 of 7,058
==6522==    at 0x48396AF: malloc (vg_replace_malloc.c:306)
==6522==    by 0x733D728: g_realloc (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02CF3D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6CF: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A87C: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 16 bytes in 1 blocks are possibly lost in loss record 1,021 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02CFB7: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6CF: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00B910: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 16 bytes in 1 blocks are possibly lost in loss record 1,022 of 7,058
==6522==    at 0x48396AF: malloc (vg_replace_malloc.c:306)
==6522==    by 0x733D728: g_realloc (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02CF3D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6CF: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00B910: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 24 bytes in 1 blocks are possibly lost in loss record 1,546 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB0321CE: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB031D64: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB0186B8: g_param_spec_flags (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAF50500: ??? (in /usr/lib/libgdk-3.so.0.2413.7)
==6522==    by 0xB032091: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB031D64: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01D9CF: g_object_new_valist (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01DAB9: g_object_new (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAF0203A: ??? (in /usr/lib/libgdk-3.so.0.2413.7)
==6522==    by 0xAF01881: ??? (in /usr/lib/libgdk-3.so.0.2413.7)
==6522==
==6522== 24 bytes in 1 blocks are possibly lost in loss record 1,547 of 7,058
==6522==    at 0x483977F: malloc (vg_replace_malloc.c:307)
==6522==    by 0x65EFDAB: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F0094: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65EB399: libusb_init (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x4932620: ??? (in /usr/lib/libykpers-1.so.1.20.0)
==6522==    by 0x1D9E63: YubiKey::YubiKey() (YubiKey.cpp:109)
==6522==    by 0x1DA081: YubiKey::instance() (YubiKey.cpp:131)
==6522==    by 0x28C36C: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:92)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==    by 0x293BC3: DatabaseTabWidget::DatabaseTabWidget(QWidget*) (DatabaseTabWidget.cpp:52)
==6522==    by 0x1A99E1: Ui_MainWindow::setupUi(QMainWindow*) (ui_MainWindow.h:315)
==6522==    by 0x1990D5: MainWindow::MainWindow() (MainWindow.cpp:99)
==6522==
==6522== 24 bytes in 1 blocks are possibly lost in loss record 1,548 of 7,058
==6522==    at 0x483977F: malloc (vg_replace_malloc.c:307)
==6522==    by 0x65EFDAB: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F00F7: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65EB399: libusb_init (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x4932620: ??? (in /usr/lib/libykpers-1.so.1.20.0)
==6522==    by 0x1D9E63: YubiKey::YubiKey() (YubiKey.cpp:109)
==6522==    by 0x1DA081: YubiKey::instance() (YubiKey.cpp:131)
==6522==    by 0x28C36C: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:92)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==    by 0x293BC3: DatabaseTabWidget::DatabaseTabWidget(QWidget*) (DatabaseTabWidget.cpp:52)
==6522==    by 0x1A99E1: Ui_MainWindow::setupUi(QMainWindow*) (ui_MainWindow.h:315)
==6522==    by 0x1990D5: MainWindow::MainWindow() (MainWindow.cpp:99)
==6522==
==6522== 32 bytes in 1 blocks are possibly lost in loss record 2,584 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB0321CE: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB031D64: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01FB58: g_param_spec_enum (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAF2C488: ??? (in /usr/lib/libgdk-3.so.0.2413.7)
==6522==    by 0xB032091: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB031D64: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01D9CF: g_object_new_valist (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01DAB9: g_object_new (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAEED51C: ??? (in /usr/lib/libgdk-3.so.0.2413.7)
==6522==    by 0xAEEFC6B: ??? (in /usr/lib/libgdk-3.so.0.2413.7)
==6522==
==6522== 32 bytes in 1 blocks are possibly lost in loss record 2,585 of 7,058
==6522==    at 0x483BD7B: realloc (vg_replace_malloc.c:834)
==6522==    by 0x733D728: g_realloc (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02101F: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB03243C: g_type_register_static (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB010978: g_flags_register_static (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAA61571: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xB032091: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01D9CF: g_object_new_valist (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01DAB9: g_object_new (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAA63CDC: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xAA65F82: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xA90E196: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==
==6522== 44 bytes in 9 blocks are possibly lost in loss record 3,686 of 7,058
==6522==    at 0x483977F: malloc (vg_replace_malloc.c:307)
==6522==    by 0x646B23E: strdup (in /usr/lib/libc-2.31.so)
==6522==    by 0x65F1EC4: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F4EB8: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F5E37: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F4695: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65EB385: libusb_init (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x4932620: ??? (in /usr/lib/libykpers-1.so.1.20.0)
==6522==    by 0x1D9E63: YubiKey::YubiKey() (YubiKey.cpp:109)
==6522==    by 0x1DA081: YubiKey::instance() (YubiKey.cpp:131)
==6522==    by 0x28C36C: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:92)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==
==6522== 80 bytes in 1 blocks are possibly lost in loss record 5,055 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB0321CE: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB031D64: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02B59D: g_type_create_instance (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB017D28: g_param_spec_internal (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB018502: g_param_spec_object (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAF49633: ??? (in /usr/lib/libgdk-3.so.0.2413.7)
==6522==    by 0xB032091: g_type_class_ref (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01CFF8: g_object_new_with_properties (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01DAE1: g_object_new (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAF48FB6: gdk_display_manager_get (in /usr/lib/libgdk-3.so.0.2413.7)
==6522==
==6522== 96 bytes in 1 blocks are possibly lost in loss record 5,809 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB0210A8: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB021EEE: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A005: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 96 bytes in 1 blocks are possibly lost in loss record 5,810 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB0210A8: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB021EEE: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6C1: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A755: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==
==6522== 96 bytes in 1 blocks are possibly lost in loss record 5,811 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB0210A8: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB021EEE: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6C1: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A7B4: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==
==6522== 96 bytes in 1 blocks are possibly lost in loss record 5,812 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB0210A8: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB021EEE: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6C1: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A87C: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==
==6522== 96 bytes in 1 blocks are possibly lost in loss record 5,813 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB0210A8: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB021EEE: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D6C1: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00B910: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==
==6522== 132 bytes in 1 blocks are possibly lost in loss record 6,011 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB022E6D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D749: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A755: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 132 bytes in 1 blocks are possibly lost in loss record 6,012 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB022E6D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D749: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A7B4: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 148 bytes in 1 blocks are possibly lost in loss record 6,271 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB022C6D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D749: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A87C: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 148 bytes in 1 blocks are possibly lost in loss record 6,272 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x733D591: g_malloc0 (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB022C6D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB02D749: g_type_register_fundamental (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00B910: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x40149BD: _dl_open (in /usr/lib/ld-2.31.so)
==6522==    by 0x661534B: ??? (in /usr/lib/libdl-2.31.so)
==6522==
==6522== 184 bytes in 1 blocks are possibly lost in loss record 6,325 of 7,058
==6522==    at 0x483BD7B: realloc (vg_replace_malloc.c:834)
==6522==    by 0x733D728: g_realloc (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02101F: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB03243C: g_type_register_static (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01F9A2: g_param_type_register_static (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB009E67: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB00A96C: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0x40110F1: call_init.part.0 (in /usr/lib/ld-2.31.so)
==6522==    by 0x4011200: _dl_init (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516B54: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==    by 0x4015172: dl_open_worker (in /usr/lib/ld-2.31.so)
==6522==    by 0x6516AF7: _dl_catch_exception (in /usr/lib/libc-2.31.so)
==6522==
==6522== 248 bytes in 1 blocks are possibly lost in loss record 6,425 of 7,058
==6522==    at 0x483BD7B: realloc (vg_replace_malloc.c:834)
==6522==    by 0x733D728: g_realloc (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02101F: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB03243C: g_type_register_static (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB010688: g_enum_register_static (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xAB011BD: gtk_border_style_get_type (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xAA66620: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xA90E196: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xAA71FB1: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xAA71BEE: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xAA747A0: gtk_css_provider_load_from_file (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xAA748A8: gtk_css_provider_load_from_resource (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==
==6522== 302 (256 direct, 46 indirect) bytes in 1 blocks are definitely lost in loss record 6,465 of 7,058
==6522==    at 0x483977F: malloc (vg_replace_malloc.c:307)
==6522==    by 0x9D5B5B5: ??? (in /usr/lib/libfontconfig.so.1.12.0)
==6522==    by 0x9D5BC88: ??? (in /usr/lib/libfontconfig.so.1.12.0)
==6522==    by 0x9D5D29C: ??? (in /usr/lib/libfontconfig.so.1.12.0)
==6522==    by 0x9D64894: ??? (in /usr/lib/libfontconfig.so.1.12.0)
==6522==    by 0x9E939E7: ??? (in /usr/lib/libexpat.so.1.6.11)
==6522==    by 0x9E91DDC: ??? (in /usr/lib/libexpat.so.1.6.11)
==6522==    by 0x9E95620: ??? (in /usr/lib/libexpat.so.1.6.11)
==6522==    by 0x9E978CB: XML_ParseBuffer (in /usr/lib/libexpat.so.1.6.11)
==6522==    by 0x9D626B4: ??? (in /usr/lib/libfontconfig.so.1.12.0)
==6522==    by 0x9D62CA3: ??? (in /usr/lib/libfontconfig.so.1.12.0)
==6522==    by 0x9D62D1B: ??? (in /usr/lib/libfontconfig.so.1.12.0)
==6522==
==6522== 416 bytes in 1 blocks are possibly lost in loss record 6,523 of 7,058
==6522==    at 0x483BD7B: realloc (vg_replace_malloc.c:834)
==6522==    by 0x733D728: g_realloc (in /usr/lib/libglib-2.0.so.0.6400.3)
==6522==    by 0xB02101F: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB03243C: g_type_register_static (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB03253D: g_type_register_static_simple (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xA9F323B: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xA9F4EA5: gtk_icon_theme_get_type (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xA9F4FC9: gtk_icon_theme_new (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xA9F9D05: gtk_icon_theme_get_for_screen (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xAA7F129: ??? (in /usr/lib/libgtk-3.so.0.2413.7)
==6522==    by 0xB02B6C0: g_type_create_instance (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==    by 0xB01BE9D: ??? (in /usr/lib/libgobject-2.0.so.0.6400.3)
==6522==
==6522== 464 bytes in 1 blocks are possibly lost in loss record 6,531 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x4013DBA: _dl_allocate_tls (in /usr/lib/ld-2.31.so)
==6522==    by 0x65AD0FE: pthread_create@@GLIBC_2.2.5 (in /usr/lib/libpthread-2.31.so)
==6522==    by 0x59D58A2: QThread::start(QThread::Priority) (in /usr/lib/libQt5Core.so.5.15.0)
==6522==    by 0x5897E14: QDBusConnection::connectToBus(QDBusConnection::BusType, QString const&) (in /usr/lib/libQt5DBus.so.5.15.0)
==6522==    by 0xB76B0D2: ??? (in /usr/lib/qt/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so)
==6522==    by 0xB76FD44: ??? (in /usr/lib/qt/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so)
==6522==    by 0x52963F4: QPlatformInputContextFactory::create(QString const&) (in /usr/lib/libQt5Gui.so.5.15.0)
==6522==    by 0x9C4666F: QXcbIntegration::initialize() (in /usr/lib/libQt5XcbQpa.so.5.15.0)
==6522==    by 0x52AC5A8: QGuiApplicationPrivate::eventDispatcherReady() (in /usr/lib/libQt5Gui.so.5.15.0)
==6522==    by 0x5BC10C5: QCoreApplicationPrivate::init() (in /usr/lib/libQt5Core.so.5.15.0)
==6522==    by 0x52AF5BF: QGuiApplicationPrivate::init() (in /usr/lib/libQt5Gui.so.5.15.0)
==6522==
==6522== 464 bytes in 1 blocks are possibly lost in loss record 6,532 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x4013DBA: _dl_allocate_tls (in /usr/lib/ld-2.31.so)
==6522==    by 0x65AD0FE: pthread_create@@GLIBC_2.2.5 (in /usr/lib/libpthread-2.31.so)
==6522==    by 0x65F59F9: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F4674: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65EB385: libusb_init (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x4932620: ??? (in /usr/lib/libykpers-1.so.1.20.0)
==6522==    by 0x1D9E63: YubiKey::YubiKey() (YubiKey.cpp:109)
==6522==    by 0x1DA081: YubiKey::instance() (YubiKey.cpp:131)
==6522==    by 0x28C36C: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:92)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==    by 0x293BC3: DatabaseTabWidget::DatabaseTabWidget(QWidget*) (DatabaseTabWidget.cpp:52)
==6522==
==6522== 722 (16 direct, 706 indirect) bytes in 1 blocks are definitely lost in loss record 6,598 of 7,058
==6522==    at 0x4839DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==6522==    by 0x2BFDBB: PasswordEdit::PasswordEdit(QWidget*) (PasswordEdit.cpp:66)
==6522==    by 0x28FB13: Ui_DatabaseOpenWidget::setupUi(QWidget*) (ui_DatabaseOpenWidget.h:159)
==6522==    by 0x28BA5D: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:51)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==    by 0x293BC3: DatabaseTabWidget::DatabaseTabWidget(QWidget*) (DatabaseTabWidget.cpp:52)
==6522==    by 0x1A99E1: Ui_MainWindow::setupUi(QMainWindow*) (ui_MainWindow.h:315)
==6522==    by 0x1990D5: MainWindow::MainWindow() (MainWindow.cpp:99)
==6522==    by 0x1794B7: main (main.cpp:132)
==6522==
==6522== 806 (16 direct, 790 indirect) bytes in 1 blocks are definitely lost in loss record 6,604 of 7,058
==6522==    at 0x4839DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==6522==    by 0x2BFB0A: PasswordEdit::PasswordEdit(QWidget*) (PasswordEdit.cpp:56)
==6522==    by 0x28FB13: Ui_DatabaseOpenWidget::setupUi(QWidget*) (ui_DatabaseOpenWidget.h:159)
==6522==    by 0x28BA5D: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:51)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==    by 0x293BC3: DatabaseTabWidget::DatabaseTabWidget(QWidget*) (DatabaseTabWidget.cpp:52)
==6522==    by 0x1A99E1: Ui_MainWindow::setupUi(QMainWindow*) (ui_MainWindow.h:315)
==6522==    by 0x1990D5: MainWindow::MainWindow() (MainWindow.cpp:99)
==6522==    by 0x1794B7: main (main.cpp:132)
==6522==
==6522== 806 (16 direct, 790 indirect) bytes in 1 blocks are definitely lost in loss record 6,605 of 7,058
==6522==    at 0x4839DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==6522==    by 0x2BFB0A: PasswordEdit::PasswordEdit(QWidget*) (PasswordEdit.cpp:56)
==6522==    by 0x1B91E2: Ui_PasswordGeneratorWidget::setupUi(QWidget*) (ui_PasswordGeneratorWidget.h:168)
==6522==    by 0x1B400D: PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget*) (PasswordGeneratorWidget.cpp:39)
==6522==    by 0x1AA13C: Ui_MainWindow::setupUi(QMainWindow*) (ui_MainWindow.h:366)
==6522==    by 0x1990D5: MainWindow::MainWindow() (MainWindow.cpp:99)
==6522==    by 0x1794B7: main (main.cpp:132)
==6522==
==6522== 1,368 bytes in 9 blocks are possibly lost in loss record 6,681 of 7,058
==6522==    at 0x483BB65: calloc (vg_replace_malloc.c:760)
==6522==    by 0x65E9606: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F4E93: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F5E37: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F4695: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65EB385: libusb_init (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x4932620: ??? (in /usr/lib/libykpers-1.so.1.20.0)
==6522==    by 0x1D9E63: YubiKey::YubiKey() (YubiKey.cpp:109)
==6522==    by 0x1DA081: YubiKey::instance() (YubiKey.cpp:131)
==6522==    by 0x28C36C: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:92)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==    by 0x293BC3: DatabaseTabWidget::DatabaseTabWidget(QWidget*) (DatabaseTabWidget.cpp:52)
==6522==
==6522== 2,130 (16 direct, 2,114 indirect) bytes in 1 blocks are definitely lost in loss record 6,719 of 7,058
==6522==    at 0x4839DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==6522==    by 0x2BFDBB: PasswordEdit::PasswordEdit(QWidget*) (PasswordEdit.cpp:66)
==6522==    by 0x1B91E2: Ui_PasswordGeneratorWidget::setupUi(QWidget*) (ui_PasswordGeneratorWidget.h:168)
==6522==    by 0x1B400D: PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget*) (PasswordGeneratorWidget.cpp:39)
==6522==    by 0x1AA13C: Ui_MainWindow::setupUi(QMainWindow*) (ui_MainWindow.h:366)
==6522==    by 0x1990D5: MainWindow::MainWindow() (MainWindow.cpp:99)
==6522==    by 0x1794B7: main (main.cpp:132)
==6522==
==6522== 9,216 bytes in 9 blocks are possibly lost in loss record 6,795 of 7,058
==6522==    at 0x48396AF: malloc (vg_replace_malloc.c:306)
==6522==    by 0x65F1F8A: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F4EB8: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F5E37: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65F4695: ??? (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x65EB385: libusb_init (in /usr/lib/libusb-1.0.so.0.2.0)
==6522==    by 0x4932620: ??? (in /usr/lib/libykpers-1.so.1.20.0)
==6522==    by 0x1D9E63: YubiKey::YubiKey() (YubiKey.cpp:109)
==6522==    by 0x1DA081: YubiKey::instance() (YubiKey.cpp:131)
==6522==    by 0x28C36C: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:92)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==    by 0x293BC3: DatabaseTabWidget::DatabaseTabWidget(QWidget*) (DatabaseTabWidget.cpp:52)
==6522==
==6522== 66,584 (16 direct, 66,568 indirect) bytes in 1 blocks are definitely lost in loss record 7,051 of 7,058
==6522==    at 0x4839DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==6522==    by 0x2BFF7E: PasswordEdit::PasswordEdit(QWidget*) (PasswordEdit.cpp:75)
==6522==    by 0x28FB13: Ui_DatabaseOpenWidget::setupUi(QWidget*) (ui_DatabaseOpenWidget.h:159)
==6522==    by 0x28BA5D: DatabaseOpenWidget::DatabaseOpenWidget(QWidget*) (DatabaseOpenWidget.cpp:51)
==6522==    by 0x2C62B7: DatabaseOpenDialog::DatabaseOpenDialog(QWidget*) (DatabaseOpenDialog.cpp:25)
==6522==    by 0x293BC3: DatabaseTabWidget::DatabaseTabWidget(QWidget*) (DatabaseTabWidget.cpp:52)
==6522==    by 0x1A99E1: Ui_MainWindow::setupUi(QMainWindow*) (ui_MainWindow.h:315)
==6522==    by 0x1990D5: MainWindow::MainWindow() (MainWindow.cpp:99)
==6522==    by 0x1794B7: main (main.cpp:132)
==6522==
==6522== 66,584 (16 direct, 66,568 indirect) bytes in 1 blocks are definitely lost in loss record 7,052 of 7,058
==6522==    at 0x4839DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==6522==    by 0x2BFF7E: PasswordEdit::PasswordEdit(QWidget*) (PasswordEdit.cpp:75)
==6522==    by 0x1B91E2: Ui_PasswordGeneratorWidget::setupUi(QWidget*) (ui_PasswordGeneratorWidget.h:168)
==6522==    by 0x1B400D: PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget*) (PasswordGeneratorWidget.cpp:39)
==6522==    by 0x1AA13C: Ui_MainWindow::setupUi(QMainWindow*) (ui_MainWindow.h:366)
==6522==    by 0x1990D5: MainWindow::MainWindow() (MainWindow.cpp:99)
==6522==    by 0x1794B7: main (main.cpp:132)
==6522==
==6522== LEAK SUMMARY:
==6522==    definitely lost: 352 bytes in 7 blocks
==6522==    indirectly lost: 137,582 bytes in 65 blocks
==6522==      possibly lost: 13,788 bytes in 55 blocks
==6522==    still reachable: 17,866,622 bytes in 29,966 blocks
==6522==                       of which reachable via heuristic:
==6522==                         length64           : 2,432 bytes in 44 blocks
==6522==                         newarray           : 1,936 bytes in 41 blocks
==6522==         suppressed: 0 bytes in 0 blocks
==6522== Reachable blocks (those to which a pointer was found) are not shown.
==6522== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==6522==
==6522== Use --track-origins=yes to see where uninitialised values come from
==6522== For lists of detected and suppressed errors, rerun with: -s
==6522== ERROR SUMMARY: 72 errors from 71 contexts (suppressed: 2 from 2)
```

</details>

</summary>

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
