### PR TITLE
Move icon handling from Resources to gui/Icons

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ set(keepassx_SOURCES
         gui/PasswordEdit.cpp
         gui/PasswordGeneratorWidget.cpp
         gui/ApplicationSettingsWidget.cpp
+        gui/IconResources.cpp
         gui/SearchWidget.cpp
         gui/SortFilterHideProxyModel.cpp
         gui/SquareSvgWidget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,7 +126,7 @@ set(keepassx_SOURCES
         gui/PasswordEdit.cpp
         gui/PasswordGeneratorWidget.cpp
         gui/ApplicationSettingsWidget.cpp
-        gui/IconResources.cpp
+        gui/Icons.cpp
         gui/SearchWidget.cpp
         gui/SortFilterHideProxyModel.cpp
         gui/SquareSvgWidget.cpp

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@
 #include "autotype/AutoTypeSelectView.h"
 #include "core/AutoTypeMatch.h"
 #include "core/Config.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "gui/entry/AutoTypeMatchModel.h"
 
 AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
@@ -49,7 +49,7 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     setAttribute(Qt::WA_X11BypassTransientForHint);
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     setWindowTitle(tr("Auto-Type - KeePassXC"));
-    setWindowIcon(resources()->applicationIcon());
+    setWindowIcon(iconResources()->applicationIcon());
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     QRect screenGeometry = QApplication::screenAt(QCursor::pos())->availableGeometry();

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -34,7 +34,7 @@
 #include "autotype/AutoTypeSelectView.h"
 #include "core/AutoTypeMatch.h"
 #include "core/Config.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/entry/AutoTypeMatchModel.h"
 
 AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
@@ -49,7 +49,7 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     setAttribute(Qt::WA_X11BypassTransientForHint);
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     setWindowTitle(tr("Auto-Type - KeePassXC"));
-    setWindowIcon(iconResources()->applicationIcon());
+    setWindowIcon(icons()->applicationIcon());
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     QRect screenGeometry = QApplication::screenAt(QCursor::pos())->availableGeometry();

--- a/src/browser/BrowserSettingsPage.cpp
+++ b/src/browser/BrowserSettingsPage.cpp
@@ -20,7 +20,7 @@
 #include "BrowserService.h"
 #include "BrowserSettings.h"
 #include "BrowserSettingsWidget.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 QString BrowserSettingsPage::name()
 {
@@ -29,7 +29,7 @@ QString BrowserSettingsPage::name()
 
 QIcon BrowserSettingsPage::icon()
 {
-    return iconResources()->icon("internet-web-browser");
+    return icons()->icon("internet-web-browser");
 }
 
 QWidget* BrowserSettingsPage::createWidget()

--- a/src/browser/BrowserSettingsPage.cpp
+++ b/src/browser/BrowserSettingsPage.cpp
@@ -20,7 +20,7 @@
 #include "BrowserService.h"
 #include "BrowserSettings.h"
 #include "BrowserSettingsWidget.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 QString BrowserSettingsPage::name()
 {
@@ -29,7 +29,7 @@ QString BrowserSettingsPage::name()
 
 QIcon BrowserSettingsPage::icon()
 {
-    return Resources::instance()->icon("internet-web-browser");
+    return iconResources()->icon("internet-web-browser");
 }
 
 QWidget* BrowserSettingsPage::createWidget()

--- a/src/core/Resources.cpp
+++ b/src/core/Resources.cpp
@@ -18,17 +18,13 @@
 
 #include "Resources.h"
 
-#include <QBitmap>
 #include <QDir>
+#include <QCoreApplication>
 #include <QLibrary>
-#include <QPainter>
-#include <QStyle>
 
 #include "config-keepassx.h"
 #include "core/Config.h"
 #include "core/Global.h"
-#include "gui/MainWindow.h"
-#include "gui/osutils/OSUtils.h"
 
 Resources* Resources::m_instance(nullptr);
 
@@ -96,138 +92,6 @@ QString Resources::wordlistPath(const QString& name) const
     return dataPath(QStringLiteral("wordlists/%1").arg(name));
 }
 
-QIcon Resources::applicationIcon()
-{
-    return icon("keepassxc", false);
-}
-
-QString Resources::trayIconAppearance() const
-{
-    auto iconAppearance = config()->get(Config::GUI_TrayIconAppearance).toString();
-    if (iconAppearance.isNull()) {
-#ifdef Q_OS_MACOS
-        iconAppearance = osUtils->isDarkMode() ? "monochrome-light" : "monochrome-dark";
-#else
-        iconAppearance = "monochrome-light";
-#endif
-    }
-    return iconAppearance;
-}
-
-QIcon Resources::trayIcon()
-{
-    return trayIconUnlocked();
-}
-
-QIcon Resources::trayIconLocked()
-{
-    auto iconApperance = trayIconAppearance();
-
-    if (iconApperance == "monochrome-light") {
-        return icon("keepassxc-monochrome-light-locked", false);
-    }
-    if (iconApperance == "monochrome-dark") {
-        return icon("keepassxc-monochrome-dark-locked", false);
-    }
-    return icon("keepassxc-locked", false);
-}
-
-QIcon Resources::trayIconUnlocked()
-{
-    auto iconApperance = trayIconAppearance();
-
-    if (iconApperance == "monochrome-light") {
-        return icon("keepassxc-monochrome-light", false);
-    }
-    if (iconApperance == "monochrome-dark") {
-        return icon("keepassxc-monochrome-dark", false);
-    }
-    return icon("keepassxc", false);
-}
-
-QIcon Resources::icon(const QString& name, bool recolor, const QColor& overrideColor)
-{
-    QIcon icon = m_iconCache.value(name);
-
-    if (!icon.isNull() && !overrideColor.isValid()) {
-        return icon;
-    }
-
-    // Resetting the application theme name before calling QIcon::fromTheme() is required for hacky
-    // QPA platform themes such as qt5ct, which randomly mess with the configured icon theme.
-    // If we do not reset the theme name here, it will become empty at some point, causing
-    // Qt to look for icons at the user-level and global default locations.
-    //
-    // See issue #4963: https://github.com/keepassxreboot/keepassxc/issues/4963
-    // and qt5ct issue #80: https://sourceforge.net/p/qt5ct/tickets/80/
-    QIcon::setThemeName("application");
-
-    icon = QIcon::fromTheme(name);
-    if (getMainWindow() && recolor) {
-        const QRect rect(0, 0, 48, 48);
-        QImage img = icon.pixmap(rect.width(), rect.height()).toImage();
-        img = img.convertToFormat(QImage::Format_ARGB32_Premultiplied);
-        icon = {};
-
-        QPainter painter(&img);
-        painter.setCompositionMode(QPainter::CompositionMode_SourceAtop);
-
-        if (!overrideColor.isValid()) {
-            QPalette palette = getMainWindow()->palette();
-            painter.fillRect(rect, palette.color(QPalette::Normal, QPalette::WindowText));
-            icon.addPixmap(QPixmap::fromImage(img), QIcon::Normal);
-
-            painter.fillRect(rect, palette.color(QPalette::Active, QPalette::ButtonText));
-            icon.addPixmap(QPixmap::fromImage(img), QIcon::Active);
-
-            painter.fillRect(rect, palette.color(QPalette::Active, QPalette::HighlightedText));
-            icon.addPixmap(QPixmap::fromImage(img), QIcon::Selected);
-
-            painter.fillRect(rect, palette.color(QPalette::Disabled, QPalette::WindowText));
-            icon.addPixmap(QPixmap::fromImage(img), QIcon::Disabled);
-        } else {
-            painter.fillRect(rect, overrideColor);
-            icon.addPixmap(QPixmap::fromImage(img), QIcon::Normal);
-        }
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-        icon.setIsMask(true);
-#endif
-    }
-
-    if (!overrideColor.isValid()) {
-        m_iconCache.insert(name, icon);
-    }
-
-    return icon;
-}
-
-QIcon Resources::onOffIcon(const QString& name, bool recolor)
-{
-    QString cacheName = "onoff/" + name;
-
-    QIcon icon = m_iconCache.value(cacheName);
-
-    if (!icon.isNull()) {
-        return icon;
-    }
-
-    const QSize size(48, 48);
-    QIcon on = Resources::icon(name + "-on", recolor);
-    icon.addPixmap(on.pixmap(size, QIcon::Mode::Normal), QIcon::Mode::Normal, QIcon::On);
-    icon.addPixmap(on.pixmap(size, QIcon::Mode::Selected), QIcon::Mode::Selected, QIcon::On);
-    icon.addPixmap(on.pixmap(size, QIcon::Mode::Disabled), QIcon::Mode::Disabled, QIcon::On);
-
-    QIcon off = Resources::icon(name + "-off", recolor);
-    icon.addPixmap(off.pixmap(size, QIcon::Mode::Normal), QIcon::Mode::Normal, QIcon::Off);
-    icon.addPixmap(off.pixmap(size, QIcon::Mode::Selected), QIcon::Mode::Selected, QIcon::Off);
-    icon.addPixmap(off.pixmap(size, QIcon::Mode::Disabled), QIcon::Mode::Disabled, QIcon::Off);
-
-    m_iconCache.insert(cacheName, icon);
-
-    return icon;
-}
-
 Resources::Resources()
 {
     const QString appDirPath = QCoreApplication::applicationDirPath();
@@ -265,10 +129,6 @@ Resources* Resources::instance()
 {
     if (!m_instance) {
         m_instance = new Resources();
-
-        Q_INIT_RESOURCE(icons);
-        QIcon::setThemeSearchPaths(QStringList{":/icons"} << QIcon::themeSearchPaths());
-        QIcon::setThemeName("application");
     }
 
     return m_instance;

--- a/src/core/Resources.cpp
+++ b/src/core/Resources.cpp
@@ -18,8 +18,8 @@
 
 #include "Resources.h"
 
-#include <QDir>
 #include <QCoreApplication>
+#include <QDir>
 #include <QLibrary>
 
 #include "config-keepassx.h"

--- a/src/core/Resources.h
+++ b/src/core/Resources.h
@@ -19,7 +19,6 @@
 #ifndef KEEPASSX_RESOURCES_H
 #define KEEPASSX_RESOURCES_H
 
-#include <QHash>
 #include <QString>
 
 class Resources

--- a/src/fdosecrets/DatabaseSettingsPageFdoSecrets.cpp
+++ b/src/fdosecrets/DatabaseSettingsPageFdoSecrets.cpp
@@ -19,7 +19,7 @@
 
 #include "fdosecrets/widgets/DatabaseSettingsWidgetFdoSecrets.h"
 
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 QString DatabaseSettingsPageFdoSecrets::name()
 {
@@ -28,7 +28,7 @@ QString DatabaseSettingsPageFdoSecrets::name()
 
 QIcon DatabaseSettingsPageFdoSecrets::icon()
 {
-    return iconResources()->icon(QStringLiteral("freedesktop"));
+    return icons()->icon(QStringLiteral("freedesktop"));
 }
 
 QWidget* DatabaseSettingsPageFdoSecrets::createWidget()

--- a/src/fdosecrets/DatabaseSettingsPageFdoSecrets.cpp
+++ b/src/fdosecrets/DatabaseSettingsPageFdoSecrets.cpp
@@ -19,7 +19,7 @@
 
 #include "fdosecrets/widgets/DatabaseSettingsWidgetFdoSecrets.h"
 
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 QString DatabaseSettingsPageFdoSecrets::name()
 {
@@ -28,7 +28,7 @@ QString DatabaseSettingsPageFdoSecrets::name()
 
 QIcon DatabaseSettingsPageFdoSecrets::icon()
 {
-    return resources()->icon(QStringLiteral("freedesktop"));
+    return iconResources()->icon(QStringLiteral("freedesktop"));
 }
 
 QWidget* DatabaseSettingsPageFdoSecrets::createWidget()

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -19,7 +19,7 @@
 #define KEEPASSXC_FDOSECRETSPLUGIN_H
 
 #include "gui/ApplicationSettingsWidget.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QPointer>
 #include <QScopedPointer>
@@ -45,7 +45,7 @@ public:
 
     QIcon icon() override
     {
-        return iconResources()->icon("freedesktop");
+        return icons()->icon("freedesktop");
     }
 
     QWidget* createWidget() override;

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -18,8 +18,8 @@
 #ifndef KEEPASSXC_FDOSECRETSPLUGIN_H
 #define KEEPASSXC_FDOSECRETSPLUGIN_H
 
-#include "gui/IconResources.h"
 #include "gui/ApplicationSettingsWidget.h"
+#include "gui/IconResources.h"
 
 #include <QPointer>
 #include <QScopedPointer>

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -18,7 +18,7 @@
 #ifndef KEEPASSXC_FDOSECRETSPLUGIN_H
 #define KEEPASSXC_FDOSECRETSPLUGIN_H
 
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "gui/ApplicationSettingsWidget.h"
 
 #include <QPointer>
@@ -45,7 +45,7 @@ public:
 
     QIcon icon() override
     {
-        return Resources::instance()->icon("freedesktop");
+        return iconResources()->icon("freedesktop");
     }
 
     QWidget* createWidget() override;

--- a/src/fdosecrets/widgets/SettingsModels.cpp
+++ b/src/fdosecrets/widgets/SettingsModels.cpp
@@ -26,7 +26,7 @@
 #include "core/DatabaseIcons.h"
 #include "gui/DatabaseTabWidget.h"
 #include "gui/DatabaseWidget.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QFileInfo>
 
@@ -130,7 +130,7 @@ namespace FdoSecrets
             case Qt::DisplayRole:
                 return tr("Unlock to show");
             case Qt::DecorationRole:
-                return iconResources()->icon(QStringLiteral("object-locked"));
+                return icons()->icon(QStringLiteral("object-locked"));
             case Qt::FontRole: {
                 QFont font;
                 font.setItalic(true);
@@ -164,7 +164,7 @@ namespace FdoSecrets
             case Qt::DisplayRole:
                 return tr("None");
             case Qt::DecorationRole:
-                return iconResources()->icon(QStringLiteral("paint-none"));
+                return icons()->icon(QStringLiteral("paint-none"));
             default:
                 return {};
             }

--- a/src/fdosecrets/widgets/SettingsModels.cpp
+++ b/src/fdosecrets/widgets/SettingsModels.cpp
@@ -24,7 +24,7 @@
 
 #include "core/Database.h"
 #include "core/DatabaseIcons.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "gui/DatabaseTabWidget.h"
 #include "gui/DatabaseWidget.h"
 
@@ -130,7 +130,7 @@ namespace FdoSecrets
             case Qt::DisplayRole:
                 return tr("Unlock to show");
             case Qt::DecorationRole:
-                return resources()->icon(QStringLiteral("object-locked"));
+                return iconResources()->icon(QStringLiteral("object-locked"));
             case Qt::FontRole: {
                 QFont font;
                 font.setItalic(true);
@@ -164,7 +164,7 @@ namespace FdoSecrets
             case Qt::DisplayRole:
                 return tr("None");
             case Qt::DecorationRole:
-                return resources()->icon(QStringLiteral("paint-none"));
+                return iconResources()->icon(QStringLiteral("paint-none"));
             default:
                 return {};
             }

--- a/src/fdosecrets/widgets/SettingsModels.cpp
+++ b/src/fdosecrets/widgets/SettingsModels.cpp
@@ -24,9 +24,9 @@
 
 #include "core/Database.h"
 #include "core/DatabaseIcons.h"
-#include "gui/IconResources.h"
 #include "gui/DatabaseTabWidget.h"
 #include "gui/DatabaseWidget.h"
+#include "gui/IconResources.h"
 
 #include <QFileInfo>
 

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
@@ -24,7 +24,7 @@
 #include "fdosecrets/widgets/SettingsModels.h"
 
 #include "gui/DatabaseWidget.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QAction>
 #include <QDBusConnection>
@@ -63,7 +63,7 @@ namespace
 
             // db settings
             m_dbSettingsAct = new QAction(tr("Database settings"), this);
-            m_dbSettingsAct->setIcon(iconResources()->icon(QStringLiteral("document-edit")));
+            m_dbSettingsAct->setIcon(icons()->icon(QStringLiteral("document-edit")));
             m_dbSettingsAct->setToolTip(tr("Edit database settings"));
             m_dbSettingsAct->setEnabled(false);
             connect(m_dbSettingsAct, &QAction::triggered, this, [this]() {
@@ -77,7 +77,7 @@ namespace
 
             // unlock/lock
             m_lockAct = new QAction(tr("Unlock database"), this);
-            m_lockAct->setIcon(iconResources()->icon(QStringLiteral("object-locked")));
+            m_lockAct->setIcon(icons()->icon(QStringLiteral("object-locked")));
             m_lockAct->setToolTip(tr("Unlock database to show more information"));
             connect(m_lockAct, &QAction::triggered, this, [this]() {
                 if (!m_dbWidget) {
@@ -135,13 +135,13 @@ namespace
             }
             connect(m_dbWidget, &DatabaseWidget::databaseLocked, this, [this]() {
                 m_lockAct->setText(tr("Unlock database"));
-                m_lockAct->setIcon(iconResources()->icon(QStringLiteral("object-locked")));
+                m_lockAct->setIcon(icons()->icon(QStringLiteral("object-locked")));
                 m_lockAct->setToolTip(tr("Unlock database to show more information"));
                 m_dbSettingsAct->setEnabled(false);
             });
             connect(m_dbWidget, &DatabaseWidget::databaseUnlocked, this, [this]() {
                 m_lockAct->setText(tr("Lock database"));
-                m_lockAct->setIcon(iconResources()->icon(QStringLiteral("object-unlocked")));
+                m_lockAct->setIcon(icons()->icon(QStringLiteral("object-unlocked")));
                 m_lockAct->setToolTip(tr("Lock database"));
                 m_dbSettingsAct->setEnabled(true);
             });
@@ -174,7 +174,7 @@ namespace
             addWidget(spacer);
 
             m_disconnectAct = new QAction(tr("Disconnect"), this);
-            m_disconnectAct->setIcon(iconResources()->icon(QStringLiteral("dialog-close")));
+            m_disconnectAct->setIcon(icons()->icon(QStringLiteral("dialog-close")));
             m_disconnectAct->setToolTip(tr("Disconnect this application"));
             connect(m_disconnectAct, &QAction::triggered, this, [this]() {
                 if (m_session) {

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
@@ -23,7 +23,7 @@
 #include "fdosecrets/objects/Session.h"
 #include "fdosecrets/widgets/SettingsModels.h"
 
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "gui/DatabaseWidget.h"
 
 #include <QAction>
@@ -63,7 +63,7 @@ namespace
 
             // db settings
             m_dbSettingsAct = new QAction(tr("Database settings"), this);
-            m_dbSettingsAct->setIcon(resources()->icon(QStringLiteral("document-edit")));
+            m_dbSettingsAct->setIcon(iconResources()->icon(QStringLiteral("document-edit")));
             m_dbSettingsAct->setToolTip(tr("Edit database settings"));
             m_dbSettingsAct->setEnabled(false);
             connect(m_dbSettingsAct, &QAction::triggered, this, [this]() {
@@ -77,7 +77,7 @@ namespace
 
             // unlock/lock
             m_lockAct = new QAction(tr("Unlock database"), this);
-            m_lockAct->setIcon(resources()->icon(QStringLiteral("object-locked")));
+            m_lockAct->setIcon(iconResources()->icon(QStringLiteral("object-locked")));
             m_lockAct->setToolTip(tr("Unlock database to show more information"));
             connect(m_lockAct, &QAction::triggered, this, [this]() {
                 if (!m_dbWidget) {
@@ -135,13 +135,13 @@ namespace
             }
             connect(m_dbWidget, &DatabaseWidget::databaseLocked, this, [this]() {
                 m_lockAct->setText(tr("Unlock database"));
-                m_lockAct->setIcon(resources()->icon(QStringLiteral("object-locked")));
+                m_lockAct->setIcon(iconResources()->icon(QStringLiteral("object-locked")));
                 m_lockAct->setToolTip(tr("Unlock database to show more information"));
                 m_dbSettingsAct->setEnabled(false);
             });
             connect(m_dbWidget, &DatabaseWidget::databaseUnlocked, this, [this]() {
                 m_lockAct->setText(tr("Lock database"));
-                m_lockAct->setIcon(resources()->icon(QStringLiteral("object-unlocked")));
+                m_lockAct->setIcon(iconResources()->icon(QStringLiteral("object-unlocked")));
                 m_lockAct->setToolTip(tr("Lock database"));
                 m_dbSettingsAct->setEnabled(true);
             });
@@ -174,7 +174,7 @@ namespace
             addWidget(spacer);
 
             m_disconnectAct = new QAction(tr("Disconnect"), this);
-            m_disconnectAct->setIcon(resources()->icon(QStringLiteral("dialog-close")));
+            m_disconnectAct->setIcon(iconResources()->icon(QStringLiteral("dialog-close")));
             m_disconnectAct->setToolTip(tr("Disconnect this application"));
             connect(m_disconnectAct, &QAction::triggered, this, [this]() {
                 if (m_session) {

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
@@ -23,8 +23,8 @@
 #include "fdosecrets/objects/Session.h"
 #include "fdosecrets/widgets/SettingsModels.h"
 
-#include "gui/IconResources.h"
 #include "gui/DatabaseWidget.h"
+#include "gui/IconResources.h"
 
 #include <QAction>
 #include <QDBusConnection>

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -20,9 +20,9 @@
 #include "ui_AboutDialog.h"
 
 #include "config-keepassx.h"
-#include "core/Resources.h"
 #include "core/Tools.h"
 #include "crypto/Crypto.h"
+#include "gui/IconResources.h"
 
 #include <QClipboard>
 
@@ -210,7 +210,7 @@ AboutDialog::AboutDialog(QWidget* parent)
     nameLabelFont.setPointSize(nameLabelFont.pointSize() + 4);
     m_ui->nameLabel->setFont(nameLabelFont);
 
-    m_ui->iconLabel->setPixmap(resources()->applicationIcon().pixmap(48));
+    m_ui->iconLabel->setPixmap(iconResources()->applicationIcon().pixmap(48));
 
     QString debugInfo = Tools::debugInfo().append("\n").append(Crypto::debugInfo());
     m_ui->debugInfo->setPlainText(debugInfo);

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -22,7 +22,7 @@
 #include "config-keepassx.h"
 #include "core/Tools.h"
 #include "crypto/Crypto.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QClipboard>
 
@@ -210,7 +210,7 @@ AboutDialog::AboutDialog(QWidget* parent)
     nameLabelFont.setPointSize(nameLabelFont.pointSize() + 4);
     m_ui->nameLabel->setFont(nameLabelFont);
 
-    m_ui->iconLabel->setPixmap(iconResources()->applicationIcon().pixmap(48));
+    m_ui->iconLabel->setPixmap(icons()->applicationIcon().pixmap(48));
 
     QString debugInfo = Tools::debugInfo().append("\n").append(Crypto::debugInfo());
     m_ui->debugInfo->setPlainText(debugInfo);

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -25,8 +25,8 @@
 #include "autotype/AutoType.h"
 #include "core/Config.h"
 #include "core/Global.h"
-#include "core/Resources.h"
 #include "core/Translator.h"
+#include "gui/IconResources.h"
 #include "gui/MainWindow.h"
 #include "gui/osutils/OSUtils.h"
 
@@ -93,8 +93,8 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
 
     m_secUi->setupUi(m_secWidget);
     m_generalUi->setupUi(m_generalWidget);
-    addPage(tr("General"), Resources::instance()->icon("preferences-other"), m_generalWidget);
-    addPage(tr("Security"), Resources::instance()->icon("security-high"), m_secWidget);
+    addPage(tr("General"), iconResources()->icon("preferences-other"), m_generalWidget);
+    addPage(tr("Security"), iconResources()->icon("security-high"), m_secWidget);
 
     if (!autoType()->isAvailable()) {
         m_generalUi->generalSettingsTabWidget->removeTab(1);
@@ -254,7 +254,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->trayIconAppearance->addItem(tr("Monochrome (light)"), "monochrome-light");
     m_generalUi->trayIconAppearance->addItem(tr("Monochrome (dark)"), "monochrome-dark");
     m_generalUi->trayIconAppearance->addItem(tr("Colorful"), "colorful");
-    int trayIconIndex = m_generalUi->trayIconAppearance->findData(resources()->trayIconAppearance());
+    int trayIconIndex = m_generalUi->trayIconAppearance->findData(iconResources()->trayIconAppearance());
     if (trayIconIndex > 0) {
         m_generalUi->trayIconAppearance->setCurrentIndex(trayIconIndex);
     }

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -26,7 +26,7 @@
 #include "core/Config.h"
 #include "core/Global.h"
 #include "core/Translator.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/MainWindow.h"
 #include "gui/osutils/OSUtils.h"
 
@@ -93,8 +93,8 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
 
     m_secUi->setupUi(m_secWidget);
     m_generalUi->setupUi(m_generalWidget);
-    addPage(tr("General"), iconResources()->icon("preferences-other"), m_generalWidget);
-    addPage(tr("Security"), iconResources()->icon("security-high"), m_secWidget);
+    addPage(tr("General"), icons()->icon("preferences-other"), m_generalWidget);
+    addPage(tr("Security"), icons()->icon("security-high"), m_secWidget);
 
     if (!autoType()->isAvailable()) {
         m_generalUi->generalSettingsTabWidget->removeTab(1);
@@ -254,7 +254,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->trayIconAppearance->addItem(tr("Monochrome (light)"), "monochrome-light");
     m_generalUi->trayIconAppearance->addItem(tr("Monochrome (dark)"), "monochrome-dark");
     m_generalUi->trayIconAppearance->addItem(tr("Colorful"), "colorful");
-    int trayIconIndex = m_generalUi->trayIconAppearance->findData(iconResources()->trayIconAppearance());
+    int trayIconIndex = m_generalUi->trayIconAppearance->findData(icons()->trayIconAppearance());
     if (trayIconIndex > 0) {
         m_generalUi->trayIconAppearance->setCurrentIndex(trayIconIndex);
     }

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -24,7 +24,7 @@
 #include "crypto/Random.h"
 #include "format/KeePass2Reader.h"
 #include "gui/FileDialog.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/MainWindow.h"
 #include "gui/MessageBox.h"
 #include "keys/FileKey.h"
@@ -71,14 +71,14 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(openDatabase()));
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(reject()));
 
-    m_ui->hardwareKeyLabelHelp->setIcon(iconResources()->icon("system-help").pixmap(QSize(12, 12)));
+    m_ui->hardwareKeyLabelHelp->setIcon(icons()->icon("system-help").pixmap(QSize(12, 12)));
     connect(m_ui->hardwareKeyLabelHelp, SIGNAL(clicked(bool)), SLOT(openHardwareKeyHelp()));
-    m_ui->keyFileLabelHelp->setIcon(iconResources()->icon("system-help").pixmap(QSize(12, 12)));
+    m_ui->keyFileLabelHelp->setIcon(icons()->icon("system-help").pixmap(QSize(12, 12)));
     connect(m_ui->keyFileLabelHelp, SIGNAL(clicked(bool)), SLOT(openKeyFileHelp()));
 
     connect(m_ui->keyFileLineEdit, SIGNAL(textChanged(QString)), SLOT(keyFileTextChanged()));
     m_ui->keyFileLineEdit->addAction(m_ui->keyFileClearIcon, QLineEdit::TrailingPosition);
-    m_ui->keyFileClearIcon->setIcon(iconResources()->icon("edit-clear-locationbar-rtl"));
+    m_ui->keyFileClearIcon->setIcon(icons()->icon("edit-clear-locationbar-rtl"));
     m_ui->keyFileClearIcon->setVisible(false);
     connect(m_ui->keyFileClearIcon, SIGNAL(triggered(bool)), SLOT(clearKeyFileText()));
 

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -21,10 +21,10 @@
 
 #include "core/Config.h"
 #include "core/Database.h"
-#include "core/Resources.h"
 #include "crypto/Random.h"
 #include "format/KeePass2Reader.h"
 #include "gui/FileDialog.h"
+#include "gui/IconResources.h"
 #include "gui/MainWindow.h"
 #include "gui/MessageBox.h"
 #include "keys/FileKey.h"
@@ -71,14 +71,14 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(openDatabase()));
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(reject()));
 
-    m_ui->hardwareKeyLabelHelp->setIcon(resources()->icon("system-help").pixmap(QSize(12, 12)));
+    m_ui->hardwareKeyLabelHelp->setIcon(iconResources()->icon("system-help").pixmap(QSize(12, 12)));
     connect(m_ui->hardwareKeyLabelHelp, SIGNAL(clicked(bool)), SLOT(openHardwareKeyHelp()));
-    m_ui->keyFileLabelHelp->setIcon(resources()->icon("system-help").pixmap(QSize(12, 12)));
+    m_ui->keyFileLabelHelp->setIcon(iconResources()->icon("system-help").pixmap(QSize(12, 12)));
     connect(m_ui->keyFileLabelHelp, SIGNAL(clicked(bool)), SLOT(openKeyFileHelp()));
 
     connect(m_ui->keyFileLineEdit, SIGNAL(textChanged(QString)), SLOT(keyFileTextChanged()));
     m_ui->keyFileLineEdit->addAction(m_ui->keyFileClearIcon, QLineEdit::TrailingPosition);
-    m_ui->keyFileClearIcon->setIcon(resources()->icon("edit-clear-locationbar-rtl"));
+    m_ui->keyFileClearIcon->setIcon(iconResources()->icon("edit-clear-locationbar-rtl"));
     m_ui->keyFileClearIcon->setVisible(false);
     connect(m_ui->keyFileClearIcon, SIGNAL(triggered(bool)), SLOT(clearKeyFileText()));
 

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -24,9 +24,9 @@
 #include <QDir>
 
 #include "core/Config.h"
-#include "core/Resources.h"
 #include "entry/EntryAttachmentsModel.h"
 #include "gui/Clipboard.h"
+#include "gui/IconResources.h"
 #if defined(WITH_XC_KEESHARE)
 #include "keeshare/KeeShare.h"
 #endif
@@ -48,11 +48,11 @@ EntryPreviewWidget::EntryPreviewWidget(QWidget* parent)
     m_ui->setupUi(this);
 
     // Entry
-    m_ui->entryTotpButton->setIcon(resources()->icon("chronometer"));
-    m_ui->entryCloseButton->setIcon(resources()->icon("dialog-close"));
-    m_ui->togglePasswordButton->setIcon(resources()->onOffIcon("password-show"));
-    m_ui->toggleEntryNotesButton->setIcon(resources()->onOffIcon("password-show"));
-    m_ui->toggleGroupNotesButton->setIcon(resources()->onOffIcon("password-show"));
+    m_ui->entryTotpButton->setIcon(iconResources()->icon("chronometer"));
+    m_ui->entryCloseButton->setIcon(iconResources()->icon("dialog-close"));
+    m_ui->togglePasswordButton->setIcon(iconResources()->onOffIcon("password-show"));
+    m_ui->toggleEntryNotesButton->setIcon(iconResources()->onOffIcon("password-show"));
+    m_ui->toggleGroupNotesButton->setIcon(iconResources()->onOffIcon("password-show"));
 
     m_ui->entryAttachmentsWidget->setReadOnly(true);
     m_ui->entryAttachmentsWidget->setButtonsVisible(false);
@@ -83,7 +83,7 @@ EntryPreviewWidget::EntryPreviewWidget(QWidget* parent)
     });
 
     // Group
-    m_ui->groupCloseButton->setIcon(resources()->icon("dialog-close"));
+    m_ui->groupCloseButton->setIcon(iconResources()->icon("dialog-close"));
     connect(m_ui->groupCloseButton, SIGNAL(clicked()), SLOT(hide()));
     connect(m_ui->groupTabWidget, SIGNAL(tabBarClicked(int)), SLOT(updateTabIndexes()), Qt::QueuedConnection);
 

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -26,7 +26,7 @@
 #include "core/Config.h"
 #include "entry/EntryAttachmentsModel.h"
 #include "gui/Clipboard.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #if defined(WITH_XC_KEESHARE)
 #include "keeshare/KeeShare.h"
 #endif
@@ -48,11 +48,11 @@ EntryPreviewWidget::EntryPreviewWidget(QWidget* parent)
     m_ui->setupUi(this);
 
     // Entry
-    m_ui->entryTotpButton->setIcon(iconResources()->icon("chronometer"));
-    m_ui->entryCloseButton->setIcon(iconResources()->icon("dialog-close"));
-    m_ui->togglePasswordButton->setIcon(iconResources()->onOffIcon("password-show"));
-    m_ui->toggleEntryNotesButton->setIcon(iconResources()->onOffIcon("password-show"));
-    m_ui->toggleGroupNotesButton->setIcon(iconResources()->onOffIcon("password-show"));
+    m_ui->entryTotpButton->setIcon(icons()->icon("chronometer"));
+    m_ui->entryCloseButton->setIcon(icons()->icon("dialog-close"));
+    m_ui->togglePasswordButton->setIcon(icons()->onOffIcon("password-show"));
+    m_ui->toggleEntryNotesButton->setIcon(icons()->onOffIcon("password-show"));
+    m_ui->toggleGroupNotesButton->setIcon(icons()->onOffIcon("password-show"));
 
     m_ui->entryAttachmentsWidget->setReadOnly(true);
     m_ui->entryAttachmentsWidget->setButtonsVisible(false);
@@ -83,7 +83,7 @@ EntryPreviewWidget::EntryPreviewWidget(QWidget* parent)
     });
 
     // Group
-    m_ui->groupCloseButton->setIcon(iconResources()->icon("dialog-close"));
+    m_ui->groupCloseButton->setIcon(icons()->icon("dialog-close"));
     connect(m_ui->groupCloseButton, SIGNAL(clicked()), SLOT(hide()));
     connect(m_ui->groupTabWidget, SIGNAL(tabBarClicked(int)), SLOT(updateTabIndexes()), Qt::QueuedConnection);
 

--- a/src/gui/IconResources.cpp
+++ b/src/gui/IconResources.cpp
@@ -1,0 +1,181 @@
+/*
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "IconResources.h"
+
+#include <QBitmap>
+#include <QDir>
+#include <QLibrary>
+#include <QPainter>
+#include <QStyle>
+
+#include "config-keepassx.h"
+#include "core/Config.h"
+#include "gui/MainWindow.h"
+#include "gui/osutils/OSUtils.h"
+
+IconResources* IconResources::m_instance(nullptr);
+
+QIcon IconResources::applicationIcon()
+{
+    return icon("keepassxc", false);
+}
+
+QString IconResources::trayIconAppearance() const
+{
+    auto iconAppearance = config()->get(Config::GUI_TrayIconAppearance).toString();
+    if (iconAppearance.isNull()) {
+#ifdef Q_OS_MACOS
+        iconAppearance = osUtils->isDarkMode() ? "monochrome-light" : "monochrome-dark";
+#else
+        iconAppearance = "monochrome-light";
+#endif
+    }
+    return iconAppearance;
+}
+
+QIcon IconResources::trayIcon()
+{
+    return trayIconUnlocked();
+}
+
+QIcon IconResources::trayIconLocked()
+{
+    auto iconApperance = trayIconAppearance();
+
+    if (iconApperance == "monochrome-light") {
+        return icon("keepassxc-monochrome-light-locked", false);
+    }
+    if (iconApperance == "monochrome-dark") {
+        return icon("keepassxc-monochrome-dark-locked", false);
+    }
+    return icon("keepassxc-locked", false);
+}
+
+QIcon IconResources::trayIconUnlocked()
+{
+    auto iconApperance = trayIconAppearance();
+
+    if (iconApperance == "monochrome-light") {
+        return icon("keepassxc-monochrome-light", false);
+    }
+    if (iconApperance == "monochrome-dark") {
+        return icon("keepassxc-monochrome-dark", false);
+    }
+    return icon("keepassxc", false);
+}
+
+QIcon IconResources::icon(const QString& name, bool recolor, const QColor& overrideColor)
+{
+    QIcon icon = m_iconCache.value(name);
+
+    if (!icon.isNull() && !overrideColor.isValid()) {
+        return icon;
+    }
+
+    // Resetting the application theme name before calling QIcon::fromTheme() is required for hacky
+    // QPA platform themes such as qt5ct, which randomly mess with the configured icon theme.
+    // If we do not reset the theme name here, it will become empty at some point, causing
+    // Qt to look for icons at the user-level and global default locations.
+    //
+    // See issue #4963: https://github.com/keepassxreboot/keepassxc/issues/4963
+    // and qt5ct issue #80: https://sourceforge.net/p/qt5ct/tickets/80/
+    QIcon::setThemeName("application");
+
+    icon = QIcon::fromTheme(name);
+    if (getMainWindow() && recolor) {
+        const QRect rect(0, 0, 48, 48);
+        QImage img = icon.pixmap(rect.width(), rect.height()).toImage();
+        img = img.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+        icon = {};
+
+        QPainter painter(&img);
+        painter.setCompositionMode(QPainter::CompositionMode_SourceAtop);
+
+        if (!overrideColor.isValid()) {
+            QPalette palette = getMainWindow()->palette();
+            painter.fillRect(rect, palette.color(QPalette::Normal, QPalette::WindowText));
+            icon.addPixmap(QPixmap::fromImage(img), QIcon::Normal);
+
+            painter.fillRect(rect, palette.color(QPalette::Active, QPalette::ButtonText));
+            icon.addPixmap(QPixmap::fromImage(img), QIcon::Active);
+
+            painter.fillRect(rect, palette.color(QPalette::Active, QPalette::HighlightedText));
+            icon.addPixmap(QPixmap::fromImage(img), QIcon::Selected);
+
+            painter.fillRect(rect, palette.color(QPalette::Disabled, QPalette::WindowText));
+            icon.addPixmap(QPixmap::fromImage(img), QIcon::Disabled);
+        } else {
+            painter.fillRect(rect, overrideColor);
+            icon.addPixmap(QPixmap::fromImage(img), QIcon::Normal);
+        }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+        icon.setIsMask(true);
+#endif
+    }
+
+    if (!overrideColor.isValid()) {
+        m_iconCache.insert(name, icon);
+    }
+
+    return icon;
+}
+
+QIcon IconResources::onOffIcon(const QString& name, bool recolor)
+{
+    QString cacheName = "onoff/" + name;
+
+    QIcon icon = m_iconCache.value(cacheName);
+
+    if (!icon.isNull()) {
+        return icon;
+    }
+
+    const QSize size(48, 48);
+    QIcon on = IconResources::icon(name + "-on", recolor);
+    icon.addPixmap(on.pixmap(size, QIcon::Mode::Normal), QIcon::Mode::Normal, QIcon::On);
+    icon.addPixmap(on.pixmap(size, QIcon::Mode::Selected), QIcon::Mode::Selected, QIcon::On);
+    icon.addPixmap(on.pixmap(size, QIcon::Mode::Disabled), QIcon::Mode::Disabled, QIcon::On);
+
+    QIcon off = IconResources::icon(name + "-off", recolor);
+    icon.addPixmap(off.pixmap(size, QIcon::Mode::Normal), QIcon::Mode::Normal, QIcon::Off);
+    icon.addPixmap(off.pixmap(size, QIcon::Mode::Selected), QIcon::Mode::Selected, QIcon::Off);
+    icon.addPixmap(off.pixmap(size, QIcon::Mode::Disabled), QIcon::Mode::Disabled, QIcon::Off);
+
+    m_iconCache.insert(cacheName, icon);
+
+    return icon;
+}
+
+IconResources::IconResources()
+{
+}
+
+IconResources* IconResources::instance()
+{
+    if (!m_instance) {
+        m_instance = new IconResources();
+
+        Q_INIT_RESOURCE(icons);
+        QIcon::setThemeSearchPaths(QStringList{":/icons"} << QIcon::themeSearchPaths());
+        QIcon::setThemeName("application");
+    }
+
+    return m_instance;
+}

--- a/src/gui/IconResources.cpp
+++ b/src/gui/IconResources.cpp
@@ -19,8 +19,6 @@
 #include "IconResources.h"
 
 #include <QBitmap>
-#include <QDir>
-#include <QLibrary>
 #include <QPainter>
 #include <QStyle>
 

--- a/src/gui/IconResources.h
+++ b/src/gui/IconResources.h
@@ -16,35 +16,40 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_RESOURCES_H
-#define KEEPASSX_RESOURCES_H
+#ifndef KEEPASSX_ICONRESOURCES_H
+#define KEEPASSX_ICONRESOURCES_H
 
+#include <QColor>
 #include <QHash>
+#include <QIcon>
 #include <QString>
 
-class Resources
+class IconResources
 {
 public:
-    QString dataPath(const QString& name) const;
-    QString pluginPath(const QString& name) const;
-    QString wordlistPath(const QString& name) const;
+    QIcon applicationIcon();
+    QIcon trayIcon();
+    QIcon trayIconLocked();
+    QIcon trayIconUnlocked();
+    QString trayIconAppearance() const;
+    QIcon icon(const QString& name, bool recolor = true, const QColor& overrideColor = QColor::Invalid);
+    QIcon onOffIcon(const QString& name, bool recolor = true);
 
-    static Resources* instance();
+    static IconResources* instance();
 
 private:
-    Resources();
-    bool trySetResourceDir(const QString& path);
+    IconResources();
 
-    static Resources* m_instance;
+    static IconResources* m_instance;
 
-    QString m_dataPath;
+    QHash<QString, QIcon> m_iconCache;
 
-    Q_DISABLE_COPY(Resources)
+    Q_DISABLE_COPY(IconResources)
 };
 
-inline Resources* resources()
+inline IconResources* iconResources()
 {
-    return Resources::instance();
+    return IconResources::instance();
 }
 
-#endif // KEEPASSX_RESOURCES_H
+#endif // KEEPASSX_ICONRESOURCES_H

--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -16,7 +16,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "IconResources.h"
+#include "Icons.h"
 
 #include <QBitmap>
 #include <QPainter>
@@ -27,14 +27,14 @@
 #include "gui/MainWindow.h"
 #include "gui/osutils/OSUtils.h"
 
-IconResources* IconResources::m_instance(nullptr);
+Icons* Icons::m_instance(nullptr);
 
-QIcon IconResources::applicationIcon()
+QIcon Icons::applicationIcon()
 {
     return icon("keepassxc", false);
 }
 
-QString IconResources::trayIconAppearance() const
+QString Icons::trayIconAppearance() const
 {
     auto iconAppearance = config()->get(Config::GUI_TrayIconAppearance).toString();
     if (iconAppearance.isNull()) {
@@ -47,12 +47,12 @@ QString IconResources::trayIconAppearance() const
     return iconAppearance;
 }
 
-QIcon IconResources::trayIcon()
+QIcon Icons::trayIcon()
 {
     return trayIconUnlocked();
 }
 
-QIcon IconResources::trayIconLocked()
+QIcon Icons::trayIconLocked()
 {
     auto iconApperance = trayIconAppearance();
 
@@ -65,7 +65,7 @@ QIcon IconResources::trayIconLocked()
     return icon("keepassxc-locked", false);
 }
 
-QIcon IconResources::trayIconUnlocked()
+QIcon Icons::trayIconUnlocked()
 {
     auto iconApperance = trayIconAppearance();
 
@@ -78,7 +78,7 @@ QIcon IconResources::trayIconUnlocked()
     return icon("keepassxc", false);
 }
 
-QIcon IconResources::icon(const QString& name, bool recolor, const QColor& overrideColor)
+QIcon Icons::icon(const QString& name, bool recolor, const QColor& overrideColor)
 {
     QIcon icon = m_iconCache.value(name);
 
@@ -135,7 +135,7 @@ QIcon IconResources::icon(const QString& name, bool recolor, const QColor& overr
     return icon;
 }
 
-QIcon IconResources::onOffIcon(const QString& name, bool recolor)
+QIcon Icons::onOffIcon(const QString& name, bool recolor)
 {
     QString cacheName = "onoff/" + name;
 
@@ -146,12 +146,12 @@ QIcon IconResources::onOffIcon(const QString& name, bool recolor)
     }
 
     const QSize size(48, 48);
-    QIcon on = IconResources::icon(name + "-on", recolor);
+    QIcon on = Icons::icon(name + "-on", recolor);
     icon.addPixmap(on.pixmap(size, QIcon::Mode::Normal), QIcon::Mode::Normal, QIcon::On);
     icon.addPixmap(on.pixmap(size, QIcon::Mode::Selected), QIcon::Mode::Selected, QIcon::On);
     icon.addPixmap(on.pixmap(size, QIcon::Mode::Disabled), QIcon::Mode::Disabled, QIcon::On);
 
-    QIcon off = IconResources::icon(name + "-off", recolor);
+    QIcon off = Icons::icon(name + "-off", recolor);
     icon.addPixmap(off.pixmap(size, QIcon::Mode::Normal), QIcon::Mode::Normal, QIcon::Off);
     icon.addPixmap(off.pixmap(size, QIcon::Mode::Selected), QIcon::Mode::Selected, QIcon::Off);
     icon.addPixmap(off.pixmap(size, QIcon::Mode::Disabled), QIcon::Mode::Disabled, QIcon::Off);
@@ -161,14 +161,14 @@ QIcon IconResources::onOffIcon(const QString& name, bool recolor)
     return icon;
 }
 
-IconResources::IconResources()
+Icons::Icons()
 {
 }
 
-IconResources* IconResources::instance()
+Icons* Icons::instance()
 {
     if (!m_instance) {
-        m_instance = new IconResources();
+        m_instance = new Icons();
 
         Q_INIT_RESOURCE(icons);
         QIcon::setThemeSearchPaths(QStringList{":/icons"} << QIcon::themeSearchPaths());

--- a/src/gui/Icons.h
+++ b/src/gui/Icons.h
@@ -16,15 +16,15 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_ICONRESOURCES_H
-#define KEEPASSX_ICONRESOURCES_H
+#ifndef KEEPASSX_ICONS_H
+#define KEEPASSX_ICONS_H
 
 #include <QColor>
 #include <QHash>
 #include <QIcon>
 #include <QString>
 
-class IconResources
+class Icons
 {
 public:
     QIcon applicationIcon();
@@ -35,21 +35,21 @@ public:
     QIcon icon(const QString& name, bool recolor = true, const QColor& overrideColor = QColor::Invalid);
     QIcon onOffIcon(const QString& name, bool recolor = true);
 
-    static IconResources* instance();
+    static Icons* instance();
 
 private:
-    IconResources();
+    Icons();
 
-    static IconResources* m_instance;
+    static Icons* m_instance;
 
     QHash<QString, QIcon> m_iconCache;
 
-    Q_DISABLE_COPY(IconResources)
+    Q_DISABLE_COPY(Icons)
 };
 
-inline IconResources* iconResources()
+inline Icons* icons()
 {
-    return IconResources::instance();
+    return Icons::instance();
 }
 
-#endif // KEEPASSX_ICONRESOURCES_H
+#endif // KEEPASSX_ICONS_H

--- a/src/gui/KMessageWidget.cpp
+++ b/src/gui/KMessageWidget.cpp
@@ -21,7 +21,7 @@
 #include "KMessageWidget.h"
 
 #include "core/Global.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QAction>
 #include <QEvent>
@@ -94,7 +94,7 @@ void KMessageWidgetPrivate::init(KMessageWidget *q_ptr)
     QAction *closeAction = new QAction(q);
     closeAction->setText(KMessageWidget::tr("&Close"));
     closeAction->setToolTip(KMessageWidget::tr("Close message"));
-    closeAction->setIcon(iconResources()->icon("message-close"));
+    closeAction->setIcon(icons()->icon("message-close"));
 
     QObject::connect(closeAction, SIGNAL(triggered(bool)), q, SLOT(animatedHide()));
 

--- a/src/gui/KMessageWidget.cpp
+++ b/src/gui/KMessageWidget.cpp
@@ -20,8 +20,8 @@
  */
 #include "KMessageWidget.h"
 
-#include "core/Resources.h"
 #include "core/Global.h"
+#include "gui/IconResources.h"
 
 #include <QAction>
 #include <QEvent>
@@ -94,7 +94,7 @@ void KMessageWidgetPrivate::init(KMessageWidget *q_ptr)
     QAction *closeAction = new QAction(q);
     closeAction->setText(KMessageWidget::tr("&Close"));
     closeAction->setToolTip(KMessageWidget::tr("Close message"));
-    closeAction->setIcon(Resources::instance()->icon("message-close"));
+    closeAction->setIcon(iconResources()->icon("message-close"));
 
     QObject::connect(closeAction, SIGNAL(triggered(bool)), q, SLOT(animatedHide()));
 

--- a/src/gui/LineEdit.cpp
+++ b/src/gui/LineEdit.cpp
@@ -22,7 +22,7 @@
 #include <QStyle>
 #include <QToolButton>
 
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 LineEdit::LineEdit(QWidget* parent)
     : QLineEdit(parent)
@@ -33,7 +33,7 @@ LineEdit::LineEdit(QWidget* parent)
     QString iconNameDirected =
         QString("edit-clear-locationbar-").append((layoutDirection() == Qt::LeftToRight) ? "rtl" : "ltr");
 
-    const auto icon = resources()->icon(iconNameDirected);
+    const auto icon = iconResources()->icon(iconNameDirected);
 
     m_clearButton->setIcon(icon);
     m_clearButton->setCursor(Qt::ArrowCursor);

--- a/src/gui/LineEdit.cpp
+++ b/src/gui/LineEdit.cpp
@@ -22,7 +22,7 @@
 #include <QStyle>
 #include <QToolButton>
 
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 LineEdit::LineEdit(QWidget* parent)
     : QLineEdit(parent)
@@ -33,7 +33,7 @@ LineEdit::LineEdit(QWidget* parent)
     QString iconNameDirected =
         QString("edit-clear-locationbar-").append((layoutDirection() == Qt::LeftToRight) ? "rtl" : "ltr");
 
-    const auto icon = iconResources()->icon(iconNameDirected);
+    const auto icon = icons()->icon(iconNameDirected);
 
     m_clearButton->setIcon(icon);
     m_clearButton->setCursor(Qt::ArrowCursor);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -37,7 +37,7 @@
 #include "core/Tools.h"
 #include "gui/AboutDialog.h"
 #include "gui/DatabaseWidget.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/MessageBox.h"
 #include "gui/SearchWidget.h"
 #include "keys/CompositeKey.h"
@@ -166,8 +166,8 @@ MainWindow::MainWindow()
     m_entryContextMenu->addAction(m_ui->actionEntryAddToAgent);
     m_entryContextMenu->addAction(m_ui->actionEntryRemoveFromAgent);
 
-    m_ui->actionEntryAddToAgent->setIcon(iconResources()->icon("utilities-terminal"));
-    m_ui->actionEntryRemoveFromAgent->setIcon(iconResources()->icon("utilities-terminal"));
+    m_ui->actionEntryAddToAgent->setIcon(icons()->icon("utilities-terminal"));
+    m_ui->actionEntryRemoveFromAgent->setIcon(icons()->icon("utilities-terminal"));
 #endif
 
     m_ui->actionEntryAddToAgent->setVisible(false);
@@ -197,7 +197,7 @@ MainWindow::MainWindow()
     connect(YubiKey::instance(), SIGNAL(challengeCompleted()), SLOT(hideYubiKeyPopup()), Qt::QueuedConnection);
 #endif
 
-    setWindowIcon(iconResources()->applicationIcon());
+    setWindowIcon(icons()->applicationIcon());
     m_ui->globalMessageWidget->hideMessage();
     connect(m_ui->globalMessageWidget, &MessageWidget::linkActivated, &MessageWidget::openHttpUrl);
 
@@ -335,59 +335,59 @@ MainWindow::MainWindow()
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C, this, SLOT(togglePasswordsHidden()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_B, this, SLOT(toggleUsernamesHidden()));
 
-    m_ui->actionDatabaseNew->setIcon(iconResources()->icon("document-new"));
-    m_ui->actionDatabaseOpen->setIcon(iconResources()->icon("document-open"));
-    m_ui->menuRecentDatabases->setIcon(iconResources()->icon("document-open-recent"));
-    m_ui->actionDatabaseSave->setIcon(iconResources()->icon("document-save"));
-    m_ui->actionDatabaseSaveAs->setIcon(iconResources()->icon("document-save-as"));
-    m_ui->actionDatabaseSaveBackup->setIcon(iconResources()->icon("document-save-copy"));
-    m_ui->actionDatabaseClose->setIcon(iconResources()->icon("document-close"));
-    m_ui->actionReports->setIcon(iconResources()->icon("reports"));
-    m_ui->actionDatabaseSettings->setIcon(iconResources()->icon("document-edit"));
-    m_ui->actionDatabaseSecurity->setIcon(iconResources()->icon("database-change-key"));
-    m_ui->actionLockDatabases->setIcon(iconResources()->icon("database-lock"));
-    m_ui->actionQuit->setIcon(iconResources()->icon("application-exit"));
-    m_ui->actionDatabaseMerge->setIcon(iconResources()->icon("database-merge"));
-    m_ui->menuImport->setIcon(iconResources()->icon("document-import"));
-    m_ui->menuExport->setIcon(iconResources()->icon("document-export"));
+    m_ui->actionDatabaseNew->setIcon(icons()->icon("document-new"));
+    m_ui->actionDatabaseOpen->setIcon(icons()->icon("document-open"));
+    m_ui->menuRecentDatabases->setIcon(icons()->icon("document-open-recent"));
+    m_ui->actionDatabaseSave->setIcon(icons()->icon("document-save"));
+    m_ui->actionDatabaseSaveAs->setIcon(icons()->icon("document-save-as"));
+    m_ui->actionDatabaseSaveBackup->setIcon(icons()->icon("document-save-copy"));
+    m_ui->actionDatabaseClose->setIcon(icons()->icon("document-close"));
+    m_ui->actionReports->setIcon(icons()->icon("reports"));
+    m_ui->actionDatabaseSettings->setIcon(icons()->icon("document-edit"));
+    m_ui->actionDatabaseSecurity->setIcon(icons()->icon("database-change-key"));
+    m_ui->actionLockDatabases->setIcon(icons()->icon("database-lock"));
+    m_ui->actionQuit->setIcon(icons()->icon("application-exit"));
+    m_ui->actionDatabaseMerge->setIcon(icons()->icon("database-merge"));
+    m_ui->menuImport->setIcon(icons()->icon("document-import"));
+    m_ui->menuExport->setIcon(icons()->icon("document-export"));
 
-    m_ui->actionEntryNew->setIcon(iconResources()->icon("entry-new"));
-    m_ui->actionEntryClone->setIcon(iconResources()->icon("entry-clone"));
-    m_ui->actionEntryEdit->setIcon(iconResources()->icon("entry-edit"));
-    m_ui->actionEntryDelete->setIcon(iconResources()->icon("entry-delete"));
-    m_ui->actionEntryAutoType->setIcon(iconResources()->icon("auto-type"));
-    m_ui->menuEntryAutoTypeWithSequence->setIcon(iconResources()->icon("auto-type"));
-    m_ui->actionEntryAutoTypeUsername->setIcon(iconResources()->icon("auto-type"));
-    m_ui->actionEntryAutoTypeUsernameEnter->setIcon(iconResources()->icon("auto-type"));
-    m_ui->actionEntryAutoTypePassword->setIcon(iconResources()->icon("auto-type"));
-    m_ui->actionEntryAutoTypePasswordEnter->setIcon(iconResources()->icon("auto-type"));
-    m_ui->actionEntryMoveUp->setIcon(iconResources()->icon("move-up"));
-    m_ui->actionEntryMoveDown->setIcon(iconResources()->icon("move-down"));
-    m_ui->actionEntryCopyUsername->setIcon(iconResources()->icon("username-copy"));
-    m_ui->actionEntryCopyPassword->setIcon(iconResources()->icon("password-copy"));
-    m_ui->actionEntryCopyURL->setIcon(iconResources()->icon("url-copy"));
-    m_ui->actionEntryDownloadIcon->setIcon(iconResources()->icon("favicon-download"));
-    m_ui->actionGroupSortAsc->setIcon(iconResources()->icon("sort-alphabetical-ascending"));
-    m_ui->actionGroupSortDesc->setIcon(iconResources()->icon("sort-alphabetical-descending"));
+    m_ui->actionEntryNew->setIcon(icons()->icon("entry-new"));
+    m_ui->actionEntryClone->setIcon(icons()->icon("entry-clone"));
+    m_ui->actionEntryEdit->setIcon(icons()->icon("entry-edit"));
+    m_ui->actionEntryDelete->setIcon(icons()->icon("entry-delete"));
+    m_ui->actionEntryAutoType->setIcon(icons()->icon("auto-type"));
+    m_ui->menuEntryAutoTypeWithSequence->setIcon(icons()->icon("auto-type"));
+    m_ui->actionEntryAutoTypeUsername->setIcon(icons()->icon("auto-type"));
+    m_ui->actionEntryAutoTypeUsernameEnter->setIcon(icons()->icon("auto-type"));
+    m_ui->actionEntryAutoTypePassword->setIcon(icons()->icon("auto-type"));
+    m_ui->actionEntryAutoTypePasswordEnter->setIcon(icons()->icon("auto-type"));
+    m_ui->actionEntryMoveUp->setIcon(icons()->icon("move-up"));
+    m_ui->actionEntryMoveDown->setIcon(icons()->icon("move-down"));
+    m_ui->actionEntryCopyUsername->setIcon(icons()->icon("username-copy"));
+    m_ui->actionEntryCopyPassword->setIcon(icons()->icon("password-copy"));
+    m_ui->actionEntryCopyURL->setIcon(icons()->icon("url-copy"));
+    m_ui->actionEntryDownloadIcon->setIcon(icons()->icon("favicon-download"));
+    m_ui->actionGroupSortAsc->setIcon(icons()->icon("sort-alphabetical-ascending"));
+    m_ui->actionGroupSortDesc->setIcon(icons()->icon("sort-alphabetical-descending"));
 
-    m_ui->actionGroupNew->setIcon(iconResources()->icon("group-new"));
-    m_ui->actionGroupEdit->setIcon(iconResources()->icon("group-edit"));
-    m_ui->actionGroupDelete->setIcon(iconResources()->icon("group-delete"));
-    m_ui->actionGroupEmptyRecycleBin->setIcon(iconResources()->icon("group-empty-trash"));
-    m_ui->actionEntryOpenUrl->setIcon(iconResources()->icon("web"));
-    m_ui->actionGroupDownloadFavicons->setIcon(iconResources()->icon("favicon-download"));
+    m_ui->actionGroupNew->setIcon(icons()->icon("group-new"));
+    m_ui->actionGroupEdit->setIcon(icons()->icon("group-edit"));
+    m_ui->actionGroupDelete->setIcon(icons()->icon("group-delete"));
+    m_ui->actionGroupEmptyRecycleBin->setIcon(icons()->icon("group-empty-trash"));
+    m_ui->actionEntryOpenUrl->setIcon(icons()->icon("web"));
+    m_ui->actionGroupDownloadFavicons->setIcon(icons()->icon("favicon-download"));
 
-    m_ui->actionSettings->setIcon(iconResources()->icon("configure"));
-    m_ui->actionPasswordGenerator->setIcon(iconResources()->icon("password-generator"));
+    m_ui->actionSettings->setIcon(icons()->icon("configure"));
+    m_ui->actionPasswordGenerator->setIcon(icons()->icon("password-generator"));
 
-    m_ui->actionAbout->setIcon(iconResources()->icon("help-about"));
-    m_ui->actionDonate->setIcon(iconResources()->icon("donate"));
-    m_ui->actionBugReport->setIcon(iconResources()->icon("bugreport"));
-    m_ui->actionGettingStarted->setIcon(iconResources()->icon("getting-started"));
-    m_ui->actionUserGuide->setIcon(iconResources()->icon("user-guide"));
-    m_ui->actionOnlineHelp->setIcon(iconResources()->icon("system-help"));
-    m_ui->actionKeyboardShortcuts->setIcon(iconResources()->icon("keyboard-shortcuts"));
-    m_ui->actionCheckForUpdates->setIcon(iconResources()->icon("system-software-update"));
+    m_ui->actionAbout->setIcon(icons()->icon("help-about"));
+    m_ui->actionDonate->setIcon(icons()->icon("donate"));
+    m_ui->actionBugReport->setIcon(icons()->icon("bugreport"));
+    m_ui->actionGettingStarted->setIcon(icons()->icon("getting-started"));
+    m_ui->actionUserGuide->setIcon(icons()->icon("user-guide"));
+    m_ui->actionOnlineHelp->setIcon(icons()->icon("system-help"));
+    m_ui->actionKeyboardShortcuts->setIcon(icons()->icon("keyboard-shortcuts"));
+    m_ui->actionCheckForUpdates->setIcon(icons()->icon("system-software-update"));
 
     m_actionMultiplexer.connect(
         SIGNAL(currentModeChanged(DatabaseWidget::Mode)), this, SLOT(setMenuActionState(DatabaseWidget::Mode)));
@@ -1283,7 +1283,7 @@ void MainWindow::updateTrayIcon()
 
             auto* actionToggle = new QAction(tr("Toggle window"), menu);
             menu->addAction(actionToggle);
-            actionToggle->setIcon(iconResources()->icon("keepassxc-monochrome-dark"));
+            actionToggle->setIcon(icons()->icon("keepassxc-monochrome-dark"));
 
             menu->addAction(m_ui->actionLockDatabases);
 
@@ -1303,16 +1303,16 @@ void MainWindow::updateTrayIcon()
 
             m_trayIcon->setContextMenu(menu);
 
-            m_trayIcon->setIcon(iconResources()->trayIcon());
+            m_trayIcon->setIcon(icons()->trayIcon());
             m_trayIcon->show();
         }
 
         if (m_ui->tabWidget->count() == 0) {
-            m_trayIcon->setIcon(iconResources()->trayIcon());
+            m_trayIcon->setIcon(icons()->trayIcon());
         } else if (m_ui->tabWidget->hasLockableDatabases()) {
-            m_trayIcon->setIcon(iconResources()->trayIconUnlocked());
+            m_trayIcon->setIcon(icons()->trayIconUnlocked());
         } else {
-            m_trayIcon->setIcon(iconResources()->trayIconLocked());
+            m_trayIcon->setIcon(icons()->trayIconLocked());
         }
     } else {
         QApplication::setQuitOnLastWindowClosed(true);
@@ -1690,7 +1690,7 @@ void MainWindow::displayDesktopNotification(const QString& msg, QString title, i
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
-    m_trayIcon->showMessage(title, msg, iconResources()->applicationIcon(), msTimeoutHint);
+    m_trayIcon->showMessage(title, msg, icons()->applicationIcon(), msTimeoutHint);
 #else
     m_trayIcon->showMessage(title, msg, QSystemTrayIcon::Information, msTimeoutHint);
 #endif

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -37,6 +37,7 @@
 #include "core/Tools.h"
 #include "gui/AboutDialog.h"
 #include "gui/DatabaseWidget.h"
+#include "gui/IconResources.h"
 #include "gui/MessageBox.h"
 #include "gui/SearchWidget.h"
 #include "keys/CompositeKey.h"
@@ -165,8 +166,8 @@ MainWindow::MainWindow()
     m_entryContextMenu->addAction(m_ui->actionEntryAddToAgent);
     m_entryContextMenu->addAction(m_ui->actionEntryRemoveFromAgent);
 
-    m_ui->actionEntryAddToAgent->setIcon(resources()->icon("utilities-terminal"));
-    m_ui->actionEntryRemoveFromAgent->setIcon(resources()->icon("utilities-terminal"));
+    m_ui->actionEntryAddToAgent->setIcon(iconResources()->icon("utilities-terminal"));
+    m_ui->actionEntryRemoveFromAgent->setIcon(iconResources()->icon("utilities-terminal"));
 #endif
 
     m_ui->actionEntryAddToAgent->setVisible(false);
@@ -196,7 +197,7 @@ MainWindow::MainWindow()
     connect(YubiKey::instance(), SIGNAL(challengeCompleted()), SLOT(hideYubiKeyPopup()), Qt::QueuedConnection);
 #endif
 
-    setWindowIcon(resources()->applicationIcon());
+    setWindowIcon(iconResources()->applicationIcon());
     m_ui->globalMessageWidget->hideMessage();
     connect(m_ui->globalMessageWidget, &MessageWidget::linkActivated, &MessageWidget::openHttpUrl);
 
@@ -334,59 +335,59 @@ MainWindow::MainWindow()
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C, this, SLOT(togglePasswordsHidden()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_B, this, SLOT(toggleUsernamesHidden()));
 
-    m_ui->actionDatabaseNew->setIcon(resources()->icon("document-new"));
-    m_ui->actionDatabaseOpen->setIcon(resources()->icon("document-open"));
-    m_ui->menuRecentDatabases->setIcon(resources()->icon("document-open-recent"));
-    m_ui->actionDatabaseSave->setIcon(resources()->icon("document-save"));
-    m_ui->actionDatabaseSaveAs->setIcon(resources()->icon("document-save-as"));
-    m_ui->actionDatabaseSaveBackup->setIcon(resources()->icon("document-save-copy"));
-    m_ui->actionDatabaseClose->setIcon(resources()->icon("document-close"));
-    m_ui->actionReports->setIcon(resources()->icon("reports"));
-    m_ui->actionDatabaseSettings->setIcon(resources()->icon("document-edit"));
-    m_ui->actionDatabaseSecurity->setIcon(resources()->icon("database-change-key"));
-    m_ui->actionLockDatabases->setIcon(resources()->icon("database-lock"));
-    m_ui->actionQuit->setIcon(resources()->icon("application-exit"));
-    m_ui->actionDatabaseMerge->setIcon(resources()->icon("database-merge"));
-    m_ui->menuImport->setIcon(resources()->icon("document-import"));
-    m_ui->menuExport->setIcon(resources()->icon("document-export"));
+    m_ui->actionDatabaseNew->setIcon(iconResources()->icon("document-new"));
+    m_ui->actionDatabaseOpen->setIcon(iconResources()->icon("document-open"));
+    m_ui->menuRecentDatabases->setIcon(iconResources()->icon("document-open-recent"));
+    m_ui->actionDatabaseSave->setIcon(iconResources()->icon("document-save"));
+    m_ui->actionDatabaseSaveAs->setIcon(iconResources()->icon("document-save-as"));
+    m_ui->actionDatabaseSaveBackup->setIcon(iconResources()->icon("document-save-copy"));
+    m_ui->actionDatabaseClose->setIcon(iconResources()->icon("document-close"));
+    m_ui->actionReports->setIcon(iconResources()->icon("reports"));
+    m_ui->actionDatabaseSettings->setIcon(iconResources()->icon("document-edit"));
+    m_ui->actionDatabaseSecurity->setIcon(iconResources()->icon("database-change-key"));
+    m_ui->actionLockDatabases->setIcon(iconResources()->icon("database-lock"));
+    m_ui->actionQuit->setIcon(iconResources()->icon("application-exit"));
+    m_ui->actionDatabaseMerge->setIcon(iconResources()->icon("database-merge"));
+    m_ui->menuImport->setIcon(iconResources()->icon("document-import"));
+    m_ui->menuExport->setIcon(iconResources()->icon("document-export"));
 
-    m_ui->actionEntryNew->setIcon(resources()->icon("entry-new"));
-    m_ui->actionEntryClone->setIcon(resources()->icon("entry-clone"));
-    m_ui->actionEntryEdit->setIcon(resources()->icon("entry-edit"));
-    m_ui->actionEntryDelete->setIcon(resources()->icon("entry-delete"));
-    m_ui->actionEntryAutoType->setIcon(resources()->icon("auto-type"));
-    m_ui->menuEntryAutoTypeWithSequence->setIcon(resources()->icon("auto-type"));
-    m_ui->actionEntryAutoTypeUsername->setIcon(resources()->icon("auto-type"));
-    m_ui->actionEntryAutoTypeUsernameEnter->setIcon(resources()->icon("auto-type"));
-    m_ui->actionEntryAutoTypePassword->setIcon(resources()->icon("auto-type"));
-    m_ui->actionEntryAutoTypePasswordEnter->setIcon(resources()->icon("auto-type"));
-    m_ui->actionEntryMoveUp->setIcon(resources()->icon("move-up"));
-    m_ui->actionEntryMoveDown->setIcon(resources()->icon("move-down"));
-    m_ui->actionEntryCopyUsername->setIcon(resources()->icon("username-copy"));
-    m_ui->actionEntryCopyPassword->setIcon(resources()->icon("password-copy"));
-    m_ui->actionEntryCopyURL->setIcon(resources()->icon("url-copy"));
-    m_ui->actionEntryDownloadIcon->setIcon(resources()->icon("favicon-download"));
-    m_ui->actionGroupSortAsc->setIcon(resources()->icon("sort-alphabetical-ascending"));
-    m_ui->actionGroupSortDesc->setIcon(resources()->icon("sort-alphabetical-descending"));
+    m_ui->actionEntryNew->setIcon(iconResources()->icon("entry-new"));
+    m_ui->actionEntryClone->setIcon(iconResources()->icon("entry-clone"));
+    m_ui->actionEntryEdit->setIcon(iconResources()->icon("entry-edit"));
+    m_ui->actionEntryDelete->setIcon(iconResources()->icon("entry-delete"));
+    m_ui->actionEntryAutoType->setIcon(iconResources()->icon("auto-type"));
+    m_ui->menuEntryAutoTypeWithSequence->setIcon(iconResources()->icon("auto-type"));
+    m_ui->actionEntryAutoTypeUsername->setIcon(iconResources()->icon("auto-type"));
+    m_ui->actionEntryAutoTypeUsernameEnter->setIcon(iconResources()->icon("auto-type"));
+    m_ui->actionEntryAutoTypePassword->setIcon(iconResources()->icon("auto-type"));
+    m_ui->actionEntryAutoTypePasswordEnter->setIcon(iconResources()->icon("auto-type"));
+    m_ui->actionEntryMoveUp->setIcon(iconResources()->icon("move-up"));
+    m_ui->actionEntryMoveDown->setIcon(iconResources()->icon("move-down"));
+    m_ui->actionEntryCopyUsername->setIcon(iconResources()->icon("username-copy"));
+    m_ui->actionEntryCopyPassword->setIcon(iconResources()->icon("password-copy"));
+    m_ui->actionEntryCopyURL->setIcon(iconResources()->icon("url-copy"));
+    m_ui->actionEntryDownloadIcon->setIcon(iconResources()->icon("favicon-download"));
+    m_ui->actionGroupSortAsc->setIcon(iconResources()->icon("sort-alphabetical-ascending"));
+    m_ui->actionGroupSortDesc->setIcon(iconResources()->icon("sort-alphabetical-descending"));
 
-    m_ui->actionGroupNew->setIcon(resources()->icon("group-new"));
-    m_ui->actionGroupEdit->setIcon(resources()->icon("group-edit"));
-    m_ui->actionGroupDelete->setIcon(resources()->icon("group-delete"));
-    m_ui->actionGroupEmptyRecycleBin->setIcon(resources()->icon("group-empty-trash"));
-    m_ui->actionEntryOpenUrl->setIcon(resources()->icon("web"));
-    m_ui->actionGroupDownloadFavicons->setIcon(resources()->icon("favicon-download"));
+    m_ui->actionGroupNew->setIcon(iconResources()->icon("group-new"));
+    m_ui->actionGroupEdit->setIcon(iconResources()->icon("group-edit"));
+    m_ui->actionGroupDelete->setIcon(iconResources()->icon("group-delete"));
+    m_ui->actionGroupEmptyRecycleBin->setIcon(iconResources()->icon("group-empty-trash"));
+    m_ui->actionEntryOpenUrl->setIcon(iconResources()->icon("web"));
+    m_ui->actionGroupDownloadFavicons->setIcon(iconResources()->icon("favicon-download"));
 
-    m_ui->actionSettings->setIcon(resources()->icon("configure"));
-    m_ui->actionPasswordGenerator->setIcon(resources()->icon("password-generator"));
+    m_ui->actionSettings->setIcon(iconResources()->icon("configure"));
+    m_ui->actionPasswordGenerator->setIcon(iconResources()->icon("password-generator"));
 
-    m_ui->actionAbout->setIcon(resources()->icon("help-about"));
-    m_ui->actionDonate->setIcon(resources()->icon("donate"));
-    m_ui->actionBugReport->setIcon(resources()->icon("bugreport"));
-    m_ui->actionGettingStarted->setIcon(resources()->icon("getting-started"));
-    m_ui->actionUserGuide->setIcon(resources()->icon("user-guide"));
-    m_ui->actionOnlineHelp->setIcon(resources()->icon("system-help"));
-    m_ui->actionKeyboardShortcuts->setIcon(resources()->icon("keyboard-shortcuts"));
-    m_ui->actionCheckForUpdates->setIcon(resources()->icon("system-software-update"));
+    m_ui->actionAbout->setIcon(iconResources()->icon("help-about"));
+    m_ui->actionDonate->setIcon(iconResources()->icon("donate"));
+    m_ui->actionBugReport->setIcon(iconResources()->icon("bugreport"));
+    m_ui->actionGettingStarted->setIcon(iconResources()->icon("getting-started"));
+    m_ui->actionUserGuide->setIcon(iconResources()->icon("user-guide"));
+    m_ui->actionOnlineHelp->setIcon(iconResources()->icon("system-help"));
+    m_ui->actionKeyboardShortcuts->setIcon(iconResources()->icon("keyboard-shortcuts"));
+    m_ui->actionCheckForUpdates->setIcon(iconResources()->icon("system-software-update"));
 
     m_actionMultiplexer.connect(
         SIGNAL(currentModeChanged(DatabaseWidget::Mode)), this, SLOT(setMenuActionState(DatabaseWidget::Mode)));
@@ -1282,7 +1283,7 @@ void MainWindow::updateTrayIcon()
 
             auto* actionToggle = new QAction(tr("Toggle window"), menu);
             menu->addAction(actionToggle);
-            actionToggle->setIcon(resources()->icon("keepassxc-monochrome-dark"));
+            actionToggle->setIcon(iconResources()->icon("keepassxc-monochrome-dark"));
 
             menu->addAction(m_ui->actionLockDatabases);
 
@@ -1302,16 +1303,16 @@ void MainWindow::updateTrayIcon()
 
             m_trayIcon->setContextMenu(menu);
 
-            m_trayIcon->setIcon(resources()->trayIcon());
+            m_trayIcon->setIcon(iconResources()->trayIcon());
             m_trayIcon->show();
         }
 
         if (m_ui->tabWidget->count() == 0) {
-            m_trayIcon->setIcon(resources()->trayIcon());
+            m_trayIcon->setIcon(iconResources()->trayIcon());
         } else if (m_ui->tabWidget->hasLockableDatabases()) {
-            m_trayIcon->setIcon(resources()->trayIconUnlocked());
+            m_trayIcon->setIcon(iconResources()->trayIconUnlocked());
         } else {
-            m_trayIcon->setIcon(resources()->trayIconLocked());
+            m_trayIcon->setIcon(iconResources()->trayIconLocked());
         }
     } else {
         QApplication::setQuitOnLastWindowClosed(true);
@@ -1689,7 +1690,7 @@ void MainWindow::displayDesktopNotification(const QString& msg, QString title, i
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
-    m_trayIcon->showMessage(title, msg, resources()->applicationIcon(), msTimeoutHint);
+    m_trayIcon->showMessage(title, msg, iconResources()->applicationIcon(), msTimeoutHint);
 #else
     m_trayIcon->showMessage(title, msg, QSystemTrayIcon::Information, msTimeoutHint);
 #endif

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -20,7 +20,7 @@
 
 #include "core/Config.h"
 #include "gui/Font.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/PasswordGeneratorWidget.h"
 #include "gui/osutils/OSUtils.h"
 #include "gui/styles/StateColorPalette.h"
@@ -33,12 +33,12 @@
 PasswordEdit::PasswordEdit(QWidget* parent)
     : QLineEdit(parent)
 {
-    const QIcon errorIcon = iconResources()->icon("dialog-error");
+    const QIcon errorIcon = icons()->icon("dialog-error");
     m_errorAction = addAction(errorIcon, QLineEdit::TrailingPosition);
     m_errorAction->setVisible(false);
     m_errorAction->setToolTip(tr("Passwords do not match"));
 
-    const QIcon correctIcon = iconResources()->icon("dialog-ok");
+    const QIcon correctIcon = icons()->icon("dialog-ok");
     m_correctAction = addAction(correctIcon, QLineEdit::TrailingPosition);
     m_correctAction->setVisible(false);
     m_correctAction->setToolTip(tr("Passwords match so far"));
@@ -58,7 +58,7 @@ PasswordEdit::PasswordEdit(QWidget* parent)
 #endif
 
     m_toggleVisibleAction = new QAction(
-        iconResources()->icon("password-show-off"),
+        icons()->icon("password-show-off"),
         tr("Toggle Password (%1)").arg(QKeySequence(modifier + Qt::Key_H).toString(QKeySequence::NativeText)),
         nullptr);
     m_toggleVisibleAction->setCheckable(true);
@@ -68,7 +68,7 @@ PasswordEdit::PasswordEdit(QWidget* parent)
     connect(m_toggleVisibleAction, &QAction::triggered, this, &PasswordEdit::setShowPassword);
 
     m_passwordGeneratorAction = new QAction(
-        iconResources()->icon("password-generator"),
+        icons()->icon("password-generator"),
         tr("Generate Password (%1)").arg(QKeySequence(modifier + Qt::Key_G).toString(QKeySequence::NativeText)),
         nullptr);
     m_passwordGeneratorAction->setShortcut(modifier + Qt::Key_G);
@@ -77,7 +77,7 @@ PasswordEdit::PasswordEdit(QWidget* parent)
     m_passwordGeneratorAction->setVisible(false);
 
     m_capslockAction =
-        new QAction(iconResources()->icon("dialog-warning", true, StateColorPalette().color(StateColorPalette::Error)),
+        new QAction(icons()->icon("dialog-warning", true, StateColorPalette().color(StateColorPalette::Error)),
                     tr("Warning: Caps Lock enabled!"),
                     nullptr);
     addAction(m_capslockAction, QLineEdit::LeadingPosition);
@@ -113,7 +113,7 @@ void PasswordEdit::enablePasswordGenerator()
 void PasswordEdit::setShowPassword(bool show)
 {
     setEchoMode(show ? QLineEdit::Normal : QLineEdit::Password);
-    m_toggleVisibleAction->setIcon(iconResources()->icon(show ? "password-show-on" : "password-show-off"));
+    m_toggleVisibleAction->setIcon(icons()->icon(show ? "password-show-on" : "password-show-off"));
     m_toggleVisibleAction->setChecked(show);
 
     if (m_repeatPasswordEdit) {

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,8 +19,8 @@
 #include "PasswordEdit.h"
 
 #include "core/Config.h"
-#include "core/Resources.h"
 #include "gui/Font.h"
+#include "gui/IconResources.h"
 #include "gui/PasswordGeneratorWidget.h"
 #include "gui/osutils/OSUtils.h"
 #include "gui/styles/StateColorPalette.h"
@@ -33,12 +33,12 @@
 PasswordEdit::PasswordEdit(QWidget* parent)
     : QLineEdit(parent)
 {
-    const QIcon errorIcon = resources()->icon("dialog-error");
+    const QIcon errorIcon = iconResources()->icon("dialog-error");
     m_errorAction = addAction(errorIcon, QLineEdit::TrailingPosition);
     m_errorAction->setVisible(false);
     m_errorAction->setToolTip(tr("Passwords do not match"));
 
-    const QIcon correctIcon = resources()->icon("dialog-ok");
+    const QIcon correctIcon = iconResources()->icon("dialog-ok");
     m_correctAction = addAction(correctIcon, QLineEdit::TrailingPosition);
     m_correctAction->setVisible(false);
     m_correctAction->setToolTip(tr("Passwords match so far"));
@@ -58,7 +58,7 @@ PasswordEdit::PasswordEdit(QWidget* parent)
 #endif
 
     m_toggleVisibleAction = new QAction(
-        resources()->icon("password-show-off"),
+        iconResources()->icon("password-show-off"),
         tr("Toggle Password (%1)").arg(QKeySequence(modifier + Qt::Key_H).toString(QKeySequence::NativeText)),
         nullptr);
     m_toggleVisibleAction->setCheckable(true);
@@ -68,7 +68,7 @@ PasswordEdit::PasswordEdit(QWidget* parent)
     connect(m_toggleVisibleAction, &QAction::triggered, this, &PasswordEdit::setShowPassword);
 
     m_passwordGeneratorAction = new QAction(
-        resources()->icon("password-generator"),
+        iconResources()->icon("password-generator"),
         tr("Generate Password (%1)").arg(QKeySequence(modifier + Qt::Key_G).toString(QKeySequence::NativeText)),
         nullptr);
     m_passwordGeneratorAction->setShortcut(modifier + Qt::Key_G);
@@ -77,7 +77,7 @@ PasswordEdit::PasswordEdit(QWidget* parent)
     m_passwordGeneratorAction->setVisible(false);
 
     m_capslockAction =
-        new QAction(resources()->icon("dialog-warning", true, StateColorPalette().color(StateColorPalette::Error)),
+        new QAction(iconResources()->icon("dialog-warning", true, StateColorPalette().color(StateColorPalette::Error)),
                     tr("Warning: Caps Lock enabled!"),
                     nullptr);
     addAction(m_capslockAction, QLineEdit::LeadingPosition);
@@ -113,7 +113,7 @@ void PasswordEdit::enablePasswordGenerator()
 void PasswordEdit::setShowPassword(bool show)
 {
     setEchoMode(show ? QLineEdit::Normal : QLineEdit::Password);
-    m_toggleVisibleAction->setIcon(resources()->icon(show ? "password-show-on" : "password-show-off"));
+    m_toggleVisibleAction->setIcon(iconResources()->icon(show ? "password-show-on" : "password-show-off"));
     m_toggleVisibleAction->setChecked(show);
 
     if (m_repeatPasswordEdit) {

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -29,6 +29,7 @@
 #include "core/PasswordHealth.h"
 #include "core/Resources.h"
 #include "gui/Clipboard.h"
+#include "gui/IconResources.h"
 #include "gui/styles/StateColorPalette.h"
 
 PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
@@ -39,17 +40,17 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
 
-    m_ui->buttonGenerate->setIcon(resources()->icon("refresh"));
+    m_ui->buttonGenerate->setIcon(iconResources()->icon("refresh"));
     m_ui->buttonGenerate->setToolTip(
         tr("Regenerate password (%1)").arg(m_ui->buttonGenerate->shortcut().toString(QKeySequence::NativeText)));
-    m_ui->buttonCopy->setIcon(resources()->icon("clipboard-text"));
+    m_ui->buttonCopy->setIcon(iconResources()->icon("clipboard-text"));
     m_ui->buttonClose->setShortcut(Qt::Key_Escape);
 
-    m_ui->clearInclude->setIcon(resources()->icon("edit-clear-locationbar-rtl"));
+    m_ui->clearInclude->setIcon(iconResources()->icon("edit-clear-locationbar-rtl"));
     m_ui->editAdditionalChars->addAction(m_ui->clearInclude, QLineEdit::TrailingPosition);
     m_ui->clearInclude->setVisible(false);
 
-    m_ui->clearExclude->setIcon(resources()->icon("edit-clear-locationbar-rtl"));
+    m_ui->clearExclude->setIcon(iconResources()->icon("edit-clear-locationbar-rtl"));
     m_ui->editExcludedChars->addAction(m_ui->clearExclude, QLineEdit::TrailingPosition);
     m_ui->clearExclude->setVisible(false);
 

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -29,7 +29,7 @@
 #include "core/PasswordHealth.h"
 #include "core/Resources.h"
 #include "gui/Clipboard.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/styles/StateColorPalette.h"
 
 PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
@@ -40,17 +40,17 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
 
-    m_ui->buttonGenerate->setIcon(iconResources()->icon("refresh"));
+    m_ui->buttonGenerate->setIcon(icons()->icon("refresh"));
     m_ui->buttonGenerate->setToolTip(
         tr("Regenerate password (%1)").arg(m_ui->buttonGenerate->shortcut().toString(QKeySequence::NativeText)));
-    m_ui->buttonCopy->setIcon(iconResources()->icon("clipboard-text"));
+    m_ui->buttonCopy->setIcon(icons()->icon("clipboard-text"));
     m_ui->buttonClose->setShortcut(Qt::Key_Escape);
 
-    m_ui->clearInclude->setIcon(iconResources()->icon("edit-clear-locationbar-rtl"));
+    m_ui->clearInclude->setIcon(icons()->icon("edit-clear-locationbar-rtl"));
     m_ui->editAdditionalChars->addAction(m_ui->clearInclude, QLineEdit::TrailingPosition);
     m_ui->clearInclude->setVisible(false);
 
-    m_ui->clearExclude->setIcon(iconResources()->icon("edit-clear-locationbar-rtl"));
+    m_ui->clearExclude->setIcon(icons()->icon("edit-clear-locationbar-rtl"));
     m_ui->editExcludedChars->addAction(m_ui->clearExclude, QLineEdit::TrailingPosition);
     m_ui->clearExclude->setVisible(false);
 

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@
 #include <QToolButton>
 
 #include "core/Config.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "gui/widgets/PopupHelpWidget.h"
 
 SearchWidget::SearchWidget(QWidget* parent)
@@ -69,13 +69,13 @@ SearchWidget::SearchWidget(QWidget* parent)
     m_actionLimitGroup->setCheckable(true);
     m_actionLimitGroup->setChecked(config()->get(Config::SearchLimitGroup).toBool());
 
-    m_ui->searchIcon->setIcon(resources()->icon("system-search"));
+    m_ui->searchIcon->setIcon(iconResources()->icon("system-search"));
     m_ui->searchEdit->addAction(m_ui->searchIcon, QLineEdit::LeadingPosition);
 
-    m_ui->helpIcon->setIcon(resources()->icon("system-help"));
+    m_ui->helpIcon->setIcon(iconResources()->icon("system-help"));
     m_ui->searchEdit->addAction(m_ui->helpIcon, QLineEdit::TrailingPosition);
 
-    m_ui->clearIcon->setIcon(resources()->icon("edit-clear-locationbar-rtl"));
+    m_ui->clearIcon->setIcon(iconResources()->icon("edit-clear-locationbar-rtl"));
     m_ui->clearIcon->setVisible(false);
     m_ui->searchEdit->addAction(m_ui->clearIcon, QLineEdit::TrailingPosition);
 

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -25,7 +25,7 @@
 #include <QToolButton>
 
 #include "core/Config.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/widgets/PopupHelpWidget.h"
 
 SearchWidget::SearchWidget(QWidget* parent)
@@ -69,13 +69,13 @@ SearchWidget::SearchWidget(QWidget* parent)
     m_actionLimitGroup->setCheckable(true);
     m_actionLimitGroup->setChecked(config()->get(Config::SearchLimitGroup).toBool());
 
-    m_ui->searchIcon->setIcon(iconResources()->icon("system-search"));
+    m_ui->searchIcon->setIcon(icons()->icon("system-search"));
     m_ui->searchEdit->addAction(m_ui->searchIcon, QLineEdit::LeadingPosition);
 
-    m_ui->helpIcon->setIcon(iconResources()->icon("system-help"));
+    m_ui->helpIcon->setIcon(icons()->icon("system-help"));
     m_ui->searchEdit->addAction(m_ui->helpIcon, QLineEdit::TrailingPosition);
 
-    m_ui->clearIcon->setIcon(iconResources()->icon("edit-clear-locationbar-rtl"));
+    m_ui->clearIcon->setIcon(icons()->icon("edit-clear-locationbar-rtl"));
     m_ui->clearIcon->setVisible(false);
     m_ui->searchEdit->addAction(m_ui->clearIcon, QLineEdit::TrailingPosition);
 

--- a/src/gui/URLEdit.cpp
+++ b/src/gui/URLEdit.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,15 +21,15 @@
 #include <QRegularExpression>
 
 #include "core/Config.h"
-#include "core/Resources.h"
 #include "core/Tools.h"
 #include "gui/Font.h"
+#include "gui/IconResources.h"
 #include "gui/styles/StateColorPalette.h"
 
 URLEdit::URLEdit(QWidget* parent)
     : QLineEdit(parent)
 {
-    const QIcon errorIcon = resources()->icon("dialog-error");
+    const QIcon errorIcon = iconResources()->icon("dialog-error");
     m_errorAction = addAction(errorIcon, QLineEdit::TrailingPosition);
     m_errorAction->setVisible(false);
     m_errorAction->setToolTip(tr("Invalid URL"));

--- a/src/gui/URLEdit.cpp
+++ b/src/gui/URLEdit.cpp
@@ -23,13 +23,13 @@
 #include "core/Config.h"
 #include "core/Tools.h"
 #include "gui/Font.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/styles/StateColorPalette.h"
 
 URLEdit::URLEdit(QWidget* parent)
     : QLineEdit(parent)
 {
-    const QIcon errorIcon = iconResources()->icon("dialog-error");
+    const QIcon errorIcon = icons()->icon("dialog-error");
     m_errorAction = addAction(errorIcon, QLineEdit::TrailingPosition);
     m_errorAction->setVisible(false);
     m_errorAction->setToolTip(tr("Invalid URL"));

--- a/src/gui/UpdateCheckDialog.cpp
+++ b/src/gui/UpdateCheckDialog.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "UpdateCheckDialog.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "ui_UpdateCheckDialog.h"
 #include "updatecheck/UpdateChecker.h"
 
@@ -28,7 +28,7 @@ UpdateCheckDialog::UpdateCheckDialog(QWidget* parent)
     setWindowFlags(Qt::Window);
     setAttribute(Qt::WA_DeleteOnClose);
 
-    m_ui->iconLabel->setPixmap(iconResources()->applicationIcon().pixmap(48));
+    m_ui->iconLabel->setPixmap(icons()->applicationIcon().pixmap(48));
 
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(close()));
     connect(UpdateChecker::instance(),

--- a/src/gui/UpdateCheckDialog.cpp
+++ b/src/gui/UpdateCheckDialog.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "UpdateCheckDialog.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "ui_UpdateCheckDialog.h"
 #include "updatecheck/UpdateChecker.h"
 
@@ -28,7 +28,7 @@ UpdateCheckDialog::UpdateCheckDialog(QWidget* parent)
     setWindowFlags(Qt::Window);
     setAttribute(Qt::WA_DeleteOnClose);
 
-    m_ui->iconLabel->setPixmap(resources()->applicationIcon().pixmap(48));
+    m_ui->iconLabel->setPixmap(iconResources()->applicationIcon().pixmap(48));
 
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(close()));
     connect(UpdateChecker::instance(),

--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -22,7 +22,7 @@
 
 #include "config-keepassx.h"
 #include "core/Config.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 WelcomeWidget::WelcomeWidget(QWidget* parent)
     : QWidget(parent)
@@ -36,7 +36,7 @@ WelcomeWidget::WelcomeWidget(QWidget* parent)
     welcomeLabelFont.setPointSize(welcomeLabelFont.pointSize() + 4);
     m_ui->welcomeLabel->setFont(welcomeLabelFont);
 
-    m_ui->iconLabel->setPixmap(iconResources()->applicationIcon().pixmap(64));
+    m_ui->iconLabel->setPixmap(icons()->applicationIcon().pixmap(64));
 
     refreshLastDatabases();
 

--- a/src/gui/WelcomeWidget.cpp
+++ b/src/gui/WelcomeWidget.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@
 
 #include "config-keepassx.h"
 #include "core/Config.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 WelcomeWidget::WelcomeWidget(QWidget* parent)
     : QWidget(parent)
@@ -36,7 +36,7 @@ WelcomeWidget::WelcomeWidget(QWidget* parent)
     welcomeLabelFont.setPointSize(welcomeLabelFont.pointSize() + 4);
     m_ui->welcomeLabel->setFont(welcomeLabelFont);
 
-    m_ui->iconLabel->setPixmap(resources()->applicationIcon().pixmap(64));
+    m_ui->iconLabel->setPixmap(iconResources()->applicationIcon().pixmap(64));
 
     refreshLastDatabases();
 

--- a/src/gui/dbsettings/DatabaseSettingsDialog.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.cpp
@@ -35,7 +35,7 @@
 #include "core/Config.h"
 #include "core/Database.h"
 #include "core/Global.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "touchid/TouchID.h"
 
 class DatabaseSettingsDialog::ExtraPage
@@ -76,8 +76,8 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(save()));
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(reject()));
 
-    m_ui->categoryList->addCategory(tr("General"), iconResources()->icon("preferences-other"));
-    m_ui->categoryList->addCategory(tr("Security"), iconResources()->icon("security-high"));
+    m_ui->categoryList->addCategory(tr("General"), icons()->icon("preferences-other"));
+    m_ui->categoryList->addCategory(tr("Security"), icons()->icon("security-high"));
     m_ui->stackedWidget->addWidget(m_generalWidget);
 
     m_ui->stackedWidget->addWidget(m_securityTabWidget);
@@ -100,7 +100,7 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
     connect(m_ui->advancedSettingsToggle, SIGNAL(toggled(bool)), SLOT(toggleAdvancedMode(bool)));
 
 #ifdef WITH_XC_BROWSER
-    m_ui->categoryList->addCategory(tr("Browser Integration"), iconResources()->icon("internet-web-browser"));
+    m_ui->categoryList->addCategory(tr("Browser Integration"), icons()->icon("internet-web-browser"));
     m_ui->stackedWidget->addWidget(m_browserWidget);
 #endif
 

--- a/src/gui/dbsettings/DatabaseSettingsDialog.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.cpp
@@ -35,7 +35,7 @@
 #include "core/Config.h"
 #include "core/Database.h"
 #include "core/Global.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "touchid/TouchID.h"
 
 class DatabaseSettingsDialog::ExtraPage
@@ -76,8 +76,8 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(save()));
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(reject()));
 
-    m_ui->categoryList->addCategory(tr("General"), Resources::instance()->icon("preferences-other"));
-    m_ui->categoryList->addCategory(tr("Security"), Resources::instance()->icon("security-high"));
+    m_ui->categoryList->addCategory(tr("General"), iconResources()->icon("preferences-other"));
+    m_ui->categoryList->addCategory(tr("Security"), iconResources()->icon("security-high"));
     m_ui->stackedWidget->addWidget(m_generalWidget);
 
     m_ui->stackedWidget->addWidget(m_securityTabWidget);
@@ -100,7 +100,7 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
     connect(m_ui->advancedSettingsToggle, SIGNAL(toggled(bool)), SLOT(toggleAdvancedMode(bool)));
 
 #ifdef WITH_XC_BROWSER
-    m_ui->categoryList->addCategory(tr("Browser Integration"), Resources::instance()->icon("internet-web-browser"));
+    m_ui->categoryList->addCategory(tr("Browser Integration"), iconResources()->icon("internet-web-browser"));
     m_ui->stackedWidget->addWidget(m_browserWidget);
 #endif
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -43,7 +43,6 @@
 #include "core/Entry.h"
 #include "core/Metadata.h"
 #include "core/PasswordHealth.h"
-#include "core/Resources.h"
 #include "core/TimeDelta.h"
 #include "core/Tools.h"
 #ifdef WITH_XC_SSHAGENT
@@ -60,6 +59,7 @@
 #include "gui/EditWidgetProperties.h"
 #include "gui/FileDialog.h"
 #include "gui/Font.h"
+#include "gui/IconResources.h"
 #include "gui/MessageBox.h"
 #include "gui/entry/AutoTypeAssociationsModel.h"
 #include "gui/entry/EntryAttachmentsModel.h"
@@ -147,7 +147,7 @@ EditEntryWidget::~EditEntryWidget()
 void EditEntryWidget::setupMain()
 {
     m_mainUi->setupUi(m_mainWidget);
-    addPage(tr("Entry"), Resources::instance()->icon("document-edit"), m_mainWidget);
+    addPage(tr("Entry"), iconResources()->icon("document-edit"), m_mainWidget);
 
     m_mainUi->usernameComboBox->setEditable(true);
     m_usernameCompleter->setCompletionMode(QCompleter::InlineCompletion);
@@ -156,7 +156,7 @@ void EditEntryWidget::setupMain()
     m_mainUi->usernameComboBox->setCompleter(m_usernameCompleter);
 
 #ifdef WITH_XC_NETWORKING
-    m_mainUi->fetchFaviconButton->setIcon(resources()->icon("favicon-download"));
+    m_mainUi->fetchFaviconButton->setIcon(iconResources()->icon("favicon-download"));
     m_mainUi->fetchFaviconButton->setDisabled(true);
 #else
     m_mainUi->fetchFaviconButton->setVisible(false);
@@ -186,7 +186,7 @@ void EditEntryWidget::setupMain()
 void EditEntryWidget::setupAdvanced()
 {
     m_advancedUi->setupUi(m_advancedWidget);
-    addPage(tr("Advanced"), Resources::instance()->icon("preferences-other"), m_advancedWidget);
+    addPage(tr("Advanced"), iconResources()->icon("preferences-other"), m_advancedWidget);
 
     m_advancedUi->attachmentsWidget->setReadOnly(false);
     m_advancedUi->attachmentsWidget->setButtonsVisible(true);
@@ -216,7 +216,7 @@ void EditEntryWidget::setupAdvanced()
 void EditEntryWidget::setupIcon()
 {
     m_iconsWidget->setShowApplyIconToButton(false);
-    addPage(tr("Icon"), Resources::instance()->icon("preferences-desktop-icons"), m_iconsWidget);
+    addPage(tr("Icon"), iconResources()->icon("preferences-desktop-icons"), m_iconsWidget);
     connect(this, SIGNAL(accepted()), m_iconsWidget, SLOT(abortRequests()));
     connect(this, SIGNAL(rejected()), m_iconsWidget, SLOT(abortRequests()));
 }
@@ -230,9 +230,9 @@ void EditEntryWidget::openAutotypeHelp()
 void EditEntryWidget::setupAutoType()
 {
     m_autoTypeUi->setupUi(m_autoTypeWidget);
-    addPage(tr("Auto-Type"), Resources::instance()->icon("key-enter"), m_autoTypeWidget);
+    addPage(tr("Auto-Type"), iconResources()->icon("key-enter"), m_autoTypeWidget);
 
-    m_autoTypeUi->openHelpButton->setIcon(resources()->icon("system-help"));
+    m_autoTypeUi->openHelpButton->setIcon(iconResources()->icon("system-help"));
 
     m_autoTypeDefaultSequenceGroup->addButton(m_autoTypeUi->inheritSequenceButton);
     m_autoTypeDefaultSequenceGroup->addButton(m_autoTypeUi->customSequenceButton);
@@ -271,7 +271,7 @@ void EditEntryWidget::setupBrowser()
     m_browserUi->setupUi(m_browserWidget);
 
     if (config()->get(Config::Browser_Enabled).toBool()) {
-        addPage(tr("Browser Integration"), Resources::instance()->icon("internet-web-browser"), m_browserWidget);
+        addPage(tr("Browser Integration"), iconResources()->icon("internet-web-browser"), m_browserWidget);
         m_additionalURLsDataModel->setEntryAttributes(m_entryAttributes);
         m_browserUi->additionalURLsView->setModel(m_additionalURLsDataModel);
 
@@ -394,13 +394,13 @@ void EditEntryWidget::updateCurrentURL()
 
 void EditEntryWidget::setupProperties()
 {
-    addPage(tr("Properties"), Resources::instance()->icon("document-properties"), m_editWidgetProperties);
+    addPage(tr("Properties"), iconResources()->icon("document-properties"), m_editWidgetProperties);
 }
 
 void EditEntryWidget::setupHistory()
 {
     m_historyUi->setupUi(m_historyWidget);
-    addPage(tr("History"), Resources::instance()->icon("view-history"), m_historyWidget);
+    addPage(tr("History"), iconResources()->icon("view-history"), m_historyWidget);
 
     m_sortModel->setSourceModel(m_historyModel);
     m_sortModel->setDynamicSortFilter(true);
@@ -546,7 +546,7 @@ void EditEntryWidget::setupSSHAgent()
             SIGNAL(entryAttachmentsModified()),
             SLOT(updateSSHAgentAttachments()));
 
-    addPage(tr("SSH Agent"), Resources::instance()->icon("utilities-terminal"), m_sshAgentWidget);
+    addPage(tr("SSH Agent"), iconResources()->icon("utilities-terminal"), m_sshAgentWidget);
 }
 
 void EditEntryWidget::setSSHAgentSettings()

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -59,7 +59,7 @@
 #include "gui/EditWidgetProperties.h"
 #include "gui/FileDialog.h"
 #include "gui/Font.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/MessageBox.h"
 #include "gui/entry/AutoTypeAssociationsModel.h"
 #include "gui/entry/EntryAttachmentsModel.h"
@@ -147,7 +147,7 @@ EditEntryWidget::~EditEntryWidget()
 void EditEntryWidget::setupMain()
 {
     m_mainUi->setupUi(m_mainWidget);
-    addPage(tr("Entry"), iconResources()->icon("document-edit"), m_mainWidget);
+    addPage(tr("Entry"), icons()->icon("document-edit"), m_mainWidget);
 
     m_mainUi->usernameComboBox->setEditable(true);
     m_usernameCompleter->setCompletionMode(QCompleter::InlineCompletion);
@@ -156,7 +156,7 @@ void EditEntryWidget::setupMain()
     m_mainUi->usernameComboBox->setCompleter(m_usernameCompleter);
 
 #ifdef WITH_XC_NETWORKING
-    m_mainUi->fetchFaviconButton->setIcon(iconResources()->icon("favicon-download"));
+    m_mainUi->fetchFaviconButton->setIcon(icons()->icon("favicon-download"));
     m_mainUi->fetchFaviconButton->setDisabled(true);
 #else
     m_mainUi->fetchFaviconButton->setVisible(false);
@@ -186,7 +186,7 @@ void EditEntryWidget::setupMain()
 void EditEntryWidget::setupAdvanced()
 {
     m_advancedUi->setupUi(m_advancedWidget);
-    addPage(tr("Advanced"), iconResources()->icon("preferences-other"), m_advancedWidget);
+    addPage(tr("Advanced"), icons()->icon("preferences-other"), m_advancedWidget);
 
     m_advancedUi->attachmentsWidget->setReadOnly(false);
     m_advancedUi->attachmentsWidget->setButtonsVisible(true);
@@ -216,7 +216,7 @@ void EditEntryWidget::setupAdvanced()
 void EditEntryWidget::setupIcon()
 {
     m_iconsWidget->setShowApplyIconToButton(false);
-    addPage(tr("Icon"), iconResources()->icon("preferences-desktop-icons"), m_iconsWidget);
+    addPage(tr("Icon"), icons()->icon("preferences-desktop-icons"), m_iconsWidget);
     connect(this, SIGNAL(accepted()), m_iconsWidget, SLOT(abortRequests()));
     connect(this, SIGNAL(rejected()), m_iconsWidget, SLOT(abortRequests()));
 }
@@ -230,9 +230,9 @@ void EditEntryWidget::openAutotypeHelp()
 void EditEntryWidget::setupAutoType()
 {
     m_autoTypeUi->setupUi(m_autoTypeWidget);
-    addPage(tr("Auto-Type"), iconResources()->icon("key-enter"), m_autoTypeWidget);
+    addPage(tr("Auto-Type"), icons()->icon("key-enter"), m_autoTypeWidget);
 
-    m_autoTypeUi->openHelpButton->setIcon(iconResources()->icon("system-help"));
+    m_autoTypeUi->openHelpButton->setIcon(icons()->icon("system-help"));
 
     m_autoTypeDefaultSequenceGroup->addButton(m_autoTypeUi->inheritSequenceButton);
     m_autoTypeDefaultSequenceGroup->addButton(m_autoTypeUi->customSequenceButton);
@@ -271,7 +271,7 @@ void EditEntryWidget::setupBrowser()
     m_browserUi->setupUi(m_browserWidget);
 
     if (config()->get(Config::Browser_Enabled).toBool()) {
-        addPage(tr("Browser Integration"), iconResources()->icon("internet-web-browser"), m_browserWidget);
+        addPage(tr("Browser Integration"), icons()->icon("internet-web-browser"), m_browserWidget);
         m_additionalURLsDataModel->setEntryAttributes(m_entryAttributes);
         m_browserUi->additionalURLsView->setModel(m_additionalURLsDataModel);
 
@@ -394,13 +394,13 @@ void EditEntryWidget::updateCurrentURL()
 
 void EditEntryWidget::setupProperties()
 {
-    addPage(tr("Properties"), iconResources()->icon("document-properties"), m_editWidgetProperties);
+    addPage(tr("Properties"), icons()->icon("document-properties"), m_editWidgetProperties);
 }
 
 void EditEntryWidget::setupHistory()
 {
     m_historyUi->setupUi(m_historyWidget);
-    addPage(tr("History"), iconResources()->icon("view-history"), m_historyWidget);
+    addPage(tr("History"), icons()->icon("view-history"), m_historyWidget);
 
     m_sortModel->setSourceModel(m_historyModel);
     m_sortModel->setDynamicSortFilter(true);
@@ -546,7 +546,7 @@ void EditEntryWidget::setupSSHAgent()
             SIGNAL(entryAttachmentsModified()),
             SLOT(updateSSHAgentAttachments()));
 
-    addPage(tr("SSH Agent"), iconResources()->icon("utilities-terminal"), m_sshAgentWidget);
+    addPage(tr("SSH Agent"), icons()->icon("utilities-terminal"), m_sshAgentWidget);
 }
 
 void EditEntryWidget::setSSHAgentSettings()

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -29,7 +29,7 @@
 #include "core/Global.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #ifdef Q_OS_MACOS
 #include "gui/osutils/macutils/MacUtils.h"
 #endif
@@ -280,12 +280,12 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return entry->iconPixmap();
         case Paperclip:
             if (!entry->attachments()->isEmpty()) {
-                return iconResources()->icon("paperclip");
+                return icons()->icon("paperclip");
             }
             break;
         case Totp:
             if (entry->hasTotp()) {
-                return iconResources()->icon("chronometer");
+                return icons()->icon("chronometer");
             }
             break;
         }
@@ -358,9 +358,9 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
     } else if (role == Qt::DecorationRole) {
         switch (section) {
         case Paperclip:
-            return iconResources()->icon("paperclip");
+            return icons()->icon("paperclip");
         case Totp:
-            return iconResources()->icon("chronometer");
+            return icons()->icon("chronometer");
         }
     } else if (role == Qt::ToolTipRole) {
         switch (section) {

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -29,7 +29,7 @@
 #include "core/Global.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #ifdef Q_OS_MACOS
 #include "gui/osutils/macutils/MacUtils.h"
 #endif
@@ -280,12 +280,12 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return entry->iconPixmap();
         case Paperclip:
             if (!entry->attachments()->isEmpty()) {
-                return resources()->icon("paperclip");
+                return iconResources()->icon("paperclip");
             }
             break;
         case Totp:
             if (entry->hasTotp()) {
-                return resources()->icon("chronometer");
+                return iconResources()->icon("chronometer");
             }
             break;
         }
@@ -358,9 +358,9 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
     } else if (role == Qt::DecorationRole) {
         switch (section) {
         case Paperclip:
-            return resources()->icon("paperclip");
+            return iconResources()->icon("paperclip");
         case Totp:
-            return resources()->icon("chronometer");
+            return iconResources()->icon("chronometer");
         }
     } else if (role == Qt::ToolTipRole) {
         switch (section) {

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -19,8 +19,8 @@
 #include "EntryURLModel.h"
 
 #include "core/Entry.h"
-#include "core/Resources.h"
 #include "core/Tools.h"
+#include "gui/IconResources.h"
 #include "gui/styles/StateColorPalette.h"
 
 #include <algorithm>
@@ -28,7 +28,7 @@
 EntryURLModel::EntryURLModel(QObject* parent)
     : QStandardItemModel(parent)
     , m_entryAttributes(nullptr)
-    , m_errorIcon(resources()->icon("dialog-error"))
+    , m_errorIcon(iconResources()->icon("dialog-error"))
 {
 }
 

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -20,7 +20,7 @@
 
 #include "core/Entry.h"
 #include "core/Tools.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/styles/StateColorPalette.h"
 
 #include <algorithm>
@@ -28,7 +28,7 @@
 EntryURLModel::EntryURLModel(QObject* parent)
     : QStandardItemModel(parent)
     , m_entryAttributes(nullptr)
-    , m_errorIcon(iconResources()->icon("dialog-error"))
+    , m_errorIcon(icons()->icon("dialog-error"))
 {
 }
 

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -21,9 +21,9 @@
 
 #include "core/Config.h"
 #include "core/Metadata.h"
-#include "core/Resources.h"
 #include "gui/EditWidgetIcons.h"
 #include "gui/EditWidgetProperties.h"
+#include "gui/IconResources.h"
 #include "gui/MessageBox.h"
 
 #if defined(WITH_XC_KEESHARE)
@@ -69,12 +69,12 @@ EditGroupWidget::EditGroupWidget(QWidget* parent)
 {
     m_mainUi->setupUi(m_editGroupWidgetMain);
 
-    addPage(tr("Group"), Resources::instance()->icon("document-edit"), m_editGroupWidgetMain);
-    addPage(tr("Icon"), Resources::instance()->icon("preferences-desktop-icons"), m_editGroupWidgetIcons);
+    addPage(tr("Group"), iconResources()->icon("document-edit"), m_editGroupWidgetMain);
+    addPage(tr("Icon"), iconResources()->icon("preferences-desktop-icons"), m_editGroupWidgetIcons);
 #if defined(WITH_XC_KEESHARE)
     addEditPage(new EditGroupPageKeeShare(this));
 #endif
-    addPage(tr("Properties"), Resources::instance()->icon("document-properties"), m_editWidgetProperties);
+    addPage(tr("Properties"), iconResources()->icon("document-properties"), m_editWidgetProperties);
 
     connect(m_mainUi->expireCheck, SIGNAL(toggled(bool)), m_mainUi->expireDatePicker, SLOT(setEnabled(bool)));
     connect(m_mainUi->autoTypeSequenceCustomRadio,

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -23,7 +23,7 @@
 #include "core/Metadata.h"
 #include "gui/EditWidgetIcons.h"
 #include "gui/EditWidgetProperties.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/MessageBox.h"
 
 #if defined(WITH_XC_KEESHARE)
@@ -69,12 +69,12 @@ EditGroupWidget::EditGroupWidget(QWidget* parent)
 {
     m_mainUi->setupUi(m_editGroupWidgetMain);
 
-    addPage(tr("Group"), iconResources()->icon("document-edit"), m_editGroupWidgetMain);
-    addPage(tr("Icon"), iconResources()->icon("preferences-desktop-icons"), m_editGroupWidgetIcons);
+    addPage(tr("Group"), icons()->icon("document-edit"), m_editGroupWidgetMain);
+    addPage(tr("Icon"), icons()->icon("preferences-desktop-icons"), m_editGroupWidgetIcons);
 #if defined(WITH_XC_KEESHARE)
     addEditPage(new EditGroupPageKeeShare(this));
 #endif
-    addPage(tr("Properties"), iconResources()->icon("document-properties"), m_editWidgetProperties);
+    addPage(tr("Properties"), icons()->icon("document-properties"), m_editWidgetProperties);
 
     connect(m_mainUi->expireCheck, SIGNAL(toggled(bool)), m_mainUi->expireDatePicker, SLOT(setEnabled(bool)));
     connect(m_mainUi->autoTypeSequenceCustomRadio,

--- a/src/gui/reports/ReportsPageHealthcheck.cpp
+++ b/src/gui/reports/ReportsPageHealthcheck.cpp
@@ -18,7 +18,7 @@
 #include "ReportsPageHealthcheck.h"
 
 #include "ReportsWidgetHealthcheck.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QApplication>
 
@@ -34,7 +34,7 @@ QString ReportsPageHealthcheck::name()
 
 QIcon ReportsPageHealthcheck::icon()
 {
-    return iconResources()->icon("health");
+    return icons()->icon("health");
 }
 
 QWidget* ReportsPageHealthcheck::createWidget()

--- a/src/gui/reports/ReportsPageHealthcheck.cpp
+++ b/src/gui/reports/ReportsPageHealthcheck.cpp
@@ -18,7 +18,7 @@
 #include "ReportsPageHealthcheck.h"
 
 #include "ReportsWidgetHealthcheck.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 #include <QApplication>
 
@@ -34,7 +34,7 @@ QString ReportsPageHealthcheck::name()
 
 QIcon ReportsPageHealthcheck::icon()
 {
-    return Resources::instance()->icon("health");
+    return iconResources()->icon("health");
 }
 
 QWidget* ReportsPageHealthcheck::createWidget()

--- a/src/gui/reports/ReportsPageHibp.cpp
+++ b/src/gui/reports/ReportsPageHibp.cpp
@@ -18,7 +18,7 @@
 #include "ReportsPageHibp.h"
 
 #include "ReportsWidgetHibp.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QApplication>
 
@@ -34,7 +34,7 @@ QString ReportsPageHibp::name()
 
 QIcon ReportsPageHibp::icon()
 {
-    return iconResources()->icon("hibp");
+    return icons()->icon("hibp");
 }
 
 QWidget* ReportsPageHibp::createWidget()

--- a/src/gui/reports/ReportsPageHibp.cpp
+++ b/src/gui/reports/ReportsPageHibp.cpp
@@ -18,7 +18,7 @@
 #include "ReportsPageHibp.h"
 
 #include "ReportsWidgetHibp.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 #include <QApplication>
 
@@ -34,7 +34,7 @@ QString ReportsPageHibp::name()
 
 QIcon ReportsPageHibp::icon()
 {
-    return resources()->icon("hibp");
+    return iconResources()->icon("hibp");
 }
 
 QWidget* ReportsPageHibp::createWidget()

--- a/src/gui/reports/ReportsPageStatistics.cpp
+++ b/src/gui/reports/ReportsPageStatistics.cpp
@@ -18,7 +18,7 @@
 #include "ReportsPageStatistics.h"
 
 #include "ReportsWidgetStatistics.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QApplication>
 
@@ -29,7 +29,7 @@ QString ReportsPageStatistics::name()
 
 QIcon ReportsPageStatistics::icon()
 {
-    return iconResources()->icon("statistics");
+    return icons()->icon("statistics");
 }
 
 QWidget* ReportsPageStatistics::createWidget()

--- a/src/gui/reports/ReportsPageStatistics.cpp
+++ b/src/gui/reports/ReportsPageStatistics.cpp
@@ -18,7 +18,7 @@
 #include "ReportsPageStatistics.h"
 
 #include "ReportsWidgetStatistics.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 #include <QApplication>
 
@@ -29,7 +29,7 @@ QString ReportsPageStatistics::name()
 
 QIcon ReportsPageStatistics::icon()
 {
-    return Resources::instance()->icon("statistics");
+    return iconResources()->icon("statistics");
 }
 
 QWidget* ReportsPageStatistics::createWidget()

--- a/src/gui/reports/ReportsWidgetHealthcheck.cpp
+++ b/src/gui/reports/ReportsWidgetHealthcheck.cpp
@@ -23,7 +23,7 @@
 #include "core/Global.h"
 #include "core/Group.h"
 #include "core/PasswordHealth.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "gui/styles/StateColorPalette.h"
 
 #include <QMenu>
@@ -140,7 +140,7 @@ Health::Health(QSharedPointer<Database> db)
 ReportsWidgetHealthcheck::ReportsWidgetHealthcheck(QWidget* parent)
     : QWidget(parent)
     , m_ui(new Ui::ReportsWidgetHealthcheck())
-    , m_errorIcon(Resources::instance()->icon("dialog-error"))
+    , m_errorIcon(iconResources()->icon("dialog-error"))
     , m_referencesModel(new QStandardItemModel(this))
     , m_modelProxy(new ReportSortProxyModel(this))
 {
@@ -325,12 +325,12 @@ void ReportsWidgetHealthcheck::customMenuRequested(QPoint pos)
     const auto menu = new QMenu(this);
 
     // Create the "edit entry" menu item
-    const auto edit = new QAction(Resources::instance()->icon("entry-edit"), tr("Edit Entry..."), this);
+    const auto edit = new QAction(iconResources()->icon("entry-edit"), tr("Edit Entry..."), this);
     menu->addAction(edit);
     connect(edit, SIGNAL(triggered()), SLOT(editFromContextmenu()));
 
     // Create the "exclude from reports" menu item
-    const auto knownbad = new QAction(Resources::instance()->icon("reports-exclude"), tr("Exclude from reports"), this);
+    const auto knownbad = new QAction(iconResources()->icon("reports-exclude"), tr("Exclude from reports"), this);
     knownbad->setCheckable(true);
     knownbad->setChecked(m_contextmenuEntry->customData()->contains(PasswordHealth::OPTION_KNOWN_BAD)
                          && m_contextmenuEntry->customData()->value(PasswordHealth::OPTION_KNOWN_BAD) == TRUE_STR);

--- a/src/gui/reports/ReportsWidgetHealthcheck.cpp
+++ b/src/gui/reports/ReportsWidgetHealthcheck.cpp
@@ -23,7 +23,7 @@
 #include "core/Global.h"
 #include "core/Group.h"
 #include "core/PasswordHealth.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/styles/StateColorPalette.h"
 
 #include <QMenu>
@@ -140,7 +140,7 @@ Health::Health(QSharedPointer<Database> db)
 ReportsWidgetHealthcheck::ReportsWidgetHealthcheck(QWidget* parent)
     : QWidget(parent)
     , m_ui(new Ui::ReportsWidgetHealthcheck())
-    , m_errorIcon(iconResources()->icon("dialog-error"))
+    , m_errorIcon(icons()->icon("dialog-error"))
     , m_referencesModel(new QStandardItemModel(this))
     , m_modelProxy(new ReportSortProxyModel(this))
 {
@@ -325,12 +325,12 @@ void ReportsWidgetHealthcheck::customMenuRequested(QPoint pos)
     const auto menu = new QMenu(this);
 
     // Create the "edit entry" menu item
-    const auto edit = new QAction(iconResources()->icon("entry-edit"), tr("Edit Entry..."), this);
+    const auto edit = new QAction(icons()->icon("entry-edit"), tr("Edit Entry..."), this);
     menu->addAction(edit);
     connect(edit, SIGNAL(triggered()), SLOT(editFromContextmenu()));
 
     // Create the "exclude from reports" menu item
-    const auto knownbad = new QAction(iconResources()->icon("reports-exclude"), tr("Exclude from reports"), this);
+    const auto knownbad = new QAction(icons()->icon("reports-exclude"), tr("Exclude from reports"), this);
     knownbad->setCheckable(true);
     knownbad->setChecked(m_contextmenuEntry->customData()->contains(PasswordHealth::OPTION_KNOWN_BAD)
                          && m_contextmenuEntry->customData()->value(PasswordHealth::OPTION_KNOWN_BAD) == TRUE_STR);

--- a/src/gui/reports/ReportsWidgetHibp.cpp
+++ b/src/gui/reports/ReportsWidgetHibp.cpp
@@ -23,7 +23,7 @@
 #include "core/Global.h"
 #include "core/Group.h"
 #include "core/PasswordHealth.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/MessageBox.h"
 
 #include <QMenu>
@@ -387,12 +387,12 @@ void ReportsWidgetHibp::customMenuRequested(QPoint pos)
     const auto menu = new QMenu(this);
 
     // Create the "edit entry" menu item
-    const auto edit = new QAction(iconResources()->icon("entry-edit"), tr("Edit Entry..."), this);
+    const auto edit = new QAction(icons()->icon("entry-edit"), tr("Edit Entry..."), this);
     menu->addAction(edit);
     connect(edit, SIGNAL(triggered()), SLOT(editFromContextmenu()));
 
     // Create the "exclude from reports" menu item
-    const auto knownbad = new QAction(iconResources()->icon("reports-exclude"), tr("Exclude from reports"), this);
+    const auto knownbad = new QAction(icons()->icon("reports-exclude"), tr("Exclude from reports"), this);
     knownbad->setCheckable(true);
     knownbad->setChecked(m_contextmenuEntry->customData()->contains(PasswordHealth::OPTION_KNOWN_BAD)
                          && m_contextmenuEntry->customData()->value(PasswordHealth::OPTION_KNOWN_BAD) == TRUE_STR);

--- a/src/gui/reports/ReportsWidgetHibp.cpp
+++ b/src/gui/reports/ReportsWidgetHibp.cpp
@@ -23,7 +23,7 @@
 #include "core/Global.h"
 #include "core/Group.h"
 #include "core/PasswordHealth.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "gui/MessageBox.h"
 
 #include <QMenu>
@@ -387,12 +387,12 @@ void ReportsWidgetHibp::customMenuRequested(QPoint pos)
     const auto menu = new QMenu(this);
 
     // Create the "edit entry" menu item
-    const auto edit = new QAction(Resources::instance()->icon("entry-edit"), tr("Edit Entry..."), this);
+    const auto edit = new QAction(iconResources()->icon("entry-edit"), tr("Edit Entry..."), this);
     menu->addAction(edit);
     connect(edit, SIGNAL(triggered()), SLOT(editFromContextmenu()));
 
     // Create the "exclude from reports" menu item
-    const auto knownbad = new QAction(Resources::instance()->icon("reports-exclude"), tr("Exclude from reports"), this);
+    const auto knownbad = new QAction(iconResources()->icon("reports-exclude"), tr("Exclude from reports"), this);
     knownbad->setCheckable(true);
     knownbad->setChecked(m_contextmenuEntry->customData()->contains(PasswordHealth::OPTION_KNOWN_BAD)
                          && m_contextmenuEntry->customData()->value(PasswordHealth::OPTION_KNOWN_BAD) == TRUE_STR);

--- a/src/gui/reports/ReportsWidgetStatistics.cpp
+++ b/src/gui/reports/ReportsWidgetStatistics.cpp
@@ -24,7 +24,7 @@
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "core/PasswordHealth.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 #include <QFileInfo>
 #include <QHash>
@@ -157,7 +157,7 @@ namespace
 ReportsWidgetStatistics::ReportsWidgetStatistics(QWidget* parent)
     : QWidget(parent)
     , m_ui(new Ui::ReportsWidgetStatistics())
-    , m_errIcon(iconResources()->icon("dialog-error"))
+    , m_errIcon(icons()->icon("dialog-error"))
 {
     m_ui->setupUi(this);
 

--- a/src/gui/reports/ReportsWidgetStatistics.cpp
+++ b/src/gui/reports/ReportsWidgetStatistics.cpp
@@ -24,7 +24,7 @@
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "core/PasswordHealth.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 #include <QFileInfo>
 #include <QHash>
@@ -157,7 +157,7 @@ namespace
 ReportsWidgetStatistics::ReportsWidgetStatistics(QWidget* parent)
     : QWidget(parent)
     , m_ui(new Ui::ReportsWidgetStatistics())
-    , m_errIcon(Resources::instance()->icon("dialog-error"))
+    , m_errIcon(iconResources()->icon("dialog-error"))
 {
     m_ui->setupUi(this);
 

--- a/src/keeshare/DatabaseSettingsPageKeeShare.cpp
+++ b/src/keeshare/DatabaseSettingsPageKeeShare.cpp
@@ -19,7 +19,7 @@
 
 #include "core/Database.h"
 #include "core/Group.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "keeshare/DatabaseSettingsWidgetKeeShare.h"
 #include "keeshare/KeeShare.h"
 
@@ -32,7 +32,7 @@ QString DatabaseSettingsPageKeeShare::name()
 
 QIcon DatabaseSettingsPageKeeShare::icon()
 {
-    return iconResources()->icon("preferences-system-network-sharing");
+    return icons()->icon("preferences-system-network-sharing");
 }
 
 QWidget* DatabaseSettingsPageKeeShare::createWidget()

--- a/src/keeshare/DatabaseSettingsPageKeeShare.cpp
+++ b/src/keeshare/DatabaseSettingsPageKeeShare.cpp
@@ -19,7 +19,7 @@
 
 #include "core/Database.h"
 #include "core/Group.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "keeshare/DatabaseSettingsWidgetKeeShare.h"
 #include "keeshare/KeeShare.h"
 
@@ -32,7 +32,7 @@ QString DatabaseSettingsPageKeeShare::name()
 
 QIcon DatabaseSettingsPageKeeShare::icon()
 {
-    return Resources::instance()->icon("preferences-system-network-sharing");
+    return iconResources()->icon("preferences-system-network-sharing");
 }
 
 QWidget* DatabaseSettingsPageKeeShare::createWidget()

--- a/src/keeshare/SettingsPageKeeShare.cpp
+++ b/src/keeshare/SettingsPageKeeShare.cpp
@@ -20,7 +20,7 @@
 #include "core/Database.h"
 #include "core/Group.h"
 #include "gui/DatabaseTabWidget.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "gui/MessageWidget.h"
 #include "keeshare/KeeShare.h"
 #include "keeshare/SettingsWidgetKeeShare.h"
@@ -39,7 +39,7 @@ QString SettingsPageKeeShare::name()
 
 QIcon SettingsPageKeeShare::icon()
 {
-    return iconResources()->icon("preferences-system-network-sharing");
+    return icons()->icon("preferences-system-network-sharing");
 }
 
 QWidget* SettingsPageKeeShare::createWidget()

--- a/src/keeshare/SettingsPageKeeShare.cpp
+++ b/src/keeshare/SettingsPageKeeShare.cpp
@@ -19,7 +19,7 @@
 
 #include "core/Database.h"
 #include "core/Group.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "gui/DatabaseTabWidget.h"
 #include "gui/MessageWidget.h"
 #include "keeshare/KeeShare.h"
@@ -39,7 +39,7 @@ QString SettingsPageKeeShare::name()
 
 QIcon SettingsPageKeeShare::icon()
 {
-    return Resources::instance()->icon("preferences-system-network-sharing");
+    return iconResources()->icon("preferences-system-network-sharing");
 }
 
 QWidget* SettingsPageKeeShare::createWidget()

--- a/src/keeshare/SettingsPageKeeShare.cpp
+++ b/src/keeshare/SettingsPageKeeShare.cpp
@@ -19,8 +19,8 @@
 
 #include "core/Database.h"
 #include "core/Group.h"
-#include "gui/IconResources.h"
 #include "gui/DatabaseTabWidget.h"
+#include "gui/IconResources.h"
 #include "gui/MessageWidget.h"
 #include "keeshare/KeeShare.h"
 #include "keeshare/SettingsWidgetKeeShare.h"

--- a/src/keeshare/group/EditGroupPageKeeShare.cpp
+++ b/src/keeshare/group/EditGroupPageKeeShare.cpp
@@ -17,7 +17,7 @@
 
 #include "EditGroupPageKeeShare.h"
 
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 #include "keeshare/group/EditGroupWidgetKeeShare.h"
 
 #include <QApplication>
@@ -34,7 +34,7 @@ QString EditGroupPageKeeShare::name()
 
 QIcon EditGroupPageKeeShare::icon()
 {
-    return Resources::instance()->icon("preferences-system-network-sharing");
+    return iconResources()->icon("preferences-system-network-sharing");
 }
 
 QWidget* EditGroupPageKeeShare::createWidget()

--- a/src/keeshare/group/EditGroupPageKeeShare.cpp
+++ b/src/keeshare/group/EditGroupPageKeeShare.cpp
@@ -17,7 +17,7 @@
 
 #include "EditGroupPageKeeShare.h"
 
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 #include "keeshare/group/EditGroupWidgetKeeShare.h"
 
 #include <QApplication>
@@ -34,7 +34,7 @@ QString EditGroupPageKeeShare::name()
 
 QIcon EditGroupPageKeeShare::icon()
 {
-    return iconResources()->icon("preferences-system-network-sharing");
+    return icons()->icon("preferences-system-network-sharing");
 }
 
 QWidget* EditGroupPageKeeShare::createWidget()

--- a/src/sshagent/AgentSettingsPage.cpp
+++ b/src/sshagent/AgentSettingsPage.cpp
@@ -18,7 +18,7 @@
 
 #include "AgentSettingsPage.h"
 #include "AgentSettingsWidget.h"
-#include "gui/IconResources.h"
+#include "gui/Icons.h"
 
 QString AgentSettingsPage::name()
 {
@@ -27,7 +27,7 @@ QString AgentSettingsPage::name()
 
 QIcon AgentSettingsPage::icon()
 {
-    return iconResources()->icon("utilities-terminal");
+    return icons()->icon("utilities-terminal");
 }
 
 QWidget* AgentSettingsPage::createWidget()

--- a/src/sshagent/AgentSettingsPage.cpp
+++ b/src/sshagent/AgentSettingsPage.cpp
@@ -18,7 +18,7 @@
 
 #include "AgentSettingsPage.h"
 #include "AgentSettingsWidget.h"
-#include "core/Resources.h"
+#include "gui/IconResources.h"
 
 QString AgentSettingsPage::name()
 {
@@ -27,7 +27,7 @@ QString AgentSettingsPage::name()
 
 QIcon AgentSettingsPage::icon()
 {
-    return Resources::instance()->icon("utilities-terminal");
+    return iconResources()->icon("utilities-terminal");
 }
 
 QWidget* AgentSettingsPage::createWidget()


### PR DESCRIPTION
This commit splits all the Icon related functions
from core/Resources and moves them into the gui/
folder. This is part of the effort to remove the
core/ dependency on Qt5::Widgets.

Related to https://github.com/keepassxreboot/keepassxc/issues/1714

## Testing strategy
unit tests + basic manual testing to make sure the icons are still displayed.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
