### PR TITLE
SSH Agent: Allow using database path to resolve keys

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -701,6 +701,7 @@ bool EditEntryWidget::getOpenSSHKey(OpenSSHKey& key, bool decrypt)
 
     if (!settings.toOpenSSHKey(m_mainUi->usernameComboBox->lineEdit()->text(),
                                m_mainUi->passwordEdit->text(),
+                               m_db->filePath(),
                                m_advancedUi->attachmentsWidget->entryAttachments(),
                                key,
                                decrypt)) {

--- a/src/sshagent/KeeAgentSettings.h
+++ b/src/sshagent/KeeAgentSettings.h
@@ -44,6 +44,7 @@ public:
     bool toOpenSSHKey(const Entry* entry, OpenSSHKey& key, bool decrypt);
     bool toOpenSSHKey(const QString& username,
                       const QString& password,
+                      const QString& databasePath,
                       const EntryAttachments* attachments,
                       OpenSSHKey& key,
                       bool decrypt);


### PR DESCRIPTION
This slightly breaks the encapsulation of KeeAgentSettings now depending on SSHAgent for the global configuration option but it's not too bad.

This has a minor header include conflict with #6209 and can wait for it to be merged first.

I will do a class forwards declaration cleanup later for all SSH Agent stuff so this continues the tradition of including the classes for now.

Closes #5225

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
