### PR TITLE
Set umask to ensure all created files are private to the current user

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,17 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 #endif
 #endif
 
+#if defined(Q_OS_UNIX)
+#include <sys/stat.h>
+#endif
+
 int main(int argc, char** argv)
 {
+#if defined(Q_OS_UNIX)
+    // Ensure that saved attachments and other files created are private to the current user
+    umask(0077);
+#endif
+
     QT_REQUIRE_VERSION(argc, argv, QT_VERSION_STR)
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)


### PR DESCRIPTION
Hello.

I found https://github.com/keepassxreboot/keepassxc/issues/2575 and https://github.com/keepassxreboot/keepassxc/commit/fbebf30b9826018e06342969660ef940ce443f30 but I think those failed to address the case when attachments are saved. I actually prepared the code before I found the issue thread and commit, which is why I went for umask rather than using `QFile::setPermissions`.

For example, if I export an SSH key from a database, it is created with permissions that are too open and the ssh binary complains with this warning which is probably familiar to a lot of people:

```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
```

A workaround for this is to set the umask before launching KeePassXC. But this is tedious to do. It is better to ensure that the umask is more restrictive when the program is initializing.

This worked for me but there may be better ways to do it. You may want to treat this PR as an issue with a possible fix, but feel free to fix it in another way.

## Testing strategy

I compiled KeePassXC and observed that attachments are now saved with bits that make the files private to the current user.

## Type of change
- ✅ New feature (change that adds functionality)

## P.S.

Can you add a suggestion to https://github.com/keepassxreboot/keepassxc/wiki/Set-up-Build-Environment-on-Linux that `libqt5x11extras5-dev` should be installed? Seems to be a new dependency in the develop branch?
