### PR TITLE
Prevent data loss when drag/drop between databases

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -36,6 +36,8 @@ const int Entry::ResolveMaximumDepth = 10;
 const QString Entry::AutoTypeSequenceUsername = "{USERNAME}{ENTER}";
 const QString Entry::AutoTypeSequencePassword = "{PASSWORD}{ENTER}";
 
+Entry::CloneFlags Entry::DefaultCloneFlags = Entry::CloneNewUuid | Entry::CloneResetTimeInfo;
+
 Entry::Entry()
     : m_attributes(new EntryAttributes(this))
     , m_attachments(new EntryAttachments(this))

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -124,11 +124,6 @@ public:
     CustomData* customData();
     const CustomData* customData() const;
 
-    static const int DefaultIconNumber;
-    static const int ResolveMaximumDepth;
-    static const QString AutoTypeSequenceUsername;
-    static const QString AutoTypeSequencePassword;
-
     void setUuid(const QUuid& uuid);
     void setIcon(int iconNumber);
     void setIcon(const QUuid& uuid);
@@ -209,13 +204,19 @@ public:
         DbDir
     };
 
+    static const int DefaultIconNumber;
+    static const int ResolveMaximumDepth;
+    static const QString AutoTypeSequenceUsername;
+    static const QString AutoTypeSequencePassword;
+    static CloneFlags DefaultCloneFlags;
+
     /**
      * Creates a duplicate of this entry except that the returned entry isn't
      * part of any group.
      * Note that you need to copy the custom icons manually when inserting the
      * new entry into another database.
      */
-    Entry* clone(CloneFlags flags) const;
+    Entry* clone(CloneFlags flags = DefaultCloneFlags) const;
     void copyDataFrom(const Entry* other);
     QString maskPasswordPlaceholders(const QString& str) const;
     Entry* resolveReference(const QString& str) const;

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -37,9 +37,7 @@ const int Group::RecycleBinIconNumber = 43;
 const QString Group::RootAutoTypeSequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}";
 
 Group::CloneFlags Group::DefaultCloneFlags =
-    static_cast<Group::CloneFlags>(Group::CloneNewUuid | Group::CloneResetTimeInfo | Group::CloneIncludeEntries);
-Entry::CloneFlags Group::DefaultEntryCloneFlags =
-    static_cast<Entry::CloneFlags>(Entry::CloneNewUuid | Entry::CloneResetTimeInfo);
+    Group::CloneNewUuid | Group::CloneResetTimeInfo | Group::CloneIncludeEntries;
 
 Group::Group()
     : m_customData(new CustomData(this))

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -109,7 +109,6 @@ public:
     static const int DefaultIconNumber;
     static const int RecycleBinIconNumber;
     static CloneFlags DefaultCloneFlags;
-    static Entry::CloneFlags DefaultEntryCloneFlags;
     static const QString RootAutoTypeSequence;
 
     Group* findChildByName(const QString& name);
@@ -158,7 +157,7 @@ public:
     QSet<QUuid> customIconsRecursive() const;
     QList<QString> usernamesRecursive(int topN = -1) const;
 
-    Group* clone(Entry::CloneFlags entryFlags = DefaultEntryCloneFlags,
+    Group* clone(Entry::CloneFlags entryFlags = Entry::DefaultCloneFlags,
                  CloneFlags groupFlags = DefaultCloneFlags) const;
 
     void copyDataFrom(const Group* other);

--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -252,19 +252,23 @@ bool GroupModel::dropMimeData(const QMimeData* data,
             row--;
         }
 
-        Group* group;
-        if (action == Qt::MoveAction) {
-            group = dragGroup;
-        } else {
-            group = dragGroup->clone();
-        }
-
         Database* sourceDb = dragGroup->database();
         Database* targetDb = parentGroup->database();
+
+        Group* group = dragGroup;
 
         if (sourceDb != targetDb) {
             QSet<QUuid> customIcons = group->customIconsRecursive();
             targetDb->metadata()->copyCustomIcons(customIcons, sourceDb->metadata());
+
+            // Always clone the group across db's to reset UUIDs
+            group = dragGroup->clone();
+            if (action == Qt::MoveAction) {
+                // Remove the original group from the sourceDb
+                delete dragGroup;
+            }
+        } else if (action == Qt::CopyAction) {
+            group = dragGroup->clone();
         }
 
         group->setParent(parentGroup, row);
@@ -288,19 +292,24 @@ bool GroupModel::dropMimeData(const QMimeData* data,
                 continue;
             }
 
-            Entry* entry;
-            if (action == Qt::MoveAction) {
-                entry = dragEntry;
-            } else {
-                entry = dragEntry->clone(Entry::CloneNewUuid | Entry::CloneResetTimeInfo);
-            }
-
             Database* sourceDb = dragEntry->group()->database();
             Database* targetDb = parentGroup->database();
-            QUuid customIcon = entry->iconUuid();
 
-            if (sourceDb != targetDb && !customIcon.isNull() && !targetDb->metadata()->hasCustomIcon(customIcon)) {
-                targetDb->metadata()->addCustomIcon(customIcon, sourceDb->metadata()->customIcon(customIcon));
+            Entry* entry = dragEntry;
+
+            if (sourceDb != targetDb) {
+                QUuid customIcon = entry->iconUuid();
+                if (!customIcon.isNull() && !targetDb->metadata()->hasCustomIcon(customIcon)) {
+                    targetDb->metadata()->addCustomIcon(customIcon, sourceDb->metadata()->customIcon(customIcon));
+                }
+
+                // Always clone the entry across db's to reset the UUID
+                entry = dragEntry->clone();
+                if (action == Qt::MoveAction) {
+                    delete dragEntry;
+                }
+            } else if (action == Qt::CopyAction) {
+                entry = dragEntry->clone();
             }
 
             entry->setGroup(parentGroup);


### PR DESCRIPTION
* Fixes #5262
* Always reset the UUID on groups and entries moved or copied between databases. This prevents data loss when the group/entry is moved back to the original database.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
