### PR TITLE
Use Alt+Tab on macOS to switch between databases

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -297,13 +297,13 @@ MainWindow::MainWindow()
     // Control database tabs
     // Ctrl+Tab is broken on Mac, so use Alt (i.e. the Option key) - https://bugreports.qt.io/browse/QTBUG-8596
     auto dbTabModifier2 = Qt::CTRL;
-#ifdef Q_OS_DARWIN
+#ifdef Q_OS_MACOS
     dbTabModifier2 = Qt::ALT;
 #endif
     new QShortcut(dbTabModifier2 + Qt::Key_Tab, this, SLOT(selectNextDatabaseTab()));
-    new QShortcut(dbTabModifier2 + Qt::Key_PageDown, this, SLOT(selectNextDatabaseTab()));
+    new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(selectNextDatabaseTab()));
     new QShortcut(dbTabModifier2 + Qt::SHIFT + Qt::Key_Tab, this, SLOT(selectPreviousDatabaseTab()));
-    new QShortcut(dbTabModifier2 + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
+    new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
 
     // Tab selection by number, Windows uses Ctrl, macOS uses Command,
     // and Linux uses Alt to emulate a browser-like experience

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -295,10 +295,15 @@ MainWindow::MainWindow()
     new QShortcut(Qt::CTRL + Qt::Key_M, this, SLOT(minimizeOrHide()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_M, this, SLOT(hideWindow()));
     // Control database tabs
-    new QShortcut(Qt::CTRL + Qt::Key_Tab, this, SLOT(selectNextDatabaseTab()));
-    new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(selectNextDatabaseTab()));
-    new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this, SLOT(selectPreviousDatabaseTab()));
-    new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
+    // Ctrl+Tab is broken on Mac, so use Alt (i.e. the Option key) - https://bugreports.qt.io/browse/QTBUG-8596
+    auto dbTabModifier2 = Qt::CTRL;
+#ifdef Q_OS_DARWIN
+    dbTabModifier2 = Qt::ALT;
+#endif
+    new QShortcut(dbTabModifier2 + Qt::Key_Tab, this, SLOT(selectNextDatabaseTab()));
+    new QShortcut(dbTabModifier2 + Qt::Key_PageDown, this, SLOT(selectNextDatabaseTab()));
+    new QShortcut(dbTabModifier2 + Qt::SHIFT + Qt::Key_Tab, this, SLOT(selectPreviousDatabaseTab()));
+    new QShortcut(dbTabModifier2 + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
 
     // Tab selection by number, Windows uses Ctrl, macOS uses Command,
     // and Linux uses Alt to emulate a browser-like experience


### PR DESCRIPTION
Change <kbd>Ctrl+Tab</kbd> (well, it was actually <kbd>Cmd+Tab</kbd>, but that is the macOS task switcher) shortcut to <kbd>Alt+Tab</kbd>. <kbd>Ctrl+Tab</kbd> does not work unfortunately, see https://bugreports.qt.io/browse/QTBUG-8596 and https://stackoverflow.com/questions/20694919/c-qt-osx-qtmetaqtkey-tab-shortcut-bind.

I also changed Ctrl+PageDown for consistency, but I can change that back. I can also change the variable name. I wanted to quickly create this PR with the gist of the proposed change in order to get feedback.

It appears that there is some kind of workaround that Chrome utilizes (https://bugreports.qt.io/browse/QTBUG-8596?focusedCommentId=321526&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-321526). But I have not idea if it is feasible or how to implement it.

I also noticed that `KeePassXC_KeyboardShortcuts.html` is not customized per platform. There should be a column per OS, or an OS-specific file should be included depending on the build.

## Screenshots
N/A

## Testing strategy
I was able to compile and run the application.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
