### PR TITLE
Ergonomics: Don't ask when removing an empty URL

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -339,20 +339,25 @@ void EditEntryWidget::removeCurrentURL()
     QModelIndex index = m_browserUi->additionalURLsView->currentIndex();
 
     if (index.isValid()) {
-        auto result = MessageBox::question(this,
-                                           tr("Confirm Removal"),
-                                           tr("Are you sure you want to remove this URL?"),
-                                           MessageBox::Remove | MessageBox::Cancel,
-                                           MessageBox::Cancel);
+        auto name = m_additionalURLsDataModel->keyByIndex(index);
+        auto url = m_entryAttributes->value(name);
+        if (url != tr("<empty URL>")) {
+            auto result = MessageBox::question(this,
+                                               tr("Confirm Removal"),
+                                               tr("Are you sure you want to remove this URL?"),
+                                               MessageBox::Remove | MessageBox::Cancel,
+                                               MessageBox::Cancel);
 
-        if (result == MessageBox::Remove) {
-            m_entryAttributes->remove(m_additionalURLsDataModel->keyByIndex(index));
-            if (m_additionalURLsDataModel->rowCount() == 0) {
-                m_browserUi->editURLButton->setEnabled(false);
-                m_browserUi->removeURLButton->setEnabled(false);
+            if (result != MessageBox::Remove) {
+                return;
             }
-            setModified(true);
         }
+        m_entryAttributes->remove(m_additionalURLsDataModel->keyByIndex(index));
+        if (m_additionalURLsDataModel->rowCount() == 0) {
+            m_browserUi->editURLButton->setEnabled(false);
+            m_browserUi->removeURLButton->setEnabled(false);
+        }
+        setModified(true);
     }
 }
 


### PR DESCRIPTION
There is no harm to deleting an empty URL from the browser integration
URL list when the user never set a value. It's a bit annoying, actually.

I kind of dislike inverting the control flow, but didn't see a better way.

## Testing strategy
There are no tests for deleting URLs yet. I would add it, but haven't yet spent the time to find out how to handle the `MessageBox`.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
