### PR TITLE
Always activate DatabaseOpenDialog on Windows

### DIFF
--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -20,12 +20,19 @@
 #include "DatabaseWidget.h"
 #include "core/Database.h"
 
+#ifdef Q_OS_WIN
+#include <QtPlatformHeaders/QWindowsWindowFunctions>
+#endif
+
 DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
     : QDialog(parent)
     , m_view(new DatabaseOpenWidget(this))
 {
     setWindowTitle(tr("Unlock Database - KeePassXC"));
     setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint);
+#ifdef Q_OS_WIN
+    QWindowsWindowFunctions::setWindowActivationBehavior(QWindowsWindowFunctions::AlwaysActivateWindow);
+#endif
     connect(m_view, SIGNAL(dialogFinished(bool)), this, SLOT(complete(bool)));
     auto* layout = new QVBoxLayout();
     layout->setMargin(0);


### PR DESCRIPTION
Always activate DatabaseOpenDialog on Windows.

Fixes #5390

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)