### PR TITLE
Fix crash if TOTP digits exceeds 10

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -481,6 +481,8 @@ void Entry::updateTotp()
                                                   m_attributes->value(Totp::ATTRIBUTE_SEED));
     } else if (m_attributes->contains(Totp::ATTRIBUTE_OTP)) {
         m_data.totpSettings = Totp::parseSettings(m_attributes->value(Totp::ATTRIBUTE_OTP));
+    } else {
+        m_data.totpSettings.reset();
     }
 }
 

--- a/src/totp/totp.cpp
+++ b/src/totp/totp.cpp
@@ -113,7 +113,7 @@ QSharedPointer<Totp::Settings> Totp::parseSettings(const QString& rawSettings, c
     }
 
     // Bound digits and step
-    settings->digits = qMax(1u, settings->digits);
+    settings->digits = qBound(1u, settings->digits, 10u);
     settings->step = qBound(1u, settings->step, 60u);
 
     // Detect custom settings, used by setup GUI


### PR DESCRIPTION
* Fix #5105 - prevent divide-by-zero segfault due to invalid TOTP settings
* Clear TOTP settings if attributes are removed

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
