### PR TITLE
Auto-Type: Allow actions to fail and be retried

### DIFF
--- a/src/autotype/AutoTypeAction.cpp
+++ b/src/autotype/AutoTypeAction.cpp
@@ -32,9 +32,9 @@ AutoTypeKey::AutoTypeKey(const QChar& character, Qt::KeyboardModifiers modifiers
 {
 }
 
-void AutoTypeKey::exec(AutoTypeExecutor* executor) const
+AutoTypeAction::Result AutoTypeKey::exec(AutoTypeExecutor* executor) const
 {
-    executor->execType(this);
+    return executor->execType(this);
 }
 
 AutoTypeDelay::AutoTypeDelay(int delayMs, bool setExecDelay)
@@ -43,7 +43,7 @@ AutoTypeDelay::AutoTypeDelay(int delayMs, bool setExecDelay)
 {
 }
 
-void AutoTypeDelay::exec(AutoTypeExecutor* executor) const
+AutoTypeAction::Result AutoTypeDelay::exec(AutoTypeExecutor* executor) const
 {
     if (setExecDelay) {
         // Change the delay between actions
@@ -52,14 +52,16 @@ void AutoTypeDelay::exec(AutoTypeExecutor* executor) const
         // Pause execution
         Tools::wait(delayMs);
     }
+
+    return AutoTypeAction::Result::Ok();
 }
 
-void AutoTypeClearField::exec(AutoTypeExecutor* executor) const
+AutoTypeAction::Result AutoTypeClearField::exec(AutoTypeExecutor* executor) const
 {
-    executor->execClearField(this);
+    return executor->execClearField(this);
 }
 
-void AutoTypeBegin::exec(AutoTypeExecutor* executor) const
+AutoTypeAction::Result AutoTypeBegin::exec(AutoTypeExecutor* executor) const
 {
-    executor->execBegin(this);
+    return executor->execBegin(this);
 }

--- a/src/autotype/mac/AutoTypeMac.cpp
+++ b/src/autotype/mac/AutoTypeMac.cpp
@@ -215,12 +215,13 @@ AutoTypeExecutorMac::AutoTypeExecutorMac(AutoTypePlatformMac* platform)
 {
 }
 
-void AutoTypeExecutorMac::execBegin(const AutoTypeBegin* action)
+AutoTypeAction::Result AutoTypeExecutorMac::execBegin(const AutoTypeBegin* action)
 {
     Q_UNUSED(action);
+    return AutoTypeAction::Result::Ok();
 }
 
-void AutoTypeExecutorMac::execType(const AutoTypeKey* action)
+AutoTypeAction::Result AutoTypeExecutorMac::execType(const AutoTypeKey* action)
 {
     if (action->modifiers & Qt::ShiftModifier) {
         m_platform->sendKey(Qt::Key_Shift, true);
@@ -251,12 +252,14 @@ void AutoTypeExecutorMac::execType(const AutoTypeKey* action)
     }
 
     Tools::sleep(execDelayMs);
+    return AutoTypeAction::Result::Ok();
 }
 
-void AutoTypeExecutorMac::execClearField(const AutoTypeClearField* action)
+AutoTypeAction::Result AutoTypeExecutorMac::execClearField(const AutoTypeClearField* action)
 {
     Q_UNUSED(action);
     execType(new AutoTypeKey(Qt::Key_Up, Qt::ControlModifier));
     execType(new AutoTypeKey(Qt::Key_Down, Qt::ControlModifier | Qt::ShiftModifier));
     execType(new AutoTypeKey(Qt::Key_Backspace));
+    return AutoTypeAction::Result::Ok();
 }

--- a/src/autotype/mac/AutoTypeMac.h
+++ b/src/autotype/mac/AutoTypeMac.h
@@ -57,9 +57,9 @@ class AutoTypeExecutorMac : public AutoTypeExecutor
 public:
     explicit AutoTypeExecutorMac(AutoTypePlatformMac* platform);
 
-    void execBegin(const AutoTypeBegin* action) override;
-    void execType(const AutoTypeKey* action) override;
-    void execClearField(const AutoTypeClearField* action) override;
+    AutoTypeAction::Result execBegin(const AutoTypeBegin* action) override;
+    AutoTypeAction::Result execType(const AutoTypeKey* action) override;
+    AutoTypeAction::Result execClearField(const AutoTypeClearField* action) override;
 
 private:
     AutoTypePlatformMac* const m_platform;

--- a/src/autotype/test/AutoTypeTest.cpp
+++ b/src/autotype/test/AutoTypeTest.cpp
@@ -102,17 +102,20 @@ AutoTypeExecutorTest::AutoTypeExecutorTest(AutoTypePlatformTest* platform)
 {
 }
 
-void AutoTypeExecutorTest::execBegin(const AutoTypeBegin* action)
+AutoTypeAction::Result AutoTypeExecutorTest::execBegin(const AutoTypeBegin* action)
 {
     Q_UNUSED(action);
+    return AutoTypeAction::Result::Ok();
 }
 
-void AutoTypeExecutorTest::execType(const AutoTypeKey* action)
+AutoTypeAction::Result AutoTypeExecutorTest::execType(const AutoTypeKey* action)
 {
     m_platform->addAction(action);
+    return AutoTypeAction::Result::Ok();
 }
 
-void AutoTypeExecutorTest::execClearField(const AutoTypeClearField* action)
+AutoTypeAction::Result AutoTypeExecutorTest::execClearField(const AutoTypeClearField* action)
 {
     Q_UNUSED(action);
+    return AutoTypeAction::Result::Ok();
 }

--- a/src/autotype/test/AutoTypeTest.h
+++ b/src/autotype/test/AutoTypeTest.h
@@ -64,9 +64,9 @@ class AutoTypeExecutorTest : public AutoTypeExecutor
 public:
     explicit AutoTypeExecutorTest(AutoTypePlatformTest* platform);
 
-    void execBegin(const AutoTypeBegin* action) override;
-    void execType(const AutoTypeKey* action) override;
-    void execClearField(const AutoTypeClearField* action) override;
+    AutoTypeAction::Result execBegin(const AutoTypeBegin* action) override;
+    AutoTypeAction::Result execType(const AutoTypeKey* action) override;
+    AutoTypeAction::Result execClearField(const AutoTypeClearField* action) override;
 
 private:
     AutoTypePlatformTest* const m_platform;

--- a/src/autotype/windows/AutoTypeWindows.cpp
+++ b/src/autotype/windows/AutoTypeWindows.cpp
@@ -226,12 +226,13 @@ AutoTypeExecutorWin::AutoTypeExecutorWin(AutoTypePlatformWin* platform)
 {
 }
 
-void AutoTypeExecutorWin::execBegin(const AutoTypeBegin* action)
+AutoTypeAction::Result AutoTypeExecutorWin::execBegin(const AutoTypeBegin* action)
 {
     Q_UNUSED(action);
+    return AutoTypeAction::Result::Ok();
 }
 
-void AutoTypeExecutorWin::execType(const AutoTypeKey* action)
+AutoTypeAction::Result AutoTypeExecutorWin::execType(const AutoTypeKey* action)
 {
     if (action->modifiers & Qt::ShiftModifier) {
         m_platform->sendKey(Qt::Key_Shift, true);
@@ -262,12 +263,14 @@ void AutoTypeExecutorWin::execType(const AutoTypeKey* action)
     }
 
     Tools::sleep(execDelayMs);
+    return AutoTypeAction::Result::Ok();
 }
 
-void AutoTypeExecutorWin::execClearField(const AutoTypeClearField* action)
+AutoTypeAction::Result AutoTypeExecutorWin::execClearField(const AutoTypeClearField* action)
 {
     Q_UNUSED(action);
     execType(new AutoTypeKey(Qt::Key_Home, Qt::ControlModifier));
     execType(new AutoTypeKey(Qt::Key_End, Qt::ControlModifier | Qt::ShiftModifier));
     execType(new AutoTypeKey(Qt::Key_Backspace));
+    return AutoTypeAction::Result::Ok();
 }

--- a/src/autotype/windows/AutoTypeWindows.h
+++ b/src/autotype/windows/AutoTypeWindows.h
@@ -54,9 +54,9 @@ class AutoTypeExecutorWin : public AutoTypeExecutor
 public:
     explicit AutoTypeExecutorWin(AutoTypePlatformWin* platform);
 
-    void execBegin(const AutoTypeBegin* action) override;
-    void execType(const AutoTypeKey* action) override;
-    void execClearField(const AutoTypeClearField* action) override;
+    AutoTypeAction::Result execBegin(const AutoTypeBegin* action) override;
+    AutoTypeAction::Result execType(const AutoTypeKey* action) override;
+    AutoTypeAction::Result execClearField(const AutoTypeClearField* action) override;
 
 private:
     AutoTypePlatformWin* const m_platform;

--- a/src/autotype/xcb/AutoTypeXCB.h
+++ b/src/autotype/xcb/AutoTypeXCB.h
@@ -56,7 +56,7 @@ public:
     AutoTypeExecutor* createExecutor() override;
     void updateKeymap();
 
-    void sendKey(KeySym keysym, unsigned int modifiers = 0);
+    AutoTypeAction::Result sendKey(KeySym keysym, unsigned int modifiers = 0);
 
 private:
     QString windowTitle(Window window, bool useBlacklist);
@@ -104,9 +104,9 @@ class AutoTypeExecutorX11 : public AutoTypeExecutor
 public:
     explicit AutoTypeExecutorX11(AutoTypePlatformX11* platform);
 
-    void execBegin(const AutoTypeBegin* action) override;
-    void execType(const AutoTypeKey* action) override;
-    void execClearField(const AutoTypeClearField* action) override;
+    AutoTypeAction::Result execBegin(const AutoTypeBegin* action) override;
+    AutoTypeAction::Result execType(const AutoTypeKey* action) override;
+    AutoTypeAction::Result execClearField(const AutoTypeClearField* action) override;
 
 private:
     AutoTypePlatformX11* const m_platform;


### PR DESCRIPTION
AutoTypeActions are required to return a result object with information if they can be retried or not. An error string is also provided to show a user friendly message why said action did not succeed if even after retries it keeps failing.

This is a prerequisite for waiting for modifier keys to be released on X11 and can be used to add friendly error messages to any executor.

We want to merge this before #6351 so it can be refactored to make use of the retry logic here.

Only X11 is actually implemented and others are just stubbed in.

## Testing strategy
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
