### PR TITLE
Add a SSH agent option to use both Pageant and OpenSSH agent simultaneously in Windows

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -168,6 +168,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     // SSHAgent
     {Config::SSHAgent_Enabled, {QS("SSHAgent/Enabled"), Roaming, false}},
     {Config::SSHAgent_UseOpenSSH, {QS("SSHAgent/UseOpenSSH"), Roaming, false}},
+    {Config::SSHAgent_UsePageant, {QS("SSHAgent/UsePageant"), Roaming, false} },
     {Config::SSHAgent_AuthSockOverride, {QS("SSHAgent/AuthSockOverride"), Local, {}}},
 
     // FdoSecrets

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -146,6 +146,7 @@ public:
 
         SSHAgent_Enabled,
         SSHAgent_UseOpenSSH,
+        SSHAgent_UsePageant,
         SSHAgent_AuthSockOverride,
 
         FdoSecrets_Enabled,

--- a/src/sshagent/AgentSettingsWidget.cpp
+++ b/src/sshagent/AgentSettingsWidget.cpp
@@ -26,6 +26,7 @@ AgentSettingsWidget::AgentSettingsWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
 #ifndef Q_OS_WIN
+    m_ui->usePageantCheckBox->setVisible(false);
     m_ui->useOpenSSHCheckBox->setVisible(false);
 #else
     m_ui->sshAuthSockWidget->setVisible(false);
@@ -46,7 +47,9 @@ void AgentSettingsWidget::loadSettings()
 
     m_ui->enableSSHAgentCheckBox->setChecked(sshAgentEnabled);
 #ifdef Q_OS_WIN
+    m_ui->usePageantCheckBox->setChecked(sshAgent()->usePageant());
     m_ui->useOpenSSHCheckBox->setChecked(sshAgent()->useOpenSSH());
+    sshAgentEnabled = sshAgentEnabled && (sshAgent()->usePageant() || sshAgent()->useOpenSSH());
 #else
     auto sshAuthSock = sshAgent()->socketPath(false);
     auto sshAuthSockOverride = sshAgent()->authSockOverride();
@@ -83,6 +86,7 @@ void AgentSettingsWidget::saveSettings()
     auto sshAuthSockOverride = m_ui->sshAuthSockOverrideEdit->text();
     sshAgent()->setAuthSockOverride(sshAuthSockOverride);
 #ifdef Q_OS_WIN
+    sshAgent()->setUsePageant(m_ui->usePageantCheckBox->isChecked());
     sshAgent()->setUseOpenSSH(m_ui->useOpenSSHCheckBox->isChecked());
 #endif
     sshAgent()->setEnabled(m_ui->enableSSHAgentCheckBox->isChecked());

--- a/src/sshagent/AgentSettingsWidget.ui
+++ b/src/sshagent/AgentSettingsWidget.ui
@@ -72,10 +72,17 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
+	  <item>
+       <widget class="QCheckBox" name="usePageantCheckBox">
+        <property name="text">
+         <string>Use Pageant</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QCheckBox" name="useOpenSSHCheckBox">
         <property name="text">
-         <string>Use OpenSSH for Windows instead of Pageant</string>
+         <string>Use OpenSSH</string>
         </property>
        </widget>
       </item>

--- a/src/sshagent/SSHAgent.h
+++ b/src/sshagent/SSHAgent.h
@@ -41,7 +41,9 @@ public:
     void setAuthSockOverride(QString& authSockOverride);
 #ifdef Q_OS_WIN
     bool useOpenSSH() const;
+    bool usePageant() const;
     void setUseOpenSSH(bool useOpenSSH);
+    void setUsePageant(bool usePageant);
 #endif
 
     const QString errorString() const;
@@ -74,6 +76,7 @@ private:
     const quint8 SSH_AGENT_CONSTRAIN_CONFIRM = 2;
 
     bool sendMessage(const QByteArray& in, QByteArray& out);
+    bool sendMessageOpenSSH(const QByteArray& in, QByteArray& out);
 #ifdef Q_OS_WIN
     bool sendMessagePageant(const QByteArray& in, QByteArray& out);
 


### PR DESCRIPTION
OpenSSH is already supported in Windows 10. In some situations, I really need to use both Pageant and OpenSSH agent at the same time. Therefore, I have modified the SSH Agent setting which is able to choice to use both agent simultaneously. As the result, the SSH key can be added/ removed from both agent by KeePassXC.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/10261662/111222005-8aec3500-85db-11eb-923f-62d4b38c8d00.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

- Choose "use Pageant", lock and unlock database, SSH keys appear in Pageant. OpenSSH command `ssh-add -L` outputs nothing.
- Choose "use OpenSSH", lock and unlock database, Pageant is empty. OpenSSH command `ssh-add -L` outputs SSH key list.
- Choose "use both", lock and unlock database, SSH keys appear in Pageant. OpenSSH command `ssh-add -L` outputs SSH key list.
## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)

## Possible issues

Currently, the stable OpenSSH version for Win10 is 7.7.2.1. However, I got error message `agent returned different signature type ssh-rsa (expected rsa-sha2-512).` when I use ssh.exe command to connect my server. The problem can be solved by updating OpenSSH to 8.1.0.0 Beta.