### PR TITLE
Add display number of characters in passphrases

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -258,6 +258,22 @@ void PasswordGeneratorWidget::updateButtonsEnabled(const QString& password)
     m_ui->buttonCopy->setEnabled(!password.isEmpty());
 }
 
+int PasswordGeneratorWidget::getPassphraseLength(const QString& password)
+{
+    if (password.isNull() || password.isEmpty()) {
+        return 0;
+    }
+
+    int passphraselength = 0;
+    for (auto character : password) {
+        if (character.isLetterOrNumber()) {
+            passphraselength += 1;
+        }
+    }
+
+    return passphraselength;
+}
+
 void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
 {
     PasswordHealth health(password);
@@ -265,14 +281,7 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
         // Diceware estimates entropy differently
         health = PasswordHealth(m_dicewareGenerator->estimateEntropy());
 
-        int passphraselength = 0;
-        for (auto character : password) {
-            if (character.isLetterOrNumber()) {
-                passphraselength += 1;
-            }
-        }
-
-        m_ui->charactersInPassphraseLabel->setText(tr("%1").arg(passphraselength));
+        m_ui->charactersInPassphraseLabel->setText(QString::number(getPassphraseLength(password)));
     }
 
     m_ui->entropyLabel->setText(tr("Entropy: %1 bit").arg(QString::number(health.entropy(), 'f', 2)));

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -258,22 +258,6 @@ void PasswordGeneratorWidget::updateButtonsEnabled(const QString& password)
     m_ui->buttonCopy->setEnabled(!password.isEmpty());
 }
 
-int PasswordGeneratorWidget::getPassphraseLength(const QString& password)
-{
-    if (password.isNull() || password.isEmpty()) {
-        return 0;
-    }
-
-    int passphraselength = 0;
-    for (auto character : password) {
-        if (character.isLetterOrNumber()) {
-            passphraselength += 1;
-        }
-    }
-
-    return passphraselength;
-}
-
 void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
 {
     PasswordHealth health(password);
@@ -281,7 +265,7 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
         // Diceware estimates entropy differently
         health = PasswordHealth(m_dicewareGenerator->estimateEntropy());
 
-        m_ui->charactersInPassphraseLabel->setText(QString::number(getPassphraseLength(password)));
+        m_ui->charactersInPassphraseLabel->setText(QString::number(password.length()));
     }
 
     m_ui->entropyLabel->setText(tr("Entropy: %1 bit").arg(QString::number(health.entropy(), 'f', 2)));

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -272,8 +272,7 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
             }
         }
 
-        m_ui->charactersInPassphraseLabel->setText(
-            tr("Characters in passphrase: %1").arg(passphraselength));
+        m_ui->charactersInPassphraseLabel->setText(tr("%1").arg(passphraselength));
     }
 
     m_ui->entropyLabel->setText(tr("Entropy: %1 bit").arg(QString::number(health.entropy(), 'f', 2)));

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -264,6 +264,10 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
     if (m_ui->tabWidget->currentIndex() == Diceware) {
         // Diceware estimates entropy differently
         health = PasswordHealth(m_dicewareGenerator->estimateEntropy());
+        int passphraselength = password.size();
+
+        m_ui->charactersInPassphraseLabel->setText(
+            tr("Characters in passphrase: %1").arg(passphraselength));
     }
 
     m_ui->entropyLabel->setText(tr("Entropy: %1 bit").arg(QString::number(health.entropy(), 'f', 2)));

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -264,7 +264,13 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
     if (m_ui->tabWidget->currentIndex() == Diceware) {
         // Diceware estimates entropy differently
         health = PasswordHealth(m_dicewareGenerator->estimateEntropy());
-        int passphraselength = password.size();
+
+        int passphraselength = 0;
+        for (auto character : password) {
+            if (character.isLetterOrNumber()) {
+                passphraselength += 1;
+            }
+        }
 
         m_ui->charactersInPassphraseLabel->setText(
             tr("Characters in passphrase: %1").arg(passphraselength));

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -55,6 +55,7 @@ public:
     void setStandaloneMode(bool standalone);
     QString getGeneratedPassword();
     bool isPasswordVisible() const;
+    int getPassphraseLength(const QString& password);
 
     static PasswordGeneratorWidget* popupGenerator(QWidget* parent = nullptr);
 

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -55,7 +55,6 @@ public:
     void setStandaloneMode(bool standalone);
     QString getGeneratedPassword();
     bool isPasswordVisible() const;
-    int getPassphraseLength(const QString& password);
 
     static PasswordGeneratorWidget* popupGenerator(QWidget* parent = nullptr);
 

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -824,6 +824,13 @@ QProgressBar::chunk {
              </property>
             </widget>
            </item>
+           <item row="4" column="0" alignment="Qt::AlignRight">
+            <widget class="QLabel" name="charactersInPassphraseLabel">
+             <property name="text">
+              <string>passphraseLength</string>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="0" alignment="Qt::AlignRight">
             <widget class="QLabel" name="labelWordList">
              <property name="sizePolicy">

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -825,9 +825,16 @@ QProgressBar::chunk {
             </widget>
            </item>
            <item row="4" column="0" alignment="Qt::AlignRight">
+            <widget class="QLabel" name="characterCountLabel">
+             <property name="text">
+              <string>Character count:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1" alignment="Qt::AlignLeft">
             <widget class="QLabel" name="charactersInPassphraseLabel">
              <property name="text">
-              <string>passphraseLength</string>
+              <string>character</string>
              </property>
             </widget>
            </item>

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -708,188 +708,184 @@ QProgressBar::chunk {
        <string>Passphrase</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="1" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="0" column="1">
-            <widget class="QComboBox" name="comboBoxWordList">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+       <item row="0" column="0">
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="2" column="1" alignment="Qt::AlignRight">
+          <widget class="QLabel" name="labelWordSeparator">
+           <property name="text">
+            <string>Word Separator:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1" alignment="Qt::AlignRight">
+          <widget class="QLabel" name="labelWordList">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Wordlist:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetMinimumSize</enum>
+           </property>
+           <item>
+            <widget class="QSlider" name="sliderWordCount">
+             <property name="minimum">
+              <number>1</number>
              </property>
-            </widget>
-           </item>
-           <item row="1" column="0" alignment="Qt::AlignRight">
-            <widget class="QLabel" name="labelWordCount">
-             <property name="text">
-              <string>Word Count:</string>
+             <property name="maximum">
+              <number>40</number>
              </property>
-             <property name="buddy">
-              <cstring>spinBoxLength</cstring>
+             <property name="value">
+              <number>6</number>
              </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <spacer name="verticalSpacer_3">
+             <property name="sliderPosition">
+              <number>6</number>
+             </property>
              <property name="orientation">
-              <enum>Qt::Vertical</enum>
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>8</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="spinBoxWordCount">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>6</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="1" alignment="Qt::AlignRight">
+          <widget class="QLabel" name="labelWordCount">
+           <property name="text">
+            <string>Word Count:</string>
+           </property>
+           <property name="buddy">
+            <cstring>spinBoxLength</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1" alignment="Qt::AlignRight">
+          <widget class="QLabel" name="characterCountLabel">
+           <property name="text">
+            <string>Character Count:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1" alignment="Qt::AlignRight">
+          <widget class="QLabel" name="wordCaseLabel">
+           <property name="text">
+            <string>Word Case:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QComboBox" name="wordCaseComboBox"/>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_4">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>20</width>
-               <height>40</height>
+               <width>40</width>
+               <height>20</height>
               </size>
              </property>
             </spacer>
            </item>
-           <item row="2" column="0" alignment="Qt::AlignRight">
-            <widget class="QLabel" name="labelWordSeparator">
-             <property name="text">
-              <string>Word Separator:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_6">
-             <item>
-              <widget class="QComboBox" name="wordCaseComboBox"/>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_4">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-           <item row="1" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <property name="sizeConstraint">
-              <enum>QLayout::SetMinimumSize</enum>
-             </property>
-             <item>
-              <widget class="QSlider" name="sliderWordCount">
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>40</number>
-               </property>
-               <property name="value">
-                <number>6</number>
-               </property>
-               <property name="sliderPosition">
-                <number>6</number>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="tickPosition">
-                <enum>QSlider::TicksBelow</enum>
-               </property>
-               <property name="tickInterval">
-                <number>8</number>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="spinBoxWordCount">
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-               <property name="value">
-                <number>6</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item row="3" column="0" alignment="Qt::AlignRight">
-            <widget class="QLabel" name="wordCaseLabel">
-             <property name="text">
-              <string>Word Case:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0" alignment="Qt::AlignRight">
-            <widget class="QLabel" name="characterCountLabel">
-             <property name="text">
-              <string>Character Count:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1" alignment="Qt::AlignLeft">
-            <widget class="QLabel" name="charactersInPassphraseLabel">
-             <property name="text">
-              <string>character</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0" alignment="Qt::AlignRight">
-            <widget class="QLabel" name="labelWordList">
+          </layout>
+         </item>
+         <item row="2" column="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <item>
+            <widget class="QLineEdit" name="editWordSeparator">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="minimumSize">
+              <size>
+               <width>20</width>
+               <height>0</height>
+              </size>
+             </property>
              <property name="text">
-              <string>Wordlist:</string>
+              <string/>
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_9">
-             <item>
-              <widget class="QLineEdit" name="editWordSeparator">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>20</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_7">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
+           <item>
+            <spacer name="horizontalSpacer_7">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </item>
+         <item row="0" column="2">
+          <widget class="QComboBox" name="comboBoxWordList">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2" alignment="Qt::AlignLeft">
+          <widget class="QLabel" name="charactersInPassphraseLabel">
+           <property name="text">
+            <string>character</string>
+           </property>
+          </widget>
+         </item>
         </layout>
+       </item>
+       <item row="1" column="0">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -827,7 +827,7 @@ QProgressBar::chunk {
            <item row="4" column="0" alignment="Qt::AlignRight">
             <widget class="QLabel" name="characterCountLabel">
              <property name="text">
-              <string>Character count:</string>
+              <string>Character Count:</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Fixes #5396 

A new information field is added to the passphrase generator view
and depicts the number of characters in the generated passphrase. 

Considering the UI-Implementation I'd be happy to hear improvement suggestions
since I'm still a Qt novice.

In the current implementation a character is only counted if it is a number or letter.

So e.g. whitespace or special characters like '&' are not counted. (see attached screenshot)
If this is not the desired behaviour, I'll change it according to the discussion.

## Screenshots
<img src="https://user-images.githubusercontent.com/34011017/93675829-570cd880-faac-11ea-996f-148aa670ee39.png" width="400">

## Testing strategy


## Type of change
- ✅ New feature (change that adds functionality)
