### PR TITLE
Prevent screen capture on Windows

### DIFF
--- a/src/gui/osutils/OSUtilsBase.cpp
+++ b/src/gui/osutils/OSUtilsBase.cpp
@@ -25,3 +25,9 @@ OSUtilsBase::OSUtilsBase(QObject* parent)
 OSUtilsBase::~OSUtilsBase()
 {
 }
+
+bool OSUtilsBase::setPreventScreenCapture(QWindow*, bool) const
+{
+    // Do nothing by default
+    return false;
+}

--- a/src/gui/osutils/OSUtilsBase.h
+++ b/src/gui/osutils/OSUtilsBase.h
@@ -21,6 +21,8 @@
 #include <QObject>
 #include <QPointer>
 
+class QWindow;
+
 /**
  * Abstract base class for generic OS-specific functionality
  * which can be reasonably expected to be available on all platforms.
@@ -62,6 +64,9 @@ public:
                                         Qt::KeyboardModifiers modifiers,
                                         QString* error = nullptr) = 0;
     virtual bool unregisterGlobalShortcut(const QString& name) = 0;
+
+    virtual bool canPreventScreenCapture() const = 0;
+    virtual bool setPreventScreenCapture(QWindow* window, bool allow) const;
 
 signals:
     void globalShortcutTriggered(const QString& name);

--- a/src/gui/osutils/macutils/AppKit.h
+++ b/src/gui/osutils/macutils/AppKit.h
@@ -23,6 +23,8 @@
 #include <QColor>
 #include <unistd.h>
 
+class QWindow;
+
 class AppKit : public QObject
 {
     Q_OBJECT
@@ -42,6 +44,7 @@ public:
     bool enableAccessibility();
     bool enableScreenRecording();
     void toggleForegroundApp(bool foreground);
+    void setWindowSecurity(QWindow* window, bool state);
 
 signals:
     void lockDatabases();

--- a/src/gui/osutils/macutils/AppKitImpl.h
+++ b/src/gui/osutils/macutils/AppKitImpl.h
@@ -20,6 +20,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AppKit/NSRunningApplication.h>
+#import <AppKit/NSWindow.h>
 
 @interface AppKitImpl : NSObject
 {
@@ -40,5 +41,6 @@
 - (bool) enableAccessibility;
 - (bool) enableScreenRecording;
 - (void) toggleForegroundApp:(bool) foreground;
+- (void) setWindowSecurity:(NSWindow*) window state:(bool) state;
 
 @end

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -18,11 +18,14 @@
 
 #import "AppKitImpl.h"
 #include "AppKit.h"
+#include <QWindow>
 
 #import <AppKit/NSStatusBar.h>
 #import <AppKit/NSStatusItem.h>
 #import <AppKit/NSStatusBarButton.h>
 #import <AppKit/NSWorkspace.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
 #import <CoreVideo/CVPixelBuffer.h>
 
 @implementation AppKitImpl
@@ -211,6 +214,11 @@
     }
 }
 
+- (void) setWindowSecurity:(NSWindow*) window state:(bool) state
+{
+    [window setSharingType: state ? NSWindowSharingNone : NSWindowSharingReadOnly];
+}
+
 @end
 
 //
@@ -284,4 +292,10 @@ bool AppKit::enableScreenRecording()
 void AppKit::toggleForegroundApp(bool foreground)
 {
     [static_cast<id>(self) toggleForegroundApp:foreground];
+}
+
+void AppKit::setWindowSecurity(QWindow* window, bool state)
+{
+    auto view = reinterpret_cast<NSView*>(window->winId());
+    [static_cast<id>(self) setWindowSecurity:view.window state:state];
 }

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -23,6 +23,7 @@
 #include <QSettings>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QWindow>
 
 #include <ApplicationServices/ApplicationServices.h>
 #include <CoreGraphics/CGEventSource.h>
@@ -40,9 +41,7 @@ MacUtils::MacUtils(QObject* parent)
     connect(m_appkit.data(), &AppKit::interfaceThemeChanged, this, [this]() {
         // Emit with delay, since isStatusBarDark() still returns the old value
         // if we call it too fast after a theme change.
-        QTimer::singleShot(100, [this]() {
-            emit statusbarThemeChanged();
-        });
+        QTimer::singleShot(100, [this]() { emit statusbarThemeChanged(); });
     });
 }
 
@@ -150,6 +149,21 @@ bool MacUtils::isCapslockEnabled()
 void MacUtils::toggleForegroundApp(bool foreground)
 {
     m_appkit->toggleForegroundApp(foreground);
+}
+
+bool MacUtils::canPreventScreenCapture() const
+{
+    return true;
+}
+
+bool MacUtils::setPreventScreenCapture(QWindow* window, bool prevent) const
+{
+    if (!window) {
+        return false;
+    }
+
+    m_appkit->setWindowSecurity(window, prevent);
+    return true;
 }
 
 void MacUtils::registerNativeEventFilter()

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -62,6 +62,9 @@ public:
     uint16 qtToNativeKeyCode(Qt::Key key);
     CGEventFlags qtToNativeModifiers(Qt::KeyboardModifiers modifiers, bool native);
 
+    bool canPreventScreenCapture() const override;
+    bool setPreventScreenCapture(QWindow* window, bool prevent) const override;
+
 signals:
     void lockDatabases();
 

--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -43,6 +43,11 @@ public:
                                 QString* error = nullptr) override;
     bool unregisterGlobalShortcut(const QString& name) override;
 
+    bool canPreventScreenCapture() const override
+    {
+        return false;
+    }
+
 signals:
     void keymapChanged();
 

--- a/src/gui/osutils/winutils/WinUtils.cpp
+++ b/src/gui/osutils/winutils/WinUtils.cpp
@@ -16,12 +16,14 @@
  */
 
 #include "WinUtils.h"
-#include <QAbstractNativeEventFilter>
+
 #include <QApplication>
 #include <QDir>
 #include <QSettings>
+#include <QWindow>
 
-#include <windows.h>
+#include <Windows.h>
+#undef MessageBox
 
 QPointer<WinUtils> WinUtils::m_instance = nullptr;
 
@@ -47,6 +49,20 @@ WinUtils* WinUtils::instance()
 WinUtils::WinUtils(QObject* parent)
     : OSUtilsBase(parent)
 {
+}
+
+bool WinUtils::canPreventScreenCapture() const
+{
+    return true;
+}
+
+bool WinUtils::setPreventScreenCapture(QWindow* window, bool prevent) const
+{
+    if (window) {
+        HWND handle = reinterpret_cast<HWND>(window->winId());
+        return SetWindowDisplayAffinity(handle, prevent ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE);
+    }
+    return false;
 }
 
 /**

--- a/src/gui/osutils/winutils/WinUtils.h
+++ b/src/gui/osutils/winutils/WinUtils.h
@@ -52,6 +52,9 @@ public:
     DWORD qtToNativeKeyCode(Qt::Key key);
     DWORD qtToNativeModifiers(Qt::KeyboardModifiers modifiers);
 
+    bool canPreventScreenCapture() const override;
+    bool setPreventScreenCapture(QWindow* window, bool prevent) const override;
+
 protected:
     explicit WinUtils(QObject* parent = nullptr);
     ~WinUtils() override = default;


### PR DESCRIPTION
On Windows this PR makes KeePassXC main window and all it's child windows invisible for screen recording and screen shooting.
This is done by capturing native events `WM_NCCREATE` & `WM_ENTERIDLE`, and set `WDA_EXCLUDEFROMCAPTURE` display affinity flag via [SetWindowDisplayAffinity](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity) to the window in action or modal dialog. If for any reason the screen capturing of an app is desired i.e. demonstration, app should be run with `--allow-screencapture` argument. ~~When screen capturing for the app is enabled a persistent warning is displayed to the user, and title bar text of every displayed window is modified to contain text `[Screen Capture Allowed]`. The title bar text is also modified to contain the same text~~ In-app warning is displayed in case of an error occurs during the call to [SetWindowDisplayAffinity](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity) function.

fix #5859

## Screenshots
Demonstration of stealth mode vs running with `--allow-screencapture` arg:
![img](https://user-images.githubusercontent.com/4377556/106371206-efbc3a80-6361-11eb-8b95-1f47e56610c2.png)

## Testing strategy
The implementation was tested using `Snipping Tool` app, making print screen via keyboard shortcut and using [ScreenToGif](https://www.screentogif.com/) screen recording app.

## Type of change
- ✅ New feature (change that adds functionality)
