### PR TITLE
Initialize Application before parser arguments

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,11 @@ int main(int argc, char** argv)
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
     Application app(argc, argv);
+    // don't set organizationName as that changes the return value of
+    // QStandardPaths::writableLocation(QDesktopServices::DataLocation)
+    Application::setApplicationName("KeePassXC");
+    Application::setApplicationVersion(KEEPASSXC_VERSION);
+    app.setProperty("KPXC_QUALIFIED_APPNAME", "org.keepassxc.KeePassXC");
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QObject::tr("KeePassXC - cross-platform password manager"));
@@ -83,12 +88,6 @@ int main(int argc, char** argv)
     if (osUtils->canPreventScreenCapture()) {
         parser.addOption(allowScreenCaptureOption);
     }
-
-    // don't set organizationName as that changes the return value of
-    // QStandardPaths::writableLocation(QDesktopServices::DataLocation)
-    Application::setApplicationName("KeePassXC");
-    Application::setApplicationVersion(KEEPASSXC_VERSION);
-    app.setProperty("KPXC_QUALIFIED_APPNAME", "org.keepassxc.KeePassXC");
 
     parser.process(app);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@ int main(int argc, char** argv)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && defined(Q_OS_WIN)
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
+    Application app(argc, argv);
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QObject::tr("KeePassXC - cross-platform password manager"));
@@ -83,7 +84,6 @@ int main(int argc, char** argv)
         parser.addOption(allowScreenCaptureOption);
     }
 
-    Application app(argc, argv);
     // don't set organizationName as that changes the return value of
     // QStandardPaths::writableLocation(QDesktopServices::DataLocation)
     Application::setApplicationName("KeePassXC");


### PR DESCRIPTION
Fixes #6169. This seems safe.

## Testing strategy
Starting KeePassXC. Segfaults without this.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)