### PR TITLE
Fix --pw-stdin by initializing text streams

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,7 @@ int main(int argc, char** argv)
             // buffer for native messaging, even if the specified file does not exist
             QTextStream out(stdout, QIODevice::WriteOnly);
             out << QObject::tr("Database password: ") << flush;
+            Utils::setDefaultTextStreams();
             password = Utils::getPassword();
         }
 


### PR DESCRIPTION
[FIX] --pw-stdin throws errors: QTextStream: No device on debian sid


## Screenshots

`$ echo foo|keepassxc --pw-stdin --keyfile bar.key baz.kdbx`
`Database password: QTextStream: No device`
`QTextStream: No device`



## Testing strategy
After changing --pw-stdin does not throw errors any more and the password is used. 


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)