### PR TITLE
Add support for drag/drop entries in natural sort mode

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -984,6 +984,19 @@ void Group::removeEntry(Entry* entry)
     emit entryRemoved(entry);
 }
 
+void Group::moveEntryToRowNum(Entry* entry, int toRowNum)
+{
+    int fromRowNum = m_entries.indexOf(entry);
+    if (fromRowNum < 0 || toRowNum < 0 || fromRowNum == toRowNum + 1) {
+        return;
+    }
+
+    emit entryAboutToMoveToRowNum(fromRowNum, toRowNum);
+    m_entries.move(fromRowNum, toRowNum);
+    emit entryMovedUp();
+    emit groupNonDataChange();
+}
+
 void Group::moveEntryUp(Entry* entry)
 {
     int row = m_entries.indexOf(entry);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -987,13 +987,11 @@ void Group::removeEntry(Entry* entry)
 void Group::moveEntryToRowNum(Entry* entry, int toRowNum)
 {
     int fromRowNum = m_entries.indexOf(entry);
-    if (fromRowNum < 0 || toRowNum < 0 || fromRowNum == toRowNum + 1) {
+    if (fromRowNum < 0 || toRowNum < 0 || toRowNum >= m_entries.size()) {
         return;
     }
 
-    emit entryAboutToMoveToRowNum(fromRowNum, toRowNum);
     m_entries.move(fromRowNum, toRowNum);
-    emit entryMovedUp();
     emit groupNonDataChange();
 }
 
@@ -1006,7 +1004,7 @@ void Group::moveEntryUp(Entry* entry)
 
     emit entryAboutToMoveUp(row);
     m_entries.move(row, row - 1);
-    emit entryMovedUp();
+    emit entryMoved();
     emit groupNonDataChange();
 }
 
@@ -1019,7 +1017,7 @@ void Group::moveEntryDown(Entry* entry)
 
     emit entryAboutToMoveDown(row);
     m_entries.move(row, row + 1);
-    emit entryMovedDown();
+    emit entryMoved();
     emit groupNonDataChange();
 }
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -189,10 +189,9 @@ signals:
     void entryAboutToRemove(Entry* entry);
     void entryRemoved(Entry* entry);
     void entryAboutToMoveUp(int row);
-    void entryAboutToMoveToRowNum(int fromRow, int toRow);
-    void entryMovedUp();
     void entryAboutToMoveDown(int row);
-    void entryMovedDown();
+    void entryAboutToMoveToRowNum(int fromRow, int toRow);
+    void entryMoved();
     void entryDataChanged(Entry* entry);
 
 private slots:

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -163,6 +163,7 @@ public:
 
     void addEntry(Entry* entry);
     void removeEntry(Entry* entry);
+    void moveEntryToRowNum(Entry* entry, int toRowNum);
     void moveEntryUp(Entry* entry);
     void moveEntryDown(Entry* entry);
 
@@ -188,6 +189,7 @@ signals:
     void entryAboutToRemove(Entry* entry);
     void entryRemoved(Entry* entry);
     void entryAboutToMoveUp(int row);
+    void entryAboutToMoveToRowNum(int fromRow, int toRow);
     void entryMovedUp();
     void entryAboutToMoveDown(int row);
     void entryMovedDown();

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -67,12 +67,16 @@ public:
     void setGroup(Group* group);
     void setEntries(const QList<Entry*>& entries);
 
+    bool
+    dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) override;
+
 private slots:
     void entryAboutToAdd(Entry* entry);
     void entryAdded(Entry* entry);
     void entryAboutToRemove(Entry* entry);
     void entryRemoved();
     void entryAboutToMoveUp(int row);
+    void entryAboutToMoveToRowNum(int fromRow, int toRow);
     void entryMovedUp();
     void entryAboutToMoveDown(int row);
     void entryMovedDown();

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -76,10 +76,8 @@ private slots:
     void entryAboutToRemove(Entry* entry);
     void entryRemoved();
     void entryAboutToMoveUp(int row);
-    void entryAboutToMoveToRowNum(int fromRow, int toRow);
-    void entryMovedUp();
     void entryAboutToMoveDown(int row);
-    void entryMovedDown();
+    void entryMoved();
     void entryDataChanged(Entry* entry);
 
     void onConfigChanged(Config::ConfigKey key);

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -77,6 +77,12 @@ EntryView::EntryView(QWidget* parent)
     setRootIsDecorated(false);
     setAlternatingRowColors(true);
     setDragEnabled(true);
+
+    viewport()->setAcceptDrops(true);
+    setDropIndicatorShown(true);
+    setDefaultDropAction(Qt::MoveAction);
+    setDragDropMode(QAbstractItemView::InternalMove);
+
     setSortingEnabled(true);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
 
@@ -161,6 +167,15 @@ void EntryView::sortIndicatorChanged(int logicalIndex, Qt::SortOrder order)
 
     header()->setSortIndicatorShown(true);
     resetFixedColumns();
+}
+
+void EntryView::dragMoveEvent(QDragMoveEvent* event)
+{
+    if (event->isAccepted() && isSorted()) {
+        event->ignore();
+    } else {
+        event->acceptProposedAction();
+    }
 }
 
 void EntryView::keyPressEvent(QKeyEvent* event)

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -76,12 +76,10 @@ EntryView::EntryView(QWidget* parent)
     setUniformRowHeights(true);
     setRootIsDecorated(false);
     setAlternatingRowColors(true);
-    setDragEnabled(true);
 
-    viewport()->setAcceptDrops(true);
+    setDragDropMode(InternalMove);
     setDropIndicatorShown(true);
     setDefaultDropAction(Qt::MoveAction);
-    setDragDropMode(QAbstractItemView::InternalMove);
 
     setSortingEnabled(true);
     setSelectionMode(QAbstractItemView::ExtendedSelection);

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -169,6 +169,7 @@ void EntryView::sortIndicatorChanged(int logicalIndex, Qt::SortOrder order)
 
 void EntryView::dragMoveEvent(QDragMoveEvent* event)
 {
+    QTreeView::dragMoveEvent(event);
     if (event->isAccepted() && isSorted()) {
         event->ignore();
     } else {

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -72,6 +72,9 @@ private slots:
     void contextMenuShortcutPressed();
     void sortIndicatorChanged(int logicalIndex, Qt::SortOrder order);
 
+protected:
+    void dragMoveEvent(QDragMoveEvent* event) override;
+
 private:
     void resetFixedColumns();
     bool isColumnHidden(int logicalIndex);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
Drag and drop entries within EntryView
[NOTE]: # ( Explain large or complex code modifications. )
Exactly like move entry up or down,
I've added logic of moveentry(fromRowNum, toRowNum);
Notice, I have not modified any of existing Moveup ot MoveDown logic at all
However, it is possible to refactored to reduce repetitive code common to  MoveDown/MoveUp

[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
Draged few itemRows up and down to ensure 
- no loopbacks occurred that might hang the app.
- no "new items" created due to moving above the total items in list
- Moving Items disabled when isSorted()
2. moved to most first item
3. move to most last item
4. move in between
5. Drag of Group to Items is rejected
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
No unit test. it is based on existing move up or down.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )

- ✅ New feature (change that adds functionality)


