### PR TITLE
Substitute tilde with USERPROFILE on Windows

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -331,10 +331,14 @@ namespace Tools
 
 #if defined(Q_OS_WIN)
         QRegularExpression varRe("\\%([A-Za-z][A-Za-z0-9_]*)\\%");
+        QString homeEnv = "USERPROFILE";
 #else
         QRegularExpression varRe("\\$([A-Za-z][A-Za-z0-9_]*)");
-        subbed.replace("~", environment.value("HOME"));
+        QString homeEnv = "HOME";
 #endif
+
+        if (subbed.startsWith("~/") || subbed.startsWith("~\\"))
+            subbed.replace(0, 1, environment.value(homeEnv));
 
         QRegularExpressionMatch match;
 

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -72,10 +72,14 @@ void TestTools::testEnvSubstitute()
 #if defined(Q_OS_WIN)
     environment.insert("HOMEDRIVE", "C:");
     environment.insert("HOMEPATH", "\\Users\\User");
+    environment.insert("USERPROFILE", "C:\\Users\\User");
 
     QCOMPARE(Tools::envSubstitute("%HOMEDRIVE%%HOMEPATH%\\.ssh\\id_rsa", environment),
              QString("C:\\Users\\User\\.ssh\\id_rsa"));
     QCOMPARE(Tools::envSubstitute("start%EMPTY%%EMPTY%%%HOMEDRIVE%%end", environment), QString("start%C:%end"));
+    QCOMPARE(Tools::envSubstitute("%USERPROFILE%\\.ssh\\id_rsa", environment),
+             QString("C:\\Users\\User\\.ssh\\id_rsa"));
+    QCOMPARE(Tools::envSubstitute("~\\.ssh\\id_rsa", environment), QString("C:\\Users\\User\\.ssh\\id_rsa"));
 #else
     environment.insert("HOME", QString("/home/user"));
     environment.insert("USER", QString("user"));


### PR DESCRIPTION
Fixes #5008 partly. We can safely assume `~` means some sort of home directory on any platform.

## Testing strategy
Updated tests.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
