### PR TITLE
Fix FileDialog closing randomly on macOS

### DIFF
--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -21,20 +21,6 @@
 
 #include <QDir>
 
-namespace
-{
-    QString modFilter(const QString& filter)
-    {
-#ifdef Q_OS_MACOS
-        // Fix macOS bug that causes the file dialog to freeze when a dot is included in the filters
-        // See https://github.com/keepassxreboot/keepassxc/issues/3895#issuecomment-586724167
-        auto mod = filter;
-        return mod.replace("*.", "*");
-#endif
-        return filter;
-    }
-} // namespace
-
 FileDialog* FileDialog::m_instance(nullptr);
 
 QString FileDialog::getOpenFileName(QWidget* parent,
@@ -51,7 +37,7 @@ QString FileDialog::getOpenFileName(QWidget* parent,
     } else {
         const auto& workingDir = dir.isEmpty() ? config()->get(Config::LastDir).toString() : dir;
         const auto result = QDir::toNativeSeparators(
-            QFileDialog::getOpenFileName(parent, caption, workingDir, modFilter(filter), selectedFilter, options));
+            QFileDialog::getOpenFileName(parent, caption, workingDir, filter, selectedFilter, options));
 
 #ifdef Q_OS_MACOS
         // on Mac OS X the focus is lost after closing the native dialog
@@ -77,8 +63,7 @@ QStringList FileDialog::getOpenFileNames(QWidget* parent,
         return results;
     } else {
         const auto& workingDir = dir.isEmpty() ? config()->get(Config::LastDir).toString() : dir;
-        auto results =
-            QFileDialog::getOpenFileNames(parent, caption, workingDir, modFilter(filter), selectedFilter, options);
+        auto results = QFileDialog::getOpenFileNames(parent, caption, workingDir, filter, selectedFilter, options);
 
         for (auto& path : results) {
             path = QDir::toNativeSeparators(path);
@@ -111,7 +96,7 @@ QString FileDialog::getSaveFileName(QWidget* parent,
     } else {
         const auto& workingDir = dir.isEmpty() ? config()->get(Config::LastDir).toString() : dir;
         const auto result = QDir::toNativeSeparators(
-            QFileDialog::getSaveFileName(parent, caption, workingDir, modFilter(filter), selectedFilter, options));
+            QFileDialog::getSaveFileName(parent, caption, workingDir, filter, selectedFilter, options));
 
 #ifdef Q_OS_MACOS
         // on Mac OS X the focus is lost after closing the native dialog


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
* Fixes #5295
* Introduce a callback approach to AsyncTask instead of entering multiple QEventLoop in the stack. This has additional benefits including not returning to the original stack location and potentially operating on deleted objects (use after free).
* Revert FileDialog filter mods for macOS

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows and macOS Catalina

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)