### PR TITLE
Release/2.6.0 [FIX] --pw-stdin throws errors: QTextStream: No device on debian sid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 project(KeePassXC)
 
@@ -225,10 +225,22 @@ macro(check_add_gcc_compiler_cflag FLAG FLAGNAME)
     endif()
 endmacro(check_add_gcc_compiler_cflag)
 
+# This is the "front-end" for the above macros
+# Optionally takes additional parameter(s) with language to check (currently "C" or "CXX")
 macro(check_add_gcc_compiler_flag FLAG)
     string(REGEX REPLACE "[-=]" "_" FLAGNAME "${FLAG}")
-    check_add_gcc_compiler_cxxflag("${FLAG}" "${FLAGNAME}")
-    check_add_gcc_compiler_cflag("${FLAG}" "${FLAGNAME}")
+    set(check_lang_spec ${ARGN})
+    list(LENGTH check_lang_spec num_extra_args)
+    set(langs C CXX)
+    if(num_extra_args GREATER 0)
+        set(langs "${check_lang_spec}")
+    endif()
+    if("C" IN_LIST langs)
+        check_add_gcc_compiler_cflag("${FLAG}" "${FLAGNAME}")
+    endif()
+    if("CXX" IN_LIST langs)
+        check_add_gcc_compiler_cxxflag("${FLAG}" "${FLAGNAME}")
+    endif()
 endmacro(check_add_gcc_compiler_flag)
 
 add_definitions(-DQT_NO_EXCEPTIONS -DQT_STRICT_ITERATORS -DQT_NO_CAST_TO_ASCII)
@@ -281,7 +293,7 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "(release|relwithdebinfo|minsizerel)")
 endif()
 
 check_add_gcc_compiler_flag("-Werror=format-security")
-check_add_gcc_compiler_flag("-Werror=implicit-function-declaration")
+check_add_gcc_compiler_flag("-Werror=implicit-function-declaration" C)
 check_add_gcc_compiler_flag("-Wcast-align")
 
 if(WITH_COVERAGE AND CMAKE_COMPILER_IS_CLANGXX)
@@ -305,7 +317,7 @@ endif()
 add_gcc_compiler_cflags("-std=c99")
 add_gcc_compiler_cxxflags("-std=c++11")
 
-check_add_gcc_compiler_flag("-fsized-deallocation")
+check_add_gcc_compiler_flag("-fsized-deallocation" CXX)
 
 if(APPLE AND CMAKE_COMPILER_IS_CLANGXX)
     add_gcc_compiler_cxxflags("-stdlib=libc++")

--- a/release-tool
+++ b/release-tool
@@ -736,11 +736,8 @@ EOF
     local appimage_name="KeePassXC-x86_64.AppImage"
     if [ "" != "$RELEASE_NAME" ]; then
         appimage_name="KeePassXC-${RELEASE_NAME}-x86_64.AppImage"
+        echo "X-AppImage-Version=${RELEASE_NAME}" >> "$desktop_file"
     fi
-
-    # Allow appimagetool to insert version information into the AppImage to allow
-    # desktop integration tools to display that in app launchers
-    export VERSION="${RELEASE_NAME}"
 
     # Run appimagetool to package (and possibly sign) AppImage
     # --no-appstream is required, since it may crash on newer systems

--- a/share/translations/keepassx_en_US.ts
+++ b/share/translations/keepassx_en_US.ts
@@ -6587,7 +6587,7 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>Own certificate</source>
-        <translation>Own certificate</translation>
+        <translation>Personal certificate</translation>
     </message>
     <message>
         <source>Fingerprint:</source>
@@ -6724,7 +6724,7 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>Export own certificate</source>
-        <translation>Export own certificate</translation>
+        <translation>Export personal certificate</translation>
     </message>
     <message>
         <source>Known shares</source>

--- a/share/translations/keepassx_fr.ts
+++ b/share/translations/keepassx_fr.ts
@@ -619,7 +619,7 @@ Veuillez sélectionner la base de donnée souhaitée pour enregistrer les identi
     </message>
     <message>
         <source>Re&amp;quest to unlock the database if it is locked</source>
-        <translation>Demander de déverrouiller la base de données lorsque celle-ci est verrouillée</translation>
+        <translation>Demander de &amp;déverrouiller la base de données si elle est verrouillée</translation>
     </message>
     <message>
         <source>Only entries with the same scheme (http://, https://, ...) are returned.</source>
@@ -735,7 +735,7 @@ Veuillez sélectionner la base de donnée souhaitée pour enregistrer les identi
     </message>
     <message>
         <source>Please see special instructions for browser extension use below</source>
-        <translation>Veuillez regarder les instructions spéciales pour l&apos;extension pour navigateur web utilisé ci-dessous</translation>
+        <translation>Veuillez consulter ci-dessous les instructions spéciales de l’extension pour navigateurs</translation>
     </message>
     <message>
         <source>KeePassXC-Browser is needed for the browser integration to work. &lt;br /&gt;Download it for %1 and %2. %3</source>
@@ -2194,7 +2194,7 @@ Désactiver les enregistrements sécurisés et ressayer ?</translation>
     </message>
     <message>
         <source>n/a</source>
-        <translation>n/a</translation>
+        <translation>s.o.</translation>
     </message>
     <message>
         <source>(encrypted)</source>
@@ -2270,7 +2270,7 @@ Désactiver les enregistrements sécurisés et ressayer ?</translation>
     </message>
     <message>
         <source>[PROTECTED] Press reveal to view or edit</source>
-        <translation>[PROTÉGÉ] Appuyez pour voir ou modifier</translation>
+        <translation>[PROTÉGÉ] Appuyer sur Révéler pour visualiser ou modifier</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
@@ -2321,7 +2321,7 @@ Désactiver les enregistrements sécurisés et ressayer ?</translation>
     </message>
     <message>
         <source>Attachments</source>
-        <translation>Pièces jointes</translation>
+        <translation>Fichiers joints</translation>
     </message>
     <message>
         <source>Foreground Color:</source>
@@ -2644,11 +2644,11 @@ Désactiver les enregistrements sécurisés et ressayer ?</translation>
     </message>
     <message>
         <source>Decrypt</source>
-        <translation>Déchiffré</translation>
+        <translation>Déchiffrer</translation>
     </message>
     <message>
         <source>n/a</source>
-        <translation>n/a</translation>
+        <translation>s.o.</translation>
     </message>
     <message>
         <source>Copy to clipboard</source>
@@ -2669,7 +2669,7 @@ Désactiver les enregistrements sécurisés et ressayer ?</translation>
     </message>
     <message>
         <source>Attachment</source>
-        <translation>Pièce jointe</translation>
+        <translation>Fichier joint</translation>
     </message>
     <message>
         <source>Add to agent</source>
@@ -3124,7 +3124,7 @@ This may cause the affected plugins to malfunction.</source>
     </message>
     <message>
         <source>Save</source>
-        <translation>Enregistrer le fichier</translation>
+        <translation>Enregistrer</translation>
     </message>
     <message>
         <source>Select files</source>
@@ -3183,7 +3183,7 @@ This may cause the affected plugins to malfunction.</source>
     </message>
     <message>
         <source>Attachments</source>
-        <translation>Pièces jointes</translation>
+        <translation>Fichiers joints</translation>
     </message>
     <message>
         <source>Add new attachment</source>
@@ -3281,7 +3281,7 @@ This may cause the affected plugins to malfunction.</source>
     </message>
     <message>
         <source>Attachments</source>
-        <translation>Pièces jointes</translation>
+        <translation>Fichiers joints</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -3324,7 +3324,7 @@ This may cause the affected plugins to malfunction.</source>
     </message>
     <message>
         <source>Attachments</source>
-        <translation>Pièces jointes</translation>
+        <translation>Fichiers joints</translation>
     </message>
     <message>
         <source>Notes</source>
@@ -3548,7 +3548,7 @@ Vous pouvez activer le service d&apos;icônes de sites Web de DuckDuckGo dans la
     </message>
     <message>
         <source>Invalid header id size</source>
-        <translation>Taille de l’identifiant d’en-tête invalide</translation>
+        <translation>La taille de l’ID d’en-tête est invalide</translation>
     </message>
     <message>
         <source>Invalid header field length</source>
@@ -3556,7 +3556,7 @@ Vous pouvez activer le service d&apos;icônes de sites Web de DuckDuckGo dans la
     </message>
     <message>
         <source>Invalid header data length</source>
-        <translation>Longueur des données d’en-tête invalide</translation>
+        <translation>La longueur des données d’en-tête est invalide</translation>
     </message>
     <message>
         <source>Invalid credentials were provided, please try again.
@@ -3569,7 +3569,7 @@ Si le problème persiste, le fichier de la base de données peut être corrompu.
     <name>Kdbx3Writer</name>
     <message>
         <source>Unable to issue challenge-response.</source>
-        <translation>Impossible de lancer une question-réponse.</translation>
+        <translation>Impossible de générer une question-réponse.</translation>
     </message>
     <message>
         <source>Unable to calculate master key</source>
@@ -3580,7 +3580,7 @@ Si le problème persiste, le fichier de la base de données peut être corrompu.
     <name>Kdbx4Reader</name>
     <message>
         <source>missing database headers</source>
-        <translation>en-têtes de la base de données manquantes</translation>
+        <translation>il manque des en-têtes de base de données</translation>
     </message>
     <message>
         <source>Unable to calculate master key</source>
@@ -3588,11 +3588,11 @@ Si le problème persiste, le fichier de la base de données peut être corrompu.
     </message>
     <message>
         <source>Invalid header checksum size</source>
-        <translation>Taille de la somme de contrôle de d’en-tête invalide</translation>
+        <translation>La taille de la somme de contrôle de l’en-tête est invalide</translation>
     </message>
     <message>
         <source>Header SHA256 mismatch</source>
-        <translation>En-tête SHA256 incohérent</translation>
+        <translation>Le SHA256 de l’en-tête ne correspond pas</translation>
     </message>
     <message>
         <source>Unknown cipher</source>
@@ -3600,7 +3600,7 @@ Si le problème persiste, le fichier de la base de données peut être corrompu.
     </message>
     <message>
         <source>Invalid header id size</source>
-        <translation>Taille de l’identifiant d’en-tête invalide</translation>
+        <translation>La taille de l’ID d’en-tête est invalide</translation>
     </message>
     <message>
         <source>Invalid header field length</source>
@@ -3608,11 +3608,11 @@ Si le problème persiste, le fichier de la base de données peut être corrompu.
     </message>
     <message>
         <source>Invalid header data length</source>
-        <translation>Longueur des données d’en-tête invalide</translation>
+        <translation>La longueur des données d’en-tête est invalide</translation>
     </message>
     <message>
         <source>Failed to open buffer for KDF parameters in header</source>
-        <translation>Échec lors de l’ouverture d’une mémoire tampon pour les paramètres KDF dans l’en-tête</translation>
+        <translation>Échec d’ouverture d’un tampon pour les paramètres KDF dans l’en-tête</translation>
     </message>
     <message>
         <source>Unsupported key derivation function (KDF) or invalid parameters</source>
@@ -3624,7 +3624,7 @@ Si le problème persiste, le fichier de la base de données peut être corrompu.
     </message>
     <message>
         <source>Invalid inner header id size</source>
-        <translation>Taille de identifiant d’en-tête interne invalide</translation>
+        <translation>La taille de l’ID d’en-tête interne est invalide</translation>
     </message>
     <message>
         <source>Invalid inner header field length</source>
@@ -3746,7 +3746,7 @@ Si le problème persiste, le fichier de la base de données peut être corrompu.
     </message>
     <message>
         <source>Invalid transform seed size</source>
-        <translation>Taille du salage transformé invalide</translation>
+        <translation>La taille de la semence de transformation est invalide</translation>
     </message>
     <message>
         <source>Invalid transform rounds size</source>
@@ -3780,7 +3780,7 @@ Il s’agit d’une migration à sens unique. Vous ne pourrez pas ouvrir la base
     </message>
     <message>
         <source>Unsupported KeePass 2 database version.</source>
-        <translation>Version de la base de données KeePass 2 non prise en charge.</translation>
+        <translation>Version de base de données KeePass 2 non pris en charge.</translation>
     </message>
     <message>
         <source>Invalid cipher uuid length: %1 (length=%2)</source>
@@ -3950,7 +3950,7 @@ Ligne %2, colonne %3</translation>
     </message>
     <message>
         <source>Unsupported KeePass database version.</source>
-        <translation>Version de base de données KeePass non prise en charge.</translation>
+        <translation>Version de base de données KeePass non prise en charge.</translation>
     </message>
     <message>
         <source>Unable to read encryption IV</source>
@@ -3971,7 +3971,7 @@ Ligne %2, colonne %3</translation>
     </message>
     <message>
         <source>Invalid transform seed size</source>
-        <translation>Taille du salage transformé invalide</translation>
+        <translation>La taille de la semence de transformation est invalide</translation>
     </message>
     <message>
         <source>Invalid number of transform rounds</source>
@@ -5582,7 +5582,7 @@ Commandes disponibles :
     </message>
     <message>
         <source>Word count for the diceware passphrase.</source>
-        <translation>Nombre de mots de la phrase secrète générés avec la méthode du lancer de dés.</translation>
+        <translation>Nombre de mots de la phrase de passe générée avec la méthode du lancer de dés.</translation>
     </message>
     <message>
         <source>Wordlist for the diceware generator.
@@ -6137,7 +6137,7 @@ Noyau : %3 %4</translation>
     </message>
     <message>
         <source>Invalid word count %1</source>
-        <translation>Nombre de mots %1 invalide</translation>
+        <translation>Le nombre de mots %1 est invalide</translation>
     </message>
     <message>
         <source>The word list is too small (&lt; 1000 items)</source>
@@ -6321,7 +6321,7 @@ Noyau : %3 %4</translation>
     </message>
     <message>
         <source>Show the protected attributes in clear text.</source>
-        <translation>Afficher les attributs protégés en clair.</translation>
+        <translation>Afficher en clair les attributs protégés.</translation>
     </message>
 </context>
 <context>
@@ -6976,7 +6976,7 @@ Noyau : %3 %4</translation>
     </message>
     <message>
         <source>Algorithm:</source>
-        <translation>Algorithme :</translation>
+        <translation>Algorithme :</translation>
     </message>
     <message>
         <source>Time step field</source>

--- a/share/translations/keepassx_id.ts
+++ b/share/translations/keepassx_id.ts
@@ -97,11 +97,11 @@
     </message>
     <message>
         <source>Reset Settings?</source>
-        <translation type="unfinished"/>
+        <translation>Atur Ulang Pengaturan?</translation>
     </message>
     <message>
         <source>Are you sure you want to reset all general and security settings to default?</source>
-        <translation type="unfinished"/>
+        <translation>Apakah anda yakin ingin mengatur ulang pengaturan umum dan keamanan ke nilai bawaan?</translation>
     </message>
 </context>
 <context>
@@ -225,63 +225,63 @@
     </message>
     <message>
         <source>Remember previously used databases</source>
-        <translation type="unfinished"/>
+        <translation>Ingat basis data yang sebelumnya digunakan</translation>
     </message>
     <message>
         <source>Load previously open databases on startup</source>
-        <translation type="unfinished"/>
+        <translation>Muat basis data yang sebelumnya terbuka saat memulai</translation>
     </message>
     <message>
         <source>Remember database key files and security dongles</source>
-        <translation type="unfinished"/>
+        <translation>Ingat berkas kunci dan dongle kemanan</translation>
     </message>
     <message>
         <source>Check for updates at application startup once per week</source>
-        <translation type="unfinished"/>
+        <translation>Periksa pembaruan saat memulai aplikasi sekali seminggu</translation>
     </message>
     <message>
         <source>Include beta releases when checking for updates</source>
-        <translation type="unfinished"/>
+        <translation>Termasuk rilis beta saat memeriksa pembaruan</translation>
     </message>
     <message>
         <source>Button style:</source>
-        <translation type="unfinished"/>
+        <translation>Gaya tombol:</translation>
     </message>
     <message>
         <source>Language:</source>
-        <translation type="unfinished"/>
+        <translation>Bahasa:</translation>
     </message>
     <message>
         <source>(restart program to activate)</source>
-        <translation type="unfinished"/>
+        <translation>(mulai ulang program untuk mengaktifkan)</translation>
     </message>
     <message>
         <source>Minimize window after unlocking database</source>
-        <translation type="unfinished"/>
+        <translation>Minimalkan jendela setelah membuka basis data</translation>
     </message>
     <message>
         <source>Minimize when opening a URL</source>
-        <translation type="unfinished"/>
+        <translation>Minimalkan saat membuka URL</translation>
     </message>
     <message>
         <source>Hide window when copying to clipboard</source>
-        <translation type="unfinished"/>
+        <translation>Sembunyikan jendela saat menyalin ke papan klip</translation>
     </message>
     <message>
         <source>Minimize</source>
-        <translation type="unfinished"/>
+        <translation>Minimalkan</translation>
     </message>
     <message>
         <source>Drop to background</source>
-        <translation type="unfinished"/>
+        <translation>Beralih ke latar belakang</translation>
     </message>
     <message>
         <source>Favicon download timeout:</source>
-        <translation type="unfinished"/>
+        <translation>Waktu habis mengunduh favicon:</translation>
     </message>
     <message>
         <source>Website icon download timeout in seconds</source>
-        <translation type="unfinished"/>
+        <translation>Waktu habis mengunduh ikon situs web dalam detik</translation>
     </message>
     <message>
         <source> sec</source>
@@ -290,15 +290,15 @@
     </message>
     <message>
         <source>Toolbar button style</source>
-        <translation type="unfinished"/>
+        <translation>Gaya tombol bilah perkakas</translation>
     </message>
     <message>
         <source>Use monospaced font for Notes</source>
-        <translation type="unfinished"/>
+        <translation>Gunakan fon monospace untuk Catatan</translation>
     </message>
     <message>
         <source>Language selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan bahasa</translation>
     </message>
     <message>
         <source>Reset Settings to Default</source>
@@ -306,15 +306,15 @@
     </message>
     <message>
         <source>Global auto-type shortcut</source>
-        <translation type="unfinished"/>
+        <translation>Pintasan ketik-otomatis global</translation>
     </message>
     <message>
         <source>Auto-type character typing delay milliseconds</source>
-        <translation type="unfinished"/>
+        <translation>Tundaan pengetikan karakter ketik-otomatis dalam milidetik</translation>
     </message>
     <message>
         <source>Auto-type start delay milliseconds</source>
-        <translation type="unfinished"/>
+        <translation>Tundaan mulai ketik-otomatis dalam milidetik</translation>
     </message>
 </context>
 <context>
@@ -390,15 +390,15 @@
     </message>
     <message>
         <source>Use DuckDuckGo service to download website icons</source>
-        <translation type="unfinished"/>
+        <translation>Gunakan layanan DuckDuckGo untuk mengunduh ikon situs web</translation>
     </message>
     <message>
         <source>Clipboard clear seconds</source>
-        <translation type="unfinished"/>
+        <translation>Waktu menghapus papan klip (detik)</translation>
     </message>
     <message>
         <source>Touch ID inactivity reset</source>
-        <translation type="unfinished"/>
+        <translation>Atur ulang Touch ID setelah tidak aktif</translation>
     </message>
     <message>
         <source>Database lock timeout seconds</source>
@@ -411,7 +411,7 @@
     </message>
     <message>
         <source>Clear search query after</source>
-        <translation type="unfinished"/>
+        <translation>Hapus kueri pencarian setelah</translation>
     </message>
 </context>
 <context>
@@ -446,11 +446,11 @@
     </message>
     <message>
         <source>Permission Required</source>
-        <translation type="unfinished"/>
+        <translation>Membutuhkan Izin</translation>
     </message>
     <message>
         <source>KeePassXC requires the Accessibility permission in order to perform entry level Auto-Type. If you already granted permission, you may have to restart KeePassXC.</source>
-        <translation type="unfinished"/>
+        <translation>KeePassXC membutuhkan izin Aksesibilitas untuk menjalankan Ketik-Otomatis entri. Jika anda sudah memberikan izin, anda perlu memulai ulang KeePassXC.</translation>
     </message>
 </context>
 <context>
@@ -502,11 +502,11 @@
     <name>AutoTypePlatformMac</name>
     <message>
         <source>Permission Required</source>
-        <translation type="unfinished"/>
+        <translation>Membutuhkan Izin</translation>
     </message>
     <message>
         <source>KeePassXC requires the Accessibility and Screen Recorder permission in order to perform global Auto-Type. Screen Recording is necessary to use the window title to find entries. If you already granted permission, you may have to restart KeePassXC.</source>
-        <translation type="unfinished"/>
+        <translation>KeePassXC membutuhkan izin Aksesibilitas dan Perekaman Layar untuk menjalankan Ketik-Otomatis secara global. Perekaman Layar dibutuhkan untuk mengakses judul jendela dari entri terkait. Jika anda sudah memberikan izin, anda perlu memulai ulang KeePassXC.</translation>
     </message>
 </context>
 <context>
@@ -755,11 +755,11 @@ Silakan pilih basis data yang digunakan untuk menyimpan kredensial.</translation
     </message>
     <message>
         <source>Enable browser integration</source>
-        <translation type="unfinished"/>
+        <translation>Aktifkan integrasi peramban</translation>
     </message>
     <message>
         <source>Browsers installed as snaps are currently not supported.</source>
-        <translation type="unfinished"/>
+        <translation>Peramban yang dipasang sebagai snap saat ini tidak didukung.</translation>
     </message>
     <message>
         <source>All databases connected to the extension will return matching credentials.</source>
@@ -767,7 +767,7 @@ Silakan pilih basis data yang digunakan untuk menyimpan kredensial.</translation
     </message>
     <message>
         <source>Don&apos;t display the popup suggesting migration of legacy KeePassHTTP settings.</source>
-        <translation type="unfinished"/>
+        <translation>Jangan pernah tampilkan popup yang menyarankan migrasi pengaturan KeePassHTTP versi lama.</translation>
     </message>
     <message>
         <source>&amp;Do not prompt for KeePassHTTP settings migration.</source>
@@ -775,11 +775,11 @@ Silakan pilih basis data yang digunakan untuk menyimpan kredensial.</translation
     </message>
     <message>
         <source>Custom proxy location field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas lokasi proksi khusus</translation>
     </message>
     <message>
         <source>Browser for custom proxy file</source>
-        <translation type="unfinished"/>
+        <translation>Peramban untuk berkas proksi khusus</translation>
     </message>
     <message>
         <source>&lt;b&gt;Warning&lt;/b&gt;, the keepassxc-proxy application was not found!&lt;br /&gt;Please check the KeePassXC installation directory or confirm the custom path in advanced options.&lt;br /&gt;Browser integration WILL NOT WORK without the proxy application.&lt;br /&gt;Expected Path: %1</source>
@@ -985,23 +985,24 @@ chrome-laptop.</source>
     <message>
         <source>CSV import: writer has errors:
 %1</source>
-        <translation type="unfinished"/>
+        <translation>Impor CSV: galat penulis:
+%1</translation>
     </message>
     <message>
         <source>Text qualification</source>
-        <translation type="unfinished"/>
+        <translation>Kualifikasi teks</translation>
     </message>
     <message>
         <source>Field separation</source>
-        <translation type="unfinished"/>
+        <translation>Pemisahan ruas</translation>
     </message>
     <message>
         <source>Number of header lines to discard</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah baris tajuk untuk dibuang</translation>
     </message>
     <message>
         <source>CSV import preview</source>
-        <translation type="unfinished"/>
+        <translation>Pratinjau impor CSV</translation>
     </message>
 </context>
 <context>
@@ -1054,19 +1055,20 @@ chrome-laptop.</source>
     <message>
         <source>%1
 Backup database located at %2</source>
-        <translation type="unfinished"/>
+        <translation>%1
+Lokasi cadangan basis data ada di %2</translation>
     </message>
     <message>
         <source>Could not save, database does not point to a valid file.</source>
-        <translation type="unfinished"/>
+        <translation>Tidak bisa menyimpan, basis data tidak merujuk ke berkas yang valid.</translation>
     </message>
     <message>
         <source>Could not save, database file is read-only.</source>
-        <translation type="unfinished"/>
+        <translation>Tidak bisa menyimpan, basis data memiliki atribut baca-saja.</translation>
     </message>
     <message>
         <source>Database file has unmerged changes.</source>
-        <translation type="unfinished"/>
+        <translation>Berkas basis data memiliki perubahan yang belum digabung.</translation>
     </message>
     <message>
         <source>Recycle Bin</source>
@@ -1122,7 +1124,7 @@ Harap pertimbangkan membuat berkas kunci baru.</translation>
     </message>
     <message>
         <source>Failed to open key file: %1</source>
-        <translation type="unfinished"/>
+        <translation>Gagal untuk membuka berkas kunci: %1</translation>
     </message>
     <message>
         <source>Select slot...</source>
@@ -1130,15 +1132,15 @@ Harap pertimbangkan membuat berkas kunci baru.</translation>
     </message>
     <message>
         <source>Unlock KeePassXC Database</source>
-        <translation type="unfinished"/>
+        <translation>Buka Kunci Basis Data KeePassXC</translation>
     </message>
     <message>
         <source>Enter Password:</source>
-        <translation type="unfinished"/>
+        <translation>Masukkan Sandi:</translation>
     </message>
     <message>
         <source>Password field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas sandi</translation>
     </message>
     <message>
         <source>Toggle password visibility</source>
@@ -1146,15 +1148,15 @@ Harap pertimbangkan membuat berkas kunci baru.</translation>
     </message>
     <message>
         <source>Key file selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan berkas kunci</translation>
     </message>
     <message>
         <source>Hardware key slot selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan slot kunci perangkat keras</translation>
     </message>
     <message>
         <source>Browse for key file</source>
-        <translation type="unfinished"/>
+        <translation>Temukan berkas kunci</translation>
     </message>
     <message>
         <source>Browse...</source>
@@ -1162,19 +1164,19 @@ Harap pertimbangkan membuat berkas kunci baru.</translation>
     </message>
     <message>
         <source>Refresh hardware tokens</source>
-        <translation type="unfinished"/>
+        <translation>Segarkan token perangkat keras</translation>
     </message>
     <message>
         <source>Hardware Key:</source>
-        <translation type="unfinished"/>
+        <translation>Kunci Perangkat Keras:</translation>
     </message>
     <message>
         <source>Hardware key help</source>
-        <translation type="unfinished"/>
+        <translation>Bantuan kunci perangkat keras</translation>
     </message>
     <message>
         <source>TouchID for Quick Unlock</source>
-        <translation type="unfinished"/>
+        <translation>TouchID untuk Buka Cepat</translation>
     </message>
     <message>
         <source>Clear</source>
@@ -1182,11 +1184,11 @@ Harap pertimbangkan membuat berkas kunci baru.</translation>
     </message>
     <message>
         <source>Clear Key File</source>
-        <translation type="unfinished"/>
+        <translation>Kosongkan Berkas Kunci</translation>
     </message>
     <message>
         <source>Unlock failed and no password given</source>
-        <translation type="unfinished"/>
+        <translation>Gagal membuka dan sandi tidak tersedia</translation>
     </message>
     <message>
         <source>Unlocking the database failed and you did not enter a password.
@@ -1197,11 +1199,11 @@ To prevent this error from appearing, you must go to &quot;Database Settings / S
     </message>
     <message>
         <source>Retry with empty password</source>
-        <translation type="unfinished"/>
+        <translation>Ulangi dengan sandi kosong</translation>
     </message>
     <message>
         <source>Enter Additional Credentials (if any):</source>
-        <translation type="unfinished"/>
+        <translation>Masukkan Kredensial Tambahan (jika ada):</translation>
     </message>
     <message>
         <source>&lt;p&gt;You can use a hardware security key such as a &lt;strong&gt;YubiKey&lt;/strong&gt; or &lt;strong&gt;OnlyKey&lt;/strong&gt; with slots configured for HMAC-SHA1.&lt;/p&gt;
@@ -1214,24 +1216,25 @@ To prevent this error from appearing, you must go to &quot;Database Settings / S
     </message>
     <message>
         <source>Key file help</source>
-        <translation type="unfinished"/>
+        <translation>Bantuan berkas kunci</translation>
     </message>
     <message>
         <source>?</source>
-        <translation type="unfinished"/>
+        <translation>?</translation>
     </message>
     <message>
         <source>Select key file...</source>
-        <translation type="unfinished"/>
+        <translation>Pilih berkas kunci...</translation>
     </message>
     <message>
         <source>Cannot use database file as key file</source>
-        <translation type="unfinished"/>
+        <translation>Tidak bisa menggunakan berkas basis data sebagai berkas kunci</translation>
     </message>
     <message>
         <source>You cannot use your database file as a key file.
 If you do not have a key file, please leave the field empty.</source>
-        <translation type="unfinished"/>
+        <translation>Anda tidak bisa menggunakan berkas basis data anda sebagai berkas kunci,
+Jika anda tidak memiliki berkas kunci, biarkan ruas tetap kosong.</translation>
     </message>
 </context>
 <context>
@@ -1388,11 +1391,11 @@ Hal ini diperlukan untuk mempertahankan kompatibilitas dengan plugin peramban.</
     </message>
     <message>
         <source>Stored browser keys</source>
-        <translation type="unfinished"/>
+        <translation>Simpan kunci peramban</translation>
     </message>
     <message>
         <source>Remove selected key</source>
-        <translation type="unfinished"/>
+        <translation>Buang kunci yang dipilih</translation>
     </message>
 </context>
 <context>
@@ -1538,23 +1541,23 @@ Jika anda tetap mempertahankan jumlah serendah ini, basis data anda mungkin akan
     </message>
     <message>
         <source>Change existing decryption time</source>
-        <translation type="unfinished"/>
+        <translation>Ubah waktu dekripsi yang ada</translation>
     </message>
     <message>
         <source>Decryption time in seconds</source>
-        <translation type="unfinished"/>
+        <translation>Waktu dekripsi dalam detik</translation>
     </message>
     <message>
         <source>Database format</source>
-        <translation type="unfinished"/>
+        <translation>Format basis data</translation>
     </message>
     <message>
         <source>Encryption algorithm</source>
-        <translation type="unfinished"/>
+        <translation>Algoritma enkripsi</translation>
     </message>
     <message>
         <source>Key derivation function</source>
-        <translation type="unfinished"/>
+        <translation>Fungi derivasi kunci</translation>
     </message>
     <message>
         <source>Transform rounds</source>
@@ -1562,18 +1565,18 @@ Jika anda tetap mempertahankan jumlah serendah ini, basis data anda mungkin akan
     </message>
     <message>
         <source>Memory usage</source>
-        <translation type="unfinished"/>
+        <translation>Penggunaan memori</translation>
     </message>
     <message>
         <source>Parallelism</source>
-        <translation type="unfinished"/>
+        <translation>Paralelisme</translation>
     </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetFdoSecrets</name>
     <message>
         <source>Exposed Entries</source>
-        <translation type="unfinished"/>
+        <translation>Entri Yang Diekspos</translation>
     </message>
     <message>
         <source>Don&apos;t e&amp;xpose this database</source>
@@ -1636,36 +1639,37 @@ Jika anda tetap mempertahankan jumlah serendah ini, basis data anda mungkin akan
     </message>
     <message>
         <source>Database name field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas nama basis data</translation>
     </message>
     <message>
         <source>Database description field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas deskripsi basis data</translation>
     </message>
     <message>
         <source>Default username field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas nama pengguna baku</translation>
     </message>
     <message>
         <source>Maximum number of history items per entry</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah maksimum item riwayat per entri</translation>
     </message>
     <message>
         <source>Maximum size of history per entry</source>
-        <translation type="unfinished"/>
+        <translation>Ukuran maksimum riwayat per entri</translation>
     </message>
     <message>
         <source>Delete Recycle Bin</source>
-        <translation type="unfinished"/>
+        <translation>Hapus Keranjang Sampah</translation>
     </message>
     <message>
         <source>Do you want to delete the current recycle bin and all its contents?
 This action is not reversible.</source>
-        <translation type="unfinished"/>
+        <translation>Apakah anda yakin ingin menghapus keranjang sampah dan semua isinya?
+Tidakan ini tidak bisa diurungkan.</translation>
     </message>
     <message>
         <source> (old)</source>
-        <translation type="unfinished"/>
+        <translation>(lama)</translation>
     </message>
 </context>
 <context>
@@ -1688,7 +1692,7 @@ This action is not reversible.</source>
     </message>
     <message>
         <source>Last Signer</source>
-        <translation type="unfinished"/>
+        <translation>Penanda Tangan Terakhir</translation>
     </message>
     <message>
         <source>Certificates</source>
@@ -1736,7 +1740,7 @@ Apakah anda tetap ingin melanjutkan tanpa mengatur sandi?</translation>
     </message>
     <message>
         <source>Continue without password</source>
-        <translation type="unfinished"/>
+        <translation>Lanjutkan tanpa sandi</translation>
     </message>
 </context>
 <context>
@@ -1751,18 +1755,18 @@ Apakah anda tetap ingin melanjutkan tanpa mengatur sandi?</translation>
     </message>
     <message>
         <source>Database name field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas nama basis data</translation>
     </message>
     <message>
         <source>Database description field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas deskripsi basis data</translation>
     </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetStatistics</name>
     <message>
         <source>Statistics</source>
-        <translation type="unfinished"/>
+        <translation>Statistik</translation>
     </message>
     <message>
         <source>Hover over lines with error icons for further information.</source>
@@ -1950,27 +1954,27 @@ Masalah ini jelas sebuah bug, silakan laporkan ke pengembang.</translation>
     </message>
     <message>
         <source>Failed to open %1. It either does not exist or is not accessible.</source>
-        <translation type="unfinished"/>
+        <translation>Gagal untuk membuka %1. Mungkin tidak ada atau tidak bisa diakses.</translation>
     </message>
     <message>
         <source>Export database to HTML file</source>
-        <translation type="unfinished"/>
+        <translation>Ekspor basis data ke berkas HTML</translation>
     </message>
     <message>
         <source>HTML file</source>
-        <translation type="unfinished"/>
+        <translation>Berkas HTML</translation>
     </message>
     <message>
         <source>Writing the HTML file failed.</source>
-        <translation type="unfinished"/>
+        <translation>Gagal menyimpan ke berkas HTML.</translation>
     </message>
     <message>
         <source>Export Confirmation</source>
-        <translation type="unfinished"/>
+        <translation>Konfirmasi Ekspor</translation>
     </message>
     <message>
         <source>You are about to export your database to an unencrypted file. This will leave your passwords and sensitive information vulnerable! Are you sure you want to continue?</source>
-        <translation type="unfinished"/>
+        <translation>Anda akan mengekspor basis data anda ke berkas tanpa enkripsi. Ini akan membuat sandi dan informasi sensitif lainnya menjadi sangat rentan. Apakah anda yakin ingin melanjutkan?</translation>
     </message>
 </context>
 <context>
@@ -2151,7 +2155,7 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>This database is opened in read-only mode. Autosave is disabled.</source>
-        <translation type="unfinished"/>
+        <translation>Basis data ini dibuka dalam mode baca-saja. Simpan otomatis dinonaktifkan.</translation>
     </message>
 </context>
 <context>
@@ -2278,11 +2282,11 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>&lt;empty URL&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;empty URL&gt;</translation>
     </message>
     <message>
         <source>Are you sure you want to remove this URL?</source>
-        <translation type="unfinished"/>
+        <translation>Apakah anda yakin ingin membuang URL ini?</translation>
     </message>
 </context>
 <context>
@@ -2325,39 +2329,39 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Attribute selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan atribut</translation>
     </message>
     <message>
         <source>Attribute value</source>
-        <translation type="unfinished"/>
+        <translation>Nilai atribut</translation>
     </message>
     <message>
         <source>Add a new attribute</source>
-        <translation type="unfinished"/>
+        <translation>Tambah atribut baru</translation>
     </message>
     <message>
         <source>Remove selected attribute</source>
-        <translation type="unfinished"/>
+        <translation>Buang atribut yang dipilih</translation>
     </message>
     <message>
         <source>Edit attribute name</source>
-        <translation type="unfinished"/>
+        <translation>Sunting nama atribut</translation>
     </message>
     <message>
         <source>Toggle attribute protection</source>
-        <translation type="unfinished"/>
+        <translation>Aktif/Nonaktifkan proteksi atribut</translation>
     </message>
     <message>
         <source>Show a protected attribute</source>
-        <translation type="unfinished"/>
+        <translation>Tampilkan atribut yang dilindungi</translation>
     </message>
     <message>
         <source>Foreground color selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan warna latar depan</translation>
     </message>
     <message>
         <source>Background color selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan warna latar belakang</translation>
     </message>
 </context>
 <context>
@@ -2396,46 +2400,46 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Custom Auto-Type sequence</source>
-        <translation type="unfinished"/>
+        <translation>Urutan Ketik-Otomatis khusus</translation>
     </message>
     <message>
         <source>Open Auto-Type help webpage</source>
-        <translation type="unfinished"/>
+        <translation>Buka laman bantuan Ketik-Otomatis</translation>
     </message>
     <message>
         <source>Existing window associations</source>
-        <translation type="unfinished"/>
+        <translation>Asosiasi jendela yang ada</translation>
     </message>
     <message>
         <source>Add new window association</source>
-        <translation type="unfinished"/>
+        <translation>Tambah asosiasi jendela baru</translation>
     </message>
     <message>
         <source>Remove selected window association</source>
-        <translation type="unfinished"/>
+        <translation>Buang asosiasi jendela yang dipilih</translation>
     </message>
     <message>
         <source>You can use an asterisk (*) to match everything</source>
-        <translation type="unfinished"/>
+        <translation>Anda bisa menggunakan asterik (*) untuk mencocokkan semuanya</translation>
     </message>
     <message>
         <source>Set the window association title</source>
-        <translation type="unfinished"/>
+        <translation>Atur judul asosiasi jendela</translation>
     </message>
     <message>
         <source>You can use an asterisk to match everything</source>
-        <translation type="unfinished"/>
+        <translation>Anda bisa menggunakan asterik untuk mencocokkan semuanya</translation>
     </message>
     <message>
         <source>Custom Auto-Type sequence for this window</source>
-        <translation type="unfinished"/>
+        <translation>Urutan Ketik-Otomatis khusus untuk jendela ini</translation>
     </message>
 </context>
 <context>
     <name>EditEntryWidgetBrowser</name>
     <message>
         <source>These settings affect to the entry&apos;s behaviour with the browser extension.</source>
-        <translation type="unfinished"/>
+        <translation>Pengaturan ini mempengaruhi perilaku entri dengan ekstensi peramban.</translation>
     </message>
     <message>
         <source>General</source>
@@ -2443,15 +2447,15 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Skip Auto-Submit for this entry</source>
-        <translation type="unfinished"/>
+        <translation>Lewati Kirim-Otomatis untuk entri ini</translation>
     </message>
     <message>
         <source>Hide this entry from the browser extension</source>
-        <translation type="unfinished"/>
+        <translation>Sembunyikan entri ini dari ekstensi peramban</translation>
     </message>
     <message>
         <source>Additional URL&apos;s</source>
-        <translation type="unfinished"/>
+        <translation>URL tambahan</translation>
     </message>
     <message>
         <source>Add</source>
@@ -2486,7 +2490,7 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Entry history selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan riwayat entri</translation>
     </message>
     <message>
         <source>Show entry at selected history state</source>
@@ -2502,7 +2506,7 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Delete all history</source>
-        <translation type="unfinished"/>
+        <translation>Hapus semua riwayat</translation>
     </message>
 </context>
 <context>
@@ -2545,15 +2549,15 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Url field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas url</translation>
     </message>
     <message>
         <source>Download favicon for URL</source>
-        <translation type="unfinished"/>
+        <translation>Untuk favicon untuk URL</translation>
     </message>
     <message>
         <source>Repeat password field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas pengulangan sandi</translation>
     </message>
     <message>
         <source>Toggle password generator</source>
@@ -2561,7 +2565,7 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Password field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas sandi</translation>
     </message>
     <message>
         <source>Toggle password visibility</source>
@@ -2569,11 +2573,11 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Toggle notes visible</source>
-        <translation type="unfinished"/>
+        <translation>Aktif/Nonaktifkan visibilitas cacatan</translation>
     </message>
     <message>
         <source>Expiration field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas kedaluwarsa</translation>
     </message>
     <message>
         <source>Expiration Presets</source>
@@ -2585,26 +2589,26 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Notes field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas catatan</translation>
     </message>
     <message>
         <source>Title field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas judul</translation>
     </message>
     <message>
         <source>Username field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas nama pengguna</translation>
     </message>
     <message>
         <source>Toggle expiration</source>
-        <translation type="unfinished"/>
+        <translation>Aktif/Nonaktifkan kedaluwarsa</translation>
     </message>
 </context>
 <context>
     <name>EditEntryWidgetSSHAgent</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"/>
+        <translation>Formulir</translation>
     </message>
     <message>
         <source>Remove key from agent after</source>
@@ -2681,15 +2685,15 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Browser for key file</source>
-        <translation type="unfinished"/>
+        <translation>Peramban untuk berkas kunci</translation>
     </message>
     <message>
         <source>External key file</source>
-        <translation type="unfinished"/>
+        <translation>Berkas kunci eksternal</translation>
     </message>
     <message>
         <source>Select attachment file</source>
-        <translation type="unfinished"/>
+        <translation>Pilih berkas lampiran</translation>
     </message>
 </context>
 <context>
@@ -2735,7 +2739,7 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     <name>EditGroupWidgetKeeShare</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"/>
+        <translation>Formulir</translation>
     </message>
     <message>
         <source>Type:</source>
@@ -2759,11 +2763,11 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>KeeShare unsigned container</source>
-        <translation type="unfinished"/>
+        <translation>Kontainer KeeShare tak bertanda tangan</translation>
     </message>
     <message>
         <source>KeeShare signed container</source>
-        <translation type="unfinished"/>
+        <translation>Kontainer KeeShare bertanda tangan</translation>
     </message>
     <message>
         <source>Select import source</source>
@@ -2791,20 +2795,21 @@ Nonaktifkan penyimpanan aman dan coba lagi?</translation>
     </message>
     <message>
         <source>Synchronize</source>
-        <translation type="unfinished"/>
+        <translation>Sinkronkan</translation>
     </message>
     <message>
         <source>Your KeePassXC version does not support sharing this container type.
 Supported extensions are: %1.</source>
-        <translation type="unfinished"/>
+        <translation>Versi KeePassXC anda tidak mendukung fitur berbagi untuk tipe kontainer ini.
+Ekstensi yang didukung adalah: %1.</translation>
     </message>
     <message>
         <source>%1 is already being exported by this database.</source>
-        <translation type="unfinished"/>
+        <translation>%1 sudah diekspor oleh basis data ini.</translation>
     </message>
     <message>
         <source>%1 is already being imported by this database.</source>
-        <translation type="unfinished"/>
+        <translation>%1 telah diimpor oleh basis data ini.</translation>
     </message>
     <message>
         <source>%1 is being imported and exported by different groups in this database.</source>
@@ -2817,19 +2822,19 @@ Supported extensions are: %1.</source>
     </message>
     <message>
         <source>Database export is currently disabled by application settings.</source>
-        <translation type="unfinished"/>
+        <translation>Ekspor basis data saat ini dinonaktifkan oleh pengaturan aplikasi.</translation>
     </message>
     <message>
         <source>Database import is currently disabled by application settings.</source>
-        <translation type="unfinished"/>
+        <translation>Impor basis data saat ini dinonaktifkan oleh pengaturan aplikasi.</translation>
     </message>
     <message>
         <source>Sharing mode field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas mode berbagi</translation>
     </message>
     <message>
         <source>Path to share file field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas jalur ke berkas yang dibagikan</translation>
     </message>
     <message>
         <source>Browser for share file</source>
@@ -2837,7 +2842,7 @@ Supported extensions are: %1.</source>
     </message>
     <message>
         <source>Password field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas sandi</translation>
     </message>
     <message>
         <source>Toggle password visibility</source>
@@ -2849,7 +2854,7 @@ Supported extensions are: %1.</source>
     </message>
     <message>
         <source>Clear fields</source>
-        <translation type="unfinished"/>
+        <translation>Kosongkan ruas</translation>
     </message>
 </context>
 <context>
@@ -2884,31 +2889,31 @@ Supported extensions are: %1.</source>
     </message>
     <message>
         <source>Name field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas nama</translation>
     </message>
     <message>
         <source>Notes field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas catatan</translation>
     </message>
     <message>
         <source>Toggle expiration</source>
-        <translation type="unfinished"/>
+        <translation>Aktif/Nonaktifkan kedaluwarsa</translation>
     </message>
     <message>
         <source>Auto-Type toggle for this and sub groups</source>
-        <translation type="unfinished"/>
+        <translation>Aktif/Nonaktifkan Ketik-Otomatis untuk ini dan sub grup</translation>
     </message>
     <message>
         <source>Expiration field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas kedaluwarsa</translation>
     </message>
     <message>
         <source>Search toggle for this and sub groups</source>
-        <translation type="unfinished"/>
+        <translation>Aktif/Nonaktifkan pencarian untuk ini dan sub grup</translation>
     </message>
     <message>
         <source>Default auto-type sequence field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas urutan ketik-otomatis baku</translation>
     </message>
 </context>
 <context>
@@ -2975,15 +2980,15 @@ Supported extensions are: %1.</source>
     </message>
     <message>
         <source>You can enable the DuckDuckGo website icon service under Tools -&gt; Settings -&gt; Security</source>
-        <translation type="unfinished"/>
+        <translation>Anda bisa mengaktifkan layanan ikon situs web oleh DuckDuckGo di Perkakas &gt; Pengaturan &gt; Keamanan</translation>
     </message>
     <message>
         <source>Download favicon for URL</source>
-        <translation type="unfinished"/>
+        <translation>Untuk favicon untuk URL</translation>
     </message>
     <message>
         <source>Apply selected icon to subgroups and entries</source>
-        <translation type="unfinished"/>
+        <translation>Terapkan ikon yang dipilih ke subgrup dan entri</translation>
     </message>
     <message>
         <source>Apply icon &amp;to ...</source>
@@ -3068,15 +3073,15 @@ Ini mungkin akan menyebabkan plugin terkait tidak berfungsi.</translation>
     </message>
     <message>
         <source>Unique ID</source>
-        <translation type="unfinished"/>
+        <translation>ID Unik</translation>
     </message>
     <message>
         <source>Plugin data</source>
-        <translation type="unfinished"/>
+        <translation>Data pengaya</translation>
     </message>
     <message>
         <source>Remove selected plugin data</source>
-        <translation type="unfinished"/>
+        <translation>Buang data pengaya yang dipilih</translation>
     </message>
 </context>
 <context>
@@ -3101,7 +3106,7 @@ Ini mungkin akan menyebabkan plugin terkait tidak berfungsi.</translation>
     <name>EntryAttachmentsWidget</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"/>
+        <translation>Formulir</translation>
     </message>
     <message>
         <source>Add</source>
@@ -3178,19 +3183,19 @@ Ini mungkin akan menyebabkan plugin terkait tidak berfungsi.</translation>
     </message>
     <message>
         <source>Add new attachment</source>
-        <translation type="unfinished"/>
+        <translation>Tambah lampiran baru</translation>
     </message>
     <message>
         <source>Remove selected attachment</source>
-        <translation type="unfinished"/>
+        <translation>Buang lampiran yang dipilih</translation>
     </message>
     <message>
         <source>Open selected attachment</source>
-        <translation type="unfinished"/>
+        <translation>Buka lampiran yang dipilih</translation>
     </message>
     <message>
         <source>Save selected attachment to disk</source>
-        <translation type="unfinished"/>
+        <translation>Simpan lampiran yang dipilih ke diska</translation>
     </message>
 </context>
 <context>
@@ -3372,7 +3377,7 @@ Ini mungkin akan menyebabkan plugin terkait tidak berfungsi.</translation>
     </message>
     <message>
         <source>Display current TOTP value</source>
-        <translation type="unfinished"/>
+        <translation>Tampilkan nilai TOTP saat ini</translation>
     </message>
     <message>
         <source>Advanced</source>
@@ -3414,7 +3419,7 @@ Ini mungkin akan menyebabkan plugin terkait tidak berfungsi.</translation>
     <name>FdoSecrets::Item</name>
     <message>
         <source>Entry &quot;%1&quot; from database &quot;%2&quot; was used by %3</source>
-        <translation type="unfinished"/>
+        <translation>Entri &quot;%1&quot; dari basis data &quot;%2&quot; telah digunakan oleh %3</translation>
     </message>
 </context>
 <context>
@@ -3459,7 +3464,7 @@ Ini mungkin akan menyebabkan plugin terkait tidak berfungsi.</translation>
     <name>IconDownloaderDialog</name>
     <message>
         <source>Download Favicons</source>
-        <translation type="unfinished"/>
+        <translation>Unduh Favicon</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -3484,11 +3489,11 @@ You can enable the DuckDuckGo website icon service in the security section of th
     </message>
     <message>
         <source>Please wait, processing entry list...</source>
-        <translation type="unfinished"/>
+        <translation>Silakan tunggu, sedang memproses daftar entri...</translation>
     </message>
     <message>
         <source>Downloading...</source>
-        <translation type="unfinished"/>
+        <translation>Mengunduh...</translation>
     </message>
     <message>
         <source>Ok</source>
@@ -3496,15 +3501,15 @@ You can enable the DuckDuckGo website icon service in the security section of th
     </message>
     <message>
         <source>Already Exists</source>
-        <translation type="unfinished"/>
+        <translation>Sudah Ada</translation>
     </message>
     <message>
         <source>Download Failed</source>
-        <translation type="unfinished"/>
+        <translation>Gagal Mengunduh</translation>
     </message>
     <message>
         <source>Downloading favicons (%1/%2)...</source>
-        <translation type="unfinished"/>
+        <translation>Mengunduh favicon (%1/%2)...</translation>
     </message>
 </context>
 <context>
@@ -3534,7 +3539,7 @@ You can enable the DuckDuckGo website icon service in the security section of th
     </message>
     <message>
         <source>Header doesn&apos;t match hash</source>
-        <translation type="unfinished"/>
+        <translation>Header tidak cocok dengan hash</translation>
     </message>
     <message>
         <source>Invalid header id size</source>
@@ -3551,7 +3556,8 @@ You can enable the DuckDuckGo website icon service in the security section of th
     <message>
         <source>Invalid credentials were provided, please try again.
 If this reoccurs, then your database file may be corrupt.</source>
-        <translation type="unfinished"/>
+        <translation>Kredensial yang diberikan tidak valid, silakan coba lagi.
+Jika terus berulang, maka basis data anda mungkin rusak.</translation>
     </message>
 </context>
 <context>
@@ -3686,7 +3692,8 @@ If this reoccurs, then your database file may be corrupt.</source>
     <message>
         <source>Invalid credentials were provided, please try again.
 If this reoccurs, then your database file may be corrupt.</source>
-        <translation type="unfinished"/>
+        <translation>Kredensial yang diberikan tidak valid, silakan coba lagi.
+Jika terus berulang, maka basis data anda mungkin rusak.</translation>
     </message>
     <message>
         <source>(HMAC mismatch)</source>
@@ -3919,7 +3926,7 @@ Baris %2, kolom %3</translation>
     </message>
     <message>
         <source>Import KeePass1 Database</source>
-        <translation type="unfinished"/>
+        <translation>Impor Basis Data KeePass1</translation>
     </message>
 </context>
 <context>
@@ -4076,7 +4083,8 @@ Baris %2, kolom %3</translation>
     <message>
         <source>Invalid credentials were provided, please try again.
 If this reoccurs, then your database file may be corrupt.</source>
-        <translation type="unfinished"/>
+        <translation>Kredensial yang diberikan tidak valid, silakan coba lagi.
+Jika terus berulang, maka basis data anda mungkin rusak.</translation>
     </message>
 </context>
 <context>
@@ -4095,19 +4103,19 @@ If this reoccurs, then your database file may be corrupt.</source>
     </message>
     <message>
         <source>Exported to %1</source>
-        <translation type="unfinished"/>
+        <translation>Diekspor ke %1</translation>
     </message>
     <message>
         <source>Synchronized with %1</source>
-        <translation type="unfinished"/>
+        <translation>Disinkronkan dengan %1</translation>
     </message>
     <message>
         <source>Import is disabled in settings</source>
-        <translation type="unfinished"/>
+        <translation>Impor dinonaktifkan di dalam pengaturan</translation>
     </message>
     <message>
         <source>Export is disabled in settings</source>
-        <translation type="unfinished"/>
+        <translation>Ekspor dinonaktifkan di dalam pengaturan</translation>
     </message>
     <message>
         <source>Inactive share</source>
@@ -4115,15 +4123,15 @@ If this reoccurs, then your database file may be corrupt.</source>
     </message>
     <message>
         <source>Imported from</source>
-        <translation type="unfinished"/>
+        <translation>Diimpor ke</translation>
     </message>
     <message>
         <source>Exported to</source>
-        <translation type="unfinished"/>
+        <translation>Diekspor dari</translation>
     </message>
     <message>
         <source>Synchronized with</source>
-        <translation type="unfinished"/>
+        <translation>Disinkronkan dengan</translation>
     </message>
 </context>
 <context>
@@ -4225,11 +4233,11 @@ Pesan: %2</translation>
     </message>
     <message>
         <source>Key file selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan berkas kunci</translation>
     </message>
     <message>
         <source>Browse for key file</source>
-        <translation type="unfinished"/>
+        <translation>Temukan berkas kunci</translation>
     </message>
     <message>
         <source>Browse...</source>
@@ -4237,7 +4245,7 @@ Pesan: %2</translation>
     </message>
     <message>
         <source>Generate a new key file</source>
-        <translation type="unfinished"/>
+        <translation>Buat berkas kunci baru</translation>
     </message>
     <message>
         <source>Note: Do not use a file that may change as that will prevent you from unlocking your database!</source>
@@ -4245,7 +4253,7 @@ Pesan: %2</translation>
     </message>
     <message>
         <source>Invalid Key File</source>
-        <translation type="unfinished"/>
+        <translation>Berkas Kunci Tidak Valid</translation>
     </message>
     <message>
         <source>You cannot use the current database as its own keyfile. Please choose a different file or generate a new key file.</source>
@@ -4253,7 +4261,7 @@ Pesan: %2</translation>
     </message>
     <message>
         <source>Suspicious Key File</source>
-        <translation type="unfinished"/>
+        <translation>Berkas Kunci Mencurigakan</translation>
     </message>
     <message>
         <source>The chosen key file looks like a password database file. A key file must be a static file that never changes or you will lose access to your database forever.
@@ -4553,7 +4561,7 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Ekspor</translation>
     </message>
     <message>
         <source>&amp;Check for Updates...</source>
@@ -4565,15 +4573,15 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Sort &amp;A-Z</source>
-        <translation type="unfinished"/>
+        <translation>Urutkan &amp;A-Z</translation>
     </message>
     <message>
         <source>Sort &amp;Z-A</source>
-        <translation type="unfinished"/>
+        <translation>Urutkan &amp;Z-A</translation>
     </message>
     <message>
         <source>&amp;Password Generator</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Pembuat Sandi</translation>
     </message>
     <message>
         <source>Download favicon</source>
@@ -4589,15 +4597,15 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Import a 1Password Vault</source>
-        <translation type="unfinished"/>
+        <translation>Impor Brankas 1Password</translation>
     </message>
     <message>
         <source>&amp;Getting Started</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Memulai</translation>
     </message>
     <message>
         <source>Open Getting Started Guide PDF</source>
-        <translation type="unfinished"/>
+        <translation>Buka PDF Panduan Memulai</translation>
     </message>
     <message>
         <source>&amp;Online Help...</source>
@@ -4605,19 +4613,19 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Go to online documentation (opens browser)</source>
-        <translation type="unfinished"/>
+        <translation>Kunjungi dokumentasi daring (membuka peramban)</translation>
     </message>
     <message>
         <source>&amp;User Guide</source>
-        <translation type="unfinished"/>
+        <translation>Pand&amp;uan Pengguna</translation>
     </message>
     <message>
         <source>Open User Guide PDF</source>
-        <translation type="unfinished"/>
+        <translation>Buka PDF Panduan Pengguna</translation>
     </message>
     <message>
         <source>&amp;Keyboard Shortcuts</source>
-        <translation type="unfinished"/>
+        <translation>Pintasan &amp;Kibor</translation>
     </message>
 </context>
 <context>
@@ -4924,7 +4932,7 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     <name>PasswordEdit</name>
     <message>
         <source>Passwords do not match</source>
-        <translation type="unfinished"/>
+        <translation>Sandi tidak sama</translation>
     </message>
     <message>
         <source>Passwords match so far</source>
@@ -4959,7 +4967,7 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Password field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas sandi</translation>
     </message>
     <message>
         <source>Toggle password visibility</source>
@@ -4967,7 +4975,7 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Repeat password field</source>
-        <translation type="unfinished"/>
+        <translation>Ruas pengulangan sandi</translation>
     </message>
     <message>
         <source>Toggle password generator</source>
@@ -5175,39 +5183,39 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Generated password</source>
-        <translation type="unfinished"/>
+        <translation>Sandi yang dibuat</translation>
     </message>
     <message>
         <source>Upper-case letters</source>
-        <translation type="unfinished"/>
+        <translation>Huruf besar</translation>
     </message>
     <message>
         <source>Lower-case letters</source>
-        <translation type="unfinished"/>
+        <translation>Huruf kecil</translation>
     </message>
     <message>
         <source>Special characters</source>
-        <translation type="unfinished"/>
+        <translation>Karakter spesial</translation>
     </message>
     <message>
         <source>Math Symbols</source>
-        <translation type="unfinished"/>
+        <translation>Simbol Matematika</translation>
     </message>
     <message>
         <source>Dashes and Slashes</source>
-        <translation type="unfinished"/>
+        <translation>Garis Tengah dan Miring</translation>
     </message>
     <message>
         <source>Excluded characters</source>
-        <translation type="unfinished"/>
+        <translation>Karakter yang dikecualikan</translation>
     </message>
     <message>
         <source>Hex Passwords</source>
-        <translation type="unfinished"/>
+        <translation>Sandi Hex</translation>
     </message>
     <message>
         <source>Password length</source>
-        <translation type="unfinished"/>
+        <translation>Panjang sandi</translation>
     </message>
     <message>
         <source>Word Case:</source>
@@ -5215,7 +5223,7 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Regenerate password</source>
-        <translation type="unfinished"/>
+        <translation>Buat ulang sandi</translation>
     </message>
     <message>
         <source>Copy password</source>
@@ -5227,11 +5235,11 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>lower case</source>
-        <translation type="unfinished"/>
+        <translation>huruf kecil</translation>
     </message>
     <message>
         <source>UPPER CASE</source>
-        <translation type="unfinished"/>
+        <translation>HURUF BESAR</translation>
     </message>
     <message>
         <source>Title Case</source>
@@ -5250,14 +5258,14 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Statistics</source>
-        <translation type="unfinished"/>
+        <translation>Statistik</translation>
     </message>
 </context>
 <context>
     <name>QMessageBox</name>
     <message>
         <source>Overwrite</source>
-        <translation type="unfinished"/>
+        <translation>Timpa</translation>
     </message>
     <message>
         <source>Delete</source>
@@ -5289,7 +5297,7 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Continue</source>
-        <translation type="unfinished"/>
+        <translation>Lanjutkan</translation>
     </message>
 </context>
 <context>
@@ -5304,7 +5312,7 @@ Jangan kaget jika ada masalah dan bug, versi ini tidak ditujukan untuk penggunaa
     </message>
     <message>
         <source>Client public key not received</source>
-        <translation type="unfinished"/>
+        <translation>Kunci publik klien tidak diterima</translation>
     </message>
     <message>
         <source>Cannot decrypt message</source>
@@ -5668,7 +5676,7 @@ Perintah yang tersedia:
     </message>
     <message>
         <source>Log10 %1</source>
-        <translation type="unfinished"/>
+        <translation>Log10 %1</translation>
     </message>
     <message>
         <source>Multi-word extra bits %1</source>
@@ -5988,7 +5996,7 @@ Perintah yang tersedia:
     </message>
     <message>
         <source>Displays debugging information.</source>
-        <translation type="unfinished"/>
+        <translation>Tampilkan informasi pengawakutuan.</translation>
     </message>
     <message>
         <source>Deactivate password key for the database to merge from.</source>
@@ -6495,7 +6503,7 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>File Name</source>
-        <translation type="unfinished"/>
+        <translation>Nama Berkas</translation>
     </message>
     <message>
         <source>Group</source>
@@ -6503,7 +6511,7 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>Manage</source>
-        <translation type="unfinished"/>
+        <translation>Kelola</translation>
     </message>
     <message>
         <source>Authorization</source>
@@ -6515,11 +6523,11 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>Application</source>
-        <translation type="unfinished"/>
+        <translation>Aplikasi</translation>
     </message>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"/>
+        <translation>Putuskan koneksi</translation>
     </message>
     <message>
         <source>Database settings</source>
@@ -6527,7 +6535,7 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>Edit database settings</source>
-        <translation type="unfinished"/>
+        <translation>Sunting pengaturan basisdata</translation>
     </message>
     <message>
         <source>Unlock database</source>
@@ -6535,7 +6543,7 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>Unlock database to show more information</source>
-        <translation type="unfinished"/>
+        <translation>Buka kunci basisdata untuk menampilkan lebih banyak informasi</translation>
     </message>
     <message>
         <source>Lock database</source>
@@ -6543,7 +6551,7 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>Unlock to show</source>
-        <translation type="unfinished"/>
+        <translation>Buka kunci untuk menampilkan</translation>
     </message>
     <message>
         <source>None</source>
@@ -7105,11 +7113,11 @@ Example: JBSWY3DPEHPK3PXP</source>
     </message>
     <message>
         <source>Refresh hardware tokens</source>
-        <translation type="unfinished"/>
+        <translation>Segarkan token perangkat keras</translation>
     </message>
     <message>
         <source>Hardware key slot selection</source>
-        <translation type="unfinished"/>
+        <translation>Pemilihan slot kunci perangkat keras</translation>
     </message>
 </context>
 </TS>

--- a/share/translations/keepassx_lt.ts
+++ b/share/translations/keepassx_lt.ts
@@ -97,7 +97,7 @@
     </message>
     <message>
         <source>Reset Settings?</source>
-        <translation type="unfinished"/>
+        <translation>Atstatyti nustatymus?</translation>
     </message>
     <message>
         <source>Are you sure you want to reset all general and security settings to default?</source>
@@ -249,7 +249,7 @@
     </message>
     <message>
         <source>Language:</source>
-        <translation type="unfinished"/>
+        <translation>Kalba:</translation>
     </message>
     <message>
         <source>(restart program to activate)</source>

--- a/share/translations/keepassx_nl_NL.ts
+++ b/share/translations/keepassx_nl_NL.ts
@@ -865,7 +865,7 @@ Wil je deze groep aanmaken?
 This is necessary to maintain your current browser connections.
 Would you like to migrate your existing settings now?</source>
         <translation>De KeePassXC-Browser instellingen moeten worden verplaatst naar de instellingen-database.
-Dit is nodig om de huidige browser verbindingen te behouden.
+Dit is nodig om de huidige browserverbindingen te behouden.
 Wil je de bestaande instellingen nu migreren?</translation>
     </message>
     <message>
@@ -6570,7 +6570,7 @@ Kernelversie: %3 %4</translation>
     <name>SettingsWidgetKeeShare</name>
     <message>
         <source>Active</source>
-        <translation>Actieve</translation>
+        <translation>Activering</translation>
     </message>
     <message>
         <source>Allow export</source>

--- a/share/translations/keepassx_pt.ts
+++ b/share/translations/keepassx_pt.ts
@@ -225,7 +225,7 @@
     </message>
     <message>
         <source>Remember previously used databases</source>
-        <translation type="unfinished"/>
+        <translation>Lembrar bases de dados usadas anteriormente</translation>
     </message>
     <message>
         <source>Load previously open databases on startup</source>
@@ -249,7 +249,7 @@
     </message>
     <message>
         <source>Language:</source>
-        <translation type="unfinished"/>
+        <translation>Idioma:</translation>
     </message>
     <message>
         <source>(restart program to activate)</source>
@@ -269,7 +269,7 @@
     </message>
     <message>
         <source>Minimize</source>
-        <translation type="unfinished"/>
+        <translation>Minimizar</translation>
     </message>
     <message>
         <source>Drop to background</source>
@@ -298,7 +298,7 @@
     </message>
     <message>
         <source>Language selection</source>
-        <translation type="unfinished"/>
+        <translation>Seleção de idioma</translation>
     </message>
     <message>
         <source>Reset Settings to Default</source>
@@ -550,11 +550,11 @@ Selecione se deseja permitir o acesso.</translation>
     </message>
     <message>
         <source>Allow access</source>
-        <translation type="unfinished"/>
+        <translation>Permitir acesso</translation>
     </message>
     <message>
         <source>Deny access</source>
-        <translation type="unfinished"/>
+        <translation>Negar acesso</translation>
     </message>
 </context>
 <context>

--- a/share/translations/keepassx_th.ts
+++ b/share/translations/keepassx_th.ts
@@ -98,7 +98,7 @@
     </message>
     <message>
         <source>Reset Settings?</source>
-        <translation type="unfinished"/>
+        <translation>ล้างการตั้งค่าหรือไม่?</translation>
     </message>
     <message>
         <source>Are you sure you want to reset all general and security settings to default?</source>
@@ -230,7 +230,7 @@
     </message>
     <message>
         <source>Load previously open databases on startup</source>
-        <translation type="unfinished"/>
+        <translation>เรียกใช้ฐานข้อมูลที่เปิดใช้ก่อนหน้าในตอนเริ่มโปรแกรม</translation>
     </message>
     <message>
         <source>Remember database key files and security dongles</source>
@@ -246,7 +246,7 @@
     </message>
     <message>
         <source>Button style:</source>
-        <translation type="unfinished"/>
+        <translation>สไตล์ปุ่ม:</translation>
     </message>
     <message>
         <source>Language:</source>
@@ -266,7 +266,7 @@
     </message>
     <message>
         <source>Hide window when copying to clipboard</source>
-        <translation type="unfinished"/>
+        <translation>ซ่อนหน้าต่างขณะที่คัดลอกไปยังคลิปบอร์ด</translation>
     </message>
     <message>
         <source>Minimize</source>
@@ -278,7 +278,7 @@
     </message>
     <message>
         <source>Favicon download timeout:</source>
-        <translation type="unfinished"/>
+        <translation>ระยะหมดเวลาดาวน์โหลด favicon:</translation>
     </message>
     <message>
         <source>Website icon download timeout in seconds</source>
@@ -291,31 +291,31 @@
     </message>
     <message>
         <source>Toolbar button style</source>
-        <translation type="unfinished"/>
+        <translation>รูปแบบปุ่มบนแถบเครื่องมือ</translation>
     </message>
     <message>
         <source>Use monospaced font for Notes</source>
-        <translation type="unfinished"/>
+        <translation>ใช้ฟอนต์ความกว้างเดียวสำหรับบันทึก</translation>
     </message>
     <message>
         <source>Language selection</source>
-        <translation type="unfinished"/>
+        <translation>เลือกภาษา</translation>
     </message>
     <message>
         <source>Reset Settings to Default</source>
-        <translation type="unfinished"/>
+        <translation>ล้างการตั้งค่ากลับไปเป็นค่าเริ่มต้น</translation>
     </message>
     <message>
         <source>Global auto-type shortcut</source>
-        <translation type="unfinished"/>
+        <translation>ปุ่มลัดพิมพ์อัตโนมัติในทุกโปรแกรม</translation>
     </message>
     <message>
         <source>Auto-type character typing delay milliseconds</source>
-        <translation type="unfinished"/>
+        <translation>หน่วงเวลาพิมพ์อัตโนมัติแต่ละตัวอักษร หน่วยเป็นมิลลิวินาที</translation>
     </message>
     <message>
         <source>Auto-type start delay milliseconds</source>
-        <translation type="unfinished"/>
+        <translation>หน่วงเวลาเริ่มพิมพ์อัตโนมัติ หน่วยเป็นมิลลิวินาที</translation>
     </message>
 </context>
 <context>
@@ -391,11 +391,11 @@
     </message>
     <message>
         <source>Use DuckDuckGo service to download website icons</source>
-        <translation type="unfinished"/>
+        <translation>ใช้บริการของ DuckDuckGo เพื่อดาวน์โหลดไอคอนของเว็บไซต์</translation>
     </message>
     <message>
         <source>Clipboard clear seconds</source>
-        <translation type="unfinished"/>
+        <translation>ล้างคลิปบอร์ดภายใน หน่วยเป็นวินาที</translation>
     </message>
     <message>
         <source>Touch ID inactivity reset</source>
@@ -412,7 +412,7 @@
     </message>
     <message>
         <source>Clear search query after</source>
-        <translation type="unfinished"/>
+        <translation>ล้างคำค้นหลังจาก</translation>
     </message>
 </context>
 <context>
@@ -551,11 +551,11 @@ Please select whether you want to allow access.</source>
     </message>
     <message>
         <source>Allow access</source>
-        <translation type="unfinished"/>
+        <translation>อนุญาตการเข้าถึง</translation>
     </message>
     <message>
         <source>Deny access</source>
-        <translation type="unfinished"/>
+        <translation>ปฏิเสธการเข้าถึง</translation>
     </message>
 </context>
 <context>
@@ -1123,7 +1123,7 @@ Please consider generating a new key file.</source>
     </message>
     <message>
         <source>Select slot...</source>
-        <translation type="unfinished"/>
+        <translation>เลือกช่อง...</translation>
     </message>
     <message>
         <source>Unlock KeePassXC Database</source>
@@ -1179,7 +1179,7 @@ Please consider generating a new key file.</source>
     </message>
     <message>
         <source>Clear Key File</source>
-        <translation type="unfinished"/>
+        <translation>ล้างแฟ้มกุญแจ</translation>
     </message>
     <message>
         <source>Unlock failed and no password given</source>
@@ -1211,15 +1211,15 @@ To prevent this error from appearing, you must go to &quot;Database Settings / S
     </message>
     <message>
         <source>Key file help</source>
-        <translation type="unfinished"/>
+        <translation>ช่วยเหลือเรื่องแฟ้มกุญแจ</translation>
     </message>
     <message>
         <source>?</source>
-        <translation type="unfinished"/>
+        <translation>?</translation>
     </message>
     <message>
         <source>Select key file...</source>
-        <translation type="unfinished"/>
+        <translation>เลือกแฟ้มกุญแจ...</translation>
     </message>
     <message>
         <source>Cannot use database file as key file</source>
@@ -1388,7 +1388,7 @@ This is necessary to maintain compatibility with the browser plugin.</source>
     </message>
     <message>
         <source>Remove selected key</source>
-        <translation type="unfinished"/>
+        <translation>ลบกุญแจที่เลือก</translation>
     </message>
 </context>
 <context>
@@ -1538,15 +1538,15 @@ If you keep this number, your database may be too easy to crack!</source>
     </message>
     <message>
         <source>Decryption time in seconds</source>
-        <translation type="unfinished"/>
+        <translation>เวลาถอดรหัสลับ หน่วยเป็นวินาที</translation>
     </message>
     <message>
         <source>Database format</source>
-        <translation type="unfinished"/>
+        <translation>รูปแบบฐานข้อมูล</translation>
     </message>
     <message>
         <source>Encryption algorithm</source>
-        <translation type="unfinished"/>
+        <translation>อัลกอริทึมการเข้ารหัสลับ</translation>
     </message>
     <message>
         <source>Key derivation function</source>
@@ -1558,7 +1558,7 @@ If you keep this number, your database may be too easy to crack!</source>
     </message>
     <message>
         <source>Memory usage</source>
-        <translation type="unfinished"/>
+        <translation>หน่วยความจำที่ใช้</translation>
     </message>
     <message>
         <source>Parallelism</source>
@@ -1632,15 +1632,15 @@ If you keep this number, your database may be too easy to crack!</source>
     </message>
     <message>
         <source>Database name field</source>
-        <translation type="unfinished"/>
+        <translation>ช่องข้อมูลชื่อฐานข้อมูล</translation>
     </message>
     <message>
         <source>Database description field</source>
-        <translation type="unfinished"/>
+        <translation>ช่องข้อมูลคำอธิบายฐานข้อมูล</translation>
     </message>
     <message>
         <source>Default username field</source>
-        <translation type="unfinished"/>
+        <translation>ช่องข้อมูลชื่อผู้ใช้ฐานข้อมูล</translation>
     </message>
     <message>
         <source>Maximum number of history items per entry</source>
@@ -1652,7 +1652,7 @@ If you keep this number, your database may be too easy to crack!</source>
     </message>
     <message>
         <source>Delete Recycle Bin</source>
-        <translation type="unfinished"/>
+        <translation>ลบถังขยะ</translation>
     </message>
     <message>
         <source>Do you want to delete the current recycle bin and all its contents?
@@ -1661,7 +1661,7 @@ This action is not reversible.</source>
     </message>
     <message>
         <source> (old)</source>
-        <translation type="unfinished"/>
+        <translation> (เก่า)</translation>
     </message>
 </context>
 <context>
@@ -1747,18 +1747,18 @@ Are you sure you want to continue without a password?</source>
     </message>
     <message>
         <source>Database name field</source>
-        <translation type="unfinished"/>
+        <translation>ช่องข้อมูลชื่อฐานข้อมูล</translation>
     </message>
     <message>
         <source>Database description field</source>
-        <translation type="unfinished"/>
+        <translation>ช่องข้อมูลคำอธิบายฐานข้อมูล</translation>
     </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetStatistics</name>
     <message>
         <source>Statistics</source>
-        <translation type="unfinished"/>
+        <translation>สถิติ</translation>
     </message>
     <message>
         <source>Hover over lines with error icons for further information.</source>
@@ -1774,31 +1774,31 @@ Are you sure you want to continue without a password?</source>
     </message>
     <message>
         <source>Database name</source>
-        <translation type="unfinished"/>
+        <translation>ชื่อฐานข้อมูล</translation>
     </message>
     <message>
         <source>Description</source>
-        <translation type="unfinished"/>
+        <translation>คำอธิบาย</translation>
     </message>
     <message>
         <source>Location</source>
-        <translation type="unfinished"/>
+        <translation>ที่ตั้ง</translation>
     </message>
     <message>
         <source>Last saved</source>
-        <translation type="unfinished"/>
+        <translation>บันทึกครั้งสุดท้าย</translation>
     </message>
     <message>
         <source>Unsaved changes</source>
-        <translation type="unfinished"/>
+        <translation>ความเปลี่ยนแปลงที่ยังไม่ได้บันทึก</translation>
     </message>
     <message>
         <source>yes</source>
-        <translation type="unfinished"/>
+        <translation>ใช่</translation>
     </message>
     <message>
         <source>no</source>
-        <translation type="unfinished"/>
+        <translation>ไม่</translation>
     </message>
     <message>
         <source>The database was modified, but the changes have not yet been saved to disk.</source>
@@ -1806,31 +1806,31 @@ Are you sure you want to continue without a password?</source>
     </message>
     <message>
         <source>Number of groups</source>
-        <translation type="unfinished"/>
+        <translation>จำนวนกลุ่ม</translation>
     </message>
     <message>
         <source>Number of entries</source>
-        <translation type="unfinished"/>
+        <translation>จำนวนรายการ</translation>
     </message>
     <message>
         <source>Number of expired entries</source>
-        <translation type="unfinished"/>
+        <translation>จำนวนรายการที่หมดอายุ</translation>
     </message>
     <message>
         <source>The database contains entries that have expired.</source>
-        <translation type="unfinished"/>
+        <translation>ฐานข้อมูลมีรายการที่หมดอายุแล้ว</translation>
     </message>
     <message>
         <source>Unique passwords</source>
-        <translation type="unfinished"/>
+        <translation>รหัสผ่านที่ไม่ซ้ำ</translation>
     </message>
     <message>
         <source>Non-unique passwords</source>
-        <translation type="unfinished"/>
+        <translation>รหัสผ่านที่ซ้ำ</translation>
     </message>
     <message>
         <source>More than 10% of passwords are reused. Use unique passwords when possible.</source>
-        <translation type="unfinished"/>
+        <translation>มากกว่า 10% ของรหัสผ่านถูกใช้ซ้ำ ควรใช้รหัสผ่านที่ไม่ซ้ำถ้าทำได้</translation>
     </message>
     <message>
         <source>Maximum password reuse</source>
@@ -1862,7 +1862,7 @@ Are you sure you want to continue without a password?</source>
     </message>
     <message>
         <source>%1 characters</source>
-        <translation type="unfinished"/>
+        <translation>%1 ตัวอักษร</translation>
     </message>
     <message>
         <source>Average password length is less than ten characters. Longer passwords provide more security.</source>
@@ -1954,7 +1954,7 @@ This is definitely a bug, please report it to the developers.</source>
     </message>
     <message>
         <source>HTML file</source>
-        <translation type="unfinished"/>
+        <translation>แฟ้ม HTML</translation>
     </message>
     <message>
         <source>Writing the HTML file failed.</source>
@@ -2051,7 +2051,7 @@ Do you want to merge your changes?</source>
     </message>
     <message numerus="yes">
         <source>Delete entry(s)?</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>ลบรายการหรือไม่?</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>Move entry(s) to recycle bin?</source>
@@ -5252,7 +5252,7 @@ Expect some bugs and minor issues, this version is not meant for production use.
     </message>
     <message>
         <source>Statistics</source>
-        <translation type="unfinished"/>
+        <translation>สถิติ</translation>
     </message>
 </context>
 <context>
@@ -6053,7 +6053,7 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation>ไม่มี</translation>
     </message>
     <message>
         <source>Enabled extensions:</source>
@@ -6468,7 +6468,7 @@ Kernel: %3 %4</source>
     <name>SettingsWidgetFdoSecrets</name>
     <message>
         <source>Options</source>
-        <translation type="unfinished"/>
+        <translation>ตัวเลือก</translation>
     </message>
     <message>
         <source>Enable KeepassXC Freedesktop.org Secret Service integration</source>
@@ -6496,7 +6496,7 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>File Name</source>
-        <translation type="unfinished"/>
+        <translation>ชื่อแฟ้ม</translation>
     </message>
     <message>
         <source>Group</source>
@@ -6504,11 +6504,11 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Manage</source>
-        <translation type="unfinished"/>
+        <translation>จัดการ</translation>
     </message>
     <message>
         <source>Authorization</source>
-        <translation type="unfinished"/>
+        <translation>ตรวจยืนยันสิทธิ์</translation>
     </message>
     <message>
         <source>These applications are currently connected:</source>
@@ -6516,11 +6516,11 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Application</source>
-        <translation type="unfinished"/>
+        <translation>แอปพลิเคชัน</translation>
     </message>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"/>
+        <translation>หยุดเชื่อมต่อ</translation>
     </message>
     <message>
         <source>Database settings</source>
@@ -6528,7 +6528,7 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Edit database settings</source>
-        <translation type="unfinished"/>
+        <translation>แก้ไขการตั้งค่าฐานข้อมูล</translation>
     </message>
     <message>
         <source>Unlock database</source>
@@ -6548,7 +6548,7 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation>ไม่มี</translation>
     </message>
 </context>
 <context>
@@ -6676,11 +6676,11 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Allow KeeShare imports</source>
-        <translation type="unfinished"/>
+        <translation>อนุญาตการนำเข้า KeeShare</translation>
     </message>
     <message>
         <source>Allow KeeShare exports</source>
-        <translation type="unfinished"/>
+        <translation>อนุญาตการส่งออก KeeShare</translation>
     </message>
     <message>
         <source>Only show warnings and errors</source>
@@ -6952,7 +6952,7 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Secret Key:</source>
-        <translation type="unfinished"/>
+        <translation>กุญแจลับ:</translation>
     </message>
     <message>
         <source>Secret key must be in Base32 format</source>
@@ -6972,7 +6972,7 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source> digits</source>
-        <translation type="unfinished"/>
+        <translation>หลัก</translation>
     </message>
     <message>
         <source>Invalid TOTP Secret</source>
@@ -7075,11 +7075,11 @@ Example: JBSWY3DPEHPK3PXP</source>
     </message>
     <message>
         <source>Import from 1Password</source>
-        <translation type="unfinished"/>
+        <translation>นำเข้าจาก 1Password</translation>
     </message>
     <message>
         <source>Open a recent database</source>
-        <translation type="unfinished"/>
+        <translation>เปิดฐานข้อมูลล่าสุด</translation>
     </message>
 </context>
 <context>

--- a/share/translations/keepassx_tr.ts
+++ b/share/translations/keepassx_tr.ts
@@ -50,7 +50,7 @@
     <name>AgentSettingsWidget</name>
     <message>
         <source>Enable SSH Agent (requires restart)</source>
-        <translation>SSH İstemcisini etkinleştir (yeniden başlatma gerekli)</translation>
+        <translation>SSH İstemcisini etkinleştir (yeniden başlatılmalı)</translation>
     </message>
     <message>
         <source>Use OpenSSH for Windows instead of Pageant</source>
@@ -948,7 +948,7 @@ linux-laptop.</translation>
     </message>
     <message>
         <source>Preview</source>
-        <translation>Ön izleme</translation>
+        <translation>Ön izle</translation>
     </message>
     <message>
         <source>Column layout</source>
@@ -1131,7 +1131,7 @@ Lütfen yeni bir anahtar dosyası oluşturmayı düşünün.</translation>
     </message>
     <message>
         <source>Select slot...</source>
-        <translation>Alan seç...</translation>
+        <translation>Yuva seç...</translation>
     </message>
     <message>
         <source>Unlock KeePassXC Database</source>
@@ -1341,7 +1341,7 @@ Bu işlem, tarayıcı eklentisi bağlantısını engelleyebilir.</translation>
     </message>
     <message>
         <source>KeePassXC: Removed keys from database</source>
-        <translation>KeePassXC: Anahtarlar veritabanından kaldırıldı</translation>
+        <translation>KeePassXC: Anahtarlar veritabanı üstünden kaldırıldı</translation>
     </message>
     <message numerus="yes">
         <source>Successfully removed %n encryption key(s) from KeePassXC settings.</source>
@@ -1641,15 +1641,15 @@ Eğer bu sayı ile devam ederseniz, veritabanınız çok kolay çözülerek kır
     </message>
     <message>
         <source>Database name field</source>
-        <translation type="unfinished"/>
+        <translation>Veritabanı isim alanı</translation>
     </message>
     <message>
         <source>Database description field</source>
-        <translation type="unfinished"/>
+        <translation>Veritabanı açıklama alanı</translation>
     </message>
     <message>
         <source>Default username field</source>
-        <translation type="unfinished"/>
+        <translation>Varsayılan kullanıcı adı alanı</translation>
     </message>
     <message>
         <source>Maximum number of history items per entry</source>
@@ -1666,11 +1666,12 @@ Eğer bu sayı ile devam ederseniz, veritabanınız çok kolay çözülerek kır
     <message>
         <source>Do you want to delete the current recycle bin and all its contents?
 This action is not reversible.</source>
-        <translation type="unfinished"/>
+        <translation>Mevcut geri dönüşüm kutusunu ve tüm içeriğini silmek istiyor musunuz?
+Bu eylem geri alınamaz.</translation>
     </message>
     <message>
         <source> (old)</source>
-        <translation type="unfinished"/>
+        <translation> (eski)</translation>
     </message>
 </context>
 <context>
@@ -1741,7 +1742,7 @@ Parola olmadan devam etmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <source>Continue without password</source>
-        <translation type="unfinished"/>
+        <translation>Parola olmadan devam et</translation>
     </message>
 </context>
 <context>
@@ -1756,11 +1757,11 @@ Parola olmadan devam etmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <source>Database name field</source>
-        <translation type="unfinished"/>
+        <translation>Veritabanı isim alanı</translation>
     </message>
     <message>
         <source>Database description field</source>
-        <translation type="unfinished"/>
+        <translation>Veritabanı açıklama alanı</translation>
     </message>
 </context>
 <context>
@@ -1811,7 +1812,7 @@ Parola olmadan devam etmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <source>The database was modified, but the changes have not yet been saved to disk.</source>
-        <translation type="unfinished"/>
+        <translation>Veritabanı değiştirildi, ancak değişiklikler henüz diske kaydedilmedi.</translation>
     </message>
     <message>
         <source>Number of groups</source>
@@ -1827,7 +1828,7 @@ Parola olmadan devam etmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <source>The database contains entries that have expired.</source>
-        <translation type="unfinished"/>
+        <translation>Veritabanı süresi dolmuş girdiler içeriyor.</translation>
     </message>
     <message>
         <source>Unique passwords</source>
@@ -1863,7 +1864,7 @@ Parola olmadan devam etmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <source>Recommend using long, randomized passwords with a rating of &apos;good&apos; or &apos;excellent&apos;.</source>
-        <translation type="unfinished"/>
+        <translation>&apos;İyi&apos; veya &apos;mükemmel&apos; derecesine sahip uzun, rastgele parolalar kullanmanızı öneririz.</translation>
     </message>
     <message>
         <source>Average password length</source>
@@ -1875,11 +1876,11 @@ Parola olmadan devam etmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <source>Average password length is less than ten characters. Longer passwords provide more security.</source>
-        <translation type="unfinished"/>
+        <translation>Ortalama parola uzunluğu on karakterden az. Daha uzun parolalar daha fazla güvenlik sağlar.</translation>
     </message>
     <message>
         <source>Please wait, database statistics are being calculated...</source>
-        <translation type="unfinished"/>
+        <translation>Lütfen bekleyin, veritabanı istatistikleri hesaplanıyor...</translation>
     </message>
 </context>
 <context>
@@ -1955,7 +1956,7 @@ Bu kesinlikle bir hatadır, lütfen geliştiricilere bildirin.</translation>
     </message>
     <message>
         <source>Failed to open %1. It either does not exist or is not accessible.</source>
-        <translation type="unfinished"/>
+        <translation>%1 açılamadı. Ya mevcut değil ya da erişilebilir değil.</translation>
     </message>
     <message>
         <source>Export database to HTML file</source>
@@ -1967,7 +1968,7 @@ Bu kesinlikle bir hatadır, lütfen geliştiricilere bildirin.</translation>
     </message>
     <message>
         <source>Writing the HTML file failed.</source>
-        <translation type="unfinished"/>
+        <translation>HTML dosyası yazılamadı.</translation>
     </message>
     <message>
         <source>Export Confirmation</source>
@@ -2287,7 +2288,7 @@ Güvenli kaydetme devre dışı bırakılsın ve tekrar denensin mi?</translatio
     </message>
     <message>
         <source>Are you sure you want to remove this URL?</source>
-        <translation type="unfinished"/>
+        <translation>Bu URL&apos;yi kaldırmak istediğinizden emin misiniz?</translation>
     </message>
 </context>
 <context>
@@ -2346,7 +2347,7 @@ Güvenli kaydetme devre dışı bırakılsın ve tekrar denensin mi?</translatio
     </message>
     <message>
         <source>Edit attribute name</source>
-        <translation type="unfinished"/>
+        <translation>Öznitelik adını düzenle</translation>
     </message>
     <message>
         <source>Toggle attribute protection</source>
@@ -2425,11 +2426,11 @@ Güvenli kaydetme devre dışı bırakılsın ve tekrar denensin mi?</translatio
     </message>
     <message>
         <source>Set the window association title</source>
-        <translation type="unfinished"/>
+        <translation>Pencere ilişkilendirme başlığını ayarla</translation>
     </message>
     <message>
         <source>You can use an asterisk to match everything</source>
-        <translation type="unfinished"/>
+        <translation>Her şeyi eşleştirmek için yıldız işareti kullanabilirsiniz</translation>
     </message>
     <message>
         <source>Custom Auto-Type sequence for this window</source>
@@ -2448,15 +2449,15 @@ Güvenli kaydetme devre dışı bırakılsın ve tekrar denensin mi?</translatio
     </message>
     <message>
         <source>Skip Auto-Submit for this entry</source>
-        <translation type="unfinished"/>
+        <translation>Bu girdi için Otomatik Gönder&apos;i atla</translation>
     </message>
     <message>
         <source>Hide this entry from the browser extension</source>
-        <translation type="unfinished"/>
+        <translation>Bu girdiyi tarayıcı eklentisi üstünde gizle</translation>
     </message>
     <message>
         <source>Additional URL&apos;s</source>
-        <translation type="unfinished"/>
+        <translation>Ek URL&apos;ler</translation>
     </message>
     <message>
         <source>Add</source>
@@ -2594,11 +2595,11 @@ Güvenli kaydetme devre dışı bırakılsın ve tekrar denensin mi?</translatio
     </message>
     <message>
         <source>Title field</source>
-        <translation type="unfinished"/>
+        <translation>Başlık alanı</translation>
     </message>
     <message>
         <source>Username field</source>
-        <translation type="unfinished"/>
+        <translation>Kullanıcı adı alanı</translation>
     </message>
     <message>
         <source>Toggle expiration</source>
@@ -2835,7 +2836,7 @@ Desteklenen eklentiler: %1.</translation>
     </message>
     <message>
         <source>Path to share file field</source>
-        <translation type="unfinished"/>
+        <translation>Dosya paylaşım yolu</translation>
     </message>
     <message>
         <source>Browser for share file</source>
@@ -3062,15 +3063,15 @@ Bu etkilenen eklentilerin bozulmasına neden olabilir.</translation>
     </message>
     <message>
         <source>Datetime created</source>
-        <translation type="unfinished"/>
+        <translation>Oluşturulma tarih saati</translation>
     </message>
     <message>
         <source>Datetime modified</source>
-        <translation type="unfinished"/>
+        <translation>Düzenlenme tarih saati</translation>
     </message>
     <message>
         <source>Datetime accessed</source>
-        <translation type="unfinished"/>
+        <translation>Erişim tarih saati</translation>
     </message>
     <message>
         <source>Unique ID</source>
@@ -3560,7 +3561,8 @@ DuckDuckGo web sitesi simge servisini uygulama ayarlarının güvenlik bölümü
     <message>
         <source>Invalid credentials were provided, please try again.
 If this reoccurs, then your database file may be corrupt.</source>
-        <translation type="unfinished"/>
+        <translation>Geçersiz kimlik bilgileri sağlandı, lütfen tekrar deneyin.
+Bu yeniden oluşursa, veritabanı dosyanız bozuk olabilir.</translation>
     </message>
 </context>
 <context>
@@ -3695,7 +3697,8 @@ If this reoccurs, then your database file may be corrupt.</source>
     <message>
         <source>Invalid credentials were provided, please try again.
 If this reoccurs, then your database file may be corrupt.</source>
-        <translation type="unfinished"/>
+        <translation>Geçersiz kimlik bilgileri sağlandı, lütfen tekrar deneyin.
+Bu yeniden oluşursa, veritabanı dosyanız bozuk olabilir.</translation>
     </message>
     <message>
         <source>(HMAC mismatch)</source>
@@ -4085,14 +4088,15 @@ Satır %2, sütun %3</translation>
     <message>
         <source>Invalid credentials were provided, please try again.
 If this reoccurs, then your database file may be corrupt.</source>
-        <translation type="unfinished"/>
+        <translation>Geçersiz kimlik bilgileri sağlandı, lütfen tekrar deneyin.
+Bu yeniden oluşursa, veritabanı dosyanız bozuk olabilir.</translation>
     </message>
 </context>
 <context>
     <name>KeeShare</name>
     <message>
         <source>Invalid sharing reference</source>
-        <translation type="unfinished"/>
+        <translation>Geçersiz paylaşım referansı</translation>
     </message>
     <message>
         <source>Inactive share %1</source>
@@ -4104,19 +4108,19 @@ If this reoccurs, then your database file may be corrupt.</source>
     </message>
     <message>
         <source>Exported to %1</source>
-        <translation type="unfinished"/>
+        <translation>%1 klasörüne aktarıldı</translation>
     </message>
     <message>
         <source>Synchronized with %1</source>
-        <translation type="unfinished"/>
+        <translation>%1 ile eşitlendi</translation>
     </message>
     <message>
         <source>Import is disabled in settings</source>
-        <translation type="unfinished"/>
+        <translation>Ayarlarda içe aktarma devre dışı</translation>
     </message>
     <message>
         <source>Export is disabled in settings</source>
-        <translation type="unfinished"/>
+        <translation>Ayarlarda dışa aktarma devre dışı</translation>
     </message>
     <message>
         <source>Inactive share</source>
@@ -4124,7 +4128,7 @@ If this reoccurs, then your database file may be corrupt.</source>
     </message>
     <message>
         <source>Imported from</source>
-        <translation type="unfinished"/>
+        <translation>İçe aktarıldı</translation>
     </message>
     <message>
         <source>Exported to</source>
@@ -4250,7 +4254,7 @@ Message: %2</source>
     </message>
     <message>
         <source>Note: Do not use a file that may change as that will prevent you from unlocking your database!</source>
-        <translation type="unfinished"/>
+        <translation>Not: Veritabanınızın kilidini açmanızı engelleyeceği için değişebilecek bir dosya kullanmayın!</translation>
     </message>
     <message>
         <source>Invalid Key File</source>
@@ -4258,16 +4262,17 @@ Message: %2</source>
     </message>
     <message>
         <source>You cannot use the current database as its own keyfile. Please choose a different file or generate a new key file.</source>
-        <translation type="unfinished"/>
+        <translation>Mevcut veritabanını kendi anahtar dosyası olarak kullanamazsınız. Lütfen farklı bir dosya seçin veya yeni bir anahtar dosyası oluşturun.</translation>
     </message>
     <message>
         <source>Suspicious Key File</source>
-        <translation type="unfinished"/>
+        <translation>Şüpheli Anahtar Dosyası</translation>
     </message>
     <message>
         <source>The chosen key file looks like a password database file. A key file must be a static file that never changes or you will lose access to your database forever.
 Are you sure you want to continue with this file?</source>
-        <translation type="unfinished"/>
+        <translation>Seçilen anahtar dosyası bir parola veritabanı dosyasına benziyor. Anahtar dosya, değişmeyen statik bir dosya olmalıdır, aksi takdirde veritabanınıza sonsuza kadar erişiminizi kaybedersiniz.
+Bu dosyaya devam etmek istediğinizden emin misiniz?</translation>
     </message>
 </context>
 <context>
@@ -4689,11 +4694,11 @@ Bazı hatalar ve küçük sorunlar olabilir, bu sürüm şu an dağıtımda değ
     </message>
     <message>
         <source>Removed custom data %1 [%2]</source>
-        <translation type="unfinished"/>
+        <translation>Özel veriler kaldırıldı %1 [%2]</translation>
     </message>
     <message>
         <source>Adding custom data %1 [%2]</source>
-        <translation type="unfinished"/>
+        <translation>Özel veriler eklendi %1 [%2]</translation>
     </message>
 </context>
 <context>
@@ -5997,11 +6002,11 @@ Kullanılabilir komutlar:
     </message>
     <message>
         <source>Displays debugging information.</source>
-        <translation type="unfinished"/>
+        <translation>Hata ayıklama bilgilerini görüntüler.</translation>
     </message>
     <message>
         <source>Deactivate password key for the database to merge from.</source>
-        <translation type="unfinished"/>
+        <translation>Veritabanının birleştirileceği parola anahtarını devre dışı bırak.</translation>
     </message>
     <message>
         <source>Version %1</source>
@@ -6025,7 +6030,7 @@ Kullanılabilir komutlar:
     </message>
     <message>
         <source>Debugging mode is enabled.</source>
-        <translation type="unfinished"/>
+        <translation>Hata ayıklama kipi etkin.</translation>
     </message>
     <message>
         <source>Operating system: %1
@@ -6069,7 +6074,7 @@ MİB mimarisi: %2
     </message>
     <message>
         <source>Cryptographic libraries:</source>
-        <translation type="unfinished"/>
+        <translation>Şifreleme kütüphaneleri:</translation>
     </message>
     <message>
         <source>Cannot generate a password and prompt at the same time!</source>
@@ -6081,7 +6086,7 @@ MİB mimarisi: %2
     </message>
     <message>
         <source>Path of the group to add.</source>
-        <translation type="unfinished"/>
+        <translation>Eklenecek kümenin yolu.</translation>
     </message>
     <message>
         <source>Group %1 already exists!</source>
@@ -6161,7 +6166,7 @@ MİB mimarisi: %2
     </message>
     <message>
         <source>Use numbers</source>
-        <translation type="unfinished"/>
+        <translation>Sayıları kullan</translation>
     </message>
     <message>
         <source>Invalid password length %1</source>

--- a/src/browser/BrowserHost.cpp
+++ b/src/browser/BrowserHost.cpp
@@ -28,6 +28,16 @@
 #include "sodium.h"
 #include <iostream>
 
+#ifdef Q_OS_WIN
+#include <fcntl.h>
+#include <winsock2.h>
+
+#include <windows.h>
+#else
+#include <sys/socket.h>
+#include <sys/types.h>
+#endif
+
 BrowserHost::BrowserHost(QObject* parent)
     : QObject(parent)
 {
@@ -77,6 +87,11 @@ void BrowserHost::readProxyMessage()
     }
 
     socket->setReadBufferSize(BrowserShared::NATIVEMSG_MAX_LENGTH);
+    int socketDesc = socket->socketDescriptor();
+    if (socketDesc) {
+        int max = BrowserShared::NATIVEMSG_MAX_LENGTH;
+        setsockopt(socketDesc, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<char*>(&max), sizeof(max));
+    }
 
     QJsonParseError error;
     auto json = QJsonDocument::fromJson(socket->readAll(), &error);

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -755,7 +755,6 @@ QList<Entry*> BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
     BrowserAccessControlDialog accessControlDialog;
 
     connect(m_currentDatabaseWidget, SIGNAL(databaseLocked()), &accessControlDialog, SLOT(reject()));
-    connect(this, SIGNAL(activeDatabaseChanged()), &accessControlDialog, SLOT(reject()));
 
     connect(&accessControlDialog, &BrowserAccessControlDialog::disableAccess, [&](QTableWidgetItem* item) {
         auto entry = pwEntriesToConfirm[item->row()];

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -847,12 +847,13 @@ QJsonObject BrowserService::prepareEntry(const Entry* entry)
 BrowserService::Access
 BrowserService::checkAccess(const Entry* entry, const QString& host, const QString& submitHost, const QString& realm)
 {
+    if (entry->isExpired()) {
+        return browserSettings()->allowExpiredCredentials() ? Allowed : Denied;
+    }
+
     BrowserEntryConfig config;
     if (!config.load(entry)) {
         return Unknown;
-    }
-    if (entry->isExpired()) {
-        return browserSettings()->allowExpiredCredentials() ? Allowed : Denied;
     }
     if ((config.isAllowed(host)) && (submitHost.isEmpty() || config.isAllowed(submitHost))) {
         return Allowed;

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -441,11 +441,12 @@ Config::Config(QObject* parent)
     configPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     localConfigPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
 #elif defined(Q_OS_MACOS)
-    configPath = QDir::fromNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+    configPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     localConfigPath = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
 #else
-    configPath = QDir::fromNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation));
-    localConfigPath = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    // On case-sensitive Operating Systems, force use of lowercase app directories
+    configPath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/keepassxc";
+    localConfigPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/keepassxc";
 #endif
 
     configPath += "/keepassxc";

--- a/src/fdosecrets/FdoSecretsPlugin.cpp
+++ b/src/fdosecrets/FdoSecretsPlugin.cpp
@@ -30,11 +30,19 @@
 
 using FdoSecrets::Service;
 
+// TODO: Only used for testing. Need to split service functions away from settings page.
+QPointer<FdoSecretsPlugin> g_fdoSecretsPlugin;
+
 FdoSecretsPlugin::FdoSecretsPlugin(DatabaseTabWidget* tabWidget)
-    : QObject(tabWidget)
-    , m_dbTabs(tabWidget)
+    : m_dbTabs(tabWidget)
 {
+    g_fdoSecretsPlugin = this;
     FdoSecrets::registerDBusTypes();
+}
+
+FdoSecretsPlugin* FdoSecretsPlugin::getPlugin()
+{
+    return g_fdoSecretsPlugin;
 }
 
 QWidget* FdoSecretsPlugin::createWidget()

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -70,6 +70,9 @@ public:
      */
     QString reportExistingService() const;
 
+    // TODO: Only used for testing. Need to split service functions away from settings page.
+    static FdoSecretsPlugin* getPlugin();
+
 public slots:
     void emitRequestSwitchToDatabases();
     void emitRequestShowNotification(const QString& msg, const QString& title = {});

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -327,6 +327,9 @@
     <addaction name="separator"/>
     <addaction name="actionEntryOpenUrl"/>
     <addaction name="actionEntryDownloadIcon"/>
+    <addaction name="separator"/>
+    <addaction name="actionEntryAddToAgent"/>
+    <addaction name="actionEntryRemoveFromAgent"/>
    </widget>
    <widget class="QMenu" name="menuGroups">
     <property name="title">

--- a/src/gui/reports/ReportsWidgetHealthcheck.h
+++ b/src/gui/reports/ReportsWidgetHealthcheck.h
@@ -28,6 +28,7 @@ class Database;
 class Entry;
 class Group;
 class PasswordHealth;
+class QSortFilterProxyModel;
 class QStandardItemModel;
 
 namespace Ui
@@ -66,6 +67,7 @@ private:
     bool m_healthCalculated = false;
     QIcon m_errorIcon;
     QScopedPointer<QStandardItemModel> m_referencesModel;
+    QScopedPointer<QSortFilterProxyModel> m_modelProxy;
     QSharedPointer<Database> m_db;
     QList<QPair<const Group*, const Entry*>> m_rowToEntry;
     Entry* m_contextmenuEntry = nullptr;

--- a/src/gui/reports/ReportsWidgetHibp.h
+++ b/src/gui/reports/ReportsWidgetHibp.h
@@ -33,6 +33,7 @@
 class Database;
 class Entry;
 class Group;
+class QSortFilterProxyModel;
 class QStandardItemModel;
 
 namespace Ui
@@ -69,6 +70,7 @@ private:
 
     QScopedPointer<Ui::ReportsWidgetHibp> m_ui;
     QScopedPointer<QStandardItemModel> m_referencesModel;
+    QScopedPointer<QSortFilterProxyModel> m_modelProxy;
     QSharedPointer<Database> m_db;
 
     QMap<QString, int> m_pwndPasswords; // Passwords we found to have been pwned (value is pwn count)

--- a/src/keys/FileKey.cpp
+++ b/src/keys/FileKey.cpp
@@ -200,6 +200,7 @@ bool FileKey::create(const QString& fileName, QString* errorMsg, int size)
     }
     create(&file, size);
     file.close();
+    file.setPermissions(QFile::ReadUser);
 
     if (file.error()) {
         if (errorMsg) {

--- a/src/keys/drivers/YubiKey.cpp
+++ b/src/keys/drivers/YubiKey.cpp
@@ -203,6 +203,8 @@ void YubiKey::findValidKeys()
 
                 ykds_free(st);
                 closeKey(yk_key);
+
+                Tools::wait(100);
             } else {
                 // No more keys are connected
                 break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,7 @@ int main(int argc, char** argv)
             // buffer for native messaging, even if the specified file does not exist
             QTextStream out(stdout, QIODevice::WriteOnly);
             out << QObject::tr("Database password: ") << flush;
+            Utils::setDefaultTextStreams();
             password = Utils::getPassword();
         }
 

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -53,4 +53,8 @@ if(WITH_XC_BROWSER)
                            COMMAND ${CMAKE_COMMAND} -E copy keepassxc-proxy ${PROXY_APP_DIR}/keepassxc-proxy
                            COMMENT "Copying keepassxc-proxy inside the application")
     endif()
+
+    if(MINGW)
+      target_link_libraries(keepassxc-proxy Wtsapi32.lib Ws2_32.lib)
+    endif()
 endif()

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -680,7 +680,7 @@ void TestGuiFdoSecrets::testCollectionCreate()
 
         QCOMPARE(spyCollectionCreated.count(), 1);
         {
-            auto args = spyCollectionCreated.takeFirst();
+            args = spyCollectionCreated.takeFirst();
             QCOMPARE(args.size(), 1);
             QCOMPARE(args.at(0).value<Collection*>(), coll);
         }
@@ -754,7 +754,7 @@ void TestGuiFdoSecrets::testCollectionDelete()
 
     QCOMPARE(spyCollectionDeleted.count(), 1);
     {
-        auto args = spyCollectionDeleted.takeFirst();
+        args = spyCollectionDeleted.takeFirst();
         QCOMPARE(args.size(), 1);
         QCOMPARE(args.at(0).value<Collection*>(), rawColl);
     }
@@ -977,7 +977,7 @@ void TestGuiFdoSecrets::testItemDelete()
 
     QCOMPARE(spyItemDeleted.count(), 1);
     {
-        auto args = spyItemDeleted.takeFirst();
+        args = spyItemDeleted.takeFirst();
         QCOMPARE(args.size(), 1);
         QCOMPARE(args.at(0).value<Item*>(), rawItem);
     }

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -200,7 +200,7 @@ void TestGuiFdoSecrets::initTestCase()
     m_mainWindow.reset(new MainWindow());
     m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
     QVERIFY(m_tabWidget);
-    m_plugin = m_mainWindow->findChild<FdoSecretsPlugin*>();
+    m_plugin = FdoSecretsPlugin::getPlugin();
     QVERIFY(m_plugin);
     m_mainWindow->show();
 


### PR DESCRIPTION
[FIX] --pw-stdin throws errors: QTextStream: No device on debian sid


## Screenshots

`$ echo foo|keepassxc --pw-stdin --keyfile bar.key baz.kdbx`
`Database password: QTextStream: No device`
`QTextStream: No device`



## Testing strategy
After changing --pw-stdin does not throw errors any more and the password is used. 


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)