### PR TITLE
The Database Open Dialog should use the window flag QT::Dialog

### DIFF
--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -25,11 +25,7 @@ DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
     , m_view(new DatabaseOpenWidget(this))
 {
     setWindowTitle(tr("Unlock Database - KeePassXC"));
-#ifdef Q_OS_MACOS
-    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
-#else
-    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::ForeignWindow);
-#endif
+    setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint);
     connect(m_view, SIGNAL(dialogFinished(bool)), this, SLOT(complete(bool)));
     auto* layout = new QVBoxLayout();
     layout->setMargin(0);


### PR DESCRIPTION
Currently the Open Dialog does not behave like a dialog. In Unix it
means that the EWHM hints are not set correctly therefore the window
manager doesn't properly set the floating window style.

It should also allow removing Mac/Windows/Unix custom conditional code.


- ✅ Bug fix (non-breaking change that fixes an issue)