### PR TITLE
Abort CLI open on error

### DIFF
--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -138,10 +138,12 @@ QSharedPointer<QCommandLineParser> Command::getCommandLineParser(const QStringLi
         return {};
     }
     if (parser->positionalArguments().size() < positionalArguments.size()) {
+        err << QObject::tr("Missing positional argument(s).") << "\n\n";
         err << getHelpText();
         return {};
     }
     if (parser->positionalArguments().size() > (positionalArguments.size() + optionalArguments.size())) {
+        err << QObject::tr("Too many arguments provided.") << "\n\n";
         err << getHelpText();
         return {};
     }

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -109,7 +109,7 @@ private:
 };
 #endif
 
-void enterInteractiveMode(const QStringList& arguments)
+int enterInteractiveMode(const QStringList& arguments)
 {
     auto& err = Utils::STDERR;
     // Replace command list with interactive version
@@ -118,7 +118,9 @@ void enterInteractiveMode(const QStringList& arguments)
     Open openCmd;
     QStringList openArgs(arguments);
     openArgs.removeFirst();
-    openCmd.execute(openArgs);
+    if (openCmd.execute(openArgs) != EXIT_SUCCESS) {
+        return EXIT_FAILURE;
+    };
 
     QScopedPointer<LineReader> reader;
 #if defined(USE_READLINE)
@@ -165,6 +167,8 @@ void enterInteractiveMode(const QStringList& arguments)
     if (currentDatabase) {
         currentDatabase->releaseData();
     }
+
+    return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv)
@@ -224,8 +228,7 @@ int main(int argc, char** argv)
 
     QString commandName = parser.positionalArguments().at(0);
     if (commandName == "open") {
-        enterInteractiveMode(arguments);
-        return EXIT_SUCCESS;
+        return enterInteractiveMode(arguments);
     }
 
     auto command = Commands::getCommand(commandName);


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc/issues/6597

@sjamesr please have a look :eye: 

I also added a detailed error for the different parsing error cases, otherwise it might not be obvious what the error was.


## Testing strategy
Tried calling `open` with missing params, with `--help`, and with a proper invocation.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
