### PR TITLE
Handle tilde with custom browser paths

### DIFF
--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -20,6 +20,7 @@
 #include "BrowserSettings.h"
 #include "core/Config.h"
 #include "core/PasswordHealth.h"
+#include <QDir>
 
 #include <QJsonObject>
 
@@ -515,4 +516,28 @@ QJsonObject BrowserSettings::generatePassword()
 void BrowserSettings::updateBinaryPaths()
 {
     m_nativeMessageInstaller.updateBinaryPaths();
+}
+
+QString BrowserSettings::replaceHomePath(QString location)
+{
+#ifndef Q_OS_WIN
+    auto homePath = QDir::homePath();
+    if (location.startsWith(homePath)) {
+        location.replace(homePath, "~");
+    }
+#endif
+
+    return location;
+}
+
+QString BrowserSettings::replaceTildeHomePath(QString location)
+{
+#ifndef Q_OS_WIN
+    auto homePath = QDir::homePath();
+    if (location.startsWith("~")) {
+        location.replace("~", homePath);
+    }
+#endif
+
+    return location;
 }

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -120,6 +120,8 @@ public:
     PasswordGenerator::GeneratorFlags passwordGeneratorFlags();
     QJsonObject generatePassword();
     void updateBinaryPaths();
+    QString replaceHomePath(QString location);
+    QString replaceTildeHomePath(QString location);
 
 private:
     static BrowserSettings* m_instance;

--- a/src/browser/BrowserSettingsWidget.ui
+++ b/src/browser/BrowserSettingsWidget.ui
@@ -515,7 +515,7 @@
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
               </property>
               <property name="placeholderText">
-               <string>~/.custom/config/Mozilla/native-messaging-hosts/</string>
+               <string>~/.config/Mozilla/native-messaging-hosts/</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Handle `~/` as a home directory with Custom Proxy and Custom Browser path. The full path is still stored to the configuration, so this only affects to the UI side.

Fixes https://github.com/keepassxreboot/keepassxc/issues/6542.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
