### PR TITLE
Fix 'db-info' command name to show it right in 'help'

### DIFF
--- a/src/cli/Info.cpp
+++ b/src/cli/Info.cpp
@@ -27,7 +27,7 @@
 
 Info::Info()
 {
-    name = QString("db-show");
+    name = QString("db-info");
     description = QObject::tr("Show a database's information.");
 }
 


### PR DESCRIPTION
* Fixes #5139 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
