### PR TITLE
Set the MIME-Type to text/plain when using wl-copy on wayland.

### DIFF
--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -269,7 +269,7 @@ namespace Utils
 
 #ifdef Q_OS_UNIX
         if (QProcessEnvironment::systemEnvironment().contains("WAYLAND_DISPLAY")) {
-            clipPrograms << qMakePair(QStringLiteral("wl-copy"), QStringLiteral(""));
+            clipPrograms << qMakePair(QStringLiteral("wl-copy"), QStringLiteral("-t text/plain"));
         } else {
             clipPrograms << qMakePair(QStringLiteral("xclip"), QStringLiteral("-selection clipboard -i"));
         }


### PR DESCRIPTION
If unset, wl-copy will try to guess the MIME-Type based on the data. For some reason this did not work on my machine and i was unable to paste passwords in Firefox.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
This change was tested in the following way:
1. I opened a database with `keepassxc-cli databasename.kdbx`
2. I used the clip command to copy a password to the clipboard
3. I used `wl-paste -l` to determine what MIME-Type was used.

The output before i applied this patch:
```
$ wl-paste -l
n��
```

The output after i applied this patch:
```
wl-paste -l
text/plain
text/plain;charset=utf-8
TEXT
STRING
UTF8_STRING
```

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
