### PR TITLE
Add command line option to lock open databases

### DIFF
--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -357,15 +357,16 @@ bool Application::sendFileNamesToRunningInstance(const QStringList& fileNames)
     QByteArray data;
     QDataStream out(&data, QIODevice::WriteOnly);
     out.setVersion(QDataStream::Qt_5_0);
-    out << quint32(0); //reserve space for block size
-    out << quint32(1); //ID for file name send. TODO: move to enum
-    out << fileNames; //send file names to be opened
+    out << quint32(0); // reserve space for block size
+    out << quint32(1); // ID for file name send. TODO: move to enum
+    out << fileNames; // send file names to be opened
     out.device()->seek(0);
-    out << quint32(data.size() - sizeof(quint32)); //replace the previous constant 0 with block size
+    out << quint32(data.size() - sizeof(quint32)); // replace the previous constant 0 with block size
 
     const bool writeOk = client.write(data) != -1 && client.waitForBytesWritten(WaitTimeoutMSec);
     client.disconnectFromServer();
-    const bool disconnected = client.state() == QLocalSocket::UnconnectedState || client.waitForDisconnected(WaitTimeoutMSec);
+    const bool disconnected =
+        client.state() == QLocalSocket::UnconnectedState || client.waitForDisconnected(WaitTimeoutMSec);
     return writeOk && disconnected;
 }
 
@@ -388,15 +389,16 @@ bool Application::sendLockToInstance()
     QByteArray data;
     QDataStream out(&data, QIODevice::WriteOnly);
     out.setVersion(QDataStream::Qt_5_0);
-    out << quint32(0); //reserve space for block size
-    out << quint32(2); //ID for database lock. TODO: move to enum
+    out << quint32(0); // reserve space for block size
+    out << quint32(2); // ID for database lock. TODO: move to enum
     out.device()->seek(0);
-    out << quint32(data.size() - sizeof(quint32)); //replace the previous constant 0 with block size
+    out << quint32(data.size() - sizeof(quint32)); // replace the previous constant 0 with block size
 
     // Finish gracefully
     const bool writeOk = client.write(data) != -1 && client.waitForBytesWritten(WaitTimeoutMSec);
     client.disconnectFromServer();
-    const bool disconnected = client.state() == QLocalSocket::UnconnectedState || client.waitForConnected(WaitTimeoutMSec);
+    const bool disconnected =
+        client.state() == QLocalSocket::UnconnectedState || client.waitForConnected(WaitTimeoutMSec);
     return writeOk && disconnected;
 }
 

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -49,7 +49,8 @@ public:
     bool isAlreadyRunning() const;
     bool isDarkTheme() const;
 
-    bool sendToRunningInstance(quint32 id, const QStringList& fileNames);
+    bool sendFileNamesToRunningInstance(const QStringList& fileNames);
+    bool sendLockToInstance();
 
     void restart();
 

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -49,7 +49,7 @@ public:
     bool isAlreadyRunning() const;
     bool isDarkTheme() const;
 
-    bool sendFileNamesToRunningInstance(const QStringList& fileNames);
+    bool sendToRunningInstance(quint32 id, const QStringList& fileNames);
 
     void restart();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ int main(int argc, char** argv)
     QCommandLineOption configOption("config", QObject::tr("path to a custom config file"), "config");
     QCommandLineOption localConfigOption(
         "localconfig", QObject::tr("path to a custom local config file"), "localconfig");
+    QCommandLineOption lockOption("lock", QObject::tr("lock all open databases"));
     QCommandLineOption keyfileOption("keyfile", QObject::tr("key file of the database"), "keyfile");
     QCommandLineOption pwstdinOption("pw-stdin", QObject::tr("read password of the database from stdin"));
     QCommandLineOption allowScreenCaptureOption("allow-screencapture",
@@ -81,6 +82,7 @@ int main(int argc, char** argv)
     QCommandLineOption debugInfoOption(QStringList() << "debug-info", QObject::tr("Displays debugging information."));
     parser.addOption(configOption);
     parser.addOption(localConfigOption);
+    parser.addOption(lockOption);
     parser.addOption(keyfileOption);
     parser.addOption(pwstdinOption);
     parser.addOption(debugInfoOption);
@@ -110,12 +112,23 @@ int main(int argc, char** argv)
     }
 
     // Process single instance and early exit if already running
+    // FIXME: this is a *mess* and it is entirely my fault. --wundrweapon
     const QStringList fileNames = parser.positionalArguments();
     if (app.isAlreadyRunning()) {
-        if (!fileNames.isEmpty()) {
-            app.sendFileNamesToRunningInstance(fileNames);
+        if (parser.isSet(lockOption)) {
+            if (app.sendToRunningInstance(2, fileNames)) {
+                qInfo() << QObject::tr("Locked database.").toUtf8().constData();
+            } else {
+                qWarning() << QObject::tr("Database failed to lock.").toUtf8().constData();
+                return EXIT_FAILURE;
+            }
+        } else {
+            if (!fileNames.isEmpty()) {
+                app.sendToRunningInstance(1, fileNames);
+            }
+
+            qWarning() << QObject::tr("Another instance of KeePassXC is already running.").toUtf8().constData();
         }
-        qWarning() << QObject::tr("Another instance of KeePassXC is already running.").toUtf8().constData();
         return EXIT_SUCCESS;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,15 +116,15 @@ int main(int argc, char** argv)
     const QStringList fileNames = parser.positionalArguments();
     if (app.isAlreadyRunning()) {
         if (parser.isSet(lockOption)) {
-            if (app.sendToRunningInstance(2, fileNames)) {
-                qInfo() << QObject::tr("Locked database.").toUtf8().constData();
+            if (app.sendLockToInstance()) {
+                qInfo() << QObject::tr("Locked databases.").toUtf8().constData();
             } else {
                 qWarning() << QObject::tr("Database failed to lock.").toUtf8().constData();
                 return EXIT_FAILURE;
             }
         } else {
             if (!fileNames.isEmpty()) {
-                app.sendToRunningInstance(1, fileNames);
+                app.sendFileNamesToRunningInstance(fileNames);
             }
 
             qWarning() << QObject::tr("Another instance of KeePassXC is already running.").toUtf8().constData();


### PR DESCRIPTION
Closes/Fixes #6126

This adds a command line option `--lock` which locks all open databases in the running instance. This also makes some minor changes to the codebase ~~(e.g. changing `bool sendFileNamesToRunningInstance(const QStringList& fileNames)` to `bool sendToRunningInstance(quint32 id, const QStringList& fileNames)` for more flexibility in future)~~, as well as some comments to explain what appears to be going on in otherwise-confusing code. Some of these comments are TODOs, particularly one that urges the use of an enum going forward per droidmonkey's idea.

## Screenshots
![--lock option in the --help print](https://i.imgur.com/lLSWreR.png)

## Testing strategy
I loaded up one real database and one dummy database, then ran `keepassxc --lock`. As expected, both locked. I also made sure sending files to open works as usual.

## Type of change
- ✅ New feature (change that adds functionality)
- ✅ Documentation (non-code change)
