### PR TITLE
Removed unnecessary characters from HEX excluded chars

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -352,7 +352,7 @@ void PasswordGeneratorWidget::setAdvancedMode(bool advanced)
 
 void PasswordGeneratorWidget::excludeHexChars()
 {
-    m_ui->editExcludedChars->setText("GHIJKLMNOPQRSTUVWXYZghijklmnopqrstuvwxyz");
+    m_ui->editExcludedChars->setText("GHIJKLMNOPQRSTUVWXYZ");
     m_ui->checkBoxNumbers->setChecked(true);
     m_ui->checkBoxUpper->setChecked(true);
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

The HEX button automatically unselects `selectBoxLower` therefore there is no need to also add `ghijklmnopqrstuvwxyz` in the excluded characters text field. This is not really a bug, just a small thing I noticed while exploring the generator options. 

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

I have not tested it yet. I tried running it in VSC and I couldn't figure out how to setup and build the project to test it. It is a very short change to the codebase and I looked at both the `excludeHexChars` and `updateGenerator` methods and the only lines where I saw any changes to the excluded characters was line 355 (which I changed) and 522 (where it sets the excluded characters to the characters in the field). I couldn't see any other places where the hex excluded characters played a role. 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )