### PR TITLE
New feature - password encryption with GpgCard

### DIFF
--- a/cmake/FindGpgme.cmake
+++ b/cmake/FindGpgme.cmake
@@ -1,0 +1,408 @@
+# Code is taken from KDE project:
+# http://code.metager.de/source/xref/kde/kdepimlibs/cmake/modules/FindGpgme.cmake
+#
+# - Try to find the gpgme library
+#
+# Algorithm:
+#  - Windows:
+#    On Windows, there's three gpgme variants: gpgme{,-glib,-qt}.
+#    - The variant used determines the event loop integration possible:
+#      - gpgme:      no event loop integration possible, only synchronous operations supported
+#      - gpgme-glib: glib event loop integration possible, only asynchronous operations supported
+#      - gpgme-qt:   qt event loop integration possible, only asynchronous operations supported
+#    - GPGME_{VANILLA,GLIB,QT}_{FOUND,LIBRARIES} will be set for each of the above
+#    - GPGME_INCLUDES is the same for all of the above
+#    - GPGME_FOUND is set if any of the above was found
+#  - *nix:
+#    There's also three variants: gpgme{,-pthread,-pth}.
+#    - The variant used determines the multithreaded use possible:
+#      - gpgme:         no multithreading support available
+#      - gpgme-pthread: multithreading available using POSIX threads
+#      - gpgme-pth:     multithreading available using GNU PTH (cooperative multithreading)
+#    - GPGME_{VANILLA,PTH,PTHREAD}_{FOUND,LIBRARIES} will be set for each of the above
+#    - GPGME_INCLUDES is the same for all of the above
+#    - GPGME_FOUND is set if any of the above was found
+#
+#  GPGME_LIBRARY_DIR - the directory where the libraries are located
+
+#
+# THIS IS ALMOST A 1:1 COPY OF FindAssuan.cmake in kdepim.
+# Any changes here likely apply there, too.
+#
+
+# do away with crappy condition repetition on else/endfoo
+set( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS_gpgme_saved ${CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS} )
+set( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true )
+
+#if this is built-in, please replace, if it isn't, export into a MacroToBool.cmake of it's own
+macro( macro_bool_to_bool FOUND_VAR )
+  foreach( _current_VAR ${ARGN} )
+    if ( ${FOUND_VAR} )
+      set( ${_current_VAR} TRUE )
+    else()
+      set( ${_current_VAR} FALSE )
+    endif()
+  endforeach()
+endmacro()
+
+#include (MacroEnsureVersion)
+
+
+
+if ( WIN32 )
+
+  # On Windows, we don't have a gpgme-config script, so we need to
+  # look for the stuff ourselves:
+
+  # in cmake, AND and OR have the same precedence, there's no
+  # subexpressions, and expressions are evaluated short-circuit'ed
+  # IOW: CMake if() suxx.
+  # Starting with CMake 2.6.3 you can group if expressions with (), but we 
+  # don't require 2.6.3 but 2.6.2, we can't use it. Alex
+  set( _seem_to_have_cached_gpgme false )
+  if ( GPGME_INCLUDES )
+    if ( GPGME_VANILLA_LIBRARIES OR GPGME_QT_LIBRARIES OR GPGME_GLIB_LIBRARIES )
+      set( _seem_to_have_cached_gpgme true )
+    endif()
+  endif()
+
+  if ( _seem_to_have_cached_gpgme )
+
+    macro_bool_to_bool( GPGME_VANILLA_LIBRARIES  GPGME_VANILLA_FOUND )
+    macro_bool_to_bool( GPGME_GLIB_LIBRARIES     GPGME_GLIB_FOUND    )
+    macro_bool_to_bool( GPGME_QT_LIBRARIES       GPGME_QT_FOUND      )
+    # this would have been preferred:
+    #set( GPGME_*_FOUND macro_bool_to_bool(GPGME_*_LIBRARIES) )
+
+    if ( GPGME_VANILLA_FOUND OR GPGME_GLIB_FOUND OR GPGME_QT_FOUND )
+      set( GPGME_FOUND true )
+    else()
+      set( GPGME_FOUND false )
+    endif()
+
+  else()
+
+    # is this needed, of just unreflected cut'n'paste?
+    # this isn't a KDE library, after all!
+    if( NOT KDEWIN_FOUND )
+      find_package( KDEWIN REQUIRED )
+    endif()
+
+    set( GPGME_FOUND         false )
+    set( GPGME_VANILLA_FOUND false )
+    set( GPGME_GLIB_FOUND    false )
+    set( GPGME_QT_FOUND      false )
+
+    find_path( GPGME_INCLUDES gpgme.h
+      ${CMAKE_INCLUDE_PATH}
+      ${CMAKE_INSTALL_PREFIX}/include
+    )
+
+    if (NOT WINCE)
+    find_library( _gpgme_vanilla_library NAMES gpgme libgpgme gpgme-11 libgpgme-11
+      PATHS 
+        ${CMAKE_LIBRARY_PATH}
+        ${CMAKE_INSTALL_PREFIX}/lib
+    )
+    else (NOT WINCE)
+      find_library( _gpgme_vanilla_library NAMES libgpgme-11-msc
+        PATHS 
+          ${CMAKE_LIBRARY_PATH}
+          ${CMAKE_INSTALL_PREFIX}/lib
+      )
+    endif()
+
+    find_library( _gpgme_glib_library    NAMES gpgme-glib libgpgme-glib gpgme-glib-11 libgpgme-glib-11
+      PATHS 
+        ${CMAKE_LIBRARY_PATH}
+        ${CMAKE_INSTALL_PREFIX}/lib
+    )
+
+    find_library( _gpgme_qt_library      NAMES gpgme-qt libgpgme-qt gpgme-qt-11 libgpgme-qt-11
+      PATHS 
+        ${CMAKE_LIBRARY_PATH}
+        ${CMAKE_INSTALL_PREFIX}/lib
+    )
+
+    if ( WINCE )
+        set( _gpg_error_library )
+    else()
+        find_library( _gpg_error_library     NAMES gpg-error libgpg-error gpg-error-0 libgpg-error-0
+           PATHS 
+                ${CMAKE_LIBRARY_PATH}
+                ${CMAKE_INSTALL_PREFIX}/lib
+        )
+    endif()
+
+    set( GPGME_INCLUDES ${GPGME_INCLUDES} )
+
+    if ( _gpgme_vanilla_library AND ( _gpg_error_library OR WINCE ) )
+      set( GPGME_VANILLA_LIBRARIES ${_gpgme_vanilla_library} ${_gpg_error_library} )
+      set( GPGME_VANILLA_FOUND     true )
+      set( GPGME_FOUND             true )
+    endif()
+
+    if ( _gpgme_glib_library AND ( _gpg_error_library OR WINCE ) )
+      set( GPGME_GLIB_LIBRARIES    ${_gpgme_glib_library}    ${_gpg_error_library} )
+      set( GPGME_GLIB_FOUND        true )
+      set( GPGME_FOUND             true )
+    endif()
+
+    if ( _gpgme_qt_library AND ( _gpg_error_library OR WINCE ) )
+      set( GPGME_QT_LIBRARIES      ${_gpgme_qt_library}      ${_gpg_error_library} )
+      set( GPGME_QT_FOUND          true )
+      set( GPGME_FOUND             true )
+    endif()
+
+  endif()
+
+  # these are Unix-only:
+  set( GPGME_PTHREAD_FOUND false )
+  set( GPGME_PTH_FOUND     false )
+  set( HAVE_GPGME_PTHREAD  0     )
+  set( HAVE_GPGME_PTH      0     )
+
+  macro_bool_to_01( GPGME_FOUND         HAVE_GPGME         )
+  macro_bool_to_01( GPGME_VANILLA_FOUND HAVE_GPGME_VANILLA )
+  macro_bool_to_01( GPGME_GLIB_FOUND    HAVE_GPGME_GLIB    )
+  macro_bool_to_01( GPGME_QT_FOUND      HAVE_GPGME_QT      )
+
+else() # not WIN32
+
+  # On *nix, we have the gpgme-config script which can tell us all we
+  # need to know:
+
+  # see WIN32 case for an explanation of what this does:
+  set( _seem_to_have_cached_gpgme false )
+  if ( GPGME_INCLUDES )
+    if ( GPGME_VANILLA_LIBRARIES OR GPGME_PTHREAD_LIBRARIES OR GPGME_PTH_LIBRARIES )
+      set( _seem_to_have_cached_gpgme true )
+    endif()
+  endif()
+
+  if ( _seem_to_have_cached_gpgme )
+
+    macro_bool_to_bool( GPGME_VANILLA_LIBRARIES GPGME_VANILLA_FOUND )
+    macro_bool_to_bool( GPGME_PTHREAD_LIBRARIES GPGME_PTHREAD_FOUND )
+    macro_bool_to_bool( GPGME_PTH_LIBRARIES     GPGME_PTH_FOUND     )
+
+    if ( GPGME_VANILLA_FOUND OR GPGME_PTHREAD_FOUND OR GPGME_PTH_FOUND )
+      set( GPGME_FOUND true )
+    else()
+      set( GPGME_FOUND false )
+    endif()
+
+  else()
+
+    set( GPGME_FOUND         false )
+    set( GPGME_VANILLA_FOUND false )
+    set( GPGME_PTHREAD_FOUND false )
+    set( GPGME_PTH_FOUND     false )
+
+    find_program( _GPGMECONFIG_EXECUTABLE NAMES gpgme-config )
+
+    # if gpgme-config has been found
+    if ( _GPGMECONFIG_EXECUTABLE )
+
+      message( STATUS "Found gpgme-config at ${_GPGMECONFIG_EXECUTABLE}" )
+
+      exec_program( ${_GPGMECONFIG_EXECUTABLE} ARGS --version OUTPUT_VARIABLE GPGME_VERSION )
+
+#      set( _GPGME_MIN_VERSION "1.1.7" )
+#      macro_ensure_version( ${_GPGME_MIN_VERSION} ${GPGME_VERSION} _GPGME_INSTALLED_VERSION_OK )
+
+#      if ( NOT _GPGME_INSTALLED_VERSION_OK )
+
+#        message( STATUS "The installed version of gpgme is too old: ${GPGME_VERSION} (required: >= ${_GPGME_MIN_VERSION})" )
+
+#      else()
+
+        message( STATUS "Found gpgme v${GPGME_VERSION}, checking for flavours..." )
+
+        exec_program( ${_GPGMECONFIG_EXECUTABLE} ARGS                  --libs OUTPUT_VARIABLE _gpgme_config_vanilla_libs RETURN_VALUE _ret )
+	if ( _ret )
+	  set( _gpgme_config_vanilla_libs )
+	endif()
+
+        exec_program( ${_GPGMECONFIG_EXECUTABLE} ARGS --thread=pthread --libs OUTPUT_VARIABLE _gpgme_config_pthread_libs RETURN_VALUE _ret )
+	if ( _ret )
+	  set( _gpgme_config_pthread_libs )
+	endif()
+
+        exec_program( ${_GPGMECONFIG_EXECUTABLE} ARGS --thread=pth     --libs OUTPUT_VARIABLE _gpgme_config_pth_libs     RETURN_VALUE _ret )
+	if ( _ret )
+	  set( _gpgme_config_pth_libs )
+	endif()
+
+        # append -lgpg-error to the list of libraries, if necessary
+        foreach ( _flavour vanilla pthread pth )
+          if ( _gpgme_config_${_flavour}_libs AND NOT _gpgme_config_${_flavour}_libs MATCHES "lgpg-error" )
+            set( _gpgme_config_${_flavour}_libs "${_gpgme_config_${_flavour}_libs} -lgpg-error" )
+          endif()
+        endforeach()
+
+        if ( _gpgme_config_vanilla_libs OR _gpgme_config_pthread_libs OR _gpgme_config_pth_libs )
+
+          exec_program( ${_GPGMECONFIG_EXECUTABLE} ARGS --cflags OUTPUT_VARIABLE _GPGME_CFLAGS )
+
+          if ( _GPGME_CFLAGS )
+            string( REGEX REPLACE "(\r?\n)+$" " " _GPGME_CFLAGS  "${_GPGME_CFLAGS}" )
+            string( REGEX REPLACE " *-I"      ";" GPGME_INCLUDES "${_GPGME_CFLAGS}" )
+          endif()
+
+          foreach ( _flavour vanilla pthread pth )
+            if ( _gpgme_config_${_flavour}_libs )
+
+              set( _gpgme_library_dirs )
+              set( _gpgme_library_names )
+              string( TOUPPER "${_flavour}" _FLAVOUR )
+
+              string( REGEX REPLACE " +" ";" _gpgme_config_${_flavour}_libs "${_gpgme_config_${_flavour}_libs}" )
+
+              foreach( _flag ${_gpgme_config_${_flavour}_libs} )
+                if ( "${_flag}" MATCHES "^-L" )
+                  string( REGEX REPLACE "^-L" "" _dir "${_flag}" )
+                  file( TO_CMAKE_PATH "${_dir}" _dir )
+                  set( _gpgme_library_dirs ${_gpgme_library_dirs} "${_dir}" )
+                elseif( "${_flag}" MATCHES "^-l" )
+                  string( REGEX REPLACE "^-l" "" _name "${_flag}" )
+                  set( _gpgme_library_names ${_gpgme_library_names} "${_name}" )
+                endif()
+              endforeach()
+
+              set( GPGME_${_FLAVOUR}_FOUND true )
+
+              foreach( _name ${_gpgme_library_names} )
+                set( _gpgme_${_name}_lib )
+
+                # if -L options were given, look only there
+                if ( _gpgme_library_dirs )
+                  find_library( _gpgme_${_name}_lib NAMES ${_name} PATHS ${_gpgme_library_dirs} NO_DEFAULT_PATH )
+                endif()
+
+                # if not found there, look in system directories
+                if ( NOT _gpgme_${_name}_lib )
+                  find_library( _gpgme_${_name}_lib NAMES ${_name} )
+                endif()
+
+                # if still not found, then the whole flavour isn't found
+                if ( NOT _gpgme_${_name}_lib )
+                  if ( GPGME_${_FLAVOUR}_FOUND )
+                    set( GPGME_${_FLAVOUR}_FOUND false )
+                    set( _not_found_reason "dependent library ${_name} wasn't found" )
+                  endif()
+                endif()
+
+                set( GPGME_${_FLAVOUR}_LIBRARIES ${GPGME_${_FLAVOUR}_LIBRARIES} "${_gpgme_${_name}_lib}" )
+              endforeach()
+
+              #check_c_library_exists_explicit( gpgme         gpgme_check_version "${_GPGME_CFLAGS}" "${GPGME_LIBRARIES}"         GPGME_FOUND         )
+              if ( GPGME_${_FLAVOUR}_FOUND )
+                message( STATUS " Found flavour '${_flavour}', checking whether it's usable...yes" )
+              else()
+                message( STATUS " Found flavour '${_flavour}', checking whether it's usable...no" )
+                message( STATUS "  (${_not_found_reason})" )
+              endif()
+            endif()
+
+          endforeach( _flavour )
+
+          # ensure that they are cached
+          # This comment above doesn't make sense, the four following lines seem to do nothing. Alex
+          set( GPGME_INCLUDES          ${GPGME_INCLUDES} )
+          set( GPGME_VANILLA_LIBRARIES ${GPGME_VANILLA_LIBRARIES} )
+          set( GPGME_PTHREAD_LIBRARIES ${GPGME_PTHREAD_LIBRARIES} )
+          set( GPGME_PTH_LIBRARIES     ${GPGME_PTH_LIBRARIES} )
+
+          if ( GPGME_VANILLA_FOUND OR GPGME_PTHREAD_FOUND OR GPGME_PTH_FOUND )
+            set( GPGME_FOUND true )
+          else()
+            set( GPGME_FOUND false )
+          endif()
+
+#        endif()
+
+      endif()
+
+    endif()
+
+  endif()
+
+  # these are Windows-only:
+  set( GPGME_GLIB_FOUND false )
+  set( GPGME_QT_FOUND   false )
+  set( HAVE_GPGME_GLIB  0     )
+  set( HAVE_GPGME_QT    0     )
+
+  #  macro_bool_to_01( GPGME_FOUND         HAVE_GPGME         )
+  #  macro_bool_to_01( GPGME_VANILLA_FOUND HAVE_GPGME_VANILLA )
+  #  macro_bool_to_01( GPGME_PTHREAD_FOUND HAVE_GPGME_PTHREAD )
+  #  macro_bool_to_01( GPGME_PTH_FOUND     HAVE_GPGME_PTH     )
+
+endif() # WIN32 | Unix
+
+
+set( _gpgme_flavours "" )
+
+if ( GPGME_VANILLA_FOUND )
+  set( _gpgme_flavours "${_gpgme_flavours} vanilla" )
+endif()
+
+if ( GPGME_GLIB_FOUND )
+  set( _gpgme_flavours "${_gpgme_flavours} Glib" )
+endif()
+
+if ( GPGME_QT_FOUND )
+  set( _gpgme_flavours "${_gpgme_flavours} Qt" )
+endif()
+
+if ( GPGME_PTHREAD_FOUND )
+  set( _gpgme_flavours "${_gpgme_flavours} pthread" )
+endif()
+
+if ( GPGME_PTH_FOUND )
+  set( _gpgme_flavours "${_gpgme_flavours} pth" )
+endif()
+
+# determine the library in one of the found flavours, can be reused e.g. by FindQgpgme.cmake, Alex
+foreach(_currentFlavour vanilla glib qt pth pthread)
+   if(NOT GPGME_LIBRARY_DIR)
+      get_filename_component(GPGME_LIBRARY_DIR "${_gpgme_${_currentFlavour}_lib}" PATH)
+   endif()
+endforeach()
+
+if ( NOT Gpgme_FIND_QUIETLY )
+
+  if ( GPGME_FOUND )
+    message( STATUS "Usable gpgme flavours found: ${_gpgme_flavours}" )
+  else()
+    message( STATUS "No usable gpgme flavours found." )
+  endif()
+
+  macro_bool_to_bool( Gpgme_FIND_REQUIRED _req )
+
+  if ( WIN32 )
+    set( _gpgme_homepage "http://www.gpg4win.org" )
+  else()
+    set( _gpgme_homepage "http://www.gnupg.org/related_software/gpgme" )
+  endif()
+
+  #  macro_log_feature(
+  #   GPGME_FOUND
+  #  "gpgme"
+  #  "GNU Privacy Guard (GPG/PGP) support"
+  #  ${_gpgme_homepage}
+  #  ${_req}
+  #  "${_GPGME_MIN_VERSION} or greater"
+  #  "Necessary to compile many PIM applications, including KMail"
+  #)
+
+else()
+
+  if ( Gpgme_FIND_REQUIRED AND NOT GPGME_FOUND )
+    message( FATAL_ERROR "Did not find GPGME" )
+  endif()
+
+endif()
+
+set( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS_gpgme_saved )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,7 @@ add_feature_info(SSHAgent WITH_XC_SSHAGENT "SSH agent integration compatible wit
 add_feature_info(KeeShare WITH_XC_KEESHARE "Sharing integration with KeeShare (requires quazip5 for secure containers)")
 add_feature_info(YubiKey WITH_XC_YUBIKEY "YubiKey HMAC-SHA1 challenge-response")
 add_feature_info(UpdateCheck WITH_XC_UPDATECHECK "Automatic update checking")
+add_feature_info(GpgEncrypt WITH_XC_GPG "Password encryption with GpgCard")
 if(UNIX AND NOT APPLE)
     add_feature_info(FdoSecrets WITH_XC_FDOSECRETS "Implement freedesktop.org Secret Storage Spec server side API.")
 endif()
@@ -242,6 +243,10 @@ if(WITH_XC_BROWSER)
     set(keepassxcbrowser_LIB keepassxcbrowser)
     set(keepassx_SOURCES ${keepassx_SOURCES} gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp)
     set(keepassx_SOURCES ${keepassx_SOURCES} gui/entry/EntryURLModel.cpp)
+endif()
+
+if(WITH_XC_GPG)
+    set(keepassx_SOURCES ${keepassx_SOURCES} core/PasswordCacheService.cpp)
 endif()
 
 add_subdirectory(autotype)
@@ -329,6 +334,7 @@ target_link_libraries(keepassx_core
         ${ZXCVBN_LIBRARIES}
         ${ARGON2_LIBRARIES}
         ${ZLIB_LIBRARIES}
+        ${GPGME_PTHREAD_LIBRARIES}
 	)
 
 if(WITH_XC_SSHAGENT)

--- a/src/browser/BrowserAction.h
+++ b/src/browser/BrowserAction.h
@@ -42,6 +42,7 @@ private:
     QJsonObject handleGetDatabaseGroups(const QJsonObject& json, const QString& action);
     QJsonObject handleCreateNewGroup(const QJsonObject& json, const QString& action);
     QJsonObject handleGetTotp(const QJsonObject& json, const QString& action);
+    QJsonObject handleGetGpgPassword(const QJsonObject& json, const QString& action);
 
     QJsonObject buildMessage(const QString& nonce) const;
     QJsonObject buildResponse(const QString& action, const QJsonObject& message, const QString& nonce);

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -82,6 +82,7 @@ public:
                                    const QString& realm,
                                    const StringPairList& keyList,
                                    const bool httpAuth = false);
+    QString getPasswordByUuid(const QString& uuid);
 
     static void convertAttributesToCustomData(QSharedPointer<Database> db);
 

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -125,7 +125,7 @@ int Add::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<Q
         QString password = passwordGenerator->generatePassword();
         entry->setPassword(password);
     }
-
+            //entry->setNotes("setting password");
     QString errorMessage;
     if (!database->save(&errorMessage, true, false)) {
         err << QObject::tr("Writing the database failed %1.").arg(errorMessage) << endl;

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -40,6 +40,10 @@ set(cli_SOURCES
         RemoveGroup.cpp
         Show.cpp)
 
+if(WITH_XC_GPG)
+    set(cli_SOURCES ${cli_SOURCES} GpgEncrypt.cpp)
+    set(cli_SOURCES ${cli_SOURCES} GpgDisable.cpp)
+endif()
 add_library(cli STATIC ${cli_SOURCES})
 target_link_libraries(cli Qt5::Core Qt5::Widgets)
 
@@ -60,7 +64,8 @@ target_link_libraries(keepassxc-cli
         ${sodium_LIBRARY_RELEASE}
         ${ARGON2_LIBRARIES}
         ${ZLIB_LIBRARIES}
-        ${ZXCVBN_LIBRARIES})
+        ${ZXCVBN_LIBRARIES}
+        ${GPGME_PTHREAD_LIBRARIES})
 
 install(TARGETS keepassxc-cli
         BUNDLE DESTINATION . COMPONENT Runtime

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -50,6 +50,11 @@
 #include "TextStream.h"
 #include "Utils.h"
 
+#ifdef WITH_XC_GPG
+#include "GpgDisable.h"
+#include "GpgEncrypt.h"
+#endif
+
 const QCommandLineOption Command::HelpOption = QCommandLineOption(QStringList()
 #ifdef Q_OS_WIN
                                                                       << QStringLiteral("?")
@@ -186,7 +191,10 @@ namespace Commands
         s_commands.insert(QStringLiteral("rm"), QSharedPointer<Command>(new Remove()));
         s_commands.insert(QStringLiteral("rmdir"), QSharedPointer<Command>(new RemoveGroup()));
         s_commands.insert(QStringLiteral("show"), QSharedPointer<Command>(new Show()));
-
+#ifdef WITH_XC_GPG
+        s_commands.insert(QStringLiteral("gpgencrypt"), QSharedPointer<Command>(new GpgEncrypt()));
+        s_commands.insert(QStringLiteral("gpgdisable"), QSharedPointer<Command>(new GpgDisable()));
+#endif
         if (interactive) {
             s_commands.insert(QStringLiteral("exit"), QSharedPointer<Command>(new Exit("exit")));
             s_commands.insert(QStringLiteral("quit"), QSharedPointer<Command>(new Exit("quit")));

--- a/src/cli/GpgDisable.cpp
+++ b/src/cli/GpgDisable.cpp
@@ -1,0 +1,40 @@
+#include "GpgDisable.h"
+
+#include "Utils.h"
+#include "cli/TextStream.h"
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Global.h"
+#include "core/Group.h"
+
+GpgDisable::GpgDisable()
+{
+    name = QString("gpgdisable");
+    description = QObject::tr("Disable encryption for a specified path");
+    positionalArguments.append({QString("path"), QObject::tr("Path to disable encryption for."), QString("[group]")});
+}
+
+int GpgDisable::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+{
+    auto& out = Utils::STDOUT;
+    auto& err = Utils::STDERR;
+
+    const QStringList args = parser->positionalArguments();
+
+    const QString& path = args.at(1);
+
+    Group* group = database->rootGroup()->findGroupByPath(path);
+    if(!group){
+        err << QObject::tr("Cannot find group %1.").arg(path) << endl;
+        return EXIT_FAILURE;
+    }
+    group->customData()->set("GPG-Key","disable");
+    QString errorMessage;
+    if (!database->save(&errorMessage, true, false)) {
+        err << QObject::tr("Writing the database failed: %1").arg(errorMessage) << endl;
+        return EXIT_FAILURE;
+    }
+
+    err << QObject::tr("Disabled GPG encryption for path %1").arg(path) << endl;
+    return EXIT_SUCCESS;
+}

--- a/src/cli/GpgDisable.h
+++ b/src/cli/GpgDisable.h
@@ -1,0 +1,15 @@
+
+#ifndef KEEPASSXC_GPG_DISABLE_H
+#define KEEPASSXC_GPG_DISABLE_H
+
+#include "DatabaseCommand.h"
+
+class GpgDisable : public DatabaseCommand
+{
+public:
+    GpgDisable();
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+};
+
+#endif // KEEPASSXC_GPG_DISABLE_H

--- a/src/cli/GpgEncrypt.cpp
+++ b/src/cli/GpgEncrypt.cpp
@@ -1,0 +1,197 @@
+#include "GpgEncrypt.h"
+
+#include <cstdlib>
+#include <stdio.h>
+
+#include "Utils.h"
+#include "cli/TextStream.h"
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Global.h"
+#include "core/Group.h"
+#include "core/PasswordCacheService.h"
+
+#include <QLocale>
+#include <QProcess>
+#include <gpgme.h>
+#include <unistd.h>
+#include <utility>
+
+const QCommandLineOption GpgEncrypt::RecoveryKeyOption =
+    QCommandLineOption(QStringList() << "r"
+                                     << "rkeyid",
+                       QObject::tr("Id of the key pair to be used for recovery.\n"));
+GpgEncrypt::GpgEncrypt()
+{
+    name = QString("gpgencrypt");
+    description = QObject::tr("Encrypt the specified path");
+    options.append(GpgEncrypt::RecoveryKeyOption);
+    positionalArguments.append({QString("key"),
+                                QObject::tr("Id of the key pair to be used for encryption and decryption.\n"
+                                            "use gpg --card-status to list available keys\n"
+                                            "if you give an invalid keys it will list available ones"),
+                                QString("[key]")});
+    optionalArguments.append({QString("path"), QObject::tr("Path to enable encryption for. Default is /."), QString("[group]")});
+}
+#include <stdio.h>
+// this leaks some resources, but if there was failure the program will be terminated soon anyway
+#define callNcheck(foo)                                                                                                \
+    error = foo;                                                                                                       \
+    if (gpgme_err_code(error) != GPG_ERR_NO_ERROR)                                                                     \
+        do {                                                                                                           \
+            Utils::STDERR << gpgme_err_code(error) << " " << gpgme_strsource(error) << " " << gpgme_strerror(error)    \
+                          << endl;                                                                                     \
+            return EXIT_FAILURE;                                                                                       \
+    } while (0)
+
+// We just quit right after start but that causes the card to be initialised
+static gpgme_error_t gpgme_interact_cb_t_impl(void* /*handle*/, const char* status, const char* /*args*/, int fd)
+{
+    if (strcmp(status, "GET_LINE") == 0) {
+        char rr[] = "quit\n\x00";
+        write(fd, rr, sizeof(rr));
+    }
+    return 0;
+}
+
+bool detectAndInitCard()
+{
+    gpgme_error_t error = 0;
+    const char* ver = gpgme_check_version(0);
+    Utils::STDERR << "GPGme version: " << ver << endl;
+    gpgme_ctx_t ctx;
+    callNcheck(gpgme_new(&ctx));
+
+    // this seems to work as the key is not touched, but the documentation doesn't state much
+    // "GPG_ERR_INV_VALUE if ctx or key is not a valid pointer."
+    gpgme_key_t empty_key = nullptr;
+    gpgme_data_t data_fun;
+    callNcheck(gpgme_data_new(&data_fun));
+    gpgme_op_interact(ctx, empty_key, GPGME_INTERACT_CARD, gpgme_interact_cb_t_impl, NULL, data_fun);
+    gpgme_data_seek(data_fun, 0, SEEK_SET);
+
+    QString output;
+    output.reserve(1024);
+    int s = 0;
+    char buff[30];
+    while ((s = gpgme_data_read(data_fun, buff, sizeof(buff))) > 0) {
+        output.append(QString::fromUtf8(buff, s));
+    }
+    gpgme_data_release(data_fun);
+    gpgme_release(ctx);
+    if (output.contains("Reader:")) {
+        int start = output.indexOf("Reader:");
+        int end = output.indexOf("\n", start);
+        if (end != -1) {
+            Utils::STDERR << "Found Card: " << output.mid(start, end - start) << endl;
+            return true;
+        }
+    }
+    return false;
+}
+void encryptRecursively(Group * startGroup){
+    auto& out = Utils::STDOUT;
+    auto& err = Utils::STDERR;
+    err << QObject::tr(" Encrypting group %1.").arg(startGroup->name()) << endl;
+    for(auto entry:startGroup->entries()){
+        err << QObject::tr("  Encrypting entry %1.").arg(entry->title()) << endl;
+        entry->beginUpdate();
+        entry->updateGpgData(true);
+        entry->endUpdate();
+    }
+    for(auto group:startGroup->children()){
+        encryptRecursively(group);
+    }
+} 
+
+int GpgEncrypt::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+{
+    auto& out = Utils::STDOUT;
+    auto& err = Utils::STDERR;
+
+    const QStringList args = parser->positionalArguments();
+
+    const QString& keyId = args.at(1);
+    const QString& path = args.size()==3? args.at(2) : "/";
+    
+    QStringList rKey = parser->values(GpgEncrypt::RecoveryKeyOption);
+
+    Group* group = database->rootGroup()->findGroupByPath(path);
+    if(!group){
+        err << QObject::tr("Cannot find group %1.").arg(path) << endl;
+        return EXIT_FAILURE;
+    }
+
+    err << QObject::tr("Detecting and initialising the OpenPGP card") << endl;
+    if (!detectAndInitCard()) {
+        err << QObject::tr("Couldn't find a smart card. Ensure the card is connected and retry.") << endl;
+        return EXIT_FAILURE;
+    }
+    err << QObject::tr("Testing key %1 ").arg(keyId) << endl;
+    gpgme_error_t error = 0;
+    gpgme_ctx_t ctx;
+    callNcheck(gpgme_new(&ctx));
+    gpgme_key_t key;
+    error = gpgme_get_key(ctx, keyId.toLatin1().data(), &key, 0);
+    if (gpgme_err_code(error) != GPG_ERR_NO_ERROR) {
+        err << gpgme_err_code(error) << gpgme_strsource(error) << gpgme_strerror(error) << endl;
+        err << QObject::tr("Could not find the specified key") << endl;
+        err << QObject::tr("GPG recognises the following keys:") << endl;
+        auto error = gpgme_op_keylist_start(ctx, NULL, 0);
+        while (!error) {
+            error = gpgme_op_keylist_next(ctx, &key);
+            if (error)
+                break;
+            err << "\t" << key->subkeys->keyid << ": " << ((key->uids && key->uids->name) ? key->uids->name : "") << " "
+                << ((key->uids && key->uids->email) ? key->uids->email : "") << endl;
+        }
+        return EXIT_FAILURE;
+    }
+    gpgme_set_armor(ctx, 1);
+    QString password = "This is a test passphrase!";
+    gpgme_data_t data;
+    gpgme_data_t target;
+    gpgme_key_t keys[2] = {key, NULL};
+    err << "key was found, testing encryption" << endl;
+    callNcheck(gpgme_data_new_from_mem(&data, password.toUtf8().data(), password.toUtf8().length(), 1));
+    callNcheck(gpgme_data_new(&target));
+    callNcheck(gpgme_op_encrypt(
+        ctx, keys, (gpgme_encrypt_flags_t)(GPGME_ENCRYPT_ALWAYS_TRUST | GPGME_ENCRYPT_NO_ENCRYPT_TO), data, target));
+    ssize_t s;
+    char buff[30];
+    gpgme_data_seek(target, 0, SEEK_SET);
+    QString output;
+    output.reserve(1024);
+    while ((s = gpgme_data_read(target, buff, sizeof(buff))) > 0) {
+        output.append(QString::fromUtf8(buff, s));
+    }
+    gpgme_key_release(key);
+    gpgme_data_release(data);
+    err << QObject::tr("Testing decryption\nIf it is a first call you will be asked for a PIN.\nIf you configured Youbikey "
+           "correctly it will start blinking. Touch it to continiue.\n"
+           "If your Youbikey didn't need to be touched please reconfigure it by running 'ykman openpgp set-touch enc on'")
+        << endl;
+    callNcheck(gpgme_data_new(&data));
+    gpgme_data_seek(target, 0, SEEK_SET);
+    callNcheck(gpgme_op_decrypt(ctx, target, data));
+    gpgme_data_seek(data, 0, SEEK_SET);
+    output="";
+    output.reserve(1024);
+    while ((s = gpgme_data_read(data, buff, sizeof(buff))) > 0) {
+        output.append(QString::fromUtf8(buff, s));
+    }
+    if(output!=password){
+        err<<QObject::tr("Decryption error: \n\tExpected: %1 Got %2").arg(password,output)<<endl;
+        return EXIT_FAILURE;
+    }
+    err<<"\nAll tests PASSED!\n\nBegining encryption of path \""<<path<<"\""<<endl;
+    group->customData()->set("GPG-Key",keyId);
+    encryptRecursively(group);
+    QString errorMessage;
+    if (!database->save(&errorMessage, true, false)) {
+        err << QObject::tr("Writing the database failed: %1").arg(errorMessage) << endl;
+        return EXIT_FAILURE;
+    }
+    err << QObject::tr("Database saved.") << endl;
+    return EXIT_SUCCESS;
+}

--- a/src/cli/GpgEncrypt.h
+++ b/src/cli/GpgEncrypt.h
@@ -1,0 +1,17 @@
+
+#ifndef KEEPASSXC_GPG_ENCRYPT_H
+#define KEEPASSXC_GPG_ENCRYPT_H
+
+#include "DatabaseCommand.h"
+
+class GpgEncrypt : public DatabaseCommand
+{
+public:
+    GpgEncrypt();
+
+    int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser);
+
+    static const QCommandLineOption RecoveryKeyOption;
+};
+
+#endif // KEEPASSXC_GPG_ENCRYPT_H

--- a/src/config-keepassx.h.cmake
+++ b/src/config-keepassx.h.cmake
@@ -23,6 +23,7 @@
 #cmakedefine WITH_XC_UPDATECHECK
 #cmakedefine WITH_XC_TOUCHID
 #cmakedefine WITH_XC_FDOSECRETS
+#cmakedefine WITH_XC_GPG
 
 #cmakedefine KEEPASSXC_BUILD_TYPE "@KEEPASSXC_BUILD_TYPE@"
 #cmakedefine KEEPASSXC_BUILD_TYPE_RELEASE

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -734,38 +734,6 @@ void Entry::setUsername(const QString& username)
 {
     m_attributes->set(EntryAttributes::UserNameKey, username, m_attributes->isProtected(EntryAttributes::UserNameKey));
 }
-QString uid="77645C96-FD60-42E4-AEE9-05F69CA890FD";
-/*QString mk_p(const QString &p){
-    return "-----BEGIN PGP MESSAGE-----\n\
-hQEMA5nIqaHb6O9+AQgAu4QCbNR75qFMSqK+QQ+PcAbA6IAeDO5Y2wkYUEMtGRS5\n\
-ReUfQwiiFlsKOy8rhZ/JymgPXbosfI9c7xHCpxy7MSZxebgrwN4EGFm3WE34ttSm\n\
-0UUkkJEDmrEqoIIyzCv2/TIAXHjci+Qn3Fu9IDWvtktDCuvrfpwUrCg07S2wR/Ua\n\
-exYO0Q4IaAErD3Ww2DXc9snYxwVSh802wu1a/YAxw1RTkO7bY7+DZ9hqElwFIfiq\n\
-5zCn3FAvCFrbka73LVqFNpDV4j56hL7C3GvRA5iQNuAF7R/6Faml0ERHAJBDfVNL\n\
-ZiRPLP5nlNCEe+Tc5mEuHR+2v51CkPiYeWBi2adZndJAAQWWqs5+/aNy2Ceezkx7\n\
-IaLYWR7xwi27fPYnKoydXf2tB5aNQYOT8YQHqURuQJSvrcRXFwx01+WAIt83p6w1\n\
-Iw==\n\
-=9rq4\n\
------END PGP MESSAGE-----";
-
-}*/
-QString mk_p(const QString &p){ 
-    QProcess gpg;
-    gpg.start("/usr/local/bin/gpg", QStringList() << "--encrypt"<< "--recipient"<< "65AB18D0BE266384" /*<<"--armor"*/);
-    if (!gpg.waitForStarted())
-        return "false";
-    gpg.write("Test password!");
-    gpg.closeWriteChannel();
-
-    if (!gpg.waitForFinished())
-        return "false";
-    QByteArray result = gpg.readAll();
-    gpg.setReadChannel(QProcess::StandardError);
-    QByteArray err = gpg.readAll();
-    QString ret = QString::fromLatin1(result.toBase64())+QString::fromUtf8(err);
-
-    return ret;
-}
 
 void Entry::setPassword(const QString& password)
 {
@@ -1039,7 +1007,7 @@ void Entry::updateModifiedSinceBegin()
 {
     m_modifiedSinceBegin = true;
 }
-//what is this for?
+
 QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxDepth) const
 {
     if (maxDepth <= 0) {

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -102,7 +102,7 @@ public:
     QString webUrl() const;
     QString displayUrl() const;
     QString username() const;
-    QString password() const;
+    QString password(bool decodeRealPassword=false) const;
     QString notes() const;
     QString attribute(const QString& key) const;
     QString totp() const;
@@ -152,6 +152,7 @@ public:
     void addHistoryItem(Entry* entry);
     void removeHistoryItems(const QList<Entry*>& historyEntries);
     void truncateHistory();
+    void updateGpgData(bool forceUpdate=false);
 
     bool equals(const Entry* other, CompareItemOptions options = CompareItemDefault) const;
 
@@ -211,6 +212,7 @@ public:
     static const QString AutoTypeSequenceUsername;
     static const QString AutoTypeSequencePassword;
     static CloneFlags DefaultCloneFlags;
+    static const QString GpgPasswordPlaceholder;
 
     /**
      * Creates a duplicate of this entry except that the returned entry isn't
@@ -284,6 +286,7 @@ private:
     bool m_modifiedSinceBegin;
     QPointer<Group> m_group;
     bool m_updateTimeinfo;
+    bool m_passwordModified;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Entry::CloneFlags)

--- a/src/core/PasswordCacheService.cpp
+++ b/src/core/PasswordCacheService.cpp
@@ -1,0 +1,193 @@
+#include "PasswordCacheService.h"
+#include <QDir>
+#include <QRegularExpression>
+#include <QProcess>
+#include <utility>
+#include <QtDebug>
+#include <QApplication>
+#include <QMessageBox>
+#include <QTimer>
+#include "gui/MessageBox.h"
+#include <gpgme.h>
+
+#include <iostream>
+#include <unistd.h>
+
+gpgme_error_t gpgme_interact_cb_t_impl(void* /*handle*/, const char* status, const char* /*args*/, int fd)
+{
+    if (strcmp(status, "GET_LINE") == 0) {
+        char rr[] = "quit\n\x00";
+        write(fd, rr, sizeof(rr));
+    }
+    return 0;
+}
+bool initGPG()
+{
+    gpgme_error_t error = 0;
+    const char* ver = gpgme_check_version(0);
+    //Utils::STDERR << "GPGme version: " << ver << endl;
+    gpgme_ctx_t ctx;
+    gpgme_new(&ctx);
+
+    // this seems to work as the key is not touched, but the documentation doesn't state much
+    // "GPG_ERR_INV_VALUE if ctx or key is not a valid pointer."
+    gpgme_key_t empty_key = nullptr;
+    gpgme_data_t data_fun;
+    gpgme_data_new(&data_fun);
+    gpgme_op_interact(ctx, empty_key, GPGME_INTERACT_CARD, gpgme_interact_cb_t_impl, NULL, data_fun);
+    gpgme_data_seek(data_fun, 0, SEEK_SET);
+
+    QString output;
+    output.reserve(1024);
+    int s = 0;
+    char buff[30];
+    while ((s = gpgme_data_read(data_fun, buff, sizeof(buff))) > 0) {
+        // fwrite(buff, 1, s, stdout);
+        output.append(QString::fromUtf8(buff, s));
+    }
+    // Utils::STDERR  << output<<endl;
+    gpgme_data_release(data_fun);
+    gpgme_release(ctx);
+    if (output.contains("Reader:")) {
+        int start = output.indexOf("Reader:");
+        int end = output.indexOf("\n", start);
+        if (end != -1) {
+            //Utils::STDERR << "Found Card: " << output.mid(start, end - start) << endl;
+            return true;
+        }
+    }
+    return false;
+}
+
+void GpgDecryptionThread::setEncryptedPassword(const QString &password){
+    m_encryptedPassword=password;
+}
+#define callNcheck(foo) error=foo;if(gpgme_err_code(error)!=GPG_ERR_NO_ERROR)do{qInfo()<<"GPGme error: "<<gpgme_err_code(error)<< " "<<gpgme_strsource (error)<<" " <<gpgme_strerror(error);emit decryptionError(2,QString()+gpgme_err_code(error)+" "+gpgme_strsource (error)+" "+gpgme_strerror(error));}while(0)
+
+void GpgDecryptionThread::run(){
+    bool init=initGPG();
+    if(!init){
+        emit decryptionError(0,"init");
+        return;
+    }
+    QByteArray data=QByteArray::fromBase64(m_encryptedPassword.toLatin1());
+    gpgme_error_t error=0;
+    const  char * ver=gpgme_check_version(0);
+    //TODO: clean memory leaks
+    gpgme_ctx_t ctx;
+    gpgme_data_t g_data;
+    gpgme_data_t target;
+    callNcheck(gpgme_new(&ctx));
+    callNcheck(gpgme_data_new_from_mem(&g_data,data.constData(),data.length(),1));
+    callNcheck(gpgme_data_new(&target));
+    callNcheck(gpgme_op_decrypt(ctx,g_data,target));
+    ssize_t s;
+    char buff[30];
+    QByteArray out_arr;
+    gpgme_data_seek(target,0,SEEK_SET);
+    while( (s=gpgme_data_read(target,buff,sizeof(buff)))>0){
+        out_arr.append(buff,s);
+    }
+    QString ret = QString::fromLatin1(out_arr);
+    gpgme_data_release(g_data);
+    gpgme_data_release(target);
+    gpgme_release(ctx);
+    emit passwordDecrypted(ret);
+}
+void PasswordCacheService::passwordDecrypted(const QString &password){
+    m_error=-1;
+    m_returned=password;
+    m_messageBox->close();
+}
+void PasswordCacheService::passwordDecriptionFailed(int error,const QString &extError){
+    m_error=error;
+    m_returned=extError;
+    m_messageBox->close();
+}
+QString PasswordCacheService::GpgDecryptPassword(const QString &username,const QString &title,const QString & gpgPassword){
+    GpgDecryptionThread *thread=new GpgDecryptionThread(this);
+
+    QMessageBox &msgBox=*new QMessageBox();
+    msgBox.setWindowTitle(tr("GPG password decrypt"));
+    msgBox.setText(tr("Title: %1\nUsername: %2\n\n Please touch youbikey to proceed").arg(title,username));
+    msgBox.setIcon(QMessageBox::Information);
+    msgBox.setStandardButtons(QMessageBox::Cancel);
+    m_messageBox=&msgBox;
+
+    connect(thread, &GpgDecryptionThread::passwordDecrypted, this, &PasswordCacheService::passwordDecrypted);
+    connect(thread, &GpgDecryptionThread::decryptionError, this, &PasswordCacheService::passwordDecriptionFailed);
+    thread->setEncryptedPassword(gpgPassword);
+    thread->start();
+    msgBox.setWindowFlags(Qt::WindowStaysOnTopHint);
+    msgBox.activateWindow();
+    msgBox.raise();
+    auto status=msgBox.exec();
+    
+    //gpg returned error
+    if(m_error!=-1){
+        //indicate to try init on the next try
+        initialized=false;
+        auto result = MessageBox::question(nullptr,
+                                           tr("GPG process failed!"),
+                                           tr("Can't decrypt your password.\n"
+                                           "Check if the yubikey is connected and click Retry.\n\n"
+                                           "The process failed with the following error message:\n")+m_returned,
+                                           MessageBox::Retry | MessageBox::Abort);
+        if(result==MessageBox::Retry){
+            return GpgDecryptPassword(username,title,gpgPassword);
+        }else{
+            return "";
+        }
+    } 
+ 
+    return m_returned;
+}
+QString PasswordCacheService::GpgDecryptPassword(const Entry& entry,const QString & gpgPassword){
+    return GpgDecryptPassword(entry.username(),entry.title(),gpgPassword);
+}
+
+
+PasswordCacheService * PasswordCacheService::s_instance=nullptr;
+PasswordCacheService::PasswordCacheService(QObject* parent)
+    :QObject(parent),initialized(0){
+
+}
+QString PasswordCacheService::value(const Entry& entry)const{
+    return value(entry.uuid());
+}
+QString PasswordCacheService::value(const QUuid& key)const{
+    //qInfo()<< " returning value from cache for "<<key<< " : "<<m_passwordMap.value(key); 
+    return m_passwordMap.value(key);
+}
+QString PasswordCacheService::decodeAndStore(const Entry& entry,const QString& encryptedPassword){
+    //qInfo()<< "Getting password for uuid "<<entry.uuid(); 
+    QString pwd=GpgDecryptPassword(entry,encryptedPassword);
+    //Disable cache as it is not needed after refactoring - no more repeated asking for unlocking.
+    //It may become handy in the future so the PasswordCacheService stays for now.
+    /* if(pwd!="")
+        m_passwordMap[entry.uuid()]=pwd;*/
+    return pwd;
+}
+void PasswordCacheService::remove(const QUuid& key){
+    m_passwordMap.remove(key);
+}
+bool PasswordCacheService::contains(const QUuid& key) const{
+    //qInfo()<< " checking if we have password for "<<key<< " : "<<m_passwordMap.contains(key); 
+    return m_passwordMap.contains(key);
+}
+void PasswordCacheService::clear(){
+    m_passwordMap.clear();
+}
+PasswordCacheService& PasswordCacheService::instance(){
+    if(!s_instance){
+        s_instance=new PasswordCacheService(nullptr);
+    }
+    return *s_instance;
+}
+
+void PasswordCacheService::expirationTimerExpired(){
+
+}
+void PasswordCacheService::touchTimerExpired(){
+
+}

--- a/src/core/PasswordCacheService.h
+++ b/src/core/PasswordCacheService.h
@@ -1,0 +1,62 @@
+#ifndef PASSWORD_CACHE_SERVICE_H
+#define PASSWORD_CACHE_SERVICE_H
+#include <QMap>
+#include <QObject>
+#include <QRegularExpression>
+#include <QSet>
+#include <QStringList>
+#include <QUuid>
+#include <QMessageBox>
+#include <QTimer>
+#include <QThread>
+#include "core/Entry.h"
+
+enum class DecryptionError{
+    initFailed,
+    startProcessFailed
+};
+
+class GpgDecryptionThread : public QThread
+{
+    Q_OBJECT
+    virtual void run() override;
+    QString m_encryptedPassword;
+public:
+    GpgDecryptionThread(QObject* parent = nullptr):QThread(parent){}
+    void setEncryptedPassword(const QString &password);
+signals:
+    void passwordDecrypted(const QString &s);
+    void decryptionError(int error,const QString &extError);
+};
+
+class PasswordCacheService : public QObject
+{
+    Q_OBJECT
+
+public:
+    QString value(const Entry& entry) const;
+    QString value(const QUuid& key) const;
+    QString decodeAndStore(const Entry& entry,const QString& encryptedPassword);
+    bool contains(const QUuid& key) const;
+    void clear();
+    void remove(const QUuid& key);
+    static PasswordCacheService& instance();
+    QString GpgDecryptPassword(const QString &username,const QString &title,const QString & gpgPassword);
+private:
+    explicit PasswordCacheService(QObject* parent = nullptr);
+    static PasswordCacheService *s_instance;
+    bool initialized;
+    QString m_returned;
+    int m_error;
+    QString GpgDecryptPassword(const Entry& entry,const QString & gpgPassword);
+    QMap<QUuid, QString> m_passwordMap;
+    QPointer<QMessageBox> m_messageBox;
+    QPointer<QTimer> m_messageTimer;
+    QPointer<QThread> m_workerThread;
+private slots : 
+    void expirationTimerExpired();
+    void touchTimerExpired();
+    void passwordDecrypted(const QString &password);
+    void passwordDecriptionFailed(int error,const QString &extError);
+};
+#endif

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -669,7 +669,7 @@ void DatabaseWidget::copyPassword()
 
     auto currentEntry = currentSelectedEntry();
     if (currentEntry) {
-        setClipboardTextAndMinimize(currentEntry->resolveMultiplePlaceholders(currentEntry->password()));
+        setClipboardTextAndMinimize(currentEntry->resolveMultiplePlaceholders(currentEntry->password(true)));
     }
 }
 
@@ -1006,6 +1006,9 @@ void DatabaseWidget::switchToMainView(bool previousDialogAccepted)
         // Workaround: ensure entries are focused so search doesn't reset
         m_entryView->setFocus();
     }
+    if(sender()==m_editEntryWidget && previousDialogAccepted){
+                m_entryView->currentEntry()->updateGpgData(true);
+    }
 
     if (sender() == m_entryView || sender() == m_editEntryWidget) {
         onEntryChanged(m_entryView->currentEntry());
@@ -1195,7 +1198,8 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
         setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->username()));
         break;
     case EntryModel::Password:
-        setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->password()));
+    //TODO get password
+        setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->password(true)));
         break;
     case EntryModel::Url:
         if (!entry->url().isEmpty()) {

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1198,7 +1198,6 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
         setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->username()));
         break;
     case EntryModel::Password:
-    //TODO get password
         setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->password(true)));
         break;
     case EntryModel::Url:

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -189,7 +189,7 @@ void EntryPreviewWidget::updateEntryTotp()
 
 void EntryPreviewWidget::setPasswordVisible(bool state)
 {
-    const QString password = m_currentEntry->resolveMultiplePlaceholders(m_currentEntry->password());
+    const QString password = m_currentEntry->resolveMultiplePlaceholders(m_currentEntry->password(state));
     if (state) {
         m_ui->entryPasswordLabel->setText(password);
         m_ui->entryPasswordLabel->setCursorPosition(0);

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -879,7 +879,7 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_mainUi->titleEdit->setText(entry->title());
     m_mainUi->usernameComboBox->lineEdit()->setText(entry->username());
     m_mainUi->urlEdit->setText(entry->url());
-    m_mainUi->passwordEdit->setText(entry->password());
+    m_mainUi->passwordEdit->setText(entry->password(true));
     m_mainUi->passwordEdit->setShowPassword(!config()->get(Config::Security_PasswordsHidden).toBool());
     if (!m_history) {
         m_mainUi->passwordEdit->enablePasswordGenerator();
@@ -1047,7 +1047,6 @@ bool EditEntryWidget::commitEntry()
     }
 
     updateEntryData(m_entry);
-
     if (!m_create) {
         m_entry->endUpdate();
     }


### PR DESCRIPTION
This is an initial pull request to start a discussion about possibility to merge the changes.

This feature enables single-password encryption in the database using hardware smart-card. I've implemented it using Yubikey but any gpg-card-compatible device will work.

The main idea is to additionally protect some (or all) passwords even when the database is open, so if an attacker is able to gain access to the database - e.g. by exploiting other applications to gain local access or through supply chain attacks - they won't be able to access all passwords at once.

As each access to a protected password requires a user to touch the Yubikey the user will be able to notice that they're being attacked.

The implementation uses libgpgme and works in the following way:
- a key-pair is created for encryption (or existing key-pair can be used)
- certain paths in the database are marked with key id using keepassxc-cli tool for additional encryption
- when a new password is saved it is encrypted and stored in the database as attribute, password is replaced with a placeholder to signal the need for decription
- when password is accessed in most contexts only placeholder is returned to not annoy the user with constant prompts - this breaks a few features
- when password is required the user will be asked to confirm decryption with a touch (this happens when: "show password" button is clicked, password is edited, copied, autotype is performed or a browser plugin requests it)

To allow the changes to work with the existing codebase mostly intact I've modified the Password member function in Entry class to take a boolean parameter. This parameter indicates if password decryption is to be performed or if returning a placeholder value will be sufficient. The default value is set to false meaning that decryption will only take place in a few cases. Apart from that change the rest of the code is guarded with WITH_XC_GPG compile-time option.

Limitations:
- password health doesn't work correctly as it will consider the placeholder to be a reused password
- export doesn't work correctly as only placeholder will be exported 
- for the browser plugin integration a small change to the plugin is required to enable password decryption


## Screenshots
Setup procedure is shown here: https://grota.be/~michoo/gpg/test.html
<img width="1191" alt="Screenshot 2021-03-30 at 12 43 50" src="https://user-images.githubusercontent.com/75495717/117012823-99a7bc00-acef-11eb-8bd3-1d3c82252c5d.png">
<img width="1192" alt="Screenshot 2021-03-30 at 12 43 58" src="https://user-images.githubusercontent.com/75495717/117012853-9e6c7000-acef-11eb-8e80-cbf73c7b28b0.png">
<img width="540" alt="Screenshot 2021-03-30 at 12 46 14" src="https://user-images.githubusercontent.com/75495717/117012858-9f9d9d00-acef-11eb-8e3d-7f7b77723338.png">
<img width="507" alt="Screenshot 2021-03-30 at 12 46 19" src="https://user-images.githubusercontent.com/75495717/117012860-9f9d9d00-acef-11eb-9d53-9666352ec47e.png">
<img width="530" alt="Screenshot 2021-03-30 at 17 08 25" src="https://user-images.githubusercontent.com/75495717/117012862-a0363380-acef-11eb-957f-8edcb6a2d124.png">


## Testing strategy
As the changes introduce encryption with a smart card that requires touching for decryption it is not possible to create standard automated tests.

To create this feature a small program was made for encryption and decryption of arbitrary text, working in a same way as _gpg --encrypt_ / _gpg --decrypt_ and then, once working and tested manually it was integrated with KeepassXC. The changes to the application were kept to minimum as not to break the existing code.

When using a non-hardware decryption, i.e. a key-pair without a password that is added to the gpg agent, it is possible to encrypt a database and run standard tests, but that won't test gpg-card specific functions, i.e. card initialization.

For completeness a virtual gpg card could be used but that would require a lot more development effort and a separate test environment to run the tests.

## Type of change
- ✅ New feature (change that adds functionality)
