### PR TITLE
Fix AutoOpen IfDevice matching, again

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -2061,7 +2061,7 @@ void DatabaseWidget::processAutoOpen()
         // negated using '!'
         auto ifDevice = entry->attribute("IfDevice");
         if (!ifDevice.isEmpty()) {
-            bool loadDb = true;
+            bool loadDb = false;
             auto hostName = QHostInfo::localHostName();
             for (auto& device : ifDevice.split(",")) {
                 device = device.trimmed();
@@ -2070,12 +2070,13 @@ void DatabaseWidget::processAutoOpen()
                         // Machine name matched an exclusion, don't load this database
                         loadDb = false;
                         break;
+                    } else {
+                        // Not matching an exclusion allows loading on all machines
+                        loadDb = true;
                     }
                 } else if (device.compare(hostName, Qt::CaseInsensitive) == 0) {
+                    // Explicitly named for loading
                     loadDb = true;
-                } else {
-                    // Don't load the database if there are devices not starting with '!'
-                    loadDb = false;
                 }
             }
             if (!loadDb) {


### PR DESCRIPTION
* Fix case where only exclusions are entered (eg, !COMPUTER1, !COMPUTER2) which should allow opening the database on every other computer name.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)