### PR TITLE
Improve description text when changing Key File credential

### DIFF
--- a/src/gui/databasekey/KeyFileEditWidget.cpp
+++ b/src/gui/databasekey/KeyFileEditWidget.cpp
@@ -40,7 +40,7 @@ KeyFileEditWidget::~KeyFileEditWidget()
 bool KeyFileEditWidget::addToCompositeKey(QSharedPointer<CompositeKey> key)
 {
     auto fileKey = QSharedPointer<FileKey>::create();
-    QString fileKeyName = m_compUi->keyFileCombo->currentText();
+    QString fileKeyName = m_compUi->keyFileLineEdit->text();
     if (!fileKey->load(fileKeyName, nullptr)) {
         return false;
     }
@@ -62,7 +62,7 @@ bool KeyFileEditWidget::validate(QString& errorMessage) const
 {
     FileKey fileKey;
     QString fileKeyError;
-    QString fileKeyName = m_compUi->keyFileCombo->currentText();
+    QString fileKeyName = m_compUi->keyFileLineEdit->text();
     if (!fileKey.load(fileKeyName, &fileKeyError)) {
         errorMessage = tr("Error loading the key file '%1'\nMessage: %2").arg(fileKeyName, fileKeyError);
         return false;
@@ -85,7 +85,7 @@ void KeyFileEditWidget::initComponentEditWidget(QWidget* widget)
 {
     Q_UNUSED(widget);
     Q_ASSERT(m_compEditWidget);
-    m_compUi->keyFileCombo->setFocus();
+    m_compUi->keyFileLineEdit->setFocus();
 }
 
 void KeyFileEditWidget::initComponent()
@@ -120,7 +120,7 @@ void KeyFileEditWidget::createKeyFile()
                                  tr("Unable to create key file: %1").arg(errorMsg),
                                  QMessageBox::Button::Ok);
         } else {
-            m_compUi->keyFileCombo->setEditText(fileName);
+            m_compUi->keyFileLineEdit->setText(fileName);
         }
     }
 }
@@ -155,6 +155,6 @@ void KeyFileEditWidget::browseKeyFile()
     }
 
     if (!fileName.isEmpty()) {
-        m_compUi->keyFileCombo->setEditText(fileName);
+        m_compUi->keyFileLineEdit->setText(fileName);
     }
 }

--- a/src/gui/databasekey/KeyFileEditWidget.ui
+++ b/src/gui/databasekey/KeyFileEditWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>370</width>
-    <height>76</height>
+    <width>566</width>
+    <height>94</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -23,33 +23,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QComboBox" name="keyFileCombo">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="accessibleName">
-      <string>Key file selection</string>
-     </property>
-     <property name="editable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
-    <widget class="QPushButton" name="browseKeyFileButton">
-     <property name="accessibleName">
-      <string>Browse for key file</string>
-     </property>
-     <property name="text">
-      <string>Browse…</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
     <widget class="QPushButton" name="createKeyFileButton">
      <property name="accessibleName">
       <string>Generate a new key file</string>
@@ -59,31 +33,58 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="0" column="0">
+    <widget class="QLabel" name="instructions">
+     <property name="text">
+      <string>Generate a new key file or choose an existing one to protect your database.</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
-    </spacer>
+    </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
+   <item row="3" column="0">
+    <widget class="QLabel" name="instructions_2">
      <property name="font">
       <font>
        <italic>true</italic>
       </font>
      </property>
      <property name="text">
-      <string>Note: Do not use a file that may change as that will prevent you from unlocking your database!</string>
+      <string>Note: Do NOT use a file that may change as that will prevent you from unlocking your database.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLineEdit" name="keyFileLineEdit">
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="browseKeyFileButton">
+     <property name="accessibleName">
+      <string>Browse for key file</string>
+     </property>
+     <property name="text">
+      <string>Browse…</string>
      </property>
     </widget>
    </item>

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -278,15 +278,15 @@ void TestGui::testCreateDatabase()
         QTRY_VERIFY(!additionalOptionsButton->isVisible());
         QCOMPARE(passwordWidget->visiblePage(), KeyFileEditWidget::Page::Edit);
         QTest::mouseClick(keyFileWidget->findChild<QPushButton*>("addButton"), Qt::MouseButton::LeftButton);
-        auto* fileCombo = keyFileWidget->findChild<QComboBox*>("keyFileCombo");
-        QTRY_VERIFY(fileCombo);
-        QTRY_VERIFY(fileCombo->isVisible());
+        auto* fileEdit = keyFileWidget->findChild<QLineEdit*>("keyFileLineEdit");
+        QTRY_VERIFY(fileEdit);
+        QTRY_VERIFY(fileEdit->isVisible());
         fileDialog()->setNextFileName(QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
         QTest::keyClick(keyFileWidget->findChild<QPushButton*>("addButton"), Qt::Key::Key_Enter);
-        QVERIFY(fileCombo->hasFocus());
+        QVERIFY(fileEdit->hasFocus());
         auto* browseButton = keyFileWidget->findChild<QPushButton*>("browseKeyFileButton");
         QTest::keyClick(browseButton, Qt::Key::Key_Enter);
-        QCOMPARE(fileCombo->currentText(), QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
+        QCOMPARE(fileEdit->text(), QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
 
         // save database to temporary file
         TemporaryFile tmpFile;
@@ -294,7 +294,7 @@ void TestGui::testCreateDatabase()
         tmpFile.close();
         fileDialog()->setNextFileName(tmpFile.fileName());
 
-        QTest::keyClick(fileCombo, Qt::Key::Key_Enter);
+        QTest::keyClick(fileEdit, Qt::Key::Key_Enter);
         tmpFile.remove(););
 
     triggerAction("actionDatabaseNew");


### PR DESCRIPTION
The current text and the three buttons available are confusing.
It is unclear whether one should Browse current master key file
or type in a new-one and click Generate ... Make it clear what
happens.

Ideally, the "Key File" could be replaced with "Master Key File"
and the path on the "Browse" line should show in grey path to the
current keyfile.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
