### PR TITLE
Fix unlocking multiple databases with pw-stdin when input is a pipe

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,9 @@ int main(int argc, char** argv)
 #endif
 
     const bool pwstdin = parser.isSet(pwstdinOption);
+    if (!fileNames.isEmpty() && pwstdin) {
+        Utils::setDefaultTextStreams();
+    }
     for (const QString& filename : fileNames) {
         QString password;
         if (pwstdin) {
@@ -173,7 +176,6 @@ int main(int argc, char** argv)
             // buffer for native messaging, even if the specified file does not exist
             QTextStream out(stdout, QIODevice::WriteOnly);
             out << QObject::tr("Database password: ") << flush;
-            Utils::setDefaultTextStreams();
             password = Utils::getPassword();
         }
 


### PR DESCRIPTION
This works:

```
$ keepassxc test1.kdbx test2.kdbx --pw-stdin
Database password: <manual input 1234>
Database password: <manual input 4321>
```

But this doesn't (only `test1.kdbx` is unlocked):

```
$ printf '%s\n' 1234 4321 | keepassxc test1.kdbx test2.kdbx --pw-stdin
Database password:
Database password:
```

The problem is that `Utils::setDefaultTextStreams()` is called multiple times when unlocking multiple databases with `--pw-stdin`, which appears to break the pipe. Simply call it once to avoid the problem.

Fixes: #5012 (as far as I can tell by simulating the script in Linux)

## Screenshots

Before the fix:
![beforefix](https://user-images.githubusercontent.com/519004/113905302-4c5d2b00-97d3-11eb-898d-3318995aee76.png)

After the fix:
![afterfix](https://user-images.githubusercontent.com/519004/113905309-4e26ee80-97d3-11eb-85de-3aa214aab72b.png)

## Testing strategy

Tested manually on Linux. The code change is trivial as well:
* In case only one database is unlocked, the same calls are done, just slightly reordered.
* In case multiple databases are unlocked (the fixed case), it is clear that calling `Utils::setDefaultTextStreams` multiple times is unnecessary.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
