### PR TITLE
Fix "Search Results" banner improperly themed

### DIFF
--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -169,6 +169,11 @@ void Application::applyTheme()
 #ifndef Q_OS_WIN
         m_darkTheme = osUtils->isDarkMode();
 #endif
+        QFile stylesheetFile(":/styles/base/classicstyle.qss");
+        if (stylesheetFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            setStyleSheet(stylesheetFile.readAll());
+            stylesheetFile.close();
+        }
     }
 }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -141,21 +141,15 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     connect(m_entryView, SIGNAL(customContextMenuRequested(QPoint)), SLOT(emitEntryContextMenuRequested(QPoint)));
 
     // Add a notification for when we are searching
+    m_searchingLabel->setObjectName("SearchBanner");
     m_searchingLabel->setText(tr("Searching..."));
     m_searchingLabel->setAlignment(Qt::AlignCenter);
-    m_searchingLabel->setStyleSheet("color: rgb(0, 0, 0);"
-                                    "background-color: rgb(255, 253, 160);"
-                                    "border: 2px solid rgb(190, 190, 190);"
-                                    "border-radius: 4px;");
     m_searchingLabel->setVisible(false);
 
 #ifdef WITH_XC_KEESHARE
+    m_shareLabel->setObjectName("KeeShareBanner");
     m_shareLabel->setText(tr("Shared group..."));
     m_shareLabel->setAlignment(Qt::AlignCenter);
-    m_shareLabel->setStyleSheet("color: rgb(0, 0, 0);"
-                                "background-color: rgb(255, 253, 160);"
-                                "border: 2px solid rgb(190, 190, 190);"
-                                "border-radius: 4px;");
     m_shareLabel->setVisible(false);
 #endif
 

--- a/src/gui/styles/base/basestyle.qss
+++ b/src/gui/styles/base/basestyle.qss
@@ -51,3 +51,11 @@ QToolTip {
     border: none;
     padding: 3px;
 }
+
+DatabaseWidget #SearchBanner, DatabaseWidget #KeeShareBanner {
+    font-weight: bold;
+    background-color: palette(highlight);
+    color: palette(highlighted-text);
+    border: 1px solid palette(dark);
+    padding: 2px;
+}

--- a/src/gui/styles/base/classicstyle.qss
+++ b/src/gui/styles/base/classicstyle.qss
@@ -1,0 +1,15 @@
+DatabaseOpenWidget #loginFrame {
+    border: 2px groove palette(mid);
+    background: palette(light);
+}
+
+QToolTip {
+    padding: 3px;
+}
+
+DatabaseWidget #SearchBanner, DatabaseWidget #KeeShareBanner {
+    font-weight: bold;
+    background-color: rgb(94, 161, 14);
+    border: 1px solid rgb(190, 190, 190);
+    padding: 2px;
+}

--- a/src/gui/styles/styles.qrc
+++ b/src/gui/styles/styles.qrc
@@ -1,6 +1,7 @@
 <!DOCTYPE RCC>
 <RCC version="1.0">
     <qresource prefix="/styles">
+        <file>base/classicstyle.qss</file>
         <file>base/basestyle.qss</file>
         <file>dark/darkstyle.qss</file>
         <file>light/lightstyle.qss</file>


### PR DESCRIPTION
Proposed fix for: #5049

The idea here would be to adjust the search-banner theme just after search input and before actually displaying it, however I would be curious to hear your thoughts on this approach.
(also on possible refactoring of the CSS code)

Moreover I couldn't find the matching RGB-code for the blue-style in the classic theme,
so this would still be needed to be set for the correct values.

Finally, there is still the default call of "m_searchingLabel->setStyleSheet(.." in
the constructor which begs the question of how to initialize the values here.

## Screenshots

## Testing strategy
Set theme to the available, auto/dark/light/classic and type text into the search bar.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ I have compiled and verified my code with `-DWITH_ASAN=ON` . **[REQUIRED]**