### PR TITLE
Redo 'delete entries no confirm' functionality & unit-tests

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -138,6 +138,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_ResetTouchId, {QS("Security/ResetTouchId"), Roaming, false}},
     {Config::Security_ResetTouchIdTimeout, {QS("Security/ResetTouchIdTimeout"), Roaming, 30}},
     {Config::Security_ResetTouchIdScreenlock,{QS("Security/ResetTouchIdScreenlock"), Roaming, true}},
+    {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},
 
     // Browser
     {Config::Browser_Enabled, {QS("Browser/Enabled"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -119,6 +119,7 @@ public:
         Security_ResetTouchId,
         Security_ResetTouchIdTimeout,
         Security_ResetTouchIdScreenlock,
+        Security_NoConfirmMoveEntryToRecycleBin,
 
         Browser_Enabled,
         Browser_ShowNotification,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -280,6 +280,8 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->passwordsRepeatVisibleCheckBox->setChecked(
         config()->get(Config::Security_PasswordsRepeatVisible).toBool());
     m_secUi->hideNotesCheckBox->setChecked(config()->get(Config::Security_HideNotes).toBool());
+    m_secUi->NoConfirmMoveEntryToRecycleBinCheckBox->setChecked(
+        config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool());
 
     m_secUi->touchIDResetCheckBox->setChecked(config()->get(Config::Security_ResetTouchId).toBool());
     m_secUi->touchIDResetSpinBox->setValue(config()->get(Config::Security_ResetTouchIdTimeout).toInt());
@@ -379,6 +381,8 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::Security_HidePasswordPreviewPanel, m_secUi->passwordPreviewCleartextCheckBox->isChecked());
     config()->set(Config::Security_PasswordsRepeatVisible, m_secUi->passwordsRepeatVisibleCheckBox->isChecked());
     config()->set(Config::Security_HideNotes, m_secUi->hideNotesCheckBox->isChecked());
+    config()->set(Config::Security_NoConfirmMoveEntryToRecycleBin,
+                  m_secUi->NoConfirmMoveEntryToRecycleBinCheckBox->isChecked());
 
     config()->set(Config::Security_ResetTouchId, m_secUi->touchIDResetCheckBox->isChecked());
     config()->set(Config::Security_ResetTouchIdTimeout, m_secUi->touchIDResetSpinBox->value());

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -257,6 +257,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="NoConfirmMoveEntryToRecycleBinCheckBox">
+        <property name="text">
+         <string>Move entries to recycle bin without confirmation</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -571,6 +571,8 @@ bool DatabaseWidget::confirmDeleteEntries(QList<Entry*> entries, bool permanent)
                                            MessageBox::Cancel);
 
         return answer == MessageBox::Delete;
+    } else if (config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool()) {
+        return true;
     } else {
         QString prompt;
         if (entries.size() == 1) {

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1022,7 +1022,8 @@ void TestGui::testDeleteEntry()
         QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 1);
     } else {
         // no confirm dialog
-        QCOMPARE(entryView->model()->rowCount(), 1);
+        QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
+        QCOMPARE(entryView->model()->rowCount(), 3);
         QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 1);
     }
 
@@ -1042,6 +1043,7 @@ void TestGui::testDeleteEntry()
         QCOMPARE(entryView->model()->rowCount(), 1);
         QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 3);
     } else {
+        QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
         QCOMPARE(entryView->model()->rowCount(), 1);
         QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 3);
     }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1013,26 +1013,38 @@ void TestGui::testDeleteEntry()
     QVERIFY(entryDeleteWidget->isEnabled());
     QVERIFY(!m_db->metadata()->recycleBin());
 
-    MessageBox::setNextAnswer(MessageBox::Move);
-    QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
+    // Test with confirmation dialog
+    if (!config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool()) {
+        MessageBox::setNextAnswer(MessageBox::Move);
+        QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
 
-    QCOMPARE(entryView->model()->rowCount(), 3);
-    QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 1);
+        QCOMPARE(entryView->model()->rowCount(), 3);
+        QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 1);
+    } else {
+        // no confirm dialog
+        QCOMPARE(entryView->model()->rowCount(), 1);
+        QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 1);
+    }
 
     // Select multiple entries and move them to the recycling bin
     clickIndex(entryView->model()->index(1, 1), entryView, Qt::LeftButton);
     clickIndex(entryView->model()->index(2, 1), entryView, Qt::LeftButton, Qt::ControlModifier);
     QCOMPARE(entryView->selectionModel()->selectedRows().size(), 2);
 
-    MessageBox::setNextAnswer(MessageBox::Cancel);
-    QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
-    QCOMPARE(entryView->model()->rowCount(), 3);
-    QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 1);
+    if (!config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool()) {
+        MessageBox::setNextAnswer(MessageBox::Cancel);
+        QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
+        QCOMPARE(entryView->model()->rowCount(), 3);
+        QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 1);
 
-    MessageBox::setNextAnswer(MessageBox::Move);
-    QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
-    QCOMPARE(entryView->model()->rowCount(), 1);
-    QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 3);
+        MessageBox::setNextAnswer(MessageBox::Move);
+        QTest::mouseClick(entryDeleteWidget, Qt::LeftButton);
+        QCOMPARE(entryView->model()->rowCount(), 1);
+        QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 3);
+    } else {
+        QCOMPARE(entryView->model()->rowCount(), 1);
+        QCOMPARE(m_db->metadata()->recycleBin()->entries().size(), 3);
+    }
 
     // Go to the recycling bin
     QCOMPARE(groupView->currentGroup(), m_db->rootGroup());


### PR DESCRIPTION
Fixes #5232 
and this time, testgui will be fixed too !

"If this feature is considered, a new checkbox is introduced in the settings -> security -> convenience - section.
When checked, the confirmation dialog before entries are moved/deleted will not appear and the entry/entries
will be directly moved to recycle bin without confirmation dialog".

## Screenshots

## Testing strategy
Deleted entry / entries with & without checkbox checked.

## Type of change
- ✅ New feature (change that adds functionality)
