### PR TITLE
Show warning when opening an *.old.kdbx file

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -137,6 +137,15 @@ void DatabaseOpenWidget::load(const QString& filename)
     clearForms();
 
     m_filename = filename;
+    if (m_filename.contains(".old.")) {
+        QMessageBox msgBox;
+        msgBox->setWindowTitle(tr("Opening a backup file"));
+        msgBox.setText(tr("You are opening a database backup.
+        Please be aware that it could contain old entries."));
+        msgBox->setIcon(QMessageBox::Warning);
+        msgBox->setStandardButtons(QMessageBox::Ok);
+        msgBox.exec();
+    }
     m_ui->fileNameLabel->setRawText(m_filename);
 
     if (config()->get(Config::RememberLastKeyFiles).toBool()) {

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -138,13 +138,12 @@ void DatabaseOpenWidget::load(const QString& filename)
 
     m_filename = filename;
     if (m_filename.contains(".old.")) {
-        QMessageBox msgBox;
+        auto* msgBox = new QMessageBox();
         msgBox->setWindowTitle(tr("Opening a backup file"));
-        msgBox.setText(tr("You are opening a database backup.
-        Please be aware that it could contain old entries."));
+        msgBox->setText(tr("You are opening a database backup.Please be aware that it could contain old entries."));
         msgBox->setIcon(QMessageBox::Warning);
         msgBox->setStandardButtons(QMessageBox::Ok);
-        msgBox.exec();
+        msgBox->exec();
     }
     m_ui->fileNameLabel->setRawText(m_filename);
 

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -140,7 +140,7 @@ void DatabaseOpenWidget::load(const QString& filename)
     if (m_filename.contains(".old.")) {
         auto* msgBox = new QMessageBox();
         msgBox->setWindowTitle(tr("Opening a backup file"));
-        msgBox->setText(tr("You are opening a database backup.Please be aware that it could contain old entries."));
+        msgBox->setText(tr("You are opening a database backup. Please be aware that it could contain old entries."));
         msgBox->setIcon(QMessageBox::Warning);
         msgBox->setStandardButtons(QMessageBox::Ok);
         msgBox->exec();


### PR DESCRIPTION
This PR adds a warning when the user opens an .old.kdbx database file.
Fixes #5816.

## Screenshots
![grafik](https://user-images.githubusercontent.com/23658248/101994355-21017e00-3cc2-11eb-9502-e908825fb717.png)



## Testing strategy
I opened an *.old.kdbx file and looked for a warning message.

## Type of change
- ✅ New feature (change that adds functionality)