### PR TITLE
fix showing any notes in an entry without notes (Fixes #6461)

### DIFF
--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -240,14 +240,14 @@ void EntryPreviewWidget::updateEntryGeneralTab()
         m_ui->togglePasswordButton->setVisible(false);
     }
 
-    if (config()->get(Config::Security_HideNotes).toBool()) {
-        setEntryNotesVisible(false);
-        m_ui->toggleEntryNotesButton->setVisible(!m_ui->entryNotesTextEdit->toPlainText().isEmpty());
-        m_ui->toggleEntryNotesButton->setChecked(false);
-    } else {
-        setEntryNotesVisible(true);
-        m_ui->toggleEntryNotesButton->setVisible(false);
-    }
+    auto hasNotes = !m_currentEntry->notes().isEmpty();
+    auto hideNotes = config()->get(Config::Security_HideNotes).toBool();
+
+    m_ui->entryNotesTextEdit->setVisible(hasNotes);
+    setEntryNotesVisible(hasNotes && !hideNotes);
+    m_ui->toggleEntryNotesButton->setVisible(hasNotes && hideNotes
+                                             && !m_ui->entryNotesTextEdit->toPlainText().isEmpty());
+    m_ui->toggleEntryNotesButton->setChecked(false);
 
     if (config()->get(Config::GUI_MonospaceNotes).toBool()) {
         m_ui->entryNotesTextEdit->setFont(Font::fixedFont());


### PR DESCRIPTION
Fixes Issue #6461

Entries without notes were not clearing the notes field in the entry preview widget. I'm not clearing them either, but making the field invisible (it will get overwritten by next entry with notes).



## Screenshots

(gif)

![screenshot](https://user-images.githubusercontent.com/867299/116969753-136f8380-acb7-11eb-8a39-b5fa2e4e4d60.gif)


## Testing strategy
Manual testing


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

