### PR TITLE
Ignore recycle bin on KeePassHTTP migration

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1166,6 +1166,10 @@ bool BrowserService::checkLegacySettings(QSharedPointer<Database> db)
     bool legacySettingsFound = false;
     QList<Entry*> entries = db->rootGroup()->entriesRecursive();
     for (const auto& e : entries) {
+        if (e->isRecycled()) {
+            continue;
+        }
+
         if ((e->attributes()->contains(KEEPASSHTTP_NAME) || e->attributes()->contains(KEEPASSXCBROWSER_NAME))
             || (e->title() == KEEPASSHTTP_NAME || e->title().contains(KEEPASSXCBROWSER_NAME, Qt::CaseInsensitive))) {
             legacySettingsFound = true;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
KeePassHTTP Settings moved to recycle bin still shows a warning dialog for KeePassHTTP migration on every database unlock.

Fixes #5297.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)