### PR TITLE
Auto-Type: PageUp/PageDown scrolling for entries

### DIFF
--- a/src/autotype/AutoTypeMatchView.cpp
+++ b/src/autotype/AutoTypeMatchView.cpp
@@ -73,9 +73,13 @@ void AutoTypeMatchView::keyPressEvent(QKeyEvent* event)
 {
     if ((event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) && currentIndex().isValid()) {
         emit matchActivated(matchFromIndex(currentIndex()));
+    } else if (event->key() == Qt::Key_PageUp) {
+        moveSelection(-5);
+    } else if (event->key() == Qt::Key_PageDown) {
+        moveSelection(5);
+    } else {
+        QTableView::keyPressEvent(event);
     }
-
-    QTableView::keyPressEvent(event);
 }
 
 void AutoTypeMatchView::setMatchList(const QList<AutoTypeMatch>& matches, bool selectFirst)
@@ -99,6 +103,13 @@ void AutoTypeMatchView::filterList(const QString& filter)
 {
     m_sortModel->setFilterWildcard(filter);
     setCurrentIndex(m_sortModel->index(0, 0));
+}
+
+void AutoTypeMatchView::moveSelection(int offset)
+{
+    auto index = currentIndex();
+    auto row = index.isValid() ? index.row() : -1;
+    selectRow(qBound(0, row + offset, model()->rowCount() - 1));
 }
 
 AutoTypeMatch AutoTypeMatchView::currentMatch()

--- a/src/autotype/AutoTypeMatchView.h
+++ b/src/autotype/AutoTypeMatchView.h
@@ -36,6 +36,7 @@ public:
     AutoTypeMatch matchFromIndex(const QModelIndex& index);
     void setMatchList(const QList<AutoTypeMatch>& matches, bool selectFirst);
     void filterList(const QString& filter);
+    void moveSelection(int offset);
 
 signals:
     void currentMatchChanged(AutoTypeMatch match);

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -147,33 +147,6 @@ void AutoTypeSelectDialog::performSearch()
     m_ui->view->setMatchList(matches, !m_ui->search->text().isEmpty());
 }
 
-void AutoTypeSelectDialog::moveSelectionUp()
-{
-    auto current = m_ui->view->currentIndex();
-    auto previous = current.sibling(current.row() - 1, 0);
-
-    if (previous.isValid()) {
-        m_ui->view->setCurrentIndex(previous);
-    }
-}
-
-void AutoTypeSelectDialog::moveSelectionDown()
-{
-    auto current = m_ui->view->currentIndex();
-
-    // special case where we have no default selection (empty search)
-    if (!current.isValid()) {
-        m_ui->view->setCurrentIndex(m_ui->view->indexAt({0, 0}));
-        return;
-    }
-
-    auto next = current.sibling(current.row() + 1, 0);
-
-    if (next.isValid()) {
-        m_ui->view->setCurrentIndex(next);
-    }
-}
-
 void AutoTypeSelectDialog::activateCurrentMatch()
 {
     submitAutoTypeMatch(m_ui->view->currentMatch());
@@ -217,10 +190,16 @@ bool AutoTypeSelectDialog::eventFilter(QObject* obj, QEvent* event)
             auto* keyEvent = static_cast<QKeyEvent*>(event);
             switch (keyEvent->key()) {
             case Qt::Key_Up:
-                moveSelectionUp();
+                m_ui->view->moveSelection(-1);
                 return true;
             case Qt::Key_Down:
-                moveSelectionDown();
+                m_ui->view->moveSelection(1);
+                return true;
+            case Qt::Key_PageUp:
+                m_ui->view->moveSelection(-5);
+                return true;
+            case Qt::Key_PageDown:
+                m_ui->view->moveSelection(5);
                 return true;
             case Qt::Key_Escape:
                 if (m_ui->search->text().isEmpty()) {

--- a/src/autotype/AutoTypeSelectDialog.h
+++ b/src/autotype/AutoTypeSelectDialog.h
@@ -52,8 +52,6 @@ protected:
 private slots:
     void submitAutoTypeMatch(AutoTypeMatch match);
     void performSearch();
-    void moveSelectionUp();
-    void moveSelectionDown();
     void activateCurrentMatch();
     void updateActionMenu(const AutoTypeMatch& match);
 


### PR DESCRIPTION
The original issue was likely related to subtle keyboard focus issues in the old dialog but since we explicitly focus in the new input field we can capture these keys in addition to arrows to emulate paging consistently on all platforms. We can't capture Home/End keys because it would conflict with line editing.

Number 5 was chosen by fair dice roll.

Fixes #4530

## Testing strategy
Manually on Linux.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
