### PR TITLE
Fixes #6562

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -1269,7 +1269,7 @@ appsign() {
             exitError "Key file was not found!"
         fi
 
-        read -s -p "Key password: " password
+        IFS=$'\n' read -s -r -p "Key password: " password
         echo
 
         for f in "${sign_files[@]}"; do


### PR DESCRIPTION
Adding `-r` to `read` dos not allow backslashes to escape any characters.
We also need to specify that we don't want any word delimiters by adding `IFS=""` before running `read`.


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)