### PR TITLE
Issue 2110: Purging unused custom icons and bulk deletion

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,6 +158,7 @@ set(keepassx_SOURCES
         gui/dbsettings/DatabaseSettingsWidget.cpp
         gui/dbsettings/DatabaseSettingsDialog.cpp
         gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
+        gui/dbsettings/DatabaseSettingsWidgetIcons.cpp
         gui/dbsettings/DatabaseSettingsWidgetMetaDataSimple.cpp
         gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
         gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -90,8 +90,6 @@ private slots:
     void iconReceived(const QString& url, const QImage& icon);
     void addCustomIconFromFile();
     bool addCustomIcon(const QImage& icon);
-    void removeCustomIcon();
-    void purgeUnusedCustomIcons();
     void updateWidgetsDefaultIcons(bool checked);
     void updateWidgetsCustomIcons(bool checked);
     void updateRadioButtonDefaultIcons();

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -91,6 +91,7 @@ private slots:
     void addCustomIconFromFile();
     bool addCustomIcon(const QImage& icon);
     void removeCustomIcon();
+    void purgeUnusedCustomIcons();
     void updateWidgetsDefaultIcons(bool checked);
     void updateWidgetsCustomIcons(bool checked);
     void updateRadioButtonDefaultIcons();

--- a/src/gui/EditWidgetIcons.ui
+++ b/src/gui/EditWidgetIcons.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>437</width>
+    <width>631</width>
     <height>316</height>
    </rect>
   </property>
@@ -129,6 +129,19 @@
        </property>
        <property name="text">
         <string>Download favicon</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="purgeButton">
+       <property name="toolTip">
+        <string>Delete all custom icons not in use by any entry or group</string>
+       </property>
+       <property name="accessibleName">
+        <string>Delete all custom icons not in use by any entry or group</string>
+       </property>
+       <property name="text">
+        <string>Purge unused icons</string>
        </property>
       </widget>
      </item>

--- a/src/gui/EditWidgetIcons.ui
+++ b/src/gui/EditWidgetIcons.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>631</width>
+    <width>437</width>
     <height>316</height>
    </rect>
   </property>
@@ -113,13 +113,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="deleteButton">
-       <property name="text">
-        <string>Delete custom icon</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="faviconButton">
        <property name="toolTip">
         <string>Download favicon for URL</string>
@@ -129,19 +122,6 @@
        </property>
        <property name="text">
         <string>Download favicon</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="purgeButton">
-       <property name="toolTip">
-        <string>Delete all custom icons not in use by any entry or group</string>
-       </property>
-       <property name="accessibleName">
-        <string>Delete all custom icons not in use by any entry or group</string>
-       </property>
-       <property name="text">
-        <string>Purge unused icons</string>
        </property>
       </widget>
      </item>

--- a/src/gui/dbsettings/DatabaseSettingsDialog.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.cpp
@@ -25,6 +25,7 @@
 #ifdef WITH_XC_BROWSER
 #include "DatabaseSettingsWidgetBrowser.h"
 #endif
+#include "DatabaseSettingsWidgetIcons.h"
 #if defined(WITH_XC_KEESHARE)
 #include "keeshare/DatabaseSettingsPageKeeShare.h"
 #endif
@@ -72,6 +73,7 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
 #ifdef WITH_XC_BROWSER
     , m_browserWidget(new DatabaseSettingsWidgetBrowser(this))
 #endif
+    , m_iconsWidget(new DatabaseSettingsWidgetIcons(this))
 {
     m_ui->setupUi(this);
 
@@ -115,6 +117,9 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
     m_ui->stackedWidget->addWidget(m_browserWidget);
 #endif
 
+    m_ui->categoryList->addCategory(tr("Custom Icons"), icons()->icon("preferences-desktop-icons"));
+    m_ui->stackedWidget->addWidget(m_iconsWidget);
+
     pageChanged();
 }
 
@@ -131,6 +136,7 @@ void DatabaseSettingsDialog::load(const QSharedPointer<Database>& db)
 #ifdef WITH_XC_BROWSER
     m_browserWidget->load(db);
 #endif
+    m_iconsWidget->load(db);
     for (const ExtraPage& page : asConst(m_extraPages)) {
         page.loadSettings(db);
     }

--- a/src/gui/dbsettings/DatabaseSettingsDialog.h
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.h
@@ -32,6 +32,7 @@ class DatabaseSettingsWidgetDatabaseKey;
 #ifdef WITH_XC_BROWSER
 class DatabaseSettingsWidgetBrowser;
 #endif
+class DatabaseSettingsWidgetIcons;
 class QTabWidget;
 
 namespace Ui
@@ -90,6 +91,7 @@ private:
 #ifdef WITH_XC_BROWSER
     QPointer<DatabaseSettingsWidgetBrowser> m_browserWidget;
 #endif
+    QPointer<DatabaseSettingsWidgetIcons> m_iconsWidget;
 
     class ExtraPage;
     QList<ExtraPage> m_extraPages;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.cpp
@@ -25,12 +25,16 @@
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "gui/MessageBox.h"
+#include "gui/IconModels.h"
 
 DatabaseSettingsWidgetIcons::DatabaseSettingsWidgetIcons(QWidget* parent)
     : DatabaseSettingsWidget(parent)
     , m_ui(new Ui::DatabaseSettingsWidgetIcons())
+    , m_customIconModel(new CustomIconModel(this))
 {
     m_ui->setupUi(this);
+
+    m_ui->customIconsView->setModel(m_customIconModel);
 
     connect(m_ui->deleteButton, SIGNAL(clicked()), SLOT(removeCustomIcon()));
     connect(m_ui->purgeButton, SIGNAL(clicked()), SLOT(purgeUnusedCustomIcons()));
@@ -42,6 +46,10 @@ DatabaseSettingsWidgetIcons::~DatabaseSettingsWidgetIcons()
 
 void DatabaseSettingsWidgetIcons::initialize()
 {
+    auto database = DatabaseSettingsWidget::getDatabase();
+    if(!database) { return; }
+    m_customIconModel->setIcons(database->metadata()->customIconsPixmaps(IconSize::Default),
+                                database->metadata()->customIconsOrder());
 }
 
 void DatabaseSettingsWidgetIcons::removeCustomIcon()
@@ -50,4 +58,62 @@ void DatabaseSettingsWidgetIcons::removeCustomIcon()
 
 void DatabaseSettingsWidgetIcons::purgeUnusedCustomIcons()
 {
+    auto database = DatabaseSettingsWidget::getDatabase();
+    if(!database) { return; }
+
+    QList<Entry*> historyEntries;
+    QSet<QUuid> historicIcons;
+    QSet<QUuid> iconsInUse;
+
+    const QList<Entry*> allEntries = database->rootGroup()->entriesRecursive(true);
+    for (Entry* entry : allEntries) {
+        if (!entry->group()) {
+            // Icons exclusively in use by historic entries (no
+            // group assigned) are also purged from the database
+            historyEntries << entry;
+            historicIcons << entry->iconUuid();
+        } else {
+            iconsInUse << entry->iconUuid();
+        }
+    }
+
+    const QList<Group*> allGroups = database->rootGroup()->groupsRecursive(true);
+    for (Group* group : allGroups) {
+        iconsInUse.insert(group->iconUuid());
+    }
+
+    int purgeCounter = 0;
+    QList<QUuid> customIcons = database->metadata()->customIconsOrder();
+    for (QUuid iconUuid : customIcons) {
+        if (iconsInUse.contains(iconUuid)) { continue; }
+
+        if (historicIcons.contains(iconUuid)) {
+            // Remove the icon from history entries using this icon
+            for (Entry* historicEntry : asConst(historyEntries)) {
+                if (historicEntry->iconUuid() != iconUuid) { continue; }
+                historicEntry->setUpdateTimeinfo(false);
+                historicEntry->setIcon(0);
+                historicEntry->setUpdateTimeinfo(true);
+            }
+        }
+
+        ++purgeCounter;
+        database->metadata()->removeCustomIcon(iconUuid);
+    }
+
+    if (0 == purgeCounter) {
+        MessageBox::information(this,
+                tr("Custom Icons Are In Use"),
+                tr("All custom icons are in use by at least one entry or group."),
+                MessageBox::Ok);
+        return;
+    }
+
+    // update the list of icons
+    initialize();
+
+    MessageBox::information(this,
+            tr("Purged Unused Icons"),
+            tr("Purged %n icon(s) from the database.", "", purgeCounter),
+            MessageBox::Ok);
 }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.cpp
@@ -48,6 +48,7 @@ void DatabaseSettingsWidgetIcons::populateIcons(QSharedPointer<Database> db)
 {
     m_customIconModel->setIcons(db->metadata()->customIconsPixmaps(IconSize::Default),
                                 db->metadata()->customIconsOrder());
+    m_ui->customIconsView->setCurrentIndex(m_customIconModel->index(0, 0));
 }
 
 void DatabaseSettingsWidgetIcons::initialize()

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.cpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DatabaseSettingsWidgetIcons.h"
+#include "ui_DatabaseSettingsWidgetIcons.h"
+
+#include <QProgressDialog>
+
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "core/Metadata.h"
+#include "gui/MessageBox.h"
+
+DatabaseSettingsWidgetIcons::DatabaseSettingsWidgetIcons(QWidget* parent)
+    : DatabaseSettingsWidget(parent)
+    , m_ui(new Ui::DatabaseSettingsWidgetIcons())
+{
+    m_ui->setupUi(this);
+
+    connect(m_ui->deleteButton, SIGNAL(clicked()), SLOT(removeCustomIcon()));
+    connect(m_ui->purgeButton, SIGNAL(clicked()), SLOT(purgeUnusedCustomIcons()));
+}
+
+DatabaseSettingsWidgetIcons::~DatabaseSettingsWidgetIcons()
+{
+}
+
+void DatabaseSettingsWidgetIcons::initialize()
+{
+}
+
+void DatabaseSettingsWidgetIcons::removeCustomIcon()
+{
+}
+
+void DatabaseSettingsWidgetIcons::purgeUnusedCustomIcons()
+{
+}

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.h
@@ -22,6 +22,7 @@
 
 #include <QScopedPointer>
 
+class QItemSelection;
 class CustomIconModel;
 class Database;
 namespace Ui
@@ -46,17 +47,20 @@ public slots:
     inline bool save() override { return true; };
 
 private slots:
+    void selectionChanged();
     void removeCustomIcon();
     void purgeUnusedCustomIcons();
 
 private:
     void populateIcons(QSharedPointer<Database> db);
+    void removeSingleCustomIcon(QSharedPointer<Database> database, QModelIndex index);
 
 protected:
     const QScopedPointer<Ui::DatabaseSettingsWidgetIcons> m_ui;
 
 private:
     CustomIconModel* const m_customIconModel;
+    uint64_t m_deletionDecision;
 };
 
 #endif // KEEPASSXC_DATABASESETTINGSWIDGETICONS_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.h
@@ -49,6 +49,9 @@ private slots:
     void removeCustomIcon();
     void purgeUnusedCustomIcons();
 
+private:
+    void populateIcons(QSharedPointer<Database> db);
+
 protected:
     const QScopedPointer<Ui::DatabaseSettingsWidgetIcons> m_ui;
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.h
@@ -22,6 +22,7 @@
 
 #include <QScopedPointer>
 
+class CustomIconModel;
 class Database;
 namespace Ui
 {
@@ -52,6 +53,7 @@ protected:
     const QScopedPointer<Ui::DatabaseSettingsWidgetIcons> m_ui;
 
 private:
+    CustomIconModel* const m_customIconModel;
 };
 
 #endif // KEEPASSXC_DATABASESETTINGSWIDGETICONS_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.h
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_DATABASESETTINGSWIDGETICONS_H
+#define KEEPASSXC_DATABASESETTINGSWIDGETICONS_H
+
+#include "DatabaseSettingsWidget.h"
+
+#include <QScopedPointer>
+
+class Database;
+namespace Ui
+{
+    class DatabaseSettingsWidgetIcons;
+}
+
+class DatabaseSettingsWidgetIcons : public DatabaseSettingsWidget
+{
+    Q_OBJECT
+
+public:
+    explicit DatabaseSettingsWidgetIcons(QWidget* parent = nullptr);
+    Q_DISABLE_COPY(DatabaseSettingsWidgetIcons);
+    ~DatabaseSettingsWidgetIcons() override;
+
+    inline bool hasAdvancedMode() const override { return false; }
+
+public slots:
+    void initialize() override;
+    void uninitialize() override { };
+    inline bool save() override { return true; };
+
+private slots:
+    void removeCustomIcon();
+    void purgeUnusedCustomIcons();
+
+protected:
+    const QScopedPointer<Ui::DatabaseSettingsWidgetIcons> m_ui;
+
+private:
+};
+
+#endif // KEEPASSXC_DATABASESETTINGSWIDGETICONS_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.ui
@@ -46,6 +46,9 @@
         <property name="editTriggers">
          <set>QAbstractItemView::NoEditTriggers</set>
         </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::MultiSelection</enum>
+        </property>
         <property name="movement">
          <enum>QListView::Static</enum>
         </property>
@@ -71,7 +74,7 @@
         <item>
          <widget class="QPushButton" name="deleteButton">
           <property name="text">
-           <string>Delete selected icon</string>
+           <string>Delete selected icon(s)</string>
           </property>
          </widget>
         </item>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetIcons.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetIcons.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DatabaseSettingsWidgetIcons</class>
+ <widget class="QWidget" name="DatabaseSettingsWidgetIcons">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>669</width>
+    <height>395</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>450</width>
+    <height>0</height>
+   </size>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Manage Custom Icons</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QListView" name="customIconsView">
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="movement">
+         <enum>QListView::Static</enum>
+        </property>
+        <property name="flow">
+         <enum>QListView::LeftToRight</enum>
+        </property>
+        <property name="isWrapping" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="resizeMode">
+         <enum>QListView::Adjust</enum>
+        </property>
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="viewMode">
+         <enum>QListView::ListMode</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="customIconButtonsHorizontalLayout">
+        <item>
+         <widget class="QPushButton" name="deleteButton">
+          <property name="text">
+           <string>Delete selected icon</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="purgeButton">
+          <property name="toolTip">
+           <string>Delete all custom icons not in use by any entry or group</string>
+          </property>
+          <property name="accessibleName">
+           <string>Delete all custom icons not in use by any entry or group</string>
+          </property>
+          <property name="text">
+           <string>Purge unused icons</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This change implements purging custom icons that are not in use by any entry or group. These orphaned icons are easily created when downloading new favicons, or switching to new custom icons. Which icons are obsolete is hard to identify by hand, and clicking every icon and trying to delete it waiting for a confirmation not to delete if the icon is in use is very tedious.

It is now also possible to select multiple icons and bulk delete them. The user is prompted (only once) to confirm deletion of icons that are still in use by any group or entry.

Icons that are exclusively used by history entries are purged and deleted without prompting. This logic was already in place for single deletion of icons and was adopted for the purging feature.

A new database settings dialog was created for managing the icons (purging and deleting) for multiple reasons: Given the use case that a user wants to delete/purge icons, it is not intuitive to edit an arbitrary entry/group, switch to the Icon pane, and delete/purge icons from there. There are also special cases for the purging scenario in which it becomes non-trivial to decide if the icon of the currently edited entry/group is obsolete or not depending on the current list view selection (see commit messages). Moreover, the feature to select multiple icons for bulk deletion makes no sense in context of the entry/group editing dialog (what should happen when multiple icons are selected (by accident) while editing an entry).

Entry/Group edit UI: Select an icon, add acustom icon, or download a favicon.
Database settings UI: Purge or (bulk) delete icons.

Fixes #2110.

## Screenshots
![icons_no_selection](https://user-images.githubusercontent.com/3578416/105101227-d20feb00-5aae-11eb-9fb6-8261429f8930.png)
![icons_selected](https://user-images.githubusercontent.com/3578416/105102705-7c880e00-5aaf-11eb-965b-6bff0b1bdb35.png)


## Testing strategy
Manually using a dummy database with three orphaned icons, one of which is a history-entry-only icon. See 
[icontests.zip](https://github.com/keepassxreboot/keepassxc/files/5839008/icontests.zip) (password: "icontests").


## Type of change
- ✅ New feature (change that adds functionality)