### PR TITLE
Show entry background color as column 

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3840,6 +3840,10 @@ Error: %1</source>
         <source>Has TOTP</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Background Color</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EntryPreviewWidget</name>

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -116,7 +116,7 @@ int EntryModel::columnCount(const QModelIndex& parent) const
         return 0;
     }
 
-    return 15;
+    return 16;
 }
 
 QVariant EntryModel::data(const QModelIndex& index, int role) const
@@ -230,6 +230,13 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
 
             return result;
         }
+        case Color:
+            QColor backgroundColor;
+            backgroundColor.setNamedColor(entry->backgroundColor());
+            if (backgroundColor.isValid()) {
+                result = "▍";
+                return result;
+            }
         }
     } else if (role == Qt::UserRole) { // Qt::UserRole is used as sort role, see EntryView::EntryView()
         switch (index.column()) {
@@ -314,6 +321,15 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
         }
         return font;
     } else if (role == Qt::ForegroundRole) {
+
+        if (index.column() == Color) {
+            QColor backgroundColor;
+            backgroundColor.setNamedColor(entry->backgroundColor());
+            if (backgroundColor.isValid()) {
+                return backgroundColor;
+            }
+        }
+
         QColor foregroundColor;
         foregroundColor.setNamedColor(entry->foregroundColor());
         if (entry->hasReferences()) {
@@ -327,10 +343,12 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return QVariant(foregroundColor);
         }
     } else if (role == Qt::BackgroundRole) {
-        QColor backgroundColor;
-        backgroundColor.setNamedColor(entry->backgroundColor());
-        if (backgroundColor.isValid()) {
-            return QVariant(backgroundColor);
+        if (m_backgroundColorVisible) {
+            QColor backgroundColor;
+            backgroundColor.setNamedColor(entry->backgroundColor());
+            if (backgroundColor.isValid()) {
+                return QVariant(backgroundColor);
+            }
         }
     } else if (role == Qt::ToolTipRole) {
         if (index.column() == PasswordStrength && !entry->password().isEmpty() && !entry->excludeFromReports()) {
@@ -414,6 +432,8 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Has attachments");
         case Totp:
             return tr("Has TOTP");
+        case Color:
+            return tr("Background Color");
         }
     }
 
@@ -595,4 +615,8 @@ void EntryModel::makeConnections(const Group* group)
     connect(group, SIGNAL(entryAboutToMoveDown(int)), SLOT(entryAboutToMoveDown(int)));
     connect(group, SIGNAL(entryMovedDown()), SLOT(entryMovedDown()));
     connect(group, SIGNAL(entryDataChanged(Entry*)), SLOT(entryDataChanged(Entry*)));
+}
+void EntryModel::setBackgroundColorVisible(bool visible)
+{
+    m_backgroundColorVisible = visible;
 }

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -48,7 +48,8 @@ public:
         Attachments = 11,
         Totp = 12,
         Size = 13,
-        PasswordStrength = 14
+        PasswordStrength = 14,
+        Color = 15
     };
 
     explicit EntryModel(QObject* parent = nullptr);
@@ -67,6 +68,7 @@ public:
 
     void setGroup(Group* group);
     void setEntries(const QList<Entry*>& entries);
+    void setBackgroundColorVisible(bool visible);
 
 private slots:
     void entryAboutToAdd(Entry* entry);
@@ -85,6 +87,7 @@ private:
     void severConnections();
     void makeConnections(const Group* group);
 
+    bool m_backgroundColorVisible = true;
     Group* m_group;
     QList<Entry*> m_entries;
     QList<Entry*> m_orgEntries;

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -335,6 +335,7 @@ bool EntryView::setViewState(const QByteArray& state)
     bool status = header()->restoreState(state);
     resetFixedColumns();
     m_columnsNeedRelayout = state.isEmpty();
+    onHeaderChanged();
     return status;
 }
 
@@ -375,6 +376,9 @@ void EntryView::toggleColumnVisibility(QAction* action)
     // least one visible column remains, as the table header will disappear
     // entirely when all columns are hidden
     int columnIndex = action->data().toInt();
+    if (columnIndex == EntryModel::Color) {
+        m_model->setBackgroundColorVisible(!action->isChecked());
+    }
     if (action->isChecked()) {
         header()->showSection(columnIndex);
         if (header()->sectionSize(columnIndex) == 0) {
@@ -446,6 +450,8 @@ void EntryView::resetFixedColumns()
             header()->resizeSection(col, width);
         }
     }
+    header()->setMinimumSectionSize(1);
+    header()->resizeSection(EntryModel::Color, ICON_ONLY_SECTION_SIZE);
 }
 
 /**
@@ -474,6 +480,8 @@ void EntryView::resetViewToDefaults()
     header()->hideSection(EntryModel::Attachments);
     header()->hideSection(EntryModel::Size);
     header()->hideSection(EntryModel::PasswordStrength);
+    header()->hideSection(EntryModel::Color);
+    onHeaderChanged();
 
     // Reset column order to logical indices
     for (int i = 0; i < header()->count(); ++i) {
@@ -499,6 +507,11 @@ void EntryView::resetViewToDefaults()
     if (isVisible()) {
         fitColumnsToWindow();
     }
+}
+
+void EntryView::onHeaderChanged()
+{
+    m_model->setBackgroundColorVisible(isColumnHidden(EntryModel::Color));
 }
 
 void EntryView::showEvent(QShowEvent* event)

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -76,6 +76,7 @@ private slots:
 private:
     void resetFixedColumns();
     bool isColumnHidden(int logicalIndex);
+    void onHeaderChanged();
 
     EntryModel* const m_model;
     SortFilterHideProxyModel* const m_sortModel;

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -313,15 +313,11 @@ void TestEntryModel::testProxyModel()
 
     modelSource->setGroup(db->rootGroup());
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Update comparison value of modelProxy->columnCount() to account for
-     * additional columns 'Password', 'Notes', 'Expires', 'Created', 'Modified',
-     * 'Accessed', 'Paperclip', 'Attachments', and TOTP
-     */
+    // Test hiding and showing a column
+    auto columnCount = modelProxy->columnCount();
     QSignalSpy spyColumnRemove(modelProxy, SIGNAL(columnsAboutToBeRemoved(QModelIndex, int, int)));
     modelProxy->hideColumn(0, true);
-    QCOMPARE(modelProxy->columnCount(), 14);
+    QCOMPARE(modelProxy->columnCount(), columnCount - 1);
     QVERIFY(!spyColumnRemove.isEmpty());
 
     int oldSpyColumnRemoveSize = spyColumnRemove.size();
@@ -335,15 +331,9 @@ void TestEntryModel::testProxyModel()
     entryList << entry;
     modelSource->setEntries(entryList);
 
-    /**
-     * @author Fonic <https://github.com/fonic>
-     * Update comparison value of modelProxy->columnCount() to account for
-     * additional columns 'Password', 'Notes', 'Expires', 'Created', 'Modified',
-     * 'Accessed', 'Paperclip', 'Attachments', and TOTP
-     */
     QSignalSpy spyColumnInsert(modelProxy, SIGNAL(columnsAboutToBeInserted(QModelIndex, int, int)));
     modelProxy->hideColumn(0, false);
-    QCOMPARE(modelProxy->columnCount(), 15);
+    QCOMPARE(modelProxy->columnCount(), columnCount);
     QVERIFY(!spyColumnInsert.isEmpty());
 
     int oldSpyColumnInsertSize = spyColumnInsert.size();


### PR DESCRIPTION
This PR adds a setting: 'Show Background Color of Entry' which disables the background color of a row if an entry has one. 
It also introduces a new Column: 'Entrycolor' which can show the disabled background color as a box, similar to the screenshot in #6553

Todo: 
~~I would like to change the column-name to an icon, a paintbrush or similar.~~ Done
~~I also would like to move the color-column infront of the entry-title~~ Done

Fixes #6553

## Type of change
- ✅ New feature (change that adds functionality)
