### PR TITLE
CLI: Add context to commands to simplify database tracking

### DIFF
--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -45,26 +45,28 @@ const QCommandLineOption Add::GenerateOption = QCommandLineOption(QStringList() 
                                                                                 << "generate",
                                                                   QObject::tr("Generate a password for the entry."));
 
-Add::Add()
+CommandArgs Add::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("add");
-    description = QObject::tr("Add a new entry to a database.");
-    options.append(Add::UsernameOption);
-    options.append(Add::UrlOption);
-    options.append(Add::PasswordPromptOption);
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to add."), QString("")});
-
-    // Password generation options.
-    options.append(Add::GenerateOption);
-    options.append(Generate::PasswordLengthOption);
-    options.append(Generate::LowerCaseOption);
-    options.append(Generate::UpperCaseOption);
-    options.append(Generate::NumbersOption);
-    options.append(Generate::SpecialCharsOption);
-    options.append(Generate::ExtendedAsciiOption);
-    options.append(Generate::ExcludeCharsOption);
-    options.append(Generate::ExcludeSimilarCharsOption);
-    options.append(Generate::IncludeEveryGroupOption);
+    static const CommandArgs args {
+        { {"entry", QObject::tr("Path of the entry to add."), ""} },
+        {},
+        {
+            UsernameOption,
+            UrlOption,
+            PasswordPromptOption,
+            GenerateOption,
+            Generate::PasswordLengthOption,
+            Generate::LowerCaseOption,
+            Generate::UpperCaseOption,
+            Generate::NumbersOption,
+            Generate::SpecialCharsOption,
+            Generate::ExtendedAsciiOption,
+            Generate::ExcludeCharsOption,
+            Generate::ExcludeSimilarCharsOption,
+            Generate::IncludeEveryGroupOption
+        }
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int Add::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -74,9 +74,6 @@ int Add::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser.positionalArguments();
-    auto& entryPath = args.at(1);
-
     // Cannot use those 2 options at the same time!
     if (parser.isSet(Add::GenerateOption) && parser.isSet(Add::PasswordPromptOption)) {
         err << QObject::tr("Cannot generate a password and prompt at the same time!") << endl;
@@ -94,6 +91,7 @@ int Add::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
     }
 
     Database& database = ctx.getDb();
+    const QString& entryPath = getArg(0, ctx.getRunmode(), parser.positionalArguments());
     Entry* entry = database.rootGroup()->addEntryWithPath(entryPath);
     if (!entry) {
         err << QObject::tr("Could not create entry with path %1.").arg(entryPath) << endl;

--- a/src/cli/Add.h
+++ b/src/cli/Add.h
@@ -25,7 +25,7 @@ class Add : public DatabaseCommand
 public:
     Add();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
     static const QCommandLineOption UsernameOption;
     static const QCommandLineOption UrlOption;
@@ -33,5 +33,6 @@ public:
     static const QCommandLineOption GenerateOption;
     static const QCommandLineOption PasswordLengthOption;
 };
+DECL_TRAITS(Add, "add", "Add a new entry to a database.");
 
 #endif // KEEPASSXC_ADD_H

--- a/src/cli/Add.h
+++ b/src/cli/Add.h
@@ -20,10 +20,11 @@
 
 #include "DatabaseCommand.h"
 
-class Add : public DatabaseCommand
+class Add final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Add();
+    using Ancestor::Ancestor;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
@@ -32,6 +33,9 @@ public:
     static const QCommandLineOption PasswordPromptOption;
     static const QCommandLineOption GenerateOption;
     static const QCommandLineOption PasswordLengthOption;
+
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Add, "add", "Add a new entry to a database.");
 

--- a/src/cli/Add.h
+++ b/src/cli/Add.h
@@ -22,9 +22,8 @@
 
 class Add final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 

--- a/src/cli/AddGroup.cpp
+++ b/src/cli/AddGroup.cpp
@@ -42,7 +42,7 @@ int AddGroup::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& par
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QString& groupPath = parser.positionalArguments().at(1);
+    const QString& groupPath = getArg(0, ctx.getRunmode(), parser.positionalArguments());
     QStringList pathParts = groupPath.split("/");
     QString groupName = pathParts.takeLast();
     QString parentGroupPath = pathParts.join("/");

--- a/src/cli/AddGroup.cpp
+++ b/src/cli/AddGroup.cpp
@@ -26,15 +26,15 @@
 #include "core/Entry.h"
 #include "core/Group.h"
 
-AddGroup::AddGroup()
-{
-    name = QString("mkdir");
-    description = QObject::tr("Adds a new group to a database.");
-    positionalArguments.append({QString("group"), QObject::tr("Path of the group to add."), QString("")});
-}
 
-AddGroup::~AddGroup()
+CommandArgs AddGroup::getParserArgs(const CommandCtx& ctx) const
 {
+    static const CommandArgs args {
+        { {QString("group"), QObject::tr("Path of the group to add."), QString("")} },
+        {},
+        {}
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int AddGroup::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/AddGroup.h
+++ b/src/cli/AddGroup.h
@@ -26,7 +26,8 @@ public:
     AddGroup();
     ~AddGroup();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
 };
+DECL_TRAITS(AddGroup, "mkdir", "Adds a new group to a database.");
 
 #endif // KEEPASSXC_ADDGROUP_H

--- a/src/cli/AddGroup.h
+++ b/src/cli/AddGroup.h
@@ -22,9 +22,8 @@
 
 class AddGroup final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 

--- a/src/cli/AddGroup.h
+++ b/src/cli/AddGroup.h
@@ -20,13 +20,16 @@
 
 #include "DatabaseCommand.h"
 
-class AddGroup : public DatabaseCommand
+class AddGroup final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    AddGroup();
-    ~AddGroup();
+    using Ancestor::Ancestor;
 
-    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(AddGroup, "mkdir", "Adds a new group to a database.");
 

--- a/src/cli/Analyze.cpp
+++ b/src/cli/Analyze.cpp
@@ -27,18 +27,22 @@
 #include "core/Group.h"
 #include "core/Tools.h"
 
-const QCommandLineOption Analyze::HIBPDatabaseOption = QCommandLineOption(
+const QCommandLineOption HIBPDatabaseOption = QCommandLineOption(
     {"H", "hibp"},
     QObject::tr("Check if any passwords have been publicly leaked. FILENAME must be the path of a file listing "
                 "SHA-1 hashes of leaked passwords in HIBP format, as available from "
                 "https://haveibeenpwned.com/Passwords."),
     QObject::tr("FILENAME"));
 
-Analyze::Analyze()
+
+CommandArgs Analyze::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("analyze");
-    description = QObject::tr("Analyze passwords for weaknesses and problems.");
-    options.append(Analyze::HIBPDatabaseOption);
+    static const CommandArgs args {
+        {},
+        {},
+        { HIBPDatabaseOption }
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int Analyze::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
@@ -46,7 +50,7 @@ int Analyze::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& pars
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    QString hibpDatabase = parser.value(Analyze::HIBPDatabaseOption);
+    QString hibpDatabase = parser.value(HIBPDatabaseOption);
     QFile hibpFile(hibpDatabase);
     if (!hibpFile.open(QFile::ReadOnly)) {
         err << QObject::tr("Failed to open HIBP file %1: %2").arg(hibpDatabase).arg(hibpFile.errorString()) << endl;

--- a/src/cli/Analyze.cpp
+++ b/src/cli/Analyze.cpp
@@ -41,12 +41,12 @@ Analyze::Analyze()
     options.append(Analyze::HIBPDatabaseOption);
 }
 
-int Analyze::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+int Analyze::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    QString hibpDatabase = parser->value(Analyze::HIBPDatabaseOption);
+    QString hibpDatabase = parser.value(Analyze::HIBPDatabaseOption);
     QFile hibpFile(hibpDatabase);
     if (!hibpFile.open(QFile::ReadOnly)) {
         err << QObject::tr("Failed to open HIBP file %1: %2").arg(hibpDatabase).arg(hibpFile.errorString()) << endl;
@@ -57,7 +57,7 @@ int Analyze::executeWithDatabase(QSharedPointer<Database> database, QSharedPoint
 
     QList<QPair<const Entry*, int>> findings;
     QString error;
-    if (!HibpOffline::report(database, hibpFile, findings, &error)) {
+    if (!HibpOffline::report(ctx.getDb(), hibpFile, findings, &error)) {
         err << error << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Analyze.h
+++ b/src/cli/Analyze.h
@@ -24,12 +24,13 @@ class Analyze : public DatabaseCommand
 {
 public:
     Analyze();
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
     static const QCommandLineOption HIBPDatabaseOption;
 
 private:
     void printHibpFinding(const Entry* entry, int count, QTextStream& out);
 };
+DECL_TRAITS(Analyze, "analyze", "Analyze passwords for weaknesses and problems.");
 
 #endif // KEEPASSXC_HIBP_H

--- a/src/cli/Analyze.h
+++ b/src/cli/Analyze.h
@@ -27,6 +27,7 @@ public:
     using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+
 private:
     CommandArgs getParserArgs(const CommandCtx& ctx) const override;
     void printHibpFinding(const Entry* entry, int count, QTextStream& out);

--- a/src/cli/Analyze.h
+++ b/src/cli/Analyze.h
@@ -22,9 +22,9 @@
 
 class Analyze final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
+
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 private:

--- a/src/cli/Analyze.h
+++ b/src/cli/Analyze.h
@@ -20,15 +20,15 @@
 
 #include "DatabaseCommand.h"
 
-class Analyze : public DatabaseCommand
+class Analyze final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Analyze();
+    using Ancestor::Ancestor;
+
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
-
-    static const QCommandLineOption HIBPDatabaseOption;
-
 private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
     void printHibpFinding(const Entry* entry, int count, QTextStream& out);
 };
 DECL_TRAITS(Analyze, "analyze", "Analyze passwords for weaknesses and problems.");

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -21,6 +21,7 @@ set(cli_SOURCES
         Close.cpp
         Create.cpp
         Command.cpp
+        CommandCtx.cpp
         DatabaseCommand.cpp
         Diceware.cpp
         Edit.cpp

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -59,10 +59,12 @@ int Clip::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& err = Utils::STDERR;
 
     const QStringList args = parser.positionalArguments();
-    const QString& entryPath = args.at(1);
+    const int kMaxArgs = ctx.getRunmode() == Runmode::InteractiveCmd ? 2 : 3;
+    Q_ASSERT(args.size() <= kMaxArgs);
+    const QString& entryPath = getArg(0, ctx.getRunmode(), args);
     QString timeout;
-    if (args.size() == 3) {
-        timeout = args.at(2);
+    if (args.size() == kMaxArgs) {
+        timeout = getArg(1, ctx.getRunmode(), args);
     }
 
     int timeoutSeconds = 0;

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -51,12 +51,12 @@ Clip::Clip()
         {QString("timeout"), QObject::tr("Timeout in seconds before clearing the clipboard."), QString("[timeout]")});
 }
 
-int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+int Clip::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
-    auto& out = parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT;
+    auto& out = parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser->positionalArguments();
+    const QStringList args = parser.positionalArguments();
     const QString& entryPath = args.at(1);
     QString timeout;
     if (args.size() == 3) {
@@ -71,21 +71,21 @@ int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         timeoutSeconds = timeout.toInt();
     }
 
-    Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
+    Entry* entry = ctx.getDb().rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
         err << QObject::tr("Entry %1 not found.").arg(entryPath) << endl;
         return EXIT_FAILURE;
     }
 
-    if (parser->isSet(AttributeOption) && parser->isSet(TotpOption)) {
+    if (parser.isSet(AttributeOption) && parser.isSet(TotpOption)) {
         err << QObject::tr("ERROR: Please specify one of --attribute or --totp, not both.") << endl;
         return EXIT_FAILURE;
     }
 
-    QString selectedAttribute = parser->value(AttributeOption);
+    QString selectedAttribute = parser.value(AttributeOption);
     QString value;
     bool found = false;
-    if (parser->isSet(TotpOption) || selectedAttribute == "totp") {
+    if (parser.isSet(TotpOption) || selectedAttribute == "totp") {
         if (!entry->hasTotp()) {
             err << QObject::tr("Entry with path %1 has no TOTP set up.").arg(entryPath) << endl;
             return EXIT_FAILURE;

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -27,28 +27,30 @@
 #include "core/Entry.h"
 #include "core/Group.h"
 
-const QCommandLineOption Clip::AttributeOption = QCommandLineOption(
+const QCommandLineOption AttributeOption = QCommandLineOption(
     QStringList() << "a"
                   << "attribute",
     QObject::tr("Copy the given attribute to the clipboard. Defaults to \"password\" if not specified."),
     "attr",
     "password");
 
-const QCommandLineOption Clip::TotpOption =
+const QCommandLineOption TotpOption =
     QCommandLineOption(QStringList() << "t"
                                      << "totp",
                        QObject::tr("Copy the current TOTP to the clipboard (equivalent to \"-a totp\")."));
 
-Clip::Clip()
+
+CommandArgs Clip::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("clip");
-    description = QObject::tr("Copy an entry's attribute to the clipboard.");
-    options.append(Clip::AttributeOption);
-    options.append(Clip::TotpOption);
-    positionalArguments.append(
-        {QString("entry"), QObject::tr("Path of the entry to clip.", "clip = copy to clipboard"), QString("")});
-    optionalArguments.append(
-        {QString("timeout"), QObject::tr("Timeout in seconds before clearing the clipboard."), QString("[timeout]")});
+    static const CommandArgs args {
+        { {"entry", QObject::tr("Path of the entry to clip.", "clip = copy to clipboard"), ""} },
+        { {"timeout", QObject::tr("Timeout in seconds before clearing the clipboard."), "[timeout]"} },
+        {
+            AttributeOption,
+            TotpOption
+        }
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int Clip::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -22,9 +22,8 @@
 
 class Clip final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -20,15 +20,16 @@
 
 #include "DatabaseCommand.h"
 
-class Clip : public DatabaseCommand
+class Clip final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Clip();
+    using Ancestor::Ancestor;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
-    static const QCommandLineOption AttributeOption;
-    static const QCommandLineOption TotpOption;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Clip, "clip", "Copy an entry's attribute to the clipboard.");
 

--- a/src/cli/Clip.h
+++ b/src/cli/Clip.h
@@ -25,10 +25,11 @@ class Clip : public DatabaseCommand
 public:
     Clip();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
     static const QCommandLineOption AttributeOption;
     static const QCommandLineOption TotpOption;
 };
+DECL_TRAITS(Clip, "clip", "Copy an entry's attribute to the clipboard.");
 
 #endif // KEEPASSXC_CLIP_H

--- a/src/cli/Close.cpp
+++ b/src/cli/Close.cpp
@@ -24,11 +24,6 @@
 #include "TextStream.h"
 #include "Utils.h"
 
-Close::Close()
-{
-    name = QString("close");
-    description = QObject::tr("Close the currently opened database.");
-}
 
 int Close::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
 {

--- a/src/cli/Close.cpp
+++ b/src/cli/Close.cpp
@@ -30,9 +30,9 @@ Close::Close()
     description = QObject::tr("Close the currently opened database.");
 }
 
-int Close::execute(const QStringList& arguments)
+int Close::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
 {
-    Q_UNUSED(arguments)
-    currentDatabase.reset(nullptr);
+    Q_UNUSED(parser)
+    ctx.setDb(nullptr);
     return EXIT_SUCCESS;
 }

--- a/src/cli/Close.h
+++ b/src/cli/Close.h
@@ -26,7 +26,10 @@ class Close : public Command
 {
 public:
     Close();
-    int execute(const QStringList& arguments) override;
+
+private:
+    int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };
+DECL_TRAITS(Close, "close", "Close the currently opened database.");
 
 #endif // KEEPASSXC_CLOSE_H

--- a/src/cli/Close.h
+++ b/src/cli/Close.h
@@ -22,10 +22,12 @@
 
 #include "Command.h"
 
-class Close : public Command
+class Close final : public Command
 {
 public:
-    Close();
+    Close(const QString& name, const QString& description)
+        : Command(name, description, runmodeMask(Runmode::InteractiveCmd))
+    {}
 
 private:
     int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -93,20 +93,28 @@ QSharedPointer<QCommandLineParser> Command::makeParser(const CommandCtx& ctx) co
 QSharedPointer<QCommandLineParser> Command::parse(CommandCtx& ctx, const QStringList& args)
 {
     QSharedPointer<QCommandLineParser> parser = makeParser(ctx);
-    BREAK_IF(!parser, QSharedPointer<QCommandLineParser>(nullptr), ctx,
+    BREAK_IF(!parser,
+             QSharedPointer<QCommandLineParser>(nullptr),
+             ctx,
              QString("Failed to create command parser for args={ '%1' }").arg(args.join("', '")));
 
-    BREAK_IF(!parser->parse(args), QSharedPointer<QCommandLineParser>(nullptr),
-             ctx, QString("Failed to parse arguments { '%1' }: %2").arg(args.join("', '")).arg(parser->errorText()));
+    BREAK_IF(!parser->parse(args),
+             QSharedPointer<QCommandLineParser>(nullptr),
+             ctx,
+             QString("Failed to parse arguments { '%1' }: %2").arg(args.join("', '")).arg(parser->errorText()));
 
     const QStringList& parsedArgs = parser->positionalArguments();
     const CommandArgs& parserArgs = getParserArgs(ctx);
     const QList<CommandLineArgument>& posArgs = parserArgs.positionalArguments;
     const QList<CommandLineArgument>& optArgs = parserArgs.optionalArguments;
-    BREAK_IF(parsedArgs.size() < posArgs.size() && !parser->isSet(HelpOption), QSharedPointer<QCommandLineParser>(nullptr),
-             ctx, QString("Too few arguments.\n\n").append(getHelpText(ctx)));
-    BREAK_IF(parsedArgs.size() > posArgs.size() + optArgs.size(), QSharedPointer<QCommandLineParser>(nullptr),
-             ctx, QString("Too much arguments.\n\n").append(getHelpText(ctx)));
+    BREAK_IF(parsedArgs.size() < posArgs.size() && !parser->isSet(HelpOption),
+             QSharedPointer<QCommandLineParser>(nullptr),
+             ctx,
+             QString("Too few arguments.\n\n").append(getHelpText(ctx)));
+    BREAK_IF(parsedArgs.size() > posArgs.size() + optArgs.size(),
+             QSharedPointer<QCommandLineParser>(nullptr),
+             ctx,
+             QString("Too much arguments.\n\n").append(getHelpText(ctx)));
 
     return parser;
 }

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -68,7 +68,7 @@ QSharedPointer<QCommandLineParser> Command::makeParser(const CommandCtx& ctx) co
 {
     auto parser = QSharedPointer<QCommandLineParser>::create();
     if (!parser)
-        return nullptr;
+        return QSharedPointer<QCommandLineParser>(nullptr);
 
     parser->setApplicationDescription(m_description);
     const CommandArgs& parserArgs = getParserArgs(ctx);

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -92,7 +92,8 @@ QSharedPointer<QCommandLineParser> Command::makeParser(const CommandCtx& ctx) co
 QSharedPointer<QCommandLineParser> Command::parse(CommandCtx& ctx, const QStringList& args)
 {
     QSharedPointer<QCommandLineParser> parser = makeParser(ctx);
-    BREAK_IF(!parser, nullptr, ctx, QString("Failed to create command parser for args={ '%1' }").arg(args.join("', '")));
+    BREAK_IF(!parser, QSharedPointer<QCommandLineParser>(nullptr), ctx,
+             QString("Failed to create command parser for args={ '%1' }").arg(args.join("', '")));
 
     BREAK_IF(!parser->parse(args), nullptr, ctx, QString("Failed to parse arguments { '%1' }: '%2'").arg(args.join("', '")).arg(parser->errorText()));
 
@@ -100,9 +101,9 @@ QSharedPointer<QCommandLineParser> Command::parse(CommandCtx& ctx, const QString
     const CommandArgs& parserArgs = getParserArgs(ctx);
     const QList<CommandLineArgument>& posArgs = parserArgs.positionalArguments;
     const QList<CommandLineArgument>& optArgs = parserArgs.optionalArguments;
-    BREAK_IF(parsedArgs.size() < posArgs.size() && !parser->isSet(HelpOption), nullptr,
+    BREAK_IF(parsedArgs.size() < posArgs.size() && !parser->isSet(HelpOption), QSharedPointer<QCommandLineParser>(nullptr),
              ctx, QString("Too few arguments.\n\n").append(getHelpText(ctx)));
-    BREAK_IF(parsedArgs.size() > posArgs.size() + optArgs.size(), nullptr,
+    BREAK_IF(parsedArgs.size() > posArgs.size() + optArgs.size(), QSharedPointer<QCommandLineParser>(nullptr),
              ctx, QString("Too much arguments.\n\n").append(getHelpText(ctx)));
 
     return parser;

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -67,8 +67,9 @@ const QCommandLineOption Command::QuietOption =
 QSharedPointer<QCommandLineParser> Command::makeParser(const CommandCtx& ctx) const
 {
     auto parser = QSharedPointer<QCommandLineParser>::create();
-    if (!parser)
+    if (!parser) {
         return QSharedPointer<QCommandLineParser>(nullptr);
+    }
 
     parser->setApplicationDescription(m_description);
     const CommandArgs& parserArgs = getParserArgs(ctx);
@@ -136,8 +137,9 @@ QString Command::getHelpText(const CommandCtx& ctx) const
 int Command::execute(CommandCtx& ctx, const QStringList& args)
 {
     QSharedPointer<QCommandLineParser> parser = parse(ctx, args);
-    if (parser.isNull())
+    if (parser.isNull()) {
         return EXIT_FAILURE;
+    }
     if (parser->isSet(HelpOption)) {
         Utils::STDOUT << getHelpText(ctx) << endl;
         return EXIT_SUCCESS;

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -95,7 +95,8 @@ QSharedPointer<QCommandLineParser> Command::parse(CommandCtx& ctx, const QString
     BREAK_IF(!parser, QSharedPointer<QCommandLineParser>(nullptr), ctx,
              QString("Failed to create command parser for args={ '%1' }").arg(args.join("', '")));
 
-    BREAK_IF(!parser->parse(args), nullptr, ctx, QString("Failed to parse arguments { '%1' }: '%2'").arg(args.join("', '")).arg(parser->errorText()));
+    BREAK_IF(!parser->parse(args), QSharedPointer<QCommandLineParser>(nullptr),
+             ctx, QString("Failed to parse arguments { '%1' }: '%2'").arg(args.join("', '")).arg(parser->errorText()));
 
     const QStringList& parsedArgs = parser->positionalArguments();
     const CommandArgs& parserArgs = getParserArgs(ctx);

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -96,7 +96,7 @@ QSharedPointer<QCommandLineParser> Command::parse(CommandCtx& ctx, const QString
              QString("Failed to create command parser for args={ '%1' }").arg(args.join("', '")));
 
     BREAK_IF(!parser->parse(args), QSharedPointer<QCommandLineParser>(nullptr),
-             ctx, QString("Failed to parse arguments { '%1' }: '%2'").arg(args.join("', '")).arg(parser->errorText()));
+             ctx, QString("Failed to parse arguments { '%1' }: %2").arg(args.join("', '")).arg(parser->errorText()));
 
     const QStringList& parsedArgs = parser->positionalArguments();
     const CommandArgs& parserArgs = getParserArgs(ctx);

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -126,5 +126,12 @@ private:
     int m_allowedRunmodes = runmodeMaskBoth();
 };
 
+static inline const QString& getArg(int idx, Runmode currentRunmode, const QStringList& args)
+{
+    if (currentRunmode == Runmode::SingleCmd)
+        ++idx;
+    Q_ASSERT(idx < args.size());
+    return args.at(idx);
+}
 
 #endif // KEEPASSXC_COMMAND_H

--- a/src/cli/Command.h
+++ b/src/cli/Command.h
@@ -25,16 +25,14 @@
 #include <QString>
 #include <QStringList>
 
-#include "core/Database.h"
 #include "CommandCtx.h"
-
+#include "core/Database.h"
 
 ///
 /// Following traits are mandatory:
 /// const char* Name        - printable command name
 /// const char* Description - printable description
-template<class Cmd>
-struct CommandTraits;
+template<class Cmd> struct CommandTraits;
 
 #define DECL_TRAITS(TYPE, NAME, DESC)                       \
     template<> struct CommandTraits<TYPE> {                 \
@@ -108,7 +106,11 @@ protected:
     /// \param ctx configured environment ctx
     /// \return initialized CommandArgs structure
     ///
-    virtual CommandArgs getParserArgs(const CommandCtx& ctx) const { Q_UNUSED(ctx); return {}; };
+    virtual CommandArgs getParserArgs(const CommandCtx& ctx) const
+    {
+        Q_UNUSED(ctx);
+        return {};
+    };
 
     QSharedPointer<QCommandLineParser> makeParser(const CommandCtx& ctx) const;
 

--- a/src/cli/CommandCtx.cpp
+++ b/src/cli/CommandCtx.cpp
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "CommandCtx.h"
+
+#include "Add.h"
+#include "AddGroup.h"
+#include "Analyze.h"
+#include "Clip.h"
+#include "Close.h"
+#include "Create.h"
+#include "Diceware.h"
+#include "Edit.h"
+#include "Estimate.h"
+#include "Exit.h"
+#include "Export.h"
+#include "Generate.h"
+#include "Help.h"
+#include "Import.h"
+#include "Info.h"
+#include "List.h"
+#include "Locate.h"
+#include "Merge.h"
+#include "Move.h"
+#include "Open.h"
+#include "Remove.h"
+#include "RemoveGroup.h"
+#include "Show.h"
+
+
+template<class Cmd>
+void regCmd(QHash<QString, QSharedPointer<Command>>& map)
+{
+    map.insert(CommandTraits<Cmd>::Name, QSharedPointer<Cmd>::create());
+}
+
+void CommandCtx::cmdInit()
+{
+#define REG_CMD(CMD_T) regCmd<CMD_T>(m_commands)
+
+    REG_CMD(Add);
+    REG_CMD(Analyze);
+    REG_CMD(Clip);
+    REG_CMD(Close);
+    REG_CMD(Create);
+    REG_CMD(Info);
+    REG_CMD(Diceware);
+    REG_CMD(Edit);
+    REG_CMD(Estimate);
+    REG_CMD(Generate);
+    REG_CMD(Help);
+    REG_CMD(Locate);
+    REG_CMD(List);
+    REG_CMD(Merge);
+    REG_CMD(AddGroup);
+    REG_CMD(Move);
+    REG_CMD(Open);
+    REG_CMD(Remove);
+    REG_CMD(RemoveGroup);
+    REG_CMD(Show);
+    // TODO_vanda interactive
+    // TODO_vanda alias 'quit'
+    REG_CMD(Exit);
+    // TODO_vanda non-interactive
+    REG_CMD(Export);
+    REG_CMD(Import);
+
+#undef REG_CMD
+}
+
+int CommandCtx::parseArgs(QCommandLineParser& parser, const QStringList& args)
+{
+    parser.setOptionsAfterPositionalArgumentsMode(QCommandLineParser::ParseAsPositionalArguments);
+
+    QString description("KeePassXC command line interface.");
+    description = description.append(QObject::tr("\n\nAvailable commands:\n"));
+    for (const auto& command : m_commands)
+        description = description.append(command->getDescriptionLine());
+    parser.setApplicationDescription(description);
+    parser.addPositionalArgument("command", QObject::tr("Name of the command to execute."));
+    const QCommandLineOption debugInfo("debug-info", QObject::tr("Displays debugging information."));
+    parser.addOption(debugInfo);
+    const QCommandLineOption help = parser.addHelpOption();
+    const QCommandLineOption version = parser.addVersionOption();
+
+    if (!parser.parse(args)) {
+        logError(parser.errorText());
+        return EXIT_FAILURE;
+    }
+
+    if (parser.isSet(version)) {
+        m_runmode = Runmode::Version;
+        return EXIT_SUCCESS;
+    }
+    if (parser.isSet(debugInfo)) {
+        m_runmode = Runmode::DebugInfo;
+        return EXIT_SUCCESS;
+    }
+    if (parser.isSet(help)) {
+        m_runmode = Runmode::Help;
+        return EXIT_SUCCESS;
+    }
+
+    if (parser.positionalArguments().empty()) {
+        logError(QObject::tr("Argument 'command' missing.\n").append(parser.helpText()));
+        return EXIT_FAILURE;
+    }
+    m_runmode = Runmode::SingleCmd;
+    return EXIT_SUCCESS;
+}

--- a/src/cli/CommandCtx.cpp
+++ b/src/cli/CommandCtx.cpp
@@ -42,7 +42,6 @@
 #include "RemoveGroup.h"
 #include "Show.h"
 
-
 template<class Cmd>
 void regCmd(QMap<QString, QSharedPointer<Command>>& map)
 {

--- a/src/cli/CommandCtx.cpp
+++ b/src/cli/CommandCtx.cpp
@@ -58,6 +58,7 @@ void CommandCtx::cmdInit()
 #define REG_CMD(CMD_T) regCmd<CMD_T>(m_commands)
 
     REG_CMD(Add);
+    REG_CMD(AddGroup);
     REG_CMD(Analyze);
     REG_CMD(Clip);
     REG_CMD(Close);
@@ -71,7 +72,6 @@ void CommandCtx::cmdInit()
     REG_CMD(Locate);
     REG_CMD(List);
     REG_CMD(Merge);
-    REG_CMD(AddGroup);
     REG_CMD(Move);
     REG_CMD(Open);
     REG_CMD(Remove);

--- a/src/cli/CommandCtx.cpp
+++ b/src/cli/CommandCtx.cpp
@@ -97,9 +97,11 @@ int CommandCtx::parseArgs(QCommandLineParser& parser, const QStringList& args)
 {
     QString description("KeePassXC command line interface.");
     description = description.append(QObject::tr("\n\nAvailable commands:\n"));
-    for (const auto& command : m_commands)
-        if (command->isAllowedRunmode(Runmode::SingleCmd))
+    for (const auto& command : m_commands) {
+        if (command->isAllowedRunmode(Runmode::SingleCmd)) {
             description.append(command->getDescriptionLine());
+        }
+    }
     parser.setApplicationDescription(description);
     parser.addPositionalArgument("command", QObject::tr("Name of the command to execute."));
     const QCommandLineOption debugInfo("debug-info", QObject::tr("Displays debugging information."));

--- a/src/cli/CommandCtx.cpp
+++ b/src/cli/CommandCtx.cpp
@@ -95,8 +95,6 @@ void CommandCtx::cmdInit()
 
 int CommandCtx::parseArgs(QCommandLineParser& parser, const QStringList& args)
 {
-    parser.setOptionsAfterPositionalArgumentsMode(QCommandLineParser::ParseAsPositionalArguments);
-
     QString description("KeePassXC command line interface.");
     description = description.append(QObject::tr("\n\nAvailable commands:\n"));
     for (const auto& command : m_commands)

--- a/src/cli/CommandCtx.cpp
+++ b/src/cli/CommandCtx.cpp
@@ -107,10 +107,7 @@ int CommandCtx::parseArgs(QCommandLineParser& parser, const QStringList& args)
     const QCommandLineOption help = parser.addHelpOption();
     const QCommandLineOption version = parser.addVersionOption();
 
-    if (!parser.parse(args)) {
-        logError(parser.errorText());
-        return EXIT_FAILURE;
-    }
+    parser.parse(args);
 
     if (parser.isSet(version)) {
         m_runmode = Runmode::Version;

--- a/src/cli/CommandCtx.h
+++ b/src/cli/CommandCtx.h
@@ -61,8 +61,9 @@ struct CommandCtx
     template<class F>
     void forEachCmd(const F& f) const
     {
-        for (const auto& cmd : m_commands)
+        for (const auto& cmd : m_commands) {
             f(*cmd);
+        }
     }
 
     Database& getDb()

--- a/src/cli/CommandCtx.h
+++ b/src/cli/CommandCtx.h
@@ -32,7 +32,7 @@ constexpr int runmodeMaskBoth()
     return runmodeMask(Runmode::SingleCmd) | runmodeMask(Runmode::InteractiveCmd);
 }
 
-struct Command;
+class Command;
 
 struct CommandCtx
 {

--- a/src/cli/CommandCtx.h
+++ b/src/cli/CommandCtx.h
@@ -23,6 +23,15 @@ enum class Runmode
     InteractiveCmd
 };
 
+constexpr int runmodeMask(Runmode mode)
+{
+    return 1 << static_cast<int>(mode);
+}
+constexpr int runmodeMaskBoth()
+{
+    return runmodeMask(Runmode::SingleCmd) | runmodeMask(Runmode::InteractiveCmd);
+}
+
 struct Command;
 
 struct CommandCtx
@@ -49,6 +58,13 @@ struct CommandCtx
                 : nullptr;
     }
 
+    template<class F>
+    void forEachCmd(const F& f) const
+    {
+        for (const auto& cmd : m_commands)
+            f(*cmd);
+    }
+
     Database& getDb()
     {
         Q_ASSERT(m_db);
@@ -72,7 +88,7 @@ private:
     int parseArgs(QCommandLineParser& parser, const QStringList& args);
 
     Runmode m_runmode;
-    QHash<QString, QSharedPointer<Command>> m_commands;
+    QMap<QString, QSharedPointer<Command>> m_commands;
     std::unique_ptr<Database> m_db;
     QStack<QString> m_errors;
 };

--- a/src/cli/CommandCtx.h
+++ b/src/cli/CommandCtx.h
@@ -1,7 +1,6 @@
 #ifndef COMMANDCTX_H
 #define COMMANDCTX_H
 
-#include <memory>
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QList>
@@ -9,10 +8,10 @@
 #include <QString>
 #include <QStringList>
 #include <QStack>
+#include <memory>
 
-#include "core/Database.h"
 #include "Utils.h"
-
+#include "core/Database.h"
 
 enum class Runmode
 {

--- a/src/cli/CommandCtx.h
+++ b/src/cli/CommandCtx.h
@@ -53,9 +53,9 @@ struct CommandCtx
     QSharedPointer<Command> getCmd(const QString& name)
     {
         const auto cmd = m_commands.find(name);
-        return cmd != m_commands.end()
-                ? *cmd
-                : nullptr;
+        if (cmd != m_commands.end())
+            return *cmd;
+        return nullptr;
     }
 
     template<class F>

--- a/src/cli/CommandCtx.h
+++ b/src/cli/CommandCtx.h
@@ -53,9 +53,9 @@ struct CommandCtx
     QSharedPointer<Command> getCmd(const QString& name)
     {
         const auto cmd = m_commands.find(name);
-        if (cmd != m_commands.end())
-            return *cmd;
-        return nullptr;
+        return cmd != m_commands.end()
+            ? *cmd
+            : QSharedPointer<Command>(nullptr);
     }
 
     template<class F>

--- a/src/cli/CommandCtx.h
+++ b/src/cli/CommandCtx.h
@@ -1,0 +1,86 @@
+#ifndef COMMANDCTX_H
+#define COMMANDCTX_H
+
+#include <memory>
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QList>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QStack>
+
+#include "core/Database.h"
+#include "Utils.h"
+
+
+enum class Runmode
+{
+    Version,
+    DebugInfo,
+    Help,
+    SingleCmd,
+    InteractiveCmd
+};
+
+struct Command;
+
+struct CommandCtx
+{
+    CommandCtx(QCommandLineParser& parser, const QStringList& args)
+    {
+        cmdInit();
+        parseArgs(parser, args);
+    }
+
+    bool error()                        const { return !m_errors.empty(); }
+    const QStack<QString>& getErrors()  const { return m_errors; }
+    void clearErrors()                        { m_errors.clear(); }
+    Runmode getRunmode()                const { return m_runmode; }
+    void startInteractive()                   { m_runmode = Runmode::InteractiveCmd; }
+    void stopInteractive()                    { m_runmode = Runmode::SingleCmd; }
+    bool hasDb()                        const { return !!m_db; }
+
+    QSharedPointer<Command> getCmd(const QString& name)
+    {
+        const auto cmd = m_commands.find(name);
+        return cmd != m_commands.end()
+                ? *cmd
+                : nullptr;
+    }
+
+    Database& getDb()
+    {
+        Q_ASSERT(m_db);
+        Q_ASSERT(m_db->isInitialized());
+        return *m_db;
+    }
+
+    void setDb(std::unique_ptr<Database> db)
+    {
+        Q_ASSERT(db->isInitialized());
+        m_db = std::move(db);
+    }
+
+    void logError(const QString& msg)
+    {
+        m_errors.push(msg);
+    }
+
+private:
+    void cmdInit();
+    int parseArgs(QCommandLineParser& parser, const QStringList& args);
+
+    Runmode m_runmode;
+    QHash<QString, QSharedPointer<Command>> m_commands;
+    std::unique_ptr<Database> m_db;
+    QStack<QString> m_errors;
+};
+
+#define BREAK_IF(COND, RET_VAL, CTX, ERR_MSG)   \
+    if (!!(COND)) {                             \
+        (CTX).logError((ERR_MSG));              \
+        return (RET_VAL);                       \
+    }
+
+#endif // COMMANDCTX_H

--- a/src/cli/Create.h
+++ b/src/cli/Create.h
@@ -24,15 +24,13 @@
 
 class Create final : public Command
 {
+    using Ancestor = Command;
 public:
-    Create();
-
-    static const QCommandLineOption SetKeyFileOption;
-    static const QCommandLineOption SetPasswordOption;
-    static const QCommandLineOption DecryptionTimeOption;
+    using Ancestor::Ancestor;
 
 private:
-    virtual int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
+    int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
     bool loadFileKey(const QString& path, QSharedPointer<FileKey>& fileKey);
 };
 DECL_TRAITS(Create, "db-create", "Create a new database.");

--- a/src/cli/Create.h
+++ b/src/cli/Create.h
@@ -22,18 +22,19 @@
 
 #include "keys/FileKey.h"
 
-class Create : public Command
+class Create final : public Command
 {
 public:
     Create();
-    int execute(const QStringList& arguments) override;
 
     static const QCommandLineOption SetKeyFileOption;
     static const QCommandLineOption SetPasswordOption;
     static const QCommandLineOption DecryptionTimeOption;
 
 private:
+    virtual int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
     bool loadFileKey(const QString& path, QSharedPointer<FileKey>& fileKey);
 };
+DECL_TRAITS(Create, "db-create", "Create a new database.");
 
 #endif // KEEPASSXC_CREATE_H

--- a/src/cli/DatabaseCommand.cpp
+++ b/src/cli/DatabaseCommand.cpp
@@ -47,7 +47,7 @@ CommandArgs DatabaseCommand::getParserArgs(const CommandCtx& ctx) const
         {
             KeyFileOption,
 #ifdef WITH_XC_YUBIKEY
-            YubiKeyOption;
+            YubiKeyOption,
 #endif
             NoPasswordOption }
     };

--- a/src/cli/DatabaseCommand.cpp
+++ b/src/cli/DatabaseCommand.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<Database> DatabaseCommand::openDatabase(const QCommandLineParser
                                  !parser.isSet(NoPasswordOption),
                                  parser.value(KeyFileOption),
 #ifdef WITH_XC_YUBIKEY
-                                 parser->value(YubiKeyOption),
+                                 parser.value(YubiKeyOption),
 #else
                                  "",
 #endif

--- a/src/cli/DatabaseCommand.cpp
+++ b/src/cli/DatabaseCommand.cpp
@@ -69,8 +69,9 @@ std::unique_ptr<Database> DatabaseCommand::openDatabase(const QCommandLineParser
 
 int DatabaseCommand::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
 {
-    if (ctx.hasDb())
+    if (ctx.hasDb()) {
         return executeWithDatabase(ctx, parser);
+    }
     std::unique_ptr<Database> db = openDatabase(parser);
     BREAK_IF(!db, EXIT_FAILURE,
              ctx, QString("Error opening database '%1'.").arg(parser.positionalArguments().first()));

--- a/src/cli/DatabaseCommand.cpp
+++ b/src/cli/DatabaseCommand.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<Database> DatabaseCommand::openDatabase(const QCommandLineParser
                                  !parser.isSet(NoPasswordOption),
                                  parser.value(KeyFileOption),
 #ifdef WITH_XC_YUBIKEY
-                                 parser->value(Command::YubiKeyOption),
+                                 parser->value(YubiKeyOption),
 #else
                                  "",
 #endif

--- a/src/cli/DatabaseCommand.h
+++ b/src/cli/DatabaseCommand.h
@@ -26,10 +26,8 @@
 
 class DatabaseCommand : public Command
 {
-    using Ancestor = Command;
-
 public:
-    using Ancestor::Ancestor;
+    using Command::Command;
 
     virtual int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) = 0;
 

--- a/src/cli/DatabaseCommand.h
+++ b/src/cli/DatabaseCommand.h
@@ -28,8 +28,18 @@ class DatabaseCommand : public Command
 {
 public:
     DatabaseCommand();
-    int execute(const QStringList& arguments) override;
-    virtual int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) = 0;
+
+    virtual int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) = 0;
+
+    static const QCommandLineOption KeyFileOption;
+    static const QCommandLineOption NoPasswordOption;
+    static const QCommandLineOption YubiKeyOption;
+
+protected:
+    std::unique_ptr<Database> openDatabase(const QCommandLineParser& parser);
+
+private:
+    int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };
 
 #endif // KEEPASSXC_DATABASECOMMAND_H

--- a/src/cli/DatabaseCommand.h
+++ b/src/cli/DatabaseCommand.h
@@ -26,17 +26,16 @@
 
 class DatabaseCommand : public Command
 {
+    using Ancestor = Command;
+
 public:
-    DatabaseCommand();
+    using Ancestor::Ancestor;
 
     virtual int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) = 0;
 
-    static const QCommandLineOption KeyFileOption;
-    static const QCommandLineOption NoPasswordOption;
-    static const QCommandLineOption YubiKeyOption;
-
 protected:
     std::unique_ptr<Database> openDatabase(const QCommandLineParser& parser);
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 
 private:
     int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -24,24 +24,31 @@
 #include "cli/TextStream.h"
 #include "core/PassphraseGenerator.h"
 
-const QCommandLineOption Diceware::WordCountOption =
+const QCommandLineOption WordCountOption =
     QCommandLineOption(QStringList() << "W"
                                      << "words",
                        QObject::tr("Word count for the diceware passphrase."),
                        QObject::tr("count", "CLI parameter"));
 
-const QCommandLineOption Diceware::WordListOption =
+const QCommandLineOption WordListOption =
     QCommandLineOption(QStringList() << "w"
                                      << "word-list",
                        QObject::tr("Wordlist for the diceware generator.\n[Default: EFF English]"),
                        QObject::tr("path"));
 
-Diceware::Diceware()
+
+CommandArgs Diceware::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("diceware");
-    description = QObject::tr("Generate a new random diceware passphrase.");
-    options.append(Diceware::WordCountOption);
-    options.append(Diceware::WordListOption);
+    Q_UNUSED(ctx);
+    static const CommandArgs args {
+        {},
+        {},
+        {
+            WordCountOption,
+            WordListOption
+        }
+    };
+    return args;
 }
 
 int Diceware::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
@@ -53,7 +60,7 @@ int Diceware::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
 
     PassphraseGenerator dicewareGenerator;
 
-    QString wordCount = parser.value(Diceware::WordCountOption);
+    QString wordCount = parser.value(WordCountOption);
     if (wordCount.isEmpty()) {
         dicewareGenerator.setWordCount(PassphraseGenerator::DefaultWordCount);
     } else if (wordCount.toInt() <= 0) {
@@ -63,7 +70,7 @@ int Diceware::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
         dicewareGenerator.setWordCount(wordCount.toInt());
     }
 
-    QString wordListFile = parser.value(Diceware::WordListOption);
+    QString wordListFile = parser.value(WordListOption);
     if (!wordListFile.isEmpty()) {
         dicewareGenerator.setWordList(wordListFile);
     }

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -44,19 +44,16 @@ Diceware::Diceware()
     options.append(Diceware::WordListOption);
 }
 
-int Diceware::execute(const QStringList& arguments)
+int Diceware::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
 {
-    QSharedPointer<QCommandLineParser> parser = getCommandLineParser(arguments);
-    if (parser.isNull()) {
-        return EXIT_FAILURE;
-    }
+    Q_UNUSED(ctx);
 
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
     PassphraseGenerator dicewareGenerator;
 
-    QString wordCount = parser->value(Diceware::WordCountOption);
+    QString wordCount = parser.value(Diceware::WordCountOption);
     if (wordCount.isEmpty()) {
         dicewareGenerator.setWordCount(PassphraseGenerator::DefaultWordCount);
     } else if (wordCount.toInt() <= 0) {
@@ -66,7 +63,7 @@ int Diceware::execute(const QStringList& arguments)
         dicewareGenerator.setWordCount(wordCount.toInt());
     }
 
-    QString wordListFile = parser->value(Diceware::WordListOption);
+    QString wordListFile = parser.value(Diceware::WordListOption);
     if (!wordListFile.isEmpty()) {
         dicewareGenerator.setWordList(wordListFile);
     }
@@ -77,9 +74,6 @@ int Diceware::execute(const QStringList& arguments)
         err << QObject::tr("The word list is too small (< 1000 items)") << endl;
         return EXIT_FAILURE;
     }
-
-    QString password = dicewareGenerator.generatePassphrase();
-    out << password << endl;
-
+    out << dicewareGenerator.generatePassphrase() << endl;
     return EXIT_SUCCESS;
 }

--- a/src/cli/Diceware.h
+++ b/src/cli/Diceware.h
@@ -25,10 +25,12 @@ class Diceware : public Command
 public:
     Diceware();
 
-    int execute(const QStringList& arguments) override;
-
     static const QCommandLineOption WordCountOption;
     static const QCommandLineOption WordListOption;
+
+private:
+    int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
 };
+DECL_TRAITS(Diceware, "diceware", "Generate a new random diceware passphrase.");
 
 #endif // KEEPASSXC_DICEWARE_H

--- a/src/cli/Diceware.h
+++ b/src/cli/Diceware.h
@@ -22,9 +22,8 @@
 
 class Diceware final : public Command
 {
-    using Ancestor = Command;
 public:
-    using Ancestor::Ancestor;
+    using Command::Command;
 
 private:
     CommandArgs getParserArgs(const CommandCtx& ctx) const override;

--- a/src/cli/Diceware.h
+++ b/src/cli/Diceware.h
@@ -20,15 +20,14 @@
 
 #include "Command.h"
 
-class Diceware : public Command
+class Diceware final : public Command
 {
+    using Ancestor = Command;
 public:
-    Diceware();
-
-    static const QCommandLineOption WordCountOption;
-    static const QCommandLineOption WordListOption;
+    using Ancestor::Ancestor;
 
 private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
     int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
 };
 DECL_TRAITS(Diceware, "diceware", "Generate a new random diceware passphrase.");

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -29,33 +29,36 @@
 #include "core/Group.h"
 #include "core/PasswordGenerator.h"
 
-const QCommandLineOption Edit::TitleOption = QCommandLineOption(QStringList() << "t"
-                                                                              << "title",
-                                                                QObject::tr("Title for the entry."),
-                                                                QObject::tr("title"));
+const QCommandLineOption TitleOption = QCommandLineOption(QStringList() << "t" << "title",
+                                                          QObject::tr("Title for the entry."),
+                                                          QObject::tr("title"));
 
-Edit::Edit()
+
+CommandArgs Edit::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("edit");
-    description = QObject::tr("Edit an entry.");
-    // Using some of the options from the Add command since they are the same.
-    options.append(Add::UsernameOption);
-    options.append(Add::UrlOption);
-    options.append(Add::PasswordPromptOption);
-    options.append(Edit::TitleOption);
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to edit."), QString("")});
-
-    // Password generation options.
-    options.append(Add::GenerateOption);
-    options.append(Generate::PasswordLengthOption);
-    options.append(Generate::LowerCaseOption);
-    options.append(Generate::UpperCaseOption);
-    options.append(Generate::NumbersOption);
-    options.append(Generate::SpecialCharsOption);
-    options.append(Generate::ExtendedAsciiOption);
-    options.append(Generate::ExcludeCharsOption);
-    options.append(Generate::ExcludeSimilarCharsOption);
-    options.append(Generate::IncludeEveryGroupOption);
+    static const CommandArgs args {
+        { {QString("entry"), QObject::tr("Path of the entry to edit."), QString("")} },
+        {},
+        {
+            TitleOption,
+            // Using some of the options from the Add command since they are the same.
+            Add::UsernameOption,
+            Add::UrlOption,
+            Add::PasswordPromptOption,
+            // Password generation options.
+            Add::GenerateOption,
+            Generate::PasswordLengthOption,
+            Generate::LowerCaseOption,
+            Generate::UpperCaseOption,
+            Generate::NumbersOption,
+            Generate::SpecialCharsOption,
+            Generate::ExtendedAsciiOption,
+            Generate::ExcludeCharsOption,
+            Generate::ExcludeSimilarCharsOption,
+            Generate::IncludeEveryGroupOption
+        }
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int Edit::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
@@ -92,7 +95,7 @@ int Edit::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 
     QString username = parser.value(Add::UsernameOption);
     QString url = parser.value(Add::UrlOption);
-    QString title = parser.value(Edit::TitleOption);
+    QString title = parser.value(TitleOption);
     bool prompt = parser.isSet(Add::PasswordPromptOption);
     if (username.isEmpty() && url.isEmpty() && title.isEmpty() && !prompt && !generate) {
         err << QObject::tr("Not changing any field for entry %1.").arg(entryPath) << endl;

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -66,9 +66,7 @@ int Edit::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& out = parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser.positionalArguments();
-    const QString& entryPath = args.at(1);
-
+    const QString& entryPath = getArg(0, ctx.getRunmode(), parser.positionalArguments());
     // Cannot use those 2 options at the same time!
     if (parser.isSet(Add::GenerateOption) && parser.isSet(Add::PasswordPromptOption)) {
         err << QObject::tr("Cannot generate a password and prompt at the same time!") << endl;

--- a/src/cli/Edit.h
+++ b/src/cli/Edit.h
@@ -24,9 +24,10 @@ class Edit : public DatabaseCommand
 {
 public:
     Edit();
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
     static const QCommandLineOption TitleOption;
 };
+DECL_TRAITS(Edit, "edit", "Edit an entry.");
 
 #endif // KEEPASSXC_EDIT_H

--- a/src/cli/Edit.h
+++ b/src/cli/Edit.h
@@ -22,9 +22,8 @@
 
 class Edit : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 private:

--- a/src/cli/Edit.h
+++ b/src/cli/Edit.h
@@ -22,11 +22,13 @@
 
 class Edit : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Edit();
-    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+    using Ancestor::Ancestor;
 
-    static const QCommandLineOption TitleOption;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Edit, "edit", "Edit an entry.");
 

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -32,18 +32,21 @@
 #endif
 #endif
 
-const QCommandLineOption Estimate::AdvancedOption =
+const QCommandLineOption AdvancedOption =
     QCommandLineOption(QStringList() << "a"
                                      << "advanced",
                        QObject::tr("Perform advanced analysis on the password."));
 
-Estimate::Estimate()
+CommandArgs Estimate::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("estimate");
-    optionalArguments.append(
-        {QString("password"), QObject::tr("Password for which to estimate the entropy."), QString("[password]")});
-    options.append(Estimate::AdvancedOption);
-    description = QObject::tr("Estimate the entropy of a password.");
+    Q_UNUSED(ctx);
+    static const CommandArgs args {
+        {},
+        // if doesn't passed, read from stdin
+        { {QString("password"), QObject::tr("Password for which to estimate the entropy."), QString("[password]")} },
+        { AdvancedOption }
+    };
+    return args;
 }
 
 static void estimate(const char* pwd, bool advanced)
@@ -168,6 +171,6 @@ int Estimate::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
         password = Utils::STDIN.readLine();
     }
 
-    estimate(password.toLatin1(), parser.isSet(Estimate::AdvancedOption));
+    estimate(password.toLatin1(), parser.isSet(AdvancedOption));
     return EXIT_SUCCESS;
 }

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -156,23 +156,18 @@ static void estimate(const char* pwd, bool advanced)
     }
 }
 
-int Estimate::execute(const QStringList& arguments)
+int Estimate::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
 {
-    QSharedPointer<QCommandLineParser> parser = getCommandLineParser(arguments);
-    if (parser.isNull()) {
-        return EXIT_FAILURE;
-    }
+    Q_UNUSED(ctx);
 
-    auto& in = Utils::STDIN;
-    const QStringList args = parser->positionalArguments();
-
+    const QStringList& args = parser.positionalArguments();
     QString password;
     if (args.size() == 1) {
         password = args.at(0);
     } else {
-        password = in.readLine();
+        password = Utils::STDIN.readLine();
     }
 
-    estimate(password.toLatin1(), parser->isSet(Estimate::AdvancedOption));
+    estimate(password.toLatin1(), parser.isSet(Estimate::AdvancedOption));
     return EXIT_SUCCESS;
 }

--- a/src/cli/Estimate.h
+++ b/src/cli/Estimate.h
@@ -22,9 +22,8 @@
 
 class Estimate final : public Command
 {
-    using Ancestor = Command;
 public:
-    using Ancestor::Ancestor;
+    using Command::Command;
 
 private:
     CommandArgs getParserArgs(const CommandCtx& ctx) const override;

--- a/src/cli/Estimate.h
+++ b/src/cli/Estimate.h
@@ -24,9 +24,12 @@ class Estimate : public Command
 {
 public:
     Estimate();
-    int execute(const QStringList& arguments) override;
 
     static const QCommandLineOption AdvancedOption;
+
+private:
+    int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
 };
+DECL_TRAITS(Estimate, "estimate", "Estimate the entropy of a password.");
 
 #endif // KEEPASSXC_ESTIMATE_H

--- a/src/cli/Estimate.h
+++ b/src/cli/Estimate.h
@@ -20,14 +20,14 @@
 
 #include "Command.h"
 
-class Estimate : public Command
+class Estimate final : public Command
 {
+    using Ancestor = Command;
 public:
-    Estimate();
-
-    static const QCommandLineOption AdvancedOption;
+    using Ancestor::Ancestor;
 
 private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
     int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
 };
 DECL_TRAITS(Estimate, "estimate", "Estimate the entropy of a password.");

--- a/src/cli/Exit.cpp
+++ b/src/cli/Exit.cpp
@@ -21,11 +21,6 @@
 #include <QObject>
 #include <QtGlobal>
 
-Exit::Exit()
-{
-    this->name = "exit";
-    description = QObject::tr("Exit interactive mode.");
-}
 
 int Exit::execImpl(CommandCtx &ctx, const QCommandLineParser &parser)
 {

--- a/src/cli/Exit.cpp
+++ b/src/cli/Exit.cpp
@@ -21,15 +21,17 @@
 #include <QObject>
 #include <QtGlobal>
 
-Exit::Exit(const QString& name)
+Exit::Exit()
 {
-    this->name = name;
+    this->name = "exit";
     description = QObject::tr("Exit interactive mode.");
 }
 
-int Exit::execute(const QStringList& arguments)
+int Exit::execImpl(CommandCtx &ctx, const QCommandLineParser &parser)
 {
-    Q_UNUSED(arguments)
-    // A placeholder only, behavior is implemented in keepassxc-cli.cpp.
+    Q_UNUSED(parser);
+    Q_ASSERT(ctx.getRunmode() == Runmode::InteractiveCmd);
+
+    ctx.stopInteractive();
     return EXIT_SUCCESS;
 }

--- a/src/cli/Exit.h
+++ b/src/cli/Exit.h
@@ -26,8 +26,18 @@
 class Exit : public Command
 {
 public:
-    Exit(const QString& name);
-    int execute(const QStringList& arguments) override;
+    Exit();
+
+private:
+    int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
+};
+
+template<>
+struct CommandTraits<Exit>
+{
+    static constexpr const char* Name = "exit";
+    static constexpr const char* Alias = "quit";
+    static constexpr const char* Description = "Exit interactive mode.";
 };
 
 #endif // KEEPASSXC_EXIT_H

--- a/src/cli/Exit.h
+++ b/src/cli/Exit.h
@@ -23,10 +23,12 @@
 
 #include "Command.h"
 
-class Exit : public Command
+class Exit final : public Command
 {
 public:
-    Exit();
+    Exit(const QString& name, const QString& description)
+        : Command(name, description, runmodeMask(Runmode::InteractiveCmd))
+    {}
 
 private:
     int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;

--- a/src/cli/Export.cpp
+++ b/src/cli/Export.cpp
@@ -25,17 +25,21 @@
 #include "core/Database.h"
 #include "format/CsvExporter.h"
 
-const QCommandLineOption Export::FormatOption = QCommandLineOption(
+const QCommandLineOption FormatOption = QCommandLineOption(
     QStringList() << "f"
                   << "format",
     QObject::tr("Format to use when exporting. Available choices are 'xml' or 'csv'. Defaults to 'xml'."),
     QStringLiteral("xml|csv"));
 
-Export::Export()
+
+CommandArgs Export::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QStringLiteral("export");
-    options.append(Export::FormatOption);
-    description = QObject::tr("Exports the content of a database to standard output in the specified format.");
+    static const CommandArgs args {
+        {},
+        {},
+        { FormatOption }
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int Export::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
@@ -44,7 +48,7 @@ int Export::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parse
     auto& err = Utils::STDERR;
 
     Database& database = ctx.getDb();
-    QString format = parser.value(Export::FormatOption);
+    QString format = parser.value(FormatOption);
     if (format.isEmpty() || format.startsWith(QStringLiteral("xml"), Qt::CaseInsensitive)) {
         QByteArray xmlData;
         QString errorMessage;

--- a/src/cli/Export.cpp
+++ b/src/cli/Export.cpp
@@ -38,16 +38,17 @@ Export::Export()
     description = QObject::tr("Exports the content of a database to standard output in the specified format.");
 }
 
-int Export::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+int Export::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     TextStream out(Utils::STDOUT.device());
     auto& err = Utils::STDERR;
 
-    QString format = parser->value(Export::FormatOption);
+    Database& database = ctx.getDb();
+    QString format = parser.value(Export::FormatOption);
     if (format.isEmpty() || format.startsWith(QStringLiteral("xml"), Qt::CaseInsensitive)) {
         QByteArray xmlData;
         QString errorMessage;
-        if (!database->extract(xmlData, &errorMessage)) {
+        if (!database.extract(xmlData, &errorMessage)) {
             err << QObject::tr("Unable to export database to XML: %1").arg(errorMessage) << endl;
             return EXIT_FAILURE;
         }

--- a/src/cli/Export.h
+++ b/src/cli/Export.h
@@ -25,9 +25,10 @@ class Export : public DatabaseCommand
 public:
     Export();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
     static const QCommandLineOption FormatOption;
 };
+DECL_TRAITS(Export, "export", "Exports the content of a database to standard output in the specified format.");
 
 #endif // KEEPASSXC_EXPORT_H

--- a/src/cli/Export.h
+++ b/src/cli/Export.h
@@ -20,14 +20,16 @@
 
 #include "DatabaseCommand.h"
 
-class Export : public DatabaseCommand
+class Export final : public DatabaseCommand
 {
 public:
-    Export();
+    Export(const QString& name, const QString& description)
+        : DatabaseCommand(name, description, runmodeMask(Runmode::SingleCmd))
+    {}
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
-
-    static const QCommandLineOption FormatOption;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Export, "export", "Exports the content of a database to standard output in the specified format.");
 

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -32,7 +32,7 @@ QSharedPointer<PasswordGenerator> createGenerator(CommandCtx& ctx, const QComman
         passwordGenerator->setLength(PasswordGenerator::DefaultLength);
 
     const int length = passwordLength.toInt();
-    BREAK_IF(length <= 0, nullptr,
+    BREAK_IF(length <= 0, QSharedPointer<PasswordGenerator>(nullptr),
              ctx, QObject::tr("Invalid password length=%1").arg(passwordLength));
     passwordGenerator->setLength(length);
 
@@ -69,7 +69,7 @@ QSharedPointer<PasswordGenerator> createGenerator(CommandCtx& ctx, const QComman
     passwordGenerator->setFlags(flags);
     passwordGenerator->setExcludedChars(parser.value(Generate::ExcludeCharsOption));
 
-    BREAK_IF(!passwordGenerator->isValid(), nullptr,
+    BREAK_IF(!passwordGenerator->isValid(), QSharedPointer<PasswordGenerator>(nullptr),
              ctx, QObject::tr("Invalid password generator after applying all options"));
     return passwordGenerator;
 }

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -111,19 +111,27 @@ const QCommandLineOption Generate::ExcludeSimilarCharsOption =
 
 const QCommandLineOption Generate::IncludeEveryGroupOption =
     QCommandLineOption(QStringList() << "every-group", QObject::tr("Include characters from every selected group"));
-Generate::Generate()
+
+
+CommandArgs Generate::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("generate");
-    description = QObject::tr("Generate a new random password.");
-    options.append(Generate::PasswordLengthOption);
-    options.append(Generate::LowerCaseOption);
-    options.append(Generate::UpperCaseOption);
-    options.append(Generate::NumbersOption);
-    options.append(Generate::SpecialCharsOption);
-    options.append(Generate::ExtendedAsciiOption);
-    options.append(Generate::ExcludeCharsOption);
-    options.append(Generate::ExcludeSimilarCharsOption);
-    options.append(Generate::IncludeEveryGroupOption);
+    Q_UNUSED(ctx);
+    static const CommandArgs args {
+        {},
+        {},
+        {
+            Generate::PasswordLengthOption,
+            Generate::LowerCaseOption,
+            Generate::UpperCaseOption,
+            Generate::NumbersOption,
+            Generate::SpecialCharsOption,
+            Generate::ExtendedAsciiOption,
+            Generate::ExcludeCharsOption,
+            Generate::ExcludeSimilarCharsOption,
+            Generate::IncludeEveryGroupOption
+        }
+    };
+    return args;
 }
 
 int Generate::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -27,17 +27,16 @@
 QSharedPointer<PasswordGenerator> createGenerator(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     auto passwordGenerator = QSharedPointer<PasswordGenerator>::create();
-    const QString& passwordLength = parser.value(Generate::PasswordLengthOption);
-    if (passwordLength.isEmpty())
-        passwordGenerator->setLength(PasswordGenerator::DefaultLength);
-
-    const int length = passwordLength.toInt();
-    BREAK_IF(length <= 0, QSharedPointer<PasswordGenerator>(nullptr),
-             ctx, QObject::tr("Invalid password length=%1").arg(passwordLength));
+    int length = PasswordGenerator::DefaultLength;
+    if (parser.isSet(Generate::PasswordLengthOption)) {
+        const QString& passwordLength = parser.value(Generate::PasswordLengthOption);
+        length = passwordLength.toInt();
+        BREAK_IF(length <= 0, QSharedPointer<PasswordGenerator>(nullptr),
+                 ctx, QObject::tr("Invalid password length %1").arg(passwordLength));
+    }
     passwordGenerator->setLength(length);
 
     PasswordGenerator::CharClasses classes = 0x0;
-
     if (parser.isSet(Generate::LowerCaseOption)) {
         classes |= PasswordGenerator::LowerLetters;
     }

--- a/src/cli/Generate.h
+++ b/src/cli/Generate.h
@@ -23,17 +23,17 @@
 #include "core/PasswordGenerator.h"
 
 
-
 /**
  * Creates a password generator instance using the command line options
  * of the parser object.
  */
 QSharedPointer<PasswordGenerator> createGenerator(CommandCtx& ctx, const QCommandLineParser& parser);
 
-class Generate : public Command
+class Generate final : public Command
 {
+    using Ancestor = Command;
 public:
-    Generate();
+    using Ancestor::Ancestor;
 
     static const QCommandLineOption PasswordLengthOption;
     static const QCommandLineOption LowerCaseOption;
@@ -46,7 +46,8 @@ public:
     static const QCommandLineOption IncludeEveryGroupOption;
 
 private:
-    int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
+    int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };
 DECL_TRAITS(Generate, "generate", "Generate a new random password.");
 

--- a/src/cli/Generate.h
+++ b/src/cli/Generate.h
@@ -31,9 +31,8 @@ QSharedPointer<PasswordGenerator> createGenerator(CommandCtx& ctx, const QComman
 
 class Generate final : public Command
 {
-    using Ancestor = Command;
 public:
-    using Ancestor::Ancestor;
+    using Command::Command;
 
     static const QCommandLineOption PasswordLengthOption;
     static const QCommandLineOption LowerCaseOption;

--- a/src/cli/Generate.h
+++ b/src/cli/Generate.h
@@ -22,13 +22,18 @@
 
 #include "core/PasswordGenerator.h"
 
+
+
+/**
+ * Creates a password generator instance using the command line options
+ * of the parser object.
+ */
+QSharedPointer<PasswordGenerator> createGenerator(CommandCtx& ctx, const QCommandLineParser& parser);
+
 class Generate : public Command
 {
 public:
     Generate();
-    int execute(const QStringList& arguments) override;
-
-    static QSharedPointer<PasswordGenerator> createGenerator(QSharedPointer<QCommandLineParser> parser);
 
     static const QCommandLineOption PasswordLengthOption;
     static const QCommandLineOption LowerCaseOption;
@@ -39,6 +44,10 @@ public:
     static const QCommandLineOption ExcludeCharsOption;
     static const QCommandLineOption ExcludeSimilarCharsOption;
     static const QCommandLineOption IncludeEveryGroupOption;
+
+private:
+    int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
 };
+DECL_TRAITS(Generate, "generate", "Generate a new random password.");
 
 #endif // KEEPASSXC_GENERATE_H

--- a/src/cli/Help.cpp
+++ b/src/cli/Help.cpp
@@ -25,20 +25,19 @@ Help::Help()
 {
     name = QString("help");
     description = QObject::tr("Display command help.");
+
+    positionalArguments.append({QString("command"), QObject::tr("Command name."), QString("")});
 }
 
-int Help::execute(const QStringList& arguments)
+int Help::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     auto& out = Utils::STDOUT;
-    QSharedPointer<Command> command;
-    if (arguments.size() > 1 && (command = Commands::getCommand(arguments.at(1)))) {
-        out << command->getHelpText();
-    } else {
-        out << "\n\n" << QObject::tr("Available commands:") << "\n";
-        for (auto& cmd : Commands::getCommands()) {
-            out << cmd->getDescriptionLine();
-        }
-    }
-    out.flush();
+
+    const QString& cmdName = parser.positionalArguments().first();
+    QSharedPointer<Command> cmd = ctx.getCmd(cmdName);
+    BREAK_IF(!cmd, EXIT_FAILURE,
+             ctx, QString("Command '%1' not found.").arg(cmdName));
+
+    out << cmd->getHelpText(parser) << endl;
     return EXIT_SUCCESS;
 }

--- a/src/cli/Help.cpp
+++ b/src/cli/Help.cpp
@@ -42,8 +42,9 @@ int Help::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
     if (args.empty()) {
         out << "\n\n" << QObject::tr("Available commands:") << "\n";
         ctx.forEachCmd([&out, &ctx] (const Command& cmd) {
-            if (cmd.isAllowedRunmode(ctx.getRunmode()))
+            if (cmd.isAllowedRunmode(ctx.getRunmode())) {
                 out << cmd.getDescriptionLine();
+            }
         });
         out << endl;
         return EXIT_SUCCESS;

--- a/src/cli/Help.h
+++ b/src/cli/Help.h
@@ -20,14 +20,15 @@
 
 #include "Command.h"
 
-class Help : public Command
+class Help final : public Command
 {
+    using Ancestor = Command;
 public:
-    Help();
-    ~Help() override = default;
+    using Ancestor::Ancestor;
 
 private:
-    int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
+    int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };
 DECL_TRAITS(Help, "help", "Display command help.");
 

--- a/src/cli/Help.h
+++ b/src/cli/Help.h
@@ -22,9 +22,8 @@
 
 class Help final : public Command
 {
-    using Ancestor = Command;
 public:
-    using Ancestor::Ancestor;
+    using Command::Command;
 
 private:
     CommandArgs getParserArgs(const CommandCtx& ctx) const override;

--- a/src/cli/Help.h
+++ b/src/cli/Help.h
@@ -25,7 +25,10 @@ class Help : public Command
 public:
     Help();
     ~Help() override = default;
-    int execute(const QStringList& arguments) override;
+
+private:
+    int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
 };
+DECL_TRAITS(Help, "help", "Display command help.");
 
 #endif // KEEPASSXC_HELP_H

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -48,17 +48,14 @@ Import::Import()
     positionalArguments.append({QString("database"), QObject::tr("Path of the new database."), QString("")});
 }
 
-int Import::execute(const QStringList& arguments)
+int Import::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
 {
-    QSharedPointer<QCommandLineParser> parser = getCommandLineParser(arguments);
-    if (parser.isNull()) {
-        return EXIT_FAILURE;
-    }
+    Q_UNUSED(ctx);
 
-    auto& out = parser->isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT;
+    auto& out = parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser->positionalArguments();
+    const QStringList& args = parser.positionalArguments();
     const QString& xmlExportPath = args.at(0);
     const QString& dbPath = args.at(1);
 

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -64,8 +64,9 @@ int Import::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& err = Utils::STDERR;
 
     const QStringList& args = parser.positionalArguments();
-    const QString& xmlExportPath = getArg(0, ctx.getRunmode(), args);
-    const QString& dbPath = getArg(1, ctx.getRunmode(), args);
+    Q_ASSERT(args.size() == 2);
+    const QString& xmlExportPath = args.first();
+    const QString& dbPath = args.last();
 
     if (QFileInfo::exists(dbPath)) {
         err << QObject::tr("File %1 already exists.").arg(dbPath) << endl;

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -64,8 +64,8 @@ int Import::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& err = Utils::STDERR;
 
     const QStringList& args = parser.positionalArguments();
-    const QString& xmlExportPath = args.at(0);
-    const QString& dbPath = args.at(1);
+    const QString& xmlExportPath = getArg(0, ctx.getRunmode(), args);
+    const QString& dbPath = getArg(1, ctx.getRunmode(), args);
 
     if (QFileInfo::exists(dbPath)) {
         err << QObject::tr("File %1 already exists.").arg(dbPath) << endl;

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -40,12 +40,20 @@
  *
  * @return EXIT_SUCCESS on success, or EXIT_FAILURE on failure
  */
-Import::Import()
+
+
+CommandArgs Import::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("import");
-    description = QObject::tr("Import the contents of an XML database.");
-    positionalArguments.append({QString("xml"), QObject::tr("Path of the XML database export."), QString("")});
-    positionalArguments.append({QString("database"), QObject::tr("Path of the new database."), QString("")});
+    Q_UNUSED(ctx);
+    static const CommandArgs args {
+        {
+            { "xml", QObject::tr("Path of the XML database export."), "" },
+            { "database", QObject::tr("Path of the new database."), "" }
+        },
+        {},
+        {}
+    };
+    return args;
 }
 
 int Import::execImpl(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/Import.h
+++ b/src/cli/Import.h
@@ -24,7 +24,10 @@ class Import : public Command
 {
 public:
     Import();
-    int execute(const QStringList& arguments) override;
+
+private:
+    int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
 };
+DECL_TRAITS(Import, "import", "Import the contents of an XML database.");
 
 #endif // KEEPASSXC_IMPORT_H

--- a/src/cli/Import.h
+++ b/src/cli/Import.h
@@ -20,13 +20,16 @@
 
 #include "Command.h"
 
-class Import : public Command
+class Import final : public Command
 {
 public:
-    Import();
+    Import(const QString& name, const QString& description)
+        : Command(name, description, runmodeMask(Runmode::SingleCmd))
+    {}
 
 private:
-    int execImpl(CommandCtx &ctx, const QCommandLineParser &parser) override;
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
+    int execImpl(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };
 DECL_TRAITS(Import, "import", "Import the contents of an XML database.");
 

--- a/src/cli/Info.cpp
+++ b/src/cli/Info.cpp
@@ -25,12 +25,6 @@
 #include "core/Metadata.h"
 #include "format/KeePass2.h"
 
-Info::Info()
-{
-    name = QString("db-info");
-    description = QObject::tr("Show a database's information.");
-}
-
 int Info::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     Q_UNUSED(parser);

--- a/src/cli/Info.cpp
+++ b/src/cli/Info.cpp
@@ -31,20 +31,22 @@ Info::Info()
     description = QObject::tr("Show a database's information.");
 }
 
-int Info::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser>)
+int Info::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
+    Q_UNUSED(parser);
     auto& out = Utils::STDOUT;
 
-    out << QObject::tr("UUID: ") << database->uuid().toString() << endl;
-    out << QObject::tr("Name: ") << database->metadata()->name() << endl;
-    out << QObject::tr("Description: ") << database->metadata()->description() << endl;
+    const Database& database = ctx.getDb();
+    out << QObject::tr("UUID: ") << database.uuid().toString() << endl;
+    out << QObject::tr("Name: ") << database.metadata()->name() << endl;
+    out << QObject::tr("Description: ") << database.metadata()->description() << endl;
     for (auto& cipher : asConst(KeePass2::CIPHERS)) {
-        if (cipher.first == database->cipher()) {
+        if (cipher.first == database.cipher()) {
             out << QObject::tr("Cipher: ") << cipher.second << endl;
         }
     }
-    out << QObject::tr("KDF: ") << database->kdf()->toString() << endl;
-    if (database->metadata()->recycleBinEnabled()) {
+    out << QObject::tr("KDF: ") << database.kdf()->toString() << endl;
+    if (database.metadata()->recycleBinEnabled()) {
         out << QObject::tr("Recycle bin is enabled.") << endl;
     } else {
         out << QObject::tr("Recycle bin is not enabled.") << endl;

--- a/src/cli/Info.h
+++ b/src/cli/Info.h
@@ -20,12 +20,13 @@
 
 #include "DatabaseCommand.h"
 
-class Info : public DatabaseCommand
+class Info final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Info();
+    using Ancestor::Ancestor;
 
-    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };
 DECL_TRAITS(Info, "db-info", "Show a database's information.");
 

--- a/src/cli/Info.h
+++ b/src/cli/Info.h
@@ -22,9 +22,8 @@
 
 class Info final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };

--- a/src/cli/Info.h
+++ b/src/cli/Info.h
@@ -25,7 +25,8 @@ class Info : public DatabaseCommand
 public:
     Info();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
 };
+DECL_TRAITS(Info, "db-info", "Show a database's information.");
 
 #endif // KEEPASSXC_INFO_H

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -53,18 +53,17 @@ int List::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser.positionalArguments();
-    bool recursive = parser.isSet(RecursiveOption);
-    bool flatten = parser.isSet(FlattenOption);
+    const bool recursive = parser.isSet(RecursiveOption);
+    const bool flatten = parser.isSet(FlattenOption);
 
     Database& database = ctx.getDb();
+    const QStringList args = parser.positionalArguments();
     // No group provided, defaulting to root group.
-    if (args.size() == 1) {
+    if (args.empty() || (ctx.getRunmode() == Runmode::SingleCmd && args.size() == 1)) {
         out << database.rootGroup()->print(recursive, flatten) << flush;
         return EXIT_SUCCESS;
     }
-
-    const QString& groupPath = args.at(1);
+    const QString& groupPath = getArg(0, ctx.getRunmode(), args);
     const Group* group = database.rootGroup()->findGroupByPath(groupPath);
     if (!group) {
         err << QObject::tr("Cannot find group %1.").arg(groupPath) << endl;

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -26,23 +26,26 @@
 #include "core/Entry.h"
 #include "core/Group.h"
 
-const QCommandLineOption List::RecursiveOption =
+const QCommandLineOption RecursiveOption =
     QCommandLineOption(QStringList() << "R"
                                      << "recursive",
                        QObject::tr("Recursively list the elements of the group."));
 
-const QCommandLineOption List::FlattenOption = QCommandLineOption(QStringList() << "f"
+const QCommandLineOption FlattenOption = QCommandLineOption(QStringList() << "f"
                                                                                 << "flatten",
                                                                   QObject::tr("Flattens the output to single lines."));
 
-List::List()
+CommandArgs List::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("ls");
-    description = QObject::tr("List database entries.");
-    options.append(List::RecursiveOption);
-    options.append(List::FlattenOption);
-    optionalArguments.append(
-        {QString("group"), QObject::tr("Path of the group to list. Default is /"), QString("[group]")});
+    static const CommandArgs args {
+        {},
+        { {"group", QObject::tr("Path of the group to list. Default is /"), "[group]"} },
+        {
+            RecursiveOption,
+            FlattenOption
+        }
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int List::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
@@ -51,8 +54,8 @@ int List::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& err = Utils::STDERR;
 
     const QStringList args = parser.positionalArguments();
-    bool recursive = parser.isSet(List::RecursiveOption);
-    bool flatten = parser.isSet(List::FlattenOption);
+    bool recursive = parser.isSet(RecursiveOption);
+    bool flatten = parser.isSet(FlattenOption);
 
     Database& database = ctx.getDb();
     // No group provided, defaulting to root group.

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -45,23 +45,24 @@ List::List()
         {QString("group"), QObject::tr("Path of the group to list. Default is /"), QString("[group]")});
 }
 
-int List::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+int List::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser->positionalArguments();
-    bool recursive = parser->isSet(List::RecursiveOption);
-    bool flatten = parser->isSet(List::FlattenOption);
+    const QStringList args = parser.positionalArguments();
+    bool recursive = parser.isSet(List::RecursiveOption);
+    bool flatten = parser.isSet(List::FlattenOption);
 
+    Database& database = ctx.getDb();
     // No group provided, defaulting to root group.
     if (args.size() == 1) {
-        out << database->rootGroup()->print(recursive, flatten) << flush;
+        out << database.rootGroup()->print(recursive, flatten) << flush;
         return EXIT_SUCCESS;
     }
 
     const QString& groupPath = args.at(1);
-    Group* group = database->rootGroup()->findGroupByPath(groupPath);
+    const Group* group = database.rootGroup()->findGroupByPath(groupPath);
     if (!group) {
         err << QObject::tr("Cannot find group %1.").arg(groupPath) << endl;
         return EXIT_FAILURE;

--- a/src/cli/List.h
+++ b/src/cli/List.h
@@ -22,9 +22,8 @@
 
 class List final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 

--- a/src/cli/List.h
+++ b/src/cli/List.h
@@ -20,15 +20,16 @@
 
 #include "DatabaseCommand.h"
 
-class List : public DatabaseCommand
+class List final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    List();
+    using Ancestor::Ancestor;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
-    static const QCommandLineOption RecursiveOption;
-    static const QCommandLineOption FlattenOption;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(List, "ls", "List database entries.");
 

--- a/src/cli/List.h
+++ b/src/cli/List.h
@@ -25,10 +25,11 @@ class List : public DatabaseCommand
 public:
     List();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
     static const QCommandLineOption RecursiveOption;
     static const QCommandLineOption FlattenOption;
 };
+DECL_TRAITS(List, "ls", "List database entries.");
 
 #endif // KEEPASSXC_LIST_H

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -36,15 +36,15 @@ Locate::Locate()
     positionalArguments.append({QString("term"), QObject::tr("Search term."), QString("")});
 }
 
-int Locate::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+int Locate::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser->positionalArguments();
+    const QStringList args = parser.positionalArguments();
     const QString& searchTerm = args.at(1);
 
-    QStringList results = database->rootGroup()->locate(searchTerm);
+    const QStringList& results = ctx.getDb().rootGroup()->locate(searchTerm);
     if (results.isEmpty()) {
         err << "No results for that search term." << endl;
         return EXIT_FAILURE;

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -45,16 +45,14 @@ int Locate::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parse
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser.positionalArguments();
-    const QString& searchTerm = args.at(1);
-
-    const QStringList& results = ctx.getDb().rootGroup()->locate(searchTerm);
+    const QStringList& results = ctx.getDb().rootGroup()->locate(getArg(0, ctx.getRunmode(),
+                                                                        parser.positionalArguments()));
     if (results.isEmpty()) {
         err << "No results for that search term." << endl;
-        return EXIT_FAILURE;
+        return EXIT_SUCCESS;
     }
 
-    for (const QString& result : asConst(results)) {
+    for (const QString& result : results) {
         out << result << endl;
     }
     return EXIT_SUCCESS;

--- a/src/cli/Locate.cpp
+++ b/src/cli/Locate.cpp
@@ -29,11 +29,15 @@
 #include "core/Global.h"
 #include "core/Group.h"
 
-Locate::Locate()
+
+CommandArgs Locate::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("locate");
-    description = QObject::tr("Find entries quickly.");
-    positionalArguments.append({QString("term"), QObject::tr("Search term."), QString("")});
+    static const CommandArgs args {
+        { {"term", QObject::tr("Search term."), ""} },
+        {},
+        {}
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int Locate::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/Locate.h
+++ b/src/cli/Locate.h
@@ -22,10 +22,14 @@
 
 class Locate : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Locate();
+    using Ancestor::Ancestor;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Locate, "locate", "Find entries quickly.");
 

--- a/src/cli/Locate.h
+++ b/src/cli/Locate.h
@@ -22,9 +22,8 @@
 
 class Locate : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 

--- a/src/cli/Locate.h
+++ b/src/cli/Locate.h
@@ -25,7 +25,8 @@ class Locate : public DatabaseCommand
 public:
     Locate();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };
+DECL_TRAITS(Locate, "locate", "Find entries quickly.");
 
 #endif // KEEPASSXC_LOCATE_H

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -73,10 +73,11 @@ int Merge::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser
     auto& err = Utils::STDERR;
 
     const QStringList args = parser.positionalArguments();
-
     Database& database = ctx.getDb();
-    const QString& toDatabasePath = args.at(0);
-    const QString& fromDatabasePath = args.at(1);
+    const int db2ArgIdx = ctx.getRunmode() == Runmode::InteractiveCmd ? 0 : 1;
+    Q_ASSERT(args.size() == db2ArgIdx + 1);
+    const QString& toDatabasePath = ctx.getDb().filePath();
+    const QString& fromDatabasePath = args.at(db2ArgIdx);
 
     std::unique_ptr<Database> db2;
     if (!parser.isSet(SameCredentialsOption)) {

--- a/src/cli/Merge.h
+++ b/src/cli/Merge.h
@@ -20,18 +20,16 @@
 
 #include "DatabaseCommand.h"
 
-class Merge : public DatabaseCommand
+class Merge final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Merge();
+    using Ancestor::Ancestor;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
-    static const QCommandLineOption SameCredentialsOption;
-    static const QCommandLineOption KeyFileFromOption;
-    static const QCommandLineOption NoPasswordFromOption;
-    static const QCommandLineOption YubiKeyFromOption;
-    static const QCommandLineOption DryRunOption;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Merge, "merge", "Merge two databases.");
 

--- a/src/cli/Merge.h
+++ b/src/cli/Merge.h
@@ -25,7 +25,7 @@ class Merge : public DatabaseCommand
 public:
     Merge();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 
     static const QCommandLineOption SameCredentialsOption;
     static const QCommandLineOption KeyFileFromOption;
@@ -33,5 +33,6 @@ public:
     static const QCommandLineOption YubiKeyFromOption;
     static const QCommandLineOption DryRunOption;
 };
+DECL_TRAITS(Merge, "merge", "Merge two databases.");
 
 #endif // KEEPASSXC_MERGE_H

--- a/src/cli/Merge.h
+++ b/src/cli/Merge.h
@@ -22,9 +22,8 @@
 
 class Merge final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 

--- a/src/cli/Move.cpp
+++ b/src/cli/Move.cpp
@@ -38,22 +38,23 @@ Move::~Move()
 {
 }
 
-int Move::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+int Move::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser->positionalArguments();
+    const QStringList args = parser.positionalArguments();
     const QString& entryPath = args.at(1);
     const QString& destinationPath = args.at(2);
 
-    Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
+    Database& database = ctx.getDb();
+    Entry* entry = database.rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
         err << QObject::tr("Could not find entry with path %1.").arg(entryPath) << endl;
         return EXIT_FAILURE;
     }
 
-    Group* destinationGroup = database->rootGroup()->findGroupByPath(destinationPath);
+    Group* destinationGroup = database.rootGroup()->findGroupByPath(destinationPath);
     if (!destinationGroup) {
         err << QObject::tr("Could not find group with path %1.").arg(destinationPath) << endl;
         return EXIT_FAILURE;
@@ -69,7 +70,7 @@ int Move::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     entry->endUpdate();
 
     QString errorMessage;
-    if (!database->save(&errorMessage, true, false)) {
+    if (!database.save(&errorMessage, true, false)) {
         err << QObject::tr("Writing the database failed %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Move.cpp
+++ b/src/cli/Move.cpp
@@ -46,8 +46,8 @@ int Move::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& err = Utils::STDERR;
 
     const QStringList args = parser.positionalArguments();
-    const QString& entryPath = args.at(1);
-    const QString& destinationPath = args.at(2);
+    const QString& entryPath = getArg(0, ctx.getRunmode(), args);
+    const QString& destinationPath = getArg(1, ctx.getRunmode(), args);
 
     Database& database = ctx.getDb();
     Entry* entry = database.rootGroup()->findEntryByPath(entryPath);

--- a/src/cli/Move.cpp
+++ b/src/cli/Move.cpp
@@ -26,16 +26,18 @@
 #include "core/Entry.h"
 #include "core/Group.h"
 
-Move::Move()
-{
-    name = QString("mv");
-    description = QObject::tr("Moves an entry to a new group.");
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to move."), QString("")});
-    positionalArguments.append({QString("group"), QObject::tr("Path of the destination group."), QString("")});
-}
 
-Move::~Move()
+CommandArgs Move::getParserArgs(const CommandCtx& ctx) const
 {
+    static const CommandArgs args {
+        {
+            {"entry", QObject::tr("Path of the entry to move."), ""},
+            {"group", QObject::tr("Path of the destination group."), ""}
+        },
+        {},
+        {}
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int Move::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/Move.h
+++ b/src/cli/Move.h
@@ -26,7 +26,8 @@ public:
     Move();
     ~Move();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
 };
+DECL_TRAITS(Move, "mv", "Moves an entry to a new group.");
 
 #endif // KEEPASSXC_MOVE_H

--- a/src/cli/Move.h
+++ b/src/cli/Move.h
@@ -22,9 +22,8 @@
 
 class Move final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 private:

--- a/src/cli/Move.h
+++ b/src/cli/Move.h
@@ -20,13 +20,15 @@
 
 #include "DatabaseCommand.h"
 
-class Move : public DatabaseCommand
+class Move final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Move();
-    ~Move();
+    using Ancestor::Ancestor;
 
-    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Move, "mv", "Moves an entry to a new group.");
 

--- a/src/cli/Open.cpp
+++ b/src/cli/Open.cpp
@@ -25,13 +25,6 @@
 #include "Utils.h"
 #include "core/Metadata.h"
 
-#include "Exit.h"
-
-Open::Open()
-{
-    name = QString("open");
-    description = QObject::tr("Open a database.");
-}
 
 class LineReader
 {
@@ -107,8 +100,6 @@ private:
 static int commandLoop(CommandCtx& ctx)
 {
     auto& err = Utils::STDERR;
-    // TODO_vanda: replace command list with interactive version
-    // Commands::setupCommands(true);
 
     QScopedPointer<LineReader> reader(new
 #if defined(USE_READLINE)
@@ -146,9 +137,6 @@ static int commandLoop(CommandCtx& ctx)
             err.flush();
             continue;
         }
-        // TODO_vanda: no need to insert 'path' when the command args become
-        // appropriate to current runmode
-        args.insert(1, ctx.getDb().filePath());
         if (cmd->execute(ctx, args) == EXIT_FAILURE) {
             err << QObject::tr("Failed to execute command '%1'.").arg(cmdName) << endl;
             for (const auto& e : ctx.getErrors())

--- a/src/cli/Open.cpp
+++ b/src/cli/Open.cpp
@@ -139,8 +139,9 @@ static int commandLoop(CommandCtx& ctx)
         }
         if (cmd->execute(ctx, args) == EXIT_FAILURE) {
             err << QObject::tr("Failed to execute command '%1'.").arg(cmdName) << endl;
-            for (const auto& e : ctx.getErrors())
+            for (const auto& e : ctx.getErrors()) {
                 err << e << endl;
+            }
             ctx.clearErrors();
         }
     }

--- a/src/cli/Open.h
+++ b/src/cli/Open.h
@@ -22,9 +22,8 @@
 
 class Open : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };

--- a/src/cli/Open.h
+++ b/src/cli/Open.h
@@ -24,8 +24,9 @@ class Open : public DatabaseCommand
 {
 public:
     Open();
-    int execute(const QStringList& arguments) override;
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
+
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };
+DECL_TRAITS(Open, "open", "Open a database.");
 
 #endif // KEEPASSXC_OPEN_H

--- a/src/cli/Open.h
+++ b/src/cli/Open.h
@@ -22,8 +22,9 @@
 
 class Open : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Open();
+    using Ancestor::Ancestor;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 };

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -45,7 +45,7 @@ int Remove::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parse
     auto& err = Utils::STDERR;
 
     Database& database = ctx.getDb();
-    auto& entryPath = parser.positionalArguments().at(1);
+    const QString& entryPath = getArg(0, ctx.getRunmode(), parser.positionalArguments());
     QPointer<Entry> entry = database.rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
         err << QObject::tr("Entry %1 not found.").arg(entryPath) << endl;

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -28,11 +28,15 @@
 #include "core/Metadata.h"
 #include "core/Tools.h"
 
-Remove::Remove()
+
+CommandArgs Remove::getParserArgs(const CommandCtx& ctx) const
 {
-    name = QString("rm");
-    description = QString("Remove an entry from the database.");
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to remove."), QString("")});
+    static const CommandArgs args {
+        { {"entry", QObject::tr("Path of the entry to remove."), ""} },
+        {},
+        {}
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int Remove::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/Remove.h
+++ b/src/cli/Remove.h
@@ -25,7 +25,8 @@ class Remove : public DatabaseCommand
 public:
     Remove();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
 };
+DECL_TRAITS(Remove, "rm", "Remove an entry from the database.");
 
 #endif // KEEPASSXC_REMOVE_H

--- a/src/cli/Remove.h
+++ b/src/cli/Remove.h
@@ -22,9 +22,8 @@
 
 class Remove final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 private:

--- a/src/cli/Remove.h
+++ b/src/cli/Remove.h
@@ -20,12 +20,15 @@
 
 #include "DatabaseCommand.h"
 
-class Remove : public DatabaseCommand
+class Remove final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Remove();
+    using Ancestor::Ancestor;
 
-    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Remove, "rm", "Remove an entry from the database.");
 

--- a/src/cli/RemoveGroup.cpp
+++ b/src/cli/RemoveGroup.cpp
@@ -44,11 +44,10 @@ int RemoveGroup::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& 
     auto& out = parser.isSet(Command::QuietOption) ? Utils::DEVNULL : Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    QString groupPath = parser.positionalArguments().at(1);
-
     // Recursive option means were looking for a group to remove.
     Database& database = ctx.getDb();
-    QPointer<Group> group = database.rootGroup()->findGroupByPath(groupPath);
+    const QString& groupPath = getArg(0, ctx.getRunmode(), parser.positionalArguments());
+    const QPointer<Group> group = database.rootGroup()->findGroupByPath(groupPath);
     if (!group) {
         err << QObject::tr("Group %1 not found.").arg(groupPath) << endl;
         return EXIT_FAILURE;

--- a/src/cli/RemoveGroup.cpp
+++ b/src/cli/RemoveGroup.cpp
@@ -28,15 +28,15 @@
 #include "core/Metadata.h"
 #include "core/Tools.h"
 
-RemoveGroup::RemoveGroup()
-{
-    name = QString("rmdir");
-    description = QString("Removes a group from a database.");
-    positionalArguments.append({QString("group"), QObject::tr("Path of the group to remove."), QString("")});
-}
 
-RemoveGroup::~RemoveGroup()
+CommandArgs RemoveGroup::getParserArgs(const CommandCtx& ctx) const
 {
+    static const CommandArgs args {
+        { {"group", QObject::tr("Path of the group to remove."), ""} },
+        {},
+        {}
+    };
+    return DatabaseCommand::getParserArgs(ctx).merge(args);
 }
 
 int RemoveGroup::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)

--- a/src/cli/RemoveGroup.h
+++ b/src/cli/RemoveGroup.h
@@ -22,9 +22,8 @@
 
 class RemoveGroup final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 private:

--- a/src/cli/RemoveGroup.h
+++ b/src/cli/RemoveGroup.h
@@ -26,7 +26,8 @@ public:
     RemoveGroup();
     ~RemoveGroup();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
 };
+DECL_TRAITS(RemoveGroup, "rmdir", "Removes a group from a database.");
 
 #endif // KEEPASSXC_REMOVEGROUP_H

--- a/src/cli/RemoveGroup.h
+++ b/src/cli/RemoveGroup.h
@@ -20,13 +20,15 @@
 
 #include "DatabaseCommand.h"
 
-class RemoveGroup : public DatabaseCommand
+class RemoveGroup final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    RemoveGroup();
-    ~RemoveGroup();
+    using Ancestor::Ancestor;
 
-    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(RemoveGroup, "rmdir", "Removes a group from a database.");
 

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -57,18 +57,18 @@ Show::Show()
     positionalArguments.append({QString("entry"), QObject::tr("Name of the entry to show."), QString("")});
 }
 
-int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+int Show::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
 {
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QStringList args = parser->positionalArguments();
-    const QString& entryPath = args.at(1);
-    bool showTotp = parser->isSet(Show::TotpOption);
-    bool showProtectedAttributes = parser->isSet(Show::ProtectedAttributesOption);
-    QStringList attributes = parser->values(Show::AttributesOption);
+    // TODO_vanda why at(1) ???
+    const QString& entryPath = parser.positionalArguments().at(1);
+    bool showTotp = parser.isSet(Show::TotpOption);
+    bool showProtectedAttributes = parser.isSet(Show::ProtectedAttributesOption);
+    QStringList attributes = parser.values(Show::AttributesOption);
 
-    Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
+    const Entry* entry = ctx.getDb().rootGroup()->findEntryByPath(entryPath);
     if (!entry) {
         err << QObject::tr("Could not find entry with path %1.").arg(entryPath) << endl;
         return EXIT_FAILURE;

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -64,7 +64,7 @@ int Show::executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser)
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
-    const QString entryPath = parser.positionalArguments().first();
+    const QString& entryPath = getArg(0, ctx.getRunmode(), parser.positionalArguments());
     bool showTotp = parser.isSet(TotpOption);
     bool showProtectedAttributes = parser.isSet(ProtectedAttributesOption);
     QStringList attributes = parser.values(AttributesOption);

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -22,9 +22,8 @@
 
 class Show final : public DatabaseCommand
 {
-    using Ancestor = DatabaseCommand;
 public:
-    using Ancestor::Ancestor;
+    using DatabaseCommand::DatabaseCommand;
 
     int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
 private:

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -25,11 +25,12 @@ class Show : public DatabaseCommand
 public:
     Show();
 
-    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
 
     static const QCommandLineOption TotpOption;
     static const QCommandLineOption AttributesOption;
     static const QCommandLineOption ProtectedAttributesOption;
 };
+DECL_TRAITS(Show, "show", "Show an entry's information.");
 
 #endif // KEEPASSXC_SHOW_H

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -20,16 +20,15 @@
 
 #include "DatabaseCommand.h"
 
-class Show : public DatabaseCommand
+class Show final : public DatabaseCommand
 {
+    using Ancestor = DatabaseCommand;
 public:
-    Show();
+    using Ancestor::Ancestor;
 
-    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser);
-
-    static const QCommandLineOption TotpOption;
-    static const QCommandLineOption AttributesOption;
-    static const QCommandLineOption ProtectedAttributesOption;
+    int executeWithDatabase(CommandCtx& ctx, const QCommandLineParser& parser) override;
+private:
+    CommandArgs getParserArgs(const CommandCtx& ctx) const override;
 };
 DECL_TRAITS(Show, "show", "Show an entry's information.");
 

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -304,7 +304,7 @@ namespace Utils
         }
 
         // No clipping program worked
-        err << QObject::tr("All clipping programs failed. Tried %1\n").arg(failedProgramNames.join(", "));
+        err << QObject::tr("All clipping programs failed. Tried: [%1]\n").arg(failedProgramNames.join(", "));
         err.flush();
         return EXIT_FAILURE;
     }

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -90,7 +90,7 @@ namespace Utils
 #endif
     }
 
-    QSharedPointer<Database> unlockDatabase(const QString& databaseFilename,
+    std::unique_ptr<Database> unlockDatabase(const QString& databaseFilename,
                                             const bool isPasswordProtected,
                                             const QString& keyFilename,
                                             const QString& yubiKeySlot,
@@ -173,13 +173,13 @@ namespace Utils
         Q_UNUSED(yubiKeySlot);
 #endif // WITH_XC_YUBIKEY
 
-        auto db = QSharedPointer<Database>::create();
+        auto db = Utils::make_unique<Database>();
         QString error;
         if (db->open(databaseFilename, compositeKey, &error, false)) {
             return db;
         } else {
             err << error << endl;
-            return {};
+            return nullptr;
         }
     }
 

--- a/src/cli/Utils.h
+++ b/src/cli/Utils.h
@@ -18,6 +18,8 @@
 #ifndef KEEPASSXC_UTILS_H
 #define KEEPASSXC_UTILS_H
 
+#include <memory>
+
 #include "cli/TextStream.h"
 #include "core/Database.h"
 #include "core/EntryAttributes.h"
@@ -25,6 +27,9 @@
 #include "keys/FileKey.h"
 #include "keys/PasswordKey.h"
 #include <QtCore/qglobal.h>
+#include "core/Tools.h"
+#include "crypto/Crypto.h"
+
 
 namespace Utils
 {
@@ -39,11 +44,11 @@ namespace Utils
     QString getPassword(bool quiet = false);
     QSharedPointer<PasswordKey> getConfirmedPassword();
     int clipText(const QString& text);
-    QSharedPointer<Database> unlockDatabase(const QString& databaseFilename,
-                                            const bool isPasswordProtected = true,
-                                            const QString& keyFilename = {},
-                                            const QString& yubiKeySlot = {},
-                                            bool quiet = false);
+    std::unique_ptr<Database> unlockDatabase(const QString& databaseFilename,
+                                             const bool isPasswordProtected = true,
+                                             const QString& keyFilename = {},
+                                             const QString& yubiKeySlot = {},
+                                             bool quiet = false);
 
     QStringList splitCommandString(const QString& command);
 
@@ -54,6 +59,19 @@ namespace Utils
      * (case-insensitive).
      */
     QStringList findAttributes(const EntryAttributes& attributes, const QString& name);
+
+    inline QTextStream& debugInfo(QTextStream& out)
+    {
+        out << Tools::debugInfo() << endl
+            << Crypto::debugInfo() << endl;
+        return out;
+    }
+
+    template<class T, class... Args>
+    std::unique_ptr<T> make_unique(Args&&... args)
+    {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
 }; // namespace Utils
 
 #endif // KEEPASSXC_UTILS_H

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -54,13 +54,13 @@ static int run(const QStringList& args)
     CommandCtx ctx(parser, args);
     if (ctx.error()) {
         err << "Failed to parse command:\n";
-        for (const auto& e : ctx.getErrors())
+        for (const auto& e : ctx.getErrors()) {
             err << e << endl;
+        }
         return EXIT_FAILURE;
     }
 
-    switch (ctx.getRunmode())
-    {
+    switch (ctx.getRunmode()) {
         case Runmode::Version:
             out << KEEPASSXC_VERSION << endl;
             return EXIT_SUCCESS;
@@ -82,8 +82,9 @@ static int run(const QStringList& args)
             }
             const int result = cmd->execute(ctx, cmdArgs);
             if (result == EXIT_FAILURE && ctx.error()) {
-                for (const auto& e : ctx.getErrors())
+                for (const auto& e : ctx.getErrors()) {
                     err << e << endl;
+                }
             }
             return result;
         }
@@ -104,8 +105,9 @@ int main(int argc, char** argv)
     Utils::setDefaultTextStreams();
 
     QStringList args;
-    for (int i = 0; i < argc; ++i)
+    for (int i = 0; i < argc; ++i) {
         args.push_back(argv[i]);
+    }
     const int exitCode = run(args);
 
 #if defined(WITH_ASAN) && defined(WITH_LSAN)

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -72,7 +72,8 @@ static int run(const QStringList& args)
             out << parser.helpText() << endl;
             return EXIT_SUCCESS;
         default: {
-            const QStringList& cmdArgs = parser.positionalArguments();
+            QStringList cmdArgs = args;
+            cmdArgs.removeFirst();
             const QString cmdName = cmdArgs.first();
             QSharedPointer<Command> cmd = ctx.getCmd(cmdName);
             if (!cmd) {

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -61,33 +61,33 @@ static int run(const QStringList& args)
     }
 
     switch (ctx.getRunmode()) {
-        case Runmode::Version:
-            out << KEEPASSXC_VERSION << endl;
-            return EXIT_SUCCESS;
-        case Runmode::DebugInfo:
-            Utils::debugInfo(out);
-            return EXIT_SUCCESS;
-        case Runmode::Help:
-            // cannot use 'showHelp' because of the asan postprocessing
-            out << parser.helpText() << endl;
-            return EXIT_SUCCESS;
-        default: {
-            QStringList cmdArgs = args;
-            cmdArgs.removeFirst();
-            const QString cmdName = cmdArgs.first();
-            QSharedPointer<Command> cmd = ctx.getCmd(cmdName);
-            if (!cmd) {
-                err << QObject::tr("Command '%1' not found.").arg(cmdName) << endl;
-                return EXIT_FAILURE;
-            }
-            const int result = cmd->execute(ctx, cmdArgs);
-            if (result == EXIT_FAILURE && ctx.error()) {
-                for (const auto& e : ctx.getErrors()) {
-                    err << e << endl;
-                }
-            }
-            return result;
+    case Runmode::Version:
+        out << KEEPASSXC_VERSION << endl;
+        return EXIT_SUCCESS;
+    case Runmode::DebugInfo:
+        Utils::debugInfo(out);
+        return EXIT_SUCCESS;
+    case Runmode::Help:
+        // cannot use 'showHelp' because of the asan postprocessing
+        out << parser.helpText() << endl;
+        return EXIT_SUCCESS;
+    default: {
+        QStringList cmdArgs = args;
+        cmdArgs.removeFirst();
+        const QString cmdName = cmdArgs.first();
+        QSharedPointer<Command> cmd = ctx.getCmd(cmdName);
+        if (!cmd) {
+            err << QObject::tr("Command '%1' not found.").arg(cmdName) << endl;
+            return EXIT_FAILURE;
         }
+        const int result = cmd->execute(ctx, cmdArgs);
+        if (result == EXIT_FAILURE && ctx.error()) {
+            for (const auto& e : ctx.getErrors()) {
+                err << e << endl;
+            }
+        }
+        return result;
+    }
     }
 }
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -726,7 +726,7 @@ Group* Group::findGroupByPathRecursive(const QString& groupPath, const QString& 
     return nullptr;
 }
 
-QString Group::print(bool recursive, bool flatten, int depth)
+QString Group::print(bool recursive, bool flatten, int depth) const
 {
     QString response;
     QString prefix;

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -162,7 +162,7 @@ public:
                  CloneFlags groupFlags = DefaultCloneFlags) const;
 
     void copyDataFrom(const Group* other);
-    QString print(bool recursive = false, bool flatten = false, int depth = 0);
+    QString print(bool recursive = false, bool flatten = false, int depth = 0) const;
 
     void addEntry(Entry* entry);
     void removeEntry(Entry* entry);

--- a/src/core/HibpOffline.cpp
+++ b/src/core/HibpOffline.cpp
@@ -77,10 +77,10 @@ namespace HibpOffline
     }
 
     bool
-    report(QSharedPointer<Database> db, QIODevice& hibpInput, QList<QPair<const Entry*, int>>& findings, QString* error)
+    report(const Database& db, QIODevice& hibpInput, QList<QPair<const Entry*, int>>& findings, QString* error)
     {
         QMultiHash<QByteArray, const Entry*> entriesBySha1;
-        for (const auto* entry : db->rootGroup()->entriesRecursive()) {
+        for (const auto* entry : db.rootGroup()->entriesRecursive()) {
             if (!entry->isRecycled()) {
                 const auto sha1 = QCryptographicHash::hash(entry->password().toUtf8(), QCryptographicHash::Sha1);
                 entriesBySha1.insert(sha1, entry);
@@ -105,5 +105,12 @@ namespace HibpOffline
                 findings.append({entry, count});
             }
         }
+    }
+
+    bool
+    report(QSharedPointer<Database> db, QIODevice& hibpInput, QList<QPair<const Entry*, int>>& findings, QString* error)
+    {
+        Q_ASSERT(!db.isNull());
+        return report(*db, hibpInput, findings, error);
     }
 } // namespace HibpOffline

--- a/src/core/HibpOffline.h
+++ b/src/core/HibpOffline.h
@@ -27,15 +27,12 @@ class Entry;
 
 namespace HibpOffline
 {
-    bool report(const Database& db,
-                QIODevice& hibpInput,
-                QList<QPair<const Entry*, int>>& findings,
-                QString* error);
+    bool report(const Database& db, QIODevice& hibpInput, QList<QPair<const Entry*, int>>& findings, QString* error);
 
     bool report(QSharedPointer<Database> db,
                 QIODevice& hibpInput,
                 QList<QPair<const Entry*, int>>& findings,
                 QString* error);
-}
+} // namespace HibpOffline
 
 #endif // KEEPASSXC_HIBPOFFLINE_H

--- a/src/core/HibpOffline.h
+++ b/src/core/HibpOffline.h
@@ -27,6 +27,11 @@ class Entry;
 
 namespace HibpOffline
 {
+    bool report(const Database& db,
+                QIODevice& hibpInput,
+                QList<QPair<const Entry*, int>>& findings,
+                QString* error);
+
     bool report(QSharedPointer<Database> db,
                 QIODevice& hibpInput,
                 QList<QPair<const Entry*, int>>& findings,

--- a/src/format/CsvExporter.cpp
+++ b/src/format/CsvExporter.cpp
@@ -48,9 +48,15 @@ bool CsvExporter::exportDatabase(QIODevice* device, const QSharedPointer<const D
     return true;
 }
 
+QString CsvExporter::exportDatabase(const Database& db)
+{
+    return exportHeader() + exportGroup(db.rootGroup());
+}
+
 QString CsvExporter::exportDatabase(const QSharedPointer<const Database>& db)
 {
-    return exportHeader() + exportGroup(db->rootGroup());
+    Q_ASSERT(db);
+    return exportDatabase(*db);
 }
 
 QString CsvExporter::errorString() const

--- a/src/format/CsvExporter.h
+++ b/src/format/CsvExporter.h
@@ -31,6 +31,7 @@ class CsvExporter
 public:
     bool exportDatabase(const QString& filename, const QSharedPointer<const Database>& db);
     bool exportDatabase(QIODevice* device, const QSharedPointer<const Database>& db);
+    QString exportDatabase(const Database& db);
     QString exportDatabase(const QSharedPointer<const Database>& db);
     QString errorString() const;
 

--- a/tests/TestCli.h
+++ b/tests/TestCli.h
@@ -66,13 +66,11 @@ private slots:
     void testKeyFileOption();
     void testNoPasswordOption();
     void testHelp();
-    void testInteractiveCommands();
     void testList();
     void testLocate();
     void testMerge();
     void testMergeWithKeys();
     void testMove();
-    void testOpen();
     void testRemove();
     void testRemoveGroup();
     void testRemoveQuiet();


### PR DESCRIPTION
Fixes #5166 and #4553.
Fixes asan posprocessing leak report (it wasn't suppressed).

Command hierarchy and execution process refactored.
Command execution process uses context object to retrieve all neccessary data.
Now the 'CommandCtx' is a single point of control: it keeps DB reference and current runmode info thus allowing commands to be freed from tracking this. 
Command is responsible only for parsing its arguments (by building QCommandLineParser object) and executing.

## Testing strategy
Checked existing unit-tests.
Checked cli commands by hand.
Don't provide new unit-tests.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Refactor (significant modification to existing code)
