### PR TITLE
Fix Argon2id UUID mixup

### DIFF
--- a/src/crypto/kdf/Argon2Kdf.cpp
+++ b/src/crypto/kdf/Argon2Kdf.cpp
@@ -30,8 +30,7 @@
  * or associated data. KeePass uses the latest version of Argon2, v1.3.
  */
 Argon2Kdf::Argon2Kdf(Type type)
-    : Kdf::Kdf(KeePass2::KDF_ARGON2D)
-    , m_type(type)
+    : Kdf::Kdf(type == Type::Argon2d ? KeePass2::KDF_ARGON2D : KeePass2::KDF_ARGON2ID)
     , m_version(0x13)
     , m_memory(1 << 16)
     , m_parallelism(static_cast<quint32>(QThread::idealThreadCount()))
@@ -57,12 +56,7 @@ bool Argon2Kdf::setVersion(quint32 version)
 
 Argon2Kdf::Type Argon2Kdf::type() const
 {
-    return m_type;
-}
-
-void Argon2Kdf::setType(Type type)
-{
-    m_type = type;
+    return uuid() == KeePass2::KDF_ARGON2D ? Type::Argon2d : Type::Argon2id;
 }
 
 quint64 Argon2Kdf::memory() const
@@ -144,11 +138,7 @@ bool Argon2Kdf::processParameters(const QVariantMap& p)
 QVariantMap Argon2Kdf::writeParameters()
 {
     QVariantMap p;
-    if (type() == Type::Argon2d) {
-        p.insert(KeePass2::KDFPARAM_UUID, KeePass2::KDF_ARGON2D.toRfc4122());
-    } else {
-        p.insert(KeePass2::KDFPARAM_UUID, KeePass2::KDF_ARGON2ID.toRfc4122());
-    }
+    p.insert(KeePass2::KDFPARAM_UUID, uuid().toRfc4122());
     p.insert(KeePass2::KDFPARAM_ARGON2_VERSION, version());
     p.insert(KeePass2::KDFPARAM_ARGON2_PARALLELISM, parallelism());
     p.insert(KeePass2::KDFPARAM_ARGON2_MEMORY, memory() * 1024);

--- a/src/crypto/kdf/Argon2Kdf.h
+++ b/src/crypto/kdf/Argon2Kdf.h
@@ -39,7 +39,6 @@ public:
     quint32 version() const;
     bool setVersion(quint32 version);
     Type type() const;
-    void setType(Type type);
     quint64 memory() const;
     bool setMemory(quint64 kibibytes);
     quint32 parallelism() const;
@@ -49,7 +48,6 @@ public:
 protected:
     int benchmarkImpl(int msec) const override;
 
-    Type m_type;
     quint32 m_version;
     quint64 m_memory;
     quint32 m_parallelism;


### PR DESCRIPTION
Argon2Kdf was using a wrong UUID internally for the id variant, resulting in the incorrect dropdown entry being selected in the database encryption settings.

Reading and writing databases was not affected.

Fixes #5922

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )



## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)