### PR TITLE
Fix regression: Remove length limit on password

### DIFF
--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -259,9 +259,6 @@ QProgressBar::chunk {
            <property name="minimum">
             <number>1</number>
            </property>
-           <property name="maximum">
-            <number>128</number>
-           </property>
            <property name="value">
             <number>20</number>
            </property>


### PR DESCRIPTION

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

A feature of keepassxc, that I used, was to generate long passwords e.g. of 255 characters.
This feature was broken lately.

Not completely sure if this fix will just work like that, but it seemed worth a shot to me.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
