### PR TITLE
SSH Agent: Add support for OpenSSH 8.2 FIDO/U2F keys

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -120,6 +120,14 @@
         <source>Use OpenSSH</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>SSH_SK_PROVIDER value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SSH_SK_PROVIDER override</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidget</name>
@@ -5472,6 +5480,14 @@ We recommend you use the AppImage available on our downloads page.</source>
         <source>Decryption failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unexpected EOF while reading key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsupported key part</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PasswordEdit</name>
@@ -7622,6 +7638,10 @@ Please consider generating a new key file.</source>
     </message>
     <message>
         <source>No agent running, cannot list identities.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Security keys are not supported by the agent or the security key provider is unavailable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -170,6 +170,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::SSHAgent_UseOpenSSH, {QS("SSHAgent/UseOpenSSH"), Roaming, false}},
     {Config::SSHAgent_UsePageant, {QS("SSHAgent/UsePageant"), Roaming, false} },
     {Config::SSHAgent_AuthSockOverride, {QS("SSHAgent/AuthSockOverride"), Local, {}}},
+    {Config::SSHAgent_SecurityKeyProviderOverride, {QS("SSHAgent/SecurityKeyProviderOverride"), Local, {}}},
 
     // FdoSecrets
     {Config::FdoSecrets_Enabled, {QS("FdoSecrets/Enabled"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -148,6 +148,7 @@ public:
         SSHAgent_UseOpenSSH,
         SSHAgent_UsePageant,
         SSHAgent_AuthSockOverride,
+        SSHAgent_SecurityKeyProviderOverride,
 
         FdoSecrets_Enabled,
         FdoSecrets_ShowNotification,

--- a/src/sshagent/ASN1Key.cpp
+++ b/src/sshagent/ASN1Key.cpp
@@ -109,18 +109,20 @@ bool ASN1Key::parseDSA(QByteArray& ba, OpenSSHKey& key)
     readInt(stream, y);
     readInt(stream, x);
 
-    QList<QByteArray> publicData;
-    publicData.append(p);
-    publicData.append(q);
-    publicData.append(g);
-    publicData.append(y);
+    QByteArray publicData;
+    BinaryStream publicDataStream(&publicData);
+    publicDataStream.writeString(p);
+    publicDataStream.writeString(q);
+    publicDataStream.writeString(g);
+    publicDataStream.writeString(y);
 
-    QList<QByteArray> privateData;
-    privateData.append(p);
-    privateData.append(q);
-    privateData.append(g);
-    privateData.append(y);
-    privateData.append(x);
+    QByteArray privateData;
+    BinaryStream privateDataStream(&privateData);
+    privateDataStream.writeString(p);
+    privateDataStream.writeString(q);
+    privateDataStream.writeString(g);
+    privateDataStream.writeString(y);
+    privateDataStream.writeString(x);
 
     key.setType("ssh-dss");
     key.setPublicData(publicData);
@@ -148,17 +150,19 @@ bool ASN1Key::parseRSA(QByteArray& ba, OpenSSHKey& key)
     readInt(stream, qinv);
 
     // Note: To properly calculate the key fingerprint, e and n are reversed per RFC 4253
-    QList<QByteArray> publicData;
-    publicData.append(e);
-    publicData.append(n);
+    QByteArray publicData;
+    BinaryStream publicDataStream(&publicData);
+    publicDataStream.writeString(e);
+    publicDataStream.writeString(n);
 
-    QList<QByteArray> privateData;
-    privateData.append(n);
-    privateData.append(e);
-    privateData.append(d);
-    privateData.append(qinv);
-    privateData.append(p);
-    privateData.append(q);
+    QByteArray privateData;
+    BinaryStream privateDataStream(&privateData);
+    privateDataStream.writeString(n);
+    privateDataStream.writeString(e);
+    privateDataStream.writeString(d);
+    privateDataStream.writeString(qinv);
+    privateDataStream.writeString(p);
+    privateDataStream.writeString(q);
 
     key.setType("ssh-rsa");
     key.setPublicData(publicData);

--- a/src/sshagent/AgentSettingsWidget.cpp
+++ b/src/sshagent/AgentSettingsWidget.cpp
@@ -55,6 +55,11 @@ void AgentSettingsWidget::loadSettings()
     auto sshAuthSockOverride = sshAgent()->authSockOverride();
     m_ui->sshAuthSockLabel->setText(sshAuthSock.isEmpty() ? tr("(empty)") : sshAuthSock);
     m_ui->sshAuthSockOverrideEdit->setText(sshAuthSockOverride);
+    auto sshSecurityKeyProvider = sshAgent()->securityKeyProvider(false);
+    auto sshSecurityKeyProviderOverride = sshAgent()->securityKeyProviderOverride();
+    m_ui->sshSecurityKeyProviderLabel->setText(sshSecurityKeyProvider.isEmpty() ? tr("(empty)")
+                                                                                : sshSecurityKeyProvider);
+    m_ui->sshSecurityKeyProviderOverrideEdit->setText(sshSecurityKeyProviderOverride);
 #endif
 
     m_ui->sshAuthSockMessageWidget->setVisible(sshAgentEnabled);
@@ -85,6 +90,8 @@ void AgentSettingsWidget::saveSettings()
 {
     auto sshAuthSockOverride = m_ui->sshAuthSockOverrideEdit->text();
     sshAgent()->setAuthSockOverride(sshAuthSockOverride);
+    auto sshSecurityKeyProviderOverride = m_ui->sshSecurityKeyProviderOverrideEdit->text();
+    sshAgent()->setSecurityKeyProviderOverride(sshSecurityKeyProviderOverride);
 #ifdef Q_OS_WIN
     sshAgent()->setUsePageant(m_ui->usePageantCheckBox->isChecked());
     sshAgent()->setUseOpenSSH(m_ui->useOpenSSHCheckBox->isChecked());

--- a/src/sshagent/AgentSettingsWidget.ui
+++ b/src/sshagent/AgentSettingsWidget.ui
@@ -100,6 +100,16 @@
         <property name="verticalSpacing">
          <number>8</number>
         </property>
+        <item row="1" column="0">
+         <widget class="QLabel" name="sshAuthSockOverrideLabel">
+          <property name="text">
+           <string>SSH_AUTH_SOCK override</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="sshAuthSockValueLabel">
           <property name="text">
@@ -110,15 +120,18 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="sshAuthSockOverrideLabel">
-          <property name="text">
-           <string>SSH_AUTH_SOCK override</string>
+        <item row="4" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
           </property>
-         </widget>
+         </spacer>
         </item>
         <item row="1" column="1">
          <widget class="QLineEdit" name="sshAuthSockOverrideEdit"/>
@@ -139,17 +152,42 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+         <widget class="QLabel" name="sshSecurityKeyProviderValueLabel">
+          <property name="text">
+           <string>SSH_SK_PROVIDER value</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
-         </spacer>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="sshSecurityKeyProviderLabel">
+          <property name="font">
+           <font>
+            <family>Monospace</family>
+           </font>
+          </property>
+          <property name="text">
+           <string>(empty)</string>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="sshSecurityKeyProviderOverrideLabel">
+          <property name="text">
+           <string>SSH_SK_PROVIDER override</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLineEdit" name="sshSecurityKeyProviderOverrideEdit"/>
         </item>
        </layout>
       </item>

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -473,6 +473,8 @@ bool OpenSSHKey::readPublic(BinaryStream& stream)
         { "ecdsa-sha2-nistp384",                {STR_PART, STR_PART} },
         { "ecdsa-sha2-nistp521",                {STR_PART, STR_PART} },
         { "ssh-ed25519",                        {STR_PART} },
+        { "sk-ecdsa-sha2-nistp256@openssh.com", {STR_PART, STR_PART, STR_PART} },
+        { "sk-ssh-ed25519@openssh.com",         {STR_PART, STR_PART} },
     };
     // clang-format on
 
@@ -502,6 +504,8 @@ bool OpenSSHKey::readPrivate(BinaryStream& stream)
         { "ecdsa-sha2-nistp384",                {STR_PART, STR_PART, STR_PART} },
         { "ecdsa-sha2-nistp521",                {STR_PART, STR_PART, STR_PART} },
         { "ssh-ed25519",                        {STR_PART, STR_PART} },
+        { "sk-ecdsa-sha2-nistp256@openssh.com", {STR_PART, STR_PART, STR_PART, UINT8_PART, STR_PART, STR_PART} },
+        { "sk-ssh-ed25519@openssh.com",         {STR_PART, STR_PART, UINT8_PART, STR_PART, STR_PART} },
     };
     // clang-format on
 

--- a/src/sshagent/OpenSSHKey.h
+++ b/src/sshagent/OpenSSHKey.h
@@ -60,6 +60,13 @@ public:
     static const QString TYPE_OPENSSH_PRIVATE;
 
 private:
+    enum KeyPart
+    {
+        STR_PART,
+        UINT8_PART
+    };
+    bool readKeyParts(BinaryStream& in, const QList<KeyPart> parts, BinaryStream& out);
+
     bool extractPEM(const QByteArray& in, QByteArray& out);
 
     QString m_type;

--- a/src/sshagent/OpenSSHKey.h
+++ b/src/sshagent/OpenSSHKey.h
@@ -44,8 +44,8 @@ public:
     const QString errorString() const;
 
     void setType(const QString& type);
-    void setPublicData(const QList<QByteArray>& data);
-    void setPrivateData(const QList<QByteArray>& data);
+    void setPublicData(const QByteArray& data);
+    void setPrivateData(const QByteArray& data);
     void setComment(const QString& comment);
 
     void clearPrivate();
@@ -70,8 +70,8 @@ private:
 
     QString m_rawType;
     QByteArray m_rawData;
-    QList<QByteArray> m_rawPublicData;
-    QList<QByteArray> m_rawPrivateData;
+    QByteArray m_rawPublicData;
+    QByteArray m_rawPrivateData;
     QString m_comment;
     QString m_error;
 };

--- a/src/sshagent/SSHAgent.h
+++ b/src/sshagent/SSHAgent.h
@@ -37,8 +37,11 @@ public:
     bool isEnabled() const;
     void setEnabled(bool enabled);
     QString socketPath(bool allowOverride = true) const;
+    QString securityKeyProvider(bool allowOverride = true) const;
     QString authSockOverride() const;
+    QString securityKeyProviderOverride() const;
     void setAuthSockOverride(QString& authSockOverride);
+    void setSecurityKeyProviderOverride(QString& securityKeyProviderOverride);
 #ifdef Q_OS_WIN
     bool useOpenSSH() const;
     bool usePageant() const;
@@ -74,6 +77,7 @@ private:
 
     const quint8 SSH_AGENT_CONSTRAIN_LIFETIME = 1;
     const quint8 SSH_AGENT_CONSTRAIN_CONFIRM = 2;
+    const quint8 SSH_AGENT_CONSTRAIN_EXTENSION = 255;
 
     bool sendMessage(const QByteArray& in, QByteArray& out);
     bool sendMessageOpenSSH(const QByteArray& in, QByteArray& out);

--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -256,6 +256,80 @@ void TestOpenSSHKey::testParseRSACompare()
     QCOMPARE(oldPrivateKey, newPrivateKey);
 }
 
+void TestOpenSSHKey::testParseECDSA256()
+{
+    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                                      "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS\n"
+                                      "1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQT461x/QlaUUc+H7BxfI5CFXvcMGXA7\n"
+                                      "Wp/U/2sfTMuKWUHumBJyjGM4/wJ9V1EldWp3e4MqH2oztQBDoXNlUsn9AAAAwP2/iHH9v4\n"
+                                      "hxAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPjrXH9CVpRRz4fs\n"
+                                      "HF8jkIVe9wwZcDtan9T/ax9My4pZQe6YEnKMYzj/An1XUSV1and7gyofajO1AEOhc2VSyf\n"
+                                      "0AAAAhAIS/QBNpB92hLjYQjpfjguDRkRDYqL6mMbNqX9/5o9fsAAAAIm9wZW5zc2hrZXkt\n"
+                                      "dGVzdC1lY2RzYTI1NkBrZWVwYXNzeGMBAgMEBQ==\n"
+                                      "-----END OPENSSH PRIVATE KEY-----\n");
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parsePKCS1PEM(keyData));
+    QVERIFY(!key.encrypted());
+    QCOMPARE(key.cipherName(), QString("none"));
+    QCOMPARE(key.type(), QString("ecdsa-sha2-nistp256"));
+    QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa256@keepassxc"));
+    QCOMPARE(key.fingerprint(), QString("SHA256:nwwovZmQbBeiR3GZRpK4OWHgCUE7E0wFtCN7Ng7eX5g"));
+}
+
+void TestOpenSSHKey::testParseECDSA384()
+{
+    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                                      "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAiAAAABNlY2RzYS\n"
+                                      "1zaGEyLW5pc3RwMzg0AAAACG5pc3RwMzg0AAAAYQSLw/MlwQSW/y+mD9KpoXkoHLK88uKJ\n"
+                                      "hD8HLTNpJ+fdIP24Z6w4vJeddJo/dmsl945UwMzIaHA5DPQmUyAIAcId8wTZRF9xqRpaQI\n"
+                                      "uegjFVkxyusj5edC4qNaRKF4V6tTcAAADwdh56A3YeegMAAAATZWNkc2Etc2hhMi1uaXN0\n"
+                                      "cDM4NAAAAAhuaXN0cDM4NAAAAGEEi8PzJcEElv8vpg/SqaF5KByyvPLiiYQ/By0zaSfn3S\n"
+                                      "D9uGesOLyXnXSaP3ZrJfeOVMDMyGhwOQz0JlMgCAHCHfME2URfcakaWkCLnoIxVZMcrrI+\n"
+                                      "XnQuKjWkSheFerU3AAAAMCECw8BmZ1isLTJnOVcHoohmtfXr4lzCbSOWkQH5tPlo2tntUd\n"
+                                      "5u1XXrWlo9+5nrAgAAACJvcGVuc3Noa2V5LXRlc3QtZWNkc2EzODRAa2VlcGFzc3hjAQID\n"
+                                      "BAUG\n"
+                                      "-----END OPENSSH PRIVATE KEY-----\n");
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parsePKCS1PEM(keyData));
+    QVERIFY(!key.encrypted());
+    QCOMPARE(key.cipherName(), QString("none"));
+    QCOMPARE(key.type(), QString("ecdsa-sha2-nistp384"));
+    QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa384@keepassxc"));
+    QCOMPARE(key.fingerprint(), QString("SHA256:B5tLMG976BZ6nyi/oRUmKaTJcaEaFagEjBfOAgru0OY"));
+}
+
+void TestOpenSSHKey::testParseECDSA521()
+{
+    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                                      "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAArAAAABNlY2RzYS\n"
+                                      "1zaGEyLW5pc3RwNTIxAAAACG5pc3RwNTIxAAAAhQQBIxaAOfN2yDEHakGVzGfTTzhqwLYf\n"
+                                      "7lcOgVpSSbjsDylAV9l+Pd0yBNmf/WqLWN9nzmDaSf2KqGm1HjSKgF+kt60BOyMqNIY1g/\n"
+                                      "o6jg4lgKnGiAsIo3bePzYyHBH9EC6aX2mLnCm6v/bJL4AEKuzamRlj+R/juQYFIolLJ6OS\n"
+                                      "rg6Wn/UAAAEg4p6+WOKevlgAAAATZWNkc2Etc2hhMi1uaXN0cDUyMQAAAAhuaXN0cDUyMQ\n"
+                                      "AAAIUEASMWgDnzdsgxB2pBlcxn0084asC2H+5XDoFaUkm47A8pQFfZfj3dMgTZn/1qi1jf\n"
+                                      "Z85g2kn9iqhptR40ioBfpLetATsjKjSGNYP6Oo4OJYCpxogLCKN23j82MhwR/RAuml9pi5\n"
+                                      "wpur/2yS+ABCrs2pkZY/kf47kGBSKJSyejkq4Olp/1AAAAQgC4lKZk989FOK7axlAsF3Da\n"
+                                      "H8/Ejk2o+aGOGIxe4UU3nw1QnWG0RhBsIkSir10ZBcKklg0coqcBqPQrwYc8GHBoxgAAAC\n"
+                                      "JvcGVuc3Noa2V5LXRlc3QtZWNkc2E1MjFAa2VlcGFzc3hj\n"
+                                      "-----END OPENSSH PRIVATE KEY-----\n");
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parsePKCS1PEM(keyData));
+    QVERIFY(!key.encrypted());
+    QCOMPARE(key.cipherName(), QString("none"));
+    QCOMPARE(key.type(), QString("ecdsa-sha2-nistp521"));
+    QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa521@keepassxc"));
+    QCOMPARE(key.fingerprint(), QString("SHA256:m3LtA9MtZW8FN0R3vwA0AAI+YtegbggGCy3EGKWya+s"));
+}
+
 void TestOpenSSHKey::testDecryptOpenSSHAES256CBC()
 {
     const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"

--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -509,3 +509,52 @@ void TestOpenSSHKey::testDecryptUTF8()
     QCOMPARE(key.type(), QString("ssh-ed25519"));
     QCOMPARE(key.comment(), QString("opensshkey-test-utf8@keepassxc"));
 }
+
+void TestOpenSSHKey::testParseECDSASecurityKey()
+{
+    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                                      "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAfwAAACJzay1lY2\n"
+                                      "RzYS1zaGEyLW5pc3RwMjU2QG9wZW5zc2guY29tAAAACG5pc3RwMjU2AAAAQQQ2Pr1d6zUa\n"
+                                      "qcmYgjTGQUF9QPkFEo2Q7aQbvyL/0KL9FObuOfzqxs8mDqswXEsXR4g5L6P7vEe6nPqzSW\n"
+                                      "X9/jJfAAAABHNzaDoAAAD4kyJ795Mie/cAAAAic2stZWNkc2Etc2hhMi1uaXN0cDI1NkBv\n"
+                                      "cGVuc3NoLmNvbQAAAAhuaXN0cDI1NgAAAEEENj69Xes1GqnJmII0xkFBfUD5BRKNkO2kG7\n"
+                                      "8i/9Ci/RTm7jn86sbPJg6rMFxLF0eIOS+j+7xHupz6s0ll/f4yXwAAAARzc2g6AQAAAEA4\n"
+                                      "Dbqd2ub7R1QQRm8nBZWDGJSiNIh58vvJ4EuAh0FnJsRvvASsSDiGuuXqh56wT5xmlnYvbb\n"
+                                      "nLWO4/1+Mp5PaDAAAAAAAAACJvcGVuc3Noa2V5LXRlc3QtZWNkc2Etc2tAa2VlcGFzc3hj\n"
+                                      "AQI=\n"
+                                      "-----END OPENSSH PRIVATE KEY-----\n");
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parsePKCS1PEM(keyData));
+    QVERIFY(!key.encrypted());
+    QCOMPARE(key.cipherName(), QString("none"));
+    QCOMPARE(key.type(), QString("sk-ecdsa-sha2-nistp256@openssh.com"));
+    QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa-sk@keepassxc"));
+    QCOMPARE(key.fingerprint(), QString("SHA256:ctOtAsPMqbtumGI41o2oeWfGDah4m1ACILRj+x0gx0E"));
+}
+
+void TestOpenSSHKey::testParseED25519SecurityKey()
+{
+    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                                      "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAASgAAABpzay1zc2\n"
+                                      "gtZWQyNTUxOUBvcGVuc3NoLmNvbQAAACCSIfzsjUBlhsVBfHHlQCUpj1Yt+404RetvfTnd\n"
+                                      "DJIIqgAAAARzc2g6AAABCN1MUOzdTFDsAAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY2\n"
+                                      "9tAAAAIJIh/OyNQGWGxUF8ceVAJSmPVi37jThF6299Od0MkgiqAAAABHNzaDoBAAAAgF+0\n"
+                                      "UB3uNf48T/u9eSHmhfTfqgZZZxQ81UQmlw9Xw1eNZ2F+y+JwbQYK3gLMxro2cv2PHgYqIW\n"
+                                      "MAHFxdJjUn62D88bywmHaFT7ftu8/4bh38G+aQsmTFW38li97FiLz+Ytz0X9oSCo1jerkC\n"
+                                      "fYe8pcZZ7zWWSMzRnZKP11QMEkEQAAAAAAAAACRvcGVuc3Noa2V5LXRlc3QtZWQyNTUxOS\n"
+                                      "1za0BrZWVwYXNzeGMBAgMEBQ==\n"
+                                      "-----END OPENSSH PRIVATE KEY-----\n");
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parsePKCS1PEM(keyData));
+    QVERIFY(!key.encrypted());
+    QCOMPARE(key.cipherName(), QString("none"));
+    QCOMPARE(key.type(), QString("sk-ssh-ed25519@openssh.com"));
+    QCOMPARE(key.comment(), QString("opensshkey-test-ed25519-sk@keepassxc"));
+    QCOMPARE(key.fingerprint(), QString("SHA256:PGtS5WvbnYmNqFIeRbzO6cVP9GLh8eEzENgkHp02XIA"));
+}

--- a/tests/TestOpenSSHKey.h
+++ b/tests/TestOpenSSHKey.h
@@ -41,6 +41,8 @@ private slots:
     void testDecryptOpenSSHAES256CTR();
     void testDecryptRSAAES256CTR();
     void testDecryptUTF8();
+    void testParseECDSASecurityKey();
+    void testParseED25519SecurityKey();
 };
 
 #endif // TESTOPENSSHKEY_H

--- a/tests/TestOpenSSHKey.h
+++ b/tests/TestOpenSSHKey.h
@@ -32,6 +32,9 @@ private slots:
     void testParseDSA();
     void testParseRSA();
     void testParseRSACompare();
+    void testParseECDSA256();
+    void testParseECDSA384();
+    void testParseECDSA521();
     void testDecryptRSAAES128CBC();
     void testDecryptOpenSSHAES256CBC();
     void testDecryptRSAAES256CBC();


### PR DESCRIPTION
Finally closes #4334 :sweat_smile: 

Shout-out to @yubico for sending me keys with up-to-date firmware to properly test this!

## Testing strategy
Manual tests with Yubikeys on Linux. Automated tests for the in-wire format.

This needs to be tested by people with Yubikeys other than me before merging.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
