### PR TITLE
Add search 'by-path' url for browser

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1009,8 +1009,10 @@ bool BrowserService::removeFirstDomain(QString& hostname)
 bool BrowserService::handleEntry(Entry* entry, const QString& url, const QString& submitUrl)
 {
     // Use this special scheme to find entries by UUID
-    if (url.startsWith("keepassxc://")) {
-        return ("keepassxc://by-uuid/" + entry->uuidToHex()) == url;
+    if (url.startsWith("keepassxc://by-uuid/")) {
+        return url.endsWith("by-uuid/" + entry->uuidToHex());
+    } else if (url.startsWith("keepassxc://by-path/")) {
+        return url.endsWith("by-path/" + entry->path());
     }
     return handleURL(entry->url(), url, submitUrl);
 }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -503,6 +503,13 @@ QString Entry::totpSettingsString() const
     return {};
 }
 
+QString Entry::path() const
+{
+    auto path = group()->hierarchy();
+    path << title();
+    return path.mid(1).join("/");
+}
+
 void Entry::setUuid(const QUuid& uuid)
 {
     Q_ASSERT(!uuid.isNull());

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -109,6 +109,7 @@ public:
     QString totpSettingsString() const;
     QSharedPointer<Totp::Settings> totpSettings() const;
     int size() const;
+    QString path() const;
 
     bool hasTotp() const;
     bool isExpired() const;

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -42,6 +42,7 @@ private slots:
     void testSortPriority();
     void testSortPriority_data();
     void testSearchEntries();
+    void testSearchEntriesByPath();
     void testSearchEntriesByUUID();
     void testSearchEntriesWithPort();
     void testSearchEntriesWithAdditionalURLs();
@@ -54,9 +55,9 @@ private slots:
 
 private:
     QList<Entry*> createEntries(QStringList& urls, Group* root) const;
+    void compareEntriesByPath(QSharedPointer<Database> db, QList<Entry*> entries, QString path);
 
     QScopedPointer<BrowserAction> m_browserAction;
     QPointer<BrowserService> m_browserService;
 };
-
 #endif // KEEPASSXC_TESTBROWSER_H


### PR DESCRIPTION
This PR adds the option to use the URL scheme to search for an entry by path. Hence, tools implementing the keepassxc-browser API can use a credential's path to request a specific credential.

The code currently reuses the strategy implemented by @piegamesde in https://github.com/keepassxreboot/keepassxc/pull/4763.

## Testing strategy
- Unit tests.


## Type of change
- ✅ New feature (change that adds functionality)
