### PR TITLE
Do not return unnecessary copy of QSharedPointer. Fixes #6393.

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -237,7 +237,7 @@ DatabaseWidget::~DatabaseWidget()
     delete m_EntrySearcher;
 }
 
-QSharedPointer<Database> DatabaseWidget::database() const
+const QSharedPointer<Database> &DatabaseWidget::database() const
 {
     return m_db;
 }

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -78,7 +78,7 @@ public:
 
     void setFocus(Qt::FocusReason reason);
 
-    QSharedPointer<Database> database() const;
+    const QSharedPointer<Database> &database() const;
 
     DatabaseWidget::Mode currentMode() const;
     bool isLocked() const;


### PR DESCRIPTION
When `DatabaseWidget::database()` is accessed during `DatabaseWidget`'s destruction, e.g., from a slot connected to the `Database`,
the `QSharedPointer` may be copied while it's executing its destructor.

This may trigger a Qt bug in some Qt version:
Even though a copy is created, the original QSharedPointer carries on its destruction, causing double delete error later when the copied QSharedPointer goes out of scope.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
I can't actually reproduce the crash locally. I guess the bug is Qt version specific.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
