### PR TITLE
Prevent crash when KeeShare merges an entry that is in edit mode

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -997,6 +997,15 @@ bool EditEntryWidget::commitEntry()
         return true;
     }
 
+    // HACK: Check that entry pointer is still valid, see https://github.com/keepassxreboot/keepassxc/issues/5722
+    if (!m_entry) {
+        QMessageBox::information(this,
+                                 tr("Invalid Entry"),
+                                 tr("An external merge operation has invalidated this entry.\n"
+                                    "Unfortunately, any changes made have been lost."));
+        return true;
+    }
+
     // Check Auto-Type validity early
     if (!AutoType::verifyAutoTypeSyntax(m_autoTypeUi->sequenceEdit->text())) {
         return false;

--- a/src/keeshare/ShareObserver.h
+++ b/src/keeshare/ShareObserver.h
@@ -83,6 +83,7 @@ private:
     QMap<QPointer<Group>, KeeShareSettings::Reference> m_groupToReference;
     QMap<QString, QPointer<Group>> m_shareToGroup;
     QMap<QString, QSharedPointer<FileWatcher>> m_fileWatchers;
+    bool m_inFileUpdate = false;
 };
 
 #endif // KEEPASSXC_SHAREOBSERVER_H


### PR DESCRIPTION
* Hack for #5722 until a refactor of KeeShare, Merger, and EditEntryWidget can be performed. This hack should only ever be triggered on the rare occurrence of two people editing the same entry at the same time.  The end result is potential data loss, but the current result is a hard crash. Unfortunately the way everything is interfaced currently doesn't afford any solution without a major refactor.

* Additionally add a short delay before actually reloading a share to prevent read/write locks from preventing proper import. This delay also prevents conflicting saves between the main database and the KeeShare database. This should eventually be moved into the FileObserver itself to smooth out all merge operations once the above refactor occurs.

Side note: KeeShare operates independently of DatabaseWidget causing unexpected behavior when files are updated/merged/etc. This needs to be corrected in a refactor.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/102017759-d837dc80-3d36-11eb-936c-6f067d876958.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows using two instances of KeePassXC modifying a KeeShare database.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
