### PR TITLE
Remove loaded SSH keys on application close

### DIFF
--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -402,13 +402,11 @@ void SSHAgent::removeAllIdentities()
 {
     auto it = m_addedKeys.begin();
     while (it != m_addedKeys.end()) {
-        // Remove key if requested to remove on lock
-        if (it.value().second) {
-            OpenSSHKey key = it.key();
-            removeIdentity(key);
-        }
-        it = m_addedKeys.erase(it);
+        auto key = it.key();
+        removeIdentity(key);
+        ++it;
     }
+    m_addedKeys.clear();
 }
 
 /**
@@ -439,11 +437,13 @@ void SSHAgent::databaseLocked(QSharedPointer<Database> db)
         }
         OpenSSHKey key = it.key();
         if (it.value().second) {
-            if (!removeIdentity(key)) {
+            if (removeIdentity(key)) {
+                m_addedKeys.erase(it);
+            } else {
                 emit error(m_error);
             }
         }
-        it = m_addedKeys.erase(it);
+        ++it;
     }
 }
 


### PR DESCRIPTION
* Also fixes bug where loaded keys are forgotten even though they are not removed on database lock

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
