### PR TITLE
Fixed typo in German translation

### DIFF
--- a/share/translations/keepassx_de.ts
+++ b/share/translations/keepassx_de.ts
@@ -233,7 +233,7 @@
     </message>
     <message>
         <source>Check for updates at application startup once per week</source>
-        <translation>Bei Programmstartstart wöchentlich auf Updates prüfen</translation>
+        <translation>Bei Programmstart wöchentlich auf Updates prüfen</translation>
     </message>
     <message>
         <source>Include beta releases when checking for updates</source>


### PR DESCRIPTION
Not much to say, just changed the Word
"Programmstartstart" to "Programmstart" due to the doubled phrase "start".

Section:
Settings -> Check weekly for updates after program start.