### PR TITLE
Move local config from ~/.cache to ~/.local/share on Linux

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -446,7 +446,7 @@ Config::Config(QObject* parent)
 #else
     // On case-sensitive Operating Systems, force use of lowercase app directories
     configPath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/keepassxc";
-    localConfigPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/keepassxc";
+    localConfigPath = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/keepassxc";
 #endif
 
     configPath += "/keepassxc";

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -479,6 +479,17 @@ void Config::init(const QString& configFileName, const QString& localConfigFileN
         QDir().rmdir(QFileInfo(localConfigFileName).absolutePath());
     }
 
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
+    // Move config from ~/.cache to ~/.local/share equivalent
+    QString oldLocalConfig = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/keepassxc/keepassxc.ini";
+    if (QFile::exists(oldLocalConfig) && !QFile::exists(localConfigFileName)) {
+        QDir().mkpath(QFileInfo(localConfigFileName).absolutePath());
+        QFile::copy(oldLocalConfig, localConfigFileName);
+        QFile::remove(oldLocalConfig);
+        QDir().rmdir(QFileInfo(oldLocalConfig).absolutePath());
+    }
+#endif
+
     m_settings.reset(new QSettings(configFileName, QSettings::IniFormat));
     if (!localConfigFileName.isEmpty() && configFileName != localConfigFileName) {
         m_localSettings.reset(new QSettings(localConfigFileName, QSettings::IniFormat));


### PR DESCRIPTION
Some users have ~/.cache mounted on tmpfs which meant that the
'Recent Databases' were lost after every reboot. Move that config to
~/.local/share which is meant for this kind of data.

Fixes #4911
Fixes #5313

## Testing strategy

`~/.local/share/keepassxc/keepassxc.ini` gets created now and not `~/.cache/keepassxc/keepassxc.ini`

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

---

I wasn't sure which branch to target with this PR, it's currently targeting develop, #5313 has the milestone v2.6.2