### PR TITLE
Add option to auto-type just the username/password

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -269,7 +269,7 @@ void AutoType::executeAutoTypeActions(const Entry* entry, QWidget* hideWindow, c
 
 /**
  * Single Autotype entry-point function
- * Perfom autotype sequence in the active window
+ * Look up the Auto-Type sequence for the given entry then perfom Auto-Type in the active window
  */
 void AutoType::performAutoType(const Entry* entry, QWidget* hideWindow)
 {
@@ -283,6 +283,19 @@ void AutoType::performAutoType(const Entry* entry, QWidget* hideWindow)
     }
 
     executeAutoTypeActions(entry, hideWindow, sequences.first());
+}
+
+/**
+ * Extra Autotype entry-point function
+ * Perfom Auto-Type of the directly specified sequence in the active window
+ */
+void AutoType::performAutoTypeWithSequence(const Entry* entry, const QString& sequence, QWidget* hideWindow)
+{
+    if (!m_plugin) {
+        return;
+    }
+
+    executeAutoTypeActions(entry, hideWindow, sequence);
 }
 
 void AutoType::startGlobalAutoType()

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -48,6 +48,7 @@ public:
     static bool checkHighDelay(const QString& string);
     static bool verifyAutoTypeSyntax(const QString& sequence);
     void performAutoType(const Entry* entry, QWidget* hideWindow = nullptr);
+    void performAutoTypeWithSequence(const Entry* entry, const QString& sequence, QWidget* hideWindow = nullptr);
 
     inline bool isAvailable()
     {

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -799,6 +799,38 @@ void DatabaseWidget::performAutoType()
     }
 }
 
+void DatabaseWidget::performAutoTypeUsername()
+{
+    auto currentEntry = currentSelectedEntry();
+    if (currentEntry) {
+        autoType()->performAutoTypeWithSequence(currentEntry, QStringLiteral("{USERNAME}"), window());
+    }
+}
+
+void DatabaseWidget::performAutoTypeUsernameEnter()
+{
+    auto currentEntry = currentSelectedEntry();
+    if (currentEntry) {
+        autoType()->performAutoTypeWithSequence(currentEntry, QStringLiteral("{USERNAME}{ENTER}"), window());
+    }
+}
+
+void DatabaseWidget::performAutoTypePassword()
+{
+    auto currentEntry = currentSelectedEntry();
+    if (currentEntry) {
+        autoType()->performAutoTypeWithSequence(currentEntry, QStringLiteral("{PASSWORD}"), window());
+    }
+}
+
+void DatabaseWidget::performAutoTypePasswordEnter()
+{
+    auto currentEntry = currentSelectedEntry();
+    if (currentEntry) {
+        autoType()->performAutoTypeWithSequence(currentEntry, QStringLiteral("{PASSWORD}{ENTER}"), window());
+    }
+}
+
 void DatabaseWidget::openUrl()
 {
     auto currentEntry = currentSelectedEntry();

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -186,6 +186,10 @@ public slots:
     void removeFromAgent();
 #endif
     void performAutoType();
+    void performAutoTypeUsername();
+    void performAutoTypeUsernameEnter();
+    void performAutoTypePassword();
+    void performAutoTypePasswordEnter();
     void openUrl();
     void downloadSelectedFavicons();
     void downloadAllFavicons();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -126,6 +126,7 @@ MainWindow::MainWindow()
     m_entryContextMenu->addAction(m_ui->menuEntryTotp->menuAction());
     m_entryContextMenu->addSeparator();
     m_entryContextMenu->addAction(m_ui->actionEntryAutoType);
+    m_entryContextMenu->addAction(m_ui->menuEntryAutoTypeWithSequence->menuAction());
     m_entryContextMenu->addSeparator();
     m_entryContextMenu->addAction(m_ui->actionEntryEdit);
     m_entryContextMenu->addAction(m_ui->actionEntryClone);
@@ -220,7 +221,12 @@ MainWindow::MainWindow()
     m_ui->toolbarSeparator->setVisible(false);
     m_showToolbarSeparator = config()->get(Config::GUI_ApplicationTheme).toString() != "classic";
 
-    m_ui->actionEntryAutoType->setVisible(autoType()->isAvailable());
+    bool isAutoTypeAvailable = autoType()->isAvailable();
+    m_ui->actionEntryAutoType->setVisible(isAutoTypeAvailable);
+    m_ui->actionEntryAutoTypeUsername->setVisible(isAutoTypeAvailable);
+    m_ui->actionEntryAutoTypeUsernameEnter->setVisible(isAutoTypeAvailable);
+    m_ui->actionEntryAutoTypePassword->setVisible(isAutoTypeAvailable);
+    m_ui->actionEntryAutoTypePasswordEnter->setVisible(isAutoTypeAvailable);
 
     m_inactivityTimer = new InactivityTimer(this);
     connect(m_inactivityTimer, SIGNAL(inactivityDetected()), this, SLOT(lockDatabasesAfterInactivity()));
@@ -352,6 +358,11 @@ MainWindow::MainWindow()
     m_ui->actionEntryEdit->setIcon(resources()->icon("entry-edit"));
     m_ui->actionEntryDelete->setIcon(resources()->icon("entry-delete"));
     m_ui->actionEntryAutoType->setIcon(resources()->icon("auto-type"));
+    m_ui->menuEntryAutoTypeWithSequence->setIcon(resources()->icon("auto-type"));
+    m_ui->actionEntryAutoTypeUsername->setIcon(resources()->icon("auto-type"));
+    m_ui->actionEntryAutoTypeUsernameEnter->setIcon(resources()->icon("auto-type"));
+    m_ui->actionEntryAutoTypePassword->setIcon(resources()->icon("auto-type"));
+    m_ui->actionEntryAutoTypePasswordEnter->setIcon(resources()->icon("auto-type"));
     m_ui->actionEntryMoveUp->setIcon(resources()->icon("move-up"));
     m_ui->actionEntryMoveDown->setIcon(resources()->icon("move-down"));
     m_ui->actionEntryCopyUsername->setIcon(resources()->icon("username-copy"));
@@ -446,6 +457,14 @@ MainWindow::MainWindow()
     m_actionMultiplexer.connect(m_ui->actionEntryCopyURL, SIGNAL(triggered()), SLOT(copyURL()));
     m_actionMultiplexer.connect(m_ui->actionEntryCopyNotes, SIGNAL(triggered()), SLOT(copyNotes()));
     m_actionMultiplexer.connect(m_ui->actionEntryAutoType, SIGNAL(triggered()), SLOT(performAutoType()));
+    m_actionMultiplexer.connect(
+        m_ui->actionEntryAutoTypeUsername, SIGNAL(triggered()), SLOT(performAutoTypeUsername()));
+    m_actionMultiplexer.connect(
+        m_ui->actionEntryAutoTypeUsernameEnter, SIGNAL(triggered()), SLOT(performAutoTypeUsernameEnter()));
+    m_actionMultiplexer.connect(
+        m_ui->actionEntryAutoTypePassword, SIGNAL(triggered()), SLOT(performAutoTypePassword()));
+    m_actionMultiplexer.connect(
+        m_ui->actionEntryAutoTypePasswordEnter, SIGNAL(triggered()), SLOT(performAutoTypePasswordEnter()));
     m_actionMultiplexer.connect(m_ui->actionEntryOpenUrl, SIGNAL(triggered()), SLOT(openUrl()));
     m_actionMultiplexer.connect(m_ui->actionEntryDownloadIcon, SIGNAL(triggered()), SLOT(downloadSelectedFavicons()));
 #ifdef WITH_XC_SSHAGENT
@@ -711,6 +730,13 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->menuEntryCopyAttribute->setEnabled(singleEntrySelected);
             m_ui->menuEntryTotp->setEnabled(singleEntrySelected);
             m_ui->actionEntryAutoType->setEnabled(singleEntrySelected);
+            m_ui->menuEntryAutoTypeWithSequence->setEnabled(singleEntrySelected);
+            m_ui->actionEntryAutoTypeUsername->setEnabled(singleEntrySelected && dbWidget->currentEntryHasUsername());
+            m_ui->actionEntryAutoTypeUsernameEnter->setEnabled(singleEntrySelected
+                                                               && dbWidget->currentEntryHasUsername());
+            m_ui->actionEntryAutoTypePassword->setEnabled(singleEntrySelected && dbWidget->currentEntryHasPassword());
+            m_ui->actionEntryAutoTypePasswordEnter->setEnabled(singleEntrySelected
+                                                               && dbWidget->currentEntryHasPassword());
             m_ui->actionEntryOpenUrl->setEnabled(singleEntrySelected && dbWidget->currentEntryHasUrl());
             m_ui->actionEntryTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
             m_ui->actionEntryCopyTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
@@ -761,6 +787,7 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
                                                                m_ui->actionEntryCopyURL,
                                                                m_ui->actionEntryOpenUrl,
                                                                m_ui->actionEntryAutoType,
+                                                               m_ui->menuEntryAutoTypeWithSequence->menuAction(),
                                                                m_ui->actionEntryDownloadIcon,
                                                                m_ui->actionEntryCopyNotes,
                                                                m_ui->actionEntryCopyTitle,

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -310,6 +310,18 @@
      <addaction name="actionEntryTotpQRCode"/>
      <addaction name="actionEntrySetupTotp"/>
     </widget>
+    <widget class="QMenu" name="menuEntryAutoTypeWithSequence">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Perform Auto-Type Sequence</string>
+     </property>
+     <addaction name="actionEntryAutoTypeUsername"/>
+     <addaction name="actionEntryAutoTypeUsernameEnter"/>
+     <addaction name="actionEntryAutoTypePassword"/>
+     <addaction name="actionEntryAutoTypePasswordEnter"/>
+    </widget>
     <addaction name="actionEntryNew"/>
     <addaction name="actionEntryEdit"/>
     <addaction name="actionEntryClone"/>
@@ -324,6 +336,7 @@
     <addaction name="menuEntryTotp"/>
     <addaction name="separator"/>
     <addaction name="actionEntryAutoType"/>
+    <addaction name="menuEntryAutoTypeWithSequence"/>
     <addaction name="separator"/>
     <addaction name="actionEntryOpenUrl"/>
     <addaction name="actionEntryDownloadIcon"/>
@@ -678,6 +691,38 @@
    </property>
    <property name="text">
     <string>Perform &amp;Auto-Type</string>
+   </property>
+  </action>
+  <action name="actionEntryAutoTypeUsername">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>{USERNAME}</string>
+   </property>
+  </action>
+  <action name="actionEntryAutoTypeUsernameEnter">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>{USERNAME}{ENTER}</string>
+   </property>
+  </action>
+  <action name="actionEntryAutoTypePassword">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>{PASSWORD}</string>
+   </property>
+  </action>
+  <action name="actionEntryAutoTypePasswordEnter">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>{PASSWORD}{ENTER}</string>
    </property>
   </action>
   <action name="actionEntryDownloadIcon">


### PR DESCRIPTION
**Add option to Auto-Type just the username/password**

Fixes #4444

Some websites these days do not present both the "username" and the "password"
input box on the same webpage (e.g. Google, Amazon). So no custom sequence is
possible to enter both the said attributes in one go.

So, two new context menu actions have been added:
1. To perform the Auto-Type-ing of just the username
2. To perform the Auto-Type-ing of just the password

These context menu actions are analogous to "Copy username" and "Copy
password", except it avoids sending all characters via clipboard.

It "partially fixes" #3630, which is about the ability to perform Auto-Type-ing
of any arbitrary attribute. This PR gives the ability for just the two most
important attributes: the username and the password, for now.

## Explain changes

The `QString`s `Entry::AutoTypeSequenceUsername` and
`Entry::AutoTypeSequencePassword` have been re-used as the `sequence`s for the
Auto-Type-ing of the username and the password respectively.

Analogous to `AutoType::performAutoType`, additional functions
`AutoType::performAutoTypeUsername` and `AutoType::performAutoTypePassword`
were created, which basically skip searching for the `Entry`'s configured
Auto-Type sequence and instead just supply the desired sequence to
`AutoType::executeAutoTypeActions`.

Context menu actions were added so that user can right-click the entry and
trigger an Auto-Type for just the username/password.

## Screenshot

![Screenshot from 2020-06-21 08-54-42](https://user-images.githubusercontent.com/20044850/85216206-655d3280-b39f-11ea-9582-8b37ca63ebe5.png)

_Observe the Auto-Type actions available in the context menu_

## Testing strategy

Tested it for real on Ubuntu with GNOME X.org, and it worked.

Doesn't need new unit test, as it borrows and modifies a few lines of code
for the main Auto-Type functionality, which has its own unit tests already.

## Type of change
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
