### PR TITLE
Fix unloading ssh keys on database lock

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -601,6 +601,9 @@ MainWindow::MainWindow()
 
 MainWindow::~MainWindow()
 {
+#ifdef WITH_XC_SSHAGENT
+    sshAgent()->removeAllIdentities();
+#endif
 }
 
 QList<DatabaseWidget*> MainWindow::getOpenDatabases()

--- a/src/sshagent/SSHAgent.h
+++ b/src/sshagent/SSHAgent.h
@@ -24,7 +24,6 @@
 #include <QtCore>
 
 #include "crypto/ssh/OpenSSHKey.h"
-#include "gui/DatabaseWidget.h"
 #include "sshagent/KeeAgentSettings.h"
 
 class SSHAgent : public QObject
@@ -32,7 +31,7 @@ class SSHAgent : public QObject
     Q_OBJECT
 
 public:
-    ~SSHAgent() override;
+    ~SSHAgent() override = default;
     static SSHAgent* instance();
 
     bool isEnabled() const;
@@ -59,8 +58,8 @@ signals:
     void enabledChanged(bool enabled);
 
 public slots:
-    void databaseLocked();
-    void databaseUnlocked();
+    void databaseLocked(QSharedPointer<Database> db);
+    void databaseUnlocked(QSharedPointer<Database> db);
 
 private:
     const quint8 SSH_AGENT_FAILURE = 5;


### PR DESCRIPTION
* Fix #5928 - SSH Agent keys are properly removed on database lock. Also fixes crash when keys are still loaded on application close.
* Remove dependency on DatabaseWidget within SSH Agent.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Winodws with Pageant.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)