### PR TITLE
Add 'delete entry without confirm' functionality

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -134,6 +134,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_ResetTouchId, {QS("Security/ResetTouchId"), Roaming, false}},
     {Config::Security_ResetTouchIdTimeout, {QS("Security/ResetTouchIdTimeout"), Roaming, 30}},
     {Config::Security_ResetTouchIdScreenlock,{QS("Security/ResetTouchIdScreenlock"), Roaming, true}},
+    {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},
 
     // Browser
     {Config::Browser_Enabled, {QS("Browser/Enabled"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -116,6 +116,7 @@ public:
         Security_ResetTouchId,
         Security_ResetTouchIdTimeout,
         Security_ResetTouchIdScreenlock,
+        Security_NoConfirmMoveEntryToRecycleBin,
 
         Browser_Enabled,
         Browser_ShowNotification,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -278,6 +278,8 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->passwordsRepeatVisibleCheckBox->setChecked(
         config()->get(Config::Security_PasswordsRepeatVisible).toBool());
     m_secUi->hideNotesCheckBox->setChecked(config()->get(Config::Security_HideNotes).toBool());
+    m_secUi->NoConfirmMoveEntryToRecycleBinCheckBox->setChecked(
+        config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool());
 
     m_secUi->touchIDResetCheckBox->setChecked(config()->get(Config::Security_ResetTouchId).toBool());
     m_secUi->touchIDResetSpinBox->setValue(config()->get(Config::Security_ResetTouchIdTimeout).toInt());
@@ -376,6 +378,8 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::Security_HidePasswordPreviewPanel, m_secUi->passwordPreviewCleartextCheckBox->isChecked());
     config()->set(Config::Security_PasswordsRepeatVisible, m_secUi->passwordsRepeatVisibleCheckBox->isChecked());
     config()->set(Config::Security_HideNotes, m_secUi->hideNotesCheckBox->isChecked());
+    config()->set(Config::Security_NoConfirmMoveEntryToRecycleBin,
+                  m_secUi->NoConfirmMoveEntryToRecycleBinCheckBox->isChecked());
 
     config()->set(Config::Security_ResetTouchId, m_secUi->touchIDResetCheckBox->isChecked());
     config()->set(Config::Security_ResetTouchIdTimeout, m_secUi->touchIDResetSpinBox->value());

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -257,6 +257,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="NoConfirmMoveEntryToRecycleBinCheckBox">
+        <property name="text">
+         <string>Move entries to recycle bin without confirmation</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -609,6 +609,8 @@ bool DatabaseWidget::confirmDeleteEntries(QList<Entry*> entries, bool permanent)
                                            MessageBox::Cancel);
 
         return answer == MessageBox::Delete;
+    } else if (config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool()) {
+        return true;
     } else {
         QString prompt;
         if (entries.size() == 1) {


### PR DESCRIPTION
Fixes #5232 

If this feature is considered, a new checkbox is introduced in the settings -> security -> convenience - section. 
When checked, the confirmation dialog before entries are moved/deleted will not appear and the entry/entries
will be moved to recycle bin or deleted.

## Screenshots

## Testing strategy
Deleted entry / entries with & without checkbox checked.

## Type of change
- ✅ New feature (change that adds functionality) 