### PR TITLE
Implement empty-area drag.

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -35,6 +35,7 @@ namespace Ui
 
 class InactivityTimer;
 class SearchWidget;
+class MainWindowEventFilter;
 
 class MainWindow : public QMainWindow
 {
@@ -182,7 +183,20 @@ private:
     QTimer m_updateCheckTimer;
     QTimer m_trayIconTriggerTimer;
     QSystemTrayIcon::ActivationReason m_trayIconTriggerReason;
+
+    friend class MainWindowEventFilter;
 };
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+class MainWindowEventFilter : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit MainWindowEventFilter(QObject* parent);
+    bool eventFilter(QObject* watched, QEvent* event) override;
+};
+#endif
 
 /**
  * Return instance of MainWindow created on app load


### PR DESCRIPTION
Uses Qt 5.15's new QWindow::startSystemMove() to implement empty-area drag, which allows the user to click and drag any empty area on the menubar, toolbar, or tabbar to move the window around.

This was part of another futile attempt at implementing properly style CSDs on Windows. This time, I tested this new Qt feature for it: https://www.qt.io/blog/custom-window-decorations
Turns out, the feature is pretty useless for the thing it was designed for (https://bugreports.qt.io/browse/QTBUG-84466), but we can use it to implement empty-area drag without any custom window moving logic.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)