### PR TITLE
Fix autostart .desktop file

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -104,7 +104,7 @@ void NixUtils::setLaunchAtStartup(bool enable)
                << QStringLiteral("StartupNotify=true") << '\n'
                << QStringLiteral("Terminal=false") << '\n'
                << QStringLiteral("Type=Application") << '\n'
-               << QStringLiteral("Version=1.0") << "true" << '\n'
+               << QStringLiteral("Version=1.0") << '\n'
                << QStringLiteral("Categories=Utility;Security;Qt;") << '\n'
                << QStringLiteral("MimeType=application/x-keepass2;") << '\n'
                << QStringLiteral("X-GNOME-Autostart-enabled=true") << '\n'


### PR DESCRIPTION
It had "Version=1.0true", which seems wrong

## Screenshots

## Testing strategy
With patched KeePassXC, disabling and enabling "Automatically launch KeePassXC at system startup" brings the correct desktop file.

Before this patch:
```
[Desktop Entry]
Name=KeePassXC
GenericName=Password Manager
Exec=/usr/bin/keepassxc
TryExec=/usr/bin/keepassxc
Icon=keepassxc
StartupWMClass=keepassxc
StartupNotify=true
Terminal=false
Type=Application
Version=1.0true
Categories=Utility;Security;Qt;
MimeType=application/x-keepass2;
X-GNOME-Autostart-enabled=true
```
With this patch:
```
[Desktop Entry]
Name=KeePassXC
GenericName=Password Manager
Exec=/usr/bin/keepassxc
TryExec=/usr/bin/keepassxc
Icon=keepassxc
StartupWMClass=keepassxc
StartupNotify=true
Terminal=false
Type=Application
Version=1.0
Categories=Utility;Security;Qt;
MimeType=application/x-keepass2;
X-GNOME-Autostart-enabled=true
```

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
