### PR TITLE
Allow CSV import of bare TOTP secrets

### DIFF
--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -208,8 +208,13 @@ void CsvImportWidget::writeDatabase()
         entry->setUrl(m_parserModel->data(m_parserModel->index(r, 4)).toString());
         entry->setNotes(m_parserModel->data(m_parserModel->index(r, 5)).toString());
 
-        if (m_parserModel->data(m_parserModel->index(r, 6)).isValid()) {
-            auto totp = Totp::parseSettings(m_parserModel->data(m_parserModel->index(r, 6)).toString());
+        auto otpString = m_parserModel->data(m_parserModel->index(r, 6));
+        if (otpString.isValid() && !otpString.toString().isEmpty()) {
+            auto totp = Totp::parseSettings(otpString.toString());
+            if (totp->key.isEmpty()) {
+                // Bare secret, use default TOTP settings
+                totp = Totp::parseSettings({}, otpString.toString());
+            }
             entry->setTotp(totp);
         }
 


### PR DESCRIPTION
I had some extracted secrets from another TOTP app in CSV format and they didn't import.
That was because they were stored as bare TOTP secrets instead of otpauth url format.
This was an easy enough fix for me so I took the liberty to implement it.

Fixes #6167

## Testing strategy
So... Yeah...
I didn't find any test of the CSV importing wizard, so I don't know where to add a test if I really should.
However, the fix is trivial enough (and can't cause data loss) so it may be OK as it is. Just tell me.
I did test manually however and the TOTP seems to correctly generate

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
