### PR TITLE
Add "parent directory match" priority between exact and host match

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -948,6 +948,11 @@ int BrowserService::sortPriority(const QStringList& urls, const QString& siteUrl
             return 90;
         }
 
+        // Parent directory match
+        if (url.isParentOf(siteUrl) || url.isParentOf(formUrl)) {
+            return 85;
+        }
+
         // Match without path (ie, FQDN match), form url prioritizes lower than site url
         if (url.host() == siteUrl.host()) {
             return 80;

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -165,10 +165,13 @@ void TestBrowser::testSortPriority_data()
 
     QTest::newRow("Site Query Mismatch") << siteUrl << siteUrl + "?test=test" << formUrl << 90;
 
-    QTest::newRow("Path Mismatch (site)") << "https://github.com/" << siteUrl << formUrl << 80;
-    QTest::newRow("Path Mismatch (site) No Scheme") << "github.com" << siteUrl << formUrl << 80;
+    QTest::newRow("Path Mismatch (site)") << "https://github.com/" << siteUrl << formUrl << 85;
+    QTest::newRow("Path Mismatch (site) No Scheme") << "github.com" << siteUrl << formUrl << 85;
     QTest::newRow("Path Mismatch (form)") << "https://github.com/"
-                                          << "https://github.net" << formUrl << 70;
+                                          << "https://github.net" << formUrl << 85;
+    QTest::newRow("Path Mismatch (diff parent)") << "https://github.com/keepassxreboot" << siteUrl << formUrl << 80;
+    QTest::newRow("Path Mismatch (diff parent, form)") << "https://github.com/keepassxreboot"
+                                                       << "https://github.net" << formUrl << 70;
 
     QTest::newRow("Subdomain Mismatch (site)") << siteUrl << "https://sub.github.com/"
                                                << "https://github.net/" << 60;


### PR DESCRIPTION
This is a change for browser integration with "Return only best-matching credentials". It adds an additional priority level for "parent directory match" between "exact url match" and "FQDN match".

Fixes #6892
(I have slightly changed the first proposal so that only new lines are added.)

## Testing strategy
* Enable browser integration
* Enable "Return only best-matching credentials"
* Create a first KeePassXC entry with URL https://www.example.net/ *(no path!)*
* Create a second KeePassXC entry with URL https://www.example.net/second/
* Visit https://www.example.net/first/ (any subdirectory **except** `/second/` – should have a login form)
* KeePassXC-Browser should only offer username/password from the first but **not** the second entry

## Type of change
- ✅ New feature (change that adds functionality)
