### PR TITLE
Open and save attachment in readonly mode

### DIFF
--- a/src/gui/entry/EntryAttachmentsWidget.cpp
+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
@@ -40,9 +40,7 @@ EntryAttachmentsWidget::EntryAttachmentsWidget(QWidget* parent)
     m_ui->attachmentsView->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_ui->attachmentsView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-    m_ui->actionsWidget->setVisible(m_buttonsVisible);
-    connect(this, SIGNAL(buttonsVisibleChanged(bool)), m_ui->actionsWidget, SLOT(setVisible(bool)));
-
+    connect(this, SIGNAL(buttonsVisibleChanged(bool)), this, SLOT(updateButtonsVisible()));
     connect(this, SIGNAL(readOnlyChanged(bool)), SLOT(updateButtonsEnabled()));
     connect(m_attachmentsModel, SIGNAL(modelReset()), SLOT(updateButtonsEnabled()));
 
@@ -58,6 +56,7 @@ EntryAttachmentsWidget::EntryAttachmentsWidget(QWidget* parent)
     connect(m_ui->addAttachmentButton, SIGNAL(clicked()), SLOT(insertAttachments()));
     connect(m_ui->removeAttachmentButton, SIGNAL(clicked()), SLOT(removeSelectedAttachments()));
 
+    updateButtonsVisible();
     updateButtonsEnabled();
 }
 
@@ -293,6 +292,12 @@ void EntryAttachmentsWidget::updateButtonsEnabled()
 
     m_ui->saveAttachmentButton->setEnabled(hasSelection);
     m_ui->openAttachmentButton->setEnabled(hasSelection);
+}
+
+void EntryAttachmentsWidget::updateButtonsVisible()
+{
+    m_ui->addAttachmentButton->setVisible(m_buttonsVisible && !m_readOnly);
+    m_ui->removeAttachmentButton->setVisible(m_buttonsVisible && !m_readOnly);
 }
 
 bool EntryAttachmentsWidget::insertAttachments(const QStringList& filenames, QString& errorMessage)

--- a/src/gui/entry/EntryAttachmentsWidget.h
+++ b/src/gui/entry/EntryAttachmentsWidget.h
@@ -48,6 +48,7 @@ private slots:
     void saveSelectedAttachments();
     void openAttachment(const QModelIndex& index);
     void openSelectedAttachments();
+    void updateButtonsVisible();
     void updateButtonsEnabled();
 
 private:


### PR DESCRIPTION
Buttons Save and Open are now always visible.
User needs to save and open attachment in read-only mode using buttons.
Fixes #2039

## Screenshots
Please check how it looks with dummy database
![image](https://user-images.githubusercontent.com/67578386/86822426-4a273e00-c094-11ea-8e88-f7694453159b.png)

## Testing strategy
View and check attachment panel in read-only mode and edit mode.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
