### PR TITLE
Fix re-select previously selected entry on database unlock

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1081,6 +1081,9 @@ void DatabaseWidget::loadDatabase(bool accepted)
         replaceDatabase(openWidget->database());
         switchToMainView();
         processAutoOpen();
+        restoreGroupEntryFocus(m_groupBeforeLock, m_entryBeforeLock);
+        m_groupBeforeLock = QUuid();
+        m_entryBeforeLock = QUuid();
         m_saveAttempts = 0;
         emit databaseUnlocked();
         if (config()->get(Config::MinimizeAfterUnlock).toBool()) {


### PR DESCRIPTION
Fixes #5548


## Screenshots

## Testing strategy
1.) Open up a .kdbx file with KeePassXC
2.) Select sub-group and subGroup-entry
3.) Lock the database
4.) Unlock it again and verify the selection.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

