### PR TITLE
Add support for Diceware wordlists in numbered and/or PGP-signed formats

### DIFF
--- a/docs/man/keepassxc-cli.1.adoc
+++ b/docs/man/keepassxc-cli.1.adoc
@@ -257,6 +257,7 @@ The same password generation options as documented for the generate command can 
   Sets the Path of the wordlist for the diceware generator.
   The wordlist must have > 1000 words, otherwise the program will fail.
   If the wordlist has < 4000 words a warning will be printed to STDERR.
+  Any *diceware*-compatible wordlist can used. Note however that *KeePassXC* will NOT verify the PGP signature of signed wordlists.
 
 === Export options
 *-f*, *--format*::


### PR DESCRIPTION
## Rationale
This allows one to directly use Diceware-compatible wordlists without having to convert the file to the plain wordlist format.

The accepted formats are described in the Diceware documentation: <https://diceware.readthedocs.io/en/stable/wordlists.html>.

## Testing strategy
Tested with several wordlists from <https://github.com/ulif/diceware/tree/master/diceware/wordlists>. In particular, tested with a numbered wordlist ([`wordlist_en_eff.txt`](https://github.com/ulif/diceware/blob/master/diceware/wordlists/wordlist_en_eff.txt)), a PGP-signed wordlist ([`wordlist_en_securedrop.asc`](https://github.com/ulif/diceware/blob/master/diceware/wordlists/wordlist_en_securedrop.asc)) and a PGP-signed numbered wordlist ([`wordlist_en_orig.asc`](https://github.com/ulif/diceware/blob/master/diceware/wordlists/wordlist_en_orig.asc)).

## Type of change
- ✅ New feature (change that adds functionality)