### PR TITLE
Auto-Type: Allow selection of modal dialogs on X11

### DIFF
--- a/src/autotype/xcb/AutoTypeXCB.h
+++ b/src/autotype/xcb/AutoTypeXCB.h
@@ -68,7 +68,6 @@ private:
     void updateKeymap();
     bool isRemapKeycodeValid();
     int AddKeysym(KeySym keysym);
-    void AddModifier(KeySym keysym);
     void SendKeyEvent(unsigned keycode, bool press);
     void SendModifiers(unsigned int mask, bool press);
     int GetKeycode(KeySym keysym, unsigned int* mask);
@@ -84,6 +83,8 @@ private:
     Atom m_atomString;
     Atom m_atomUtf8String;
     Atom m_atomNetActiveWindow;
+    Atom m_atomTransientFor;
+    Atom m_atomWindow;
     QSet<QString> m_classBlacklist;
 
     XkbDescPtr m_xkb;


### PR DESCRIPTION
* Fix #5958 - Modal dialogs do not have WM_STATE set even though they are a valid top-level window with a valid name. In this case, we need to poll for WM_TRANSIENT_FOR which returns the top level window the dialog is a child of.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on XFCE

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
