### PR TITLE
Update timestamp server for appsign

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -44,6 +44,7 @@ ORIG_BRANCH=""
 ORIG_CWD="$(pwd)"
 MACOSX_DEPLOYMENT_TARGET=10.12
 GREP="grep"
+TIMESTAMP_SERVER="http://timestamp.sectigo.com"
 
 # -----------------------------------------------------------------------
 #                          helper functions
@@ -113,6 +114,7 @@ Options:
       --appimage          Build a Linux AppImage after compilation.
                           If this option is set, --install-prefix has no effect
       --appsign           Perform platform specific App Signing before packaging
+      --timestamp         Explicitly set the timestamp server to use for appsign (default: '${TIMESTAMP_SERVER}')
   -k, --key               Specify the App Signing Key/Identity
   -c, --cmake-options     Additional CMake options for compiling the sources
       --compiler          Compiler to use (default: '${COMPILER}')
@@ -144,6 +146,7 @@ Options:
   -f, --files        Files to sign (required)
   -k, --key, -i, --identity
                      Signing Key or Apple Developer ID (required)
+      --timestamp    Explicitly set the timestamp server to use for appsign (default: '${TIMESTAMP_SERVER}')
   -u, --username     Apple username for notarization (required on macOS)
   -c, --keychain     Apple keychain entry name storing the notarization
                      app password (default: 'AC_PASSWORD')
@@ -484,6 +487,10 @@ merge() {
                 GPG_GIT_KEY="$2"
                 shift ;;
 
+            --timestamp)
+                TIMESTAMP_SERVER="$2"
+                shift ;;
+
             -r|--release-branch)
                 SOURCE_BRANCH="$2"
                 shift ;;
@@ -799,6 +806,10 @@ build() {
 
             --appsign)
                 build_appsign=true ;;
+
+            --timestamp)
+                TIMESTAMP_SERVER="$2"
+                shift ;;
 
             -k|--key)
                 build_key="$2"
@@ -1301,7 +1312,7 @@ appsign() {
                 # osslsigncode does not succeed at signing MSI files at this time...
                 logInfo "Signing file '${f}' using Microsoft signtool..."
                 signtool sign -f "${key}" -p "${password}" -d "KeePassXC" -td sha256 \
-                    -fd sha256 -tr "http://timestamp.comodoca.com/authenticode" "${f}"
+                    -fd sha256 -tr "${TIMESTAMP_SERVER}" "${f}"
 
                 if [ 0 -ne $? ]; then
                     exitError "Signing failed!"

--- a/src/core/PasswordHealth.cpp
+++ b/src/core/PasswordHealth.cpp
@@ -173,12 +173,14 @@ QSharedPointer<PasswordHealth> HealthChecker::evaluate(const Entry* entry) const
             if (health->score() > 60) {
                 health->setScore(60);
             }
+            // clang-format off
             health->adjustScore((30 - days) * -2);
             health->addScoreReason(days <= 2 ? QApplication::tr("Password is about to expire")
                                              : days <= 10 ? QApplication::tr("Password expires in %1 days").arg(days)
                                                           : QApplication::tr("Password will expire soon"));
             health->addScoreDetails(QApplication::tr("Password expires on %1")
                                         .arg(entry->timeInfo().expiryTime().toString(Qt::DefaultLocaleShortDate)));
+            //clang-format on
         }
     }
 

--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -2695,8 +2695,10 @@ void BaseStyle::drawControl(ControlElement element,
                 if (isChecked) {
                     painter->setRenderHint(QPainter::Antialiasing);
                     painter->setPen(Qt::NoPen);
+                    // clang-format off
                     QPalette::ColorRole textRole =
                         !isEnabled ? QPalette::Text : isSelected ? QPalette::HighlightedText : QPalette::ButtonText;
+                    // clang-format on
                     painter->setBrush(option->palette.brush(option->palette.currentColorGroup(), textRole));
                     qreal rx, ry, rw, rh;
                     QRectF(checkRect).getRect(&rx, &ry, &rw, &rh);


### PR DESCRIPTION
Also add ability to set the timestamp server by command line switch.

Second commit: backport ignoring format changes when using newer versions of clang-format

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
