### PR TITLE
Switch to classic if theme set to auto and high contast mode is on

### DIFF
--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -147,6 +147,11 @@ void Application::applyTheme()
     auto appTheme = config()->get(Config::GUI_ApplicationTheme).toString();
     if (appTheme == "auto") {
         appTheme = osUtils->isDarkMode() ? "dark" : "light";
+#ifdef Q_OS_WIN
+        if (winUtils()->isHighContrastMode()) {
+            appTheme = "classic";
+        }
+#endif
     }
 
     if (appTheme == "light") {

--- a/src/gui/osutils/winutils/WinUtils.cpp
+++ b/src/gui/osutils/winutils/WinUtils.cpp
@@ -105,3 +105,9 @@ bool WinUtils::isCapslockEnabled()
 {
     return GetKeyState(VK_CAPITAL) == 1;
 }
+
+bool WinUtils::isHighContrastMode() const
+{
+    QSettings settings(R"(HKEY_CURRENT_USER\Control Panel\Accessibility\HighContrast)", QSettings::NativeFormat);
+    return (settings.value("Flags").toInt() & 1u) != 0;
+}

--- a/src/gui/osutils/winutils/WinUtils.h
+++ b/src/gui/osutils/winutils/WinUtils.h
@@ -36,6 +36,7 @@ public:
     bool isLaunchAtStartupEnabled() const override;
     void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
+    bool isHighContrastMode() const;
 
 protected:
     explicit WinUtils(QObject* parent = nullptr);


### PR DESCRIPTION
The light and dark theme don't respond to Windows's high contrast accessibility mode, so when the theme is set to "auto", we
default to "classic" instead of "light".

Fixes #5044 

## Testing strategy
Set theme to auto and enabled high contrast mode in the Windows settings.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
