### PR TITLE
Fix the warning about QTimer cannot be stopped from another thread

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -431,7 +431,7 @@ void Database::releaseData()
 
     setEmitModified(false);
     m_modified = false;
-    m_modifiedTimer.stop();
+    stopModifiedTimer();
 
     s_uuidMap.remove(m_uuid);
     m_uuid = QUuid();
@@ -842,7 +842,7 @@ void Database::emptyRecycleBin()
 void Database::setEmitModified(bool value)
 {
     if (m_emitModified && !value) {
-        m_modifiedTimer.stop();
+        stopModifiedTimer();
     }
 
     m_emitModified = value;
@@ -863,7 +863,7 @@ void Database::markAsModified()
     m_modified = true;
     if (m_emitModified && !m_modifiedTimer.isActive()) {
         // Small time delay prevents numerous consecutive saves due to repeated signals
-        m_modifiedTimer.start(150);
+        startModifiedTimer();
     }
 }
 
@@ -871,7 +871,7 @@ void Database::markAsClean()
 {
     bool emitSignal = m_modified;
     m_modified = false;
-    m_modifiedTimer.stop();
+    stopModifiedTimer();
     m_hasNonDataChange = false;
     if (emitSignal) {
         emit databaseSaved();
@@ -926,4 +926,14 @@ bool Database::changeKdf(const QSharedPointer<Kdf>& kdf)
     markAsModified();
 
     return true;
+}
+
+void Database::startModifiedTimer()
+{
+    QMetaObject::invokeMethod(&m_modifiedTimer, "start", Q_ARG(int, 150));
+}
+
+void Database::stopModifiedTimer()
+{
+    QMetaObject::invokeMethod(&m_modifiedTimer, "stop");
 }

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -202,6 +202,8 @@ private:
     bool backupDatabase(const QString& filePath);
     bool restoreDatabase(const QString& filePath);
     bool performSave(const QString& filePath, QString* error, bool atomic, bool backup);
+    void startModifiedTimer();
+    void stopModifiedTimer();
 
     QPointer<Metadata> const m_metadata;
     DatabaseData m_data;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
`Database` may be accessed from a different thread in `Database::saveAs`, where the `m_modifiedTimer` is stopped during the saving. The solution is simply to post the timer stop call to the timer thread's event loop. Before this, the timer is not actually stopped, so I guess this has caused some unnecessary saves.

This was mentioned in #5370, but closed as a minor defect. Today the warning becomes annoying enough for me when working on the codebase and I happen to have a debug build of Qt to track this down.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Run existing tests, no more "timer cannot be stopped from another thread" warnings.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)