### PR TITLE
Display `Database created` timestamp #6356

### DIFF
--- a/src/gui/reports/ReportsWidgetStatistics.cpp
+++ b/src/gui/reports/ReportsWidgetStatistics.cpp
@@ -211,6 +211,7 @@ void ReportsWidgetStatistics::calculateStats()
     addStatsRow(tr("Database name"), m_db->metadata()->name());
     addStatsRow(tr("Description"), m_db->metadata()->description());
     addStatsRow(tr("Location"), m_db->filePath());
+    addStatsRow(tr("Database created"), m_db->rootGroup()->timeInfo().creationTime().toString(Qt::DefaultLocaleShortDate));
     addStatsRow(tr("Last saved"), stats->modified.toString(Qt::DefaultLocaleShortDate));
     addStatsRow(tr("Unsaved changes"),
                 m_db->isModified() ? tr("yes") : tr("no"),

--- a/src/gui/reports/ReportsWidgetStatistics.cpp
+++ b/src/gui/reports/ReportsWidgetStatistics.cpp
@@ -211,7 +211,8 @@ void ReportsWidgetStatistics::calculateStats()
     addStatsRow(tr("Database name"), m_db->metadata()->name());
     addStatsRow(tr("Description"), m_db->metadata()->description());
     addStatsRow(tr("Location"), m_db->filePath());
-    addStatsRow(tr("Database created"), m_db->rootGroup()->timeInfo().creationTime().toString(Qt::DefaultLocaleShortDate));
+    addStatsRow(tr("Database created"),
+                m_db->rootGroup()->timeInfo().creationTime().toString(Qt::DefaultLocaleShortDate));
     addStatsRow(tr("Last saved"), stats->modified.toString(Qt::DefaultLocaleShortDate));
     addStatsRow(tr("Unsaved changes"),
                 m_db->isModified() ? tr("yes") : tr("no"),


### PR DESCRIPTION
Fixes #6356.

## Screenshots
![screen04](https://user-images.githubusercontent.com/5195222/131206685-794919d1-f841-4b16-8ab8-e57d730f812b.jpg)

## Testing strategy
The `ReportsPageStatistics` does not appear to have any existing unit tests setup.  Happy to extend them if they do exist somewhere.

## Type of change
- ✅ New feature (change that adds (very minor) functionality)

This change adds a simple `Database created` entry to the database statistics report, as requested by @ghost in #6356.  As suggested by @droidmonkey, it uses the timestamp of the database's root group, which seems to work well.

A couple of open questions / things I'm not sure about:
1. I chose what felt like a natural position in the list, but happy to move as appropriate.
2. do I need to check that `m_db->rootGroup()` is valid, or is it safe to assume that the db always has a root group? (happy to add a check, but doesn't appear to be the existing convention for that area of code).
3. do I need to do anything the have the `tr`'d string added to the L10n files?
4. anything else I missed / should do? 🙂

Thanks! 😊 