### PR TITLE
Change actions for F1-F2-F3  keys

### DIFF
--- a/docs/topics/KeyboardShortcuts.adoc
+++ b/docs/topics/KeyboardShortcuts.adoc
@@ -33,7 +33,9 @@ include::.sharedheader[]
 |Select Previous Database Tab | Ctrl + Shift + Tab ; Ctrl + PageUp
 |Toggle Passwords Hidden      | Ctrl + Shift + C
 |Toggle Usernames Hidden      | Ctrl + Shift + B
-|Focus Search                 | Ctrl + F
+|Focus Groups (edit if focused)  | F1
+|Focus Entries (edit if focused) | F2
+|Focus Search                 | F3 ; Ctrl + F
 |Clear Search                 | Escape
 |Show Keyboard Shortcuts      | Ctrl + /
 |===

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -631,17 +631,25 @@ void DatabaseWidget::setFocus(Qt::FocusReason reason)
     }
 }
 
-void DatabaseWidget::focusOnEntries()
+void DatabaseWidget::focusOnEntries(bool editIfFocused)
 {
     if (isEntryViewActive()) {
-        m_entryView->setFocus();
+        if (editIfFocused && m_entryView->hasFocus()) {
+            switchToEntryEdit();
+        } else {
+            m_entryView->setFocus();
+        }
     }
 }
 
-void DatabaseWidget::focusOnGroups()
+void DatabaseWidget::focusOnGroups(bool editIfFocused)
 {
     if (isEntryViewActive()) {
-        m_groupView->setFocus();
+        if (editIfFocused && m_groupView->hasFocus()) {
+            switchToGroupEdit();
+        } else {
+            m_groupView->setFocus();
+        }
     }
 }
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -167,8 +167,8 @@ public slots:
     void cloneEntry();
     void deleteSelectedEntries();
     void deleteEntries(QList<Entry*> entries);
-    void focusOnEntries();
-    void focusOnGroups();
+    void focusOnEntries(bool editIfFocused = false);
+    void focusOnGroups(bool editIfFocused = false);
     void moveEntryUp();
     void moveEntryDown();
     void copyTitle();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -325,14 +325,6 @@ MainWindow::MainWindow()
     shortcut = new QShortcut(dbTabModifier + Qt::Key_9, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(m_ui->tabWidget->count() - 1); });
 
-    // Allow for direct focus of search, group view, and entry view
-    shortcut = new QShortcut(Qt::Key_F1, this);
-    connect(shortcut, SIGNAL(activated()), m_searchWidget, SLOT(searchFocus()));
-    shortcut = new QShortcut(Qt::Key_F2, this);
-    m_actionMultiplexer.connect(shortcut, SIGNAL(activated()), SLOT(focusOnGroups()));
-    shortcut = new QShortcut(Qt::Key_F3, this);
-    m_actionMultiplexer.connect(shortcut, SIGNAL(activated()), SLOT(focusOnEntries()));
-
     // Toggle password and username visibility in entry view
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C, this, SLOT(togglePasswordsHidden()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_B, this, SLOT(toggleUsernamesHidden()));
@@ -1187,6 +1179,28 @@ void MainWindow::changeEvent(QEvent* event)
     } else {
         QMainWindow::changeEvent(event);
     }
+}
+
+void MainWindow::keyPressEvent(QKeyEvent* event)
+{
+    if (!event->modifiers()) {
+        // Allow for direct focus of search, group view, and entry view
+        auto dbWidget = m_ui->tabWidget->currentDatabaseWidget();
+        if (dbWidget && dbWidget->isEntryViewActive()) {
+            if (event->key() == Qt::Key_F1) {
+                dbWidget->focusOnGroups(true);
+                return;
+            } else if (event->key() == Qt::Key_F2) {
+                dbWidget->focusOnEntries(true);
+                return;
+            } else if (event->key() == Qt::Key_F3) {
+                m_searchWidget->searchFocus();
+                return;
+            }
+        }
+    }
+
+    QWidget::keyPressEvent(event);
 }
 
 bool MainWindow::focusNextPrevChild(bool next)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -86,6 +86,7 @@ public slots:
 protected:
     void closeEvent(QCloseEvent* event) override;
     void changeEvent(QEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
     bool focusNextPrevChild(bool next) override;
 
 private slots:

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -61,13 +61,13 @@ signals:
 
 public slots:
     void databaseChanged(DatabaseWidget* dbWidget = nullptr);
+    void searchFocus();
 
 private slots:
     void startSearchTimer();
     void startSearch();
     void updateCaseSensitive();
     void updateLimitGroup();
-    void searchFocus();
     void toggleHelp();
     void showSearchMenu();
     void resetSearchClearTimer();

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -904,10 +904,10 @@ void TestGui::testSearch()
     QTest::keyClick(searchTextEdit, Qt::Key_Down);
     QTRY_VERIFY(entryView->hasFocus());
     auto* searchedEntry = entryView->currentEntry();
-    // Restore focus using F1 key and search text selection
-    QTest::keyClick(m_mainWindow.data(), Qt::Key_F1);
-    QTRY_COMPARE(searchTextEdit->selectedText(), QString("someTHING"));
+    // Restore focus using F3 key and search text selection
+    QTest::keyClick(m_mainWindow.data(), Qt::Key_F3);
     QTRY_VERIFY(searchTextEdit->hasFocus());
+    QTRY_COMPARE(searchTextEdit->selectedText(), QString("someTHING"));
 
     searchedEntry->setPassword("password");
     QClipboard* clipboard = QApplication::clipboard();


### PR DESCRIPTION
* Fixes #5037
* F1 focuses group view, if already focused it opens the focused group for editing
* F2 focuses entry view, if already focused it opens the focused entry for editing
* F3 focuses search

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
* Documentation updated for keyboard shortcuts

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)