### PR TITLE
Properly block modified signal during Database destruction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ set(keepassx_SOURCES
         core/InactivityTimer.cpp
         core/Merger.cpp
         core/Metadata.cpp
+        core/ModifiableObject.cpp
         core/PasswordGenerator.cpp
         core/PasswordHealth.cpp
         core/PassphraseGenerator.cpp

--- a/src/core/AutoTypeAssociations.cpp
+++ b/src/core/AutoTypeAssociations.cpp
@@ -28,7 +28,7 @@ bool AutoTypeAssociations::Association::operator!=(const AutoTypeAssociations::A
 }
 
 AutoTypeAssociations::AutoTypeAssociations(QObject* parent)
-    : QObject(parent)
+    : ModifiableObject(parent)
 {
 }
 
@@ -41,7 +41,7 @@ void AutoTypeAssociations::copyDataFrom(const AutoTypeAssociations* other)
     emit aboutToReset();
     m_associations = other->m_associations;
     emit reset();
-    emit modified();
+    emitModified();
 }
 
 void AutoTypeAssociations::add(const AutoTypeAssociations::Association& association)
@@ -50,7 +50,7 @@ void AutoTypeAssociations::add(const AutoTypeAssociations::Association& associat
     emit aboutToAdd(index);
     m_associations.append(association);
     emit added(index);
-    emit modified();
+    emitModified();
 }
 
 void AutoTypeAssociations::remove(int index)
@@ -60,7 +60,7 @@ void AutoTypeAssociations::remove(int index)
     emit aboutToRemove(index);
     m_associations.removeAt(index);
     emit removed(index);
-    emit modified();
+    emitModified();
 }
 
 void AutoTypeAssociations::removeEmpty()
@@ -81,7 +81,7 @@ void AutoTypeAssociations::update(int index, const AutoTypeAssociations::Associa
     if (m_associations.at(index) != association) {
         m_associations[index] = association;
         emit dataChanged(index);
-        emit modified();
+        emitModified();
     }
 }
 

--- a/src/core/AutoTypeAssociations.h
+++ b/src/core/AutoTypeAssociations.h
@@ -18,9 +18,9 @@
 #ifndef KEEPASSX_AUTOTYPEASSOCIATIONS_H
 #define KEEPASSX_AUTOTYPEASSOCIATIONS_H
 
-#include <QObject>
+#include "core/ModifiableObject.h"
 
-class AutoTypeAssociations : public QObject
+class AutoTypeAssociations : public ModifiableObject
 {
     Q_OBJECT
 
@@ -53,7 +53,6 @@ private:
     QList<AutoTypeAssociations::Association> m_associations;
 
 signals:
-    void modified();
     void dataChanged(int index);
     void aboutToAdd(int index);
     void added(int index);

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -27,7 +27,7 @@ const QString CustomData::BrowserLegacyKeyPrefix = QStringLiteral("Public Key: "
 const QString CustomData::ExcludeFromReports = QStringLiteral("KnownBad");
 
 CustomData::CustomData(QObject* parent)
-    : QObject(parent)
+    : ModifiableObject(parent)
 {
 }
 
@@ -68,7 +68,7 @@ void CustomData::set(const QString& key, const QString& value)
     if (addAttribute || changeValue) {
         m_data.insert(key, value);
         updateLastModified();
-        emit customDataModified();
+        emitModified();
     }
 
     if (addAttribute) {
@@ -84,7 +84,7 @@ void CustomData::remove(const QString& key)
 
     updateLastModified();
     emit removed(key);
-    emit customDataModified();
+    emitModified();
 }
 
 void CustomData::rename(const QString& oldKey, const QString& newKey)
@@ -104,7 +104,7 @@ void CustomData::rename(const QString& oldKey, const QString& newKey)
     m_data.insert(newKey, data);
 
     updateLastModified();
-    emit customDataModified();
+    emitModified();
     emit renamed(oldKey, newKey);
 }
 
@@ -120,7 +120,7 @@ void CustomData::copyDataFrom(const CustomData* other)
 
     updateLastModified();
     emit reset();
-    emit customDataModified();
+    emitModified();
 }
 
 QDateTime CustomData::getLastModified() const
@@ -153,7 +153,7 @@ void CustomData::clear()
     m_data.clear();
 
     emit reset();
-    emit customDataModified();
+    emitModified();
 }
 
 bool CustomData::isEmpty() const

--- a/src/core/CustomData.h
+++ b/src/core/CustomData.h
@@ -23,7 +23,9 @@
 #include <QSet>
 #include <QStringList>
 
-class CustomData : public QObject
+#include "core/ModifiableObject.h"
+
+class CustomData : public ModifiableObject
 {
     Q_OBJECT
 
@@ -54,7 +56,6 @@ public:
     static const QString ExcludeFromReports;
 
 signals:
-    void customDataModified();
     void aboutToBeAdded(const QString& key);
     void added(const QString& key);
     void aboutToBeRemoved(const QString& key);
@@ -63,7 +64,6 @@ signals:
     void renamed(const QString& oldKey, const QString& newKey);
     void aboutToBeReset();
     void reset();
-    void lastModified();
 
 private slots:
     void updateLastModified();

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -57,8 +57,8 @@ Database::Database()
 
     connect(m_metadata, &Metadata::modified, this, &Database::markAsModified);
     connect(&m_modifiedTimer, &QTimer::timeout, this, &Database::emitModified);
-    connect(this, SIGNAL(databaseOpened()), SLOT(updateCommonUsernames()));
-    connect(this, SIGNAL(databaseSaved()), SLOT(updateCommonUsernames()));
+    connect(this, &Database::databaseOpened, this, [this]() { updateCommonUsernames(); });
+    connect(this, &Database::databaseSaved, this, [this]() { updateCommonUsernames(); });
     connect(m_fileWatcher, &FileWatcher::fileChanged, this, &Database::databaseFileChanged);
 
     m_modified = false;

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -84,7 +84,6 @@ public:
     bool isInitialized() const;
     bool isModified() const;
     bool hasNonDataChanges() const;
-    void setEmitModified(bool value) override;
     bool isReadOnly() const;
     void setReadOnly(bool readOnly);
     bool isSaving();

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -27,6 +27,7 @@
 #include <QTimer>
 
 #include "config-keepassx.h"
+#include "core/ModifiableObject.h"
 #include "crypto/kdf/AesKdf.h"
 #include "crypto/kdf/Kdf.h"
 #include "format/KeePass2.h"
@@ -52,7 +53,7 @@ struct DeletedObject
 
 Q_DECLARE_TYPEINFO(DeletedObject, Q_MOVABLE_TYPE);
 
-class Database : public QObject
+class Database : public ModifiableObject
 {
     Q_OBJECT
 
@@ -83,7 +84,7 @@ public:
     bool isInitialized() const;
     bool isModified() const;
     bool hasNonDataChanges() const;
-    void setEmitModified(bool value);
+    void setEmitModified(bool value) override;
     bool isReadOnly() const;
     void setReadOnly(bool readOnly);
     bool isSaving();
@@ -151,7 +152,6 @@ signals:
     void groupAboutToMove(Group* group, Group* toGroup, int index);
     void groupMoved();
     void databaseOpened();
-    void databaseModified();
     void databaseSaved();
     void databaseDiscarded();
     void databaseFileChanged();
@@ -213,7 +213,6 @@ private:
     QMutex m_saveMutex;
     QPointer<FileWatcher> m_fileWatcher;
     bool m_modified = false;
-    bool m_emitModified;
     bool m_hasNonDataChange = false;
     QString m_keyError;
 

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -47,15 +47,15 @@ Entry::Entry()
     m_data.autoTypeEnabled = true;
     m_data.autoTypeObfuscation = 0;
 
-    connect(m_attributes, SIGNAL(entryAttributesModified()), SLOT(updateTotp()));
-    connect(m_attributes, SIGNAL(entryAttributesModified()), this, SIGNAL(entryModified()));
+    connect(m_attributes, &EntryAttributes::modified, this, &Entry::updateTotp);
+    connect(m_attributes, &EntryAttributes::modified, this, &Entry::modified);
     connect(m_attributes, SIGNAL(defaultKeyModified()), SLOT(emitDataChanged()));
-    connect(m_attachments, SIGNAL(entryAttachmentsModified()), this, SIGNAL(entryModified()));
-    connect(m_autoTypeAssociations, SIGNAL(modified()), SIGNAL(entryModified()));
-    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(entryModified()));
+    connect(m_attachments, &EntryAttachments::modified, this, &Entry::modified);
+    connect(m_autoTypeAssociations, &AutoTypeAssociations::modified, this, &Entry::modified);
+    connect(m_customData, &CustomData::modified, this, &Entry::modified);
 
-    connect(this, SIGNAL(entryModified()), SLOT(updateTimeinfo()));
-    connect(this, SIGNAL(entryModified()), SLOT(updateModifiedSinceBegin()));
+    connect(this, &Entry::modified, this, &Entry::updateTimeinfo);
+    connect(this, &Entry::modified, this, &Entry::updateModifiedSinceBegin);
 }
 
 Entry::~Entry()
@@ -76,7 +76,7 @@ template <class T> inline bool Entry::set(T& property, const T& value)
 {
     if (property != value) {
         property = value;
-        emit entryModified();
+        emitModified();
         return true;
     }
     return false;
@@ -609,7 +609,7 @@ void Entry::setIcon(int iconNumber)
         m_data.iconNumber = iconNumber;
         m_data.customIcon = QUuid();
 
-        emit entryModified();
+        emitModified();
         emitDataChanged();
     }
 }
@@ -622,7 +622,7 @@ void Entry::setIcon(const QUuid& uuid)
         m_data.customIcon = uuid;
         m_data.iconNumber = 0;
 
-        emit entryModified();
+        emitModified();
         emitDataChanged();
     }
 }
@@ -715,7 +715,7 @@ void Entry::setExpires(const bool& value)
 {
     if (m_data.timeInfo.expires() != value) {
         m_data.timeInfo.setExpires(value);
-        emit entryModified();
+        emitModified();
     }
 }
 
@@ -723,7 +723,7 @@ void Entry::setExpiryTime(const QDateTime& dateTime)
 {
     if (m_data.timeInfo.expiryTime() != dateTime) {
         m_data.timeInfo.setExpiryTime(dateTime);
-        emit entryModified();
+        emitModified();
     }
 }
 
@@ -742,7 +742,7 @@ void Entry::addHistoryItem(Entry* entry)
     Q_ASSERT(!entry->parent());
 
     m_history.append(entry);
-    emit entryModified();
+    emitModified();
 }
 
 void Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
@@ -760,7 +760,7 @@ void Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
         delete entry;
     }
 
-    emit entryModified();
+    emitModified();
 }
 
 void Entry::truncateHistory()
@@ -813,7 +813,7 @@ void Entry::truncateHistory()
     }
 
     if (changed) {
-        emit entryModified();
+        emitModified();
     }
 }
 

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -49,7 +49,7 @@ Entry::Entry()
 
     connect(m_attributes, &EntryAttributes::modified, this, &Entry::updateTotp);
     connect(m_attributes, &EntryAttributes::modified, this, &Entry::modified);
-    connect(m_attributes, SIGNAL(defaultKeyModified()), SLOT(emitDataChanged()));
+    connect(m_attributes, &EntryAttributes::defaultKeyModified, this, &Entry::emitDataChanged);
     connect(m_attachments, &EntryAttachments::modified, this, &Entry::modified);
     connect(m_autoTypeAssociations, &AutoTypeAssociations::modified, this, &Entry::modified);
     connect(m_customData, &CustomData::modified, this, &Entry::modified);

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -32,6 +32,7 @@
 #include "core/EntryAttachments.h"
 #include "core/EntryAttributes.h"
 #include "core/Global.h"
+#include "core/ModifiableObject.h"
 #include "core/TimeInfo.h"
 
 class Database;
@@ -75,7 +76,7 @@ struct EntryData
     bool equals(const EntryData& other, CompareItemOptions options) const;
 };
 
-class Entry : public QObject
+class Entry : public ModifiableObject
 {
     Q_OBJECT
 
@@ -260,7 +261,6 @@ signals:
      * Emitted when a default attribute has been changed.
      */
     void entryDataChanged(Entry* entry);
-    void entryModified();
 
 private slots:
     void emitDataChanged();

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -23,7 +23,7 @@
 #include <QStringList>
 
 EntryAttachments::EntryAttachments(QObject* parent)
-    : QObject(parent)
+    : ModifiableObject(parent)
 {
 }
 
@@ -49,7 +49,7 @@ QByteArray EntryAttachments::value(const QString& key) const
 
 void EntryAttachments::set(const QString& key, const QByteArray& value)
 {
-    bool emitModified = false;
+    bool shouldEmitModified = false;
     bool addAttachment = !m_attachments.contains(key);
 
     if (addAttachment) {
@@ -58,7 +58,7 @@ void EntryAttachments::set(const QString& key, const QByteArray& value)
 
     if (addAttachment || m_attachments.value(key) != value) {
         m_attachments.insert(key, value);
-        emitModified = true;
+        shouldEmitModified = true;
     }
 
     if (addAttachment) {
@@ -67,8 +67,8 @@ void EntryAttachments::set(const QString& key, const QByteArray& value)
         emit keyModified(key);
     }
 
-    if (emitModified) {
-        emit entryAttachmentsModified();
+    if (shouldEmitModified) {
+        emitModified();
     }
 }
 
@@ -84,7 +84,7 @@ void EntryAttachments::remove(const QString& key)
     m_attachments.remove(key);
 
     emit removed(key);
-    emit entryAttachmentsModified();
+    emitModified();
 }
 
 void EntryAttachments::remove(const QStringList& keys)
@@ -108,7 +108,7 @@ void EntryAttachments::remove(const QStringList& keys)
     }
 
     if (isModified) {
-        emit entryAttachmentsModified();
+        emitModified();
     }
 }
 
@@ -135,7 +135,7 @@ void EntryAttachments::clear()
     m_attachments.clear();
 
     emit reset();
-    emit entryAttachmentsModified();
+    emitModified();
 }
 
 void EntryAttachments::copyDataFrom(const EntryAttachments* other)
@@ -146,7 +146,7 @@ void EntryAttachments::copyDataFrom(const EntryAttachments* other)
         m_attachments = other->m_attachments;
 
         emit reset();
-        emit entryAttachmentsModified();
+        emitModified();
     }
 }
 

--- a/src/core/EntryAttachments.h
+++ b/src/core/EntryAttachments.h
@@ -21,9 +21,11 @@
 #include <QMap>
 #include <QObject>
 
+#include "core/ModifiableObject.h"
+
 class QStringList;
 
-class EntryAttachments : public QObject
+class EntryAttachments : public ModifiableObject
 {
     Q_OBJECT
 
@@ -45,7 +47,6 @@ public:
     int attachmentsSize() const;
 
 signals:
-    void entryAttachmentsModified();
     void keyModified(const QString& key);
     void aboutToBeAdded(const QString& key);
     void added(const QString& key);

--- a/src/core/EntryAttributes.h
+++ b/src/core/EntryAttributes.h
@@ -26,7 +26,9 @@
 #include <QStringList>
 #include <QUuid>
 
-class EntryAttributes : public QObject
+#include "core/ModifiableObject.h"
+
+class EntryAttributes : public ModifiableObject
 {
     Q_OBJECT
 
@@ -69,7 +71,6 @@ public:
     static const QString SearchTextGroupName;
 
 signals:
-    void entryAttributesModified();
     void defaultKeyModified();
     void customKeyModified(const QString& key);
     void aboutToBeAdded(const QString& key);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -927,7 +927,7 @@ void Group::addEntry(Entry* entry)
     emit entryAboutToAdd(entry);
 
     m_entries << entry;
-    connect(entry, SIGNAL(entryDataChanged(Entry*)), SIGNAL(entryDataChanged(Entry*)));
+    connect(entry, &Entry::entryDataChanged, this, &Group::entryDataChanged);
     if (m_db) {
         connect(entry, &Entry::modified, m_db, &Database::markAsModified);
     }
@@ -996,14 +996,14 @@ void Group::connectDatabaseSignalsRecursive(Database* db)
 
     if (db) {
         // clang-format off
-        connect(this, SIGNAL(groupDataChanged(Group*)), db, SIGNAL(groupDataChanged(Group*)));
-        connect(this, SIGNAL(groupAboutToRemove(Group*)), db, SIGNAL(groupAboutToRemove(Group*)));
-        connect(this, SIGNAL(groupRemoved()), db, SIGNAL(groupRemoved()));
-        connect(this, SIGNAL(groupAboutToAdd(Group*, int)), db, SIGNAL(groupAboutToAdd(Group*,int)));
-        connect(this, SIGNAL(groupAdded()), db, SIGNAL(groupAdded()));
-        connect(this, SIGNAL(aboutToMove(Group*,Group*,int)), db, SIGNAL(groupAboutToMove(Group*,Group*,int)));
-        connect(this, SIGNAL(groupMoved()), db, SIGNAL(groupMoved()));
-        connect(this, SIGNAL(groupNonDataChange()), db, SLOT(markNonDataChange()));
+        connect(this, &Group::groupDataChanged, db, &Database::groupDataChanged);
+        connect(this, &Group::groupAboutToRemove, db, &Database::groupAboutToRemove);
+        connect(this, &Group::groupRemoved, db, &Database::groupRemoved);
+        connect(this, &Group::groupAboutToAdd, db, &Database::groupAboutToAdd);
+        connect(this, &Group::groupAdded, db, &Database::groupAdded);
+        connect(this, &Group::aboutToMove, db, &Database::groupAboutToMove);
+        connect(this, &Group::groupMoved, db, &Database::groupMoved);
+        connect(this, &Group::groupNonDataChange, db, &Database::markNonDataChange);
         connect(this, &Group::modified, db, &Database::markAsModified);
         // clang-format on
     }

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -46,9 +46,9 @@ Group::Group()
     m_data.searchingEnabled = Inherit;
     m_data.mergeMode = Default;
 
-    connect(m_customData, SIGNAL(customDataModified()), this, SIGNAL(groupModified()));
-    connect(this, SIGNAL(groupModified()), SLOT(updateTimeinfo()));
-    connect(this, SIGNAL(groupNonDataChange()), SLOT(updateTimeinfo()));
+    connect(m_customData, &CustomData::modified, this, &Group::modified);
+    connect(this, &Group::modified, this, &Group::updateTimeinfo);
+    connect(this, &Group::groupNonDataChange, this, &Group::updateTimeinfo);
 }
 
 Group::~Group()
@@ -80,7 +80,7 @@ template <class P, class V> inline bool Group::set(P& property, const V& value)
 {
     if (property != value) {
         property = value;
-        emit groupModified();
+        emitModified();
         return true;
     } else {
         return false;
@@ -333,7 +333,7 @@ void Group::setIcon(int iconNumber)
     if (iconNumber >= 0 && (m_data.iconNumber != iconNumber || !m_data.customIcon.isNull())) {
         m_data.iconNumber = iconNumber;
         m_data.customIcon = QUuid();
-        emit groupModified();
+        emitModified();
         emit groupDataChanged(this);
     }
 }
@@ -343,7 +343,7 @@ void Group::setIcon(const QUuid& uuid)
     if (!uuid.isNull() && m_data.customIcon != uuid) {
         m_data.customIcon = uuid;
         m_data.iconNumber = 0;
-        emit groupModified();
+        emitModified();
         emit groupDataChanged(this);
     }
 }
@@ -385,7 +385,7 @@ void Group::setExpires(bool value)
 {
     if (m_data.timeInfo.expires() != value) {
         m_data.timeInfo.setExpires(value);
-        emit groupModified();
+        emitModified();
     }
 }
 
@@ -393,7 +393,7 @@ void Group::setExpiryTime(const QDateTime& dateTime)
 {
     if (m_data.timeInfo.expiryTime() != dateTime) {
         m_data.timeInfo.setExpiryTime(dateTime);
-        emit groupModified();
+        emitModified();
     }
 }
 
@@ -465,7 +465,7 @@ void Group::setParent(Group* parent, int index)
         m_data.timeInfo.setLocationChanged(Clock::currentDateTimeUtc());
     }
 
-    emit groupModified();
+    emitModified();
 
     if (!moveWithinDatabase) {
         emit groupAdded();
@@ -929,10 +929,10 @@ void Group::addEntry(Entry* entry)
     m_entries << entry;
     connect(entry, SIGNAL(entryDataChanged(Entry*)), SIGNAL(entryDataChanged(Entry*)));
     if (m_db) {
-        connect(entry, SIGNAL(entryModified()), m_db, SLOT(markAsModified()));
+        connect(entry, &Entry::modified, m_db, &Database::markAsModified);
     }
 
-    emit groupModified();
+    emitModified();
     emit entryAdded(entry);
 }
 
@@ -949,7 +949,7 @@ void Group::removeEntry(Entry* entry)
         entry->disconnect(m_db);
     }
     m_entries.removeAll(entry);
-    emit groupModified();
+    emitModified();
     emit entryRemoved(entry);
 }
 
@@ -990,7 +990,7 @@ void Group::connectDatabaseSignalsRecursive(Database* db)
             entry->disconnect(m_db);
         }
         if (db) {
-            connect(entry, SIGNAL(entryModified()), db, SLOT(markAsModified()));
+            connect(entry, &Entry::modified, db, &Database::markAsModified);
         }
     }
 
@@ -1003,8 +1003,8 @@ void Group::connectDatabaseSignalsRecursive(Database* db)
         connect(this, SIGNAL(groupAdded()), db, SIGNAL(groupAdded()));
         connect(this, SIGNAL(aboutToMove(Group*,Group*,int)), db, SIGNAL(groupAboutToMove(Group*,Group*,int)));
         connect(this, SIGNAL(groupMoved()), db, SIGNAL(groupMoved()));
-        connect(this, SIGNAL(groupModified()), db, SLOT(markAsModified()));
         connect(this, SIGNAL(groupNonDataChange()), db, SLOT(markNonDataChange()));
+        connect(this, &Group::modified, db, &Database::markAsModified);
         // clang-format on
     }
 
@@ -1020,7 +1020,7 @@ void Group::cleanupParent()
     if (m_parent) {
         emit groupAboutToRemove(this);
         m_parent->m_children.removeAll(this);
-        emit groupModified();
+        emitModified();
         emit groupRemoved();
     }
 }
@@ -1189,7 +1189,7 @@ void Group::sortChildrenRecursively(bool reverse)
         child->sortChildrenRecursively(reverse);
     }
 
-    emit groupModified();
+    emitModified();
 }
 
 bool Group::GroupData::operator==(const Group::GroupData& other) const

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -27,9 +27,10 @@
 #include "core/Database.h"
 #include "core/Entry.h"
 #include "core/Global.h"
+#include "core/ModifiableObject.h"
 #include "core/TimeInfo.h"
 
-class Group : public QObject
+class Group : public ModifiableObject
 {
     Q_OBJECT
 
@@ -184,7 +185,6 @@ signals:
     void groupRemoved();
     void aboutToMove(Group* group, Group* toGroup, int index);
     void groupMoved();
-    void groupModified();
     void groupNonDataChange();
     void entryAboutToAdd(Entry* entry);
     void entryAdded(Entry* entry);

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -29,12 +29,12 @@ const int Metadata::DefaultHistoryMaxItems = 10;
 const int Metadata::DefaultHistoryMaxSize = 6 * 1024 * 1024;
 
 Metadata::Metadata(QObject* parent)
-    : QObject(parent)
+    : ModifiableObject(parent)
     , m_customData(new CustomData(this))
     , m_updateDatetime(true)
 {
     init();
-    connect(m_customData, SIGNAL(customDataModified()), SIGNAL(metadataModified()));
+    connect(m_customData, &CustomData::modified, this, &Metadata::modified);
 }
 
 void Metadata::init()
@@ -76,7 +76,7 @@ template <class P, class V> bool Metadata::set(P& property, const V& value)
 {
     if (property != value) {
         property = value;
-        emit metadataModified();
+        emitModified();
         return true;
     } else {
         return false;
@@ -90,7 +90,7 @@ template <class P, class V> bool Metadata::set(P& property, const V& value, QDat
         if (m_updateDatetime) {
             dateTime = Clock::currentDateTimeUtc();
         }
-        emit metadataModified();
+        emitModified();
         return true;
     } else {
         return false;
@@ -386,7 +386,7 @@ void Metadata::addCustomIcon(const QUuid& uuid, const QImage& image)
         m_customIcons.insert(uuid, QIcon());
     }
 
-    emit metadataModified();
+    emitModified();
 }
 
 void Metadata::removeCustomIcon(const QUuid& uuid)
@@ -404,7 +404,7 @@ void Metadata::removeCustomIcon(const QUuid& uuid)
     m_customIconsRaw.remove(uuid);
     m_customIconsOrder.removeAll(uuid);
     Q_ASSERT(m_customIconsRaw.count() == m_customIconsOrder.count());
-    emit metadataModified();
+    emitModified();
 }
 
 QUuid Metadata::findCustomIcon(const QImage& candidate)

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -30,11 +30,12 @@
 
 #include "core/CustomData.h"
 #include "core/Global.h"
+#include "core/ModifiableObject.h"
 
 class Database;
 class Group;
 
-class Metadata : public QObject
+class Metadata : public ModifiableObject
 {
     Q_OBJECT
 
@@ -148,9 +149,6 @@ public:
      * - Settings changed date
      */
     void copyAttributesFrom(const Metadata* other);
-
-signals:
-    void metadataModified();
 
 private:
     template <class P, class V> bool set(P& property, const V& value);

--- a/src/core/ModifiableObject.cpp
+++ b/src/core/ModifiableObject.cpp
@@ -51,7 +51,11 @@ bool ModifiableObject::modifiedSignalEnabled() const
 
 void ModifiableObject::setEmitModified(bool value)
 {
+    auto old = m_emitModified;
     m_emitModified = value;
+    if (old != m_emitModified) {
+        emit emitModifiedChanged(m_emitModified);
+    }
 }
 
 void ModifiableObject::emitModified()

--- a/src/core/ModifiableObject.cpp
+++ b/src/core/ModifiableObject.cpp
@@ -51,9 +51,8 @@ bool ModifiableObject::modifiedSignalEnabled() const
 
 void ModifiableObject::setEmitModified(bool value)
 {
-    auto old = m_emitModified;
-    m_emitModified = value;
-    if (old != m_emitModified) {
+    if (m_emitModified != value) {
+        m_emitModified = value;
         emit emitModifiedChanged(m_emitModified);
     }
 }

--- a/src/core/ModifiableObject.cpp
+++ b/src/core/ModifiableObject.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ModifiableObject.h"
+
+namespace
+{
+    template <typename T> T findParent(const QObject* obj)
+    {
+        if (!obj) {
+            return {};
+        }
+
+        auto p = obj->parent();
+        while (p) {
+            auto casted = qobject_cast<T>(p);
+            if (casted) {
+                return casted;
+            }
+            p = p->parent();
+        }
+        return {};
+    }
+} // namespace
+
+bool ModifiableObject::modifiedSignalEnabled() const
+{
+    auto p = this;
+    while (p) {
+        if (!p->m_emitModified) {
+            return false;
+        }
+        p = findParent<ModifiableObject*>(p);
+    }
+    return true;
+}
+
+void ModifiableObject::setEmitModified(bool value)
+{
+    m_emitModified = value;
+}
+
+void ModifiableObject::emitModified()
+{
+    if (modifiedSignalEnabled()) {
+        emit modified();
+    }
+}

--- a/src/core/ModifiableObject.h
+++ b/src/core/ModifiableObject.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_MODIFIABLEOBJECT_H
+#define KEEPASSXC_MODIFIABLEOBJECT_H
+
+#include <QObject>
+
+class ModifiableObject : public QObject
+{
+    Q_OBJECT
+public:
+    using QObject::QObject;
+
+public:
+    /**
+     * @brief check if the modified signal is enabled.
+     *
+     * The signal is enabled if neither the current object nor any of its parents disabled the signal.
+     */
+    bool modifiedSignalEnabled() const;
+
+public slots:
+    /**
+     * @brief set whether the modified signal should be emitted from this object and all its children.
+     *
+     * This means that even after calling `setEmitModified(true)` on this object,
+     * the signal may still be blocked in one of its parents.
+     *
+     * @param value
+     */
+    virtual void setEmitModified(bool value);
+
+protected:
+    void emitModified();
+
+signals:
+    void modified();
+
+private:
+    bool m_emitModified{true};
+};
+
+#endif // KEEPASSXC_MODIFIABLEOBJECT_H

--- a/src/core/ModifiableObject.h
+++ b/src/core/ModifiableObject.h
@@ -29,7 +29,7 @@ public:
 public:
     /**
      * @brief check if the modified signal is enabled.
-     *
+     * Note that this is NOT the same as m_emitModified.
      * The signal is enabled if neither the current object nor any of its parents disabled the signal.
      */
     bool modifiedSignalEnabled() const;
@@ -43,13 +43,14 @@ public slots:
      *
      * @param value
      */
-    virtual void setEmitModified(bool value);
+    void setEmitModified(bool value);
 
 protected:
     void emitModified();
 
 signals:
     void modified();
+    void emitModifiedChanged(bool value);
 
 private:
     bool m_emitModified{true};

--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -475,7 +475,7 @@ namespace FdoSecrets
             }
         });
         // Another possibility is the group being moved to recycle bin.
-        connect(m_exposedGroup.data(), &Group::groupModified, this, [this]() {
+        connect(m_exposedGroup.data(), &Group::modified, this, [this]() {
             if (inRecycleBin(m_exposedGroup->parentGroup())) {
                 // reset the exposed group to none
                 FdoSecrets::settings()->setExposedGroup(m_backend->database().data(), {});
@@ -483,7 +483,7 @@ namespace FdoSecrets
         });
 
         // Monitor exposed group settings
-        connect(m_backend->database()->metadata()->customData(), &CustomData::customDataModified, this, [this]() {
+        connect(m_backend->database()->metadata()->customData(), &CustomData::modified, this, [this]() {
             if (!m_exposedGroup || backendLocked()) {
                 return;
             }
@@ -500,8 +500,8 @@ namespace FdoSecrets
             onEntryAdded(entry, false);
         }
 
-        // Do not connect to databaseModified signal because we only want signals for the subset under m_exposedGroup
-        connect(m_backend->database()->metadata(), &Metadata::metadataModified, this, &Collection::collectionChanged);
+        // Do not connect to Database::modified signal because we only want signals for the subset under m_exposedGroup
+        connect(m_backend->database()->metadata(), &Metadata::modified, this, &Collection::collectionChanged);
         connectGroupSignalRecursive(m_exposedGroup);
     }
 
@@ -556,7 +556,7 @@ namespace FdoSecrets
             return;
         }
 
-        connect(group, &Group::groupModified, this, &Collection::collectionChanged);
+        connect(group, &Group::modified, this, &Collection::collectionChanged);
         connect(group, &Group::entryAdded, this, [this](Entry* entry) { onEntryAdded(entry, true); });
 
         const auto children = group->children();

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -63,7 +63,7 @@ namespace FdoSecrets
         : DBusObject(parent)
         , m_backend(backend)
     {
-        connect(m_backend.data(), &Entry::entryModified, this, &Item::itemChanged);
+        connect(m_backend, &Entry::modified, this, &Item::itemChanged);
     }
 
     DBusResult Item::locked(const DBusClientPtr& client, bool& locked) const

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -157,12 +157,11 @@ namespace FdoSecrets
     void Service::monitorDatabaseExposedGroup(DatabaseWidget* dbWidget)
     {
         Q_ASSERT(dbWidget);
-        connect(
-            dbWidget->database()->metadata()->customData(), &CustomData::customDataModified, this, [this, dbWidget]() {
-                if (!FdoSecrets::settings()->exposedGroup(dbWidget->database()).isNull() && !findCollection(dbWidget)) {
-                    onDatabaseTabOpened(dbWidget, true);
-                }
-            });
+        connect(dbWidget->database()->metadata()->customData(), &CustomData::modified, this, [this, dbWidget]() {
+            if (!FdoSecrets::settings()->exposedGroup(dbWidget->database()).isNull() && !findCollection(dbWidget)) {
+                onDatabaseTabOpened(dbWidget, true);
+            }
+        });
     }
 
     void Service::ensureDefaultAlias()

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1067,8 +1067,8 @@ void DatabaseWidget::connectDatabaseSignals()
             SIGNAL(filePathChanged(QString, QString)),
 
             SIGNAL(databaseFilePathChanged(QString, QString)));
-    connect(m_db.data(), SIGNAL(databaseModified()), SIGNAL(databaseModified()));
-    connect(m_db.data(), SIGNAL(databaseModified()), SLOT(onDatabaseModified()));
+    connect(m_db.data(), &Database::modified, this, &DatabaseWidget::databaseModified);
+    connect(m_db.data(), &Database::modified, this, &DatabaseWidget::onDatabaseModified);
     connect(m_db.data(), SIGNAL(databaseSaved()), SIGNAL(databaseSaved()));
     connect(m_db.data(), SIGNAL(databaseFileChanged()), this, SLOT(reloadDatabaseFile()));
 }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1069,8 +1069,8 @@ void DatabaseWidget::connectDatabaseSignals()
             SIGNAL(databaseFilePathChanged(QString, QString)));
     connect(m_db.data(), &Database::modified, this, &DatabaseWidget::databaseModified);
     connect(m_db.data(), &Database::modified, this, &DatabaseWidget::onDatabaseModified);
-    connect(m_db.data(), SIGNAL(databaseSaved()), SIGNAL(databaseSaved()));
-    connect(m_db.data(), SIGNAL(databaseFileChanged()), this, SLOT(reloadDatabaseFile()));
+    connect(m_db.data(), &Database::databaseSaved, this, &DatabaseWidget::databaseSaved);
+    connect(m_db.data(), &Database::databaseFileChanged, this, &DatabaseWidget::reloadDatabaseFile);
 }
 
 void DatabaseWidget::loadDatabase(bool accepted)

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -99,6 +99,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     , m_opVaultOpenWidget(new OpVaultOpenWidget(this))
     , m_groupView(new GroupView(m_db.data(), m_mainSplitter))
     , m_saveAttempts(0)
+    , m_entrySearcher(new EntrySearcher(false))
 {
     Q_ASSERT(m_db);
 
@@ -211,7 +212,6 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
 
     m_blockAutoSave = false;
 
-    m_EntrySearcher = new EntrySearcher(false);
     m_searchLimitGroup = config()->get(Config::SearchLimitGroup).toBool();
 
 #ifdef WITH_XC_KEESHARE
@@ -234,7 +234,6 @@ DatabaseWidget::DatabaseWidget(const QString& filePath, QWidget* parent)
 
 DatabaseWidget::~DatabaseWidget()
 {
-    delete m_EntrySearcher;
 }
 
 QSharedPointer<Database> DatabaseWidget::database() const
@@ -1362,7 +1361,7 @@ void DatabaseWidget::search(const QString& searchtext)
 
     Group* searchGroup = m_searchLimitGroup ? currentGroup() : m_db->rootGroup();
 
-    QList<Entry*> searchResult = m_EntrySearcher->search(searchtext, searchGroup);
+    QList<Entry*> searchResult = m_entrySearcher->search(searchtext, searchGroup);
 
     m_entryView->displaySearch(searchResult);
     m_lastSearchText = searchtext;
@@ -1384,7 +1383,7 @@ void DatabaseWidget::search(const QString& searchtext)
 
 void DatabaseWidget::setSearchCaseSensitive(bool state)
 {
-    m_EntrySearcher->setCaseSensitive(state);
+    m_entrySearcher->setCaseSensitive(state);
     refreshSearch();
 }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -234,6 +234,13 @@ DatabaseWidget::DatabaseWidget(const QString& filePath, QWidget* parent)
 
 DatabaseWidget::~DatabaseWidget()
 {
+    // Trigger any Database deletion related signals manually by
+    // explicitly clearing the Database pointer, instead of leaving it to ~QSharedPointer.
+    // QSharedPointer may behave differently depending on whether it is cleared by the `clear` method
+    // or by its destructor. In the latter case, the ref counter may not be correctly maintained
+    // if a copy of the QSharedPointer is created in any slots activated by the Database destructor.
+    // More details: https://github.com/keepassxreboot/keepassxc/issues/6393.
+    m_db.clear();
 }
 
 QSharedPointer<Database> DatabaseWidget::database() const

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -290,7 +290,7 @@ private:
     int m_saveAttempts;
 
     // Search state
-    EntrySearcher* m_EntrySearcher;
+    QScopedPointer<EntrySearcher> m_entrySearcher;
     QString m_lastSearchText;
     bool m_searchLimitGroup;
 

--- a/src/gui/EditWidgetProperties.cpp
+++ b/src/gui/EditWidgetProperties.cpp
@@ -63,7 +63,7 @@ void EditWidgetProperties::setCustomData(CustomData* customData)
     m_customData = customData;
 
     if (m_customData) {
-        connect(m_customData, SIGNAL(customDataModified()), SLOT(update()));
+        connect(m_customData, &CustomData::modified, this, &EditWidgetProperties::update);
     }
 
     update();

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -532,6 +532,7 @@ void EditEntryWidget::setupSSHAgent()
     m_sshAgentUi->commentTextLabel->setFont(fixedFont);
     m_sshAgentUi->publicKeyEdit->setFont(fixedFont);
 
+    // clang-format off
     connect(m_sshAgentUi->attachmentRadioButton, SIGNAL(clicked(bool)), SLOT(updateSSHAgentKeyInfo()));
     connect(m_sshAgentUi->attachmentComboBox, SIGNAL(currentIndexChanged(int)), SLOT(updateSSHAgentAttachment()));
     connect(m_sshAgentUi->externalFileRadioButton, SIGNAL(clicked(bool)), SLOT(updateSSHAgentKeyInfo()));
@@ -542,9 +543,9 @@ void EditEntryWidget::setupSSHAgent()
     connect(m_sshAgentUi->decryptButton, SIGNAL(clicked()), SLOT(decryptPrivateKey()));
     connect(m_sshAgentUi->copyToClipboardButton, SIGNAL(clicked()), SLOT(copyPublicKey()));
 
-    connect(m_advancedUi->attachmentsWidget->entryAttachments(),
-            SIGNAL(entryAttachmentsModified()),
-            SLOT(updateSSHAgentAttachments()));
+    connect(m_advancedUi->attachmentsWidget->entryAttachments(), &EntryAttachments::modified,
+            this, &EditEntryWidget::updateSSHAgentAttachments);
+    // clang-format on
 
     addPage(tr("SSH Agent"), icons()->icon("utilities-terminal"), m_sshAgentWidget);
 }
@@ -803,7 +804,7 @@ void EditEntryWidget::loadEntry(Entry* entry,
     m_create = create;
     m_history = history;
 
-    connect(m_entry, &Entry::entryModified, this, [this] { m_entryModifiedTimer.start(); });
+    connect(m_entry, &Entry::modified, this, [this] { m_entryModifiedTimer.start(); });
 
     if (history) {
         setHeadline(QString("%1 \u2022 %2").arg(parentName, tr("Entry history")));

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -533,15 +533,18 @@ void EditEntryWidget::setupSSHAgent()
     m_sshAgentUi->publicKeyEdit->setFont(fixedFont);
 
     // clang-format off
-    connect(m_sshAgentUi->attachmentRadioButton, SIGNAL(clicked(bool)), SLOT(updateSSHAgentKeyInfo()));
-    connect(m_sshAgentUi->attachmentComboBox, SIGNAL(currentIndexChanged(int)), SLOT(updateSSHAgentAttachment()));
-    connect(m_sshAgentUi->externalFileRadioButton, SIGNAL(clicked(bool)), SLOT(updateSSHAgentKeyInfo()));
-    connect(m_sshAgentUi->externalFileEdit, SIGNAL(textChanged(QString)), SLOT(updateSSHAgentKeyInfo()));
-    connect(m_sshAgentUi->browseButton, SIGNAL(clicked()), SLOT(browsePrivateKey()));
-    connect(m_sshAgentUi->addToAgentButton, SIGNAL(clicked()), SLOT(addKeyToAgent()));
-    connect(m_sshAgentUi->removeFromAgentButton, SIGNAL(clicked()), SLOT(removeKeyFromAgent()));
-    connect(m_sshAgentUi->decryptButton, SIGNAL(clicked()), SLOT(decryptPrivateKey()));
-    connect(m_sshAgentUi->copyToClipboardButton, SIGNAL(clicked()), SLOT(copyPublicKey()));
+    connect(m_sshAgentUi->attachmentRadioButton, &QRadioButton::clicked,
+            this, &EditEntryWidget::updateSSHAgentKeyInfo);
+    connect(m_sshAgentUi->attachmentComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, &EditEntryWidget::updateSSHAgentAttachment);
+    connect(m_sshAgentUi->externalFileRadioButton, &QRadioButton::clicked,
+            this, &EditEntryWidget::updateSSHAgentKeyInfo);
+    connect(m_sshAgentUi->externalFileEdit, &QLineEdit::textChanged, this, &EditEntryWidget::updateSSHAgentKeyInfo);
+    connect(m_sshAgentUi->browseButton, &QPushButton::clicked, this, &EditEntryWidget::browsePrivateKey);
+    connect(m_sshAgentUi->addToAgentButton, &QPushButton::clicked, this, &EditEntryWidget::addKeyToAgent);
+    connect(m_sshAgentUi->removeFromAgentButton, &QPushButton::clicked, this, &EditEntryWidget::removeKeyFromAgent);
+    connect(m_sshAgentUi->decryptButton, &QPushButton::clicked, this, &EditEntryWidget::decryptPrivateKey);
+    connect(m_sshAgentUi->copyToClipboardButton, &QPushButton::clicked, this, &EditEntryWidget::copyPublicKey);
 
     connect(m_advancedUi->attachmentsWidget->entryAttachments(), &EntryAttachments::modified,
             this, &EditEntryWidget::updateSSHAgentAttachments);

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -124,7 +124,7 @@ void EditGroupWidget::loadGroup(Group* group, bool create, const QSharedPointer<
     m_db = database;
 
     m_temporaryGroup.reset(group->clone(Entry::CloneNoFlags, Group::CloneNoFlags));
-    connect(m_temporaryGroup->customData(), SIGNAL(customDataModified()), SLOT(setModified()));
+    connect(m_temporaryGroup->customData(), &CustomData::modified, this, [this]() { setModified(true); });
 
     if (create) {
         setHeadline(tr("Add group"));

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -49,7 +49,7 @@ ShareObserver::ShareObserver(QSharedPointer<Database> db, QObject* parent)
     connect(m_db.data(), SIGNAL(groupAdded()), SLOT(handleDatabaseChanged()));
     connect(m_db.data(), SIGNAL(groupRemoved()), SLOT(handleDatabaseChanged()));
 
-    connect(m_db.data(), SIGNAL(databaseModified()), SLOT(handleDatabaseChanged()));
+    connect(m_db.data(), &Database::modified, this, &ShareObserver::handleDatabaseChanged);
     connect(m_db.data(), SIGNAL(databaseSaved()), SLOT(handleDatabaseSaved()));
 
     handleDatabaseChanged();

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -43,14 +43,14 @@ ShareObserver::ShareObserver(QSharedPointer<Database> db, QObject* parent)
     : QObject(parent)
     , m_db(std::move(db))
 {
-    connect(KeeShare::instance(), SIGNAL(activeChanged()), SLOT(handleDatabaseChanged()));
+    connect(KeeShare::instance(), &KeeShare::activeChanged, this, &ShareObserver::handleDatabaseChanged);
 
-    connect(m_db.data(), SIGNAL(groupDataChanged(Group*)), SLOT(handleDatabaseChanged()));
-    connect(m_db.data(), SIGNAL(groupAdded()), SLOT(handleDatabaseChanged()));
-    connect(m_db.data(), SIGNAL(groupRemoved()), SLOT(handleDatabaseChanged()));
+    connect(m_db.data(), &Database::groupDataChanged, this, &ShareObserver::handleDatabaseChanged);
+    connect(m_db.data(), &Database::groupAdded, this, &ShareObserver::handleDatabaseChanged);
+    connect(m_db.data(), &Database::groupRemoved, this, &ShareObserver::handleDatabaseChanged);
 
     connect(m_db.data(), &Database::modified, this, &ShareObserver::handleDatabaseChanged);
-    connect(m_db.data(), SIGNAL(databaseSaved()), SLOT(handleDatabaseSaved()));
+    connect(m_db.data(), &Database::databaseSaved, this, &ShareObserver::handleDatabaseSaved);
 
     handleDatabaseChanged();
 }

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -87,7 +87,7 @@ void EditGroupWidgetKeeShare::setGroup(Group* temporaryGroup, QSharedPointer<Dat
     m_temporaryGroup = temporaryGroup;
 
     if (m_temporaryGroup) {
-        connect(m_temporaryGroup, SIGNAL(groupModified()), SLOT(update()));
+        connect(m_temporaryGroup, &Group::modified, this, &EditGroupWidgetKeeShare::update);
     }
 
     update();

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -110,7 +110,7 @@ void TestDatabase::testSignals()
     QVERIFY(ok);
     QCOMPARE(spyFilePathChanged.count(), 1);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
     db->metadata()->setName("test1");
     QTRY_COMPARE(spyModified.count(), 1);
 
@@ -143,7 +143,7 @@ void TestDatabase::testEmptyRecycleBinOnDisabled()
     // Prevents assertion failures on CI systems when the data dir is not writable
     db->setReadOnly(false);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.
@@ -159,7 +159,7 @@ void TestDatabase::testEmptyRecycleBinOnNotCreated()
     QVERIFY(db->open(filename, key, nullptr, false));
     db->setReadOnly(false);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.
@@ -175,7 +175,7 @@ void TestDatabase::testEmptyRecycleBinOnEmpty()
     QVERIFY(db->open(filename, key, nullptr, false));
     db->setReadOnly(false);
 
-    QSignalSpy spyModified(db.data(), SIGNAL(databaseModified()));
+    QSignalSpy spyModified(db.data(), SIGNAL(modified()));
 
     db->emptyRecycleBin();
     // The database must be unmodified in this test after emptying the recycle bin.

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -841,7 +841,7 @@ void TestGroup::testCopyDataFrom()
     group3->setName("TestGroup3");
     group3->customData()->set("testKey", "value");
 
-    QSignalSpy spyGroupModified(group.data(), SIGNAL(groupModified()));
+    QSignalSpy spyGroupModified(group.data(), SIGNAL(modified()));
     QSignalSpy spyGroupDataChanged(group.data(), SIGNAL(groupDataChanged(Group*)));
 
     group->copyDataFrom(group2.data());

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -1479,7 +1479,7 @@ void TestMerge::testMergeNotModified()
     QScopedPointer<Database> dbSource(
         createTestDatabaseStructureClone(dbDestination.data(), Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
-    QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(databaseModified()));
+    QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(modified()));
     Merger merger(dbSource.data(), dbDestination.data());
     merger.merge();
     QTRY_VERIFY(modifiedSignalSpy.empty());
@@ -1491,7 +1491,7 @@ void TestMerge::testMergeModified()
     QScopedPointer<Database> dbSource(
         createTestDatabaseStructureClone(dbDestination.data(), Entry::CloneNoFlags, Group::CloneIncludeEntries));
 
-    QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(databaseModified()));
+    QSignalSpy modifiedSignalSpy(dbDestination.data(), SIGNAL(modified()));
     // Make sure the two changes have a different timestamp.
     QTest::qSleep(1);
     Entry* entry = dbSource->rootGroup()->findEntryByPath("entry1");

--- a/tests/TestModified.h
+++ b/tests/TestModified.h
@@ -34,6 +34,7 @@ private slots:
     void testHistoryItems();
     void testHistoryMaxSize();
     void testCustomData();
+    void testBlockModifiedSignal();
 };
 
 #endif // KEEPASSX_TESTMODIFIED_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes #6393, another attempt.

- Explicitly clear `m_db` in DatabaseWidget
- Introduce `ModifiableObject` to manage all objects that can emit modified signals. Properly block the signal from all sub-objects during Database destruction

While at it, also some cosmetic changes in the neighboring lines:

- Use QScopedPointer for `m_entrySearcher` in `DatabaseWidget`
- Convert neighboring lines to new signal/slot syntax

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added unit test for modified signals not firing when they are blocked.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Refactor (significant modification to existing code)