### PR TITLE
Fix average password length in the Statistics report

### DIFF
--- a/src/gui/reports/ReportsWidgetStatistics.cpp
+++ b/src/gui/reports/ReportsWidgetStatistics.cpp
@@ -58,7 +58,8 @@ namespace
         // Get average password length
         int averagePwdLength() const
         {
-            return m_passwords.empty() ? 0 : pwdTotalLen / m_passwords.size();
+            const auto nPwds = nPwdsUnique + nPwdsReused;
+            return nPwds == 0 ? 0 : std::round(pwdTotalLen / double(nPwds));
         }
 
         // Get max number of password reuse (=how many entries


### PR DESCRIPTION
The average password length shown in the Statistics report is now computed based on the total number of passwords. Previously, it was erroneously computed based on the number of unique passwords.

Also, round average password length to the nearest integer instead of truncating to the floor.

Fixes #5134.

## Screenshots

n/a

## Testing strategy

Tested manually with the test database as described in #5134.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
