### PR TITLE
Hide window after unlock dialog

### DIFF
--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -73,6 +73,13 @@ private slots:
     void unloadPlugin();
 
 private:
+    enum WindowState
+    {
+        Normal,
+        Minimized,
+        Hidden
+    };
+
     explicit AutoType(QObject* parent = nullptr, bool test = false);
     ~AutoType() override;
     void loadPlugin(const QString& pluginPath);
@@ -86,6 +93,7 @@ private:
     bool windowMatchesTitle(const QString& windowTitle, const QString& resolvedTitle);
     bool windowMatchesUrl(const QString& windowTitle, const QString& resolvedUrl);
     bool windowMatches(const QString& windowTitle, const QString& windowPattern);
+    void restoreWindowState();
 
     QMutex m_inAutoType;
     QMutex m_inGlobalAutoTypeDialog;
@@ -98,6 +106,7 @@ private:
     static AutoType* m_instance;
 
     QString m_windowTitleForGlobal;
+    WindowState m_windowState;
     WId m_windowForGlobal;
 
     Q_DISABLE_COPY(AutoType)

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -154,6 +154,7 @@ private:
     QHash<QString, QSharedPointer<BrowserAction>> m_browserClients;
 
     bool m_dialogActive;
+    bool m_bringToFrontRequested;
     WindowState m_prevWindowState;
     QUuid m_keepassBrowserUUID;
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Hides the KeePassXC main window properly when unlocking a database, showing Access Confirm dialog or saving new credentials.

Fixes #4904.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

