### PR TITLE
Use macdeployqt for all executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,8 +401,16 @@ set(QT_COMPONENTS Core Network Concurrent Gui Svg Widgets Test LinguistTools)
 if(UNIX AND NOT APPLE)
     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} DBus X11Extras REQUIRED)
 elseif(APPLE)
-    find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED HINTS /usr/local/opt/qt/lib/cmake /usr/local/Cellar/qt/*/lib/cmake ENV PATH)
-    find_package(Qt5 COMPONENTS MacExtras HINTS /usr/local/opt/qt/lib/cmake /usr/local/Cellar/qt/*/lib/cmake ENV PATH)
+    find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED HINTS
+            /usr/local/opt/qt/lib/cmake
+            /usr/local/Cellar/qt/*/lib/cmake
+            /opt/homebrew/opt/qt/lib/cmake
+            ENV PATH)
+    find_package(Qt5 COMPONENTS MacExtras HINTS
+            /usr/local/opt/qt/lib/cmake
+            /usr/local/Cellar/qt/*/lib/cmake
+            /opt/homebrew/opt/qt/lib/cmake
+            ENV PATH)
 else()
     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -406,7 +406,7 @@ if(APPLE AND WITH_APP_BUNDLE)
 
     add_custom_command(TARGET ${PROGNAME}
             POST_BUILD
-            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app
+            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app 2> /dev/null
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
             COMMENT "Deploying app bundle")
 endif()

--- a/src/autotype/mac/CMakeLists.txt
+++ b/src/autotype/mac/CMakeLists.txt
@@ -7,8 +7,8 @@ target_link_libraries(keepassx-autotype-cocoa ${PROGNAME} Qt5::Core Qt5::Widgets
 if(WITH_APP_BUNDLE)
     add_custom_command(TARGET keepassx-autotype-cocoa
             POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libkeepassx-autotype-cocoa.so ${PLUGIN_INSTALL_DIR}
-            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PLUGIN_INSTALL_DIR}/libkeepassx-autotype-cocoa.so -no-plugins
+            COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libkeepassx-autotype-cocoa.so ${PLUGIN_INSTALL_DIR}/libkeepassx-autotype-cocoa.so
+            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PLUGIN_INSTALL_DIR}/libkeepassx-autotype-cocoa.so -no-plugins 2> /dev/null
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
             COMMENT "Deploying autotype plugin")
 else()

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -73,48 +73,11 @@ if(MINGW)
 endif()
 
 if(APPLE AND WITH_APP_BUNDLE)
-    add_custom_command(TARGET keepassxc-cli
-                       POST_BUILD
-                       COMMAND ${CMAKE_INSTALL_NAME_TOOL}
-                            -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore
-                                "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore"
-                            -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui
-                                "@executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui"
-                            -change /usr/local/opt/qt/lib/QtMacExtras.framework/Versions/5/QtMacExtras
-                                "@executable_path/../Frameworks/QtMacExtras.framework/Versions/5/QtMacExtras"
-                            -change /usr/local/opt/qt/lib/QtConcurrent.framework/Versions/5/QtConcurrent
-                                "@executable_path/../Frameworks/QtConcurrent.framework/Versions/5/QtConcurrent"
-                            -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore
-                                "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore"
-                            -change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork
-                                "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork"
-                            -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets
-                                "@executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets"
-                            -change /usr/local/opt/qt/lib/QtSvg.framework/Versions/5/QtSvg
-                                "@executable_path/../Frameworks/QtSvg.framework/Versions/5/QtSvg"
-                            -change /usr/local/opt/libgcrypt/lib/libgcrypt.20.dylib
-                                "@executable_path/../Frameworks/libgcrypt.20.dylib"
-                            -change /usr/local/opt/argon2/lib/libargon2.1.dylib
-                                "@executable_path/../Frameworks/libargon2.1.dylib"
-                            -change /usr/local/opt/libgpg-error/lib/libgpg-error.0.dylib
-                                "@executable_path/../Frameworks/libgpg-error.0.dylib"
-                            -change /usr/local/opt/libsodium/lib/libsodium.23.dylib
-                                "@executable_path/../Frameworks/libsodium.23.dylib"
-                            -change /usr/local/opt/qrencode/lib/libqrencode.4.dylib
-                                "@executable_path/../Frameworks/libqrencode.4.dylib"
-                            -change /usr/local/opt/libyubikey/lib/libyubikey.0.dylib
-                                "@executable_path/../Frameworks/libyubikey.0.dylib"
-                            -change /usr/local/opt/ykpers/lib/libykpers-1.1.dylib
-                                "@executable_path/../Frameworks/libykpers-1.1.dylib"
-                            -change /usr/local/opt/quazip/lib/libquazip.1.dylib
-                                "@executable_path/../Frameworks/libquazip.1.dylib"
-                       keepassxc-cli
-                       COMMENT "Changing linking of keepassxc-cli")
-
-    # Copy app to staging directory for pre-install testing
     set(CLI_APP_DIR "${CMAKE_BINARY_DIR}/src/${CLI_INSTALL_DIR}")
     add_custom_command(TARGET keepassxc-cli
-                       POST_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E copy keepassxc-cli ${CLI_APP_DIR}/keepassxc-cli
-                       COMMENT "Copying keepassxc-cli inside the application")
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/keepassxc-cli ${CLI_APP_DIR}/keepassxc-cli
+            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${CLI_APP_DIR}/keepassxc-cli -no-plugins 2> /dev/null
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+            COMMENT "Deploying keepassxc-cli")
 endif()

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -30,28 +30,13 @@ if(WITH_XC_BROWSER)
             RUNTIME DESTINATION ${PROXY_INSTALL_DIR} COMPONENT Runtime)
 
     if(APPLE AND WITH_APP_BUNDLE)
-        add_custom_command(TARGET keepassxc-proxy
-                           POST_BUILD
-                           COMMAND ${CMAKE_INSTALL_NAME_TOOL}
-                                -change ${Qt5_PREFIX}/lib/QtCore.framework/Versions/5/QtCore
-                                    "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore"
-                                -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore
-                                    "@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore"
-                                -change ${Qt5_PREFIX}/lib/QtNetwork.framework/Versions/5/QtNetwork
-                                    "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork"
-                                -change /usr/local/opt/qt/lib/QtNetwork.framework/Versions/5/QtNetwork
-                                    "@executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork"
-                                -change /usr/local/opt/libsodium/lib/libsodium.23.dylib
-                                    "@executable_path/../Frameworks/libsodium.23.dylib"
-                           keepassxc-proxy
-                           COMMENT "Changing linking of keepassxc-proxy")
-
-        # Copy app to staging directory for pre-install testing
         set(PROXY_APP_DIR "${CMAKE_BINARY_DIR}/src/${PROXY_INSTALL_DIR}")
         add_custom_command(TARGET keepassxc-proxy
-                           POST_BUILD
-                           COMMAND ${CMAKE_COMMAND} -E copy keepassxc-proxy ${PROXY_APP_DIR}/keepassxc-proxy
-                           COMMENT "Copying keepassxc-proxy inside the application")
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/keepassxc-proxy ${PROXY_APP_DIR}/keepassxc-proxy
+                COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PROXY_APP_DIR}/keepassxc-proxy -no-plugins 2> /dev/null
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+                COMMENT "Deploying keepassxc-proxy")
     endif()
 
     if(MINGW)


### PR DESCRIPTION
Since Homebrew moved all its stuff to /opt/homebrew, our hard-coded install_name_tool patch magic stopped working. This patch uses macdeployqt for all executables to prevent this kind of behaviour.

Fixes #6042

I still cannot get it to build properly with XCode's standard CMake (missing paths and such), but using Homebrew's own CMake, everything works fine and both keepassxc-cli and keepassxc-proxy have proper relocatable rpaths.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)