### PR TITLE
Correct macOS window activation from hidden state

### DIFF
--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -206,11 +206,10 @@
 
 - (void) toggleForegroundApp:(bool) foreground
 {
-    ProcessSerialNumber psn = {0, kCurrentProcess};
     if (foreground) {
-        TransformProcessType(&psn, kProcessTransformToForegroundApplication);
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
     } else {
-        TransformProcessType(&psn, kProcessTransformToUIElementApplication);
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
     }
 }
 

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -70,6 +70,7 @@ bool MacUtils::raiseWindow(WId pid)
 
 bool MacUtils::raiseOwnWindow()
 {
+    m_appkit->toggleForegroundApp(true);
     return m_appkit->activateProcess(m_appkit->ownProcessId());
 }
 


### PR DESCRIPTION
* Fix #6234 - properly set NSApplication activation policies when the window is hidden and shown

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on macOS

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
