### PR TITLE
Update "Open Auto-Type help webpage" URL

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -220,7 +220,8 @@ void EditEntryWidget::setupIcon()
 
 void EditEntryWidget::openAutotypeHelp()
 {
-    QDesktopServices::openUrl(QUrl("https://github.com/keepassxreboot/keepassxc/wiki/Autotype-Custom-Sequence"));
+    QDesktopServices::openUrl(
+        QUrl("https://keepassxc.org/docs/KeePassXC_UserGuide.html#_configure_auto_type_sequences"));
 }
 
 void EditEntryWidget::setupAutoType()


### PR DESCRIPTION
Update "Open Auto-Type help webpage" URL to the actual documentation site.

## Testing strategy

Probably not necessary just for an updated URL.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Documentation (non-code change)
