### PR TITLE
Fix crash when toggling capslock rapidly

### DIFF
--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -180,7 +180,9 @@ void PasswordEdit::autocompletePassword(const QString& password)
 
 bool PasswordEdit::event(QEvent* event)
 {
-    if (isVisible()) {
+    if (isVisible()
+        && (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease
+            || event->type() == QEvent::FocusIn)) {
         checkCapslockState();
     }
     return QLineEdit::event(event);
@@ -204,7 +206,9 @@ void PasswordEdit::checkCapslockState()
 
         if (newCapslockState) {
             QTimer::singleShot(
-                150, [this]() { QToolTip::showText(mapToGlobal(rect().bottomLeft()), m_capslockAction->text()); });
+                150, [this] { QToolTip::showText(mapToGlobal(rect().bottomLeft()), m_capslockAction->text()); });
+        } else if (QToolTip::isVisible()) {
+            QToolTip::hideText();
         }
     }
 }


### PR DESCRIPTION
* Fix #5543 - Only check caps lock state when key is pressed/released or widget is focused.

The previous implementation called a repaint() during a QEvent which causes an infinite recursion in some cases. We also checked the state of caps lock on EVERY event, which is incredibly wasteful.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)