### PR TITLE
MinimizeAfterUnlock also when unlocking through browser

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1178,6 +1178,10 @@ void DatabaseWidget::unlockDatabase(bool accepted)
     sshAgent()->databaseUnlocked(m_db);
 #endif
 
+    if (config()->get(Config::MinimizeAfterUnlock).toBool()) {
+        getMainWindow()->minimizeOrHide();
+    }
+
     if (senderDialog && senderDialog->intent() == DatabaseOpenDialog::Intent::AutoType) {
         QList<QSharedPointer<Database>> dbList;
         dbList.append(m_db);


### PR DESCRIPTION
The MinimizeAfterUnlock setting added in #3439 closes the main window
after unlock. However, when the unlock is triggered through
KeePassXC-Browser, a password dialog is shown on top of the main window
and the main window remains open after the unlock. This is fixed
in this commit.

## Screenshots

<img width="802" alt="image" src="https://user-images.githubusercontent.com/119636/112344870-d205b480-8cc4-11eb-8b06-be173fc91cf5.png">



## Testing strategy

Tested only locally on macOS.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
