### PR TITLE
Make KeePassXC start after the system tray is available on LXQt

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -132,7 +132,8 @@ void NixUtils::setLaunchAtStartup(bool enable)
                << QStringLiteral("MimeType=application/x-keepass2;") << '\n'
                << QStringLiteral("X-GNOME-Autostart-enabled=true") << '\n'
                << QStringLiteral("X-GNOME-Autostart-Delay=2") << '\n'
-               << QStringLiteral("X-KDE-autostart-after=panel") << endl;
+               << QStringLiteral("X-KDE-autostart-after=panel") << '\n'
+               << QStringLiteral("X-LXQt-Need-Tray=true") << endl;
         desktopFile.close();
     } else if (isLaunchAtStartupEnabled()) {
         QFile::remove(getAutostartDesktopFilename());


### PR DESCRIPTION
This extends the feature for GNOME and KDE in https://github.com/keepassxreboot/keepassxc/pull/5724 to also include LXQt. The key `X-LXQt-Need-Tray` is not documented, though. It is seen in the source code https://github.com/lxqt/lxqt-session/blob/0.16.0/lxqt-session/src/lxqtmodman.cpp#L111.

This feature can also be added manually from the `lxqt-config-session` program, or by modifying the file `~/.config/autostart/org.keepassxc.KeePassXC.desktop` directly. However, changes are lost with Tools -> Settings -> OK.

---

## Screenshots
N/A

## Testing strategy
Regenerate the autostart desktop file via settings, logout LXQt and login. The KeePassXC tray icon is always visible. Before this change, the tray icon may be lost if KeePassXC is run before the system tray plugin on the panel is available.

## Type of change
- ✅ New feature (change that adds functionality)
