### PR TITLE
Hide auto-type items from GUI when WITH_XC_AUTOTYPE=OFF configured

### DIFF
--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -142,6 +142,10 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
     m_generalUi->faviconTimeoutSpinBox->setVisible(false);
 #endif
 
+#ifndef WITH_XC_AUTOTYPE
+    m_secUi->relockDatabaseAutoTypeCheckBox->setVisible(false);
+#endif
+
 #ifndef WITH_XC_TOUCHID
     bool hideTouchID = true;
 #else

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -92,6 +92,9 @@ EntryPreviewWidget::EntryPreviewWidget(QWidget* parent)
 #if !defined(WITH_XC_KEESHARE)
     removeTab(m_ui->groupTabWidget, m_ui->groupShareTab);
 #endif
+#if !defined(WITH_XC_AUTOTYPE)
+    removeTab(m_ui->entryTabWidget, m_ui->entryAutotypeTab);
+#endif
 }
 
 EntryPreviewWidget::~EntryPreviewWidget()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -532,6 +532,9 @@ MainWindow::MainWindow()
     m_ui->actionCheckForUpdates->setVisible(false);
 #endif
 
+#ifndef WITH_XC_AUTOTYPE
+    m_ui->menuEntryAutoTypeWithSequence->menuAction()->setVisible(false);
+#endif
 #ifndef WITH_XC_NETWORKING
     m_ui->actionGroupDownloadFavicons->setVisible(false);
     m_ui->actionEntryDownloadIcon->setVisible(false);


### PR DESCRIPTION
When building without auto-type support, there should be no auto-type related GUI item visible.

This change, if auto-type support is disabled,
- hides the (dysfunctional) "Perform Auto-Type Sequence" action menu from entry context menus.
- removes the auto-type tab from the entry preview widget.
- hides the "re-lock database after performing auto-type" checkbox from the application settings widget.

## Screenshots
![context](https://user-images.githubusercontent.com/3578416/105414793-42964380-5c38-11eb-90fe-4ee9625533fd.jpg)
![settings](https://user-images.githubusercontent.com/3578416/105414798-43c77080-5c38-11eb-9e2e-a9fed5dcb8a7.jpg)

## Testing strategy
Manual.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)