### PR TITLE
Fix slot detection when first YubiKey is configured on slot 2

### DIFF
--- a/src/keys/drivers/YubiKey.cpp
+++ b/src/keys/drivers/YubiKey.cpp
@@ -176,7 +176,7 @@ void YubiKey::findValidKeys()
                 bool wouldBlock;
                 QList<QPair<int, QString>> ykSlots;
                 for (int slot = 1; slot <= 2; ++slot) {
-                    auto config = (i == 1 ? CONFIG1_VALID : CONFIG2_VALID);
+                    auto config = (slot == 1 ? CONFIG1_VALID : CONFIG2_VALID);
                     if (!(ykds_touch_level(st) & config)) {
                         // Slot is not configured
                         continue;


### PR DESCRIPTION
Yubikey code was checking the slot number based on the yubikey key number instead of the slot loop number. This PR fixes that typo so that if a single yubikey is plugged in, slot 2 will still be checked (and if a second yubikey is plugged in, then its slot 1 will be checked) which is not currently happening.

Fixes #4987 

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
