### PR TITLE
Use native QComboBox behavior

### DIFF
--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -128,7 +128,7 @@ namespace Phantom
         constexpr bool AllowToolBarAutoRaise = true;
         // Note that this only applies to the disclosure etc. decorators in tree views.
         constexpr bool ShowItemViewDecorationSelected = false;
-        constexpr bool UseQMenuForComboBoxPopup = true;
+        constexpr bool UseQMenuForComboBoxPopup = false;
         constexpr bool ItemView_UseFontHeightForDecorationSize = true;
 
         // Whether or not the non-raised tabs in a tab bar have shininess/highlights to


### PR DESCRIPTION
* Prevents QComboBox from displaying all entries at once. Combo boxes with more than the maximum visible entries show a scrollbar as intended.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
**BEFORE:**
![image](https://user-images.githubusercontent.com/2809491/86698486-57cdbc80-bfdd-11ea-9da2-c0509a1b761e.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/2809491/86698517-5e5c3400-bfdd-11ea-8c42-6c363ea40330.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
