### PR TITLE
Final push for 2.6.2

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -99,6 +99,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_MinimizeOnStartup, {QS("GUI/MinimizeOnStartup"), Roaming, false}},
     {Config::GUI_MinimizeOnClose, {QS("GUI/MinimizeOnClose"), Roaming, false}},
     {Config::GUI_HideUsernames, {QS("GUI/HideUsernames"), Roaming, false}},
+    {Config::GUI_HidePasswords, {QS("GUI/HidePasswords"), Roaming, true}},
     {Config::GUI_AdvancedSettings, {QS("GUI/AdvancedSettings"), Roaming, false}},
     {Config::GUI_MonospaceNotes, {QS("GUI/MonospaceNotes"), Roaming, false}},
     {Config::GUI_ApplicationTheme, {QS("GUI/ApplicationTheme"), Roaming, QS("auto")}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -81,6 +81,7 @@ public:
         GUI_MinimizeOnStartup,
         GUI_MinimizeOnClose,
         GUI_HideUsernames,
+        GUI_HidePasswords,
         GUI_AdvancedSettings,
         GUI_MonospaceNotes,
         GUI_ApplicationTheme,

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -330,38 +330,6 @@ void DatabaseWidget::setPreviewSplitterSizes(const QList<int>& sizes)
 }
 
 /**
- * Get current state of entry view 'Hide Usernames' setting
- */
-bool DatabaseWidget::isUsernamesHidden() const
-{
-    return m_entryView->isUsernamesHidden();
-}
-
-/**
- * Set state of entry view 'Hide Usernames' setting
- */
-void DatabaseWidget::setUsernamesHidden(bool hide)
-{
-    m_entryView->setUsernamesHidden(hide);
-}
-
-/**
- * Get current state of entry view 'Hide Passwords' setting
- */
-bool DatabaseWidget::isPasswordsHidden() const
-{
-    return m_entryView->isPasswordsHidden();
-}
-
-/**
- * Set state of entry view 'Hide Passwords' setting
- */
-void DatabaseWidget::setPasswordsHidden(bool hide)
-{
-    m_entryView->setPasswordsHidden(hide);
-}
-
-/**
  * Get current view state of entry view
  */
 QByteArray DatabaseWidget::entryViewState() const

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -858,7 +858,8 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
 
         // otherwise ask user
         if (!launch && cmdString.length() > 6) {
-            QString cmdTruncated = cmdString.mid(6);
+            QString cmdTruncated = entry->resolveMultiplePlaceholders(entry->maskPasswordPlaceholders(entry->url()));
+            cmdTruncated = cmdTruncated.mid(6);
             if (cmdTruncated.length() > 400) {
                 cmdTruncated = cmdTruncated.left(400) + " […]";
             }

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -104,10 +104,6 @@ public:
 
     QStringList customEntryAttributes() const;
     bool isEditWidgetModified() const;
-    bool isUsernamesHidden() const;
-    void setUsernamesHidden(bool hide);
-    bool isPasswordsHidden() const;
-    void setPasswordsHidden(bool hide);
     void clearAllWidgets();
     bool currentEntryHasTitle();
     bool currentEntryHasUsername();

--- a/src/gui/DatabaseWidgetStateSync.cpp
+++ b/src/gui/DatabaseWidgetStateSync.cpp
@@ -29,8 +29,6 @@ DatabaseWidgetStateSync::DatabaseWidgetStateSync(QObject* parent)
 {
     m_mainSplitterSizes = variantToIntList(config()->get(Config::GUI_SplitterState));
     m_previewSplitterSizes = variantToIntList(config()->get(Config::GUI_PreviewSplitterState));
-    m_hideUsernames = config()->get(Config::GUI_HideUsernames).toBool();
-    m_hidePasswords = true;
     m_listViewState = config()->get(Config::GUI_ListViewState).toByteArray();
     m_searchViewState = config()->get(Config::GUI_SearchViewState).toByteArray();
 
@@ -48,7 +46,6 @@ void DatabaseWidgetStateSync::sync()
 {
     config()->set(Config::GUI_SplitterState, intListToVariant(m_mainSplitterSizes));
     config()->set(Config::GUI_PreviewSplitterState, intListToVariant(m_previewSplitterSizes));
-    config()->set(Config::GUI_HideUsernames, m_hideUsernames);
     config()->set(Config::GUI_ListViewState, m_listViewState);
     config()->set(Config::GUI_SearchViewState, m_searchViewState);
     config()->sync();
@@ -104,9 +101,6 @@ void DatabaseWidgetStateSync::setActive(DatabaseWidget* dbWidget)
  */
 void DatabaseWidgetStateSync::restoreListView()
 {
-    m_activeDbWidget->setUsernamesHidden(m_hideUsernames);
-    m_activeDbWidget->setPasswordsHidden(m_hidePasswords);
-
     if (!m_listViewState.isEmpty()) {
         m_activeDbWidget->setEntryViewState(m_listViewState);
     }
@@ -129,9 +123,6 @@ void DatabaseWidgetStateSync::restoreListView()
  */
 void DatabaseWidgetStateSync::restoreSearchView()
 {
-    m_activeDbWidget->setUsernamesHidden(m_hideUsernames);
-    m_activeDbWidget->setPasswordsHidden(m_hidePasswords);
-
     if (!m_searchViewState.isEmpty()) {
         m_activeDbWidget->setEntryViewState(m_searchViewState);
     } else {
@@ -168,9 +159,6 @@ void DatabaseWidgetStateSync::updateViewState()
     if (m_blockUpdates) {
         return;
     }
-
-    m_hideUsernames = m_activeDbWidget->isUsernamesHidden();
-    m_hidePasswords = m_activeDbWidget->isPasswordsHidden();
 
     if (m_activeDbWidget->isSearchActive()) {
         m_searchViewState = m_activeDbWidget->entryViewState();

--- a/src/gui/DatabaseWidgetStateSync.h
+++ b/src/gui/DatabaseWidgetStateSync.h
@@ -51,9 +51,6 @@ private:
     QList<int> m_mainSplitterSizes;
     QList<int> m_previewSplitterSizes;
 
-    bool m_hideUsernames;
-    bool m_hidePasswords;
-
     QByteArray m_listViewState;
     QByteArray m_searchViewState;
 };

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -332,10 +332,6 @@ MainWindow::MainWindow()
     shortcut = new QShortcut(dbTabModifier + Qt::Key_9, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(m_ui->tabWidget->count() - 1); });
 
-    // Toggle password and username visibility in entry view
-    new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_C, this, SLOT(togglePasswordsHidden()));
-    new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_B, this, SLOT(toggleUsernamesHidden()));
-
     m_ui->actionDatabaseNew->setIcon(resources()->icon("document-new"));
     m_ui->actionDatabaseOpen->setIcon(resources()->icon("document-open"));
     m_ui->menuRecentDatabases->setIcon(resources()->icon("document-open-recent"));
@@ -1126,22 +1122,6 @@ void MainWindow::databaseTabChanged(int tabIndex)
     m_actionMultiplexer.setCurrentObject(m_ui->tabWidget->currentDatabaseWidget());
 }
 
-void MainWindow::togglePasswordsHidden()
-{
-    auto dbWidget = m_ui->tabWidget->currentDatabaseWidget();
-    if (dbWidget) {
-        dbWidget->setPasswordsHidden(!dbWidget->isPasswordsHidden());
-    }
-}
-
-void MainWindow::toggleUsernamesHidden()
-{
-    auto dbWidget = m_ui->tabWidget->currentDatabaseWidget();
-    if (dbWidget) {
-        dbWidget->setUsernamesHidden(!dbWidget->isUsernamesHidden());
-    }
-}
-
 void MainWindow::closeEvent(QCloseEvent* event)
 {
     if (m_appExiting) {
@@ -1767,4 +1747,13 @@ void MainWindow::initViewMenu()
         show();
     });
 
+    m_ui->actionHideUsernames->setChecked(config()->get(Config::GUI_HideUsernames).toBool());
+    connect(m_ui->actionHideUsernames, &QAction::toggled, this, [](bool checked) {
+        config()->set(Config::GUI_HideUsernames, checked);
+    });
+
+    m_ui->actionHidePasswords->setChecked(config()->get(Config::GUI_HidePasswords).toBool());
+    connect(m_ui->actionHidePasswords, &QAction::toggled, this, [](bool checked) {
+        config()->set(Config::GUI_HidePasswords, checked);
+    });
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1757,4 +1757,14 @@ void MainWindow::initViewMenu()
     connect(m_ui->actionShowPreviewPanel, &QAction::toggled, this, [](bool checked) {
         config()->set(Config::GUI_HidePreviewPanel, !checked);
     });
+
+    connect(m_ui->actionAlwaysOnTop, &QAction::toggled, this, [this](bool checked) {
+        if (checked) {
+            setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+        } else {
+            setWindowFlags(windowFlags() & ~Qt::WindowStaysOnTopHint);
+        }
+        show();
+    });
+
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -131,8 +131,6 @@ private slots:
     void selectNextDatabaseTab();
     void selectPreviousDatabaseTab();
     void selectDatabaseTab(int tabIndex, bool wrap = false);
-    void togglePasswordsHidden();
-    void toggleUsernamesHidden();
     void obtainContextFocusLock();
     void releaseContextFocusLock();
     void agentEnabled(bool enabled);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -381,6 +381,7 @@
     </widget>
     <addaction name="menuTheme"/>
     <addaction name="actionCompactMode"/>
+    <addaction name="actionAlwaysOnTop"/>
     <addaction name="actionShowPreviewPanel"/>
     <addaction name="actionShowToolbar"/>
    </widget>
@@ -970,6 +971,17 @@
    </property>
    <property name="text">
     <string>Show Preview Panel</string>
+   </property>
+  </action>
+  <action name="actionAlwaysOnTop">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Always on Top</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+A</string>
    </property>
   </action>
  </widget>

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -384,6 +384,8 @@
     <addaction name="actionAlwaysOnTop"/>
     <addaction name="actionShowPreviewPanel"/>
     <addaction name="actionShowToolbar"/>
+    <addaction name="actionHideUsernames"/>
+    <addaction name="actionHidePasswords"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEntries"/>
@@ -982,6 +984,31 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Shift+A</string>
+   </property>
+  </action>
+  <action name="actionHideUsernames">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Hide Usernames</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+B</string>
+   </property>
+  </action>
+  <action name="actionHidePasswords">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Hide Passwords</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+C</string>
    </property>
   </action>
  </widget>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -997,6 +997,11 @@ bool EditEntryWidget::commitEntry()
         return true;
     }
 
+    // Check Auto-Type validity early
+    if (!AutoType::verifyAutoTypeSyntax(m_autoTypeUi->sequenceEdit->text())) {
+        return false;
+    }
+
     if (m_advancedUi->attributesView->currentIndex().isValid() && m_advancedUi->attributesEdit->isEnabled()) {
         QString key = m_attributesModel->keyByIndex(m_advancedUi->attributesView->currentIndex());
         m_entryAttributes->set(key, m_advancedUi->attributesEdit->toPlainText(), m_entryAttributes->isProtected(key));
@@ -1095,7 +1100,7 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
     entry->setAutoTypeEnabled(m_autoTypeUi->enableButton->isChecked());
     if (m_autoTypeUi->inheritSequenceButton->isChecked()) {
         entry->setDefaultAutoTypeSequence(QString());
-    } else if (AutoType::verifyAutoTypeSyntax(m_autoTypeUi->sequenceEdit->text())) {
+    } else {
         entry->setDefaultAutoTypeSequence(m_autoTypeUi->sequenceEdit->text());
     }
 
@@ -1364,6 +1369,7 @@ void EditEntryWidget::removeAutoTypeAssoc()
 
 void EditEntryWidget::loadCurrentAssoc(const QModelIndex& current)
 {
+    bool modified = isModified();
     if (current.isValid() && current.row() < m_autoTypeAssoc->size()) {
         AutoTypeAssociations::Association assoc = m_autoTypeAssoc->get(current.row());
         m_autoTypeUi->windowTitleCombo->setEditText(assoc.window);
@@ -1379,6 +1385,7 @@ void EditEntryWidget::loadCurrentAssoc(const QModelIndex& current)
     } else {
         clearCurrentAssoc();
     }
+    setModified(modified);
 }
 
 void EditEntryWidget::clearCurrentAssoc()

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -21,6 +21,8 @@
 #include <QAbstractTableModel>
 #include <QPixmap>
 
+#include "core/Config.h"
+
 class Entry;
 class Group;
 
@@ -64,15 +66,6 @@ public:
     void setGroup(Group* group);
     void setEntries(const QList<Entry*>& entries);
 
-    bool isUsernamesHidden() const;
-    void setUsernamesHidden(bool hide);
-    bool isPasswordsHidden() const;
-    void setPasswordsHidden(bool hide);
-
-signals:
-    void usernamesHiddenChanged();
-    void passwordsHiddenChanged();
-
 private slots:
     void entryAboutToAdd(Entry* entry);
     void entryAdded(Entry* entry);
@@ -84,6 +77,8 @@ private slots:
     void entryMovedDown();
     void entryDataChanged(Entry* entry);
 
+    void onConfigChanged(Config::ConfigKey key);
+
 private:
     void severConnections();
     void makeConnections(const Group* group);
@@ -92,9 +87,6 @@ private:
     QList<Entry*> m_entries;
     QList<Entry*> m_orgEntries;
     QList<const Group*> m_allGroups;
-
-    bool m_hideUsernames;
-    bool m_hidePasswords;
 
     const QString HiddenContentDisplay;
     const Qt::DateFormat DateFormat;

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -44,8 +44,6 @@ public:
     bool isSorted();
     int numberOfSelectedEntries();
     void setFirstEntryActive();
-    bool isUsernamesHidden() const;
-    bool isPasswordsHidden() const;
     QByteArray viewState() const;
     bool setViewState(const QByteArray& state);
 
@@ -56,10 +54,6 @@ signals:
     void entryActivated(Entry* entry, EntryModel::ModelColumn column);
     void entrySelectionChanged(Entry* entry);
     void viewStateChanged();
-
-public slots:
-    void setUsernamesHidden(bool hide);
-    void setPasswordsHidden(bool hide);
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
@@ -86,12 +80,10 @@ private:
     SortFilterHideProxyModel* const m_sortModel;
     int m_lastIndex;
     Qt::SortOrder m_lastOrder;
-    bool m_inSearchMode;
+    bool m_inSearchMode = false;
     bool m_columnsNeedRelayout = true;
 
     QMenu* m_headerMenu;
-    QAction* m_hideUsernamesAction;
-    QAction* m_hidePasswordsAction;
     QActionGroup* m_columnActions;
 };
 

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -66,7 +66,7 @@ void ShareObserver::deinitialize()
 
 void ShareObserver::reinitialize()
 {
-    QList<QPair<Group*, KeeShareSettings::Reference>> shares;
+    QList<QPair<QPointer<Group>, KeeShareSettings::Reference>> shares;
     for (Group* group : m_db->rootGroup()->groupsRecursive(true)) {
         auto oldReference = m_groupToReference.value(group);
         auto newReference = KeeShare::referenceOf(group);
@@ -97,6 +97,10 @@ void ShareObserver::reinitialize()
     for (const auto& share : shares) {
         auto group = share.first;
         auto& reference = share.second;
+        // Check group validity, it may have been deleted by a merge action
+        if (!group) {
+            continue;
+        }
 
         if (!reference.path.isEmpty() && reference.type != KeeShareSettings::Inactive) {
             const auto newResolvedPath = resolvePath(reference.path, m_db);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
* Closes #4151 - implement windows always on top in view menu
* Fixes #4982 - Move hide usernames/passwords into view menu (cleans up code a bunch!)
* Fixes #4463 - Mask password placeholder in command execution dialog
* Fix #4083 - move auto-type checks early in the commit process to prevent half-saving an entry if there is a bail-out.
* Fix #4182 - prevent setting modified by just viewing auto-type window associations
* Fix #4895 - when KeeShare imports a database it performs a merge operation. If that share was deleted from another identical database (ie, same base group UUID), then the group would be deleted in the middle of reinit causing a crash. This fix moves the group into a QPointer catching the delete operation.
* Fix #5127 - use `which keepassxc.proxy` to find the path of the snap proxy. Warn the user if the snap proxy was not found and bail out early.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/95806511-d5d4ea00-0cd5-11eb-9c50-cd3a7c9bc37b.png)

![image](https://user-images.githubusercontent.com/2809491/95806540-e8e7ba00-0cd5-11eb-9b99-2c2511a0b7f2.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows and Linux

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
