### PR TITLE
Fix menubar click-to-move window with Qt 5.15

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1784,9 +1784,11 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
 
     if (event->type() == QEvent::MouseButtonPress) {
         if (watched == mainWindow->m_ui->menubar) {
-            mainWindow->windowHandle()->startSystemMove();
-            // Continue processing events, so menus keep working.
-            return false;
+            auto* m = static_cast<QMouseEvent*>(event);
+            if (!mainWindow->m_ui->menubar->actionAt(m->pos())) {
+                mainWindow->windowHandle()->startSystemMove();
+                return false;
+            }
         } else if (watched == mainWindow->m_ui->toolBar) {
             if (!mainWindow->m_ui->toolBar->isMovable() || mainWindow->m_ui->toolBar->cursor() != Qt::SizeAllCursor) {
                 mainWindow->windowHandle()->startSystemMove();


### PR DESCRIPTION
Change logic in click handler in eventFilter so that startSystemMove() is only called when there is no menubar action under the mouse cursor (i.e., when a blank area of the menubar is clicked).

Fixes #5925

## Testing strategy
Tested on Arch Linux with Qt 5.15.2

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
