### PR TITLE
only display advanced settings checkbox on tabs that have them (partially fixes #6190)

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1582,10 +1582,6 @@ If you do not have a key file, please leave the field empty.</source>
 <context>
     <name>DatabaseSettingsDialog</name>
     <message>
-        <source>Advanced Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1779,14 +1775,6 @@ Are you sure you want to continue without a password?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change existing decryption time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Decryption time in seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1867,11 +1855,6 @@ Are you sure you want to continue without a password?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>unchanged</source>
-        <comment>Database decryption time is unchanged</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Number of rounds too high</source>
         <comment>Key transformation rounds</comment>
         <translation type="unfinished"></translation>
@@ -1924,6 +1907,18 @@ If you keep this number, your database will not be protected from brute force at
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Encryption Settings:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5590,14 +5585,6 @@ We recommend you use the AppImage available on our downloads page.</source>
     </message>
     <message>
         <source>Here you can adjust the database encryption settings. Don&apos;t worry, you can change them later in the database settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Advanced Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Simple Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -104,7 +104,6 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_MinimizeOnClose, {QS("GUI/MinimizeOnClose"), Roaming, false}},
     {Config::GUI_HideUsernames, {QS("GUI/HideUsernames"), Roaming, false}},
     {Config::GUI_HidePasswords, {QS("GUI/HidePasswords"), Roaming, true}},
-    {Config::GUI_AdvancedSettings, {QS("GUI/AdvancedSettings"), Roaming, false}},
     {Config::GUI_ColorPasswords, {QS("GUI/ColorPasswords"), Roaming, false}},
     {Config::GUI_MonospaceNotes, {QS("GUI/MonospaceNotes"), Roaming, false}},
     {Config::GUI_ApplicationTheme, {QS("GUI/ApplicationTheme"), Roaming, QS("auto")}},
@@ -371,7 +370,10 @@ static const QHash<QString, Config::ConfigKey> deprecationMap = {
     {QS("UseTouchID"), Config::Deleted},
     {QS("Security/ResetTouchId"), Config::Deleted},
     {QS("Security/ResetTouchIdTimeout"), Config::Deleted},
-    {QS("Security/ResetTouchIdScreenlock"), Config::Deleted}};
+    {QS("Security/ResetTouchIdScreenlock"), Config::Deleted},
+
+    // 2.8.0
+    {QS("GUI/AdvancedSettings"), Config::Deleted}};
 
 /**
  * Migrate settings from previous versions.

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -85,7 +85,6 @@ public:
         GUI_MinimizeOnClose,
         GUI_HideUsernames,
         GUI_HidePasswords,
-        GUI_AdvancedSettings,
         GUI_ColorPasswords,
         GUI_MonospaceNotes,
         GUI_ApplicationTheme,

--- a/src/gui/dbsettings/DatabaseSettingsDialog.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.cpp
@@ -33,7 +33,6 @@
 #include "fdosecrets/DatabaseSettingsPageFdoSecrets.h"
 #endif
 
-#include "core/Config.h"
 #include "core/Database.h"
 #include "core/Global.h"
 #include "gui/Icons.h"
@@ -109,7 +108,6 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
 
     connect(m_securityTabWidget, SIGNAL(currentChanged(int)), SLOT(pageChanged()));
     connect(m_ui->categoryList, SIGNAL(categoryChanged(int)), m_ui->stackedWidget, SLOT(setCurrentIndex(int)));
-    connect(m_ui->advancedSettingsToggle, SIGNAL(toggled(bool)), SLOT(toggleAdvancedMode(bool)));
 
 #ifdef WITH_XC_BROWSER
     m_ui->categoryList->addCategory(tr("Browser Integration"), icons()->icon("internet-web-browser"));
@@ -137,7 +135,6 @@ void DatabaseSettingsDialog::load(const QSharedPointer<Database>& db)
     for (const ExtraPage& page : asConst(m_extraPages)) {
         page.loadSettings(db);
     }
-    m_ui->advancedSettingsToggle->setChecked(config()->get(Config::GUI_AdvancedSettings).toBool());
     m_db = db;
 }
 
@@ -189,32 +186,5 @@ void DatabaseSettingsDialog::reject()
 
 void DatabaseSettingsDialog::pageChanged()
 {
-    int pageIndex = m_ui->stackedWidget->currentIndex();
-
-    bool enabled = (pageIndex == Page::General && m_generalWidget->hasAdvancedMode());
-
-    if (Page::Security == pageIndex) {
-        int tabIndex = m_securityTabWidget->currentIndex();
-        enabled = (tabIndex == 0 && m_databaseKeyWidget->hasAdvancedMode());
-        enabled |= (tabIndex == 1 && m_encryptionWidget->hasAdvancedMode());
-    }
-
-    m_ui->advancedSettingsToggle->setEnabled(enabled);
-}
-
-void DatabaseSettingsDialog::toggleAdvancedMode(bool advanced)
-{
-    if (m_generalWidget->hasAdvancedMode()) {
-        m_generalWidget->setAdvancedMode(advanced);
-    }
-
-    if (m_databaseKeyWidget->hasAdvancedMode()) {
-        m_databaseKeyWidget->setAdvancedMode(advanced);
-    }
-
-    if (m_encryptionWidget->hasAdvancedMode()) {
-        m_encryptionWidget->setAdvancedMode(advanced);
-    }
-
-    config()->set(Config::GUI_AdvancedSettings, advanced);
+    m_ui->stackedWidget->currentIndex();
 }

--- a/src/gui/dbsettings/DatabaseSettingsDialog.h
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.h
@@ -69,7 +69,6 @@ private slots:
     void save();
     void reject();
     void pageChanged();
-    void toggleAdvancedMode(bool advanced);
 
 private:
     enum Page

--- a/src/gui/dbsettings/DatabaseSettingsDialog.ui
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.ui
@@ -18,22 +18,11 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="advancedSettingsToggle">
-       <property name="text">
-        <string>Advanced Settings</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.h
@@ -43,10 +43,6 @@ public:
     ~DatabaseSettingsWidgetBrowser() override;
 
     CustomData* customData() const;
-    inline bool hasAdvancedMode() const override
-    {
-        return false;
-    }
 
 public slots:
     void initialize() override;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.h
@@ -44,11 +44,6 @@ public:
 
     void load(QSharedPointer<Database> db) override;
 
-    inline bool hasAdvancedMode() const override
-    {
-        return false;
-    }
-
 public slots:
     void initialize() override;
     void uninitialize() override;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
@@ -27,7 +27,23 @@
 #include "format/KeePass2Writer.h"
 #include "gui/MessageBox.h"
 
+#include <QPushButton>
+
 const char* DatabaseSettingsWidgetEncryption::CD_DECRYPTION_TIME_PREFERENCE_KEY = "KPXC_DECRYPTION_TIME_PREFERENCE";
+
+#define IS_ARGON2(uuid) (uuid == KeePass2::KDF_ARGON2D || uuid == KeePass2::KDF_ARGON2ID)
+#define IS_AES_KDF(uuid) (uuid == KeePass2::KDF_AES_KDBX3 || uuid == KeePass2::KDF_AES_KDBX4)
+
+namespace
+{
+    QString getTextualEncryptionTime(int millisecs)
+    {
+        if (millisecs < 1000) {
+            return QObject::tr("%1 ms", "milliseconds", millisecs).arg(millisecs);
+        }
+        return QObject::tr("%1 s", "seconds", millisecs / 1000).arg(millisecs / 1000.0, 0, 'f', 1);
+    }
+} // namespace
 
 DatabaseSettingsWidgetEncryption::DatabaseSettingsWidgetEncryption(QWidget* parent)
     : DatabaseSettingsWidget(parent)
@@ -50,19 +66,16 @@ DatabaseSettingsWidgetEncryption::DatabaseSettingsWidgetEncryption(QWidget* pare
     updateDecryptionTime(m_ui->decryptionTimeSlider->value());
 
     m_ui->transformBenchmarkButton->setText(
-        QObject::tr("Benchmark %1 delay")
-            .arg(DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(Kdf::DEFAULT_ENCRYPTION_TIME)));
-    m_ui->minTimeLabel->setText(DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(Kdf::MIN_ENCRYPTION_TIME));
-    m_ui->maxTimeLabel->setText(DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(Kdf::MAX_ENCRYPTION_TIME));
+        QObject::tr("Benchmark %1 delay").arg(getTextualEncryptionTime(Kdf::DEFAULT_ENCRYPTION_TIME)));
+    m_ui->minTimeLabel->setText(getTextualEncryptionTime(Kdf::MIN_ENCRYPTION_TIME));
+    m_ui->maxTimeLabel->setText(getTextualEncryptionTime(Kdf::MAX_ENCRYPTION_TIME));
 
-    connect(m_ui->activateChangeDecryptionTimeButton, SIGNAL(clicked()), SLOT(activateChangeDecryptionTime()));
     connect(m_ui->decryptionTimeSlider, SIGNAL(valueChanged(int)), SLOT(updateDecryptionTime(int)));
     connect(m_ui->compatibilitySelection, SIGNAL(currentIndexChanged(int)), SLOT(updateFormatCompatibility(int)));
 
     // conditions under which a key re-transformation is needed
     connect(m_ui->decryptionTimeSlider, SIGNAL(valueChanged(int)), SLOT(markDirty()));
     connect(m_ui->compatibilitySelection, SIGNAL(currentIndexChanged(int)), SLOT(markDirty()));
-    connect(m_ui->activateChangeDecryptionTimeButton, SIGNAL(clicked()), SLOT(markDirty()));
     connect(m_ui->algorithmComboBox, SIGNAL(currentIndexChanged(int)), SLOT(markDirty()));
     connect(m_ui->kdfComboBox, SIGNAL(currentIndexChanged(int)), SLOT(markDirty()));
     connect(m_ui->transformRoundsSpinBox, SIGNAL(valueChanged(int)), SLOT(markDirty()));
@@ -72,8 +85,13 @@ DatabaseSettingsWidgetEncryption::DatabaseSettingsWidgetEncryption(QWidget* pare
 
 DatabaseSettingsWidgetEncryption::~DatabaseSettingsWidgetEncryption() = default;
 
-#define IS_ARGON2(uuid) (uuid == KeePass2::KDF_ARGON2D || uuid == KeePass2::KDF_ARGON2ID)
-#define IS_AES_KDF(uuid) (uuid == KeePass2::KDF_AES_KDBX3 || uuid == KeePass2::KDF_AES_KDBX4)
+void DatabaseSettingsWidgetEncryption::showBasicEncryption(int decryptionMillisecs)
+{
+    // Show the basic encryption settings tab and set the slider to the stored values
+    m_ui->decryptionTimeSlider->setValue(decryptionMillisecs / 100);
+    m_ui->encryptionSettingsTabWidget->setCurrentWidget(m_ui->basicTab);
+    m_initWithAdvanced = false;
+}
 
 void DatabaseSettingsWidgetEncryption::initialize()
 {
@@ -82,39 +100,44 @@ void DatabaseSettingsWidgetEncryption::initialize()
         return;
     }
 
-    bool isDirty = false;
+    auto version = KDBX4;
+    if (m_db->kdf()) {
+        version = (m_db->kdf()->uuid() == KeePass2::KDF_AES_KDBX3) ? KDBX3 : KDBX4;
+    }
+    m_ui->compatibilitySelection->setCurrentIndex(version);
+
+    bool isNewDatabase = false;
 
     if (!m_db->kdf()) {
         m_db->setKdf(KeePass2::uuidToKdf(KeePass2::KDF_ARGON2D));
-        isDirty = true;
+        isNewDatabase = true;
     }
     if (!m_db->key()) {
         m_db->setKey(QSharedPointer<CompositeKey>::create(), true, false, false);
         m_db->setCipher(KeePass2::CIPHER_AES256);
-        isDirty = true;
+        isNewDatabase = true;
     }
     bool kdbx3Enabled = KeePass2Writer::kdbxVersionRequired(m_db.data(), true, true) <= KeePass2::FILE_VERSION_3_1;
 
     // check if the DB's custom data has a decryption time setting stored
     // and set the slider to it, otherwise just state that the time is unchanged
     // (we cannot infer the time from the raw KDF settings)
+
     auto* cd = m_db->metadata()->customData();
     if (cd->hasKey(CD_DECRYPTION_TIME_PREFERENCE_KEY)) {
         int decryptionTime = qMax(100, cd->value(CD_DECRYPTION_TIME_PREFERENCE_KEY).toInt());
-        bool block = m_ui->decryptionTimeSlider->blockSignals(true);
-        m_ui->decryptionTimeSlider->setValue(decryptionTime / 100);
-        updateDecryptionTime(decryptionTime / 100);
-        m_ui->decryptionTimeSlider->blockSignals(block);
-        m_ui->activateChangeDecryptionTimeButton->setVisible(false);
+        showBasicEncryption(decryptionTime);
+    } else if (isNewDatabase) {
+        showBasicEncryption();
     } else {
-        m_ui->decryptionTimeSettings->setVisible(isDirty);
-        m_ui->activateChangeDecryptionTimeButton->setVisible(!isDirty);
-        if (!isDirty) {
-            m_ui->decryptionTimeValueLabel->setText(tr("unchanged", "Database decryption time is unchanged"));
-        }
+        // Set default basic decryption time
+        m_ui->decryptionTimeSlider->setValue(Kdf::DEFAULT_ENCRYPTION_TIME / 100);
+        // Show the advanced encryption settings tab
+        m_ui->encryptionSettingsTabWidget->setCurrentWidget(m_ui->advancedTab);
+        m_initWithAdvanced = true;
     }
 
-    updateFormatCompatibility(m_db->kdf()->uuid() == KeePass2::KDF_AES_KDBX3 ? KDBX3 : KDBX4, isDirty);
+    updateFormatCompatibility(m_db->kdf()->uuid() == KeePass2::KDF_AES_KDBX3 ? KDBX3 : KDBX4, isNewDatabase);
     setupAlgorithmComboBox();
     setupKdfComboBox(kdbx3Enabled);
     loadKdfParameters();
@@ -124,7 +147,7 @@ void DatabaseSettingsWidgetEncryption::initialize()
         m_ui->formatCannotBeChanged->setVisible(true);
     }
 
-    m_isDirty = isDirty;
+    m_isDirty = isNewDatabase;
 }
 
 void DatabaseSettingsWidgetEncryption::uninitialize()
@@ -170,7 +193,6 @@ void DatabaseSettingsWidgetEncryption::loadKdfParameters()
     }
 
     auto kdf = m_db->kdf();
-    Q_ASSERT(kdf);
     if (!kdf) {
         return;
     }
@@ -202,13 +224,6 @@ void DatabaseSettingsWidgetEncryption::updateKdfFields()
     m_ui->parallelismSpinBox->setVisible(IS_ARGON2(id));
 }
 
-void DatabaseSettingsWidgetEncryption::activateChangeDecryptionTime()
-{
-    m_ui->decryptionTimeSettings->setVisible(true);
-    m_ui->activateChangeDecryptionTimeButton->setVisible(false);
-    updateDecryptionTime(m_ui->decryptionTimeSlider->value());
-}
-
 void DatabaseSettingsWidgetEncryption::markDirty()
 {
     m_isDirty = true;
@@ -221,6 +236,11 @@ bool DatabaseSettingsWidgetEncryption::save()
         return false;
     }
 
+    if (m_initWithAdvanced != isAdvancedMode()) {
+        // Switched from basic <-> advanced mode, need to recalculate everything
+        m_isDirty = true;
+    }
+
     if (m_db->key() && !m_db->key()->keys().isEmpty() && !m_isDirty) {
         // nothing has changed, don't re-transform
         return true;
@@ -229,7 +249,7 @@ bool DatabaseSettingsWidgetEncryption::save()
     auto kdf = m_db->kdf();
     Q_ASSERT(kdf);
 
-    if (!advancedMode()) {
+    if (!isAdvancedMode()) {
         if (kdf && !m_isDirty && !m_ui->decryptionTimeSettings->isVisible()) {
             return true;
         }
@@ -352,7 +372,6 @@ void DatabaseSettingsWidgetEncryption::changeKdf(int index)
     QUuid id(m_ui->kdfComboBox->itemData(index).toByteArray());
     m_db->setKdf(KeePass2::uuidToKdf(id));
     updateKdfFields();
-    activateChangeDecryptionTime();
     benchmarkTransformRounds();
 }
 
@@ -372,22 +391,14 @@ void DatabaseSettingsWidgetEncryption::parallelismChanged(int value)
     m_ui->parallelismSpinBox->setSuffix(tr(" thread(s)", "Threads for parallel execution (KDF settings)", value));
 }
 
-void DatabaseSettingsWidgetEncryption::setAdvancedMode(bool advanced)
+bool DatabaseSettingsWidgetEncryption::isAdvancedMode()
 {
-    DatabaseSettingsWidget::setAdvancedMode(advanced);
-
-    if (advanced) {
-        loadKdfParameters();
-        m_ui->stackedWidget->setCurrentIndex(1);
-    } else {
-        m_ui->compatibilitySelection->setCurrentIndex(m_db->kdf()->uuid() == KeePass2::KDF_AES_KDBX3 ? KDBX3 : KDBX4);
-        m_ui->stackedWidget->setCurrentIndex(0);
-    }
+    return m_ui->encryptionSettingsTabWidget->currentWidget() == m_ui->advancedTab;
 }
 
 void DatabaseSettingsWidgetEncryption::updateDecryptionTime(int value)
 {
-    m_ui->decryptionTimeValueLabel->setText(DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(value * 100));
+    m_ui->decryptionTimeValueLabel->setText(getTextualEncryptionTime(value * 100));
 }
 
 void DatabaseSettingsWidgetEncryption::updateFormatCompatibility(int index, bool retransform)
@@ -415,16 +426,5 @@ void DatabaseSettingsWidgetEncryption::updateFormatCompatibility(int index, bool
             argon2Kdf->setMemory(1 << 16);
             argon2Kdf->setParallelism(2);
         }
-
-        activateChangeDecryptionTime();
-    }
-}
-
-QString DatabaseSettingsWidgetEncryption::getTextualEncryptionTime(int millisecs)
-{
-    if (millisecs < 1000) {
-        return QObject::tr("%1 ms", "milliseconds", millisecs).arg(millisecs);
-    } else {
-        return QObject::tr("%1 s", "seconds", millisecs / 1000).arg(millisecs / 1000.0, 0, 'f', 1);
     }
 }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.h
@@ -37,18 +37,10 @@ public:
     Q_DISABLE_COPY(DatabaseSettingsWidgetEncryption);
     ~DatabaseSettingsWidgetEncryption() override;
 
-    inline bool hasAdvancedMode() const override
-    {
-        return true;
-    }
-    void setAdvancedMode(bool advanced) override;
-
 public slots:
     void initialize() override;
     void uninitialize() override;
     bool save() override;
-
-    static QString getTextualEncryptionTime(int millisecs);
 
 protected:
     void showEvent(QShowEvent* event) override;
@@ -64,10 +56,12 @@ private slots:
     void setupKdfComboBox(bool enableKdbx3);
     void loadKdfParameters();
     void updateKdfFields();
-    void activateChangeDecryptionTime();
     void markDirty();
 
 private:
+    bool isAdvancedMode();
+    void showBasicEncryption(int decryptionMillisecs = Kdf::DEFAULT_ENCRYPTION_TIME);
+
     enum FormatSelection
     {
         KDBX4,
@@ -76,6 +70,7 @@ private:
     static const char* CD_DECRYPTION_TIME_PREFERENCE_KEY;
 
     bool m_isDirty = false;
+    bool m_initWithAdvanced = false;
     bool m_formatCompatibilityDirty = false;
     const QScopedPointer<Ui::DatabaseSettingsWidgetEncryption> m_ui;
 };

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.ui
@@ -6,23 +6,40 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>585</width>
-    <height>339</height>
+    <width>451</width>
+    <height>329</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="_2">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QStackedWidget" name="stackedWidget">
-     <property name="currentIndex">
-      <number>0</number>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <widget class="QWidget" name="simpleSettings">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>433</width>
+        <height>311</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,1">
+       <property name="spacing">
+        <number>6</number>
+       </property>
        <property name="leftMargin">
         <number>0</number>
        </property>
        <property name="topMargin">
-        <number>0</number>
+        <number>10</number>
        </property>
        <property name="rightMargin">
         <number>0</number>
@@ -30,6 +47,60 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
+       <item>
+        <layout class="QFormLayout" name="formLayout">
+         <property name="rowWrapPolicy">
+          <enum>QFormLayout::DontWrapRows</enum>
+         </property>
+         <property name="verticalSpacing">
+          <number>2</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="compatibilityLabel">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Database format:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="compatibilitySelection">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Unless you need to open your database with other programs, always use the latest format.</string>
+           </property>
+           <property name="accessibleName">
+            <string>Database format</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="formatCannotBeChanged">
+           <property name="font">
+            <font>
+             <italic>true</italic>
+            </font>
+           </property>
+           <property name="text">
+            <string>Format cannot be changed: Your database uses KDBX 4 features</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
@@ -47,398 +118,419 @@
         </spacer>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QLabel" name="decryptionTimeLabel">
-           <property name="text">
-            <string>Decryption Time:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="decryptionTimeValueLabel">
-           <property name="text">
-            <string notr="true">?? s</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="activateChangeDecryptionTimeButton">
-           <property name="accessibleName">
-            <string>Change existing decryption time</string>
-           </property>
-           <property name="text">
-            <string>Change</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QWidget" name="decryptionTimeSettings" native="true">
-         <layout class="QVBoxLayout" name="decryptionTimeSliderLayout">
-          <item>
-           <widget class="QSlider" name="decryptionTimeSlider">
-            <property name="accessibleName">
-             <string>Decryption time in seconds</string>
-            </property>
-            <property name="singleStep">
-             <number>1</number>
-            </property>
-            <property name="pageStep">
-             <number>10</number>
-            </property>
-            <property name="value">
-             <number>10</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="tickPosition">
-             <enum>QSlider::TicksBelow</enum>
-            </property>
-            <property name="tickInterval">
-             <number>5</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QLabel" name="minTimeLabel">
-              <property name="text">
-               <string notr="true">?? ms</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="maxTimeLabel">
-              <property name="text">
-               <string notr="true">? s</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_2">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Higher values offer more protection, but opening the database will take longer.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <layout class="QFormLayout" name="formLayout">
-         <property name="verticalSpacing">
-          <number>2</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="compatibilityLabel">
-           <property name="text">
-            <string>Database format:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="compatibilitySelection">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="accessibleName">
-            <string>Database format</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="formatCannotBeChanged">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Format cannot be changed: Your database uses KDBX 4 features</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
         <widget class="QLabel" name="label">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
-          <string>Unless you need to open your database with other programs, always use the latest format.</string>
+          <string>Encryption Settings:</string>
          </property>
         </widget>
        </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="advancedSettings">
-      <layout class="QFormLayout" name="formLayout_2">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QLabel" name="algorithmLabel">
-         <property name="text">
-          <string>Encryption Algorithm:</string>
+       <item>
+        <widget class="QTabWidget" name="encryptionSettingsTabWidget">
+         <property name="tabPosition">
+          <enum>QTabWidget::North</enum>
          </property>
+         <property name="tabShape">
+          <enum>QTabWidget::Rounded</enum>
+         </property>
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="basicTab">
+          <attribute name="title">
+           <string>Basic</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="verticalLayout_8">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>9</number>
+           </property>
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <property name="rightMargin">
+            <number>9</number>
+           </property>
+           <property name="bottomMargin">
+            <number>6</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="decryptionTimeLabel">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Decryption Time:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="decryptionTimeValueLabel">
+               <property name="font">
+                <font>
+                 <weight>50</weight>
+                 <bold>false</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string notr="true">?? s</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QWidget" name="decryptionTimeSettings" native="true">
+             <layout class="QVBoxLayout" name="decryptionTimeSliderLayout">
+              <property name="leftMargin">
+               <number>6</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>6</number>
+              </property>
+              <property name="bottomMargin">
+               <number>9</number>
+              </property>
+              <item>
+               <widget class="QSlider" name="decryptionTimeSlider">
+                <property name="accessibleName">
+                 <string>Decryption time in seconds</string>
+                </property>
+                <property name="singleStep">
+                 <number>1</number>
+                </property>
+                <property name="pageStep">
+                 <number>10</number>
+                </property>
+                <property name="value">
+                 <number>10</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBelow</enum>
+                </property>
+                <property name="tickInterval">
+                 <number>5</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout">
+                <item>
+                 <widget class="QLabel" name="minTimeLabel">
+                  <property name="text">
+                   <string notr="true">?? ms</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="maxTimeLabel">
+                  <property name="text">
+                   <string notr="true">? s</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Higher values offer more protection, but opening the database will take longer.</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="advancedTab">
+          <attribute name="title">
+           <string>Advanced</string>
+          </attribute>
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <property name="bottomMargin">
+            <number>6</number>
+           </property>
+           <item row="0" column="2">
+            <spacer name="horizontalSpacer_4">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="4" column="1">
+            <widget class="QSpinBox" name="parallelismSpinBox">
+             <property name="minimumSize">
+              <size>
+               <width>150</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>150</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="accessibleName">
+              <string>Parallelism</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>128</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="parallelismLabel">
+             <property name="text">
+              <string>Parallelism:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QSpinBox" name="memorySpinBox">
+             <property name="minimumSize">
+              <size>
+               <width>150</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>150</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="accessibleName">
+              <string>Memory usage</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>1048576</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="memoryUsageLabel">
+             <property name="text">
+              <string>Memory Usage:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="40,40,0">
+             <item>
+              <widget class="QSpinBox" name="transformRoundsSpinBox">
+               <property name="minimumSize">
+                <size>
+                 <width>150</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>150</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="accessibleName">
+                <string>Transform rounds</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>1000000000</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="transformBenchmarkButton">
+               <property name="focusPolicy">
+                <enum>Qt::WheelFocus</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="transformRoundsLabel">
+             <property name="text">
+              <string>Transform rounds:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QComboBox" name="kdfComboBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="accessibleName">
+              <string>Key derivation function</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="kdfLabel">
+             <property name="text">
+              <string>Key Derivation Function:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="algorithmComboBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="accessibleName">
+              <string>Encryption algorithm</string>
+             </property>
+             <item>
+              <property name="text">
+               <string>AES:  256 Bit   (default)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Twofish:  256 Bit</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="algorithmLabel">
+             <property name="text">
+              <string>Encryption Algorithm:</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="algorithmComboBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="accessibleName">
-          <string>Encryption algorithm</string>
-         </property>
-         <item>
-          <property name="text">
-           <string>AES:  256 Bit   (default)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Twofish:  256 Bit</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="kdfLabel">
-         <property name="text">
-          <string>Key Derivation Function:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="kdfComboBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="accessibleName">
-          <string>Key derivation function</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="transformRoundsLabel">
-         <property name="text">
-          <string>Transform rounds:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="40,40,0">
-         <item>
-          <widget class="QSpinBox" name="transformRoundsSpinBox">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>150</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="accessibleName">
-            <string>Transform rounds</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>1000000000</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="transformBenchmarkButton">
-           <property name="focusPolicy">
-            <enum>Qt::WheelFocus</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="memoryUsageLabel">
-         <property name="text">
-          <string>Memory Usage:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QSpinBox" name="memorySpinBox">
-         <property name="minimumSize">
+         <property name="sizeHint" stdset="0">
           <size>
-           <width>150</width>
+           <width>20</width>
            <height>0</height>
           </size>
          </property>
-         <property name="maximumSize">
-          <size>
-           <width>150</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="accessibleName">
-          <string>Memory usage</string>
-         </property>
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>1048576</number>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="parallelismLabel">
-         <property name="text">
-          <string>Parallelism:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QSpinBox" name="parallelismSpinBox">
-         <property name="minimumSize">
-          <size>
-           <width>150</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>150</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="accessibleName">
-          <string>Parallelism</string>
-         </property>
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>128</number>
-         </property>
-        </widget>
+        </spacer>
        </item>
       </layout>
      </widget>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>activateChangeDecryptionTimeButton</tabstop>
   <tabstop>decryptionTimeSlider</tabstop>
-  <tabstop>compatibilitySelection</tabstop>
   <tabstop>algorithmComboBox</tabstop>
   <tabstop>kdfComboBox</tabstop>
   <tabstop>transformRoundsSpinBox</tabstop>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
@@ -35,11 +35,6 @@ public:
     Q_DISABLE_COPY(DatabaseSettingsWidgetGeneral);
     ~DatabaseSettingsWidgetGeneral() override;
 
-    inline bool hasAdvancedMode() const override
-    {
-        return false;
-    }
-
 public slots:
     void initialize() override;
     void uninitialize() override;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.h
@@ -37,11 +37,6 @@ public:
     Q_DISABLE_COPY(DatabaseSettingsWidgetMaintenance);
     ~DatabaseSettingsWidgetMaintenance() override;
 
-    inline bool hasAdvancedMode() const override
-    {
-        return false;
-    }
-
 public slots:
     void initialize() override;
     void uninitialize() override{};

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMetaDataSimple.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMetaDataSimple.h
@@ -35,11 +35,6 @@ public:
     Q_DISABLE_COPY(DatabaseSettingWidgetMetaData);
     ~DatabaseSettingWidgetMetaData() override;
 
-    inline bool hasAdvancedMode() const override
-    {
-        return false;
-    }
-
 public slots:
     void initialize() override;
     void uninitialize() override;

--- a/src/gui/settings/SettingsWidget.cpp
+++ b/src/gui/settings/SettingsWidget.cpp
@@ -24,28 +24,6 @@ SettingsWidget::SettingsWidget(QWidget* parent)
 
 SettingsWidget::~SettingsWidget() = default;
 
-/**
- * Switch between simple mode (the default) and advanced mode.
- * Subclasses which implement an advanced mode, need to override this method,
- * \link advancedMode() and \link hasAdvancedMode.
- *
- * When overriding this method, make sure to also emit the
- * \link advancedModeChanged() signal.
- *
- * @param advanced whether advanced mode is enabled
- */
-void SettingsWidget::setAdvancedMode(bool advanced)
+void SettingsWidget::discard()
 {
-    if (hasAdvancedMode() && advanced != advancedMode()) {
-        m_advancedMode = advanced;
-        emit advancedModeChanged(advanced);
-    }
-}
-
-/**
- * @return true if advanced mode is on (default: false)
- */
-bool SettingsWidget::advancedMode() const
-{
-    return m_advancedMode;
 }

--- a/src/gui/settings/SettingsWidget.h
+++ b/src/gui/settings/SettingsWidget.h
@@ -34,13 +34,6 @@ public:
     Q_DISABLE_COPY(SettingsWidget);
     ~SettingsWidget() override;
 
-    /**
-     * @return true if widget has an advanced mode
-     */
-    virtual bool hasAdvancedMode() const = 0;
-    virtual void setAdvancedMode(bool advanced);
-    virtual bool advancedMode() const;
-
 public slots:
     /**
      * Initialize settings widget.
@@ -62,11 +55,10 @@ public slots:
     /**
      * Discard settings.
      */
-    virtual void discard(){};
+    virtual void discard();
 
 signals:
     void editFinished(bool saved);
-    void advancedModeChanged(bool advanced);
 
 private:
     bool m_advancedMode = false;

--- a/src/gui/wizard/NewDatabaseWizardPage.cpp
+++ b/src/gui/wizard/NewDatabaseWizardPage.cpp
@@ -27,8 +27,6 @@ NewDatabaseWizardPage::NewDatabaseWizardPage(QWidget* parent)
     , m_ui(new Ui::NewDatabaseWizardPage())
 {
     m_ui->setupUi(this);
-
-    connect(m_ui->advancedSettingsButton, SIGNAL(clicked()), SLOT(toggleAdvancedSettings()));
 }
 
 NewDatabaseWizardPage::~NewDatabaseWizardPage() = default;
@@ -43,7 +41,6 @@ void NewDatabaseWizardPage::setPageWidget(DatabaseSettingsWidget* page)
 {
     m_pageWidget = page;
     m_ui->pageContent->setWidget(m_pageWidget);
-    m_ui->advancedSettingsButton->setVisible(m_pageWidget->hasAdvancedMode());
 }
 
 /**
@@ -85,22 +82,4 @@ bool NewDatabaseWizardPage::validatePage()
     bool valid = m_pageWidget->save();
     m_pageWidget->uninitialize();
     return valid;
-}
-
-/**
- * Toggle settings page widget between simple and advanced mode.
- */
-void NewDatabaseWizardPage::toggleAdvancedSettings()
-{
-    if (!m_pageWidget || !m_pageWidget->hasAdvancedMode()) {
-        return;
-    }
-
-    if (m_pageWidget->advancedMode()) {
-        m_pageWidget->setAdvancedMode(false);
-        m_ui->advancedSettingsButton->setText(tr("Advanced Settings"));
-    } else {
-        m_pageWidget->setAdvancedMode(true);
-        m_ui->advancedSettingsButton->setText(tr("Simple Settings"));
-    }
 }

--- a/src/gui/wizard/NewDatabaseWizardPage.h
+++ b/src/gui/wizard/NewDatabaseWizardPage.h
@@ -47,9 +47,6 @@ public:
     void initializePage() override;
     bool validatePage() override;
 
-public slots:
-    void toggleAdvancedSettings();
-
 protected:
     QPointer<DatabaseSettingsWidget> m_pageWidget;
     QSharedPointer<Database> m_db;

--- a/src/gui/wizard/NewDatabaseWizardPage.ui
+++ b/src/gui/wizard/NewDatabaseWizardPage.ui
@@ -25,7 +25,7 @@
   <property name="subTitle">
    <string>Here you can adjust the database encryption settings. Don't worry, you can change them later in the database settings.</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1">
    <item>
     <widget class="QScrollArea" name="pageContent">
      <property name="sizePolicy">
@@ -66,48 +66,11 @@ QScrollArea &gt; QWidget &gt; QScrollBar { background: 1; }</string>
         <x>0</x>
         <y>0</y>
         <width>560</width>
-        <height>349</height>
+        <height>392</height>
        </rect>
       </property>
      </widget>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>6</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="advancedSettings">
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="advancedSettingsButton">
-       <property name="text">
-        <string>Advanced Settings</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/tests/gui/TestGuiBrowser.cpp
+++ b/tests/gui/TestGuiBrowser.cpp
@@ -66,8 +66,6 @@ void TestGuiBrowser::initTestCase()
     config()->set(Config::AutoSaveOnExit, false);
     // Enable the tray icon so we can test hiding/restoring the windowQByteArray
     config()->set(Config::GUI_ShowTrayIcon, true);
-    // Disable advanced settings mode (activate within individual tests to test advanced settings)
-    config()->set(Config::GUI_AdvancedSettings, false);
     // Disable the update check first time alert
     config()->set(Config::UpdateCheckMessageShown, true);
 


### PR DESCRIPTION
Current implementation has it disabled instead of hidden. Fixes #6190

In addition, it moves the checkbox into the only tab that has use for it, the Security->Encryption settings tab.

The scrolling bar is not working (yet)

## Screenshots
![advancedSettings](https://user-images.githubusercontent.com/867299/118230378-de6ce900-b48d-11eb-95f0-f7fd88c6d03d.gif)


## Testing strategy
Went to each tab and checked every configuration


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

