### PR TITLE
Fix Touch ID timeout not being set correctly

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1328,14 +1328,14 @@ void MainWindow::applySettingsChanges()
     }
 
 #ifdef WITH_XC_TOUCHID
-    // forget TouchID (in minutes)
-    timeout = config()->get(Config::Security_ResetTouchIdTimeout).toInt() * 60 * 1000;
-    if (timeout <= 0) {
-        timeout = 30 * 60 * 1000;
-    }
+    if (config()->get(Config::Security_ResetTouchId).toBool()) {
+        // Calculate TouchID timeout in milliseconds
+        timeout = config()->get(Config::Security_ResetTouchIdTimeout).toInt() * 60 * 1000;
+        if (timeout <= 0) {
+            timeout = 30 * 60 * 1000;
+        }
 
-    m_touchIDinactivityTimer->setInactivityTimeout(timeout);
-    if (config()->get(Config::Security_ResetTouchIdTimeout).toBool()) {
+        m_touchIDinactivityTimer->setInactivityTimeout(timeout);
         m_touchIDinactivityTimer->activate();
     } else {
         m_touchIDinactivityTimer->deactivate();


### PR DESCRIPTION
* Fixes #4885

After the Config changes we were checking `Config::Security_ResetTouchIdTimeout` instead of `Config::Security_ResetTouchId` to determine if the timeout value should be honored.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
