### PR TITLE
Feature/toggle groups panel option

### DIFF
--- a/docs/topics/UserInterface.adoc
+++ b/docs/topics/UserInterface.adoc
@@ -10,7 +10,7 @@ The KeePassXC interface is designed for simplicity and easy access to your infor
 .Main database interface
 image::main_interface.png[]
 
-*(A) Groups* - Organize your entries into discrete groups to bring order to all of your sensitive information. Groups can be nested under each other to create a hierarchy. Settings from parent groups get applied to their children.
+*(A) Groups* - Organize your entries into discrete groups to bring order to all of your sensitive information. Groups can be nested under each other to create a hierarchy. Settings from parent groups get applied to their children. You can hide this panel on the View menu.
 
 *(B) Entries* - Entries contain all the information for each website or application you are storing in KeePassXC. This view shows all the entries in the selected group. Each column can be resized, reordered, and shown or hidden based on your preference. Right click the header row to see all available options.
 

--- a/share/translations/keepassx_en.ts
+++ b/share/translations/keepassx_en.ts
@@ -4872,6 +4872,10 @@ Expect some bugs and minor issues, this version is not meant for production use.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show Groups Panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show Preview Panel</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -90,6 +90,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_Language, {QS("GUI/Language"), Roaming, QS("system")}},
     {Config::GUI_HideToolbar, {QS("GUI/HideToolbar"), Roaming, false}},
     {Config::GUI_MovableToolbar, {QS("GUI/MovableToolbar"), Roaming, false}},
+    {Config::GUI_HideGroupsPanel, {QS("GUI/HideGroupsPanel"), Roaming, false}},
     {Config::GUI_HidePreviewPanel, {QS("GUI/HidePreviewPanel"), Roaming, false}},
     {Config::GUI_ToolButtonStyle, {QS("GUI/ToolButtonStyle"), Roaming, Qt::ToolButtonIconOnly}},
     {Config::GUI_ShowTrayIcon, {QS("GUI/ShowTrayIcon"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -73,6 +73,7 @@ public:
         GUI_Language,
         GUI_HideToolbar,
         GUI_MovableToolbar,
+        GUI_HideGroupsPanel,
         GUI_HidePreviewPanel,
         GUI_ToolButtonStyle,
         GUI_ShowTrayIcon,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1698,6 +1698,11 @@ void MainWindow::initViewMenu()
         applySettingsChanges();
     });
 
+    m_ui->actionShowGroupsPanel->setChecked(!config()->get(Config::GUI_HideGroupsPanel).toBool());
+    connect(m_ui->actionShowGroupsPanel, &QAction::toggled, this, [](bool checked) {
+        config()->set(Config::GUI_HideGroupsPanel, !checked);
+    });
+
     m_ui->actionShowPreviewPanel->setChecked(!config()->get(Config::GUI_HidePreviewPanel).toBool());
     connect(m_ui->actionShowPreviewPanel, &QAction::toggled, this, [](bool checked) {
         config()->set(Config::GUI_HidePreviewPanel, !checked);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -368,6 +368,7 @@
     </widget>
     <addaction name="menuTheme"/>
     <addaction name="actionCompactMode"/>
+    <addaction name="actionShowGroupsPanel"/>
     <addaction name="actionShowPreviewPanel"/>
     <addaction name="actionShowToolbar"/>
    </widget>
@@ -914,6 +915,17 @@
    </property>
    <property name="text">
     <string>Show Toolbar</string>
+   </property>
+  </action>
+  <action name="actionShowGroupsPanel">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Groups Panel</string>
    </property>
   </action>
   <action name="actionShowPreviewPanel">

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -22,6 +22,7 @@
 #include <QMimeData>
 #include <QShortcut>
 
+#include "core/Config.h"
 #include "core/Database.h"
 #include "core/Group.h"
 #include "gui/group/GroupModel.h"
@@ -52,6 +53,13 @@ GroupView::GroupView(Database* db, QWidget* parent)
     viewport()->setAcceptDrops(true);
     setDropIndicatorShown(true);
     setDefaultDropAction(Qt::MoveAction);
+    setVisible(!config()->get(Config::GUI_HideGroupsPanel).toBool());
+
+    connect(config(), &Config::changed, this, [this](Config::ConfigKey key) {
+        if (key == Config::GUI_HideGroupsPanel) {
+            setVisible(!config()->get(Config::GUI_HideGroupsPanel).toBool());
+        }
+    });
 }
 
 void GroupView::contextMenuShortcutPressed()


### PR DESCRIPTION
Fixes #5243 

Add an option to toggle the groups panel. `View > Show Groups Panel`.  


## Screenshots
![keepassxc-toggle-groups](https://user-images.githubusercontent.com/805258/89724887-0c0d9900-da09-11ea-9b57-b49b6db034b5.png)


## Testing strategy
Toggled the Groups Panel using the new option on the View menu.


## Type of change
- ✅ New feature (change that adds functionality)
- ✅ Documentation (non-code change)