### PR TITLE
Allow the Group column to be toggled for entry view. Fixes #6163

### DIFF
--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -96,7 +96,7 @@ EntryView::EntryView(QWidget* parent)
     // column index as data
     m_columnActions = new QActionGroup(this);
     m_columnActions->setExclusive(false);
-    for (int visualIndex = 1; visualIndex < header()->count(); ++visualIndex) {
+    for (int visualIndex = 0; visualIndex < header()->count(); ++visualIndex) {
         int logicalIndex = header()->logicalIndex(visualIndex);
         QString caption = m_model->headerData(logicalIndex, Qt::Horizontal, Qt::DisplayRole).toString();
         if (caption.isEmpty()) {


### PR DESCRIPTION
This allows to show/hide the group column both in normal and search
mode, finding a compromise for issue #6163

## Screenshots
Search view:

<img width="553" alt="Screenshot 2021-04-17 at 09 15 58" src="https://user-images.githubusercontent.com/867299/115105209-b016ef00-9f5d-11eb-86e0-2af41a3a6a51.png">
<img width="559" alt="Screenshot 2021-04-17 at 09 15 45" src="https://user-images.githubusercontent.com/867299/115105211-b1e0b280-9f5d-11eb-93d3-a0f5bbb72b9b.png">

Main view:

<img width="532" alt="Screenshot 2021-04-17 at 09 15 20" src="https://user-images.githubusercontent.com/867299/115105212-b2794900-9f5d-11eb-9705-1ae2ad2bd7a6.png">
<img width="497" alt="Screenshot 2021-04-17 at 09 15 05" src="https://user-images.githubusercontent.com/867299/115105213-b311df80-9f5d-11eb-9ece-56d6acab4f2c.png">


## Testing strategy
Should not affect current status of testing


## Type of change
- ✅ New feature (change that adds functionality)
