### PR TITLE
Force Always on Top to be persisted

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -94,6 +94,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_MovableToolbar, {QS("GUI/MovableToolbar"), Roaming, false}},
     {Config::GUI_HideGroupsPanel, {QS("GUI/HideGroupsPanel"), Roaming, false}},
     {Config::GUI_HidePreviewPanel, {QS("GUI/HidePreviewPanel"), Roaming, false}},
+    {Config::GUI_AlwaysOnTop, {QS("GUI/GUI_AlwaysOnTop"), Roaming, false}},
     {Config::GUI_ToolButtonStyle, {QS("GUI/ToolButtonStyle"), Roaming, Qt::ToolButtonIconOnly}},
     {Config::GUI_ShowTrayIcon, {QS("GUI/ShowTrayIcon"), Roaming, false}},
     {Config::GUI_TrayIconAppearance, {QS("GUI/TrayIconAppearance"), Roaming, {}}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -76,6 +76,7 @@ public:
         GUI_MovableToolbar,
         GUI_HideGroupsPanel,
         GUI_HidePreviewPanel,
+        GUI_AlwaysOnTop,
         GUI_ToolButtonStyle,
         GUI_ShowTrayIcon,
         GUI_TrayIconAppearance,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1831,6 +1831,7 @@ void MainWindow::initViewMenu()
     });
 
     connect(m_ui->actionAlwaysOnTop, &QAction::toggled, this, [this](bool checked) {
+        config()->set(Config::GUI_AlwaysOnTop, checked);
         if (checked) {
             setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
         } else {
@@ -1838,6 +1839,8 @@ void MainWindow::initViewMenu()
         }
         show();
     });
+    // Set checked after connecting to act on a toggle in state (default state is unchecked)
+    m_ui->actionAlwaysOnTop->setChecked(config()->get(Config::GUI_AlwaysOnTop).toBool());
 
     m_ui->actionHideUsernames->setChecked(config()->get(Config::GUI_HideUsernames).toBool());
     connect(m_ui->actionHideUsernames, &QAction::toggled, this, [](bool checked) {


### PR DESCRIPTION
## Description

Regarding this issue #6231, I agree that the nature of the "Always on Top" option is to be persisted like in KeePass.
However, in order to keep the current functionality intact, and let the user decide how it will work, I made a pull request with an additional option in:
Settings -> General (Basic Settings) -> User Interface: "Force Always on Top to be persisted". Note that this option only allows persistance of the existing "Always on Top" in View submenu.

This gives the ability to the user to persist the "Always on Top" setting on "View" menu. 

## Screenshots
![screenshot_persist_always_on_top](https://user-images.githubusercontent.com/76261135/110214865-511a8080-7eaf-11eb-942b-d37d414a4d6c.jpg)

## Notable code changes
Additional Settings in .ini
- "Always on Top" -> "GUI_AlwaysOnTop"
- "Force Always on Top to be persisted" -> "GUI_PersistAlwaysOnTop"

## Testing strategy
- Open the application with both settings false (default). Close the application. Re-open it. It works as in the initial state and works with "Always on Top" disabled.
- Open the application with only "Always on Top" setting checked. Close the application. Re-open it. The "Always on Top" is reset to false and works with it disabled.
- Open the application with only "Always on Top" setting checked. Check also the "Force Always on Top to be persisted". Close the application. Re-open it. The "Always on Top" is fetched from saved settings and is checked. "Always on Top" is enabled.
- Open the application with "Always on Top" setting un-checked. Check the "Force Always on Top to be persisted". Close the application. Re-open it. The "Always on Top" remains disabled and un-checked.

- Built successfully via cmake based on "develop" branch.
- Run tests (all passed) with:
make test ARGS+="--output-on-failure"

## Type of change
- ✅ New feature (change that adds functionality)
