### PR TITLE
SSH Agent: Always forget all keys on lock

### DIFF
--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -447,12 +447,8 @@ void SSHAgent::databaseLocked()
             if (!removeIdentity(key)) {
                 emit error(m_error);
             }
-            it = m_addedKeys.erase(it);
-        } else {
-            // don't remove it yet
-            m_addedKeys[key].second = false;
-            ++it;
         }
+        it = m_addedKeys.erase(it);
     }
 }
 


### PR DESCRIPTION
The new stricter tracking of who owns a key triggered #5016 as the database uuid changes if you *close* it and re-open rather than lock and unlock. This only happens for keys that don't have remove-on-lock set.

I don't recall why we kept a known key in-memory after locking or closing databases in the first place. The snippet that this PR removes was originally introduced way back in 2018 by 785a64cc3b3123541657831e615b0e97d3341ca5.

Fixes #5016.

## Testing strategy
Manually on Linux.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
