### PR TITLE
FDO Secrets: Fix double free on exit

### DIFF
--- a/src/fdosecrets/FdoSecretsPlugin.cpp
+++ b/src/fdosecrets/FdoSecretsPlugin.cpp
@@ -30,11 +30,19 @@
 
 using FdoSecrets::Service;
 
+// TODO: Only used for testing. Need to split service functions away from settings page.
+QPointer<FdoSecretsPlugin> g_fdoSecretsPlugin;
+
 FdoSecretsPlugin::FdoSecretsPlugin(DatabaseTabWidget* tabWidget)
-    : QObject(tabWidget)
-    , m_dbTabs(tabWidget)
+    : m_dbTabs(tabWidget)
 {
+    g_fdoSecretsPlugin = this;
     FdoSecrets::registerDBusTypes();
+}
+
+FdoSecretsPlugin* FdoSecretsPlugin::getPlugin()
+{
+    return g_fdoSecretsPlugin;
 }
 
 QWidget* FdoSecretsPlugin::createWidget()

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -70,6 +70,9 @@ public:
      */
     QString reportExistingService() const;
 
+    // TODO: Only used for testing. Need to split service functions away from settings page.
+    static FdoSecretsPlugin* getPlugin();
+
 public slots:
     void emitRequestSwitchToDatabases();
     void emitRequestShowNotification(const QString& msg, const QString& title = {});

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -200,7 +200,7 @@ void TestGuiFdoSecrets::initTestCase()
     m_mainWindow.reset(new MainWindow());
     m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
     QVERIFY(m_tabWidget);
-    m_plugin = m_mainWindow->findChild<FdoSecretsPlugin*>();
+    m_plugin = FdoSecretsPlugin::getPlugin();
     QVERIFY(m_plugin);
     m_mainWindow->show();
 


### PR DESCRIPTION
* Prevent double free due to QObject cleanup happening before/after the ExtraPage  storing the QSharedPointer to FdoSecretsPlugin is deleted.
* Fixes #4877

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
