### PR TITLE
Add code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,20 @@
+# Contributor Code of Conduct
+
+KeePassXC is an open project that welcomes everybody no matter their ethnicity, sex,
+sexual identity or orientation, age, socio-economic status, nationality, or religion.
+Irregardless of what background you come from, feel encouraged to participate in
+the project and express your views as long you are respectful to others.
+
+We value all members of our community and so in order to ensure a harassment-free
+experience for everyone and mutual respect among members of this community, we
+impose the following simple rules:
+
+- No bullying, no insults. Any form of harassment will not be tolerated.
+- No racism, no sexism, no homophobia, no hurtful extremist views of any kind.
+- Be mindful of what you say, be diligent in how you say it.
+- Show respect and, as always, be excellent to each other.
+
+Violations of these rules or any other form of abuse can be reported confidentially
+to conduct AT keepassxc DOT org. Members who do not adhere to our code of conduct
+will be banned either permanently or until they change their ways so as to be
+compatible with a friendly, open, and inclusive community.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ We are always looking for suggestions on how to improve KeePassXC. If you find a
 
 You may directly contribute your own code by submitting a pull request. Please read the [CONTRIBUTING](.github/CONTRIBUTING.md) document for further information.
 
+Contributors are required to adhere to the project's [Code of Conduct](CODE-OF-CONDUCT.md).
+
 ## License
 
 KeePassXC code is licensed under GPL-2 or GPL-3. Additional licensing for third-party files is detailed in [COPYING](./COPYING).


### PR DESCRIPTION
KeePassXC is a growing project with an increasing number of contributors. Although, we haven't really needed it so far, in order to avoid potential future conflict and also considering eligibility for individual fund grants, I propose adding a code of conduct based on the template from https://www.contributor-covenant.org/.

Please discuss.

My take: The paragraph about sexualised language (not to be confused with sexist language, which is absolutely not okay) is perhaps a bit prude, and could be removed. But I have no major objections against leaving it in there. I can totally identify with the rest of the document.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Documentation (non-code change)
