### PR TITLE
Add delete-entry command to Browser Integration API

### DIFF
--- a/src/browser/BrowserAction.h
+++ b/src/browser/BrowserAction.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -43,6 +43,7 @@ private:
     QJsonObject handleGetDatabaseGroups(const QJsonObject& json, const QString& action);
     QJsonObject handleCreateNewGroup(const QJsonObject& json, const QString& action);
     QJsonObject handleGetTotp(const QJsonObject& json, const QString& action);
+    QJsonObject handleDeleteEntry(const QJsonObject& json, const QString& action);
 
     QJsonObject buildMessage(const QString& nonce) const;
     QJsonObject buildResponse(const QString& action, const QJsonObject& message, const QString& nonce);

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 2013 Francois Ferrand
  *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -576,6 +576,32 @@ bool BrowserService::updateEntry(const QString& dbid,
     }
 
     return result;
+}
+
+bool BrowserService::deleteEntry(const QString& uuid)
+{
+    auto db = selectedDatabase();
+    if (!db) {
+        return false;
+    }
+
+    auto* entry = db->rootGroup()->findEntryByUuid(Tools::hexToUuid(uuid));
+    if (!entry) {
+        return false;
+    }
+
+    auto dialogResult = MessageBox::warning(nullptr,
+                                            tr("KeePassXC: Delete entry"),
+                                            tr("A request for deleting entry \"%1\" has been received.\n"
+                                               "Do you want to delete the entry?\n")
+                                                .arg(entry->title()),
+                                            MessageBox::Yes | MessageBox::No);
+    if (dialogResult != MessageBox::Yes) {
+        return false;
+    }
+
+    db->recycleEntry(entry);
+    return true;
 }
 
 QList<Entry*>

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 2013 Francois Ferrand
  *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -71,6 +71,7 @@ public:
                      const QString& password,
                      const QString& siteUrlStr,
                      const QString& formUrlStr);
+    bool deleteEntry(const QString& uuid);
 
     QJsonArray findMatchingEntries(const QString& dbid,
                                    const QString& siteUrlStr,

--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
  *  Copyright (C) 2017 Lennart Glauer <mail@lennart-glauer.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -315,6 +315,20 @@ namespace Tools
     QUuid hexToUuid(const QString& uuid)
     {
         return QUuid::fromRfc4122(QByteArray::fromHex(uuid.toLatin1()));
+    }
+
+    bool isValidUuid(const QString& uuidStr)
+    {
+        if (uuidStr.isEmpty() || uuidStr.length() != 32 || !isHex(uuidStr.toLatin1())) {
+            return false;
+        }
+
+        const auto uuid = hexToUuid(uuidStr);
+        if (uuid.isNull() || uuid.version() == QUuid::VerUnknown) {
+            return false;
+        }
+
+        return true;
     }
 
     QString envSubstitute(const QString& filepath, QProcessEnvironment environment)

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ namespace Tools
     bool checkUrlValid(const QString& urlField);
     QString uuidToHex(const QUuid& uuid);
     QUuid hexToUuid(const QString& uuid);
+    bool isValidUuid(const QString& uuidStr);
     QRegularExpression convertToRegex(const QString& string,
                                       bool useWildcards = false,
                                       bool exactMatch = false,

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -87,4 +87,21 @@ void TestTools::testEnvSubstitute()
     QCOMPARE(Tools::envSubstitute("$HOME/.ssh/id_rsa", environment), QString("/home/user/.ssh/id_rsa"));
     QCOMPARE(Tools::envSubstitute("start/$EMPTY$$EMPTY$HOME/end", environment), QString("start/$/home/user/end"));
 #endif
+}
+
+void TestTools::testValidUuid()
+{
+    auto validUuid = Tools::uuidToHex(QUuid::createUuid());
+    auto nonValidUuid = "1234567890abcdef1234567890abcdef";
+    auto emptyUuid = QString();
+    auto shortUuid = validUuid.left(10);
+    auto longUuid = validUuid + "baddata";
+    auto nonHexUuid = Tools::uuidToHex(QUuid::createUuid()).replace(0, 1, 'p');
+
+    QVERIFY(Tools::isValidUuid(validUuid));
+    QVERIFY(not Tools::isValidUuid(nonValidUuid));
+    QVERIFY(not Tools::isValidUuid(emptyUuid));
+    QVERIFY(not Tools::isValidUuid(shortUuid));
+    QVERIFY(not Tools::isValidUuid(longUuid));
+    QVERIFY(not Tools::isValidUuid(nonHexUuid));
 }

--- a/tests/TestTools.h
+++ b/tests/TestTools.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@ private slots:
     void testIsHex();
     void testIsBase64();
     void testEnvSubstitute();
+    void testValidUuid();
 };
 
 #endif // KEEPASSX_TESTTOOLS_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds `delete-entry` command to Browser Integration API. User interaction is needed.

Only entry UUID is accepted as a parameter.
Returns `success` as `true` when entry was deleted, `false` if canceled.

Fixes #6887.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
