### PR TITLE
Backports from develop to 2.6.5 release

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -1297,10 +1297,11 @@ appsign() {
 
     elif [ "$(uname -o)" == "Msys" ]; then
         if [[ ! -f "${key}" ]]; then
-            exitError "Key file was not found!"
+            exitError "Appsign key file was not found! (${key})"
         fi
 
-        read -s -p "Key password: " password
+        logInfo "Using appsign key ${key}."
+        IFS=$'\n' read -s -r -p "Key password: " password
         echo
 
         for f in "${sign_files[@]}"; do

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,7 @@ set(keepassx_SOURCES
         gui/osutils/OSUtilsBase.cpp
         gui/settings/SettingsWidget.cpp
         gui/widgets/ElidedLabel.cpp
+        gui/widgets/KPToolBar.cpp
         gui/widgets/PopupHelpWidget.cpp
         gui/wizard/NewDatabaseWizard.cpp
         gui/wizard/NewDatabaseWizardPage.cpp

--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -39,6 +39,8 @@ AutoTypePlatformX11::AutoTypePlatformX11()
     m_atomString = XInternAtom(m_dpy, "STRING", True);
     m_atomUtf8String = XInternAtom(m_dpy, "UTF8_STRING", True);
     m_atomNetActiveWindow = XInternAtom(m_dpy, "_NET_ACTIVE_WINDOW", True);
+    m_atomTransientFor = XInternAtom(m_dpy, "WM_TRANSIENT_FOR", True);
+    m_atomWindow = XInternAtom(m_dpy, "WINDOW", True);
 
     m_classBlacklist << "desktop_window"
                      << "gnome-panel"; // Gnome
@@ -373,23 +375,31 @@ QStringList AutoTypePlatformX11::windowTitlesRecursive(Window window)
 
 bool AutoTypePlatformX11::isTopLevelWindow(Window window)
 {
+    bool result = false;
+
     Atom type = None;
     int format;
     unsigned long nitems;
     unsigned long after;
-    unsigned char* data = Q_NULLPTR;
+    unsigned char* data = nullptr;
+
+    // Check if the window has WM_STATE atom and it is not Withdrawn
     int retVal = XGetWindowProperty(
         m_dpy, window, m_atomWmState, 0, 2, False, m_atomWmState, &type, &format, &nitems, &after, &data);
 
-    bool result = false;
-
     if (retVal == 0 && data) {
         if (type == m_atomWmState && format == 32 && nitems > 0) {
-            qint32 state = static_cast<qint32>(*data);
-            result = (state != WithdrawnState);
+            result = (static_cast<quint32>(*data) != WithdrawnState);
         }
-
         XFree(data);
+    } else {
+        // See if this is a transient window without WM_STATE
+        retVal = XGetWindowProperty(
+            m_dpy, window, m_atomTransientFor, 0, 1, False, m_atomWindow, &type, &format, &nitems, &after, &data);
+        if (retVal == 0 && data) {
+            result = true;
+            XFree(data);
+        }
     }
 
     return result;

--- a/src/autotype/xcb/AutoTypeXCB.h
+++ b/src/autotype/xcb/AutoTypeXCB.h
@@ -77,7 +77,6 @@ private:
     void updateKeymap();
     bool isRemapKeycodeValid();
     int AddKeysym(KeySym keysym);
-    void AddModifier(KeySym keysym);
     void SendKeyEvent(unsigned keycode, bool press);
     void SendModifiers(unsigned int mask, bool press);
     int GetKeycode(KeySym keysym, unsigned int* mask);
@@ -93,6 +92,8 @@ private:
     Atom m_atomString;
     Atom m_atomUtf8String;
     Atom m_atomNetActiveWindow;
+    Atom m_atomTransientFor;
+    Atom m_atomWindow;
     QSet<QString> m_classBlacklist;
     Qt::Key m_currentGlobalKey;
     Qt::KeyboardModifiers m_currentGlobalModifiers;

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -92,6 +92,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_HideToolbar, {QS("GUI/HideToolbar"), Roaming, false}},
     {Config::GUI_MovableToolbar, {QS("GUI/MovableToolbar"), Roaming, false}},
     {Config::GUI_HidePreviewPanel, {QS("GUI/HidePreviewPanel"), Roaming, false}},
+    {Config::GUI_AlwaysOnTop, {QS("GUI/GUI_AlwaysOnTop"), Roaming, false}},
     {Config::GUI_ToolButtonStyle, {QS("GUI/ToolButtonStyle"), Roaming, Qt::ToolButtonIconOnly}},
     {Config::GUI_ShowTrayIcon, {QS("GUI/ShowTrayIcon"), Roaming, false}},
     {Config::GUI_TrayIconAppearance, {QS("GUI/TrayIconAppearance"), Roaming, {}}},

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -92,7 +92,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_HideToolbar, {QS("GUI/HideToolbar"), Roaming, false}},
     {Config::GUI_MovableToolbar, {QS("GUI/MovableToolbar"), Roaming, false}},
     {Config::GUI_HidePreviewPanel, {QS("GUI/HidePreviewPanel"), Roaming, false}},
-    {Config::GUI_AlwaysOnTop, {QS("GUI/GUI_AlwaysOnTop"), Roaming, false}},
+    {Config::GUI_AlwaysOnTop, {QS("GUI/GUI_AlwaysOnTop"), Local, false}},
     {Config::GUI_ToolButtonStyle, {QS("GUI/ToolButtonStyle"), Roaming, Qt::ToolButtonIconOnly}},
     {Config::GUI_ShowTrayIcon, {QS("GUI/ShowTrayIcon"), Roaming, false}},
     {Config::GUI_TrayIconAppearance, {QS("GUI/TrayIconAppearance"), Roaming, {}}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -74,6 +74,7 @@ public:
         GUI_HideToolbar,
         GUI_MovableToolbar,
         GUI_HidePreviewPanel,
+        GUI_AlwaysOnTop,
         GUI_ToolButtonStyle,
         GUI_ShowTrayIcon,
         GUI_TrayIconAppearance,

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -486,8 +486,9 @@ bool Database::restoreDatabase(const QString& filePath)
     // Only try to restore if the backup file actually exists
     if (QFile::exists(backupFilePath)) {
         QFile::remove(filePath);
-        return QFile::copy(backupFilePath, filePath);
-        QFile::setPermissions(filePath, perms);
+        if (QFile::copy(backupFilePath, filePath)) {
+            return QFile::setPermissions(filePath, perms);
+        }
     }
     return false;
 }

--- a/src/core/MacPasteboard.h
+++ b/src/core/MacPasteboard.h
@@ -18,9 +18,9 @@
 #ifndef KEEPASSXC_MACPASTEBOARD_H
 #define KEEPASSXC_MACPASTEBOARD_H
 
-#include <QMacPasteboardMime>
 #include <QObject>
 #include <QTextCodec>
+#include <QtMacExtras/QMacPasteboardMime>
 
 class MacPasteboard : public QObject, public QMacPasteboardMime
 {

--- a/src/format/OpVaultReader.h
+++ b/src/format/OpVaultReader.h
@@ -98,7 +98,7 @@ private:
     bool fillAttributes(Entry* entry, const QJsonObject& bandEntry);
 
     void fillFromSection(Entry* entry, const QJsonObject& section);
-    void fillFromSectionField(Entry* entry, const QString& sectionName, QJsonObject& field);
+    void fillFromSectionField(Entry* entry, const QString& sectionName, const QJsonObject& field);
     QString resolveAttributeName(const QString& section, const QString& name, const QString& text);
 
     void populateCategoryGroups(Group* rootGroup);

--- a/src/format/OpVaultReaderSections.cpp
+++ b/src/format/OpVaultReaderSections.cpp
@@ -53,12 +53,11 @@ namespace
 void OpVaultReader::fillFromSection(Entry* entry, const QJsonObject& section)
 {
     const auto uuid = entry->uuid();
-    QString sectionName = section["name"].toString();
+    auto sectionTitle = section["title"].toString();
 
     if (!section.contains("fields")) {
-        auto sectionNameLC = sectionName.toLower();
-        auto sectionTitleLC = section["title"].toString("").toLower();
-        if (!(sectionNameLC == "linked items" && sectionTitleLC == "related items")) {
+        auto sectionName = section["name"].toString();
+        if (!(sectionName.toLower() == "linked items" && sectionTitle.toLower() == "related items")) {
             qWarning() << R"(Skipping "fields"-less Section in UUID ")" << uuid << "\": <<" << section << ">>";
         }
         return;
@@ -67,23 +66,17 @@ void OpVaultReader::fillFromSection(Entry* entry, const QJsonObject& section)
         return;
     }
 
-    // If we have a default section name then replace with the section title if not empty
-    if (sectionName.startsWith("Section_") && !section["title"].toString().isEmpty()) {
-        sectionName = section["title"].toString();
-    }
-
     QJsonArray sectionFields = section["fields"].toArray();
     for (const QJsonValue sectionField : sectionFields) {
         if (!sectionField.isObject()) {
             qWarning() << R"(Skipping non-Object "fields" in UUID ")" << uuid << "\": << " << sectionField << ">>";
             continue;
         }
-        QJsonObject field = sectionField.toObject();
-        fillFromSectionField(entry, sectionName, field);
+        fillFromSectionField(entry, sectionTitle, sectionField.toObject());
     }
 }
 
-void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionName, QJsonObject& field)
+void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionName, const QJsonObject& field)
 {
     if (!field.contains("v")) {
         // for our purposes, we don't care if there isn't a value in the field
@@ -161,8 +154,8 @@ QString OpVaultReader::resolveAttributeName(const QString& section, const QStrin
                    || lowName == "website") {
             return EntryAttributes::URLKey;
         }
-        return name;
+        return text;
     }
 
-    return QString("%1_%2").arg(section, name);
+    return QString("%1_%2").arg(section, text);
 }

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -286,13 +286,26 @@ void Application::socketReadyRead()
     }
 
     QStringList fileNames;
-    in >> fileNames;
-    for (const QString& fileName : asConst(fileNames)) {
-        const QFileInfo fInfo(fileName);
-        if (fInfo.isFile() && fInfo.suffix().toLower() == "kdbx") {
-            emit openFile(fileName);
+    quint32 id;
+    in >> id;
+
+    // TODO: move constants to enum
+    switch (id) {
+    case 1:
+        in >> fileNames;
+        for (const QString& fileName : asConst(fileNames)) {
+            const QFileInfo fInfo(fileName);
+            if (fInfo.isFile() && fInfo.suffix().toLower() == "kdbx") {
+                emit openFile(fileName);
+            }
         }
+
+        break;
+    case 2:
+        getMainWindow()->lockAllDatabases();
+        break;
     }
+
     socket->deleteLater();
 }
 
@@ -305,6 +318,12 @@ bool Application::isAlreadyRunning() const
     return config()->get(Config::SingleInstance).toBool() && m_alreadyRunning;
 }
 
+/**
+ * Send to-open file names to the running UI instance
+ *
+ * @param fileNames - list of file names to open
+ * @return true if all operations succeeded (connection made, data sent, connection closed)
+ */
 bool Application::sendFileNamesToRunningInstance(const QStringList& fileNames)
 {
     QLocalSocket client;
@@ -317,13 +336,48 @@ bool Application::sendFileNamesToRunningInstance(const QStringList& fileNames)
     QByteArray data;
     QDataStream out(&data, QIODevice::WriteOnly);
     out.setVersion(QDataStream::Qt_5_0);
-    out << quint32(0) << fileNames;
+    out << quint32(0); // reserve space for block size
+    out << quint32(1); // ID for file name send. TODO: move to enum
+    out << fileNames; // send file names to be opened
     out.device()->seek(0);
-    out << quint32(data.size() - sizeof(quint32));
+    out << quint32(data.size() - sizeof(quint32)); // replace the previous constant 0 with block size
 
     const bool writeOk = client.write(data) != -1 && client.waitForBytesWritten(WaitTimeoutMSec);
     client.disconnectFromServer();
-    const bool disconnected = client.waitForDisconnected(WaitTimeoutMSec);
+    const bool disconnected =
+        client.state() == QLocalSocket::UnconnectedState || client.waitForDisconnected(WaitTimeoutMSec);
+    return writeOk && disconnected;
+}
+
+/**
+ * Locks all open databases in the running instance
+ *
+ * @return true if the "please lock" signal was sent successfully
+ */
+bool Application::sendLockToInstance()
+{
+    // Make a connection to avoid SIGSEGV
+    QLocalSocket client;
+    client.connectToServer(m_socketName);
+    const bool connected = client.waitForConnected(WaitTimeoutMSec);
+    if (!connected) {
+        return false;
+    }
+
+    // Send lock signal
+    QByteArray data;
+    QDataStream out(&data, QIODevice::WriteOnly);
+    out.setVersion(QDataStream::Qt_5_0);
+    out << quint32(0); // reserve space for block size
+    out << quint32(2); // ID for database lock. TODO: move to enum
+    out.device()->seek(0);
+    out << quint32(data.size() - sizeof(quint32)); // replace the previous constant 0 with block size
+
+    // Finish gracefully
+    const bool writeOk = client.write(data) != -1 && client.waitForBytesWritten(WaitTimeoutMSec);
+    client.disconnectFromServer();
+    const bool disconnected =
+        client.state() == QLocalSocket::UnconnectedState || client.waitForConnected(WaitTimeoutMSec);
     return writeOk && disconnected;
 }
 

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -48,6 +48,7 @@ public:
     bool isDarkTheme() const;
 
     bool sendFileNamesToRunningInstance(const QStringList& fileNames);
+    bool sendLockToInstance();
 
     void restart();
 

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -19,6 +19,7 @@
 #ifndef KEEPASSX_CLIPBOARD_H
 #define KEEPASSX_CLIPBOARD_H
 
+#include <QElapsedTimer>
 #include <QObject>
 #ifdef Q_OS_MACOS
 #include "core/MacPasteboard.h"
@@ -39,8 +40,11 @@ public:
 public slots:
     void clearCopiedText();
 
+signals:
+    void updateCountdown(int percentage, QString message);
+
 private slots:
-    void clearClipboard();
+    void countdownTick();
 
 private:
     explicit Clipboard(QObject* parent = nullptr);
@@ -48,6 +52,8 @@ private:
     static Clipboard* m_instance;
 
     QTimer* m_timer;
+    int m_secondsElapsed = 0;
+
 #ifdef Q_OS_MACOS
     // This object lives for the whole program lifetime and we cannot delete it on exit,
     // so ignore leak warnings. See https://bugreports.qt.io/browse/QTBUG-54832

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1391,9 +1391,8 @@ void DatabaseWidget::onGroupChanged()
     // Intercept group changes if in search mode
     if (isSearchActive() && m_searchLimitGroup) {
         search(m_lastSearchText);
-    } else if (isSearchActive()) {
-        endSearch();
     } else {
+        endSearch();
         m_entryView->displayGroup(group);
     }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1176,6 +1176,10 @@ void DatabaseWidget::unlockDatabase(bool accepted)
     sshAgent()->databaseUnlocked(m_db);
 #endif
 
+    if (config()->get(Config::MinimizeAfterUnlock).toBool()) {
+        getMainWindow()->minimizeOrHide();
+    }
+
     if (senderDialog && senderDialog->intent() == DatabaseOpenDialog::Intent::AutoType) {
         QList<QSharedPointer<Database>> dbList;
         dbList.append(m_db);

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -245,14 +245,14 @@ void EntryPreviewWidget::updateEntryGeneralTab()
         m_ui->togglePasswordButton->setVisible(false);
     }
 
-    if (config()->get(Config::Security_HideNotes).toBool()) {
-        setEntryNotesVisible(false);
-        m_ui->toggleEntryNotesButton->setVisible(!m_ui->entryNotesTextEdit->toPlainText().isEmpty());
-        m_ui->toggleEntryNotesButton->setChecked(false);
-    } else {
-        setEntryNotesVisible(true);
-        m_ui->toggleEntryNotesButton->setVisible(false);
-    }
+    auto hasNotes = !m_currentEntry->notes().isEmpty();
+    auto hideNotes = config()->get(Config::Security_HideNotes).toBool();
+
+    m_ui->entryNotesTextEdit->setVisible(hasNotes);
+    setEntryNotesVisible(hasNotes && !hideNotes);
+    m_ui->toggleEntryNotesButton->setVisible(hasNotes && hideNotes
+                                             && !m_ui->entryNotesTextEdit->toPlainText().isEmpty());
+    m_ui->toggleEntryNotesButton->setChecked(false);
 
     if (config()->get(Config::GUI_MonospaceNotes).toBool()) {
         m_ui->entryNotesTextEdit->setFont(Font::fixedFont());

--- a/src/gui/Font.cpp
+++ b/src/gui/Font.cpp
@@ -18,29 +18,29 @@
 #include "Font.h"
 
 #include <QFontDatabase>
+#include <QGuiApplication>
 
 QFont Font::defaultFont()
 {
-    return QFontDatabase::systemFont(QFontDatabase::GeneralFont);
+    return qApp->font();
 }
 
 QFont Font::fixedFont()
 {
-    QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    auto fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 
 #ifdef Q_OS_WIN
     // try to use Consolas on Windows, because the default Courier New has too many similar characters
-    QFont consolasFont = QFontDatabase().font("Consolas", fixedFont.styleName(), fixedFont.pointSize());
-    const QFont defaultFont;
-    if (fixedFont != defaultFont) {
+    auto consolasFont = QFontDatabase().font("Consolas", fixedFont.styleName(), fixedFont.pointSize());
+    if (consolasFont.family().contains("consolas", Qt::CaseInsensitive)) {
         fixedFont = consolasFont;
     }
 #endif
 #ifdef Q_OS_MACOS
     // Qt doesn't choose a monospace font correctly on macOS
-    const QFont defaultFont;
-    fixedFont = QFontDatabase().font("Menlo", defaultFont.styleName(), defaultFont.pointSize());
+    fixedFont = QFontDatabase().font("Menlo", fixedFont.styleName(), fixedFont.pointSize());
 #endif
 
+    fixedFont.setPointSize(qApp->font().pointSize());
     return fixedFont;
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -118,6 +118,17 @@ MainWindow::MainWindow()
     m_searchWidgetAction = m_ui->toolBar->addWidget(m_searchWidget);
     m_searchWidgetAction->setEnabled(false);
 
+    new QShortcut(QKeySequence::Find, this, SLOT(focusSearchWidget()));
+
+    connect(m_searchWidget, &SearchWidget::searchCanceled, this, [this] {
+        m_ui->toolBar->setExpanded(false);
+        m_ui->toolBar->setVisible(!config()->get(Config::GUI_HideToolbar).toBool());
+    });
+    connect(m_searchWidget, &SearchWidget::lostFocus, this, [this] {
+        m_ui->toolBar->setExpanded(false);
+        m_ui->toolBar->setVisible(!config()->get(Config::GUI_HideToolbar).toBool());
+    });
+
     m_countDefaultAttributes = m_ui->menuEntryCopyAttribute->actions().size();
 
     m_entryContextMenu = new QMenu(this);
@@ -1227,7 +1238,10 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
                 dbWidget->focusOnEntries(true);
                 return;
             } else if (event->key() == Qt::Key_F3) {
-                m_searchWidget->searchFocus();
+                focusSearchWidget();
+                return;
+            } else if (event->key() == Qt::Key_Escape && dbWidget->isSearchActive()) {
+                m_searchWidget->clearSearch();
                 return;
             }
         }
@@ -1248,13 +1262,13 @@ bool MainWindow::focusNextPrevChild(bool next)
             } else if (m_ui->tabWidget->hasFocus()) {
                 dbWidget->setFocus(Qt::TabFocusReason);
             } else {
-                m_searchWidget->setFocus(Qt::TabFocusReason);
+                focusSearchWidget();
             }
         } else {
             if (m_searchWidget->hasFocus()) {
                 dbWidget->setFocus(Qt::BacktabFocusReason);
             } else if (m_ui->tabWidget->hasFocus()) {
-                m_searchWidget->setFocus(Qt::BacktabFocusReason);
+                focusSearchWidget();
             } else {
                 m_ui->tabWidget->setFocus(Qt::BacktabFocusReason);
             }
@@ -1264,6 +1278,15 @@ bool MainWindow::focusNextPrevChild(bool next)
 
     // Defer to Qt to make a decision, this maintains normal behavior
     return QMainWindow::focusNextPrevChild(next);
+}
+
+void MainWindow::focusSearchWidget()
+{
+    if (m_searchWidgetAction->isEnabled()) {
+        m_ui->toolBar->setVisible(true);
+        m_ui->toolBar->setExpanded(true);
+        m_searchWidget->focusSearch();
+    }
 }
 
 void MainWindow::saveWindowInformation()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1773,6 +1773,7 @@ void MainWindow::initViewMenu()
     });
 
     connect(m_ui->actionAlwaysOnTop, &QAction::toggled, this, [this](bool checked) {
+        config()->set(Config::GUI_AlwaysOnTop, checked);
         if (checked) {
             setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
         } else {
@@ -1780,6 +1781,8 @@ void MainWindow::initViewMenu()
         }
         show();
     });
+    // Set checked after connecting to act on a toggle in state (default state is unchecked)
+    m_ui->actionAlwaysOnTop->setChecked(config()->get(Config::GUI_AlwaysOnTop).toBool());
 
     m_ui->actionHideUsernames->setChecked(config()->get(Config::GUI_HideUsernames).toBool());
     connect(m_ui->actionHideUsernames, &QAction::toggled, this, [](bool checked) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -607,6 +607,19 @@ MainWindow::MainWindow()
     QObject::connect(qApp, SIGNAL(applicationActivated()), this, SLOT(bringToFront()));
     QObject::connect(qApp, SIGNAL(openFile(QString)), this, SLOT(openDatabase(QString)));
     QObject::connect(qApp, SIGNAL(quitSignalReceived()), this, SLOT(appExit()), Qt::DirectConnection);
+
+    statusBar()->setFixedHeight(24);
+    m_progressBarLabel = new QLabel(statusBar());
+    m_progressBarLabel->setVisible(false);
+    statusBar()->addPermanentWidget(m_progressBarLabel);
+    m_progressBar = new QProgressBar(statusBar());
+    m_progressBar->setVisible(false);
+    m_progressBar->setTextVisible(false);
+    m_progressBar->setMaximumWidth(100);
+    m_progressBar->setFixedHeight(15);
+    m_progressBar->setMaximum(100);
+    statusBar()->addPermanentWidget(m_progressBar);
+    connect(clipboard(), SIGNAL(updateCountdown(int, QString)), this, SLOT(updateProgressBar(int, QString)));
 }
 
 MainWindow::~MainWindow()
@@ -1340,6 +1353,19 @@ void MainWindow::updateTrayIcon()
     }
 
     QApplication::setQuitOnLastWindowClosed(!isTrayIconEnabled());
+}
+
+void MainWindow::updateProgressBar(int percentage, QString message)
+{
+    if (percentage < 0) {
+        m_progressBar->setVisible(false);
+        m_progressBarLabel->setVisible(false);
+    } else {
+        m_progressBar->setValue(percentage);
+        m_progressBar->setVisible(true);
+        m_progressBarLabel->setText(message);
+        m_progressBarLabel->setVisible(true);
+    }
 }
 
 void MainWindow::obtainContextFocusLock()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -143,6 +143,7 @@ private slots:
 private slots:
     void updateTrayIcon();
     void updateProgressBar(int percentage, QString message);
+    void focusSearchWidget();
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -20,12 +20,16 @@
 #define KEEPASSX_MAINWINDOW_H
 
 #include <QActionGroup>
+#include <QLabel>
 #include <QMainWindow>
+#include <QProgressBar>
+#include <QStatusBar>
 #include <QSystemTrayIcon>
 
 #include "core/ScreenLockListener.h"
 #include "core/SignalMultiplexer.h"
 #include "gui/Application.h"
+#include "gui/Clipboard.h"
 #include "gui/DatabaseWidget.h"
 
 namespace Ui
@@ -138,6 +142,7 @@ private slots:
 
 private slots:
     void updateTrayIcon();
+    void updateProgressBar(int percentage, QString message);
 
 private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);
@@ -169,6 +174,8 @@ private:
     QPointer<QSystemTrayIcon> m_trayIcon;
     QPointer<ScreenLockListener> m_screenLockListener;
     QPointer<SearchWidget> m_searchWidget;
+    QPointer<QProgressBar> m_progressBar;
+    QPointer<QLabel> m_progressBarLabel;
 
     Q_DISABLE_COPY(MainWindow)
 

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -394,7 +394,7 @@
    <addaction name="menuView"/>
    <addaction name="menuHelp"/>
   </widget>
-  <widget class="QToolBar" name="toolBar">
+  <widget class="KPToolBar" name="toolBar">
    <property name="contextMenuPolicy">
     <enum>Qt::PreventContextMenu</enum>
    </property>
@@ -1042,6 +1042,11 @@
    <extends>QWidget</extends>
    <header>gui/WelcomeWidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>KPToolBar</class>
+   <extends>QToolBar</extends>
+   <header>gui/widgets/KPToolBar.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -48,8 +48,8 @@ SearchWidget::SearchWidget(QWidget* parent)
     connect(m_ui->helpIcon, SIGNAL(triggered()), SLOT(toggleHelp()));
     connect(m_ui->searchIcon, SIGNAL(triggered()), SLOT(showSearchMenu()));
     connect(m_searchTimer, SIGNAL(timeout()), SLOT(startSearch()));
-    connect(m_clearSearchTimer, SIGNAL(timeout()), m_ui->searchEdit, SLOT(clear()));
-    connect(this, SIGNAL(escapePressed()), m_ui->searchEdit, SLOT(clear()));
+    connect(m_clearSearchTimer, SIGNAL(timeout()), SLOT(clearSearch()));
+    connect(this, SIGNAL(escapePressed()), SLOT(clearSearch()));
 
     new QShortcut(QKeySequence::Find, this, SLOT(searchFocus()), nullptr, Qt::ApplicationShortcut);
     new QShortcut(Qt::Key_Escape, m_ui->searchEdit, SLOT(clear()), nullptr, Qt::ApplicationShortcut);
@@ -109,7 +109,7 @@ bool SearchWidget::eventFilter(QObject* obj, QEvent* event)
                 return true;
             }
         }
-    } else if (event->type() == QEvent::FocusOut && !m_ui->searchEdit->text().isEmpty()) {
+    } else if (event->type() == QEvent::FocusOut) {
         if (config()->get(Config::Security_ClearSearch).toBool()) {
             int timeout = config()->get(Config::Security_ClearSearchTimeout).toInt();
             if (timeout > 0) {
@@ -117,6 +117,7 @@ bool SearchWidget::eventFilter(QObject* obj, QEvent* event)
                 m_clearSearchTimer->start(timeout * 60000); // 60 sec * 1000 ms
             }
         }
+        emit lostFocus();
     } else if (event->type() == QEvent::FocusIn) {
         // Never clear the search if we are using it
         m_clearSearchTimer->stop();
@@ -133,10 +134,10 @@ void SearchWidget::connectSignals(SignalMultiplexer& mx)
     mx.connect(this, SIGNAL(limitGroupChanged(bool)), SLOT(setSearchLimitGroup(bool)));
     mx.connect(this, SIGNAL(copyPressed()), SLOT(copyPassword()));
     mx.connect(this, SIGNAL(downPressed()), SLOT(focusOnEntries()));
-    mx.connect(SIGNAL(clearSearch()), m_ui->searchEdit, SLOT(clear()));
+    mx.connect(SIGNAL(clearSearch()), this, SLOT(clearSearch()));
     mx.connect(SIGNAL(entrySelectionChanged()), this, SLOT(resetSearchClearTimer()));
     mx.connect(SIGNAL(currentModeChanged(DatabaseWidget::Mode)), this, SLOT(resetSearchClearTimer()));
-    mx.connect(SIGNAL(databaseUnlocked()), this, SLOT(searchFocus()));
+    mx.connect(SIGNAL(databaseUnlocked()), this, SLOT(focusSearch()));
     mx.connect(m_ui->searchEdit, SIGNAL(returnPressed()), SLOT(switchToEntryEdit()));
 }
 
@@ -149,7 +150,7 @@ void SearchWidget::databaseChanged(DatabaseWidget* dbWidget)
         emit caseSensitiveChanged(m_actionCaseSensitive->isChecked());
         emit limitGroupChanged(m_actionLimitGroup->isChecked());
     } else {
-        m_ui->searchEdit->clear();
+        clearSearch();
     }
 }
 
@@ -201,10 +202,16 @@ void SearchWidget::setLimitGroup(bool state)
     updateLimitGroup();
 }
 
-void SearchWidget::searchFocus()
+void SearchWidget::focusSearch()
 {
     m_ui->searchEdit->setFocus();
     m_ui->searchEdit->selectAll();
+}
+
+void SearchWidget::clearSearch()
+{
+    m_ui->searchEdit->clear();
+    emit searchCanceled();
 }
 
 void SearchWidget::toggleHelp()

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -52,16 +52,19 @@ protected:
 
 signals:
     void search(const QString& text);
+    void searchCanceled();
     void caseSensitiveChanged(bool state);
     void limitGroupChanged(bool state);
     void escapePressed();
     void copyPressed();
     void downPressed();
     void enterPressed();
+    void lostFocus();
 
 public slots:
     void databaseChanged(DatabaseWidget* dbWidget = nullptr);
-    void searchFocus();
+    void focusSearch();
+    void clearSearch();
 
 private slots:
     void startSearchTimer();

--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -208,8 +208,13 @@ void CsvImportWidget::writeDatabase()
         entry->setUrl(m_parserModel->data(m_parserModel->index(r, 4)).toString());
         entry->setNotes(m_parserModel->data(m_parserModel->index(r, 5)).toString());
 
-        if (m_parserModel->data(m_parserModel->index(r, 6)).isValid()) {
-            auto totp = Totp::parseSettings(m_parserModel->data(m_parserModel->index(r, 6)).toString());
+        auto otpString = m_parserModel->data(m_parserModel->index(r, 6));
+        if (otpString.isValid() && !otpString.toString().isEmpty()) {
+            auto totp = Totp::parseSettings(otpString.toString());
+            if (totp->key.isEmpty()) {
+                // Bare secret, use default TOTP settings
+                totp = Totp::parseSettings({}, otpString.toString());
+            }
             entry->setTotp(totp);
         }
 

--- a/src/gui/databasekey/KeyFileEditWidget.cpp
+++ b/src/gui/databasekey/KeyFileEditWidget.cpp
@@ -42,7 +42,7 @@ KeyFileEditWidget::~KeyFileEditWidget()
 bool KeyFileEditWidget::addToCompositeKey(QSharedPointer<CompositeKey> key)
 {
     auto fileKey = QSharedPointer<FileKey>::create();
-    QString fileKeyName = m_compUi->keyFileCombo->currentText();
+    QString fileKeyName = m_compUi->keyFileLineEdit->text();
     if (!fileKey->load(fileKeyName, nullptr)) {
         return false;
     }
@@ -64,7 +64,7 @@ bool KeyFileEditWidget::validate(QString& errorMessage) const
 {
     FileKey fileKey;
     QString fileKeyError;
-    QString fileKeyName = m_compUi->keyFileCombo->currentText();
+    QString fileKeyName = m_compUi->keyFileLineEdit->text();
     if (!fileKey.load(fileKeyName, &fileKeyError)) {
         errorMessage = tr("Error loading the key file '%1'\nMessage: %2").arg(fileKeyName, fileKeyError);
         return false;
@@ -87,7 +87,7 @@ void KeyFileEditWidget::initComponentEditWidget(QWidget* widget)
 {
     Q_UNUSED(widget);
     Q_ASSERT(m_compEditWidget);
-    m_compUi->keyFileCombo->setFocus();
+    m_compUi->keyFileLineEdit->setFocus();
 }
 
 void KeyFileEditWidget::createKeyFile()
@@ -108,7 +108,7 @@ void KeyFileEditWidget::createKeyFile()
                                  tr("Unable to create key file: %1").arg(errorMsg),
                                  QMessageBox::Button::Ok);
         } else {
-            m_compUi->keyFileCombo->setEditText(fileName);
+            m_compUi->keyFileLineEdit->setText(fileName);
         }
     }
 }
@@ -143,6 +143,6 @@ void KeyFileEditWidget::browseKeyFile()
     }
 
     if (!fileName.isEmpty()) {
-        m_compUi->keyFileCombo->setEditText(fileName);
+        m_compUi->keyFileLineEdit->setText(fileName);
     }
 }

--- a/src/gui/databasekey/KeyFileEditWidget.ui
+++ b/src/gui/databasekey/KeyFileEditWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>370</width>
-    <height>76</height>
+    <width>566</width>
+    <height>94</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -23,33 +23,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QComboBox" name="keyFileCombo">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="accessibleName">
-      <string>Key file selection</string>
-     </property>
-     <property name="editable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
-    <widget class="QPushButton" name="browseKeyFileButton">
-     <property name="accessibleName">
-      <string>Browse for key file</string>
-     </property>
-     <property name="text">
-      <string>Browse...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
     <widget class="QPushButton" name="createKeyFileButton">
      <property name="accessibleName">
       <string>Generate a new key file</string>
@@ -59,31 +33,58 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="0" column="0">
+    <widget class="QLabel" name="instructions">
+     <property name="text">
+      <string>Generate a new key file or choose an existing one to protect your database.</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
-    </spacer>
+    </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
+   <item row="3" column="0">
+    <widget class="QLabel" name="instructions_2">
      <property name="font">
       <font>
        <italic>true</italic>
       </font>
      </property>
      <property name="text">
-      <string>Note: Do not use a file that may change as that will prevent you from unlocking your database!</string>
+      <string>Note: Do NOT use a file that may change as that will prevent you from unlocking your database.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLineEdit" name="keyFileLineEdit">
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="browseKeyFileButton">
+     <property name="accessibleName">
+      <string>Browse for key file</string>
+     </property>
+     <property name="text">
+      <string>Browse…</string>
      </property>
     </widget>
    </item>

--- a/src/gui/entry/EntryAttachmentsWidget.cpp
+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
@@ -238,7 +238,8 @@ void EntryAttachmentsWidget::saveSelectedAttachments()
 
         QFile file(attachmentPath);
         const QByteArray attachmentData = m_entryAttachments->value(filename);
-        const bool saveOk = file.open(QIODevice::WriteOnly) && file.write(attachmentData) == attachmentData.size();
+        const bool saveOk = file.open(QIODevice::WriteOnly) && file.setPermissions(QFile::ReadUser | QFile::WriteUser)
+                            && file.write(attachmentData) == attachmentData.size();
         if (!saveOk) {
             errors.append(QString("%1 - %2").arg(filename, file.errorString()));
         }

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -120,7 +120,8 @@ void NixUtils::setLaunchAtStartup(bool enable)
                << QStringLiteral("MimeType=application/x-keepass2;") << '\n'
                << QStringLiteral("X-GNOME-Autostart-enabled=true") << '\n'
                << QStringLiteral("X-GNOME-Autostart-Delay=2") << '\n'
-               << QStringLiteral("X-KDE-autostart-after=panel") << endl;
+               << QStringLiteral("X-KDE-autostart-after=panel") << '\n'
+               << QStringLiteral("X-LXQt-Need-Tray=true") << endl;
         desktopFile.close();
     } else if (isLaunchAtStartupEnabled()) {
         QFile::remove(getAutostartDesktopFilename());

--- a/src/gui/reports/ReportsWidgetHealthcheck.cpp
+++ b/src/gui/reports/ReportsWidgetHealthcheck.cpp
@@ -150,8 +150,10 @@ ReportsWidgetHealthcheck::ReportsWidgetHealthcheck(QWidget* parent)
     m_modelProxy->setSortLocaleAware(true);
     m_ui->healthcheckTableView->setModel(m_modelProxy.data());
     m_ui->healthcheckTableView->setSelectionMode(QAbstractItemView::NoSelection);
-    m_ui->healthcheckTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    m_ui->healthcheckTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
+    m_ui->healthcheckTableView->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
     m_ui->healthcheckTableView->setSortingEnabled(true);
+    m_ui->healthcheckTableView->setWordWrap(true);
 
     connect(m_ui->healthcheckTableView, SIGNAL(customContextMenuRequested(QPoint)), SLOT(customMenuRequested(QPoint)));
     connect(m_ui->healthcheckTableView, SIGNAL(doubleClicked(QModelIndex)), SLOT(emitEntryActivated(QModelIndex)));
@@ -281,7 +283,8 @@ void ReportsWidgetHealthcheck::calculateHealth()
         m_ui->healthcheckTableView->sortByColumn(0, Qt::AscendingOrder);
     }
 
-    m_ui->healthcheckTableView->resizeRowsToContents();
+    m_ui->healthcheckTableView->resizeColumnsToContents();
+    m_ui->healthcheckTableView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
 
     // Show the "show known bad entries" checkbox if there's any known
     // bad entry in the database.

--- a/src/gui/reports/ReportsWidgetHibp.cpp
+++ b/src/gui/reports/ReportsWidgetHibp.cpp
@@ -79,7 +79,8 @@ ReportsWidgetHibp::ReportsWidgetHibp(QWidget* parent)
     m_modelProxy->setSortLocaleAware(true);
     m_ui->hibpTableView->setModel(m_modelProxy.data());
     m_ui->hibpTableView->setSelectionMode(QAbstractItemView::NoSelection);
-    m_ui->hibpTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    m_ui->hibpTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
+    m_ui->hibpTableView->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
     m_ui->hibpTableView->setSortingEnabled(true);
 
     connect(m_ui->hibpTableView, SIGNAL(doubleClicked(QModelIndex)), SLOT(emitEntryActivated(QModelIndex)));
@@ -219,7 +220,7 @@ void ReportsWidgetHibp::makeHibpTable()
         m_ui->showKnownBadCheckBox->hide();
     }
 
-    m_ui->hibpTableView->resizeRowsToContents();
+    m_ui->hibpTableView->resizeColumnsToContents();
     m_ui->hibpTableView->sortByColumn(2, Qt::DescendingOrder);
 
     m_ui->stackedWidget->setCurrentIndex(1);

--- a/src/gui/styles/base/basestyle.qss
+++ b/src/gui/styles/base/basestyle.qss
@@ -69,3 +69,7 @@ QPlainTextEdit, QTextEdit {
     background-color: palette(base);
     padding-left: 4px;
 }
+
+QStatusBar {
+    background-color: palette(window);
+}

--- a/src/gui/styles/dark/DarkStyle.cpp
+++ b/src/gui/styles/dark/DarkStyle.cpp
@@ -21,6 +21,7 @@
 #include <QDialog>
 #include <QMainWindow>
 #include <QMenuBar>
+#include <QStatusBar>
 #include <QToolBar>
 
 DarkStyle::DarkStyle()
@@ -110,7 +111,7 @@ QString DarkStyle::getAppStyleSheet() const
 void DarkStyle::polish(QWidget* widget)
 {
     if (qobject_cast<QMainWindow*>(widget) || qobject_cast<QDialog*>(widget) || qobject_cast<QMenuBar*>(widget)
-        || qobject_cast<QToolBar*>(widget)) {
+        || qobject_cast<QToolBar*>(widget) || qobject_cast<QStatusBar*>(widget)) {
         auto palette = widget->palette();
 #if defined(Q_OS_MACOS)
         if (!osUtils->isDarkMode()) {

--- a/src/gui/styles/light/LightStyle.cpp
+++ b/src/gui/styles/light/LightStyle.cpp
@@ -22,6 +22,7 @@
 #include <QDialog>
 #include <QMainWindow>
 #include <QMenuBar>
+#include <QStatusBar>
 #include <QToolBar>
 
 LightStyle::LightStyle()
@@ -111,7 +112,7 @@ QString LightStyle::getAppStyleSheet() const
 void LightStyle::polish(QWidget* widget)
 {
     if (qobject_cast<QMainWindow*>(widget) || qobject_cast<QDialog*>(widget) || qobject_cast<QMenuBar*>(widget)
-        || qobject_cast<QToolBar*>(widget)) {
+        || qobject_cast<QToolBar*>(widget) || qobject_cast<QStatusBar*>(widget)) {
         auto palette = widget->palette();
 #if defined(Q_OS_MACOS)
         if (osUtils->isDarkMode()) {

--- a/src/gui/widgets/KPToolBar.cpp
+++ b/src/gui/widgets/KPToolBar.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "KPToolBar.h"
+
+#include <QAbstractButton>
+#include <QEvent>
+#include <QLayout>
+
+KPToolBar::KPToolBar(const QString& title, QWidget* parent)
+    : QToolBar(title, parent)
+{
+    init();
+}
+
+KPToolBar::KPToolBar(QWidget* parent)
+    : QToolBar(parent)
+{
+    init();
+}
+
+void KPToolBar::init()
+{
+    m_expandButton = findChild<QAbstractButton*>("qt_toolbar_ext_button");
+    m_expandTimer.setSingleShot(true);
+    connect(&m_expandTimer, &QTimer::timeout, this, [this] { setExpanded(false); });
+}
+
+bool KPToolBar::isExpanded()
+{
+    return !canExpand() || (canExpand() && m_expandButton->isChecked());
+}
+
+bool KPToolBar::canExpand()
+{
+    return m_expandButton && m_expandButton->isVisible();
+}
+
+void KPToolBar::setExpanded(bool state)
+{
+    if (canExpand() && !QMetaObject::invokeMethod(layout(), "setExpanded", Q_ARG(bool, state))) {
+        qWarning("Toolbar: Cannot invoke setExpanded!");
+    }
+}
+
+bool KPToolBar::event(QEvent* event)
+{
+    // Override events handled by the base class for better UX when using an expandable toolbar.
+    switch (event->type()) {
+    case QEvent::Leave:
+        // Hide the toolbar after 2 seconds of mouse exit
+        m_expandTimer.start(2000);
+        return true;
+    case QEvent::Enter:
+        // Mouse came back in, stop hiding timer
+        m_expandTimer.stop();
+        return true;
+    default:
+        return QToolBar::event(event);
+    }
+}

--- a/src/gui/widgets/KPToolBar.h
+++ b/src/gui/widgets/KPToolBar.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_KPTOOLBAR_H
+#define KEEPASSXC_KPTOOLBAR_H
+
+#include <QPointer>
+#include <QTimer>
+#include <QToolBar>
+
+class QAbstractButton;
+
+class KPToolBar : public QToolBar
+{
+    Q_OBJECT
+
+public:
+    explicit KPToolBar(const QString& title, QWidget* parent = nullptr);
+    explicit KPToolBar(QWidget* parent = nullptr);
+    ~KPToolBar() override = default;
+
+    bool isExpanded();
+    bool canExpand();
+
+public slots:
+    void setExpanded(bool state);
+
+protected:
+    bool event(QEvent* event) override;
+
+private:
+    void init();
+
+    QTimer m_expandTimer;
+    QPointer<QAbstractButton> m_expandButton;
+};
+
+#endif // KEEPASSXC_KPTOOLBAR_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char** argv)
     QCommandLineOption configOption("config", QObject::tr("path to a custom config file"), "config");
     QCommandLineOption localConfigOption(
         "localconfig", QObject::tr("path to a custom local config file"), "localconfig");
+    QCommandLineOption lockOption("lock", QObject::tr("lock all open databases"));
     QCommandLineOption keyfileOption("keyfile", QObject::tr("key file of the database"), "keyfile");
     QCommandLineOption pwstdinOption("pw-stdin", QObject::tr("read password of the database from stdin"));
 
@@ -72,6 +73,7 @@ int main(int argc, char** argv)
     QCommandLineOption debugInfoOption(QStringList() << "debug-info", QObject::tr("Displays debugging information."));
     parser.addOption(configOption);
     parser.addOption(localConfigOption);
+    parser.addOption(lockOption);
     parser.addOption(keyfileOption);
     parser.addOption(pwstdinOption);
     parser.addOption(debugInfoOption);
@@ -96,12 +98,23 @@ int main(int argc, char** argv)
     }
 
     // Process single instance and early exit if already running
+    // FIXME: this is a *mess* and it is entirely my fault. --wundrweapon
     const QStringList fileNames = parser.positionalArguments();
     if (app.isAlreadyRunning()) {
-        if (!fileNames.isEmpty()) {
-            app.sendFileNamesToRunningInstance(fileNames);
+        if (parser.isSet(lockOption)) {
+            if (app.sendLockToInstance()) {
+                qInfo() << QObject::tr("Locked databases.").toUtf8().constData();
+            } else {
+                qWarning() << QObject::tr("Database failed to lock.").toUtf8().constData();
+                return EXIT_FAILURE;
+            }
+        } else {
+            if (!fileNames.isEmpty()) {
+                app.sendFileNamesToRunningInstance(fileNames);
+            }
+
+            qWarning() << QObject::tr("Another instance of KeePassXC is already running.").toUtf8().constData();
         }
-        qWarning() << QObject::tr("Another instance of KeePassXC is already running.").toUtf8().constData();
         return EXIT_SUCCESS;
     }
 

--- a/tests/TestOpVaultReader.cpp
+++ b/tests/TestOpVaultReader.cpp
@@ -97,10 +97,10 @@ void TestOpVaultReader::testReadIntoDatabase()
     entry = db->rootGroup()->findEntryByPath("/Credit Card/My Credit Card");
     QVERIFY(entry);
     auto attr = entry->attributes();
-    QCOMPARE(attr->value("cardholder"), QStringLiteral("Team KeePassXC"));
-    QVERIFY(!attr->value("validFrom").isEmpty());
-    QCOMPARE(attr->value("details_pin"), QStringLiteral("1234"));
-    QVERIFY(attr->isProtected("details_pin"));
+    QCOMPARE(attr->value("cardholder name"), QStringLiteral("Team KeePassXC"));
+    QVERIFY(!attr->value("valid from").isEmpty());
+    QCOMPARE(attr->value("Additional Details_PIN"), QStringLiteral("1234"));
+    QVERIFY(attr->isProtected("Additional Details_PIN"));
 
     // Confirm address fields
     entry = db->rootGroup()->findEntryByPath("/Identity/Team KeePassXC");

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -279,15 +279,15 @@ void TestGui::testCreateDatabase()
         QTRY_VERIFY(!additionalOptionsButton->isVisible());
         QCOMPARE(passwordWidget->visiblePage(), KeyFileEditWidget::Page::Edit);
         QTest::mouseClick(keyFileWidget->findChild<QPushButton*>("addButton"), Qt::MouseButton::LeftButton);
-        auto* fileCombo = keyFileWidget->findChild<QComboBox*>("keyFileCombo");
-        QTRY_VERIFY(fileCombo);
-        QTRY_VERIFY(fileCombo->isVisible());
+        auto* fileEdit = keyFileWidget->findChild<QLineEdit*>("keyFileLineEdit");
+        QTRY_VERIFY(fileEdit);
+        QTRY_VERIFY(fileEdit->isVisible());
         fileDialog()->setNextFileName(QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
         QTest::keyClick(keyFileWidget->findChild<QPushButton*>("addButton"), Qt::Key::Key_Enter);
-        QVERIFY(fileCombo->hasFocus());
+        QVERIFY(fileEdit->hasFocus());
         auto* browseButton = keyFileWidget->findChild<QPushButton*>("browseKeyFileButton");
         QTest::keyClick(browseButton, Qt::Key::Key_Enter);
-        QCOMPARE(fileCombo->currentText(), QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
+        QCOMPARE(fileEdit->text(), QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
 
         // save database to temporary file
         TemporaryFile tmpFile;
@@ -295,7 +295,7 @@ void TestGui::testCreateDatabase()
         tmpFile.close();
         fileDialog()->setNextFileName(tmpFile.fileName());
 
-        QTest::keyClick(fileCombo, Qt::Key::Key_Enter);
+        QTest::keyClick(fileEdit, Qt::Key::Key_Enter);
         tmpFile.remove(););
 
     triggerAction("actionDatabaseNew");


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
* Auto-Type: Allow selection of modal dialogs on X11 [#6204]
* Persist Always On Top setting [#6236]
* Make KeePassXC start after the system tray is available on LXQt [#6216]
* Allow CSV import of bare TOTP secrets [#6211]
* OPVault: Use Text instead of Name for attribute and section names [#6334]
* Show countdown for clipboard clearing [#6333]
* Fix showing preview notes in an entry without notes [#6481]
* Fix unreachable setting of file permissions [#6514]
* Show search bar when toolbar is hidden or overflow [#6279]
* MinimizeAfterUnlock also when unlocking through browser [#6338]
* Set permissions of saved attachments to be private to the current user [#6363]
* Add command line option to lock open databases [#6511]
* Use application font size when setting default or monospace fonts [#6332]
* Allow resizing of reports table columns [#6435]
* Improve description text when changing Key File credential [#6396]
* Make Always on Top a local configuration setting
* Fix read usage in release-tool

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on develop when merged and via unit tests.