### PR TITLE
OPVault: Use Text instead of Name for attribute names

### DIFF
--- a/src/format/OpVaultReader.h
+++ b/src/format/OpVaultReader.h
@@ -98,7 +98,7 @@ private:
     bool fillAttributes(Entry* entry, const QJsonObject& bandEntry);
 
     void fillFromSection(Entry* entry, const QJsonObject& section);
-    void fillFromSectionField(Entry* entry, const QString& sectionName, QJsonObject& field);
+    void fillFromSectionField(Entry* entry, const QString& sectionName, const QJsonObject& field);
     QString resolveAttributeName(const QString& section, const QString& name, const QString& text);
 
     void populateCategoryGroups(Group* rootGroup);

--- a/src/format/OpVaultReaderSections.cpp
+++ b/src/format/OpVaultReaderSections.cpp
@@ -53,12 +53,11 @@ namespace
 void OpVaultReader::fillFromSection(Entry* entry, const QJsonObject& section)
 {
     const auto uuid = entry->uuid();
-    QString sectionName = section["name"].toString();
+    auto sectionTitle = section["title"].toString();
 
     if (!section.contains("fields")) {
-        auto sectionNameLC = sectionName.toLower();
-        auto sectionTitleLC = section["title"].toString("").toLower();
-        if (!(sectionNameLC == "linked items" && sectionTitleLC == "related items")) {
+        auto sectionName = section["name"].toString();
+        if (!(sectionName.toLower() == "linked items" && sectionTitle.toLower() == "related items")) {
             qWarning() << R"(Skipping "fields"-less Section in UUID ")" << uuid << "\": <<" << section << ">>";
         }
         return;
@@ -67,23 +66,17 @@ void OpVaultReader::fillFromSection(Entry* entry, const QJsonObject& section)
         return;
     }
 
-    // If we have a default section name then replace with the section title if not empty
-    if (sectionName.startsWith("Section_") && !section["title"].toString().isEmpty()) {
-        sectionName = section["title"].toString();
-    }
-
     QJsonArray sectionFields = section["fields"].toArray();
     for (const QJsonValue sectionField : sectionFields) {
         if (!sectionField.isObject()) {
             qWarning() << R"(Skipping non-Object "fields" in UUID ")" << uuid << "\": << " << sectionField << ">>";
             continue;
         }
-        QJsonObject field = sectionField.toObject();
-        fillFromSectionField(entry, sectionName, field);
+        fillFromSectionField(entry, sectionTitle, sectionField.toObject());
     }
 }
 
-void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionName, QJsonObject& field)
+void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionName, const QJsonObject& field)
 {
     if (!field.contains("v")) {
         // for our purposes, we don't care if there isn't a value in the field
@@ -161,8 +154,8 @@ QString OpVaultReader::resolveAttributeName(const QString& section, const QStrin
                    || lowName == "website") {
             return EntryAttributes::URLKey;
         }
-        return name;
+        return text;
     }
 
-    return QString("%1_%2").arg(section, name);
+    return QString("%1_%2").arg(section, text);
 }

--- a/tests/TestOpVaultReader.cpp
+++ b/tests/TestOpVaultReader.cpp
@@ -97,10 +97,10 @@ void TestOpVaultReader::testReadIntoDatabase()
     entry = db->rootGroup()->findEntryByPath("/Credit Card/My Credit Card");
     QVERIFY(entry);
     auto attr = entry->attributes();
-    QCOMPARE(attr->value("cardholder"), QStringLiteral("Team KeePassXC"));
-    QVERIFY(!attr->value("validFrom").isEmpty());
-    QCOMPARE(attr->value("details_pin"), QStringLiteral("1234"));
-    QVERIFY(attr->isProtected("details_pin"));
+    QCOMPARE(attr->value("cardholder name"), QStringLiteral("Team KeePassXC"));
+    QVERIFY(!attr->value("valid from").isEmpty());
+    QCOMPARE(attr->value("Additional Details_PIN"), QStringLiteral("1234"));
+    QVERIFY(attr->isProtected("Additional Details_PIN"));
 
     // Confirm address fields
     entry = db->rootGroup()->findEntryByPath("/Identity/Team KeePassXC");


### PR DESCRIPTION
* Fix #6303 - the text attribute in 1Password contains the actual text seen in 1Password whereas the name attribute may contain a ref pointer and not a name.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested using our test data.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
