### PR TITLE
Fix Paperclip and Totp columns not saving state

### DIFF
--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -379,8 +379,7 @@ void EntryView::showHeaderMenu(const QPoint& position)
             continue;
         }
         int columnIndex = action->data().toInt();
-        bool hidden = header()->isSectionHidden(columnIndex) || (header()->sectionSize(columnIndex) == 0);
-        action->setChecked(!hidden);
+        action->setChecked(!isColumnHidden(columnIndex));
     }
 
     m_headerMenu->popup(mapToGlobal(position));
@@ -408,6 +407,7 @@ void EntryView::toggleColumnVisibility(QAction* action)
         if (header()->sectionSize(columnIndex) == 0) {
             header()->resizeSection(columnIndex, header()->defaultSectionSize());
         }
+        resetFixedColumns();
         return;
     }
     if ((header()->count() - header()->hiddenSectionCount()) > 1) {
@@ -460,11 +460,15 @@ void EntryView::fitColumnsToContents()
  */
 void EntryView::resetFixedColumns()
 {
-    header()->setSectionResizeMode(EntryModel::Paperclip, QHeaderView::Fixed);
-    header()->resizeSection(EntryModel::Paperclip, header()->minimumSectionSize());
+    if (!isColumnHidden(EntryModel::Paperclip)) {
+        header()->setSectionResizeMode(EntryModel::Paperclip, QHeaderView::Fixed);
+        header()->resizeSection(EntryModel::Paperclip, header()->minimumSectionSize());
+    }
 
-    header()->setSectionResizeMode(EntryModel::Totp, QHeaderView::Fixed);
-    header()->resizeSection(EntryModel::Totp, header()->minimumSectionSize());
+    if (!isColumnHidden(EntryModel::Totp)) {
+        header()->setSectionResizeMode(EntryModel::Totp, QHeaderView::Fixed);
+        header()->resizeSection(EntryModel::Totp, header()->minimumSectionSize());
+    }
 }
 
 /**
@@ -532,4 +536,9 @@ void EntryView::showEvent(QShowEvent* event)
         fitColumnsToWindow();
         m_columnsNeedRelayout = false;
     }
+}
+
+bool EntryView::isColumnHidden(int logicalIndex)
+{
+    return header()->isSectionHidden(logicalIndex) || header()->sectionSize(logicalIndex) == 0;
 }

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -80,6 +80,7 @@ private slots:
 
 private:
     void resetFixedColumns();
+    bool isColumnHidden(int logicalIndex);
 
     EntryModel* const m_model;
     SortFilterHideProxyModel* const m_sortModel;


### PR DESCRIPTION
* Work around Qt bug that causes isSectionHidden to return false after restoring state due to the section actually only being set to 0 width.
* Fixes #5317

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested multiple time when opening/closing the application and hiding showing the columns.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
