### PR TITLE
allow automatic expiration date extension on pwd modification (Addresses issue #2010)

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -23,6 +23,7 @@
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "core/PasswordHealth.h"
+#include "core/TimeDelta.h"
 #include "core/Tools.h"
 #include "totp/totp.h"
 
@@ -725,6 +726,20 @@ void Entry::setExpiryTime(const QDateTime& dateTime)
         m_data.timeInfo.setExpiryTime(dateTime);
         emit entryModified();
     }
+}
+
+void Entry::setExtendsExpirationOnPwdChange(const bool& value)
+{
+    if (m_customData->value("ExpirationExtension").toInt() != value) {
+        m_customData->set("ExpirationExtension", QString::number(value));
+        emit entryModified();
+    }
+}
+
+void Entry::setExpirationExtension(const QString& quantity, const QString& magnitude)
+{
+    m_customData->set("ExpirationExtensionQuantity", quantity);
+    m_customData->set("ExpirationExtensionMagnitude", magnitude);
 }
 
 QList<Entry*> Entry::historyItems()

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -151,6 +151,8 @@ public:
     void setDefaultAttribute(const QString& attribute, const QString& value);
     void setExpires(const bool& value);
     void setExpiryTime(const QDateTime& dateTime);
+    void setExtendsExpirationOnPwdChange(const bool& value);
+    void setExpirationExtension(const QString& quantity, const QString& magnitude);
     void setTotp(QSharedPointer<Totp::Settings> settings);
 
     QList<Entry*> historyItems();

--- a/src/core/TimeDelta.cpp
+++ b/src/core/TimeDelta.cpp
@@ -53,6 +53,16 @@ TimeDelta::TimeDelta(int days, int months, int years)
 {
 }
 
+TimeDelta TimeDelta::operator*(unsigned int n)
+{
+    return TimeDelta(n * m_days, n * m_months, n * m_years);
+}
+
+bool TimeDelta::operator==(const TimeDelta& tD) const
+{
+    return m_days == tD.getDays() && m_years == tD.getYears() && m_months == tD.getMonths();
+}
+
 int TimeDelta::getDays() const
 {
     return m_days;

--- a/src/core/TimeDelta.h
+++ b/src/core/TimeDelta.h
@@ -34,6 +34,8 @@ public:
 
     TimeDelta();
     TimeDelta(int days, int months, int years);
+    TimeDelta operator*(unsigned n);
+    bool operator==(const TimeDelta& tD) const;
 
     int getDays() const;
     int getMonths() const;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -168,7 +168,7 @@ void EditEntryWidget::setupMain()
     m_mainUi->urlEdit->enableVerifyMode();
 #endif
     connect(m_mainUi->expireCheck, &QCheckBox::toggled, [&](bool enabled) {
-        m_mainUi->expireDatePicker->setEnabled(enabled);
+        m_mainUi->expirationBox->setEnabled(enabled);
         if (enabled) {
             m_mainUi->expireDatePicker->setDateTime(Clock::currentDateTime());
         }
@@ -178,6 +178,21 @@ void EditEntryWidget::setupMain()
 
     m_mainUi->expirePresets->setMenu(createPresetsMenu());
     connect(m_mainUi->expirePresets->menu(), SIGNAL(triggered(QAction*)), this, SLOT(useExpiryPreset(QAction*)));
+    m_mainUi->extendPresets->setMenu(createPresetsMenu());
+    connect(m_mainUi->extendPresets->menu(), &QMenu::triggered, this, [&](QAction* action) {
+        m_extensionOnPwUpdate = action->data().value<TimeDelta>();
+    });
+    connect(m_mainUi->autoExtendExpire, &QCheckBox::toggled, [&](bool enabled) {
+        m_mainUi->extendPresets->setEnabled(enabled);
+    });
+    connect(m_mainUi->passwordEdit, &QLineEdit::textChanged, this, [&]() {
+        if (m_mainUi->extendPresets->isEnabled()) {
+            TimeDelta delta = m_extensionOnPwUpdate;
+            QDateTime now = Clock::currentDateTime();
+            QDateTime expiryDateTime = now + delta;
+            m_mainUi->expireDatePicker->setDateTime(expiryDateTime);
+        }
+    });
 }
 
 void EditEntryWidget::setupAdvanced()

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -215,9 +215,9 @@ void EditEntryWidget::setupMain()
             TimeDelta delta = std::get<1>(m_extensionOnPwUpdate) * std::get<0>(m_extensionOnPwUpdate);
             QDateTime now = Clock::currentDateTime();
             QDateTime expiryDateTime = now + delta;
-            if (m_mainUi->randomizeExtensionDeadline->isEnabled()) {
+            if (m_mainUi->randomizeExtensionDeadline->isChecked()) {
                 expiryDateTime =
-                    expiryDateTime.addDays(-QRandomGenerator::global()->bounded(0, m_daysRandomizeExtension));
+                    expiryDateTime.addDays(-QRandomGenerator::global()->bounded(0, m_daysRandomizeExtension+1));
             }
             m_mainUi->expireDatePicker->setDateTime(expiryDateTime);
         }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -200,12 +200,25 @@ void EditEntryWidget::setupMain()
     connect(m_mainUi->autoExtendExpire, &QCheckBox::toggled, [&](bool enabled) {
         m_mainUi->extendByQuantity->setEnabled(enabled);
         m_mainUi->extendByMagnitude->setEnabled(enabled);
+        m_mainUi->randomizeExtensionDeadline->setEnabled(enabled);
+    });
+
+    connect(m_mainUi->randomizeExtensionDeadline, &QCheckBox::toggled, [&](bool enabled) {
+        m_mainUi->randomizeByQuantity->setEnabled(enabled);
+    });
+
+    connect(m_mainUi->randomizeByQuantity, QOverload<int>::of(&QSpinBox::valueChanged), this, [&](int n) {
+        m_daysRandomizeExtension = static_cast<qint64>(n);
     });
     connect(m_mainUi->passwordEdit, &QLineEdit::textChanged, this, [&]() {
         if (m_mainUi->autoExtendExpire->isEnabled()) {
             TimeDelta delta = std::get<1>(m_extensionOnPwUpdate) * std::get<0>(m_extensionOnPwUpdate);
             QDateTime now = Clock::currentDateTime();
             QDateTime expiryDateTime = now + delta;
+            if (m_mainUi->randomizeExtensionDeadline->isEnabled()) {
+                expiryDateTime =
+                    expiryDateTime.addDays(-QRandomGenerator::global()->bounded(0, m_daysRandomizeExtension));
+            }
             m_mainUi->expireDatePicker->setDateTime(expiryDateTime);
         }
     });

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -165,6 +165,8 @@ private:
     QSharedPointer<Database> m_db;
 
     std::tuple<unsigned, TimeDelta> m_extensionOnPwUpdate;
+    qint64 m_daysRandomizeExtension;
+
     bool m_create;
     bool m_history;
 #ifdef WITH_XC_SSHAGENT

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -153,6 +153,7 @@ private:
     bool passwordsEqual();
     void setForms(Entry* entry, bool restore = false);
     QMenu* createPresetsMenu();
+    QMenu* createExtendByMenu();
     void updateEntryData(Entry* entry) const;
 #ifdef WITH_XC_SSHAGENT
     bool getOpenSSHKey(OpenSSHKey& key, bool decrypt = false);
@@ -163,7 +164,7 @@ private:
     QPointer<Entry> m_entry;
     QSharedPointer<Database> m_db;
 
-    TimeDelta m_extensionOnPwUpdate;
+    std::tuple<unsigned, TimeDelta> m_extensionOnPwUpdate;
     bool m_create;
     bool m_history;
 #ifdef WITH_XC_SSHAGENT

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -28,6 +28,7 @@
 #include <QTimer>
 
 #include "config-keepassx.h"
+#include "core/TimeDelta.h"
 #include "gui/EditWidget.h"
 
 class AutoTypeAssociations;
@@ -162,6 +163,7 @@ private:
     QPointer<Entry> m_entry;
     QSharedPointer<Database> m_db;
 
+    TimeDelta m_extensionOnPwUpdate;
     bool m_create;
     bool m_history;
 #ifdef WITH_XC_SSHAGENT

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -279,63 +279,73 @@
         </layout>
        </item>
        <item>
-         <widget class="QCheckBox" name="autoExtendExpire">
-          <property name="toolTip">
-           <string>Toggle auto updating expiration</string>
-          </property>
-          <property name="accessibleName">
-           <string>Toggle auto updating expiration date</string>
-          </property>
-          <property name="text">
-           <string>Auto assign new password expiration after modification:</string>
-          </property>
-         </widget>
-        </item>
-       <item>
-       <layout class="QHBoxLayout" name="horizontalautoUpdate">
-        <property name="spacing">
-         <number>1</number>
-        </property>
-        <item>
-         <widget class="QSpinBox" name="extendByQuantity">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="minimum">
-           <number>0</number>
-          </property>
-          <property name="maximum">
-           <number>1000</number>
-          </property>
-          <property name="FixedWidth">
-          <number>5</number>
+        <widget class="QCheckBox" name="autoExtendExpire">
+         <property name="toolTip">
+          <string>Toggle auto updating expiration</string>
          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="extendByMagnitude">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Expiration extension Presets</string>
-          </property>
-          <property name="accessibleName">
-           <string>Expiration extension presets</string>
-          </property>
-          <property name="text">
-           <string>Time period</string>
-          </property>
-         </widget>
-        </item>
-      </layout>
-      </item>
+         <property name="accessibleName">
+          <string>Toggle auto updating expiration date</string>
+         </property>
+         <property name="text">
+          <string>Update when password is changed:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalautoUpdate">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="notesHint">
+           <property name="text">
+            <string>Extend by: </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignTop</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="extendByQuantity">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="FixedWidth">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="extendByMagnitude">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Expiration extension Presets</string>
+           </property>
+           <property name="accessibleName">
+            <string>Expiration extension presets</string>
+           </property>
+           <property name="text">
+            <string>Time period</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </widget>
     </item>
@@ -368,6 +378,6 @@
   <tabstop>notesEnabled</tabstop>
   <tabstop>notesEdit</tabstop>
  </tabstops>
- <resources/>
- <connections/>
+ <resources />
+ <connections />
 </ui>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -336,6 +336,52 @@
          </item>
         </layout>
        </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalRandomize">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="randomizeExtensionDeadline">
+           <property name="toolTip">
+            <string>Toggle randomizing expiration date</string>
+           </property>
+           <property name="accessibleName">
+            <string>Toggle randomizing expiration date</string>
+           </property>
+           <property name="text">
+            <string>Randomize the extension deadline within the last </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="randomizeByQuantity">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="FixedWidth">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel">
+           <property name="visible">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string> days</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </widget>
     </item>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -353,7 +353,7 @@
             <string>Toggle randomizing expiration date</string>
            </property>
            <property name="text">
-            <string>Randomize the extension deadline within the last </string>
+            <string>Randomize the extension deadline within </string>
            </property>
           </widget>
          </item>
@@ -376,7 +376,7 @@
             <bool>true</bool>
            </property>
            <property name="text">
-            <string> days</string>
+            <string> days from the deadline</string>
            </property>
           </widget>
          </item>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -279,30 +279,20 @@
         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="autoExtendExpire">
-         <property name="toolTip">
-          <string>Toggle auto updating expiration</string>
-         </property>
-         <property name="accessibleName">
-          <string>Toggle auto updating expiration date</string>
-         </property>
-         <property name="text">
-          <string>Update when password is changed:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalautoUpdate">
          <property name="spacing">
           <number>1</number>
          </property>
          <item>
-          <widget class="QLabel" name="notesHint">
-           <property name="text">
-            <string>Extend by: </string>
+          <widget class="QCheckBox" name="autoExtendExpire">
+           <property name="toolTip">
+            <string>Toggle auto updating expiration</string>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignTop</set>
+           <property name="accessibleName">
+            <string>Toggle auto updating expiration date</string>
+           </property>
+           <property name="text">
+            <string>Extend when password is changed, by:</string>
            </property>
           </widget>
          </item>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -279,8 +279,6 @@
         </layout>
        </item>
        <item>
-       <layout class="QHBoxLayout" name="horizontalautoUpdate">
-        <item>
          <widget class="QCheckBox" name="autoExtendExpire">
           <property name="toolTip">
            <string>Toggle auto updating expiration</string>
@@ -289,12 +287,33 @@
            <string>Toggle auto updating expiration date</string>
           </property>
           <property name="text">
-           <string>Automatically extend expiration date on password modification by</string>
+           <string>Auto assign new password expiration after modification:</string>
           </property>
          </widget>
         </item>
+       <item>
+       <layout class="QHBoxLayout" name="horizontalautoUpdate">
+        <property name="spacing">
+         <number>1</number>
+        </property>
         <item>
-         <widget class="QPushButton" name="extendPresets">
+         <widget class="QSpinBox" name="extendByQuantity">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>1000</number>
+          </property>
+          <property name="FixedWidth">
+          <number>5</number>
+         </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="extendByMagnitude">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -311,7 +330,7 @@
            <string>Expiration extension presets</string>
           </property>
           <property name="text">
-           <string>Time</string>
+           <string>Time period</string>
           </property>
          </widget>
         </item>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -56,7 +56,7 @@
     <property name="verticalSpacing">
      <number>8</number>
     </property>
-    <item row="6" column="1">
+    <item row="7" column="1">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <widget class="QPlainTextEdit" name="notesEdit">
@@ -99,7 +99,7 @@
       </property>
      </widget>
     </item>
-    <item row="6" column="0">
+    <item row="7" column="0">
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="QCheckBox" name="notesEnabled">
@@ -126,45 +126,6 @@
          </size>
         </property>
        </spacer>
-      </item>
-     </layout>
-    </item>
-    <item row="5" column="1">
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>8</number>
-      </property>
-      <item>
-       <widget class="QDateTimeEdit" name="expireDatePicker">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="accessibleName">
-         <string>Expiration field</string>
-        </property>
-        <property name="calendarPopup">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="expirePresets">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Expiration Presets</string>
-        </property>
-        <property name="accessibleName">
-         <string>Expiration presets</string>
-        </property>
-        <property name="text">
-         <string>Presets</string>
-        </property>
-       </widget>
       </item>
      </layout>
     </item>
@@ -252,25 +213,112 @@
       </property>
      </widget>
     </item>
-    <item row="5" column="0">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="spacing">
-       <number>0</number>
+    <item row="5" column="1">
+     <widget class="QCheckBox" name="expireCheck">
+      <property name="toolTip">
+       <string>Toggle expiration</string>
       </property>
-      <item>
-       <widget class="QCheckBox" name="expireCheck">
-        <property name="toolTip">
-         <string>Toggle expiration</string>
-        </property>
-        <property name="accessibleName">
-         <string>Toggle expiration</string>
-        </property>
-        <property name="text">
-         <string>Expires:</string>
-        </property>
-       </widget>
+      <property name="accessibleName">
+       <string>Toggle expiration</string>
+      </property>
+      <property name="text">
+       <string>Configure an expiration date</string>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="1">
+     <widget class="QGroupBox" name="expirationBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="title">
+       <string>Expiration settings</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_expiration">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_expiration">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>8</number>
+         </property>
+         <item>
+          <widget class="QDateTimeEdit" name="expireDatePicker">
+           <property name="accessibleName">
+            <string>Expiration field</string>
+           </property>
+           <property name="calendarPopup">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="expirePresets">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Expiration Presets</string>
+           </property>
+           <property name="accessibleName">
+            <string>Expiration presets</string>
+           </property>
+           <property name="text">
+            <string>Presets</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+       <layout class="QHBoxLayout" name="horizontalautoUpdate">
+        <item>
+         <widget class="QCheckBox" name="autoExtendExpire">
+          <property name="toolTip">
+           <string>Toggle auto updating expiration</string>
+          </property>
+          <property name="accessibleName">
+           <string>Toggle auto updating expiration date</string>
+          </property>
+          <property name="text">
+           <string>Automatically extend expiration date on password modification by</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="extendPresets">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Expiration extension Presets</string>
+          </property>
+          <property name="accessibleName">
+           <string>Expiration extension presets</string>
+          </property>
+          <property name="text">
+           <string>Time</string>
+          </property>
+         </widget>
+        </item>
+      </layout>
       </item>
-     </layout>
+      </layout>
+     </widget>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
Addresses issue #2010

Creates a new Expiration Settings area in the Edit Entry widget, composed
of the expiration date settings and a new optional feature that allows for
automatic extension of the expiration date on password modification.

Allows for randomization of the expiration date, within an interval (set by the user) of days from the deadline

Tasks left:

- [ ]  Discuss and gather feedback
- [x]  Persistify the changes
- [x] Change the time menu to quantity - time unit pickers
- [ ] Fix UI spacing
- [ ] Document the new features

## Screenshots
![Extension](https://user-images.githubusercontent.com/867299/117697913-5653be80-b1c3-11eb-9300-711200a5349e.gif)


## Testing strategy
Manual testing (?)


## Type of change
- ✅ New feature (change that adds functionality)
- ✅ Documentation (non-code change)
