### PR TITLE
Add matrix channel badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![codecov](https://codecov.io/gh/keepassxreboot/keepassxc/branch/develop/graph/badge.svg)](https://codecov.io/gh/keepassxreboot/keepassxc)
 [![GitHub release](https://img.shields.io/github/release/keepassxreboot/keepassxc)](https://github.com/keepassxreboot/keepassxc/releases/)
 
+[![Matrix channel](https://img.shields.io/matrix/keepassxc-dev:matrix.org?label=Chat%20on%20Matrix&style=for-the-badge)](https://matrix.to/#/!RhJPJPGwQIFVQeXqZa:matrix.org?via=matrix.org)
+
 [KeePassXC](https://keepassxc.org) is a modern, secure, and open-source password manager that stores and manages your most sensitive information. You can run KeePassXC on Windows, macOS, and Linux systems. KeePassXC is for people with extremely high demands of secure personal data management. It saves many different types of information, such as usernames, passwords, URLs, attachments, and notes in an offline, encrypted file that can be stored in any location, including private and public cloud solutions. For easy identification and management, user-defined titles and icons can be specified for entries. In addition, entries are sorted in customizable groups. An integrated search function allows you to use advanced patterns to easily find any entry in your database. A customizable, fast, and easy-to-use password generator utility allows you to create passwords with any combination of characters or easy to remember passphrases.
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![codecov](https://codecov.io/gh/keepassxreboot/keepassxc/branch/develop/graph/badge.svg)](https://codecov.io/gh/keepassxreboot/keepassxc)
 [![GitHub release](https://img.shields.io/github/release/keepassxreboot/keepassxc)](https://github.com/keepassxreboot/keepassxc/releases/)
 
-[![Matrix channel](https://img.shields.io/matrix/keepassxc-dev:matrix.org?label=Chat%20on%20Matrix&style=for-the-badge)](https://matrix.to/#/!RhJPJPGwQIFVQeXqZa:matrix.org?via=matrix.org)
+[![Matrix community channel](https://img.shields.io/matrix/keepassxc:matrix.org?label=Community%20chat&style=for-the-badge)](https://matrix.to/#/!zUxwGnFkUyycpxeHeM:matrix.org?via=matrix.org)
+[![Matrix developers channel](https://img.shields.io/matrix/keepassxc-dev:matrix.org?label=Developers%20chat&style=for-the-badge)](https://matrix.to/#/!RhJPJPGwQIFVQeXqZa:matrix.org?via=matrix.org)
 
 [KeePassXC](https://keepassxc.org) is a modern, secure, and open-source password manager that stores and manages your most sensitive information. You can run KeePassXC on Windows, macOS, and Linux systems. KeePassXC is for people with extremely high demands of secure personal data management. It saves many different types of information, such as usernames, passwords, URLs, attachments, and notes in an offline, encrypted file that can be stored in any location, including private and public cloud solutions. For easy identification and management, user-defined titles and icons can be specified for entries. In addition, entries are sorted in customizable groups. An integrated search function allows you to use advanced patterns to easily find any entry in your database. A customizable, fast, and easy-to-use password generator utility allows you to create passwords with any combination of characters or easy to remember passphrases.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![codecov](https://codecov.io/gh/keepassxreboot/keepassxc/branch/develop/graph/badge.svg)](https://codecov.io/gh/keepassxreboot/keepassxc)
 [![GitHub release](https://img.shields.io/github/release/keepassxreboot/keepassxc)](https://github.com/keepassxreboot/keepassxc/releases/)
 
-[![Matrix community channel](https://img.shields.io/matrix/keepassxc:matrix.org?label=Community%20chat&style=for-the-badge)](https://matrix.to/#/!zUxwGnFkUyycpxeHeM:matrix.org?via=matrix.org)
-[![Matrix developers channel](https://img.shields.io/matrix/keepassxc-dev:matrix.org?label=Developers%20chat&style=for-the-badge)](https://matrix.to/#/!RhJPJPGwQIFVQeXqZa:matrix.org?via=matrix.org)
+[![Matrix community channel](https://img.shields.io/matrix/keepassxc:matrix.org?label=Community%20channel&style=for-the-badge)](https://matrix.to/#/!zUxwGnFkUyycpxeHeM:matrix.org?via=matrix.org)
+[![Matrix development channel](https://img.shields.io/matrix/keepassxc-dev:matrix.org?label=Development%20channel&style=for-the-badge)](https://matrix.to/#/!RhJPJPGwQIFVQeXqZa:matrix.org?via=matrix.org)
 
 [KeePassXC](https://keepassxc.org) is a modern, secure, and open-source password manager that stores and manages your most sensitive information. You can run KeePassXC on Windows, macOS, and Linux systems. KeePassXC is for people with extremely high demands of secure personal data management. It saves many different types of information, such as usernames, passwords, URLs, attachments, and notes in an offline, encrypted file that can be stored in any location, including private and public cloud solutions. For easy identification and management, user-defined titles and icons can be specified for entries. In addition, entries are sorted in customizable groups. An integrated search function allows you to use advanced patterns to easily find any entry in your database. A customizable, fast, and easy-to-use password generator utility allows you to create passwords with any combination of characters or easy to remember passphrases.
 


### PR DESCRIPTION
Adding badges for the 2 matrix channels, so that it's easier to find them.

## Screenshots
![matrix_badge](https://user-images.githubusercontent.com/3301383/111386194-45367780-8682-11eb-81ba-ece337d5442f.png)

## Type of change
- ✅ Documentation (non-code change)
