### PR TITLE
Add file extension if user omitted (Keeshare)

### DIFF
--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -224,9 +224,5 @@ ShareObserver::Result ShareExport::intoContainer(const QString& resolvedPath,
     if (KeeShare::isContainerType(info, KeeShare::signedContainerFileType())) {
         return intoSignedContainer(resolvedPath, reference, targetDb.data());
     }
-    if (KeeShare::isContainerType(info, KeeShare::unsignedContainerFileType())) {
-        return intoUnsignedContainer(resolvedPath, reference, targetDb.data());
-    }
-    Q_ASSERT(false);
-    return {reference.path, ShareObserver::Result::Error, tr("Unexpected export error occurred")};
+    return intoUnsignedContainer(resolvedPath, reference, targetDb.data());
 }

--- a/src/keeshare/ShareImport.cpp
+++ b/src/keeshare/ShareImport.cpp
@@ -344,8 +344,5 @@ ShareObserver::Result ShareImport::containerInto(const QString& resolvedPath,
     if (KeeShare::isContainerType(info, KeeShare::signedContainerFileType())) {
         return signedContainerInto(resolvedPath, reference, targetGroup);
     }
-    if (KeeShare::isContainerType(info, KeeShare::unsignedContainerFileType())) {
-        return unsignedContainerInto(resolvedPath, reference, targetGroup);
-    }
-    return {reference.path, ShareObserver::Result::Error, tr("Unknown share container type")};
+    return unsignedContainerInto(resolvedPath, reference, targetGroup);
 }


### PR DESCRIPTION
Fixes #6081 

The crash arises if the specified exported file path is missing either one of the 
allowed file endings ".kdbx" or "kdbx.share".

In the KeeShare settings of the group the yellow warning ("your keepassXC version does not support sharing this container type. Supported extensions are: kdbx, kdbx.share") is correctly shown, however
the user is still able to progress the control flow via "ok" or "apply" button
and trigger the QASSERT in ShareExport.cpp which crashes the application.

The default file extension ".kdbx" is appended if the user omits it. Export then runs through.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
