### PR TITLE
Allow selecting any open database in unlock dialog

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -814,11 +814,8 @@ QList<Entry*> BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
         }
     }
 
-#ifdef Q_OS_MAC
     // Re-hide the application if it wasn't visible before
-    // only affects macOS because dialogs force the main window to show
     hideWindow();
-#endif
 
     m_dialogActive = false;
 
@@ -1306,12 +1303,10 @@ void BrowserService::databaseLocked(DatabaseWidget* dbWidget)
 void BrowserService::databaseUnlocked(DatabaseWidget* dbWidget)
 {
     if (dbWidget) {
-#ifdef Q_OS_MAC
         if (m_bringToFrontRequested) {
             m_bringToFrontRequested = false;
             hideWindow();
         }
-#endif
 
         QJsonObject msg;
         msg["action"] = QString("database-unlocked");

--- a/src/gui/DatabaseOpenDialog.h
+++ b/src/gui/DatabaseOpenDialog.h
@@ -21,7 +21,9 @@
 #include "core/Global.h"
 
 #include <QDialog>
+#include <QList>
 #include <QPointer>
+#include <QTabBar>
 
 class Database;
 class DatabaseWidget;
@@ -41,11 +43,12 @@ public:
     };
 
     explicit DatabaseOpenDialog(QWidget* parent = nullptr);
-    void setFilePath(const QString& filePath);
-    void setTargetDatabaseWidget(DatabaseWidget* dbWidget);
+    void setTarget(DatabaseWidget* dbWidget, const QString& filePath);
+    void addDatabaseTab(DatabaseWidget* dbWidget);
+    void setActiveDatabaseTab(DatabaseWidget* dbWidget);
     void setIntent(Intent intent);
     Intent intent() const;
-    QSharedPointer<Database> database();
+    QSharedPointer<Database> database() const;
     void clearForms();
 
 signals:
@@ -53,11 +56,16 @@ signals:
 
 public slots:
     void complete(bool accepted);
+    void tabChanged(int index);
 
 private:
+    void selectTabOffset(int offset);
+
     QPointer<DatabaseOpenWidget> m_view;
+    QPointer<QTabBar> m_tabBar;
     QSharedPointer<Database> m_db;
-    QPointer<DatabaseWidget> m_dbWidget;
+    QList<QPointer<DatabaseWidget>> m_tabDbWidgets;
+    QPointer<DatabaseWidget> m_currentDbWidget;
     Intent m_intent = Intent::None;
 };
 

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -99,11 +99,14 @@ private slots:
     void toggleTabbar();
     void emitActiveDatabaseChanged();
     void emitDatabaseLockChanged();
+    void handleDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
 private:
     QSharedPointer<Database> execNewDatabaseWizard();
     void updateLastDatabases(const QString& filename);
     bool warnOnExport();
+    void unlockAnyDatabaseInDialog(DatabaseOpenDialog::Intent intent);
+    void displayUnlockDialog();
 
     QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
     QPointer<DatabaseWidget> m_dbWidgetPendingLock;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -186,6 +186,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     connect(m_opVaultOpenWidget, SIGNAL(dialogFinished(bool)), SLOT(loadDatabase(bool)));
     connect(m_csvImportWizard, SIGNAL(importFinished(bool)), SLOT(csvImportFinished(bool)));
     connect(this, SIGNAL(currentChanged(int)), SLOT(emitCurrentModeChanged()));
+    connect(this, SIGNAL(requestGlobalAutoType()), parent, SLOT(performGlobalAutoType()));
     // clang-format on
 
     connectDatabaseSignals();
@@ -1109,9 +1110,10 @@ void DatabaseWidget::unlockDatabase(bool accepted)
     }
 
     if (senderDialog && senderDialog->intent() == DatabaseOpenDialog::Intent::AutoType) {
-        QList<QSharedPointer<Database>> dbList;
-        dbList.append(m_db);
-        autoType()->performGlobalAutoType(dbList);
+        // Rather than starting AutoType directly for this database, signal the parent DatabaseTabWidget to
+        // restart AutoType now that this database is unlocked, so that other open+unlocked databases
+        // can be included in the search.
+        emit requestGlobalAutoType();
     }
 }
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -151,6 +151,7 @@ signals:
     void previewSplitterSizesChanged();
     void entryViewStateChanged();
     void clearSearch();
+    void requestGlobalAutoType();
 
 public slots:
     bool lock();


### PR DESCRIPTION
When showing the database unlock dialog from browser or auto-type and
there's more than one open database, add tabs to the unlock dialog so
that the user can choose which database to unlock.

This implements part of #2322 and improves the UX when working with
multiple databases after version 2.6 switched to using the dialog for
browser unlock.

Make the DatabaseOpenDialog window Application-Modal so that it blocks
input to the main UI when the dialog is open. This reduces corner cases
by avoiding the possibility of databases getting closed or unlocked
behind the open dialog.

## Screenshots
See https://github.com/keepassxreboot/keepassxc/pull/5427#issuecomment-692983371

## Testing strategy
All current tests pass; I'm not sure if or how to add a GUI test for this functionality. When building with asan, I can't find any new leaks relative to the tip of the develop branch.

## Type of change
- ✅ New feature (change that adds functionality)
