### PR TITLE
App attempts to restart after you revert theme. Fixes #4959

### DIFF
--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -148,7 +148,7 @@ void Application::applyTheme()
     if (appTheme == "auto") {
         if (osUtils->isDarkMode()) {
             setStyle(new DarkStyle);
-            m_darkTheme = true;
+            m_isDarkTheme = true;
         } else {
             setStyle(new LightStyle);
         }
@@ -156,15 +156,16 @@ void Application::applyTheme()
         setStyle(new LightStyle);
     } else if (appTheme == "dark") {
         setStyle(new DarkStyle);
-        m_darkTheme = true;
+        m_isDarkTheme = true;
     } else {
         // Classic mode, don't check for dark theme on Windows
         // because Qt 5.x does not support it
 #ifndef Q_OS_WIN
-        m_darkTheme = osUtils->isDarkMode();
+        m_isDarkTheme = osUtils->isDarkMode();
 #endif
     }
 
+    m_theme = appTheme;
     setPalette(style()->standardPalette());
 }
 
@@ -313,7 +314,12 @@ bool Application::sendFileNamesToRunningInstance(const QStringList& fileNames)
 
 bool Application::isDarkTheme() const
 {
-    return m_darkTheme;
+    return m_isDarkTheme;
+}
+
+QString Application::theme() const
+{
+    return m_theme;
 }
 
 void Application::restart()

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -46,6 +46,7 @@ public:
     bool event(QEvent* event) override;
     bool isAlreadyRunning() const;
     bool isDarkTheme() const;
+    QString theme() const;
 
     bool sendFileNamesToRunningInstance(const QStringList& fileNames);
 
@@ -75,7 +76,8 @@ private:
     static int unixSignalSocket[2];
 #endif
     bool m_alreadyRunning;
-    bool m_darkTheme = false;
+    bool m_isDarkTheme = false;
+    QString m_theme;
     QLockFile* m_lockFile;
     QLocalServer m_lockServer;
     QString m_socketName;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -93,6 +93,7 @@ MainWindow* getMainWindow()
 
 MainWindow::MainWindow()
     : m_ui(new Ui::MainWindow())
+    , m_isCompactMode(config()->get(Config::GUI_CompactMode).toBool())
 {
     g_MainWindow = this;
 
@@ -218,7 +219,7 @@ MainWindow::MainWindow()
     }
 
     m_ui->toolbarSeparator->setVisible(false);
-    m_showToolbarSeparator = config()->get(Config::GUI_ApplicationTheme).toString() != "classic";
+    m_showToolbarSeparator = kpxcApp->theme() != "classic";
 
     m_ui->actionEntryAutoType->setVisible(autoType()->isAvailable());
 
@@ -1671,25 +1672,26 @@ void MainWindow::initViewMenu()
     themeActions->addAction(m_ui->actionThemeDark);
     themeActions->addAction(m_ui->actionThemeClassic);
 
-    auto theme = config()->get(Config::GUI_ApplicationTheme).toString();
     for (auto action : themeActions->actions()) {
-        if (action->data() == theme) {
+        if (action->data() == kpxcApp->theme()) {
             action->setChecked(true);
             break;
         }
     }
 
     connect(themeActions, &QActionGroup::triggered, this, [this](QAction* action) {
-        if (action->data() != config()->get(Config::GUI_ApplicationTheme)) {
-            config()->set(Config::GUI_ApplicationTheme, action->data());
+        config()->set(Config::GUI_ApplicationTheme, action->data());
+        if (action->data() != kpxcApp->theme()) {
             restartApp(tr("You must restart the application to apply this setting. Would you like to restart now?"));
         }
     });
 
-    m_ui->actionCompactMode->setChecked(config()->get(Config::GUI_CompactMode).toBool());
+    m_ui->actionCompactMode->setChecked(m_isCompactMode);
     connect(m_ui->actionCompactMode, &QAction::toggled, this, [this](bool checked) {
         config()->set(Config::GUI_CompactMode, checked);
-        restartApp(tr("You must restart the application to apply this setting. Would you like to restart now?"));
+        if (checked != m_isCompactMode) {
+            restartApp(tr("You must restart the application to apply this setting. Would you like to restart now?"));
+        }
     });
 
     m_ui->actionShowToolbar->setChecked(!config()->get(Config::GUI_HideToolbar).toBool());

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -108,7 +108,7 @@ MainWindow::MainWindow()
 
     setAcceptDrops(true);
 
-    if (config()->get(Config::GUI_CompactMode).toBool()) {
+    if (m_isCompactMode) {
         m_ui->toolBar->setIconSize({20, 20});
     }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -177,6 +177,7 @@ private:
     bool m_restartRequested = false;
     bool m_contextMenuFocusLock = false;
     bool m_showToolbarSeparator = false;
+    bool m_isCompactMode = false;
     qint64 m_lastFocusOutTime = 0;
     qint64 m_lastShowTime = 0;
     QTimer m_updateCheckTimer;


### PR DESCRIPTION
Problem is described in the issue #4959

## Testing strategy
Change current theme in View menu and don't restart application. Observe that app doesn't attempt to restart if active theme is selected again.
Same behavior is implemented for compact mode flag.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)