### PR TITLE
Exclude additional lookalike characters (6G8B)

### DIFF
--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -150,7 +150,7 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
 
         for (int i = 65; i <= (65 + 25); i++) {
 
-            if ((m_flags & ExcludeLookAlike) && (i == 73 || i == 79)) { // "I" and "O"
+            if ((m_flags & ExcludeLookAlike) && (i == 66 || i == 71 || i == 73 || i == 79)) { //"B", "G", "I" and "O"
                 continue;
             }
 
@@ -163,7 +163,7 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
         PasswordGroup group;
 
         for (int i = 48; i < (48 + 10); i++) {
-            if ((m_flags & ExcludeLookAlike) && (i == 48 || i == 49)) { // "0" and "1"
+            if ((m_flags & ExcludeLookAlike) && (i == 48 || i == 49 || i == 54 || i == 56)) { // "0", "1", "6", and "8"
                 continue;
             }
 

--- a/tests/TestPasswordGenerator.cpp
+++ b/tests/TestPasswordGenerator.cpp
@@ -126,18 +126,18 @@ void TestPasswordGenerator::testLookalikeExclusion()
 
     generator.setFlags(PasswordGenerator::GeneratorFlag::ExcludeLookAlike);
     password = generator.generatePassword();
-    QRegularExpression regex("^[^lI0]+$");
+    QRegularExpression regex("^[^lBGIO]+$");
     QVERIFY(regex.match(password).hasMatch());
 
     generator.setCharClasses(PasswordGenerator::CharClass::LowerLetters | PasswordGenerator::CharClass::UpperLetters
                              | PasswordGenerator::CharClass::Numbers);
     password = generator.generatePassword();
-    regex.setPattern("^[^lI01]+$");
+    regex.setPattern("^[^lBGIO0168]+$");
     QVERIFY(regex.match(password).hasMatch());
 
     generator.setCharClasses(PasswordGenerator::CharClass::LowerLetters | PasswordGenerator::CharClass::UpperLetters
                              | PasswordGenerator::CharClass::Numbers | PasswordGenerator::CharClass::EASCII);
     password = generator.generatePassword();
-    regex.setPattern("^[^lI01﹒]+$");
+    regex.setPattern("^[^lBGIO0168﹒]+$");
     QVERIFY(regex.match(password).hasMatch());
 }


### PR DESCRIPTION
* Fix #6075

This change add 6/G and 8/B as additional look-alike characters to be excluded upon user request. 
This feature was requested in issue #6075. 

## Testing strategy
The existing unit tests were updated to cover the additional look-alike characters.


## Type of change
- ✅ New feature (change that adds functionality)
