### PR TITLE
Enabled cross build on Arch Linux

### DIFF
--- a/cmake/FindArgon2.cmake
+++ b/cmake/FindArgon2.cmake
@@ -26,7 +26,7 @@ if(MINGW)
             --redefine-sym _argon2_error_message=_libargon2_argon2_error_message
             ${ARGON2_SYS_LIBRARIES} ${CMAKE_BINARY_DIR}/libargon2_patched.a
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-    find_library(ARGON2_LIBRARIES libargon2_patched.a PATHS ${CMAKE_BINARY_DIR} NO_DEFAULT_PATH)
+    find_library(ARGON2_LIBRARIES libargon2_patched.a PATHS ${CMAKE_BINARY_DIR})
 else()
     find_library(ARGON2_LIBRARIES argon2)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,7 +356,7 @@ if(UNIX AND NOT APPLE)
     include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 if(MINGW)
-    target_link_libraries(keepassx_core Wtsapi32.lib Ws2_32.lib)
+    target_link_libraries(keepassx_core wtsapi32.lib ws2_32.lib)
 endif()
 
 if(MINGW)

--- a/src/autotype/windows/AutoTypeWindows.cpp
+++ b/src/autotype/windows/AutoTypeWindows.cpp
@@ -19,7 +19,7 @@
 #include "AutoTypeWindows.h"
 #include "gui/osutils/OSUtils.h"
 
-#include <VersionHelpers.h>
+#include <versionhelpers.h>
 
 #define HOTKEY_ID 1
 #define MAX_WINDOW_TITLE_LENGTH 1024

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -55,6 +55,6 @@ if(WITH_XC_BROWSER)
     endif()
 
     if(MINGW)
-      target_link_libraries(keepassxc-proxy Wtsapi32.lib Ws2_32.lib)
+      target_link_libraries(keepassxc-proxy wtsapi32.lib ws2_32.lib)
     endif()
 endif()


### PR DESCRIPTION
We cannot build Windows version using a docker container at the moment. An Arch Linux based container [docker-arch-mingw](2) can be used to cross compile KeePassXC.

## Testing strategy
Windows version can be built in a container [shugaoye/arch-mingw][1].


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix - fixed the issue when build Windows in a Linux container

[1]: https://hub.docker.com/repository/docker/shugaoye/arch-mingw
[2]: https://github.com/shugaoye/docker-arch-mingw