### PR TITLE
Partially fix appdata screenshots

### DIFF
--- a/share/linux/org.keepassxc.KeePassXC.appdata.xml
+++ b/share/linux/org.keepassxc.KeePassXC.appdata.xml
@@ -28,23 +28,23 @@
 
     <screenshots>
         <screenshot type="default">
-            <image>https://keepassxc.org/images/screenshots/linux/screen_001.png</image>
+            <image>https://keepassxc.org/images/screenshots/thumbs/welcome_screen.png</image>
             <caption>Create, Import or Open Databases</caption>
         </screenshot>
         <screenshot>
-            <image>https://keepassxc.org/images/screenshots/linux/screen_002.png</image>
+            <image>https://keepassxc.org/images/screenshots/thumbs/database_view.png</image>
             <caption>Organize with Groups and Entries</caption>
         </screenshot>
         <screenshot>
-            <image>https://keepassxc.org/images/screenshots/linux/screen_003.png</image>
+            <image>https://keepassxc.org/images/screenshots/thumbs/edit_entry.png</image>
             <caption>Database Entry</caption>
         </screenshot>
         <screenshot>
-            <image>https://keepassxc.org/images/screenshots/linux/screen_004.png</image>
+            <image>https://keepassxc.org/images/screenshots/thumbs/edit_entry_icons.png</image>
             <caption>Icon Selection for Entry</caption>
         </screenshot>
         <screenshot>
-            <image>https://keepassxc.org/images/screenshots/linux/screen_006.png</image>
+            <image>https://keepassxc.org/images/screenshots/thumbs/password_generator_advanced.png</image>
             <caption>Password Generator</caption>
         </screenshot>
     </screenshots>


### PR DESCRIPTION
Update url filenames to reflect updates at keepassxc.org. This is however not sufficient because it only satisfies `appstream-util validate-relax`. At least Flathub now enforces `appstream-util validate` which is stricter:
```
• attribute-invalid     : <screenshot> width (580) too small [https://keepassxc.org/images/screenshots/thumbs/welcome_screen.png] minimum is 624px
• attribute-invalid     : <screenshot> width (580) too small [https://keepassxc.org/images/screenshots/thumbs/edit_entry.png] minimum is 624px
• attribute-invalid     : <screenshot> width (622) too small [https://keepassxc.org/images/screenshots/thumbs/edit_entry_icons.png] minimum is 624px
• attribute-invalid     : <screenshot> width (580) too small [https://keepassxc.org/images/screenshots/thumbs/database_view.png] minimum is 624px
• attribute-invalid     : <screenshot> width (580) too small [https://keepassxc.org/images/screenshots/thumbs/password_generator_advanced.png] minimum is 624px
```

Perhaps the solution is to host separate appdata screenshots, that won't have their names changed and is taken with software centres in mind?

See: #5028 


## Testing strategy
`appstream-util validate share/linux/org.keepassxc.KeePassXC.appdata.xml`

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
