### PR TITLE
Clear clipboard on database lock

### DIFF
--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -72,7 +72,6 @@ void Clipboard::setText(const QString& text, bool clear)
         if (config()->get(Config::Security_ClearClipboard).toBool()) {
             int timeout = config()->get(Config::Security_ClearClipboardTimeout).toInt();
             if (timeout > 0) {
-                m_lastCopied = text;
                 m_timer->start(timeout * 1000);
             }
         }

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -67,11 +67,14 @@ void Clipboard::setText(const QString& text, bool clear)
     }
 #endif
 
-    if (clear && config()->get(Config::Security_ClearClipboard).toBool()) {
-        int timeout = config()->get(Config::Security_ClearClipboardTimeout).toInt();
-        if (timeout > 0) {
-            m_lastCopied = text;
-            m_timer->start(timeout * 1000);
+    if (clear) {
+        m_lastCopied = text;
+        if (config()->get(Config::Security_ClearClipboard).toBool()) {
+            int timeout = config()->get(Config::Security_ClearClipboardTimeout).toInt();
+            if (timeout > 0) {
+                m_lastCopied = text;
+                m_timer->start(timeout * 1000);
+            }
         }
     }
 }
@@ -80,8 +83,9 @@ void Clipboard::clearCopiedText()
 {
     if (m_timer->isActive()) {
         m_timer->stop();
-        clearClipboard();
     }
+
+    clearClipboard();
 }
 
 void Clipboard::clearClipboard()


### PR DESCRIPTION
Clipboard is cleared on lock only when the clipboard timer is active. This will ensure the clipboard is always cleared on database lock

Closes #5020 

## Testing strategy
Unit and manual testing

## Type of change
- ✅ New feature (change that adds functionality)
- ✅ Refactor (significant modification to existing code)
