### PR TITLE
Secret Service: cleanup and fix crash

### DIFF
--- a/src/fdosecrets/FdoSecretsPlugin.cpp
+++ b/src/fdosecrets/FdoSecretsPlugin.cpp
@@ -104,6 +104,7 @@ void FdoSecretsPlugin::emitRequestShowNotification(const QString& msg, const QSt
 void FdoSecretsPlugin::emitError(const QString& msg)
 {
     emit error(tr("<b>Fdo Secret Service:</b> %1").arg(msg));
+    qDebug() << msg;
 }
 
 QString FdoSecretsPlugin::reportExistingService() const

--- a/src/fdosecrets/FdoSecretsPlugin.cpp
+++ b/src/fdosecrets/FdoSecretsPlugin.cpp
@@ -26,8 +26,6 @@
 
 #include <QFile>
 
-#include <utility>
-
 using FdoSecrets::Service;
 
 // TODO: Only used for testing. Need to split service functions away from settings page.
@@ -65,12 +63,8 @@ void FdoSecretsPlugin::updateServiceState()
 {
     if (FdoSecrets::settings()->isEnabled()) {
         if (!m_secretService && m_dbTabs) {
-            m_secretService.reset(new Service(this, m_dbTabs));
-            connect(m_secretService.data(), &Service::error, this, [this](const QString& msg) {
-                emit error(tr("<b>Fdo Secret Service:</b> %1").arg(msg));
-            });
-            if (!m_secretService->initialize()) {
-                m_secretService.reset();
+            m_secretService = Service::Create(this, m_dbTabs);
+            if (!m_secretService) {
                 FdoSecrets::settings()->setEnabled(false);
                 return;
             }
@@ -86,7 +80,7 @@ void FdoSecretsPlugin::updateServiceState()
 
 Service* FdoSecretsPlugin::serviceInstance() const
 {
-    return m_secretService.data();
+    return m_secretService.get();
 }
 
 DatabaseTabWidget* FdoSecretsPlugin::dbTabs() const
@@ -105,6 +99,11 @@ void FdoSecretsPlugin::emitRequestShowNotification(const QString& msg, const QSt
         return;
     }
     emit requestShowNotification(msg, title, 10000);
+}
+
+void FdoSecretsPlugin::emitError(const QString& msg)
+{
+    emit error(tr("<b>Fdo Secret Service:</b> %1").arg(msg));
 }
 
 QString FdoSecretsPlugin::reportExistingService() const

--- a/src/fdosecrets/FdoSecretsPlugin.cpp
+++ b/src/fdosecrets/FdoSecretsPlugin.cpp
@@ -80,7 +80,7 @@ void FdoSecretsPlugin::updateServiceState()
 
 Service* FdoSecretsPlugin::serviceInstance() const
 {
-    return m_secretService.get();
+    return m_secretService.data();
 }
 
 DatabaseTabWidget* FdoSecretsPlugin::dbTabs() const

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -22,7 +22,8 @@
 #include "gui/Icons.h"
 
 #include <QPointer>
-#include <QScopedPointer>
+
+#include <memory>
 
 class DatabaseTabWidget;
 
@@ -77,6 +78,12 @@ public slots:
     void emitRequestSwitchToDatabases();
     void emitRequestShowNotification(const QString& msg, const QString& title = {});
 
+    /**
+     * @brief Show error in the GUI
+     * @param msg
+     */
+    void emitError(const QString& msg);
+
 signals:
     void error(const QString& msg);
     void requestSwitchToDatabases();
@@ -86,7 +93,7 @@ signals:
 
 private:
     QPointer<DatabaseTabWidget> m_dbTabs;
-    QScopedPointer<FdoSecrets::Service> m_secretService;
+    std::unique_ptr<FdoSecrets::Service> m_secretService;
 };
 
 #endif // KEEPASSXC_FDOSECRETSPLUGIN_H

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -93,7 +93,7 @@ signals:
 
 private:
     QPointer<DatabaseTabWidget> m_dbTabs;
-    std::unique_ptr<FdoSecrets::Service> m_secretService;
+    QSharedPointer<FdoSecrets::Service> m_secretService;
 };
 
 #endif // KEEPASSXC_FDOSECRETSPLUGIN_H

--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -415,7 +415,8 @@ namespace FdoSecrets
 
         emit aliasAboutToAdd(alias);
 
-        bool ok = registerWithPath(QStringLiteral(DBUS_PATH_TEMPLATE_ALIAS).arg(p()->objectPath().path(), alias), false);
+        bool ok =
+            registerWithPath(QStringLiteral(DBUS_PATH_TEMPLATE_ALIAS).arg(p()->objectPath().path(), alias), false);
         if (ok) {
             m_aliases.insert(alias);
             emit aliasAdded(alias);

--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -25,7 +25,6 @@
 #include "fdosecrets/objects/Session.h"
 
 #include "core/Config.h"
-#include "core/Database.h"
 #include "core/Tools.h"
 #include "gui/DatabaseTabWidget.h"
 #include "gui/DatabaseWidget.h"
@@ -330,12 +329,12 @@ namespace FdoSecrets
             itemPath = attributes.value(ItemAttributes::PathKey);
 
             // check existing item using attributes
-            auto existings = searchItems(attributes);
-            if (existings.isError()) {
-                return existings;
+            auto existing = searchItems(attributes);
+            if (existing.isError()) {
+                return existing;
             }
-            if (!existings.value().isEmpty() && replace) {
-                item = existings.value().front();
+            if (!existing.value().isEmpty() && replace) {
+                item = existing.value().front();
                 newlyCreated = false;
             }
         }

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -36,7 +36,7 @@ namespace FdoSecrets
     class Item;
     class PromptBase;
     class Service;
-    class Collection : public DBusObject
+    class Collection : public DBusObjectHelper<Collection, CollectionAdaptor>
     {
         Q_OBJECT
 
@@ -124,8 +124,12 @@ namespace FdoSecrets
     private slots:
         void onDatabaseLockChanged();
         void onDatabaseExposedGroupChanged();
+
         // force reload info from backend, potentially delete self
         bool reloadBackend();
+
+        // calls reloadBackend, delete self when error
+        void reloadBackendOrDelete();
 
     private:
         friend class DeleteCollectionPrompt;
@@ -165,8 +169,6 @@ namespace FdoSecrets
         QSet<QString> m_aliases;
         QList<Item*> m_items;
         QMap<const Entry*, Item*> m_entryToItem;
-
-        bool m_registered;
     };
 
 } // namespace FdoSecrets

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -39,8 +39,19 @@ namespace FdoSecrets
     class Collection : public DBusObject
     {
         Q_OBJECT
-    public:
+
         explicit Collection(Service* parent, DatabaseWidget* backend);
+    public:
+        /**
+         * @brief Create a new instance of `Collection`
+         * @param parent the owning Service
+         * @param backend the widget containing the database
+         * @return pointer to created instance, or nullptr when error happens.
+         * This may be caused by
+         *   - DBus path registration error
+         *   - database has no exposed group
+         */
+        static Collection* Create(Service* parent, DatabaseWidget* backend);
 
         DBusReturn<const QList<Item*>> items() const;
 
@@ -101,7 +112,7 @@ namespace FdoSecrets
         static EntrySearcher::SearchTerm attributeToTerm(const QString& key, const QString& value);
 
     public slots:
-        // expose some methods for Prmopt to use
+        // expose some methods for Prompt to use
         bool doLock();
         void doUnlock();
         // will remove self
@@ -114,7 +125,7 @@ namespace FdoSecrets
         void onDatabaseLockChanged();
         void onDatabaseExposedGroupChanged();
         // force reload info from backend, potentially delete self
-        void reloadBackend();
+        bool reloadBackend();
 
     private:
         friend class DeleteCollectionPrompt;

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -121,12 +121,12 @@ namespace FdoSecrets
         // delete the Entry in backend from this collection
         void doDeleteEntries(QList<Entry*> entries);
 
+        // force reload info from backend, potentially delete self
+        bool reloadBackend();
+
     private slots:
         void onDatabaseLockChanged();
         void onDatabaseExposedGroupChanged();
-
-        // force reload info from backend, potentially delete self
-        bool reloadBackend();
 
         // calls reloadBackend, delete self when error
         void reloadBackendOrDelete();

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -41,6 +41,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit Collection(Service* parent, DatabaseWidget* backend);
+
     public:
         /**
          * @brief Create a new instance of `Collection`

--- a/src/fdosecrets/objects/DBusObject.cpp
+++ b/src/fdosecrets/objects/DBusObject.cpp
@@ -31,17 +31,18 @@ namespace FdoSecrets
 
     DBusObject::DBusObject(DBusObject* parent)
         : QObject(parent)
+        , m_dbusAdaptor(nullptr)
     {
     }
 
-    void DBusObject::registerWithPath(const QString& path, QDBusAbstractAdaptor* adaptor)
+    bool DBusObject::registerWithPath(const QString& path, QDBusAbstractAdaptor* adaptor)
     {
+        Q_ASSERT(!m_dbusAdaptor);
+
         m_objectPath.setPath(path);
         m_dbusAdaptor = adaptor;
         adaptor->setParent(this);
-        auto ok = QDBusConnection::sessionBus().registerObject(m_objectPath.path(), this);
-        Q_UNUSED(ok);
-        Q_ASSERT(ok);
+        return QDBusConnection::sessionBus().registerObject(m_objectPath.path(), this);
     }
 
     QString DBusObject::callingPeerName() const

--- a/src/fdosecrets/objects/DBusObject.h
+++ b/src/fdosecrets/objects/DBusObject.h
@@ -57,7 +57,7 @@ namespace FdoSecrets
         }
 
     protected:
-        void registerWithPath(const QString& path, QDBusAbstractAdaptor* adaptor);
+        bool registerWithPath(const QString& path, QDBusAbstractAdaptor* adaptor);
 
         void unregisterCurrentPath()
         {

--- a/src/fdosecrets/objects/DBusObject.h
+++ b/src/fdosecrets/objects/DBusObject.h
@@ -21,6 +21,7 @@
 #include "fdosecrets/objects/DBusReturn.h"
 #include "fdosecrets/objects/DBusTypes.h"
 
+#include <QDBusAbstractAdaptor>
 #include <QDBusConnection>
 #include <QDBusConnectionInterface>
 #include <QDBusContext>
@@ -31,21 +32,19 @@
 #include <QObject>
 #include <QScopedPointer>
 
-class QDBusAbstractAdaptor;
-
 namespace FdoSecrets
 {
     class Service;
 
     /**
-     * @brief A common base class for all dbus-exposed objects
+     * @brief A common base class for all dbus-exposed objects.
+     * However, derived class should inherit from `DBusObjectHelper`, which is
+     * the only way to set DBus adaptor and enforces correct adaptor creation.
      */
     class DBusObject : public QObject, public QDBusContext
     {
         Q_OBJECT
     public:
-        explicit DBusObject(DBusObject* parent = nullptr);
-
         const QDBusObjectPath& objectPath() const
         {
             return m_objectPath;
@@ -57,12 +56,21 @@ namespace FdoSecrets
         }
 
     protected:
-        bool registerWithPath(const QString& path, QDBusAbstractAdaptor* adaptor);
+        /**
+         * @brief Register this object at given DBus path
+         * @param path DBus path to register at
+         * @param primary whether this path to be considered primary. The primary path is the one to be returned by
+         * `DBusObject::objectPath`.
+         * @return true on success
+         */
+        bool registerWithPath(const QString& path, bool primary = true);
 
-        void unregisterCurrentPath()
+        void unregisterPrimaryPath()
         {
+            if (m_objectPath.path() == QStringLiteral("/")) {
+                return;
+            }
             QDBusConnection::sessionBus().unregisterObject(m_objectPath.path());
-            m_dbusAdaptor = nullptr;
             m_objectPath.setPath(QStringLiteral("/"));
         }
 
@@ -85,6 +93,8 @@ namespace FdoSecrets
         }
 
     private:
+        explicit DBusObject(DBusObject* parent);
+
         /**
          * Derived class should not directly use sendErrorReply.
          * Instead, use raiseError
@@ -92,10 +102,24 @@ namespace FdoSecrets
         using QDBusContext::sendErrorReply;
 
         template <typename U> friend class DBusReturn;
+        template <typename Object, typename Adaptor> friend class DBusObjectHelper;
 
-    private:
         QDBusAbstractAdaptor* m_dbusAdaptor;
         QDBusObjectPath m_objectPath;
+    };
+
+    template <typename Object, typename Adaptor> class DBusObjectHelper : public DBusObject
+    {
+    protected:
+        explicit DBusObjectHelper(DBusObject* parent)
+            : DBusObject(parent)
+        {
+            // creating new Adaptor has to be delayed into constructor's body,
+            // and can't be simply moved to initializer list, because at that
+            // point the base QObject class hasn't been initialized and will sigfault.
+            m_dbusAdaptor = new Adaptor(static_cast<Object*>(this));
+            m_dbusAdaptor->setParent(this);
+        }
     };
 
     /**

--- a/src/fdosecrets/objects/DBusTypes.h
+++ b/src/fdosecrets/objects/DBusTypes.h
@@ -43,6 +43,7 @@
 #define DBUS_PATH_TEMPLATE_SESSION "%1/session/%2"
 #define DBUS_PATH_TEMPLATE_COLLECTION "%1/collection/%2"
 #define DBUS_PATH_TEMPLATE_ITEM "%1/%2"
+#define DBUS_PATH_TEMPLATE_PROMPT "%1/prompt/%2"
 
 namespace FdoSecrets
 {

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -27,10 +27,10 @@
 #include "core/EntryAttributes.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
-#include "core/Tools.h"
 
 #include <QMimeDatabase>
 #include <QRegularExpression>
+#include <QScopedPointer>
 #include <QSet>
 #include <QTextCodec>
 
@@ -50,13 +50,13 @@ namespace FdoSecrets
 
     Item* Item::Create(Collection* parent, Entry* backend)
     {
-        std::unique_ptr<Item> res{new Item(parent, backend)};
+        QScopedPointer<Item> res{new Item(parent, backend)};
 
         if (!res->registerSelf()) {
             return nullptr;
         }
 
-        return res.release();
+        return res.take();
     }
 
     Item::Item(Collection* parent, Entry* backend)

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -48,16 +48,34 @@ namespace FdoSecrets
         constexpr auto FDO_SECRETS_CONTENT_TYPE = "FDO_SECRETS_CONTENT_TYPE";
     } // namespace
 
+    Item* Item::Create(Collection* parent, Entry* backend)
+    {
+        std::unique_ptr<Item> res{new Item(parent, backend)};
+
+        if (!res->registerSelf()) {
+            return nullptr;
+        }
+
+        return res.release();
+    }
+
     Item::Item(Collection* parent, Entry* backend)
         : DBusObject(parent)
         , m_backend(backend)
     {
         Q_ASSERT(!p()->objectPath().path().isEmpty());
 
-        registerWithPath(QStringLiteral(DBUS_PATH_TEMPLATE_ITEM).arg(p()->objectPath().path(), m_backend->uuidToHex()),
-                         new ItemAdaptor(this));
-
         connect(m_backend.data(), &Entry::entryModified, this, &Item::itemChanged);
+    }
+
+    bool Item::registerSelf()
+    {
+        auto path = QStringLiteral(DBUS_PATH_TEMPLATE_ITEM).arg(p()->objectPath().path(), m_backend->uuidToHex());
+        bool ok = registerWithPath(path, new ItemAdaptor(this));
+        if (!ok) {
+            service()->plugin()->emitError(tr("Failed to register item on DBus at path '%1'").arg(path));
+        }
+        return ok;
     }
 
     DBusReturn<bool> Item::locked() const
@@ -206,8 +224,8 @@ namespace FdoSecrets
         if (ret.isError()) {
             return ret;
         }
-        auto prompt = new DeleteItemPrompt(service(), this);
-        return prompt;
+        auto prompt = DeleteItemPrompt::Create(service(), this);
+        return prompt.value();
     }
 
     DBusReturn<SecretStruct> Item::getSecret(Session* session)

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -60,7 +60,7 @@ namespace FdoSecrets
     }
 
     Item::Item(Collection* parent, Entry* backend)
-        : DBusObject(parent)
+        : DBusObjectHelper(parent)
         , m_backend(backend)
     {
         Q_ASSERT(!p()->objectPath().path().isEmpty());
@@ -71,7 +71,7 @@ namespace FdoSecrets
     bool Item::registerSelf()
     {
         auto path = QStringLiteral(DBUS_PATH_TEMPLATE_ITEM).arg(p()->objectPath().path(), m_backend->uuidToHex());
-        bool ok = registerWithPath(path, new ItemAdaptor(this));
+        bool ok = registerWithPath(path);
         if (!ok) {
             service()->plugin()->emitError(tr("Failed to register item on DBus at path '%1'").arg(path));
         }
@@ -340,7 +340,7 @@ namespace FdoSecrets
         // Unregister current path early, do not rely on deleteLater's call to destructor
         // as in case of Entry moving between groups, new Item will be created at the same DBus path
         // before the current Item is deleted in the event loop.
-        unregisterCurrentPath();
+        unregisterPrimaryPath();
 
         m_backend = nullptr;
         deleteLater();

--- a/src/fdosecrets/objects/Item.h
+++ b/src/fdosecrets/objects/Item.h
@@ -38,7 +38,7 @@ namespace FdoSecrets
     class Collection;
     class PromptBase;
 
-    class Item : public DBusObject
+    class Item : public DBusObjectHelper<Item, ItemAdaptor>
     {
         Q_OBJECT
 
@@ -100,7 +100,6 @@ namespace FdoSecrets
     public slots:
         void doDelete();
 
-    private:
         /**
          * @brief Register self on DBus
          * @return

--- a/src/fdosecrets/objects/Item.h
+++ b/src/fdosecrets/objects/Item.h
@@ -41,8 +41,18 @@ namespace FdoSecrets
     class Item : public DBusObject
     {
         Q_OBJECT
-    public:
+
         explicit Item(Collection* parent, Entry* backend);
+    public:
+        /**
+         * @brief Create a new instance of `Item`.
+         * @param parent the owning `Collection`
+         * @param backend the `Entry` containing the data
+         * @return pointer to newly created Item, or nullptr if error
+         * This may be caused by
+         *   - DBus path registration error
+         */
+        static Item* Create(Collection* parent, Entry* backend);
 
         DBusReturn<bool> locked() const;
 
@@ -91,6 +101,12 @@ namespace FdoSecrets
         void doDelete();
 
     private:
+        /**
+         * @brief Register self on DBus
+         * @return
+         */
+        bool registerSelf();
+
         /**
          * Check if the backend is a valid object, send error reply if not.
          * @return No error if the backend is valid.

--- a/src/fdosecrets/objects/Item.h
+++ b/src/fdosecrets/objects/Item.h
@@ -43,6 +43,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit Item(Collection* parent, Entry* backend);
+
     public:
         /**
          * @brief Create a new instance of `Item`.

--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -78,11 +78,11 @@ namespace FdoSecrets
 
     DBusReturn<DeleteCollectionPrompt*> DeleteCollectionPrompt::Create(Service* parent, Collection* coll)
     {
-        std::unique_ptr<DeleteCollectionPrompt> res{new DeleteCollectionPrompt(parent, coll)};
+        QScopedPointer<DeleteCollectionPrompt> res{new DeleteCollectionPrompt(parent, coll)};
         if (!res->registerSelf()) {
             return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
         }
-        return res.release();
+        return res.take();
     }
 
     DeleteCollectionPrompt::DeleteCollectionPrompt(Service* parent, Collection* coll)
@@ -118,11 +118,11 @@ namespace FdoSecrets
 
     DBusReturn<CreateCollectionPrompt*> CreateCollectionPrompt::Create(Service* parent)
     {
-        std::unique_ptr<CreateCollectionPrompt> res{new CreateCollectionPrompt(parent)};
+        QScopedPointer<CreateCollectionPrompt> res{new CreateCollectionPrompt(parent)};
         if (!res->registerSelf()) {
             return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
         }
-        return res.release();
+        return res.take();
     }
 
     CreateCollectionPrompt::CreateCollectionPrompt(Service* parent)
@@ -163,11 +163,11 @@ namespace FdoSecrets
 
     DBusReturn<LockCollectionsPrompt*> LockCollectionsPrompt::Create(Service* parent, const QList<Collection*>& colls)
     {
-        std::unique_ptr<LockCollectionsPrompt> res{new LockCollectionsPrompt(parent, colls)};
+        QScopedPointer<LockCollectionsPrompt> res{new LockCollectionsPrompt(parent, colls)};
         if (!res->registerSelf()) {
             return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
         }
-        return res.release();
+        return res.take();
     }
 
     LockCollectionsPrompt::LockCollectionsPrompt(Service* parent, const QList<Collection*>& colls)
@@ -215,11 +215,11 @@ namespace FdoSecrets
 
     DBusReturn<UnlockCollectionsPrompt*> UnlockCollectionsPrompt::Create(Service* parent, const QList<Collection*>& coll)
     {
-        std::unique_ptr<UnlockCollectionsPrompt> res{new UnlockCollectionsPrompt(parent, coll)};
+        QScopedPointer<UnlockCollectionsPrompt> res{new UnlockCollectionsPrompt(parent, coll)};
         if (!res->registerSelf()) {
             return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
         }
-        return res.release();
+        return res.take();
     }
 
     UnlockCollectionsPrompt::UnlockCollectionsPrompt(Service* parent, const QList<Collection*>& colls)
@@ -291,11 +291,11 @@ namespace FdoSecrets
 
     DBusReturn<DeleteItemPrompt*> DeleteItemPrompt::Create(Service* parent, Item* item)
     {
-        std::unique_ptr<DeleteItemPrompt> res{new DeleteItemPrompt(parent, item)};
+        QScopedPointer<DeleteItemPrompt> res{new DeleteItemPrompt(parent, item)};
         if (!res->registerSelf()) {
             return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
         }
-        return res.release();
+        return res.take();
     }
 
     DeleteItemPrompt::DeleteItemPrompt(Service* parent, Item* item)

--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -17,6 +17,7 @@
 
 #include "Prompt.h"
 
+#include "fdosecrets/FdoSecretsPlugin.h"
 #include "fdosecrets/FdoSecretsSettings.h"
 #include "fdosecrets/objects/Collection.h"
 #include "fdosecrets/objects/Item.h"
@@ -35,11 +36,17 @@ namespace FdoSecrets
     PromptBase::PromptBase(Service* parent)
         : DBusObject(parent)
     {
-        registerWithPath(
-            QStringLiteral("%1/prompt/%2").arg(p()->objectPath().path(), Tools::uuidToHex(QUuid::createUuid())),
-            new PromptAdaptor(this));
-
         connect(this, &PromptBase::completed, this, &PromptBase::deleteLater);
+    }
+
+    bool PromptBase::registerSelf()
+    {
+        auto path = QStringLiteral(DBUS_PATH_TEMPLATE_PROMPT).arg(p()->objectPath().path(), Tools::uuidToHex(QUuid::createUuid()));
+        bool ok = registerWithPath(path, new PromptAdaptor(this));
+        if (!ok) {
+            service()->plugin()->emitError(tr("Failed to register item on DBus at path '%1'").arg(path));
+        }
+        return ok;
     }
 
     QWindow* PromptBase::findWindow(const QString& windowId)
@@ -67,6 +74,15 @@ namespace FdoSecrets
     {
         emit completed(true, "");
         return {};
+    }
+
+    DBusReturn<DeleteCollectionPrompt*> DeleteCollectionPrompt::Create(Service* parent, Collection* coll)
+    {
+        std::unique_ptr<DeleteCollectionPrompt> res{new DeleteCollectionPrompt(parent, coll)};
+        if (!res->registerSelf()) {
+            return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
+        }
+        return res.release();
     }
 
     DeleteCollectionPrompt::DeleteCollectionPrompt(Service* parent, Collection* coll)
@@ -98,6 +114,15 @@ namespace FdoSecrets
         emit completed(!accepted, "");
 
         return {};
+    }
+
+    DBusReturn<CreateCollectionPrompt*> CreateCollectionPrompt::Create(Service* parent)
+    {
+        std::unique_ptr<CreateCollectionPrompt> res{new CreateCollectionPrompt(parent)};
+        if (!res->registerSelf()) {
+            return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
+        }
+        return res.release();
     }
 
     CreateCollectionPrompt::CreateCollectionPrompt(Service* parent)
@@ -134,6 +159,15 @@ namespace FdoSecrets
     {
         emit completed(true, QVariant::fromValue(QDBusObjectPath{"/"}));
         return {};
+    }
+
+    DBusReturn<LockCollectionsPrompt*> LockCollectionsPrompt::Create(Service* parent, const QList<Collection*>& colls)
+    {
+        std::unique_ptr<LockCollectionsPrompt> res{new LockCollectionsPrompt(parent, colls)};
+        if (!res->registerSelf()) {
+            return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
+        }
+        return res.release();
     }
 
     LockCollectionsPrompt::LockCollectionsPrompt(Service* parent, const QList<Collection*>& colls)
@@ -177,6 +211,15 @@ namespace FdoSecrets
     {
         emit completed(true, QVariant::fromValue(m_locked));
         return {};
+    }
+
+    DBusReturn<UnlockCollectionsPrompt*> UnlockCollectionsPrompt::Create(Service* parent, const QList<Collection*>& coll)
+    {
+        std::unique_ptr<UnlockCollectionsPrompt> res{new UnlockCollectionsPrompt(parent, coll)};
+        if (!res->registerSelf()) {
+            return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
+        }
+        return res.release();
     }
 
     UnlockCollectionsPrompt::UnlockCollectionsPrompt(Service* parent, const QList<Collection*>& colls)
@@ -244,6 +287,15 @@ namespace FdoSecrets
     {
         emit completed(true, QVariant::fromValue(m_unlocked));
         return {};
+    }
+
+    DBusReturn<DeleteItemPrompt*> DeleteItemPrompt::Create(Service* parent, Item* item)
+    {
+        std::unique_ptr<DeleteItemPrompt> res{new DeleteItemPrompt(parent, item)};
+        if (!res->registerSelf()) {
+            return DBusReturn<>::Error(QDBusError::InvalidObjectPath);
+        }
+        return res.release();
     }
 
     DeleteItemPrompt::DeleteItemPrompt(Service* parent, Item* item)

--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -41,7 +41,8 @@ namespace FdoSecrets
 
     bool PromptBase::registerSelf()
     {
-        auto path = QStringLiteral(DBUS_PATH_TEMPLATE_PROMPT).arg(p()->objectPath().path(), Tools::uuidToHex(QUuid::createUuid()));
+        auto path = QStringLiteral(DBUS_PATH_TEMPLATE_PROMPT)
+                        .arg(p()->objectPath().path(), Tools::uuidToHex(QUuid::createUuid()));
         bool ok = registerWithPath(path);
         if (!ok) {
             service()->plugin()->emitError(tr("Failed to register item on DBus at path '%1'").arg(path));
@@ -213,7 +214,8 @@ namespace FdoSecrets
         return {};
     }
 
-    DBusReturn<UnlockCollectionsPrompt*> UnlockCollectionsPrompt::Create(Service* parent, const QList<Collection*>& coll)
+    DBusReturn<UnlockCollectionsPrompt*> UnlockCollectionsPrompt::Create(Service* parent,
+                                                                         const QList<Collection*>& coll)
     {
         QScopedPointer<UnlockCollectionsPrompt> res{new UnlockCollectionsPrompt(parent, coll)};
         if (!res->registerSelf()) {

--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -34,7 +34,7 @@ namespace FdoSecrets
 {
 
     PromptBase::PromptBase(Service* parent)
-        : DBusObject(parent)
+        : DBusObjectHelper(parent)
     {
         connect(this, &PromptBase::completed, this, &PromptBase::deleteLater);
     }
@@ -42,7 +42,7 @@ namespace FdoSecrets
     bool PromptBase::registerSelf()
     {
         auto path = QStringLiteral(DBUS_PATH_TEMPLATE_PROMPT).arg(p()->objectPath().path(), Tools::uuidToHex(QUuid::createUuid()));
-        bool ok = registerWithPath(path, new PromptAdaptor(this));
+        bool ok = registerWithPath(path);
         if (!ok) {
             service()->plugin()->emitError(tr("Failed to register item on DBus at path '%1'").arg(path));
         }

--- a/src/fdosecrets/objects/Prompt.h
+++ b/src/fdosecrets/objects/Prompt.h
@@ -32,7 +32,7 @@ namespace FdoSecrets
 
     class Service;
 
-    class PromptBase : public DBusObject
+    class PromptBase : public DBusObjectHelper<PromptBase, PromptAdaptor>
     {
         Q_OBJECT
     public:

--- a/src/fdosecrets/objects/Prompt.h
+++ b/src/fdosecrets/objects/Prompt.h
@@ -58,6 +58,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit DeleteCollectionPrompt(Service* parent, Collection* coll);
+
     public:
         static DBusReturn<DeleteCollectionPrompt*> Create(Service* parent, Collection* coll);
 
@@ -72,6 +73,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit CreateCollectionPrompt(Service* parent);
+
     public:
         static DBusReturn<CreateCollectionPrompt*> Create(Service* parent);
 
@@ -87,6 +89,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit LockCollectionsPrompt(Service* parent, const QList<Collection*>& colls);
+
     public:
         static DBusReturn<LockCollectionsPrompt*> Create(Service* parent, const QList<Collection*>& colls);
 
@@ -103,6 +106,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit UnlockCollectionsPrompt(Service* parent, const QList<Collection*>& coll);
+
     public:
         static DBusReturn<UnlockCollectionsPrompt*> Create(Service* parent, const QList<Collection*>& coll);
 
@@ -124,6 +128,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit DeleteItemPrompt(Service* parent, Item* item);
+
     public:
         static DBusReturn<DeleteItemPrompt*> Create(Service* parent, Item* item);
 

--- a/src/fdosecrets/objects/Prompt.h
+++ b/src/fdosecrets/objects/Prompt.h
@@ -36,8 +36,6 @@ namespace FdoSecrets
     {
         Q_OBJECT
     public:
-        explicit PromptBase(Service* parent);
-
         virtual DBusReturn<void> prompt(const QString& windowId) = 0;
 
         virtual DBusReturn<void> dismiss();
@@ -46,6 +44,9 @@ namespace FdoSecrets
         void completed(bool dismissed, const QVariant& result);
 
     protected:
+        explicit PromptBase(Service* parent);
+
+        bool registerSelf();
         QWindow* findWindow(const QString& windowId);
         Service* service() const;
     };
@@ -56,8 +57,9 @@ namespace FdoSecrets
     {
         Q_OBJECT
 
-    public:
         explicit DeleteCollectionPrompt(Service* parent, Collection* coll);
+    public:
+        static DBusReturn<DeleteCollectionPrompt*> Create(Service* parent, Collection* coll);
 
         DBusReturn<void> prompt(const QString& windowId) override;
 
@@ -69,8 +71,9 @@ namespace FdoSecrets
     {
         Q_OBJECT
 
-    public:
         explicit CreateCollectionPrompt(Service* parent);
+    public:
+        static DBusReturn<CreateCollectionPrompt*> Create(Service* parent);
 
         DBusReturn<void> prompt(const QString& windowId) override;
         DBusReturn<void> dismiss() override;
@@ -82,8 +85,10 @@ namespace FdoSecrets
     class LockCollectionsPrompt : public PromptBase
     {
         Q_OBJECT
-    public:
+
         explicit LockCollectionsPrompt(Service* parent, const QList<Collection*>& colls);
+    public:
+        static DBusReturn<LockCollectionsPrompt*> Create(Service* parent, const QList<Collection*>& colls);
 
         DBusReturn<void> prompt(const QString& windowId) override;
         DBusReturn<void> dismiss() override;
@@ -96,8 +101,10 @@ namespace FdoSecrets
     class UnlockCollectionsPrompt : public PromptBase
     {
         Q_OBJECT
-    public:
+
         explicit UnlockCollectionsPrompt(Service* parent, const QList<Collection*>& coll);
+    public:
+        static DBusReturn<UnlockCollectionsPrompt*> Create(Service* parent, const QList<Collection*>& coll);
 
         DBusReturn<void> prompt(const QString& windowId) override;
         DBusReturn<void> dismiss() override;
@@ -116,8 +123,9 @@ namespace FdoSecrets
     {
         Q_OBJECT
 
-    public:
         explicit DeleteItemPrompt(Service* parent, Item* item);
+    public:
+        static DBusReturn<DeleteItemPrompt*> Create(Service* parent, Item* item);
 
         DBusReturn<void> prompt(const QString& windowId) override;
 

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -54,7 +54,7 @@ namespace FdoSecrets
         : DBusObject(nullptr)
         , m_plugin(plugin)
         , m_databases(std::move(dbTabs))
-        , m_insdieEnsureDefaultAlias(false)
+        , m_insideEnsureDefaultAlias(false)
         , m_serviceWatcher(nullptr)
     {
         connect(
@@ -176,11 +176,11 @@ namespace FdoSecrets
 
     void Service::ensureDefaultAlias()
     {
-        if (m_insdieEnsureDefaultAlias) {
+        if (m_insideEnsureDefaultAlias) {
             return;
         }
 
-        m_insdieEnsureDefaultAlias = true;
+        m_insideEnsureDefaultAlias = true;
 
         auto coll = findCollection(m_databases->currentDatabaseWidget());
         if (coll) {
@@ -188,7 +188,7 @@ namespace FdoSecrets
             coll->addAlias(DEFAULT_ALIAS).okOrDie();
         }
 
-        m_insdieEnsureDefaultAlias = false;
+        m_insideEnsureDefaultAlias = false;
     }
 
     void Service::dbusServiceUnregistered(const QString& service)

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -68,8 +68,9 @@ namespace FdoSecrets
     bool Service::initialize()
     {
         if (!QDBusConnection::sessionBus().registerService(QStringLiteral(DBUS_SERVICE_SECRET))) {
-            plugin()->emitError(tr("Failed to register DBus service at %1.<br/>").arg(QLatin1String(DBUS_SERVICE_SECRET))
-                       + m_plugin->reportExistingService());
+            plugin()->emitError(
+                tr("Failed to register DBus service at %1.<br/>").arg(QLatin1String(DBUS_SERVICE_SECRET))
+                + m_plugin->reportExistingService());
             return false;
         }
 
@@ -80,10 +81,8 @@ namespace FdoSecrets
 
         // Connect to service unregistered signal
         m_serviceWatcher.reset(new QDBusServiceWatcher());
-        connect(m_serviceWatcher.get(),
-                &QDBusServiceWatcher::serviceUnregistered,
-                this,
-                &Service::dbusServiceUnregistered);
+        connect(
+            m_serviceWatcher.get(), &QDBusServiceWatcher::serviceUnregistered, this, &Service::dbusServiceUnregistered);
 
         m_serviceWatcher->setConnection(QDBusConnection::sessionBus());
 
@@ -166,9 +165,7 @@ namespace FdoSecrets
 
         // only start relay signals when the collection is fully setup
         connect(coll, &Collection::collectionChanged, this, [this, coll]() { emit collectionChanged(coll); });
-        connect(coll, &Collection::collectionAboutToDelete, this, [this, coll]() {
-            emit collectionDeleted(coll);
-        });
+        connect(coll, &Collection::collectionAboutToDelete, this, [this, coll]() { emit collectionDeleted(coll); });
         if (emitSignal) {
             emit collectionCreated(coll);
         }
@@ -275,12 +272,15 @@ namespace FdoSecrets
 
             // collection will be created when the prompt completes.
             // once it's done, we set additional properties on the collection
-            connect(cp.value(), &CreateCollectionPrompt::collectionCreated, cp.value(), [alias, properties](Collection* coll) {
-                coll->setProperties(properties).okOrDie();
-                if (!alias.isEmpty()) {
-                    coll->addAlias(alias).okOrDie();
-                }
-            });
+            connect(cp.value(),
+                    &CreateCollectionPrompt::collectionCreated,
+                    cp.value(),
+                    [alias, properties](Collection* coll) {
+                        coll->setProperties(properties).okOrDie();
+                        if (!alias.isEmpty()) {
+                            coll->addAlias(alias).okOrDie();
+                        }
+                    });
         }
         return collection;
     }

--- a/src/fdosecrets/objects/Service.h
+++ b/src/fdosecrets/objects/Service.h
@@ -45,7 +45,7 @@ namespace FdoSecrets
     class ServiceAdaptor;
     class Session;
 
-    class Service : public DBusObject // clazy: exclude=ctor-missing-parent-argument
+    class Service : public DBusObjectHelper<Service, ServiceAdaptor> // clazy: exclude=ctor-missing-parent-argument
     {
         Q_OBJECT
 

--- a/src/fdosecrets/objects/Service.h
+++ b/src/fdosecrets/objects/Service.h
@@ -57,7 +57,7 @@ namespace FdoSecrets
          * This may be caused by
          *   - failed initialization
          */
-        static std::unique_ptr<Service> Create(FdoSecretsPlugin* plugin, QPointer<DatabaseTabWidget> dbTabs);
+        static QSharedPointer<Service> Create(FdoSecretsPlugin* plugin, QPointer<DatabaseTabWidget> dbTabs);
         ~Service() override;
 
         DBusReturn<QVariant> openSession(const QString& algorithm, const QVariant& input, Session*& result);

--- a/src/fdosecrets/objects/Service.h
+++ b/src/fdosecrets/objects/Service.h
@@ -159,7 +159,7 @@ namespace FdoSecrets
         QList<Session*> m_sessions;
         QHash<QString, Session*> m_peerToSession;
 
-        bool m_insdieEnsureDefaultAlias;
+        bool m_insideEnsureDefaultAlias;
 
         std::unique_ptr<QDBusServiceWatcher> m_serviceWatcher;
     };

--- a/src/fdosecrets/objects/Service.h
+++ b/src/fdosecrets/objects/Service.h
@@ -50,6 +50,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit Service(FdoSecretsPlugin* plugin, QPointer<DatabaseTabWidget> dbTabs);
+
     public:
         /**
          * @brief Create a new instance of `Service`. Its parent is set to `null`

--- a/src/fdosecrets/objects/Session.cpp
+++ b/src/fdosecrets/objects/Session.cpp
@@ -24,7 +24,7 @@
 namespace FdoSecrets
 {
 
-    QHash<QString, QVariant> Session::negoniationState;
+    QHash<QString, QVariant> Session::negotiationState;
 
     Session* Session::Create(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent)
     {
@@ -57,7 +57,7 @@ namespace FdoSecrets
 
     void Session::CleanupNegotiation(const QString& peer)
     {
-        negoniationState.remove(peer);
+        negotiationState.remove(peer);
     }
 
     DBusReturn<void> Session::close()

--- a/src/fdosecrets/objects/Session.cpp
+++ b/src/fdosecrets/objects/Session.cpp
@@ -16,6 +16,7 @@
  */
 #include "Session.h"
 
+#include "fdosecrets/FdoSecretsPlugin.h"
 #include "fdosecrets/objects/SessionCipher.h"
 
 #include "core/Tools.h"
@@ -25,14 +26,33 @@ namespace FdoSecrets
 
     QHash<QString, QVariant> Session::negoniationState;
 
+    Session* Session::Create(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent)
+    {
+        std::unique_ptr<Session> res{new Session(std::move(cipher), peer, parent)};
+
+        if (!res->registerSelf()) {
+            return nullptr;
+        }
+
+        return res.release();
+    }
+
     Session::Session(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent)
         : DBusObject(parent)
         , m_cipher(std::move(cipher))
         , m_peer(peer)
         , m_id(QUuid::createUuid())
     {
-        registerWithPath(QStringLiteral(DBUS_PATH_TEMPLATE_SESSION).arg(p()->objectPath().path(), id()),
-                         new SessionAdaptor(this));
+    }
+
+    bool Session::registerSelf()
+    {
+        auto path = QStringLiteral(DBUS_PATH_TEMPLATE_SESSION).arg(p()->objectPath().path(), id());
+        bool ok = registerWithPath(path, new SessionAdaptor(this));
+        if (!ok) {
+            service()->plugin()->emitError(tr("Failed to register session on DBus at path '%1'").arg(path));
+        }
+        return ok;
     }
 
     void Session::CleanupNegotiation(const QString& peer)
@@ -56,6 +76,11 @@ namespace FdoSecrets
     QString Session::id() const
     {
         return Tools::uuidToHex(m_id);
+    }
+
+    Service* Session::service() const
+    {
+        return qobject_cast<Service*>(parent());
     }
 
     std::unique_ptr<CipherPair> Session::CreateCiphers(const QString& peer,

--- a/src/fdosecrets/objects/Session.cpp
+++ b/src/fdosecrets/objects/Session.cpp
@@ -28,13 +28,13 @@ namespace FdoSecrets
 
     Session* Session::Create(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent)
     {
-        std::unique_ptr<Session> res{new Session(std::move(cipher), peer, parent)};
+        QScopedPointer<Session> res{new Session(std::move(cipher), peer, parent)};
 
         if (!res->registerSelf()) {
             return nullptr;
         }
 
-        return res.release();
+        return res.take();
     }
 
     Session::Session(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent)

--- a/src/fdosecrets/objects/Session.cpp
+++ b/src/fdosecrets/objects/Session.cpp
@@ -38,7 +38,7 @@ namespace FdoSecrets
     }
 
     Session::Session(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent)
-        : DBusObject(parent)
+        : DBusObjectHelper(parent)
         , m_cipher(std::move(cipher))
         , m_peer(peer)
         , m_id(QUuid::createUuid())
@@ -48,7 +48,7 @@ namespace FdoSecrets
     bool Session::registerSelf()
     {
         auto path = QStringLiteral(DBUS_PATH_TEMPLATE_SESSION).arg(p()->objectPath().path(), id());
-        bool ok = registerWithPath(path, new SessionAdaptor(this));
+        bool ok = registerWithPath(path);
         if (!ok) {
             service()->plugin()->emitError(tr("Failed to register session on DBus at path '%1'").arg(path));
         }

--- a/src/fdosecrets/objects/Session.h
+++ b/src/fdosecrets/objects/Session.h
@@ -34,7 +34,7 @@ namespace FdoSecrets
 {
 
     class CipherPair;
-    class Session : public DBusObject
+    class Session : public DBusObjectHelper<Session, SessionAdaptor>
     {
         Q_OBJECT
 

--- a/src/fdosecrets/objects/Session.h
+++ b/src/fdosecrets/objects/Session.h
@@ -42,7 +42,7 @@ namespace FdoSecrets
     public:
         static std::unique_ptr<CipherPair> CreateCiphers(const QString& peer,
                                                          const QString& algorithm,
-                                                         const QVariant& intpu,
+                                                         const QVariant& input,
                                                          QVariant& output,
                                                          bool& incomplete);
         static void CleanupNegotiation(const QString& peer);
@@ -99,7 +99,7 @@ namespace FdoSecrets
         QString m_peer;
         QUuid m_id;
 
-        static QHash<QString, QVariant> negoniationState;
+        static QHash<QString, QVariant> negotiationState;
     };
 
 } // namespace FdoSecrets

--- a/src/fdosecrets/objects/Session.h
+++ b/src/fdosecrets/objects/Session.h
@@ -39,6 +39,7 @@ namespace FdoSecrets
         Q_OBJECT
 
         explicit Session(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent);
+
     public:
         static std::unique_ptr<CipherPair> CreateCiphers(const QString& peer,
                                                          const QString& algorithm,

--- a/src/fdosecrets/objects/Session.h
+++ b/src/fdosecrets/objects/Session.h
@@ -37,6 +37,8 @@ namespace FdoSecrets
     class Session : public DBusObject
     {
         Q_OBJECT
+
+        explicit Session(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent);
     public:
         static std::unique_ptr<CipherPair> CreateCiphers(const QString& peer,
                                                          const QString& algorithm,
@@ -45,7 +47,16 @@ namespace FdoSecrets
                                                          bool& incomplete);
         static void CleanupNegotiation(const QString& peer);
 
-        explicit Session(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent);
+        /**
+         * @brief Create a new instance of `Session`.
+         * @param cipher the negotiated cipher
+         * @param peer connecting peer
+         * @param parent the owning Service
+         * @return pointer to newly created Session, or nullptr if error
+         * This may be caused by
+         *   - DBus path registration error
+         */
+        static Session* Create(std::unique_ptr<CipherPair>&& cipher, const QString& peer, Service* parent);
 
         DBusReturn<void> close();
 
@@ -71,12 +82,17 @@ namespace FdoSecrets
 
         QString id() const;
 
+        Service* service() const;
+
     signals:
         /**
          * The session is going to be closed
          * @param sess
          */
         void aboutToClose();
+
+    private:
+        bool registerSelf();
 
     private:
         std::unique_ptr<CipherPair> m_cipher;

--- a/src/fdosecrets/objects/adaptors/CollectionAdaptor.cpp
+++ b/src/fdosecrets/objects/adaptors/CollectionAdaptor.cpp
@@ -27,12 +27,16 @@ namespace FdoSecrets
     CollectionAdaptor::CollectionAdaptor(Collection* parent)
         : DBusAdaptor(parent)
     {
-        connect(
-            p(), &Collection::itemCreated, this, [this](const Item* item) { emit ItemCreated(objectPathSafe(item)); });
-        connect(
-            p(), &Collection::itemDeleted, this, [this](const Item* item) { emit ItemDeleted(objectPathSafe(item)); });
-        connect(
-            p(), &Collection::itemChanged, this, [this](const Item* item) { emit ItemChanged(objectPathSafe(item)); });
+        // p() isn't ready yet as this is called in Parent's constructor
+        connect(parent, &Collection::itemCreated, this, [this](const Item* item) {
+            emit ItemCreated(objectPathSafe(item));
+        });
+        connect(parent, &Collection::itemDeleted, this, [this](const Item* item) {
+            emit ItemDeleted(objectPathSafe(item));
+        });
+        connect(parent, &Collection::itemChanged, this, [this](const Item* item) {
+            emit ItemChanged(objectPathSafe(item));
+        });
     }
 
     const QList<QDBusObjectPath> CollectionAdaptor::items() const

--- a/src/fdosecrets/objects/adaptors/DBusAdaptor.h
+++ b/src/fdosecrets/objects/adaptors/DBusAdaptor.h
@@ -32,7 +32,7 @@ namespace FdoSecrets
     template <typename Parent> class DBusAdaptor : public QDBusAbstractAdaptor
     {
     public:
-        explicit DBusAdaptor(QObject* parent = nullptr)
+        explicit DBusAdaptor(Parent* parent = nullptr)
             : QDBusAbstractAdaptor(parent)
         {
         }

--- a/src/fdosecrets/objects/adaptors/PromptAdaptor.cpp
+++ b/src/fdosecrets/objects/adaptors/PromptAdaptor.cpp
@@ -25,7 +25,8 @@ namespace FdoSecrets
     PromptAdaptor::PromptAdaptor(PromptBase* parent)
         : DBusAdaptor(parent)
     {
-        connect(p(), &PromptBase::completed, this, [this](bool dismissed, QVariant result) {
+        // p() isn't ready yet as this is called in Parent's constructor
+        connect(parent, &PromptBase::completed, this, [this](bool dismissed, QVariant result) {
             // make sure the result contains a valid value, otherwise QDBusVariant refuses to marshall it.
             if (!result.isValid()) {
                 result = QString{};

--- a/src/fdosecrets/objects/adaptors/ServiceAdaptor.cpp
+++ b/src/fdosecrets/objects/adaptors/ServiceAdaptor.cpp
@@ -29,13 +29,14 @@ namespace FdoSecrets
     ServiceAdaptor::ServiceAdaptor(Service* parent)
         : DBusAdaptor(parent)
     {
-        connect(p(), &Service::collectionCreated, this, [this](Collection* coll) {
+        // p() isn't ready yet as this is called in Parent's constructor
+        connect(parent, &Service::collectionCreated, this, [this](Collection* coll) {
             emit CollectionCreated(objectPathSafe(coll));
         });
-        connect(p(), &Service::collectionDeleted, this, [this](Collection* coll) {
+        connect(parent, &Service::collectionDeleted, this, [this](Collection* coll) {
             emit CollectionDeleted(objectPathSafe(coll));
         });
-        connect(p(), &Service::collectionChanged, this, [this](Collection* coll) {
+        connect(parent, &Service::collectionChanged, this, [this](Collection* coll) {
             emit CollectionChanged(objectPathSafe(coll));
         });
     }

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -267,7 +267,7 @@ void TestGuiFdoSecrets::init()
     m_dbWidget = m_tabWidget->currentDatabaseWidget();
     m_db = m_dbWidget->database();
 
-    // by default expsoe the root group
+    // by default expose the root group
     FdoSecrets::settings()->setExposedGroup(m_db, m_db->rootGroup()->uuid());
     QVERIFY(m_dbWidget->save());
 }
@@ -1047,7 +1047,7 @@ void TestGuiFdoSecrets::testExposeSubgroup()
     QCOMPARE(exposedEntries, subgroup->entries());
 }
 
-void TestGuiFdoSecrets::testModifiyingExposedGroup()
+void TestGuiFdoSecrets::testModifyingExposedGroup()
 {
     // test when exposed group is removed the collection is not exposed anymore
     auto subgroup = m_db->rootGroup()->findGroupByPath("/Homebanking");

--- a/tests/gui/TestGuiFdoSecrets.h
+++ b/tests/gui/TestGuiFdoSecrets.h
@@ -82,7 +82,7 @@ private slots:
     void testDefaultAliasAlwaysPresent();
 
     void testExposeSubgroup();
-    void testModifiyingExposedGroup();
+    void testModifyingExposedGroup();
 
 protected slots:
     void createDatabaseCallback();

--- a/tests/gui/TestGuiFdoSecrets.h
+++ b/tests/gui/TestGuiFdoSecrets.h
@@ -84,6 +84,9 @@ private slots:
     void testExposeSubgroup();
     void testModifyingExposedGroup();
 
+    void testHiddenFilename();
+    void testDuplicateName();
+
 protected slots:
     void createDatabaseCallback();
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes #5279. Aside from typos and formatting fixing, this does the following

- Correctly propagate error message to the UI rather than ignoring them
- Simplify the internal states of `Collection`, so it's less likely to be left in an inconsistent state
- Handle corner cases when registering Collection on DBus
  * Previously `QFileInfo::baseName` was used to derive the name, but this can be empty if there are leading dots in the filename, causing #5279. `QFileInfo::completeBaseName` is used instead.
  * Although unlikely, if two open databases have the same filename (but on different paths), the second database will fail to register. New logic is added to address this.


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
New test cases added covering the corner cases mentioned above.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Refactor (significant modification to existing code)