### PR TITLE
Attach console in debug mode on Windows

### DIFF
--- a/src/gui/osutils/winutils/WinUtils.cpp
+++ b/src/gui/osutils/winutils/WinUtils.cpp
@@ -30,6 +30,14 @@ WinUtils* WinUtils::instance()
 {
     if (!m_instance) {
         m_instance = new WinUtils(qApp);
+
+#ifdef QT_DEBUG
+        // Attach console to enable debug output
+        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+            freopen("CONOUT$", "w", stdout);
+            freopen("CONOUT$", "w", stderr);
+        }
+#endif
     }
 
     return m_instance;


### PR DESCRIPTION
Attaches a console to enable printing debug output on Windows (e.g. with QDebug).

The console is attached the moment WinUtils is instantiated for the first time.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
