### PR TITLE
Use application font size when setting default or monospace fonts

### DIFF
--- a/src/gui/Font.cpp
+++ b/src/gui/Font.cpp
@@ -18,29 +18,29 @@
 #include "Font.h"
 
 #include <QFontDatabase>
+#include <QGuiApplication>
 
 QFont Font::defaultFont()
 {
-    return QFontDatabase::systemFont(QFontDatabase::GeneralFont);
+    return qApp->font();
 }
 
 QFont Font::fixedFont()
 {
-    QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    auto fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 
 #ifdef Q_OS_WIN
     // try to use Consolas on Windows, because the default Courier New has too many similar characters
-    QFont consolasFont = QFontDatabase().font("Consolas", fixedFont.styleName(), fixedFont.pointSize());
-    const QFont defaultFont;
-    if (fixedFont != defaultFont) {
+    auto consolasFont = QFontDatabase().font("Consolas", fixedFont.styleName(), fixedFont.pointSize());
+    if (consolasFont.family().contains("consolas", Qt::CaseInsensitive)) {
         fixedFont = consolasFont;
     }
 #endif
 #ifdef Q_OS_MACOS
     // Qt doesn't choose a monospace font correctly on macOS
-    const QFont defaultFont;
-    fixedFont = QFontDatabase().font("Menlo", defaultFont.styleName(), defaultFont.pointSize());
+    fixedFont = QFontDatabase().font("Menlo", fixedFont.styleName(), fixedFont.pointSize());
 #endif
 
+    fixedFont.setPointSize(qApp->font().pointSize());
     return fixedFont;
 }


### PR DESCRIPTION
* Fix #6286

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
**BEFORE:**
![image](https://user-images.githubusercontent.com/2809491/112221895-63f6ba00-8bfe-11eb-93c8-e0b93f732c8b.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/2809491/112221829-4a557280-8bfe-11eb-8f1b-69b6f2437640.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows 10 using system level font scaling of 150%

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
