### PR TITLE
Fix heap-use-after-free & error-msg output in keepassxc-cli

### DIFF
--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -158,7 +158,7 @@ void enterInteractiveMode(const QStringList& arguments)
 
         auto cmd = Commands::getCommand(args[0]);
         if (!cmd) {
-            err << QObject::tr("Unknown command %1").arg(args[0]) << "\n";
+            err << QObject::tr("Unknown command %1").arg(args[0]) << endl;
             continue;
         } else if (cmd->name == "quit" || cmd->name == "exit") {
             break;
@@ -167,6 +167,7 @@ void enterInteractiveMode(const QStringList& arguments)
         cmd->currentDatabase = currentDatabase;
         cmd->execute(args);
         currentDatabase = cmd->currentDatabase;
+        cmd->currentDatabase.reset();
     }
 
     if (currentDatabase) {


### PR DESCRIPTION
Proposed fix for #5367

After investigating with AddressSanitizer it seems that 
the ~Database destructor is called twice, since the QSharedPointer
variable cmd->currentDatabase & currentDatabase is initialized to
the the same address.

**also** fixed a issue with the cli unkown command output, since
in case of a wrong command only a "\n" character is appended to the
Utils::STDERR textstream but not flushed & printed. 
Upon exitting the shell the stream is flushed and if a bunch of unkown
commands are entered all of them are subsequently printed.

With endl the newline char is appended and the error-message is flushed,
printed and the shell continues.

## Testing strategy
1. Open a .kdbx database file with the keepassxc-cli open cmd
2. Enter any valid command as defined in the namespace commands
3. Exit the shell by either "exit" or "quit"

## Screenshots


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)