### PR TITLE
Unbreak build with Ninja

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -24,18 +24,20 @@ set(DOC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(OUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 # Build html documentation on all platforms
+file(GLOB html_depends ${DOC_DIR}/topics/* ${DOC_DIR}/styles/* ${DOC_DIR}/images/*)
 add_custom_command(OUTPUT KeePassXC_GettingStarted.html
     COMMAND ${ASCIIDOCTOR_EXE} -D ${OUT_DIR} -o KeePassXC_GettingStarted.html ${DOC_DIR}/GettingStarted.adoc
-    DEPENDS ${DOC_DIR}/topics/* ${DOC_DIR}/styles/* ${DOC_DIR}/images/* ${DOC_DIR}/GettingStarted.adoc
+    DEPENDS ${html_depends} ${DOC_DIR}/GettingStarted.adoc
     VERBATIM)
 add_custom_command(OUTPUT KeePassXC_UserGuide.html
     COMMAND ${ASCIIDOCTOR_EXE} -D ${OUT_DIR} -o KeePassXC_UserGuide.html ${DOC_DIR}/UserGuide.adoc
-    DEPENDS ${DOC_DIR}/topics/* ${DOC_DIR}/styles/* ${DOC_DIR}/images/* ${DOC_DIR}/UserGuide.adoc
+    DEPENDS ${html_depends} ${DOC_DIR}/UserGuide.adoc
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     VERBATIM)
+file(GLOB styles_depends ${DOC_DIR}/styles/*)
 add_custom_command(OUTPUT KeePassXC_KeyboardShortcuts.html
     COMMAND ${ASCIIDOCTOR_EXE} -D ${OUT_DIR} -o KeePassXC_KeyboardShortcuts.html ${DOC_DIR}/topics/KeyboardShortcuts.adoc
-    DEPENDS ${DOC_DIR}/topics/KeyboardShortcuts.adoc ${DOC_DIR}/styles/*
+    DEPENDS ${DOC_DIR}/topics/KeyboardShortcuts.adoc ${styles_depends}
     VERBATIM)
 
 add_custom_target(docs ALL DEPENDS KeePassXC_GettingStarted.html KeePassXC_UserGuide.html KeePassXC_KeyboardShortcuts.html)
@@ -50,11 +52,11 @@ install(FILES
 if(APPLE OR UNIX)
     add_custom_command(OUTPUT keepassxc.1
         COMMAND ${ASCIIDOCTOR_EXE} -D ${OUT_DIR} -b manpage ${DOC_DIR}/man/keepassxc.1.adoc
-        DEPENDS ${DOC_DIR}/man/*
+        DEPENDS ${DOC_DIR}/man/keepassxc.1.adoc
         VERBATIM)
     add_custom_command(OUTPUT keepassxc-cli.1
         COMMAND ${ASCIIDOCTOR_EXE} -D ${OUT_DIR} -b manpage ${DOC_DIR}/man/keepassxc-cli.1.adoc
-        DEPENDS ${DOC_DIR}/man/*
+        DEPENDS ${DOC_DIR}/man/keepassxc-cli.1.adoc
         VERBATIM)
     add_custom_target(manpages ALL DEPENDS keepassxc.1 keepassxc-cli.1)
 


### PR DESCRIPTION
When using `cmake -GNinja` the build fails with

```
ninja: error: '/usr/ports/security/keepassxc/work/keepassxc-2.6.0/docs/man/*', needed by 'docs/keepassxc.1', missing and no known rule to make it
```

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
