### PR TITLE
Fix icon alpha blending in QTableView

### DIFF
--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -50,9 +50,9 @@ EntryPreviewWidget::EntryPreviewWidget(QWidget* parent)
     // Entry
     m_ui->entryTotpButton->setIcon(icons()->icon("chronometer"));
     m_ui->entryCloseButton->setIcon(icons()->icon("dialog-close"));
-    m_ui->togglePasswordButton->setIcon(icons()->onOffIcon("password-show"));
-    m_ui->toggleEntryNotesButton->setIcon(icons()->onOffIcon("password-show"));
-    m_ui->toggleGroupNotesButton->setIcon(icons()->onOffIcon("password-show"));
+    m_ui->togglePasswordButton->setIcon(icons()->onOffIcon("password-show", true));
+    m_ui->toggleEntryNotesButton->setIcon(icons()->onOffIcon("password-show", true));
+    m_ui->toggleGroupNotesButton->setIcon(icons()->onOffIcon("password-show", true));
 
     m_ui->entryAttachmentsWidget->setReadOnly(true);
     m_ui->entryAttachmentsWidget->setButtonsVisible(false);
@@ -199,16 +199,19 @@ void EntryPreviewWidget::setPasswordVisible(bool state)
     } else {
         m_ui->entryPasswordLabel->setText(QString("\u25cf").repeated(6));
     }
+    m_ui->togglePasswordButton->setIcon(icons()->onOffIcon("password-show", state));
 }
 
 void EntryPreviewWidget::setEntryNotesVisible(bool state)
 {
     setNotesVisible(m_ui->entryNotesTextEdit, m_currentEntry->notes(), state);
+    m_ui->toggleEntryNotesButton->setIcon(icons()->onOffIcon("password-show", state));
 }
 
 void EntryPreviewWidget::setGroupNotesVisible(bool state)
 {
     setNotesVisible(m_ui->groupNotesTextEdit, m_currentGroup->notes(), state);
+    m_ui->toggleGroupNotesButton->setIcon(icons()->onOffIcon("password-show", state));
 }
 
 void EntryPreviewWidget::setNotesVisible(QTextEdit* notesWidget, const QString& notes, bool state)

--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -194,30 +194,9 @@ QIcon Icons::icon(const QString& name, bool recolor, const QColor& overrideColor
     return icon;
 }
 
-QIcon Icons::onOffIcon(const QString& name, bool recolor)
+QIcon Icons::onOffIcon(const QString& name, bool on, bool recolor)
 {
-    QString cacheName = "onoff/" + name;
-
-    QIcon icon = m_iconCache.value(cacheName);
-
-    if (!icon.isNull()) {
-        return icon;
-    }
-
-    const QSize size(48, 48);
-    QIcon on = Icons::icon(name + "-on", recolor);
-    icon.addPixmap(on.pixmap(size, QIcon::Mode::Normal), QIcon::Mode::Normal, QIcon::On);
-    icon.addPixmap(on.pixmap(size, QIcon::Mode::Selected), QIcon::Mode::Selected, QIcon::On);
-    icon.addPixmap(on.pixmap(size, QIcon::Mode::Disabled), QIcon::Mode::Disabled, QIcon::On);
-
-    QIcon off = Icons::icon(name + "-off", recolor);
-    icon.addPixmap(off.pixmap(size, QIcon::Mode::Normal), QIcon::Mode::Normal, QIcon::Off);
-    icon.addPixmap(off.pixmap(size, QIcon::Mode::Selected), QIcon::Mode::Selected, QIcon::Off);
-    icon.addPixmap(off.pixmap(size, QIcon::Mode::Disabled), QIcon::Mode::Disabled, QIcon::Off);
-
-    m_iconCache.insert(cacheName, icon);
-
-    return icon;
+    return icon(name + (on ? "-on" : "-off"), recolor);
 }
 
 Icons* Icons::instance()

--- a/src/gui/Icons.h
+++ b/src/gui/Icons.h
@@ -33,7 +33,7 @@ public:
     QIcon trayIconUnlocked();
     QString trayIconAppearance() const;
     QIcon icon(const QString& name, bool recolor = true, const QColor& overrideColor = QColor::Invalid);
-    QIcon onOffIcon(const QString& name, bool recolor = true);
+    QIcon onOffIcon(const QString& name, bool on, bool recolor = true);
 
     static Icons* instance();
 

--- a/src/gui/PasswordEdit.cpp
+++ b/src/gui/PasswordEdit.cpp
@@ -58,7 +58,7 @@ PasswordEdit::PasswordEdit(QWidget* parent)
 #endif
 
     m_toggleVisibleAction = new QAction(
-        icons()->icon("password-show-off"),
+        icons()->onOffIcon("password-show", false),
         tr("Toggle Password (%1)").arg(QKeySequence(modifier + Qt::Key_H).toString(QKeySequence::NativeText)),
         this);
     m_toggleVisibleAction->setCheckable(true);
@@ -113,7 +113,7 @@ void PasswordEdit::enablePasswordGenerator()
 void PasswordEdit::setShowPassword(bool show)
 {
     setEchoMode(show ? QLineEdit::Normal : QLineEdit::Password);
-    m_toggleVisibleAction->setIcon(icons()->icon(show ? "password-show-on" : "password-show-off"));
+    m_toggleVisibleAction->setIcon(icons()->onOffIcon("password-show", show));
     m_toggleVisibleAction->setChecked(show);
 
     if (m_repeatPasswordEdit) {


### PR DESCRIPTION
Some widgets such as QTableView do not call QIconEngine::pixmap(), but do
the drawing immediately through QIconEngine::paint(). This breaks alpha
blending for recolouring, since the underlying image canvas is not
necessarily transparent and also not anchored at (0, 0). This results in
a black box of the size of the icon bounding box.

Icon recolouring is now always done on a temporary QImage with
transparent background and only the finished end result is composed onto
the original canvas.

Fixes #6006

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)