### PR TITLE
Add delay to login startup on Linux

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -107,7 +107,9 @@ void NixUtils::setLaunchAtStartup(bool enable)
                << QStringLiteral("Version=1.0") << "true" << '\n'
                << QStringLiteral("Categories=Utility;Security;Qt;") << '\n'
                << QStringLiteral("MimeType=application/x-keepass2;") << '\n'
-               << QStringLiteral("X-GNOME-Autostart-enabled=true") << endl;
+               << QStringLiteral("X-GNOME-Autostart-enabled=true") << '\n'
+               << QStringLiteral("X-GNOME-Autostart-Delay=2") << '\n'
+               << QStringLiteral("X-KDE-autostart-after=panel") << endl;
         desktopFile.close();
     } else if (isLaunchAtStartupEnabled()) {
         QFile::remove(getAutostartDesktopFilename());


### PR DESCRIPTION
* Fix #5691 - add a 2 second delay to startup on Linux to allow for tray initialization and Auto-Type shortcut registration

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
