### PR TITLE
Add OARS metadata

### DIFF
--- a/share/linux/org.keepassxc.KeePassXC.appdata.xml
+++ b/share/linux/org.keepassxc.KeePassXC.appdata.xml
@@ -614,4 +614,5 @@
             </description>
         </release>
     </releases>
+    <content_rating type="oars-1.0" />
 </component>


### PR DESCRIPTION
It is usable by both Gnome Software, KDE Discover and web frontends,
such as Flathub which now enforces OARS.

By using OARS 1.0 all distributions should be supported. Version 1.1
should work almost everywhere, but there are a few notable distributions
that still lack GNOME Software >= 3.27.3.

In this case it should not matter, because the OARS data is the same for
both versions (nothing 1.1 specific is used).

You can generate and verify these changes using:
https://odrs.gnome.org/oars


## Testing strategy
`appstream-util validate share/linux/org.keepassxc.KeePassXC.appdata.xml`


## Type of change
- ✅ Documentation (non-code change)
