### PR TITLE
Add show/hide expired entries on global AutoType

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -337,10 +337,14 @@ void AutoType::performGlobalAutoType(const QList<QSharedPointer<Database>>& dbLi
     }
 
     QList<AutoTypeMatch> matchList;
+    bool hideExpired = config()->get(Config::AutoTypeHideExpiredEntry).toBool();
 
     for (const auto& db : dbList) {
         const QList<Entry*> dbEntries = db->rootGroup()->entriesRecursive();
         for (Entry* entry : dbEntries) {
+            if (hideExpired && entry->isExpired()) {
+                continue;
+            }
             const QSet<QString> sequences = autoTypeSequences(entry, m_windowTitleForGlobal).toSet();
             for (const QString& sequence : sequences) {
                 if (!sequence.isEmpty()) {

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -72,6 +72,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::AutoTypeEntryURLMatch,{QS("AutoTypeEntryURLMatch"), Roaming, true}},
     {Config::AutoTypeDelay,{QS("AutoTypeDelay"), Roaming, 25}},
     {Config::AutoTypeStartDelay,{QS("AutoTypeStartDelay"), Roaming, 500}},
+    {Config::AutoTypeHideExpiredEntry,{QS("AutoTypeHideExpiredEntry"), Roaming, false}},
     {Config::GlobalAutoTypeKey,{QS("GlobalAutoTypeKey"), Roaming, 0}},
     {Config::GlobalAutoTypeModifiers,{QS("GlobalAutoTypeModifiers"), Roaming, 0}},
     {Config::FaviconDownloadTimeout,{QS("FaviconDownloadTimeout"), Roaming, 10}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -56,6 +56,7 @@ public:
         AutoTypeEntryURLMatch,
         AutoTypeDelay,
         AutoTypeStartDelay,
+        AutoTypeHideExpiredEntry,
         GlobalAutoTypeKey,
         GlobalAutoTypeModifiers,
         FaviconDownloadTimeout,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -198,6 +198,7 @@ void ApplicationSettingsWidget::loadSettings()
         config()->get(Config::UseGroupIconOnEntryCreation).toBool());
     m_generalUi->autoTypeEntryTitleMatchCheckBox->setChecked(config()->get(Config::AutoTypeEntryTitleMatch).toBool());
     m_generalUi->autoTypeEntryURLMatchCheckBox->setChecked(config()->get(Config::AutoTypeEntryURLMatch).toBool());
+    m_generalUi->autoTypeHideExpiredEntryCheckBox->setChecked(config()->get(Config::AutoTypeHideExpiredEntry).toBool());
     m_generalUi->faviconTimeoutSpinBox->setValue(config()->get(Config::FaviconDownloadTimeout).toInt());
 
     m_generalUi->languageComboBox->clear();
@@ -324,6 +325,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::UseGroupIconOnEntryCreation, m_generalUi->useGroupIconOnEntryCreationCheckBox->isChecked());
     config()->set(Config::AutoTypeEntryTitleMatch, m_generalUi->autoTypeEntryTitleMatchCheckBox->isChecked());
     config()->set(Config::AutoTypeEntryURLMatch, m_generalUi->autoTypeEntryURLMatchCheckBox->isChecked());
+    config()->set(Config::AutoTypeHideExpiredEntry, m_generalUi->autoTypeHideExpiredEntryCheckBox->isChecked());
     config()->set(Config::FaviconDownloadTimeout, m_generalUi->faviconTimeoutSpinBox->value());
 
     auto language = m_generalUi->languageComboBox->currentData().toString();

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -851,6 +851,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="autoTypeHideExpiredEntryCheckBox">
+         <property name="text">
+          <string>Hide expired entries from Auto-Type</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_4">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Fixes #1855

A new checkbox is introduced in the Settings -> General -> Auto-Type - section 
named 'Hide expired entries on selecting multiple for global Auto-Type'.

When checked, on hitting the autoType-hotkey and entering the selection screen of multiple entries for  the autoType feature, expired entries will not be shown to the user. 

If unchecked both expired and valid entries will be shown.

Considering unit-testing, would you like to have a test which ensures the removal of expired entries in the internal matchList ?

## Screenshots

## Testing strategy
(match URL & Entry Title on global AutoType checkboxes were enabled)

Multiple entries with the same title were created and some were set to expired. 
The total count of the valid/expired entries was recorded and compared to the count
if valid/expired items in the AutoTypeSelectDialog screen depending of the checkBox 
state set/unset.

## Type of change
- ✅ New feature (change that adds functionality)