### PR TITLE
Set maximum password length to 999 characters when using spinbox text entry

### DIFF
--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -259,6 +259,9 @@ QProgressBar::chunk {
            <property name="minimum">
             <number>1</number>
            </property>
+           <property name="maximum">
+            <number>999</number>
+           </property>
            <property name="value">
             <number>20</number>
            </property>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Reverts changes from #5748 and increases the limit from 128 characters to 999 characters when setting the length using the spinbox text entry.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
