### PR TITLE
Show search bar when toolbar is hidden or overflow

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,7 @@ set(keepassx_SOURCES
         gui/osutils/ScreenLockListenerPrivate.cpp
         gui/settings/SettingsWidget.cpp
         gui/widgets/ElidedLabel.cpp
+        gui/widgets/KPToolBar.cpp
         gui/widgets/PopupHelpWidget.cpp
         gui/wizard/NewDatabaseWizard.cpp
         gui/wizard/NewDatabaseWizardPage.cpp

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1401,9 +1401,8 @@ void DatabaseWidget::onGroupChanged()
     // Intercept group changes if in search mode
     if (isSearchActive() && m_searchLimitGroup) {
         search(m_lastSearchText);
-    } else if (isSearchActive()) {
-        endSearch();
     } else {
+        endSearch();
         m_entryView->displayGroup(group);
     }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -148,6 +148,7 @@ private slots:
     void agentEnabled(bool enabled);
     void updateTrayIcon();
     void updateProgressBar(int percentage, QString message);
+    void focusSearchWidget();
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -382,7 +382,7 @@
    <addaction name="menuView"/>
    <addaction name="menuHelp"/>
   </widget>
-  <widget class="QToolBar" name="toolBar">
+  <widget class="KPToolBar" name="toolBar">
    <property name="contextMenuPolicy">
     <enum>Qt::PreventContextMenu</enum>
    </property>
@@ -1076,6 +1076,11 @@
    <extends>QWidget</extends>
    <header>gui/WelcomeWidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>KPToolBar</class>
+   <extends>QToolBar</extends>
+   <header>gui/widgets/KPToolBar.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -52,16 +52,19 @@ protected:
 
 signals:
     void search(const QString& text);
+    void searchCanceled();
     void caseSensitiveChanged(bool state);
     void limitGroupChanged(bool state);
     void escapePressed();
     void copyPressed();
     void downPressed();
     void enterPressed();
+    void lostFocus();
 
 public slots:
     void databaseChanged(DatabaseWidget* dbWidget = nullptr);
-    void searchFocus();
+    void focusSearch();
+    void clearSearch();
 
 private slots:
     void startSearchTimer();

--- a/src/gui/widgets/KPToolBar.cpp
+++ b/src/gui/widgets/KPToolBar.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "KPToolBar.h"
+
+#include <QAbstractButton>
+#include <QEvent>
+#include <QLayout>
+
+KPToolBar::KPToolBar(const QString& title, QWidget* parent)
+    : QToolBar(title, parent)
+{
+    init();
+}
+
+KPToolBar::KPToolBar(QWidget* parent)
+    : QToolBar(parent)
+{
+    init();
+}
+
+void KPToolBar::init()
+{
+    m_expandButton = findChild<QAbstractButton*>("qt_toolbar_ext_button");
+    m_expandTimer.setSingleShot(true);
+    connect(&m_expandTimer, &QTimer::timeout, this, [this] { setExpanded(false); });
+}
+
+bool KPToolBar::isExpanded()
+{
+    return !canExpand() || (canExpand() && m_expandButton->isChecked());
+}
+
+bool KPToolBar::canExpand()
+{
+    return m_expandButton && m_expandButton->isVisible();
+}
+
+void KPToolBar::setExpanded(bool state)
+{
+    if (canExpand() && !QMetaObject::invokeMethod(layout(), "setExpanded", Q_ARG(bool, state))) {
+        qWarning("Toolbar: Cannot invoke setExpanded!");
+    }
+}
+
+bool KPToolBar::event(QEvent* event)
+{
+    // Override events handled by the base class for better UX when using an expandable toolbar.
+    switch (event->type()) {
+    case QEvent::Leave:
+        // Hide the toolbar after 2 seconds of mouse exit
+        m_expandTimer.start(2000);
+        return true;
+    case QEvent::Enter:
+        // Mouse came back in, stop hiding timer
+        m_expandTimer.stop();
+        return true;
+    default:
+        return QToolBar::event(event);
+    }
+}

--- a/src/gui/widgets/KPToolBar.h
+++ b/src/gui/widgets/KPToolBar.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_KPTOOLBAR_H
+#define KEEPASSXC_KPTOOLBAR_H
+
+#include <QPointer>
+#include <QTimer>
+#include <QToolBar>
+
+class QAbstractButton;
+
+class KPToolBar : public QToolBar
+{
+    Q_OBJECT
+
+public:
+    explicit KPToolBar(const QString& title, QWidget* parent = nullptr);
+    explicit KPToolBar(QWidget* parent = nullptr);
+    ~KPToolBar() override = default;
+
+    bool isExpanded();
+    bool canExpand();
+
+public slots:
+    void setExpanded(bool state);
+
+protected:
+    bool event(QEvent* event) override;
+
+private:
+    void init();
+
+    QTimer m_expandTimer;
+    QPointer<QAbstractButton> m_expandButton;
+};
+
+#endif // KEEPASSXC_KPTOOLBAR_H


### PR DESCRIPTION
Always show the search bar when the search keyboard shortcut is pressed. If the toolbar is in overflow, the toolbar will be expanded automatically and search focused. If the toolbar is hidden it will be shown and expanded if necessary. When searching is canceled or the down arrow is pressed (to select the first entry) the toolbar will be set back to it's previous configuration.

* Fix #505

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![2021-03-13_22-16-53](https://user-images.githubusercontent.com/2809491/111056244-82fd8b00-844b-11eb-9c3a-bbe99b8d46d1.gif)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)

