### PR TITLE
Fix adaptive icon painting

### DIFF
--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -117,16 +117,8 @@ AdaptiveIconEngine::AdaptiveIconEngine(QIcon baseIcon)
 
 void AdaptiveIconEngine::paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    double dpr = !kpxcApp->testAttribute(Qt::AA_UseHighDpiPixmaps) ? 1.0 : painter->device()->devicePixelRatioF();
-#else
-    double dpr = !kpxcApp->testAttribute(Qt::AA_UseHighDpiPixmaps) ? 1.0 : painter->device()->devicePixelRatio();
-#endif
-    QSize pixmapSize = rect.size() * dpr;
-
     painter->save();
-    painter->drawPixmap(rect, m_baseIcon.pixmap(pixmapSize, mode, state));
-
+    m_baseIcon.paint(painter, rect, Qt::AlignCenter, mode, state);
     if (getMainWindow()) {
         QPalette palette = getMainWindow()->palette();
         painter->setCompositionMode(QPainter::CompositionMode_SourceAtop);


### PR DESCRIPTION
This PR fixes adaptive icon being drawn incorrectly on Windows. The change was introduced in PR #5851.
See [5851](https://github.com/keepassxreboot/keepassxc/pull/5851#discussion_r562263044) for more info.

*Note: Fix was tested only on Windows, if it causes problems on other platform I'll scope it to Windows platform only.*

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)