### PR TITLE
Fix adjusting send buffer size

### DIFF
--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -53,4 +53,8 @@ if(WITH_XC_BROWSER)
                            COMMAND ${CMAKE_COMMAND} -E copy keepassxc-proxy ${PROXY_APP_DIR}/keepassxc-proxy
                            COMMENT "Copying keepassxc-proxy inside the application")
     endif()
+
+    if(MINGW)
+      target_link_libraries(keepassxc-proxy Wtsapi32.lib Ws2_32.lib)
+    endif()
 endif()

--- a/src/proxy/NativeMessagingProxy.cpp
+++ b/src/proxy/NativeMessagingProxy.cpp
@@ -26,6 +26,10 @@
 #ifdef Q_OS_WIN
 #include <fcntl.h>
 #include <windows.h>
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#include <sys/types.h>
 #endif
 
 NativeMessagingProxy::NativeMessagingProxy()
@@ -85,6 +89,11 @@ void NativeMessagingProxy::setupLocalSocket()
     m_localSocket.reset(new QLocalSocket());
     m_localSocket->connectToServer(BrowserShared::localServerPath());
     m_localSocket->setReadBufferSize(BrowserShared::NATIVEMSG_MAX_LENGTH);
+    int socketDesc = m_localSocket->socketDescriptor();
+    if (socketDesc) {
+        int max = BrowserShared::NATIVEMSG_MAX_LENGTH;
+        setsockopt(socketDesc, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<char*>(&max), sizeof(max));
+    }
 
     connect(m_localSocket.data(), SIGNAL(readyRead()), this, SLOT(transferSocketMessage()));
     connect(m_localSocket.data(), SIGNAL(disconnected()), this, SLOT(socketDisconnected()));


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

With the new browser integration refactor adjusting the send buffer size was removed. This causes large messages to be dropped.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. For testing this you need a database with a lot of groups (30-40) which causes the reply for `get-database-groups` request being quite large. Without the higher buffer setting the message never leaves the Unix socket, or the proxy.

This can be easily tested when saving new credentials with option _Always ask where to save new credentials_ enabled which shows the group listing. Without the fix the request never gets an answer.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
