### PR TITLE
Typo, retVal == 0 means "ok" in X11

### DIFF
--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -155,7 +155,7 @@ QString AutoTypePlatformX11::windowTitle(Window window, bool useBlacklist)
     } else {
         XTextProperty textProp;
         retVal = XGetTextProperty(m_dpy, window, &textProp, m_atomWmName);
-        if ((retVal != 0) && textProp.value) {
+        if ((retVal == 0) && textProp.value) {
             char** textList = nullptr;
             int count;
 


### PR DESCRIPTION
While reading the code I saw that there's a wrong condition for checking the result code.
For X11, result codes "==0" usually means "OK" and "!=0" mean "error".

## Testing

The code is not tested and should be reviewed by someone who knows what XGetTextProperty() does.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
