### PR TITLE
Simplify browser access dialog

### DIFF
--- a/src/browser/BrowserAccessControlDialog.cpp
+++ b/src/browser/BrowserAccessControlDialog.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2013 Francois Ferrand
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
 #include <QUrl>
 
 #include "core/Entry.h"
+#include "gui/Icons.h"
 
 BrowserAccessControlDialog::BrowserAccessControlDialog(QWidget* parent)
     : QDialog(parent)
@@ -31,7 +32,12 @@ BrowserAccessControlDialog::BrowserAccessControlDialog(QWidget* parent)
     m_ui->setupUi(this);
 
     connect(m_ui->allowButton, SIGNAL(clicked()), SLOT(accept()));
-    connect(m_ui->cancelButton, SIGNAL(clicked()), SLOT(reject()));
+    connect(m_ui->denyButton, SIGNAL(clicked()), SLOT(reject()));
+    connect(m_ui->itemsTable, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(accept()));
+    connect(m_ui->itemsTable->selectionModel(),
+            SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
+            this,
+            SLOT(selectionChanged()));
 }
 
 BrowserAccessControlDialog::~BrowserAccessControlDialog()
@@ -48,34 +54,22 @@ void BrowserAccessControlDialog::setItems(const QList<Entry*>& items, const QStr
     m_ui->rememberDecisionCheckBox->setChecked(false);
 
     m_ui->itemsTable->setRowCount(items.count());
-    m_ui->itemsTable->setColumnCount(2);
+    m_ui->itemsTable->setColumnCount(1);
 
     int row = 0;
     for (const auto& entry : items) {
         auto item = new QTableWidgetItem();
         item->setText(entry->title() + " - " + entry->username());
         item->setData(Qt::UserRole, row);
-        item->setCheckState(Qt::Checked);
-        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        item->setFlags(item->flags() | Qt::ItemIsSelectable);
         m_ui->itemsTable->setItem(row, 0, item);
-
-        auto disableButton = new QPushButton(tr("Disable for this site"));
-        disableButton->setAutoDefault(false);
-        connect(disableButton, &QAbstractButton::pressed, [&, item] {
-            emit disableAccess(item);
-            m_ui->itemsTable->removeRow(item->row());
-            if (m_ui->itemsTable->rowCount() == 0) {
-                reject();
-            }
-        });
-        m_ui->itemsTable->setCellWidget(row, 1, disableButton);
 
         ++row;
     }
 
     m_ui->itemsTable->resizeColumnsToContents();
     m_ui->itemsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
-
+    m_ui->itemsTable->selectAll();
     m_ui->allowButton->setFocus();
 }
 
@@ -89,7 +83,7 @@ QList<QTableWidgetItem*> BrowserAccessControlDialog::getSelectedEntries() const
     QList<QTableWidgetItem*> selected;
     for (int i = 0; i < m_ui->itemsTable->rowCount(); ++i) {
         auto item = m_ui->itemsTable->item(i, 0);
-        if (item->checkState() == Qt::Checked) {
+        if (item->isSelected()) {
             selected.append(item);
         }
     }
@@ -101,9 +95,20 @@ QList<QTableWidgetItem*> BrowserAccessControlDialog::getNonSelectedEntries() con
     QList<QTableWidgetItem*> notSelected;
     for (int i = 0; i < m_ui->itemsTable->rowCount(); ++i) {
         auto item = m_ui->itemsTable->item(i, 0);
-        if (item->checkState() != Qt::Checked) {
+        if (!item->isSelected()) {
             notSelected.append(item);
         }
     }
     return notSelected;
+}
+
+void BrowserAccessControlDialog::selectionChanged()
+{
+    auto indexes = m_ui->itemsTable->selectionModel()->selectedIndexes();
+    m_ui->allowButton->setEnabled(!indexes.isEmpty());
+
+    if (indexes.isEmpty()) {
+        m_ui->allowButton->clearFocus();
+        m_ui->denyButton->setFocus();
+    }
 }

--- a/src/browser/BrowserAccessControlDialog.h
+++ b/src/browser/BrowserAccessControlDialog.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2013 Francois Ferrand
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -43,8 +43,8 @@ public:
     QList<QTableWidgetItem*> getSelectedEntries() const;
     QList<QTableWidgetItem*> getNonSelectedEntries() const;
 
-signals:
-    void disableAccess(QTableWidgetItem* item);
+private slots:
+    void selectionChanged();
 
 private:
     QScopedPointer<Ui::BrowserAccessControlDialog> m_ui;

--- a/src/browser/BrowserAccessControlDialog.ui
+++ b/src/browser/BrowserAccessControlDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>405</width>
-    <height>200</height>
+    <height>240</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,7 +39,10 @@
       <bool>false</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::NoSelection</enum>
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
      </property>
      <property name="cornerButtonEnabled">
       <bool>false</bool>
@@ -51,6 +54,23 @@
       <bool>false</bool>
      </attribute>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -97,7 +117,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cancelButton">
+      <widget class="QPushButton" name="denyButton">
        <property name="text">
         <string>Deny All</string>
        </property>

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -802,21 +802,6 @@ QList<Entry*> BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
     BrowserAccessControlDialog accessControlDialog;
 
     connect(m_currentDatabaseWidget, SIGNAL(databaseLockRequested()), &accessControlDialog, SLOT(reject()));
-
-    connect(&accessControlDialog, &BrowserAccessControlDialog::disableAccess, [&](QTableWidgetItem* item) {
-        auto entry = pwEntriesToConfirm[item->row()];
-        BrowserEntryConfig config;
-        config.load(entry);
-        config.deny(siteHost);
-        if (!formUrlStr.isEmpty() && siteHost != formUrlStr) {
-            config.deny(formUrlStr);
-        }
-        if (!realm.isEmpty()) {
-            config.setRealm(realm);
-        }
-        config.save(entry);
-    });
-
     accessControlDialog.setItems(pwEntriesToConfirm, siteUrlStr, httpAuth);
 
     QList<Entry*> allowedEntries;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Simplifies the browser access dialog. Removes the checkbox from entries and replaces those with a simpler selection based interface. If none of the entries are selected, Allow button will be disabled. A double click accepts a single entry right away.

Fixes https://github.com/keepassxreboot/keepassxc/issues/6425.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
