### PR TITLE
Fix clipped labels when Light/Dark theme is used

### DIFF
--- a/src/gui/CategoryListWidget.cpp
+++ b/src/gui/CategoryListWidget.cpp
@@ -221,6 +221,7 @@ void CategoryListWidgetDelegate::paint(QPainter* painter,
     opt.icon = QIcon();
     opt.decorationAlignment = Qt::AlignHCenter | Qt::AlignVCenter;
     opt.decorationPosition = QStyleOptionViewItem::Top;
+    opt.decorationSize = iconSize;
 
     QScopedPointer<QStyle> style(new IconSelectionCorrectedStyle());
     style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);


### PR DESCRIPTION
I've tested a321471 and PR #5185 doesn't fix the problem with clipped labels of category widget ~on systems with HiDPI displays~. This PR should fix the issue.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Fixes #5164

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![comparison](https://user-images.githubusercontent.com/271097/89425801-18140500-d742-11ea-845a-6a9b6532eca4.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
I've tested it only under Arch Linux though and only with 2 devices (17" HD+ and 15" FHD).

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

