### PR TITLE
Set permissions of saved attachments to be private to the current user

### DIFF
--- a/src/gui/entry/EntryAttachmentsWidget.cpp
+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
@@ -245,7 +245,9 @@ void EntryAttachmentsWidget::saveSelectedAttachments()
 
         QFile file(attachmentPath);
         const QByteArray attachmentData = m_entryAttachments->value(filename);
-        const bool saveOk = file.open(QIODevice::WriteOnly) && file.write(attachmentData) == attachmentData.size();
+        const bool saveOk = file.open(QIODevice::WriteOnly) \
+          && file.setPermissions(QFile::ReadUser | QFile::WriteUser) \
+          && file.write(attachmentData) == attachmentData.size();
         if (!saveOk) {
             errors.append(QString("%1 - %2").arg(filename, file.errorString()));
         }

--- a/src/gui/entry/EntryAttachmentsWidget.cpp
+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
@@ -245,9 +245,8 @@ void EntryAttachmentsWidget::saveSelectedAttachments()
 
         QFile file(attachmentPath);
         const QByteArray attachmentData = m_entryAttachments->value(filename);
-        const bool saveOk = file.open(QIODevice::WriteOnly) \
-          && file.setPermissions(QFile::ReadUser | QFile::WriteUser) \
-          && file.write(attachmentData) == attachmentData.size();
+        const bool saveOk = file.open(QIODevice::WriteOnly) && file.setPermissions(QFile::ReadUser | QFile::WriteUser)
+                            && file.write(attachmentData) == attachmentData.size();
         if (!saveOk) {
             errors.append(QString("%1 - %2").arg(filename, file.errorString()));
         }


### PR DESCRIPTION
I sometimes want to export an SSH key from a database and use it without having KeePassXC running (I mostly use the SSH agent integration, but in certain cases I want the key outside of the database).

But what happens in that case is that I get this warning:

```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
```

So I run `chmod 600` on the file and then continue on with my day.

But I think it would be appropriate if KeePassXC did this for me. After all, you may have things more sensitive than an SSH key and it is best if KeePassXC does whatever it can to keep those things private.

I wanted `file.setPermissions` to be run before `file.write` so that the permissions are set before the contents are written. But this would mean that an error would appear if you can't set the permissions for some reason, but I don't know if this is even a possible scenario.

## Testing strategy

I compiled KeePassXC and exported files and made sure that the permission bits are set as expected.

```
$ ls -l id_rsa
-rw-------  1 stefan staff       1294 Apr  1 18:42  id_rsa
```

## Type of change
- ✅ New feature (change that adds functionality)

## P.S.

The page https://github.com/keepassxreboot/keepassxc/wiki/Set-up-Build-Environment-on-Linux says that `libqt5x11extras5-dev` is an optional dependency, but it appears to be required now. If that's intended then the page should be updated.
