### PR TITLE
Fix sorting of database report columns

### DIFF
--- a/src/gui/reports/ReportsWidgetHealthcheck.cpp
+++ b/src/gui/reports/ReportsWidgetHealthcheck.cpp
@@ -76,6 +76,27 @@ namespace
         QList<QSharedPointer<Item>> m_items;
         bool m_anyKnownBad = false;
     };
+
+    class ReportSortProxyModel : public QSortFilterProxyModel
+    {
+    public:
+        ReportSortProxyModel(QObject* parent)
+            : QSortFilterProxyModel(parent){};
+        ~ReportSortProxyModel() override = default;
+
+    protected:
+        bool lessThan(const QModelIndex& left, const QModelIndex& right) const override
+        {
+            // Check if the display data is a number, convert and compare if so
+            bool ok = false;
+            int leftInt = sourceModel()->data(left).toString().toInt(&ok);
+            if (ok) {
+                return leftInt < sourceModel()->data(right).toString().toInt();
+            }
+            // Otherwise use default sorting
+            return QSortFilterProxyModel::lessThan(left, right);
+        }
+    };
 } // namespace
 
 Health::Health(QSharedPointer<Database> db)
@@ -121,11 +142,12 @@ ReportsWidgetHealthcheck::ReportsWidgetHealthcheck(QWidget* parent)
     , m_ui(new Ui::ReportsWidgetHealthcheck())
     , m_errorIcon(Resources::instance()->icon("dialog-error"))
     , m_referencesModel(new QStandardItemModel(this))
-    , m_modelProxy(new QSortFilterProxyModel(this))
+    , m_modelProxy(new ReportSortProxyModel(this))
 {
     m_ui->setupUi(this);
 
     m_modelProxy->setSourceModel(m_referencesModel.data());
+    m_modelProxy->setSortLocaleAware(true);
     m_ui->healthcheckTableView->setModel(m_modelProxy.data());
     m_ui->healthcheckTableView->setSelectionMode(QAbstractItemView::NoSelection);
     m_ui->healthcheckTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
@@ -256,6 +278,7 @@ void ReportsWidgetHealthcheck::calculateHealth()
     } else {
         m_referencesModel->setHorizontalHeaderLabels(QStringList() << tr("") << tr("Title") << tr("Path") << tr("Score")
                                                                    << tr("Reason"));
+        m_ui->healthcheckTableView->sortByColumn(0, Qt::AscendingOrder);
     }
 
     m_ui->healthcheckTableView->resizeRowsToContents();


### PR DESCRIPTION
Fixed columns sorting in HealthCheck and HIBP widgets in database report (#4976).

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
I'm not a Qt developer, but I wanted to try to contribute anyway; so if this PR does not reflect the programming patterns of this project, please feel free to reject it.

Since in both widgets the columns need to be sorted in a particular way (eg in HIBP widget the exposed password numbers are displayed as words but they must be sorted as digits), in this PR I suggest to apply Qt::UserRole as SortRole to the tables. In this way, each field has two values: a textual one which is displayed to the user and one set with setData() for internal use for sorting.

I also added that by default the tables are sorted in order to have the most exposed passwords or passwords with the lowest score at the top.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![immagine](https://user-images.githubusercontent.com/20026524/93028028-5b9b4200-f611-11ea-9405-e42bd4214b8b.png)
![immagine](https://user-images.githubusercontent.com/20026524/93028035-6fdf3f00-f611-11ea-8e68-0c4ab0704c66.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
I have visually tested my changes before doing the PR and they seem to be ok (no compilation errors, no crashes found, all unit tests passed, **sorting seems to work with both positive and negative numbers**).

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
