### PR TITLE
Add Argon2id KDF

### DIFF
--- a/src/crypto/kdf/Argon2Kdf.cpp
+++ b/src/crypto/kdf/Argon2Kdf.cpp
@@ -29,8 +29,9 @@
  * a 256-bit salt is generated each time the database is saved, the tag length is 256 bits, no secret key
  * or associated data. KeePass uses the latest version of Argon2, v1.3.
  */
-Argon2Kdf::Argon2Kdf()
-    : Kdf::Kdf(KeePass2::KDF_ARGON2)
+Argon2Kdf::Argon2Kdf(Type type)
+    : Kdf::Kdf(KeePass2::KDF_ARGON2D)
+    , m_type(type)
     , m_version(0x13)
     , m_memory(1 << 16)
     , m_parallelism(static_cast<quint32>(QThread::idealThreadCount()))
@@ -52,6 +53,16 @@ bool Argon2Kdf::setVersion(quint32 version)
     }
     m_version = 0x13;
     return false;
+}
+
+Argon2Kdf::Type Argon2Kdf::type() const
+{
+    return m_type;
+}
+
+void Argon2Kdf::setType(Type type)
+{
+    m_type = type;
 }
 
 quint64 Argon2Kdf::memory() const
@@ -133,7 +144,11 @@ bool Argon2Kdf::processParameters(const QVariantMap& p)
 QVariantMap Argon2Kdf::writeParameters()
 {
     QVariantMap p;
-    p.insert(KeePass2::KDFPARAM_UUID, KeePass2::KDF_ARGON2.toRfc4122());
+    if (type() == Type::Argon2d) {
+        p.insert(KeePass2::KDFPARAM_UUID, KeePass2::KDF_ARGON2D.toRfc4122());
+    } else {
+        p.insert(KeePass2::KDFPARAM_UUID, KeePass2::KDF_ARGON2ID.toRfc4122());
+    }
     p.insert(KeePass2::KDFPARAM_ARGON2_VERSION, version());
     p.insert(KeePass2::KDFPARAM_ARGON2_PARALLELISM, parallelism());
     p.insert(KeePass2::KDFPARAM_ARGON2_MEMORY, memory() * 1024);
@@ -158,18 +173,20 @@ bool Argon2Kdf::transform(const QByteArray& raw, QByteArray& result) const
 {
     result.clear();
     result.resize(32);
-    return transformKeyRaw(raw, seed(), version(), rounds(), memory(), parallelism(), result);
+    return transformKeyRaw(raw, seed(), version(), type(), rounds(), memory(), parallelism(), result);
 }
 
 bool Argon2Kdf::transformKeyRaw(const QByteArray& key,
                                 const QByteArray& seed,
                                 quint32 version,
+                                Type type,
                                 quint32 rounds,
                                 quint64 memory,
                                 quint32 parallelism,
                                 QByteArray& result)
 {
     // Time Cost, Mem Cost, Threads/Lanes, Password, length, Salt, length, out, length
+
     int rc = argon2_hash(rounds,
                          memory,
                          parallelism,
@@ -181,7 +198,7 @@ bool Argon2Kdf::transformKeyRaw(const QByteArray& key,
                          result.size(),
                          nullptr,
                          0,
-                         Argon2_d,
+                         type == Type::Argon2d ? Argon2_d : Argon2_id,
                          version);
     if (rc != ARGON2_OK) {
         qWarning("Argon2 error: %s", argon2_error_message(rc));
@@ -205,7 +222,7 @@ int Argon2Kdf::benchmarkImpl(int msec) const
     timer.start();
 
     int rounds = 4;
-    if (transformKeyRaw(key, seed, version(), rounds, memory(), parallelism(), key)) {
+    if (transformKeyRaw(key, seed, version(), type(), rounds, memory(), parallelism(), key)) {
         return static_cast<int>(rounds * (static_cast<float>(msec) / timer.elapsed()));
     }
 
@@ -214,5 +231,6 @@ int Argon2Kdf::benchmarkImpl(int msec) const
 
 QString Argon2Kdf::toString() const
 {
-    return QObject::tr("Argon2 (%1 rounds, %2 KB)").arg(QString::number(rounds()), QString::number(memory()));
+    return QObject::tr("Argon2%1 (%2 rounds, %3 KB)")
+        .arg(type() == Type::Argon2d ? "d" : "id", QString::number(rounds()), QString::number(memory()));
 }

--- a/src/crypto/kdf/Argon2Kdf.h
+++ b/src/crypto/kdf/Argon2Kdf.h
@@ -23,7 +23,13 @@
 class Argon2Kdf : public Kdf
 {
 public:
-    Argon2Kdf();
+    enum class Type
+    {
+        Argon2d,
+        Argon2id
+    };
+
+    Argon2Kdf(Type type);
 
     bool processParameters(const QVariantMap& p) override;
     QVariantMap writeParameters() override;
@@ -32,6 +38,8 @@ public:
 
     quint32 version() const;
     bool setVersion(quint32 version);
+    Type type() const;
+    void setType(Type type);
     quint64 memory() const;
     bool setMemory(quint64 kibibytes);
     quint32 parallelism() const;
@@ -41,6 +49,7 @@ public:
 protected:
     int benchmarkImpl(int msec) const override;
 
+    Type m_type;
     quint32 m_version;
     quint64 m_memory;
     quint32 m_parallelism;
@@ -49,6 +58,7 @@ private:
     Q_REQUIRED_RESULT static bool transformKeyRaw(const QByteArray& key,
                                                   const QByteArray& seed,
                                                   quint32 version,
+                                                  Type type,
                                                   quint32 rounds,
                                                   quint64 memory,
                                                   quint32 parallelism,

--- a/src/format/KeePass2.cpp
+++ b/src/format/KeePass2.cpp
@@ -30,7 +30,8 @@ const QUuid KeePass2::CIPHER_CHACHA20 = QUuid("d6038a2b-8b6f-4cb5-a524-339a31dbb
 
 const QUuid KeePass2::KDF_AES_KDBX3 = QUuid("c9d9f39a-628a-4460-bf74-0d08c18a4fea");
 const QUuid KeePass2::KDF_AES_KDBX4 = QUuid("7c02bb82-79a7-4ac0-927d-114a00648238");
-const QUuid KeePass2::KDF_ARGON2 = QUuid("ef636ddf-8c29-444b-91f7-a9a403e30a0c");
+const QUuid KeePass2::KDF_ARGON2D = QUuid("ef636ddf-8c29-444b-91f7-a9a403e30a0c");
+const QUuid KeePass2::KDF_ARGON2ID = QUuid("9e298b19-56db-4773-b23d-fc3ec6f0a1e6");
 
 const QByteArray KeePass2::INNER_STREAM_SALSA20_IV("\xe8\x30\x09\x4b\x97\x20\x5d\x2a");
 
@@ -53,7 +54,8 @@ const QList<QPair<QUuid, QString>> KeePass2::CIPHERS{
     qMakePair(KeePass2::CIPHER_CHACHA20, QObject::tr("ChaCha20 256-bit"))};
 
 const QList<QPair<QUuid, QString>> KeePass2::KDFS{
-    qMakePair(KeePass2::KDF_ARGON2, QObject::tr("Argon2 (KDBX 4 – recommended)")),
+    qMakePair(KeePass2::KDF_ARGON2D, QObject::tr("Argon2d (KDBX 4 – recommended)")),
+    qMakePair(KeePass2::KDF_ARGON2ID, QObject::tr("Argon2id (KDBX 4)")),
     qMakePair(KeePass2::KDF_AES_KDBX4, QObject::tr("AES-KDF (KDBX 4)")),
     qMakePair(KeePass2::KDF_AES_KDBX3, QObject::tr("AES-KDF (KDBX 3.1)"))};
 
@@ -109,8 +111,11 @@ QSharedPointer<Kdf> KeePass2::uuidToKdf(const QUuid& uuid)
     if (uuid == KDF_AES_KDBX4) {
         return QSharedPointer<AesKdf>::create();
     }
-    if (uuid == KDF_ARGON2) {
-        return QSharedPointer<Argon2Kdf>::create();
+    if (uuid == KDF_ARGON2D) {
+        return QSharedPointer<Argon2Kdf>::create(Argon2Kdf::Type::Argon2d);
+    }
+    if (uuid == KDF_ARGON2ID) {
+        return QSharedPointer<Argon2Kdf>::create(Argon2Kdf::Type::Argon2id);
     }
 
     return {};

--- a/src/format/KeePass2.h
+++ b/src/format/KeePass2.h
@@ -53,7 +53,8 @@ namespace KeePass2
 
     extern const QUuid KDF_AES_KDBX3;
     extern const QUuid KDF_AES_KDBX4;
-    extern const QUuid KDF_ARGON2;
+    extern const QUuid KDF_ARGON2D;
+    extern const QUuid KDF_ARGON2ID;
 
     extern const QByteArray INNER_STREAM_SALSA20_IV;
 

--- a/src/format/OpVaultReader.cpp
+++ b/src/format/OpVaultReader.cpp
@@ -72,7 +72,7 @@ Database* OpVaultReader::readDatabase(QDir& opdataDir, const QString& password)
     key->addKey(QSharedPointer<PasswordKey>::create(password));
 
     QScopedPointer<Database> db(new Database());
-    db->setKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2));
+    db->setKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2D));
     db->setCipher(KeePass2::CIPHER_AES256);
     db->setKey(key, true, false);
     db->metadata()->setName(vaultName);

--- a/tests/TestKdbx4.cpp
+++ b/tests/TestKdbx4.cpp
@@ -42,8 +42,8 @@ int main(int argc, char* argv[])
 
 void TestKdbx4Argon2::initTestCaseImpl()
 {
-    m_xmlDb->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2)));
-    m_kdbxSourceDb->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2)));
+    m_xmlDb->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2D)));
+    m_kdbxSourceDb->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2D)));
 }
 
 QSharedPointer<Database>
@@ -108,7 +108,7 @@ void TestKdbx4Argon2::readKdbx(const QString& path,
 void TestKdbx4Argon2::writeKdbx(QIODevice* device, Database* db, bool& hasError, QString& errorString)
 {
     if (db->kdf()->uuid() == KeePass2::KDF_AES_KDBX3) {
-        db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2)));
+        db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2D)));
     }
     KeePass2Writer writer;
     hasError = writer.writeDatabase(device, db);
@@ -213,26 +213,32 @@ void TestKdbx4Argon2::testFormat400Upgrade_data()
     auto constexpr kdbx3 = KeePass2::FILE_VERSION_3_1 & KeePass2::FILE_VERSION_CRITICAL_MASK;
     auto constexpr kdbx4 = KeePass2::FILE_VERSION_4   & KeePass2::FILE_VERSION_CRITICAL_MASK;
 
-    QTest::newRow("Argon2           + AES")                   << KeePass2::KDF_ARGON2    << KeePass2::CIPHER_AES256       << false << kdbx4;
-    QTest::newRow("AES-KDF          + AES")                   << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_AES256       << false << kdbx4;
-    QTest::newRow("AES-KDF (legacy) + AES")                   << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_AES256       << false << kdbx3;
-    QTest::newRow("Argon2           + AES     + CustomData")  << KeePass2::KDF_ARGON2    << KeePass2::CIPHER_AES256       << true  << kdbx4;
-    QTest::newRow("AES-KDF          + AES     + CustomData")  << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_AES256       << true  << kdbx4;
-    QTest::newRow("AES-KDF (legacy) + AES     + CustomData")  << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_AES256       << true  << kdbx4;
+    QTest::newRow("Argon2d          + AES")                  << KeePass2::KDF_ARGON2D   << KeePass2::CIPHER_AES256  << false << kdbx4;
+    QTest::newRow("Argon2id         + AES")                  << KeePass2::KDF_ARGON2ID  << KeePass2::CIPHER_AES256  << false << kdbx4;
+    QTest::newRow("AES-KDF          + AES")                  << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_AES256  << false << kdbx4;
+    QTest::newRow("AES-KDF (legacy) + AES")                  << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_AES256  << false << kdbx3;
+    QTest::newRow("Argon2d          + AES     + CustomData") << KeePass2::KDF_ARGON2D   << KeePass2::CIPHER_AES256  << true  << kdbx4;
+    QTest::newRow("Argon2id         + AES     + CustomData") << KeePass2::KDF_ARGON2ID  << KeePass2::CIPHER_AES256  << true  << kdbx4;
+    QTest::newRow("AES-KDF          + AES     + CustomData") << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_AES256  << true  << kdbx4;
+    QTest::newRow("AES-KDF (legacy) + AES     + CustomData") << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_AES256  << true  << kdbx4;
 
-    QTest::newRow("Argon2           + ChaCha20")              << KeePass2::KDF_ARGON2    << KeePass2::CIPHER_CHACHA20  << false << kdbx4;
-    QTest::newRow("AES-KDF          + ChaCha20")              << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_CHACHA20  << false << kdbx4;
-    QTest::newRow("AES-KDF (legacy) + ChaCha20")              << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_CHACHA20  << false << kdbx3;
-    QTest::newRow("Argon2           + ChaCha20 + CustomData") << KeePass2::KDF_ARGON2    << KeePass2::CIPHER_CHACHA20  << true  << kdbx4;
-    QTest::newRow("AES-KDF          + ChaCha20 + CustomData") << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_CHACHA20  << true  << kdbx4;
-    QTest::newRow("AES-KDF (legacy) + ChaCha20 + CustomData") << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_CHACHA20  << true  << kdbx4;
+    QTest::newRow("Argon2d          + ChaCha20")              << KeePass2::KDF_ARGON2D   << KeePass2::CIPHER_CHACHA20 << false << kdbx4;
+    QTest::newRow("Argon2id         + ChaCha20")              << KeePass2::KDF_ARGON2ID  << KeePass2::CIPHER_CHACHA20 << false << kdbx4;
+    QTest::newRow("AES-KDF          + ChaCha20")              << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_CHACHA20 << false << kdbx4;
+    QTest::newRow("AES-KDF (legacy) + ChaCha20")              << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_CHACHA20 << false << kdbx3;
+    QTest::newRow("Argon2d          + ChaCha20 + CustomData") << KeePass2::KDF_ARGON2D   << KeePass2::CIPHER_CHACHA20 << true  << kdbx4;
+    QTest::newRow("Argon2id         + ChaCha20 + CustomData") << KeePass2::KDF_ARGON2ID  << KeePass2::CIPHER_CHACHA20 << true  << kdbx4;
+    QTest::newRow("AES-KDF          + ChaCha20 + CustomData") << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_CHACHA20 << true  << kdbx4;
+    QTest::newRow("AES-KDF (legacy) + ChaCha20 + CustomData") << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_CHACHA20 << true  << kdbx4;
 
-    QTest::newRow("Argon2           + Twofish")               << KeePass2::KDF_ARGON2    << KeePass2::CIPHER_TWOFISH   << false << kdbx4;
-    QTest::newRow("AES-KDF          + Twofish")               << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_TWOFISH   << false << kdbx4;
-    QTest::newRow("AES-KDF (legacy) + Twofish")               << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_TWOFISH   << false << kdbx3;
-    QTest::newRow("Argon2           + Twofish  + CustomData") << KeePass2::KDF_ARGON2    << KeePass2::CIPHER_TWOFISH   << true  << kdbx4;
-    QTest::newRow("AES-KDF          + Twofish  + CustomData") << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_TWOFISH   << true  << kdbx4;
-    QTest::newRow("AES-KDF (legacy) + Twofish  + CustomData") << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_TWOFISH   << true  << kdbx4;
+    QTest::newRow("Argon2d          + Twofish")               << KeePass2::KDF_ARGON2D   << KeePass2::CIPHER_TWOFISH  << false << kdbx4;
+    QTest::newRow("Argon2id         + Twofish")               << KeePass2::KDF_ARGON2ID  << KeePass2::CIPHER_TWOFISH  << false << kdbx4;
+    QTest::newRow("AES-KDF          + Twofish")               << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_TWOFISH  << false << kdbx4;
+    QTest::newRow("AES-KDF (legacy) + Twofish")               << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_TWOFISH  << false << kdbx3;
+    QTest::newRow("Argon2d          + Twofish  + CustomData") << KeePass2::KDF_ARGON2D   << KeePass2::CIPHER_TWOFISH  << true  << kdbx4;
+    QTest::newRow("Argon2id         + Twofish  + CustomData") << KeePass2::KDF_ARGON2ID  << KeePass2::CIPHER_TWOFISH  << true  << kdbx4;
+    QTest::newRow("AES-KDF          + Twofish  + CustomData") << KeePass2::KDF_AES_KDBX4 << KeePass2::CIPHER_TWOFISH  << true  << kdbx4;
+    QTest::newRow("AES-KDF (legacy) + Twofish  + CustomData") << KeePass2::KDF_AES_KDBX3 << KeePass2::CIPHER_TWOFISH  << true  << kdbx4;
 }
 // clang-format on
 
@@ -270,7 +276,7 @@ void TestKdbx4Argon2::testUpgradeMasterKeyIntegrity()
     } else if (upgradeAction == "kdf-aes-kdbx3") {
         db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_AES_KDBX3)));
     } else if (upgradeAction == "kdf-argon2") {
-        db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2)));
+        db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2D)));
     } else if (upgradeAction == "kdf-aes-kdbx4") {
         db->changeKdf(fastKdf(KeePass2::uuidToKdf(KeePass2::KDF_AES_KDBX4)));
     } else if (upgradeAction == "public-customdata") {

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -809,7 +809,7 @@ QSharedPointer<Kdf> TestKeePass2Format::fastKdf(QSharedPointer<Kdf> kdf) const
 {
     kdf->setRounds(1);
 
-    if (kdf->uuid() == KeePass2::KDF_ARGON2) {
+    if (kdf->uuid() == KeePass2::KDF_ARGON2D) {
         kdf->processParameters({{KeePass2::KDFPARAM_ARGON2_MEMORY, 1024}, {KeePass2::KDFPARAM_ARGON2_PARALLELISM, 1}});
     }
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -301,7 +301,7 @@ void TestGui::testCreateDatabase()
     // check key and encryption
     QCOMPARE(m_db->key()->keys().size(), 2);
     QCOMPARE(m_db->kdf()->rounds(), 2);
-    QCOMPARE(m_db->kdf()->uuid(), KeePass2::KDF_ARGON2);
+    QCOMPARE(m_db->kdf()->uuid(), KeePass2::KDF_ARGON2D);
     QCOMPARE(m_db->cipher(), KeePass2::CIPHER_AES256);
     auto compositeKey = QSharedPointer<CompositeKey>::create();
     compositeKey->addKey(QSharedPointer<PasswordKey>::create("test"));


### PR DESCRIPTION
After some discussion in #4317 as to which KDF may become the future default or at least a new option and @DReichl's eagerness to implement Argon2id right away, I have now added it to our code base as a selectable KDF.

If Argon2id lands in KeePass2 rather soon, we can backport this to 2.6, since the surface for potential breakage is very small. I did not touch any of the KDBX4 defaults, so that remains Argon2d for now.

The implementation uses libargon2 for the time begin, since that requires the least amount of code changes. In the future, we may switch to libsodium if we decide we no longer need Argon2d (or if some other miracle happens).

The new KDF UUID is `9e298b19-56db-4773-b23d-fc3ec6f0a1e6`.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

I extended the KDBX4 KDF test matrix with the new option.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)