### PR TITLE
Shorter YubiKey CLI Prompt.

### DIFF
--- a/src/keys/YkChallengeResponseKeyCLI.cpp
+++ b/src/keys/YkChallengeResponseKeyCLI.cpp
@@ -37,7 +37,7 @@ YkChallengeResponseKeyCLI::YkChallengeResponseKeyCLI(YubiKeySlot keySlot, QStrin
 
 void YkChallengeResponseKeyCLI::showInteractionMessage()
 {
-    m_out << m_interactionMessage << "\n\n" << flush;
+    m_out << m_interactionMessage << "\n" << flush;
 }
 
 QByteArray YkChallengeResponseKeyCLI::rawKey() const


### PR DESCRIPTION
A single EOL space is sufficient after the YK prompt.

@droidmonkey do you remember why you used 2 in 514298101?


## Testing strategy
unit tests + manual invocation


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
