### PR TITLE
use save method if new (and existing) created group entry has unsaved changes

### DIFF
--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -250,8 +250,8 @@ void EditGroupWidget::cancel()
             return;
         }
         if (result == MessageBox::Save) {
-            apply();
-            setModified(false);
+            save();
+            return;
         }
     }
 


### PR DESCRIPTION
Save method includes apply entry, clearing und emitting editing changes (true) like the normal way of saving entries.
This pull request fixes issue #6091.

## Screenshots
See video expected behavior in issue #6091.

## Testing strategy
1. Groups / New Group...
2. Type Name XYZ
3. Press Cancel
4. Press Save
5. Look for newly created group on the left side
6. Doing (2-6) the same with a existing group entry

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

