### PR TITLE
Display default autotype sequence on entry preview pane

### DIFF
--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -303,6 +303,8 @@ void EntryPreviewWidget::updateEntryAdvancedTab()
 void EntryPreviewWidget::updateEntryAutotypeTab()
 {
     Q_ASSERT(m_currentEntry);
+
+    m_ui->entrySequenceLabel->setText(m_currentEntry->effectiveAutoTypeSequence());
     m_ui->entryAutotypeTree->clear();
     QList<QTreeWidgetItem*> items;
     const AutoTypeAssociations* autotypeAssociations = m_currentEntry->autoTypeAssociations();
@@ -314,7 +316,7 @@ void EntryPreviewWidget::updateEntryAutotypeTab()
     }
 
     m_ui->entryAutotypeTree->addTopLevelItems(items);
-    setTabEnabled(m_ui->entryTabWidget, m_ui->entryAutotypeTab, !items.isEmpty());
+    setTabEnabled(m_ui->entryTabWidget, m_ui->entryAutotypeTab, m_currentEntry->autoTypeEnabled());
 }
 
 void EntryPreviewWidget::updateGroupHeaderLine()

--- a/src/gui/EntryPreviewWidget.ui
+++ b/src/gui/EntryPreviewWidget.ui
@@ -706,6 +706,62 @@
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <item>
+            <widget class="QWidget" name="entryAutotypeWidget" native="true">
+             <layout class="QGridLayout" name="gridLayout_3">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>5</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="entrySequenceTitleLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Default Sequence</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="entrySequenceLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string notr="true">sequence</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
             <widget class="QTreeWidget" name="entryAutotypeTree">
              <property name="focusPolicy">
               <enum>Qt::ClickFocus</enum>

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -29,14 +29,18 @@
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QLineEdit>
+#include <QListWidgetItem>
 #include <QMimeData>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QSignalSpy>
 #include <QSpinBox>
+#include <QTest>
 #include <QTimer>
 #include <QToolBar>
 #include <QToolButton>
+#include <QTreeWidgetItem>
 
 #include "config-keepassx-tests.h"
 #include "core/Bootstrap.h"
@@ -142,6 +146,9 @@ void TestGui::init()
     fileDialog()->setNextFileName(m_dbFilePath);
     triggerAction("actionDatabaseOpen");
 
+    QApplication::processEvents();
+
+    m_dbWidget = m_tabWidget->currentDatabaseWidget();
     auto* databaseOpenWidget = m_tabWidget->currentDatabaseWidget()->findChild<QWidget*>("databaseOpenWidget");
     QVERIFY(databaseOpenWidget);
     auto* editPassword = databaseOpenWidget->findChild<QLineEdit*>("editPassword");
@@ -151,8 +158,10 @@ void TestGui::init()
     QTest::keyClicks(editPassword, "a");
     QTest::keyClick(editPassword, Qt::Key_Enter);
 
-    m_dbWidget = m_tabWidget->currentDatabaseWidget();
+    QTRY_VERIFY(!m_dbWidget->isLocked());
     m_db = m_dbWidget->database();
+
+    QApplication::processEvents();
 }
 
 // Every test ends with closing the temp database without saving
@@ -1484,6 +1493,163 @@ void TestGui::testTrayRestoreHide()
 
     trayIcon->activated(QSystemTrayIcon::DoubleClick);
     QTRY_VERIFY(!m_mainWindow->isVisible());
+
+    // Ensure window is visible at the end
+    trayIcon->activated(QSystemTrayIcon::DoubleClick);
+    QTRY_VERIFY(m_mainWindow->isVisible());
+}
+
+void TestGui::testAutoType()
+{
+    // Clear entries from root group to guarantee order
+    for (Entry* entry : m_db->rootGroup()->entries()) {
+        m_db->rootGroup()->removeEntry(entry);
+    }
+    Tools::wait(150);
+
+    // 1. Create an entry with Auto-Type disabled
+
+    // 1.a) Click the new entry button and set the title
+    auto* entryNewAction = m_mainWindow->findChild<QAction*>("actionEntryNew");
+    QVERIFY(entryNewAction->isEnabled());
+
+    auto* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
+    QVERIFY(toolBar);
+
+    QWidget* entryNewWidget = toolBar->widgetForAction(entryNewAction);
+    QVERIFY(entryNewWidget->isVisible());
+    QVERIFY(entryNewWidget->isEnabled());
+
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
+
+    auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
+    QVERIFY(editEntryWidget);
+
+    auto* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
+    QVERIFY(titleEdit);
+
+    QTest::keyClicks(titleEdit, "1. Entry With Disabled Auto-Type");
+
+    auto* usernameComboBox = editEntryWidget->findChild<QComboBox*>("usernameComboBox");
+    QVERIFY(usernameComboBox);
+
+    QTest::mouseClick(usernameComboBox, Qt::LeftButton);
+    QTest::keyClicks(usernameComboBox, "AutocompletionUsername");
+
+    // 1.b) Uncheck Auto-Type checkbox
+    editEntryWidget->setCurrentPage(3);
+    auto* enableAutoTypeButton = editEntryWidget->findChild<QCheckBox*>("enableButton");
+    QVERIFY(enableAutoTypeButton);
+    QVERIFY(enableAutoTypeButton->isVisible());
+    QVERIFY(enableAutoTypeButton->isEnabled());
+
+    enableAutoTypeButton->click();
+    QVERIFY(!enableAutoTypeButton->isChecked());
+
+    // 1.c) Save changes
+    editEntryWidget->setCurrentPage(0);
+    auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+
+    // 2. Create an entry with default/inherited Auto-Type sequence
+
+    // 2.a) Click the new entry button and set the title
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
+    QTest::keyClicks(titleEdit, "2. Entry With Default Auto-Type Sequence");
+    QTest::mouseClick(usernameComboBox, Qt::LeftButton);
+    QTest::keyClicks(usernameComboBox, "AutocompletionUsername");
+
+    // 2.b) Confirm AutoType is enabled and default
+    editEntryWidget->setCurrentPage(3);
+    QVERIFY(enableAutoTypeButton->isChecked());
+    auto* inheritSequenceButton = editEntryWidget->findChild<QRadioButton*>("inheritSequenceButton");
+    QVERIFY(inheritSequenceButton->isChecked());
+
+    // 2.c) Save changes
+    editEntryWidget->setCurrentPage(0);
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+
+    // 3. Create an entry with custom Auto-Type sequence
+
+    // 3.a) Click the new entry button and set the title
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
+    QTest::keyClicks(titleEdit, "3. Entry With Custom Auto-Type Sequence");
+    QTest::mouseClick(usernameComboBox, Qt::LeftButton);
+    QTest::keyClicks(usernameComboBox, "AutocompletionUsername");
+
+    // 3.b) Confirm AutoType is enabled and set custom sequence
+    editEntryWidget->setCurrentPage(3);
+    QVERIFY(enableAutoTypeButton->isChecked());
+    auto* customSequenceButton = editEntryWidget->findChild<QRadioButton*>("customSequenceButton");
+    QTest::mouseClick(customSequenceButton, Qt::LeftButton);
+    QVERIFY(customSequenceButton->isChecked());
+    QVERIFY(!inheritSequenceButton->isChecked());
+    auto* sequenceEdit = editEntryWidget->findChild<QLineEdit*>("sequenceEdit");
+    QVERIFY(sequenceEdit);
+    sequenceEdit->setFocus();
+    QTRY_VERIFY(sequenceEdit->hasFocus());
+    QTest::keyClicks(sequenceEdit, "{USERNAME}{TAB}{TAB}{PASSWORD}{ENTER}");
+
+    // 3.c) Save changes
+    editEntryWidget->setCurrentPage(0);
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    QApplication::processEvents();
+
+    // Check total number of entries matches expected
+    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
+    QVERIFY(entryView);
+    QTRY_COMPARE(entryView->model()->rowCount(), 3);
+
+    // Sort entries by title
+    entryView->sortByColumn(1, Qt::AscendingOrder);
+
+    // Select first entry
+    entryView->selectionModel()->clearSelection();
+    QModelIndex entryIndex = entryView->model()->index(0, 0);
+    entryView->selectionModel()->select(entryIndex, QItemSelectionModel::Rows | QItemSelectionModel::Select);
+
+    auto* entryPreviewWidget = m_dbWidget->findChild<EntryPreviewWidget*>("previewWidget");
+    QVERIFY(entryPreviewWidget->isVisible());
+
+    // Check that the Autotype tab in entry preview pane is disabled for entry with disabled Auto-Type
+    auto* entryAutotypeTab = entryPreviewWidget->findChild<QWidget*>("entryAutotypeTab");
+    QVERIFY(!entryAutotypeTab->isEnabled());
+
+    // Check that Auto-Type is disabled in the actual entry model as well
+    Entry* entry = entryView->entryFromIndex(entryIndex);
+    QVERIFY(!entry->autoTypeEnabled());
+
+    // Select second entry
+    entryView->selectionModel()->clearSelection();
+    entryIndex = entryView->model()->index(1, 0);
+    entryView->selectionModel()->select(entryIndex, QItemSelectionModel::Rows | QItemSelectionModel::Select);
+    QVERIFY(entryPreviewWidget->isVisible());
+
+    // Check that the Autotype tab in entry preview pane is enabled for entry with default Auto-Type sequence;
+    QVERIFY(entryAutotypeTab->isEnabled());
+
+    // Check that Auto-Type is enabled in the actual entry model as well
+    entry = entryView->entryFromIndex(entryIndex);
+    QVERIFY(entry->autoTypeEnabled());
+
+    // Select third entry
+    entryView->selectionModel()->clearSelection();
+    entryIndex = entryView->model()->index(2, 0);
+    entryView->selectionModel()->select(entryIndex, QItemSelectionModel::Rows | QItemSelectionModel::Select);
+    QVERIFY(entryPreviewWidget->isVisible());
+
+    // Check that the Autotype tab in entry preview pane is enabled for entry with custom Auto-Type sequence
+    QVERIFY(entryAutotypeTab->isEnabled());
+
+    // Check that Auto-Type is enabled in the actual entry model as well
+    entry = entryView->entryFromIndex(entryIndex);
+    QVERIFY(entry->autoTypeEnabled());
+
+    // De-select third entry
+    entryView->selectionModel()->clearSelection();
 }
 
 int TestGui::addCannedEntries()

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -68,6 +68,7 @@ private slots:
     void testDatabaseLocking();
     void testDragAndDropKdbxFiles();
     void testSortGroups();
+    void testAutoType();
     void testTrayRestoreHide();
 
 private:


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
This pull request attempts to fixes #5450. The point is to allow the user of the program to view an entry's autotype sequence in the preview pane instead of performing the whole "right click on entry -> edit entry -> select autotype tab on the side menu -> check autotype sequence"  to do the same.

Originally the Autotype tab in the preview pane is enabled only if there are actual window associations. Meaning, if a custom sequence is set, but not used for any window association, the tab would remain disabled. With the change in this PR, the tab would be disabled only if the entry has autotype disabled.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![a](https://user-images.githubusercontent.com/13034472/97808696-3c5b8100-1c60-11eb-8b9c-4980be508eed.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Changes were tested with a new test in tests/gui/TestGui.cpp. The test involves creating 3 new entries:

- one with disabled autotype
- one with default autotype sequence inherited from the group
- one with a custom autotype sequence

and then verifying that the changes are being displayed in the preview pane as originally intended.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
