### PR TITLE
Add a context menu entry to delete entries from health check reports

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ set(keepassx_SOURCES
         gui/EditWidgetProperties.cpp
         gui/FileDialog.cpp
         gui/Font.cpp
+        gui/GuiTools.cpp
         gui/IconModels.cpp
         gui/KeePass1OpenWidget.cpp
         gui/KMessageWidget.cpp

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -74,7 +74,7 @@ public:
 
     explicit DatabaseWidget(QSharedPointer<Database> db, QWidget* parent = nullptr);
     explicit DatabaseWidget(const QString& filePath, QWidget* parent = nullptr);
-    ~DatabaseWidget();
+    ~DatabaseWidget() override;
 
     void setFocus(Qt::FocusReason reason);
 
@@ -255,7 +255,6 @@ private:
     void setClipboardTextAndMinimize(const QString& text);
     void processAutoOpen();
     void openDatabaseFromEntry(const Entry* entry, bool inBackground = true);
-    bool confirmDeleteEntries(QList<Entry*> entries, bool permanent);
     void performIconDownloads(const QList<Entry*>& entries, bool force = false);
     bool performSave(QString& errorMessage, const QString& fileName = {});
 

--- a/src/gui/GuiTools.cpp
+++ b/src/gui/GuiTools.cpp
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "GuiTools.h"
+
+#include "core/Config.h"
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "gui/MessageBox.h"
+
+namespace GuiTools
+{
+    bool confirmDeleteEntries(QWidget* parent, const QList<Entry*>& entries, bool permanent)
+    {
+        if (!parent || entries.isEmpty()) {
+            return false;
+        }
+
+        if (permanent) {
+            QString prompt;
+            if (entries.size() == 1) {
+                prompt = QObject::tr("Do you really want to delete the entry \"%1\" for good?")
+                             .arg(entries.first()->title().toHtmlEscaped());
+            } else {
+                prompt = QObject::tr("Do you really want to delete %n entry(s) for good?", "", entries.size());
+            }
+
+            auto answer = MessageBox::question(parent,
+                                               QObject::tr("Delete entry(s)?", "", entries.size()),
+                                               prompt,
+                                               MessageBox::Delete | MessageBox::Cancel,
+                                               MessageBox::Cancel);
+
+            return answer == MessageBox::Delete;
+        } else if (config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool()) {
+            return true;
+        } else {
+            QString prompt;
+            if (entries.size() == 1) {
+                prompt = QObject::tr("Do you really want to move entry \"%1\" to the recycle bin?")
+                             .arg(entries.first()->title().toHtmlEscaped());
+            } else {
+                prompt = QObject::tr("Do you really want to move %n entry(s) to the recycle bin?", "", entries.size());
+            }
+
+            auto answer = MessageBox::question(parent,
+                                               QObject::tr("Move entry(s) to recycle bin?", "", entries.size()),
+                                               prompt,
+                                               MessageBox::Move | MessageBox::Cancel,
+                                               MessageBox::Cancel);
+
+            return answer == MessageBox::Move;
+        }
+    }
+
+    void deleteEntriesResolveReferences(QWidget* parent, const QList<Entry*>& entries, bool permanent)
+    {
+        if (!parent || entries.isEmpty()) {
+            return;
+        }
+
+        QList<Entry*> selectedEntries;
+        // Find references to entries and prompt for direction if necessary
+        for (auto entry : entries) {
+            if (permanent) {
+                auto references = entry->database()->rootGroup()->referencesRecursive(entry);
+                if (!references.isEmpty()) {
+                    // Ignore references that are part of this cohort
+                    for (auto e : entries) {
+                        references.removeAll(e);
+                    }
+                    // Prompt the user on what to do with the reference (Overwrite, Delete, Skip)
+                    auto result = MessageBox::question(
+                        parent,
+                        QObject::tr("Replace references to entry?"),
+                        QObject::tr(
+                            "Entry \"%1\" has %2 reference(s). "
+                            "Do you want to overwrite references with values, skip this entry, or delete anyway?",
+                            "",
+                            references.size())
+                            .arg(entry->resolvePlaceholder(entry->title()).toHtmlEscaped())
+                            .arg(references.size()),
+                        MessageBox::Overwrite | MessageBox::Skip | MessageBox::Delete,
+                        MessageBox::Overwrite);
+
+                    if (result == MessageBox::Overwrite) {
+                        for (auto ref : references) {
+                            ref->replaceReferencesWithValues(entry);
+                        }
+                    } else if (result == MessageBox::Skip) {
+                        continue;
+                    }
+                }
+            }
+            // Marked for deletion
+            selectedEntries << entry;
+        }
+
+        for (auto entry : asConst(selectedEntries)) {
+            if (permanent) {
+                delete entry;
+            } else {
+                entry->database()->recycleEntry(entry);
+            }
+        }
+    }
+} // namespace GuiTools

--- a/src/gui/GuiTools.h
+++ b/src/gui/GuiTools.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_GUITOOLS_H
+#define KEEPASSXC_GUITOOLS_H
+
+#include <QList>
+#include <QWidget>
+
+class Entry;
+
+namespace GuiTools
+{
+    bool confirmDeleteEntries(QWidget* parent, const QList<Entry*>& entries, bool permanent);
+    void deleteEntriesResolveReferences(QWidget* parent, const QList<Entry*>& entries, bool permanent);
+} // namespace GuiTools
+#endif // KEEPASSXC_GUITOOLS_H

--- a/src/gui/reports/ReportsWidgetHealthcheck.h
+++ b/src/gui/reports/ReportsWidgetHealthcheck.h
@@ -57,6 +57,7 @@ public slots:
     void emitEntryActivated(const QModelIndex& index);
     void customMenuRequested(QPoint);
     void editFromContextmenu();
+    void deleteEntry();
 
 private:
     void addHealthRow(QSharedPointer<PasswordHealth>, const Group*, const Entry*, bool knownBad);

--- a/src/gui/reports/ReportsWidgetHealthcheck.h
+++ b/src/gui/reports/ReportsWidgetHealthcheck.h
@@ -56,11 +56,10 @@ public slots:
     void calculateHealth();
     void emitEntryActivated(const QModelIndex& index);
     void customMenuRequested(QPoint);
-    void editFromContextmenu();
-    void deleteEntry();
+    void deleteSelectedEntries();
 
 private:
-    void addHealthRow(QSharedPointer<PasswordHealth>, const Group*, const Entry*, bool knownBad);
+    void addHealthRow(QSharedPointer<PasswordHealth>, Group*, Entry*, bool knownBad);
 
     QScopedPointer<Ui::ReportsWidgetHealthcheck> m_ui;
 
@@ -68,8 +67,7 @@ private:
     QScopedPointer<QStandardItemModel> m_referencesModel;
     QScopedPointer<QSortFilterProxyModel> m_modelProxy;
     QSharedPointer<Database> m_db;
-    QList<QPair<const Group*, const Entry*>> m_rowToEntry;
-    Entry* m_contextmenuEntry = nullptr;
+    QList<QPair<Group*, Entry*>> m_rowToEntry;
 };
 
 #endif // KEEPASSXC_REPORTSWIDGETHEALTHCHECK_H

--- a/src/gui/reports/ReportsWidgetHealthcheck.ui
+++ b/src/gui/reports/ReportsWidgetHealthcheck.ui
@@ -10,7 +10,7 @@
     <height>379</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -37,11 +37,14 @@
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
      <property name="textElideMode">
       <enum>Qt::ElideMiddle</enum>
      </property>
      <property name="sortingEnabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>

--- a/src/gui/reports/ReportsWidgetHibp.h
+++ b/src/gui/reports/ReportsWidgetHibp.h
@@ -61,7 +61,7 @@ public slots:
     void fetchFailed(const QString& error);
     void makeHibpTable();
     void customMenuRequested(QPoint);
-    void editFromContextmenu();
+    void deleteSelectedEntries();
 
 private:
     void startValidation();
@@ -74,11 +74,10 @@ private:
 
     QMap<QString, int> m_pwndPasswords; // Passwords we found to have been pwned (value is pwn count)
     QString m_error; // Error message if download failed, else empty
-    QList<const Entry*> m_rowToEntry; // List index is table row
-    QPointer<const Entry> m_editedEntry; // The entry we're currently editing
+    QList<Entry*> m_rowToEntry; // List index is table row
+    QPointer<Entry> m_editedEntry; // The entry we're currently editing
     QString m_editedPassword; // The old password of the entry we're editing
     bool m_editedExcluded; // The old "known bad" flag of the entry we're editing
-    Entry* m_contextmenuEntry = nullptr; // The entry that was right-clicked
 
 #ifdef WITH_XC_NETWORKING
     HibpDownloader m_downloader; // This performs the actual HIBP online query

--- a/src/gui/reports/ReportsWidgetHibp.ui
+++ b/src/gui/reports/ReportsWidgetHibp.ui
@@ -151,11 +151,14 @@
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
          <property name="textElideMode">
           <enum>Qt::ElideMiddle</enum>
          </property>
          <property name="sortingEnabled">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <attribute name="horizontalHeaderStretchLastSection">
           <bool>true</bool>


### PR DESCRIPTION
Addresses Issue #4986

Ideally we would be able to select multiple entries and delete them at once, but it would require deeper changes in the widget. This is a start.

## Screenshots
![deleteEntry](https://user-images.githubusercontent.com/867299/118829078-1b861080-b8be-11eb-97ec-50fdc912077b.gif)



## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
