### PR TITLE
feature/groupTagAware4.1kdbx NOT TO MERGE THIS IS JUST AN EXAMPLE

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -123,6 +123,11 @@ QString Group::notes() const
     return m_data.notes;
 }
 
+QString Group::tags() const
+{
+    return m_data.tags;
+}
+
 QImage Group::icon() const
 {
     if (m_data.customIcon.isNull()) {
@@ -398,6 +403,11 @@ void Group::setExpiryTime(const QDateTime& dateTime)
 void Group::setMergeMode(MergeMode newMode)
 {
     set(m_data.mergeMode, newMode);
+}
+
+void Group::setTags(const QString& tags)
+{
+    set(m_data.tags, tags);
 }
 
 Group* Group::parentGroup()
@@ -1231,6 +1241,9 @@ bool Group::GroupData::equals(const Group::GroupData& other, CompareItemOptions 
         return false;
     }
     if (::compare(mergeMode, other.mergeMode, options) != 0) {
+        return false;
+    }
+    if (::compare(tags, other.tags, options) != 0) {
         return false;
     }
     return true;

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -60,6 +60,7 @@ public:
     {
         QString name;
         QString notes;
+        QString tags;
         int iconNumber;
         QUuid customIcon;
         TimeInfo timeInfo;
@@ -88,6 +89,7 @@ public:
     const TimeInfo& timeInfo() const;
     bool isExpanded() const;
     QString defaultAutoTypeSequence() const;
+    QString tags() const;
     QString effectiveAutoTypeSequence() const;
     Group::TriState autoTypeEnabled() const;
     Group::TriState searchingEnabled() const;
@@ -129,6 +131,7 @@ public:
     void setExpires(bool value);
     void setExpiryTime(const QDateTime& dateTime);
     void setMergeMode(MergeMode newMode);
+    void setTags(const QString& tags);
 
     bool canUpdateTimeinfo() const;
     void setUpdateTimeinfo(bool value);

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -586,6 +586,10 @@ Group* KdbxXmlReader::parseGroup()
             parseCustomData(group->customData());
             continue;
         }
+        if (m_xml.name() == "Tags") {
+            group->setTags(readString());
+            continue;
+        }
 
         skipCurrentElement();
     }
@@ -752,6 +756,7 @@ Entry* KdbxXmlReader::parseEntry(bool history)
             parseCustomData(entry->customData());
             continue;
         }
+
         skipCurrentElement();
     }
 

--- a/src/format/KdbxXmlWriter.cpp
+++ b/src/format/KdbxXmlWriter.cpp
@@ -274,6 +274,7 @@ void KdbxXmlWriter::writeGroup(const Group* group)
     writeTimes(group->timeInfo());
     writeBool("IsExpanded", group->isExpanded());
     writeString("DefaultAutoTypeSequence", group->defaultAutoTypeSequence());
+    writeString("Tags", group->tags());
 
     writeTriState("EnableAutoType", group->autoTypeEnabled());
 


### PR DESCRIPTION
### DO NOT MERGE, THIS IS JUST AN EXAMPLE

[NOTE]: # ( Describe your changes in detail, why is this change required? )
Like we have Tags support for Import/Export entries
I've added Tags to group.

* I've notice 
Entry* processBandEntry(const QJsonObject& bandEntry, const QDir& attachmentDir, Group* rootGroup);
Might needs to be aware of Group Tags, but I'm not sure how/why.

So this might be used as a reference branch for a more senior developer, ** and then Deleted **
** Not to be merged **

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
- Created kdbx with Tags in windows keepass
- Export the file using 
```
keepassxc-cli export ./KeepassDbWithTags.kdbx >myoutput.txt

```

- Ensured I have Group tags displayed and no 

```

KdbxXmlReader::skipCurrentElement: skip element 'Tags'

```

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )

- ✅ New feature (change that adds functionality)
* Added "tags" support to groups
* This does not make it 4.1 compatible yet since no support for
element **PreviousParentGroup** yet

It is just a small change for not to loose tags at the group level created on Keepass C# windows

* also their will must be a Database getter for all tags (Uniq select) in the database (Group, and Entry) and this is not implemented yet.




