### PR TITLE
Remove "Select hardware key..." and select first Yubikey by default

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -410,8 +410,6 @@ void DatabaseOpenWidget::hardwareKeyResponse(bool found)
         m_ui->challengeResponseCombo->addItem(tr("No hardware keys detected"));
         m_ui->challengeResponseCombo->setEnabled(false);
         return;
-    } else {
-        m_ui->challengeResponseCombo->addItem(tr("Select hardware key…"));
     }
 
     YubiKeySlot lastUsedSlot;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

When at least one Yubikey is detected, the first should be selected by default, instead of the dummy "Select hardware key..." drop-down.

This change removes the unnecessary step of changing the Hardware Key selection from "Select hardware key..." to your detected Yubikey. For most users, only one key is used, so the correct key will be selected without further intervention.

If multiple keys are detected, the last used key will still be selected instead, as the lastUsedSlot logic remains unchanged. This will override the default selectedIndex = 0.


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![keepass-yubkey](https://user-images.githubusercontent.com/202094/104299204-d5a6df00-54bc-11eb-9cad-58504ed7bd3b.png)



## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

I am unable to test this with multiple Yubikeys because I current only have one, and cannot create a unit test for this due to the required hardware.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
