### PR TITLE
Add favicon url download dialog

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3240,10 +3240,6 @@ Supported extensions are: %1.</source>
 <context>
     <name>EditWidgetIcons</name>
     <message>
-        <source>Add custom icon</source>
-        <translation>Add custom icon</translation>
-    </message>
-    <message>
         <source>Download favicon</source>
         <translation>Download favicon</translation>
     </message>
@@ -3330,6 +3326,18 @@ Supported extensions are: %1.</source>
     </message>
     <message>
         <source>Apply icon to…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose icon…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set the URL to use to search for a favicon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Favicon URL</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -72,6 +72,9 @@ public:
               const QString& url = "");
     void setShowApplyIconToButton(bool state);
 
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
+
 public slots:
     void setUrl(const QString& url);
     void abortRequests();
@@ -102,8 +105,7 @@ private:
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;
 #ifdef WITH_XC_NETWORKING
-    QScopedPointer<IconDownloader> m_downloader;
-    QString m_url;
+    QSharedPointer<IconDownloader> m_downloader;
 #endif
 
     Q_DISABLE_COPY(EditWidgetIcons)

--- a/src/gui/EditWidgetIcons.ui
+++ b/src/gui/EditWidgetIcons.ui
@@ -104,11 +104,40 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="customIconButtonsHorizontalLayout">
+    <layout class="QHBoxLayout" name="customIconButtonsHorizontalLayout" stretch="0,0,0,0">
      <item>
       <widget class="QPushButton" name="addButton">
        <property name="text">
-        <string>Add custom icon</string>
+        <string>Choose icon…</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="faviconURL">
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Set the URL to use to search for a favicon</string>
+       </property>
+       <property name="placeholderText">
+        <string>Favicon URL</string>
        </property>
       </widget>
      </item>
@@ -174,6 +203,7 @@
   <tabstop>customIconsRadio</tabstop>
   <tabstop>customIconsView</tabstop>
   <tabstop>addButton</tabstop>
+  <tabstop>faviconURL</tabstop>
   <tabstop>faviconButton</tabstop>
   <tabstop>applyIconToPushButton</tabstop>
  </tabstops>


### PR DESCRIPTION
Previously, it was a bit cumbersome to get a favicon from a URL that you did not already have from an entry. You would need to temporarily create an entry and download the favicon with the URL before discarding it. 

To make this easier, I took the "download favicon" button on the Icon selection page that previously would appear if the URL field was filled into the entry, and converted it so that it is always visible and provides a dialog popup that allows the user to download favicons. This also makes it so that you can download icons that may not already be in your icon list when editing a group.
## Screenshots
![Screenshot_20210609_135614](https://user-images.githubusercontent.com/48135429/121428290-7b566100-c92a-11eb-8158-1ab96c0818c1.png)
![Screenshot_20210609_135849](https://user-images.githubusercontent.com/48135429/121428584-d425f980-c92a-11eb-8d0b-690281d45326.png)


## Testing strategy
Tested manually on Linux. I reused the existing favicon download implementation, so the code change just involved creating a new Dialog and altering some connection endpoints. I confirmed that the Dialog handles valid and invalid URLs properly.


## Type of change
- ✅ New feature (change that adds functionality)