### PR TITLE
Automatic launch at system startup for distribution AppImage

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -92,13 +92,18 @@ void NixUtils::setLaunchAtStartup(bool enable)
             qWarning("Failed to create autostart desktop file.");
             return;
         }
+
+        const QString appImagePath = QString::fromLocal8Bit(qgetenv("APPIMAGE"));
+        const bool isAppImage = !appImagePath.isNull() && QFile::exists(appImagePath);
+        const QString executeablePath = isAppImage ? appImagePath : QApplication::applicationFilePath();
+
         QTextStream stream(&desktopFile);
         stream.setCodec("UTF-8");
         stream << QStringLiteral("[Desktop Entry]") << '\n'
                << QStringLiteral("Name=") << QApplication::applicationDisplayName() << '\n'
                << QStringLiteral("GenericName=") << tr("Password Manager") << '\n'
-               << QStringLiteral("Exec=") << QApplication::applicationFilePath() << '\n'
-               << QStringLiteral("TryExec=") << QApplication::applicationFilePath() << '\n'
+               << QStringLiteral("Exec=") << executeablePath << '\n'
+               << QStringLiteral("TryExec=") << executeablePath << '\n'
                << QStringLiteral("Icon=") << QApplication::applicationName().toLower() << '\n'
                << QStringLiteral("StartupWMClass=keepassxc") << '\n'
                << QStringLiteral("StartupNotify=true") << '\n'


### PR DESCRIPTION
This pull request fixes #5050.

The method QApplication::applicationFilePath returns a temporary executable path for AppImage, resulting in a non working autostart of KeePassXC with AppImage. The environment variable **APPIMAGE**, provided by the the AppImage returns the path to the AppImage file, which must be used to get autostart on startup of KeePassXC with AppImage working.

## Testing strategy
1. Remove autostart entry under ./config/autostart/
2. Start patched KeePassXC AppImage
3. Enable **automatically launch KeePassXC at system startup**
4. Check autostart entry under ./config/autostart/
5. Reboot system
6. Check if KeePassXC AppImage starts automatically



## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

