### PR TITLE
Add CTRL+Enter to apply password generator changes

### DIFF
--- a/docs/topics/PasswordGenerator.adoc
+++ b/docs/topics/PasswordGenerator.adoc
@@ -22,10 +22,11 @@ image::password_generator.png[]
 5. Use the regenerate button (Ctrl + R) to make a new password using the chosen options.
 6. Use the clipboard button (Ctrl + C) to copy the generated password to the clipboard.
 // tag::advanced[]
-7.	Click the Advanced button to specify additional conditions for your desired password.
+7. Click the Advanced button to specify additional conditions for your desired password.
 +
 .Advanced Password Generator Options
 image::password_generator_advanced.png[]
+8. When generating a password for an entry, click the Apply Password button (Ctrl + S or Ctrl + Enter) to close the window and apply your changes.
 
 === Generating Passphrases
 A passphrase is a sequence of words or other text used to control access to your applications and data. A passphrase is similar to a password in usage, but is generally longer for added security. To generate the random passphrase using Password Generator, perform the following steps:
@@ -40,5 +41,6 @@ Word Count slider.
 3. In the Word Separator field, enter a character, word, number, or space that you want to use a separator between the words in your passphrase.
 4. Click the Regenerate button (Ctrl + R) to generate a new random passphrase.
 5. Click the Clipboard button (Ctrl + C) to copy the passphrase to the clipboard.
+6. When generating a password for an entry, click the Apply Password button (Ctrl + S or Ctrl + Enter) to close the window and apply your changes.
 // end::advanced[]
 // end::content[]

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -22,6 +22,7 @@
 #include <QDir>
 #include <QKeyEvent>
 #include <QLineEdit>
+#include <QShortcut>
 #include <QTimer>
 
 #include "core/Config.h"
@@ -45,6 +46,12 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
         tr("Regenerate password (%1)").arg(m_ui->buttonGenerate->shortcut().toString(QKeySequence::NativeText)));
     m_ui->buttonCopy->setIcon(icons()->icon("clipboard-text"));
     m_ui->buttonClose->setShortcut(Qt::Key_Escape);
+
+    // Add two shortcuts to save the form CTRL+Enter and CTRL+S
+    auto shortcut = new QShortcut(Qt::CTRL + Qt::Key_Return, this);
+    connect(shortcut, &QShortcut::activated, this, [this] { applyPassword(); });
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_S, this);
+    connect(shortcut, &QShortcut::activated, this, [this] { applyPassword(); });
 
     connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updateButtonsEnabled(QString)));
     connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updatePasswordStrength(QString)));

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -933,9 +933,6 @@ QProgressBar::chunk {
        <property name="text">
         <string>Apply Password</string>
        </property>
-       <property name="shortcut">
-        <string>Ctrl+S</string>
-       </property>
        <property name="default">
         <bool>true</bool>
        </property>


### PR DESCRIPTION
add the shortcut CTRL+Enter as an option (on top of the current CTRL+S)
to close the Password Generator widget and apply the changes.

Closes #6111 

Assuming desired backwards compatibility and keeping the CTRL+S shortcut

Checklist:

- [x] Implement functionality
- [x] Document functionality

## Testing strategy

How can I test this? @droidmonkey @phoerious 

## Type of change
- ✅ New feature (change that adds functionality)
- ✅ Documentation (non-code change)
