### PR TITLE
Place database credentials widget in scroll area

### DIFF
--- a/src/gui/dbsettings/DatabaseSettingsDialog.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.cpp
@@ -38,6 +38,8 @@
 #include "core/Resources.h"
 #include "touchid/TouchID.h"
 
+#include <QScrollArea>
+
 class DatabaseSettingsDialog::ExtraPage
 {
 public:
@@ -81,7 +83,16 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
     m_ui->stackedWidget->addWidget(m_generalWidget);
 
     m_ui->stackedWidget->addWidget(m_securityTabWidget);
-    m_securityTabWidget->addTab(m_databaseKeyWidget, tr("Database Credentials"));
+
+    auto* scrollArea = new QScrollArea(parent);
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setFrameShadow(QFrame::Plain);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setSizeAdjustPolicy(QScrollArea::AdjustToContents);
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setWidget(m_databaseKeyWidget);
+    m_securityTabWidget->addTab(scrollArea, tr("Database Credentials"));
+
     m_securityTabWidget->addTab(m_encryptionWidget, tr("Encryption Settings"));
 
 #if defined(WITH_XC_KEESHARE)

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
@@ -216,8 +216,6 @@ void DatabaseSettingsWidgetDatabaseKey::setAdditionalKeyOptionsVisible(bool show
 {
     m_additionalKeyOptionsToggle->setVisible(!show);
     m_additionalKeyOptions->setVisible(show);
-    m_additionalKeyOptions->layout()->setSizeConstraint(QLayout::SetMinimumSize);
-    emit sizeChanged();
 }
 
 bool DatabaseSettingsWidgetDatabaseKey::addToCompositeKey(KeyComponentWidget* widget,

--- a/src/gui/wizard/NewDatabaseWizardPage.cpp
+++ b/src/gui/wizard/NewDatabaseWizardPage.cpp
@@ -47,11 +47,7 @@ NewDatabaseWizardPage::~NewDatabaseWizardPage()
 void NewDatabaseWizardPage::setPageWidget(DatabaseSettingsWidget* page)
 {
     m_pageWidget = page;
-    if (!m_ui->pageContentLayout->isEmpty()) {
-        delete m_ui->pageContentLayout->takeAt(0);
-    }
-    m_ui->pageContentLayout->addWidget(m_pageWidget);
-    m_ui->pageContentLayout->setSizeConstraint(QLayout::SetMinimumSize);
+    m_ui->pageContent->setWidget(m_pageWidget);
     m_ui->advancedSettingsButton->setVisible(m_pageWidget->hasAdvancedMode());
 }
 

--- a/src/gui/wizard/NewDatabaseWizardPage.ui
+++ b/src/gui/wizard/NewDatabaseWizardPage.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>NewDatabaseWizardPage</class>
  <widget class="QWizardPage" name="NewDatabaseWizardPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>578</width>
+    <height>410</height>
+   </rect>
+  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
     <horstretch>0</horstretch>
@@ -17,9 +25,52 @@
   <property name="subTitle">
    <string>Here you can adjust the database encryption settings. Don't worry, you can change them later in the database settings.</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0">
    <item>
-    <layout class="QVBoxLayout" name="pageContentLayout"/>
+    <widget class="QScrollArea" name="pageContent">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>560</width>
+       <height>300</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QScrollArea { background: transparent; }
+QScrollArea &gt; QWidget &gt; QWidget { background: transparent; }
+QScrollArea &gt; QWidget &gt; QScrollBar { background: 1; }</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="content">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>560</width>
+        <height>349</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -29,7 +80,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>15</height>
+       <height>6</height>
       </size>
      </property>
     </spacer>

--- a/src/gui/wizard/NewDatabaseWizardPageDatabaseKey.cpp
+++ b/src/gui/wizard/NewDatabaseWizardPageDatabaseKey.cpp
@@ -26,16 +26,8 @@ NewDatabaseWizardPageDatabaseKey::NewDatabaseWizardPageDatabaseKey(QWidget* pare
 
     setTitle(tr("Database Credentials"));
     setSubTitle(tr("A set of credentials known only to you that protects your database."));
-
-    connect(pageWidget(), SIGNAL(sizeChanged()), SLOT(updateWindowSize()));
 }
 
 NewDatabaseWizardPageDatabaseKey::~NewDatabaseWizardPageDatabaseKey()
 {
-}
-
-void NewDatabaseWizardPageDatabaseKey::updateWindowSize()
-{
-    // ugly workaround for QWizard not managing to react to size changes automatically
-    window()->adjustSize();
 }

--- a/src/gui/wizard/NewDatabaseWizardPageDatabaseKey.h
+++ b/src/gui/wizard/NewDatabaseWizardPageDatabaseKey.h
@@ -28,9 +28,6 @@ public:
     explicit NewDatabaseWizardPageDatabaseKey(QWidget* parent = nullptr);
     Q_DISABLE_COPY(NewDatabaseWizardPageDatabaseKey);
     ~NewDatabaseWizardPageDatabaseKey() override;
-
-private slots:
-    void updateWindowSize();
 };
 
 #endif // KEEPASSXC_NEWDATABASEWIZARDPAGEDATABASEKEY_H


### PR DESCRIPTION
* Fix #5440

This was unreasonably difficult to fix, mainly because of the way Qt styles and sizes scrollareas. I dialed everything in so that the new database wizard is consistent in size and doesn't cause scrunched display. I pulled the styling trick to remove the QScrollArea backgrounds (yes plural) from https://stackoverflow.com/a/16482646.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/96326825-15ffd980-1002-11eb-9ea6-0ee28e63a550.png)

![image](https://user-images.githubusercontent.com/2809491/96326828-18faca00-1002-11eb-9fb4-dce2a6fe558c.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Linux and Windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
