### PR TITLE
Only display domain name in browser access confirm dialog

### DIFF
--- a/src/browser/BrowserAccessControlDialog.cpp
+++ b/src/browser/BrowserAccessControlDialog.cpp
@@ -37,9 +37,11 @@ BrowserAccessControlDialog::~BrowserAccessControlDialog()
 {
 }
 
-void BrowserAccessControlDialog::setItems(const QList<Entry*>& items, const QString& hostname, bool httpAuth)
+void BrowserAccessControlDialog::setItems(const QList<Entry*>& items, const QString& urlString, bool httpAuth)
 {
-    m_ui->siteLabel->setText(m_ui->siteLabel->text().arg(hostname));
+    QUrl url(urlString);
+    m_ui->siteLabel->setText(m_ui->siteLabel->text().arg(
+        url.toDisplayString(QUrl::RemoveUserInfo | QUrl::RemovePath | QUrl::RemoveQuery | QUrl::RemoveFragment)));
 
     m_ui->rememberDecisionCheckBox->setVisible(!httpAuth);
     m_ui->rememberDecisionCheckBox->setChecked(false);

--- a/src/browser/BrowserAccessControlDialog.h
+++ b/src/browser/BrowserAccessControlDialog.h
@@ -38,7 +38,7 @@ public:
     explicit BrowserAccessControlDialog(QWidget* parent = nullptr);
     ~BrowserAccessControlDialog() override;
 
-    void setItems(const QList<Entry*>& items, const QString& hostname, bool httpAuth);
+    void setItems(const QList<Entry*>& items, const QString& urlString, bool httpAuth);
     bool remember() const;
 
     QList<QTableWidgetItem*> getSelectedEntries() const;

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -776,7 +776,7 @@ QList<Entry*> BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
         config.save(entry);
     });
 
-    accessControlDialog.setItems(pwEntriesToConfirm, !submitHost.isEmpty() ? submitHost : url, httpAuth);
+    accessControlDialog.setItems(pwEntriesToConfirm, url, httpAuth);
 
     QList<Entry*> allowedEntries;
     if (accessControlDialog.exec() == QDialog::Accepted) {


### PR DESCRIPTION
* Prevents dialog from growing in width if there is a really long url requesting access.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
**BEFORE:**
![image](https://user-images.githubusercontent.com/2809491/89123745-bc2a5180-d49f-11ea-9d42-33073a35321d.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/2809491/89123741-b6347080-d49f-11ea-9992-242712be5a73.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)