### PR TITLE
Add feature to ignore entries for HTTP-Auth Logins

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -55,6 +55,7 @@ static const QString KEEPASSHTTP_GROUP_NAME = QStringLiteral("KeePassHttp Passwo
 const QString BrowserService::OPTION_SKIP_AUTO_SUBMIT = QStringLiteral("BrowserSkipAutoSubmit");
 const QString BrowserService::OPTION_HIDE_ENTRY = QStringLiteral("BrowserHideEntry");
 const QString BrowserService::OPTION_ONLY_HTTP_AUTH = QStringLiteral("BrowserOnlyHttpAuth");
+const QString BrowserService::OPTION_NOT_HTTP_AUTH = QStringLiteral("BrowserNotHttpAuth");
 // Multiple URL's
 const QString BrowserService::ADDITIONAL_URL = QStringLiteral("KP2A_URL");
 
@@ -394,6 +395,11 @@ QJsonArray BrowserService::findMatchingEntries(const QString& dbid,
 
         if (!httpAuth && entry->customData()->contains(BrowserService::OPTION_ONLY_HTTP_AUTH)
             && entry->customData()->value(BrowserService::OPTION_ONLY_HTTP_AUTH) == TRUE_STR) {
+            continue;
+        }
+
+        if (httpAuth && entry->customData()->contains(BrowserService::OPTION_NOT_HTTP_AUTH)
+            && entry->customData()->value(BrowserService::OPTION_NOT_HTTP_AUTH) == TRUE_STR) {
             continue;
         }
 

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -90,6 +90,7 @@ public:
     static const QString OPTION_SKIP_AUTO_SUBMIT;
     static const QString OPTION_HIDE_ENTRY;
     static const QString OPTION_ONLY_HTTP_AUTH;
+    static const QString OPTION_NOT_HTTP_AUTH;
     static const QString ADDITIONAL_URL;
 
 signals:

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -280,6 +280,7 @@ void EditEntryWidget::setupBrowser()
         connect(m_browserUi->skipAutoSubmitCheckbox, SIGNAL(toggled(bool)), SLOT(updateBrowserModified()));
         connect(m_browserUi->hideEntryCheckbox, SIGNAL(toggled(bool)), SLOT(updateBrowserModified()));
         connect(m_browserUi->onlyHttpAuthCheckbox, SIGNAL(toggled(bool)), SLOT(updateBrowserModified()));
+        connect(m_browserUi->notHttpAuthCheckbox, SIGNAL(toggled(bool)), SLOT(updateBrowserModified()));
         connect(m_browserUi->addURLButton, SIGNAL(clicked()), SLOT(insertURL()));
         connect(m_browserUi->removeURLButton, SIGNAL(clicked()), SLOT(removeCurrentURL()));
         connect(m_browserUi->editURLButton, SIGNAL(clicked()), SLOT(editCurrentURL()));
@@ -307,9 +308,11 @@ void EditEntryWidget::updateBrowser()
     auto skip = m_browserUi->skipAutoSubmitCheckbox->isChecked();
     auto hide = m_browserUi->hideEntryCheckbox->isChecked();
     auto onlyHttpAuth = m_browserUi->onlyHttpAuthCheckbox->isChecked();
+    auto notHttpAuth = m_browserUi->notHttpAuthCheckbox->isChecked();
     m_customData->set(BrowserService::OPTION_SKIP_AUTO_SUBMIT, (skip ? TRUE_STR : FALSE_STR));
     m_customData->set(BrowserService::OPTION_HIDE_ENTRY, (hide ? TRUE_STR : FALSE_STR));
     m_customData->set(BrowserService::OPTION_ONLY_HTTP_AUTH, (onlyHttpAuth ? TRUE_STR : FALSE_STR));
+    m_customData->set(BrowserService::OPTION_NOT_HTTP_AUTH, (notHttpAuth ? TRUE_STR : FALSE_STR));
 }
 
 void EditEntryWidget::insertURL()
@@ -479,6 +482,7 @@ void EditEntryWidget::setupEntryUpdate()
         connect(m_browserUi->skipAutoSubmitCheckbox, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->hideEntryCheckbox, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->onlyHttpAuthCheckbox, SIGNAL(toggled(bool)), SLOT(setModified()));
+        connect(m_browserUi->notHttpAuthCheckbox, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->addURLButton, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->removeURLButton, SIGNAL(toggled(bool)), SLOT(setModified()));
         connect(m_browserUi->editURLButton, SIGNAL(toggled(bool)), SLOT(setModified()));
@@ -956,6 +960,13 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
                                                       == TRUE_STR);
     } else {
         m_browserUi->onlyHttpAuthCheckbox->setChecked(false);
+    }
+
+    if (m_customData->contains(BrowserService::OPTION_NOT_HTTP_AUTH)) {
+        m_browserUi->notHttpAuthCheckbox->setChecked(m_customData->value(BrowserService::OPTION_NOT_HTTP_AUTH)
+                                                     == TRUE_STR);
+    } else {
+        m_browserUi->notHttpAuthCheckbox->setChecked(false);
     }
 
     m_browserUi->addURLButton->setEnabled(!m_history);

--- a/src/gui/entry/EditEntryWidgetBrowser.ui
+++ b/src/gui/entry/EditEntryWidgetBrowser.ui
@@ -60,6 +60,16 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="notHttpAuthCheckbox">
+        <property name="toolTip">
+         <string>Do not send this setting to the browser for HTTP Auth dialogs. If enabled, HTTP Auth dialogs will not show this entry for selection.</string>
+        </property>
+        <property name="text">
+         <string>Do not use this entry with HTTP Basic Auth</string>
+        </property>
+       </widget>
+      </item>      
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
I added this feature since there is a real use-case for me and therefore maybe others as well. 
I work in different environments - from some I need to supply basic-auth credentials when accessing certain websites in addition to the webpage credentials. I usually have two distinct entries for the site in question. However if one has to supply http basic-auth credentials one still has two entries and keepassxc-browser doesnt know which one to choose although only one of those entries is applicable for basic-auth which is slowing down my process.. The added feature enables the user - in addition to the already present option to mark entries as ONLY_HTTP_AUTH - to mark an entry with the opposite attribute - NO_HTTP_AUTH...

## Screenshots
![image](https://user-images.githubusercontent.com/3980494/92326409-3a0aeb00-f052-11ea-8661-e1f8999298d5.png)

## Testing strategy
Tested on my actual setup.. Only the correct login for the use-case remains.
http-auth-entries only for http-auth-sites instead of all entries available for a given url

## Type of change
- ✅ New feature (change that adds functionality)

