### PR TITLE
Hotfix heapUseAfterFree in db-create command

### DIFF
--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -247,6 +247,10 @@ int main(int argc, char** argv)
     arguments.removeFirst();
     int exitCode = command->execute(arguments);
 
+    if (command->currentDatabase) {
+        command->currentDatabase.reset();
+    }
+
 #if defined(WITH_ASAN) && defined(WITH_LSAN)
     // do leak check here to prevent massive tail of end-of-process leak errors from third-party libraries
     __lsan_do_leak_check();


### PR DESCRIPTION
Upon playing around with the `import` and `db-create` commands in the cli,
I stumbled over another heap-use-after-free crash after the database has been created.

The crash can be reproduced with compiling the project with the cmake flag `-DWITH_ASAN=ON`
and using the cli `db-create` command: e.g. `./keepassxc-cli db-create -k ~/exampleKeyFile ~/exampleDB`

The design problem is described in #5166 and the trouble starts right after the initialization of `currentDatabase`
in https://github.com/keepassxreboot/keepassxc/blob/develop/src/cli/Create.cpp#L164

I am aware of this PR #5212 which would address this issue already, however since I'm not sure
about the status, I wanted to **propose** a quick hotfix. 

If the other PR will get merged soon, feel free to close this PR.

cheers!

@phoerious  I'm sorry I screwed up the rebase attempt & I created this new PR.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
