### PR TITLE
Hotfix/html preview

### DIFF
--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -286,14 +286,18 @@ void EntryPreviewWidget::updateEntryAdvancedTab()
 
     setTabEnabled(m_ui->entryTabWidget, m_ui->entryAdvancedTab, hasAttributes || hasAttachments);
     if (hasAttributes) {
-        QString attributesText;
+        QString attributesText("<table>");
         for (const QString& key : customAttributes) {
-            QString value = m_currentEntry->attributes()->value(key);
+            QString value;
             if (m_currentEntry->attributes()->isProtected(key)) {
                 value = "<i>" + tr("[PROTECTED]") + "</i>";
+            } else {
+                value = m_currentEntry->attributes()->value(key).toHtmlEscaped();
+                value.replace('\n', QLatin1String("<br/>"));
             }
-            attributesText.append(tr("<b>%1</b>: %2", "attributes line").arg(key, value).append("<br/>"));
+            attributesText.append(tr("<tr><td><b>%1</b>:</td><td>%2</td></tr>", "attributes line").arg(key, value));
         }
+        attributesText.append("</table>");
         m_ui->entryAttributesEdit->setText(attributesText);
     }
 


### PR DESCRIPTION
Fixes #5755 (HTML parsing in attributes)

First commit fixes the bug _per se_.
Second commit handles new lines in user text by inserting `<br/>` tags. And to have it nicely aligned, it also uses a `<table>`…

## Testing strategy
I created an entry with several attributes and checked how they looked like in preview.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

