### PR TITLE
CLI: Add support for okon in offline HIBP checks

### DIFF
--- a/docs/man/keepassxc-cli.1.adoc
+++ b/docs/man/keepassxc-cli.1.adoc
@@ -37,7 +37,7 @@ It provides the ability to query and modify the entries of a KeePass database, d
   The same password generation options as documented for the generate command can be used when the *-g* option is set.
 
 *analyze* [_options_] <__database__>::
-  Analyzes passwords in a database for weaknesses.
+  Analyzes passwords in a database for weaknesses using offline HIBP SHA-1 hash lookup.
 
 *clip* [_options_] <__database__> <__entry__> [_timeout_]::
   Copies an attribute or the current TOTP (if the *-t* option is specified) of a database entry to the clipboard.
@@ -198,6 +198,10 @@ The same password generation options as documented for the generate command can 
   Checks if any passwords have been publicly leaked, by comparing against the given list of password SHA-1 hashes, which must be in "Have I Been Pwned" format.
   Such files are available from https://haveibeenpwned.com/Passwords;
   note that they are large, and so this operation typically takes some time (minutes up to an hour or so).
+
+*--okon* <__okon-cli path__>::
+  Use the specified okon-cli program to perform offline breach checks. You can obtain okon-cli from https://github.com/stryku/okon.
+  When using this option, *-H, --hibp* must point to a post-processed okon file (e.g. file.okon).
 
 === Clip options
 *-a*, *--attribute*::

--- a/src/cli/Analyze.h
+++ b/src/cli/Analyze.h
@@ -27,6 +27,7 @@ public:
     int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
 
     static const QCommandLineOption HIBPDatabaseOption;
+    static const QCommandLineOption OkonOption;
 
 private:
     void printHibpFinding(const Entry* entry, int count, QTextStream& out);

--- a/src/core/HibpOffline.h
+++ b/src/core/HibpOffline.h
@@ -31,6 +31,12 @@ namespace HibpOffline
                 QIODevice& hibpInput,
                 QList<QPair<const Entry*, int>>& findings,
                 QString* error);
-}
+
+    bool okonReport(QSharedPointer<Database> db,
+                    const QString& okon,
+                    const QString& okonDatabase,
+                    QList<QPair<const Entry*, int>>& findings,
+                    QString* error);
+} // namespace HibpOffline
 
 #endif // KEEPASSXC_HIBPOFFLINE_H


### PR DESCRIPTION
* Closes #5447
* Add option `--okon <okon-cli path>` to trigger the use of the okon cli tool to process a database's entries. When using this option the `-H, --hibp` option must point to a post-processed okon file instead of the standard HIBP text file.
* Updated documentation

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/94365687-e9ab0a00-00a0-11eb-81bf-a53b7363b0af.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
