### PR TITLE
Fix compilation on macOS

### DIFF
--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -17,16 +17,8 @@
  */
 
 #import "AppKitImpl.h"
-#include "AppKit.h"
-#include <QWindow>
-
-#import <AppKit/NSStatusBar.h>
-#import <AppKit/NSStatusItem.h>
-#import <AppKit/NSStatusBarButton.h>
-#import <AppKit/NSWorkspace.h>
-#import <AppKit/NSWindow.h>
-#import <AppKit/NSView.h>
-#import <CoreVideo/CVPixelBuffer.h>
+#import <QWindow>
+#import <Cocoa/Cocoa.h>
 
 @implementation AppKitImpl
 


### PR DESCRIPTION
Even though #6575 apparently passed the CI, it broke compilation on my Mac machines, because `NSApp` wasn't declared.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)