### PR TITLE
CLI: Implement Search command and remove Group::locate

### DIFF
--- a/docs/man/keepassxc-cli.1.adoc
+++ b/docs/man/keepassxc-cli.1.adoc
@@ -90,10 +90,6 @@ It provides the ability to query and modify the entries of a KeePass database, d
   If both the key file and password are empty, no database will be created.
   The new database will be in kdbx 4 format.
 
-
-*locate* [_options_] <__database__> <__term__>::
-  Locates all the entries that match a specific search term in a database.
-
 *ls* [_options_] <__database__> [_group_]::
   Lists the contents of a group in a database.
   If no group is specified, it will default to the root group.
@@ -126,6 +122,9 @@ It provides the ability to query and modify the entries of a KeePass database, d
   Removes a group from a database.
   If the database has a recycle bin, the group will be moved there.
   If the group is already in the recycle bin, it will be removed permanently.
+
+*search* [_options_] <__database__> <__term__>::
+  Searches all entries that match a specific search term in a database.
 
 *show* [_options_] <__database__> <__entry__>::
   Shows the title, username, password, URL and notes of a database entry.
@@ -221,7 +220,7 @@ The same password generation options as documented for the generate command can 
   Will report an error if no TOTP is configured for the entry.
 
 *-b*, *--best*::
-  Try to find and copy to clipboard a unique entry matching the input (similar to *-locate*)
+  Try to find and copy to clipboard a unique entry matching the input
   If a unique matching entry is found it will be copied to the clipboard.
   If multiple entries are found they will be listed to refine the search. (no clip performed)
 

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -32,12 +32,12 @@ set(cli_SOURCES
         Import.cpp
         Info.cpp
         List.cpp
-        Locate.cpp
         Merge.cpp
         Move.cpp
         Open.cpp
         Remove.cpp
         RemoveGroup.cpp
+        Search.cpp
         Show.cpp)
 
 add_library(cli STATIC ${cli_SOURCES})

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -31,12 +31,12 @@
 #include "Import.h"
 #include "Info.h"
 #include "List.h"
-#include "Locate.h"
 #include "Merge.h"
 #include "Move.h"
 #include "Open.h"
 #include "Remove.h"
 #include "RemoveGroup.h"
+#include "Search.h"
 #include "Show.h"
 #include "Utils.h"
 
@@ -173,7 +173,6 @@ namespace Commands
         s_commands.insert(QStringLiteral("estimate"), QSharedPointer<Command>(new Estimate()));
         s_commands.insert(QStringLiteral("generate"), QSharedPointer<Command>(new Generate()));
         s_commands.insert(QStringLiteral("help"), QSharedPointer<Command>(new Help()));
-        s_commands.insert(QStringLiteral("locate"), QSharedPointer<Command>(new Locate()));
         s_commands.insert(QStringLiteral("ls"), QSharedPointer<Command>(new List()));
         s_commands.insert(QStringLiteral("merge"), QSharedPointer<Command>(new Merge()));
         s_commands.insert(QStringLiteral("mkdir"), QSharedPointer<Command>(new AddGroup()));
@@ -181,6 +180,7 @@ namespace Commands
         s_commands.insert(QStringLiteral("open"), QSharedPointer<Command>(new Open()));
         s_commands.insert(QStringLiteral("rm"), QSharedPointer<Command>(new Remove()));
         s_commands.insert(QStringLiteral("rmdir"), QSharedPointer<Command>(new RemoveGroup()));
+        s_commands.insert(QStringLiteral("search"), QSharedPointer<Command>(new Search()));
         s_commands.insert(QStringLiteral("show"), QSharedPointer<Command>(new Show()));
 
         if (interactive) {

--- a/src/cli/Search.cpp
+++ b/src/cli/Search.cpp
@@ -15,36 +15,37 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Locate.h"
+#include "Search.h"
 
 #include <QCommandLineParser>
 
 #include "Utils.h"
+#include "core/EntrySearcher.h"
 #include "core/Group.h"
 
-Locate::Locate()
+Search::Search()
 {
-    name = QString("locate");
+    name = QString("search");
     description = QObject::tr("Find entries quickly.");
     positionalArguments.append({QString("term"), QObject::tr("Search term."), QString("")});
 }
 
-int Locate::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
+int Search::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
 {
     auto& out = Utils::STDOUT;
     auto& err = Utils::STDERR;
 
     const QStringList args = parser->positionalArguments();
-    const QString& searchTerm = args.at(1);
 
-    QStringList results = database->rootGroup()->locate(searchTerm);
+    EntrySearcher searcher;
+    auto results = searcher.search(args.at(1), database->rootGroup(), true);
     if (results.isEmpty()) {
         err << "No results for that search term." << endl;
         return EXIT_FAILURE;
     }
 
-    for (const QString& result : asConst(results)) {
-        out << result << endl;
+    for (const Entry* result : asConst(results)) {
+        out << result->path().prepend('/') << endl;
     }
     return EXIT_SUCCESS;
 }

--- a/src/cli/Search.h
+++ b/src/cli/Search.h
@@ -15,17 +15,17 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSXC_LOCATE_H
-#define KEEPASSXC_LOCATE_H
+#ifndef KEEPASSXC_SEARCH_H
+#define KEEPASSXC_SEARCH_H
 
 #include "DatabaseCommand.h"
 
-class Locate : public DatabaseCommand
+class Search : public DatabaseCommand
 {
 public:
-    Locate();
+    Search();
 
     int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
 };
 
-#endif // KEEPASSXC_LOCATE_H
+#endif // KEEPASSXC_SEARCH_H

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -1079,30 +1079,6 @@ bool Group::resolveAutoTypeEnabled() const
     }
 }
 
-QStringList Group::locate(const QString& locateTerm, const QString& currentPath) const
-{
-    // TODO: Replace with EntrySearcher
-    QStringList response;
-    if (locateTerm.isEmpty()) {
-        return response;
-    }
-
-    for (const Entry* entry : asConst(m_entries)) {
-        QString entryPath = currentPath + entry->title();
-        if (entryPath.contains(locateTerm, Qt::CaseInsensitive)) {
-            response << entryPath;
-        }
-    }
-
-    for (const Group* group : asConst(m_children)) {
-        for (const QString& path : group->locate(locateTerm, currentPath + group->name() + QString("/"))) {
-            response << path;
-        }
-    }
-
-    return response;
-}
-
 Entry* Group::addEntryWithPath(const QString& entryPath)
 {
     if (entryPath.isEmpty() || findEntryByPath(entryPath)) {

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -114,7 +114,6 @@ public:
     Entry* findEntryBySearchTerm(const QString& term, EntryReferenceType referenceType);
     Group* findGroupByUuid(const QUuid& uuid);
     Group* findGroupByPath(const QString& groupPath);
-    QStringList locate(const QString& locateTerm, const QString& currentPath = {"/"}) const;
     Entry* addEntryWithPath(const QString& entryPath);
     void setUuid(const QUuid& uuid);
     void setName(const QString& name);

--- a/tests/TestCli.h
+++ b/tests/TestCli.h
@@ -65,7 +65,6 @@ private slots:
     void testHelp();
     void testInteractiveCommands();
     void testList();
-    void testLocate();
     void testMerge();
     void testMergeWithKeys();
     void testMove();
@@ -73,6 +72,7 @@ private slots:
     void testRemove();
     void testRemoveGroup();
     void testRemoveQuiet();
+    void testSearch();
     void testShow();
     void testInvalidDbFiles();
     void testYubiKeyOption();

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -690,66 +690,6 @@ void TestGroup::testPrint()
     QVERIFY(output.contains(QString("subgroup/entry3\n")));
 }
 
-void TestGroup::testLocate()
-{
-    Database* db = new Database();
-
-    Entry* entry1 = new Entry();
-    entry1->setTitle("entry1");
-    entry1->setGroup(db->rootGroup());
-
-    Entry* entry2 = new Entry();
-    entry2->setTitle("entry2");
-    entry2->setGroup(db->rootGroup());
-
-    Group* group1 = new Group();
-    group1->setName("group1");
-    group1->setParent(db->rootGroup());
-
-    Group* group2 = new Group();
-    group2->setName("group2");
-    group2->setParent(group1);
-
-    Entry* entry3 = new Entry();
-    entry3->setTitle("entry3");
-    entry3->setGroup(group1);
-
-    Entry* entry43 = new Entry();
-    entry43->setTitle("entry43");
-    entry43->setGroup(group1);
-
-    Entry* google = new Entry();
-    google->setTitle("Google");
-    google->setGroup(group2);
-
-    QStringList results = db->rootGroup()->locate("entry");
-    QVERIFY(results.size() == 4);
-    QVERIFY(results.contains("/group1/entry43"));
-
-    results = db->rootGroup()->locate("entry1");
-    QVERIFY(results.size() == 1);
-    QVERIFY(results.contains("/entry1"));
-
-    results = db->rootGroup()->locate("Entry1");
-    QVERIFY(results.size() == 1);
-    QVERIFY(results.contains("/entry1"));
-
-    results = db->rootGroup()->locate("invalid");
-    QVERIFY(results.isEmpty());
-
-    results = db->rootGroup()->locate("google");
-    QVERIFY(results.size() == 1);
-    QVERIFY(results.contains("/group1/group2/Google"));
-
-    results = db->rootGroup()->locate("group1");
-    QVERIFY(results.size() == 3);
-    QVERIFY(results.contains("/group1/entry3"));
-    QVERIFY(results.contains("/group1/entry43"));
-    QVERIFY(results.contains("/group1/group2/Google"));
-
-    delete db;
-}
-
 void TestGroup::testAddEntryWithPath()
 {
     Database* db = new Database();

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -39,7 +39,6 @@ private slots:
     void testFindEntry();
     void testFindGroupByPath();
     void testPrint();
-    void testLocate();
     void testAddEntryWithPath();
     void testIsRecycled();
     void testCopyDataFrom();


### PR DESCRIPTION
Group::locate does not use EntrySearcher and has a weird behaviour.
As discussed here (#6797) I refactored cli code to use EntrySearcher and removed Group::locate completely.

It changes behaviour of the clip command as it doesn't match against group hierarchy anymore when used with best-match option but this should stay mostly unnoticed because matching against group names is likely to result in multiple entries being found anyway.

## Testing strategy
Added tests for search command
Available tests still pass without error

## Type of change
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
