### PR TITLE
Dont Scroll up When Deleting Entry

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -462,8 +462,16 @@ void DatabaseWidget::deleteSelectedEntries()
 
 void DatabaseWidget::deleteEntries(QList<Entry*> selectedEntries, bool confirm)
 {
+    if (selectedEntries.isEmpty()) {
+        return;
+    }
+
+    // Find the index above the first entry for selection after deletion
+    auto index = m_entryView->indexFromEntry(selectedEntries.first());
+    index = m_entryView->indexAbove(index);
+
     // Confirm entry removal before moving forward
-    auto* recycleBin = m_db->metadata()->recycleBin();
+    auto recycleBin = m_db->metadata()->recycleBin();
     bool permanent = (recycleBin && recycleBin->findEntryByUuid(selectedEntries.first()->uuid()))
                      || !m_db->metadata()->recycleBinEnabled();
 
@@ -475,8 +483,15 @@ void DatabaseWidget::deleteEntries(QList<Entry*> selectedEntries, bool confirm)
 
     refreshSearch();
 
-    m_entryView->setFirstEntryActive();
-    auto* currentEntry = currentSelectedEntry();
+    // Select the row above the deleted entries
+    if (index.isValid()) {
+        m_entryView->setCurrentIndex(index);
+    } else {
+        m_entryView->setFirstEntryActive();
+    }
+
+    // Update the preview widget
+    auto currentEntry = currentSelectedEntry();
     if (currentEntry) {
         m_previewView->setEntry(currentEntry);
     } else {

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -289,6 +289,11 @@ Entry* EntryView::entryFromIndex(const QModelIndex& index)
     }
 }
 
+QModelIndex EntryView::indexFromEntry(Entry* entry)
+{
+    return m_sortModel->mapFromSource(m_model->indexFromEntry(entry));
+}
+
 int EntryView::currentEntryIndex()
 {
     QModelIndexList list = selectionModel()->selectedRows();

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -39,6 +39,7 @@ public:
     Entry* currentEntry();
     void setCurrentEntry(Entry* entry);
     Entry* entryFromIndex(const QModelIndex& index);
+    QModelIndex indexFromEntry(Entry* entry);
     int currentEntryIndex();
     bool inSearchMode();
     bool isSorted();


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

When deleting an entry it now selects the entry after the deleted section or the last entry if there isn't one after the selection.
Fixes #6304 

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Before deleting:
![Screenshot_20210811_182503](https://user-images.githubusercontent.com/71401395/129116397-fe181900-e0d6-468e-89c7-6ca738135a07.png)
After deleting:
![Screenshot_20210811_182529](https://user-images.githubusercontent.com/71401395/129116410-42baac5d-8682-4e94-b854-01dc89309a82.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested deleting a single entry and multiple entries at
- the beginning
- the end
- the middle
- right before the beginning
- right before the end
- all entries

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
