### PR TITLE
Resolve compiler warnings for unused return values

### DIFF
--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -235,7 +235,7 @@ void Application::handleUnixSignal(int sig)
     case SIGINT:
     case SIGTERM: {
         char buf = 0;
-        Q_UNUSED(::write(unixSignalSocket[0], &buf, sizeof(buf)));
+        Q_UNUSED(!::write(unixSignalSocket[0], &buf, sizeof(buf)));
         return;
     }
     case SIGHUP:
@@ -247,7 +247,7 @@ void Application::quitBySignal()
 {
     m_unixSignalNotifier->setEnabled(false);
     char buf;
-    Q_UNUSED(::read(unixSignalSocket[1], &buf, sizeof(buf)));
+    Q_UNUSED(!::read(unixSignalSocket[1], &buf, sizeof(buf)));
     emit quitSignalReceived();
 }
 #endif

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -235,7 +235,7 @@ void TestKeys::benchmarkTransformKey()
 
     QBENCHMARK
     {
-        Q_UNUSED(compositeKey->transform(kdf, result));
+        Q_UNUSED(!compositeKey->transform(kdf, result));
     };
 }
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -853,7 +853,7 @@ void TestGui::testTotp()
 void TestGui::testSearch()
 {
     // Add canned entries for consistent testing
-    Q_UNUSED(addCannedEntries());
+    addCannedEntries();
 
     auto* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
 
@@ -1007,7 +1007,7 @@ void TestGui::testSearch()
 void TestGui::testDeleteEntry()
 {
     // Add canned entries for consistent testing
-    Q_UNUSED(addCannedEntries());
+    addCannedEntries();
 
     auto* groupView = m_dbWidget->findChild<GroupView*>("groupView");
     auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
@@ -1673,10 +1673,8 @@ void TestGui::testAutoType()
     entryView->selectionModel()->clearSelection();
 }
 
-int TestGui::addCannedEntries()
+void TestGui::addCannedEntries()
 {
-    int entries_added = 0;
-
     // Find buttons
     auto* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
     QWidget* entryNewWidget = toolBar->widgetForAction(m_mainWindow->findChild<QAction*>("actionEntryNew"));
@@ -1689,22 +1687,17 @@ int TestGui::addCannedEntries()
     QTest::keyClicks(titleEdit, "test");
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
-    ++entries_added;
 
     // Add entry "something 2"
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
     QTest::keyClicks(titleEdit, "something 2");
     QTest::keyClicks(passwordEdit, "something 2");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
-    ++entries_added;
 
     // Add entry "something 3"
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
     QTest::keyClicks(titleEdit, "something 3");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
-    ++entries_added;
-
-    return entries_added;
 }
 
 void TestGui::checkDatabase(QString dbFileName)

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -72,7 +72,7 @@ private slots:
     void testTrayRestoreHide();
 
 private:
-    int addCannedEntries();
+    void addCannedEntries();
     void checkDatabase(QString dbFileName = "");
     void triggerAction(const QString& name);
     void dragAndDropGroup(const QModelIndex& sourceIndex,


### PR DESCRIPTION
* Fixes #1932 - See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425#c29

Adding a negation before the function call allows the (void) syntax to work properly.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on linux build

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
