### PR TITLE
Auto-Type: Allow selection of modal dialogs on X11

### DIFF
--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -52,18 +52,24 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     setWindowIcon(resources()->applicationIcon());
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-    QRect screenGeometry = QApplication::screenAt(QCursor::pos())->availableGeometry();
+    auto screen = QApplication::screenAt(QCursor::pos());
+    if (!screen) {
+        // screenAt can return a nullptr, default to the primary screen
+        screen = QApplication::primaryScreen();
+    }
+    QRect screenGeometry = screen->availableGeometry();
 #else
     QRect screenGeometry = QApplication::desktop()->availableGeometry(QCursor::pos());
 #endif
+
+    // Resize to last used size
     QSize size = config()->get(Config::GUI_AutoTypeSelectDialogSize).toSize();
     size.setWidth(qMin(size.width(), screenGeometry.width()));
     size.setHeight(qMin(size.height(), screenGeometry.height()));
     resize(size);
 
     // move dialog to the center of the screen
-    QPoint screenCenter = screenGeometry.center();
-    move(screenCenter.x() - (size.width() / 2), screenCenter.y() - (size.height() / 2));
+    move(screenGeometry.center().x() - (size.width() / 2), screenGeometry.center().y() - (size.height() / 2));
 
     QVBoxLayout* layout = new QVBoxLayout(this);
 

--- a/src/gui/entry/AutoTypeMatchView.cpp
+++ b/src/gui/entry/AutoTypeMatchView.cpp
@@ -64,14 +64,20 @@ AutoTypeMatchView::AutoTypeMatchView(QWidget* parent)
 
 void AutoTypeMatchView::userNameCopied()
 {
-    clipboard()->setText(currentMatch().entry->username());
-    emit matchTextCopied();
+    auto entry = currentMatch().entry;
+    if (entry) {
+        clipboard()->setText(entry->resolvePlaceholder(entry->username()));
+        emit matchTextCopied();
+    }
 }
 
 void AutoTypeMatchView::passwordCopied()
 {
-    clipboard()->setText(currentMatch().entry->password());
-    emit matchTextCopied();
+    auto entry = currentMatch().entry;
+    if (entry) {
+        clipboard()->setText(entry->resolvePlaceholder(entry->password()));
+        emit matchTextCopied();
+    }
 }
 
 void AutoTypeMatchView::keyPressEvent(QKeyEvent* event)


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
* Modified backport of specific improvements introduced on develop branch. 

- Prevent crash when multiple screens are at play and QApplication::screenAt returns nullptr. 
- Resolve username/password when copying to clipboard from Auto-Type selection dialog.

Drawn from #6392 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested Auto-Type selection dialog for performance.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
