### PR TITLE
FdoSecrets: Improve client executable path handling

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -67,15 +67,35 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow access to entries</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Allow Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Deny All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Non-existing/inaccessible executable path. Please double-check the client is legit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <source>PID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Executable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3773,28 +3793,16 @@ Error: %1</source>
 <context>
     <name>FdoSecrets::SettingsClientModel</name>
     <message>
-        <source>Application</source>
-        <translation type="unfinished"></translation>
+        <source>Unknown</source>
+        <translation type="unfinished">Unknown</translation>
     </message>
     <message>
-        <source>Manage</source>
+        <source>Non-existing/inaccessible executable path. Please double-check the client is legit.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FdoSecrets::SettingsDatabaseModel</name>
-    <message>
-        <source>File Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Group</source>
-        <translation type="unfinished">Group</translation>
-    </message>
-    <message>
-        <source>Manage</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Unlock to show</source>
         <translation type="unfinished"></translation>
@@ -7249,6 +7257,14 @@ Please consider generating a new key file.</source>
         <source>Please present or touch your YubiKey to continue…</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>unknown executable (DBus address %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (invalid executable path)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QtIOCompressor</name>
@@ -7721,6 +7737,40 @@ Please consider generating a new key file.</source>
     <message>
         <source>Search (%1)…</source>
         <comment>Search placeholder text, %1 is the keyboard shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsClientModel</name>
+    <message>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DBus Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manage</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDatabaseModel</name>
+    <message>
+        <source>File Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished">Group</translation>
+    </message>
+    <message>
+        <source>Manage</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/fdosecrets/dbus/DBusClient.cpp
+++ b/src/fdosecrets/dbus/DBusClient.cpp
@@ -63,10 +63,10 @@ namespace FdoSecrets
     {
         auto exePath = m_process.exePath();
         if (exePath.isEmpty()) {
-            return m_dbus->tr("unknown executable (DBus address %1)").arg(m_process.address);
+            return QObject::tr("unknown executable (DBus address %1)").arg(m_process.address);
         }
         if (!m_process.valid) {
-            return m_dbus->tr("%1 (invalid executable path)").arg(exePath);
+            return QObject::tr("%1 (invalid executable path)").arg(exePath);
         }
         return exePath;
     }

--- a/src/fdosecrets/dbus/DBusClient.cpp
+++ b/src/fdosecrets/dbus/DBusClient.cpp
@@ -26,32 +26,49 @@
 
 namespace FdoSecrets
 {
-    bool ProcessInfo::operator==(const ProcessInfo& other) const
+    bool ProcInfo::operator==(const ProcInfo& other) const
     {
-        return this->pid == other.pid && this->exePath == other.exePath;
+        return this->pid == other.pid && this->ppid == other.ppid && this->exePath == other.exePath
+               && this->name == other.name && this->command == other.command;
     }
 
-    bool ProcessInfo::operator!=(const ProcessInfo& other) const
+    bool ProcInfo::operator!=(const ProcInfo& other) const
     {
         return !(*this == other);
     }
 
-    DBusClient::DBusClient(DBusMgr* dbus, QString address, ProcessInfo process)
+    bool PeerInfo::operator==(const PeerInfo& other) const
+    {
+        return this->address == other.address && this->pid == other.pid && this->valid == other.valid
+               && this->hierarchy == other.hierarchy;
+    }
+
+    bool PeerInfo::operator!=(const PeerInfo& other) const
+    {
+        return !(*this == other);
+    }
+
+    DBusClient::DBusClient(DBusMgr* dbus, PeerInfo process)
         : m_dbus(dbus)
-        , m_address(std::move(address))
         , m_process(std::move(process))
     {
     }
 
+    DBusMgr* DBusClient::dbus() const
+    {
+        return m_dbus;
+    }
+
     QString DBusClient::name() const
     {
-        if (m_process.exePath.isEmpty()) {
-            return m_dbus->tr("unknown executable (DBus address %1)").arg(m_address);
+        auto exePath = m_process.exePath();
+        if (exePath.isEmpty()) {
+            return m_dbus->tr("unknown executable (DBus address %1)").arg(m_process.address);
         }
         if (!m_process.valid) {
-            return m_dbus->tr("%1 (invalid executable path)").arg(m_process.exePath);
+            return m_dbus->tr("%1 (invalid executable path)").arg(exePath);
         }
-        return m_process.exePath;
+        return exePath;
     }
 
     bool DBusClient::itemKnown(const QUuid& uuid) const

--- a/src/fdosecrets/dbus/DBusClient.cpp
+++ b/src/fdosecrets/dbus/DBusClient.cpp
@@ -45,7 +45,13 @@ namespace FdoSecrets
 
     QString DBusClient::name() const
     {
-        return m_process.exePath.isEmpty() ? m_address : m_process.exePath;
+        if (m_process.exePath.isEmpty()) {
+            return m_dbus->tr("unknown executable (DBus address %1)").arg(m_address);
+        }
+        if (!m_process.valid) {
+            return m_dbus->tr("%1 (invalid executable path)").arg(m_process.exePath);
+        }
+        return m_process.exePath;
     }
 
     bool DBusClient::itemKnown(const QUuid& uuid) const

--- a/src/fdosecrets/dbus/DBusClient.cpp
+++ b/src/fdosecrets/dbus/DBusClient.cpp
@@ -22,14 +22,30 @@
 #include "fdosecrets/dbus/DBusMgr.h"
 #include "fdosecrets/objects/SessionCipher.h"
 
+#include <utility>
+
 namespace FdoSecrets
 {
-    DBusClient::DBusClient(DBusMgr* dbus, const QString& address, uint pid, const QString& name)
-        : m_dbus(dbus)
-        , m_address(address)
-        , m_pid(pid)
-        , m_name(name)
+    bool ProcessInfo::operator==(const ProcessInfo& other) const
     {
+        return this->pid == other.pid && this->exePath == other.exePath;
+    }
+
+    bool ProcessInfo::operator!=(const ProcessInfo& other) const
+    {
+        return !(*this == other);
+    }
+
+    DBusClient::DBusClient(DBusMgr* dbus, QString address, ProcessInfo process)
+        : m_dbus(dbus)
+        , m_address(std::move(address))
+        , m_process(std::move(process))
+    {
+    }
+
+    QString DBusClient::name() const
+    {
+        return m_process.exePath.isEmpty() ? m_address : m_process.exePath;
     }
 
     bool DBusClient::itemKnown(const QUuid& uuid) const

--- a/src/fdosecrets/dbus/DBusClient.h
+++ b/src/fdosecrets/dbus/DBusClient.h
@@ -37,6 +37,8 @@ namespace FdoSecrets
     struct ProcessInfo
     {
         uint pid;
+        // whether exePath points to a valid executable file
+        bool valid;
         QString exePath;
 
         bool operator==(const ProcessInfo& other) const;

--- a/src/fdosecrets/dbus/DBusClient.h
+++ b/src/fdosecrets/dbus/DBusClient.h
@@ -32,11 +32,11 @@ namespace FdoSecrets
 
     struct ProcInfo
     {
-        uint pid = 0;
-        uint ppid = 0;
-        QString exePath{};
-        QString name{};
-        QString command{};
+        uint pid;
+        uint ppid;
+        QString exePath;
+        QString name;
+        QString command;
 
         bool operator==(const ProcInfo& other) const;
         bool operator!=(const ProcInfo& other) const;

--- a/src/fdosecrets/dbus/DBusClient.h
+++ b/src/fdosecrets/dbus/DBusClient.h
@@ -31,6 +31,19 @@ namespace FdoSecrets
     class CipherPair;
 
     /**
+     * Contains info representing a process.
+     * This can be obtained by DBusMgr::serviceInfo given a dbus address.
+     */
+    struct ProcessInfo
+    {
+        uint pid;
+        QString exePath;
+
+        bool operator==(const ProcessInfo& other) const;
+        bool operator!=(const ProcessInfo& other) const;
+    };
+
+    /**
      * Represent a client that has made requests to our service. A client is identified by its
      * DBus address, which is guaranteed to be unique by the DBus protocol.
      *
@@ -48,10 +61,9 @@ namespace FdoSecrets
         /**
          * @brief Given peer's service address, construct a client object
          * @param address obtained from `QDBusMessage::service()`
-         * @param pid the process PID
-         * @param name the process name
+         * @param process the process info
          */
-        explicit DBusClient(DBusMgr* dbus, const QString& address, uint pid, const QString& name);
+        explicit DBusClient(DBusMgr* dbus, QString address, ProcessInfo process);
 
         DBusMgr* dbus() const
         {
@@ -61,10 +73,7 @@ namespace FdoSecrets
         /**
          * @return The human readable client name, usually the process name
          */
-        QString name() const
-        {
-            return m_name;
-        }
+        QString name() const;
 
         /**
          * @return The unique DBus address of the client
@@ -79,7 +88,15 @@ namespace FdoSecrets
          */
         uint pid() const
         {
-            return m_pid;
+            return m_process.pid;
+        }
+
+        /**
+         * @return The process info
+         */
+        const ProcessInfo& processInfo() const
+        {
+            return m_process;
         }
 
         QSharedPointer<CipherPair>
@@ -125,8 +142,7 @@ namespace FdoSecrets
         QPointer<DBusMgr> m_dbus;
         QString m_address;
 
-        uint m_pid{0};
-        QString m_name{};
+        ProcessInfo m_process;
 
         bool m_authorizedAll{false};
 

--- a/src/fdosecrets/dbus/DBusClient.h
+++ b/src/fdosecrets/dbus/DBusClient.h
@@ -37,7 +37,11 @@ namespace FdoSecrets
     struct ProcessInfo
     {
         uint pid;
-        // whether exePath points to a valid executable file
+        /**
+         * @brief Whether exePath points to a valid executable file.
+         *
+         * Note that an empty exePath is not valid.
+         */
         bool valid;
         QString exePath;
 

--- a/src/fdosecrets/dbus/DBusMgr.cpp
+++ b/src/fdosecrets/dbus/DBusMgr.cpp
@@ -167,6 +167,46 @@ namespace FdoSecrets
 </interface>
 )xml";
 
+    // read /proc, each field except pid may be empty
+    ProcInfo readProc(uint pid)
+    {
+        ProcInfo info{};
+        info.pid = pid;
+
+        // The /proc/pid/exe link is more reliable than /proc/pid/cmdline
+        // It's still weak and if the application does a prctl(PR_SET_DUMPABLE, 0) this link cannot be accessed.
+        QFileInfo exe(QStringLiteral("/proc/%1/exe").arg(pid));
+        info.exePath = exe.canonicalFilePath();
+        qDebug() << "process" << pid << info.exePath;
+
+        // /proc/pid/cmdline gives full command line
+        QFile cmdline(QStringLiteral("/proc/%1/cmdline").arg(pid));
+        if (cmdline.open(QFile::ReadOnly)) {
+            info.command = QString::fromLocal8Bit(cmdline.readAll().replace('\0', ' ')).trimmed();
+        }
+        qDebug() << "process" << pid << info.command;
+
+        // /proc/pid/stat gives ppid, name
+        QFile stat(QStringLiteral("/proc/%1/stat").arg(pid));
+        if (stat.open(QIODevice::ReadOnly)) {
+            auto line = stat.readAll();
+            // find comm field without looking in what's inside as it's user controlled
+            auto commStart = line.indexOf('(');
+            auto commEnd = line.lastIndexOf(')');
+            if (commStart != -1 && commEnd != -1 && commStart < commEnd) {
+                // start past '(', and subtract 2 from total length
+                info.name = QString::fromLocal8Bit(line.mid(commStart + 1, commEnd + 1 - commStart - 2));
+
+                auto parts = line.mid(commEnd + 1).trimmed().split(' ');
+                if (parts.size() >= 2) {
+                    info.ppid = parts[1].toUInt();
+                }
+            }
+        }
+
+        return info;
+    }
+
     DBusMgr::DBusMgr()
         : m_conn(QDBusConnection::sessionBus())
     {
@@ -198,21 +238,26 @@ namespace FdoSecrets
         return m_clients.values();
     }
 
-    bool DBusMgr::serviceInfo(const QString& addr, ProcessInfo& info) const
+    bool DBusMgr::serviceInfo(const QString& addr, PeerInfo& info) const
     {
+        info.address = addr;
         auto pid = m_conn.interface()->servicePid(addr);
         if (!pid.isValid()) {
             return false;
         }
         info.pid = pid.value();
-        // The /proc/pid/exe link is more reliable than /proc/pid/cmdline
-        // It's still weak and if the application does a prctl(PR_SET_DUMPABLE, 0) this link cannot be accessed.
-        QFileInfo proc(QStringLiteral("/proc/%1/exe").arg(pid.value()));
-        info.exePath = proc.canonicalFilePath();
+
+        // get the whole hierarchy
+        uint ppid = info.pid;
+        while (ppid != 0) {
+            auto proc = readProc(ppid);
+            info.hierarchy.append(proc);
+            ppid = proc.ppid;
+        }
 
         // check if the exe file is valid
         // (assuming for now that an accessible file is valid)
-        info.valid = QFileInfo::exists(info.exePath);
+        info.valid = QFileInfo::exists(info.exePath());
 
         // ask again to double-check and protect against pid reuse
         auto newPid = m_conn.interface()->servicePid(addr);
@@ -331,11 +376,11 @@ namespace FdoSecrets
         auto pidStr = tr("Unknown", "Unknown PID");
         auto exeStr = tr("Unknown", "Unknown executable path");
 
-        ProcessInfo info{};
+        PeerInfo info{};
         if (serviceInfo(DBUS_SERVICE_SECRET, info)) {
             pidStr = QString::number(info.pid);
-            if (!info.exePath.isEmpty()) {
-                exeStr = info.exePath;
+            if (!info.exePath().isEmpty()) {
+                exeStr = info.exePath();
             }
         }
 
@@ -575,12 +620,12 @@ namespace FdoSecrets
 
     DBusClientPtr DBusMgr::createClient(const QString& addr)
     {
-        ProcessInfo info{};
+        PeerInfo info{};
         if (!serviceInfo(addr, info)) {
             return {};
         }
 
-        auto client = DBusClientPtr(new DBusClient(this, addr, info));
+        auto client = DBusClientPtr(new DBusClient(this, info));
 
         emit clientConnected(client);
         m_watcher.addWatchedService(addr);

--- a/src/fdosecrets/dbus/DBusMgr.h
+++ b/src/fdosecrets/dbus/DBusMgr.h
@@ -219,7 +219,7 @@ namespace FdoSecrets
     private:
         QDBusConnection m_conn;
 
-        bool serviceInfo(const QString& addr, ProcessInfo& info) const;
+        bool serviceInfo(const QString& addr, PeerInfo& info) const;
 
         bool sendDBusSignal(const QString& path,
                             const QString& interface,

--- a/src/fdosecrets/dbus/DBusMgr.h
+++ b/src/fdosecrets/dbus/DBusMgr.h
@@ -219,11 +219,6 @@ namespace FdoSecrets
     private:
         QDBusConnection m_conn;
 
-        struct ProcessInfo
-        {
-            uint pid;
-            QString exePath;
-        };
         bool serviceInfo(const QString& addr, ProcessInfo& info) const;
 
         bool sendDBusSignal(const QString& path,

--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -291,7 +291,8 @@ namespace FdoSecrets
         }
         if (!entries.isEmpty()) {
             QString app = tr("%1 (PID: %2)").arg(client->name()).arg(client->pid());
-            auto ac = new AccessControlDialog(findWindow(m_windowId), entries, app, AuthOption::Remember);
+            auto ac = new AccessControlDialog(
+                findWindow(m_windowId), entries, app, client->processInfo(), AuthOption::Remember);
             connect(ac, &AccessControlDialog::finished, this, &UnlockPrompt::itemUnlockFinished);
             connect(ac, &AccessControlDialog::finished, ac, &AccessControlDialog::deleteLater);
             ac->open();

--- a/src/fdosecrets/widgets/AccessControlDialog.cpp
+++ b/src/fdosecrets/widgets/AccessControlDialog.cpp
@@ -20,6 +20,7 @@
 #include "AccessControlDialog.h"
 #include "ui_AccessControlDialog.h"
 
+#include "fdosecrets/dbus/DBusClient.h"
 #include "fdosecrets/widgets/RowButtonHelper.h"
 
 #include "core/Entry.h"
@@ -31,9 +32,12 @@
 AccessControlDialog::AccessControlDialog(QWindow* parent,
                                          const QList<Entry*>& entries,
                                          const QString& app,
+                                         const FdoSecrets::PeerInfo& info,
                                          AuthOptions authOptions)
     : m_ui(new Ui::AccessControlDialog())
+    , m_rememberCheck()
     , m_model(new EntryModel(entries))
+    , m_decisions()
 {
     if (parent) {
         // Force the creation of the QWindow, without this windowHandle() will return nullptr
@@ -44,19 +48,13 @@ AccessControlDialog::AccessControlDialog(QWindow* parent,
     }
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
 
-    m_ui->setupUi(this);
-
-    connect(m_ui->cancelButton, &QPushButton::clicked, this, [this]() { done(DenyAll); });
-    connect(m_ui->allowButton, &QPushButton::clicked, this, [this]() { done(AllowSelected); });
-    connect(m_ui->itemsTable, &QTableView::clicked, m_model.data(), &EntryModel::toggleCheckState);
-    connect(m_ui->rememberCheck, &QCheckBox::clicked, this, &AccessControlDialog::rememberChecked);
     connect(this, &QDialog::finished, this, &AccessControlDialog::dialogFinished);
 
-    m_ui->rememberMsg->setCloseButtonVisible(false);
-    m_ui->rememberMsg->setMessageType(MessageWidget::Information);
-
+    m_ui->setupUi(this);
     m_ui->appLabel->setText(m_ui->appLabel->text().arg(app));
 
+    // items table
+    connect(m_ui->itemsTable, &QTableView::clicked, m_model.data(), &EntryModel::toggleCheckState);
     m_ui->itemsTable->setModel(m_model.data());
     installWidgetItemDelegate<DenyButton>(m_ui->itemsTable, 2, [this](QWidget* p, const QModelIndex& idx) {
         auto btn = new DenyButton(p, idx);
@@ -68,18 +66,83 @@ AccessControlDialog::AccessControlDialog(QWindow* parent,
     m_ui->itemsTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
     m_ui->itemsTable->resizeColumnsToContents();
 
+    // the info widget
+    m_ui->rememberMsg->setMessageType(MessageWidget::Information);
+    m_ui->rememberMsg->show(); // sync with m_rememberCheck->setChecked(true)
+    m_ui->exePathWarn->setMessageType(MessageWidget::Warning);
+    m_ui->exePathWarn->hide();
+
+    setupDetails(info);
+
+    // the button box
+    QString detailsButtonText = tr("Details");
+    auto detailsButton =
+        m_ui->buttonBox->addButton(detailsButtonText + QStringLiteral(" >>"), QDialogButtonBox::HelpRole);
+    detailsButton->setCheckable(true);
+
+    m_rememberCheck = new QCheckBox(tr("Remember"), this);
+    m_rememberCheck->setChecked(true);
+    m_ui->buttonBox->addButton(m_rememberCheck, QDialogButtonBox::ActionRole);
+
+    auto allowButton = m_ui->buttonBox->addButton(tr("Allow Selected"), QDialogButtonBox::AcceptRole);
+    allowButton->setDefault(true);
+
+    auto cancelButton = m_ui->buttonBox->addButton(tr("Deny All"), QDialogButtonBox::RejectRole);
+
+    connect(cancelButton, &QPushButton::clicked, this, [this]() { done(DenyAll); });
+    connect(allowButton, &QPushButton::clicked, this, [this]() { done(AllowSelected); });
+    connect(m_rememberCheck, &QCheckBox::clicked, this, &AccessControlDialog::rememberChecked);
+    connect(detailsButton, &QPushButton::clicked, this, [=](bool checked) {
+        m_ui->detailsContainer->setVisible(checked);
+        if (checked) {
+            detailsButton->setText(detailsButtonText + QStringLiteral(" <<"));
+        } else {
+            detailsButton->setText(detailsButtonText + QStringLiteral(" >>"));
+        }
+        adjustSize();
+    });
+
+    // tune the UI according to options
     if (!authOptions.testFlag(AuthOption::Remember)) {
-        m_ui->rememberCheck->setHidden(true);
-        m_ui->rememberCheck->setChecked(false);
+        m_rememberCheck->hide();
+        m_rememberCheck->setChecked(false);
     }
     if (!authOptions.testFlag(AuthOption::PerEntryDeny)) {
         m_ui->itemsTable->horizontalHeader()->setSectionHidden(2, true);
     }
 
-    m_ui->allowButton->setFocus();
+    // show warning and details if not valid
+    if (!info.valid) {
+        m_ui->exePathWarn->show();
+        detailsButton->click();
+    }
+
+    allowButton->setFocus();
 }
 
 AccessControlDialog::~AccessControlDialog() = default;
+
+void AccessControlDialog::setupDetails(const FdoSecrets::PeerInfo& info)
+{
+    QTreeWidgetItem* item = nullptr;
+    for (auto it = info.hierarchy.crbegin(); it != info.hierarchy.crend(); ++it) {
+        QStringList columns = {
+            it->name,
+            QString::number(it->pid),
+            it->exePath,
+            it->command,
+        };
+        if (item) {
+            item = new QTreeWidgetItem(item, columns);
+        } else {
+            item = new QTreeWidgetItem(m_ui->procTree, columns);
+        }
+    }
+    m_ui->procTree->expandAll();
+    m_ui->procTree->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    m_ui->procTree->scrollToBottom();
+    m_ui->detailsContainer->hide();
+}
 
 void AccessControlDialog::rememberChecked(bool checked)
 {
@@ -101,8 +164,8 @@ void AccessControlDialog::denyEntryClicked(Entry* entry, const QModelIndex& inde
 
 void AccessControlDialog::dialogFinished(int result)
 {
-    auto allow = m_ui->rememberCheck->isChecked() ? AuthDecision::Allowed : AuthDecision::AllowedOnce;
-    auto deny = m_ui->rememberCheck->isChecked() ? AuthDecision::Denied : AuthDecision::DeniedOnce;
+    auto allow = m_rememberCheck->isChecked() ? AuthDecision::Allowed : AuthDecision::AllowedOnce;
+    auto deny = m_rememberCheck->isChecked() ? AuthDecision::Denied : AuthDecision::DeniedOnce;
 
     for (int row = 0; row != m_model->rowCount({}); ++row) {
         auto entry = m_model->data(m_model->index(row, 2), Qt::EditRole).value<Entry*>();

--- a/src/fdosecrets/widgets/AccessControlDialog.cpp
+++ b/src/fdosecrets/widgets/AccessControlDialog.cpp
@@ -81,6 +81,7 @@ AccessControlDialog::AccessControlDialog(QWindow* parent,
     detailsButton->setCheckable(true);
 
     m_rememberCheck = new QCheckBox(tr("Remember"), this);
+    m_rememberCheck->setObjectName("rememberCheck"); // for testing
     m_rememberCheck->setChecked(true);
     m_ui->buttonBox->addButton(m_rememberCheck, QDialogButtonBox::ActionRole);
 

--- a/src/fdosecrets/widgets/AccessControlDialog.h
+++ b/src/fdosecrets/widgets/AccessControlDialog.h
@@ -21,6 +21,7 @@
 #define KEEPASSXC_FDOSECRETS_ACCESSCONTROLDIALOG_H
 
 #include <QAbstractTableModel>
+#include <QCheckBox>
 #include <QDialog>
 #include <QPointer>
 #include <QPushButton>
@@ -33,6 +34,11 @@ class Entry;
 namespace Ui
 {
     class AccessControlDialog;
+}
+
+namespace FdoSecrets
+{
+    struct PeerInfo;
 }
 
 enum class AuthOption
@@ -52,6 +58,7 @@ public:
     explicit AccessControlDialog(QWindow* parent,
                                  const QList<Entry*>& entries,
                                  const QString& app,
+                                 const FdoSecrets::PeerInfo& info,
                                  AuthOptions authOptions = AuthOption::Remember | AuthOption::PerEntryDeny);
     ~AccessControlDialog() override;
 
@@ -76,7 +83,10 @@ private:
     class EntryModel;
     class DenyButton;
 
+    void setupDetails(const FdoSecrets::PeerInfo& info);
+
     QScopedPointer<Ui::AccessControlDialog> m_ui;
+    QPointer<QCheckBox> m_rememberCheck;
     QScopedPointer<EntryModel> m_model;
     QHash<Entry*, AuthDecision> m_decisions;
 };

--- a/src/fdosecrets/widgets/AccessControlDialog.ui
+++ b/src/fdosecrets/widgets/AccessControlDialog.ui
@@ -15,6 +15,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="MessageWidget" name="exePathWarn" native="true">
+     <property name="text" stdset="0">
+      <string>Non-existing/inaccessible executable path. Please double-check the client is legit.</string>
+     </property>
+     <property name="closeButtonVisible" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="appLabel">
      <property name="font">
       <font>
@@ -31,7 +41,61 @@
     </widget>
    </item>
    <item>
+    <widget class="QWidget" name="detailsContainer" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QTreeWidget" name="procTree">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="uniformRowHeights">
+         <bool>true</bool>
+        </property>
+        <property name="animated">
+         <bool>true</bool>
+        </property>
+        <property name="allColumnsShowFocus">
+         <bool>true</bool>
+        </property>
+        <attribute name="headerStretchLastSection">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Name</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>PID</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Executable</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Command Line</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableView" name="itemsTable">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
      </property>
@@ -63,56 +127,17 @@
      <property name="text" stdset="0">
       <string>Your decision for above entries will be remembered for the duration the requesting client is running.</string>
      </property>
+     <property name="closeButtonVisible" stdset="0">
+      <bool>false</bool>
+     </property>
     </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="rememberCheck">
-       <property name="text">
-        <string>Remember</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="allowButton">
-       <property name="accessibleName">
-        <string>Allow access to entries</string>
-       </property>
-       <property name="text">
-        <string>Allow Selected</string>
-       </property>
-       <property name="autoDefault">
-        <bool>true</bool>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Deny All</string>
-       </property>
-       <property name="autoDefault">
-        <bool>true</bool>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::NoButton</set>
        </property>
       </widget>
      </item>

--- a/src/fdosecrets/widgets/SettingsModels.cpp
+++ b/src/fdosecrets/widgets/SettingsModels.cpp
@@ -323,18 +323,21 @@ namespace FdoSecrets
         const auto& info = client->processInfo();
         switch (role) {
         case Qt::DisplayRole:
-            if (info.exePath.isEmpty()) {
+            if (info.exePath().isEmpty()) {
                 return tr("Unknown");
             }
-            return info.exePath;
+            return info.exePath();
         case Qt::ToolTipRole:
             if (!info.valid) {
-                return tr("Invalid executable path. The application may be running inside a container");
+                return tr("Non-existing/inaccessible executable path. Please double-check the client is legit.");
             }
             return {};
         case Qt::DecorationRole:
             // give some visual clues if the path is invalid
-            return icons()->icon(QStringLiteral("dialog-warning"));
+            if (!info.valid) {
+                return icons()->icon(QStringLiteral("dialog-warning"));
+            }
+            return {};
         default:
             return {};
         }

--- a/src/fdosecrets/widgets/SettingsModels.cpp
+++ b/src/fdosecrets/widgets/SettingsModels.cpp
@@ -309,6 +309,8 @@ namespace FdoSecrets
             return dataForApplication(client, role);
         case ColumnPID:
             return dataForPID(client, role);
+        case ColumnDBus:
+            return dataForDBus(client, role);
         case ColumnManage:
             return dataForManage(client, role);
         default:
@@ -318,9 +320,21 @@ namespace FdoSecrets
 
     QVariant SettingsClientModel::dataForApplication(const DBusClientPtr& client, int role) const
     {
+        const auto& info = client->processInfo();
         switch (role) {
         case Qt::DisplayRole:
-            return client->name();
+            if (info.exePath.isEmpty()) {
+                return tr("Unknown");
+            }
+            return info.exePath;
+        case Qt::ToolTipRole:
+            if (!info.valid) {
+                return tr("Invalid executable path. The application may be running inside a container");
+            }
+            return {};
+        case Qt::DecorationRole:
+            // give some visual clues if the path is invalid
+            return icons()->icon(QStringLiteral("dialog-warning"));
         default:
             return {};
         }
@@ -331,6 +345,16 @@ namespace FdoSecrets
         switch (role) {
         case Qt::DisplayRole:
             return client->pid();
+        default:
+            return {};
+        }
+    }
+
+    QVariant SettingsClientModel::dataForDBus(const DBusClientPtr& client, int role) const
+    {
+        switch (role) {
+        case Qt::DisplayRole:
+            return client->address();
         default:
             return {};
         }

--- a/src/fdosecrets/widgets/SettingsModels.h
+++ b/src/fdosecrets/widgets/SettingsModels.h
@@ -40,6 +40,18 @@ namespace FdoSecrets
         QVariant data(const QModelIndex& index, int role) const override;
         QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
+        enum Column
+        {
+            ColumnFileName,
+            ColumnGroup,
+            ColumnManage,
+        };
+        static constexpr const char* ColumnNames[] = {
+            QT_TRANSLATE_NOOP("SettingsDatabaseModel", "File Name"),
+            QT_TRANSLATE_NOOP("SettingsDatabaseModel", "Group"),
+            QT_TRANSLATE_NOOP("SettingsDatabaseModel", "Manage"),
+        };
+
     private:
         QVariant dataForName(DatabaseWidget* db, int role) const;
         static QVariant dataForExposedGroup(DatabaseWidget* db, int role);
@@ -71,8 +83,21 @@ namespace FdoSecrets
         QVariant data(const QModelIndex& index, int role) const override;
         QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
+        enum Column
+        {
+            ColumnApplication,
+            ColumnPID,
+            ColumnManage,
+        };
+        static constexpr const char* ColumnNames[] = {
+            QT_TRANSLATE_NOOP("SettingsClientModel", "Application"),
+            QT_TRANSLATE_NOOP("SettingsClientModel", "PID"),
+            QT_TRANSLATE_NOOP("SettingsClientModel", "Manage"),
+        };
+
     private:
         QVariant dataForApplication(const DBusClientPtr& client, int role) const;
+        QVariant dataForPID(const DBusClientPtr& client, int role) const;
         QVariant dataForManage(const DBusClientPtr& client, int role) const;
 
     private slots:

--- a/src/fdosecrets/widgets/SettingsModels.h
+++ b/src/fdosecrets/widgets/SettingsModels.h
@@ -87,17 +87,20 @@ namespace FdoSecrets
         {
             ColumnApplication,
             ColumnPID,
+            ColumnDBus,
             ColumnManage,
         };
         static constexpr const char* ColumnNames[] = {
             QT_TRANSLATE_NOOP("SettingsClientModel", "Application"),
             QT_TRANSLATE_NOOP("SettingsClientModel", "PID"),
+            QT_TRANSLATE_NOOP("SettingsClientModel", "DBus Address"),
             QT_TRANSLATE_NOOP("SettingsClientModel", "Manage"),
         };
 
     private:
         QVariant dataForApplication(const DBusClientPtr& client, int role) const;
         QVariant dataForPID(const DBusClientPtr& client, int role) const;
+        QVariant dataForDBus(const DBusClientPtr& client, int role) const;
         QVariant dataForManage(const DBusClientPtr& client, int role) const;
 
     private slots:

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
@@ -209,28 +209,32 @@ SettingsWidgetFdoSecrets::SettingsWidgetFdoSecrets(FdoSecretsPlugin* plugin, QWi
 
     auto clientModel = new SettingsClientModel(*plugin->dbus(), this);
     m_ui->tableClients->setModel(clientModel);
-    installWidgetItemDelegate<ManageSession>(
-        m_ui->tableClients, 1, [](QWidget* p, const QModelIndex&) { return new ManageSession(p); });
+    installWidgetItemDelegate<ManageSession>(m_ui->tableClients,
+                                             SettingsClientModel::ColumnManage,
+                                             [](QWidget* p, const QModelIndex&) { return new ManageSession(p); });
 
     // config header after setting model, otherwise the header doesn't have enough sections
     auto clientViewHeader = m_ui->tableClients->horizontalHeader();
     clientViewHeader->setSelectionMode(QAbstractItemView::NoSelection);
     clientViewHeader->setSectionsClickable(false);
-    clientViewHeader->setSectionResizeMode(0, QHeaderView::Stretch); // application
-    clientViewHeader->setSectionResizeMode(1, QHeaderView::ResizeToContents); // disconnect button
+    clientViewHeader->setSectionResizeMode(SettingsClientModel::ColumnApplication, QHeaderView::Stretch);
+    clientViewHeader->setSectionResizeMode(SettingsClientModel::ColumnPID, QHeaderView::ResizeToContents);
+    clientViewHeader->setSectionResizeMode(SettingsClientModel::ColumnManage, QHeaderView::ResizeToContents);
 
     auto dbModel = new SettingsDatabaseModel(plugin->dbTabs(), this);
     m_ui->tableDatabases->setModel(dbModel);
     installWidgetItemDelegate<ManageDatabase>(
-        m_ui->tableDatabases, 2, [plugin](QWidget* p, const QModelIndex&) { return new ManageDatabase(plugin, p); });
+        m_ui->tableDatabases, SettingsDatabaseModel::ColumnManage, [plugin](QWidget* p, const QModelIndex&) {
+            return new ManageDatabase(plugin, p);
+        });
 
     // config header after setting model, otherwise the header doesn't have enough sections
     auto dbViewHeader = m_ui->tableDatabases->horizontalHeader();
     dbViewHeader->setSelectionMode(QAbstractItemView::NoSelection);
     dbViewHeader->setSectionsClickable(false);
-    dbViewHeader->setSectionResizeMode(0, QHeaderView::Stretch); // file name
-    dbViewHeader->setSectionResizeMode(1, QHeaderView::Stretch); // group
-    dbViewHeader->setSectionResizeMode(2, QHeaderView::ResizeToContents); // manage button
+    dbViewHeader->setSectionResizeMode(SettingsDatabaseModel::ColumnFileName, QHeaderView::Stretch);
+    dbViewHeader->setSectionResizeMode(SettingsDatabaseModel::ColumnGroup, QHeaderView::Stretch);
+    dbViewHeader->setSectionResizeMode(SettingsDatabaseModel::ColumnManage, QHeaderView::ResizeToContents);
 
     // prompt the user to save settings before the sections are enabled
     connect(m_plugin, &FdoSecretsPlugin::secretServiceStarted, this, &SettingsWidgetFdoSecrets::updateServiceState);

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.cpp
@@ -217,9 +217,8 @@ SettingsWidgetFdoSecrets::SettingsWidgetFdoSecrets(FdoSecretsPlugin* plugin, QWi
     auto clientViewHeader = m_ui->tableClients->horizontalHeader();
     clientViewHeader->setSelectionMode(QAbstractItemView::NoSelection);
     clientViewHeader->setSectionsClickable(false);
+    clientViewHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
     clientViewHeader->setSectionResizeMode(SettingsClientModel::ColumnApplication, QHeaderView::Stretch);
-    clientViewHeader->setSectionResizeMode(SettingsClientModel::ColumnPID, QHeaderView::ResizeToContents);
-    clientViewHeader->setSectionResizeMode(SettingsClientModel::ColumnManage, QHeaderView::ResizeToContents);
 
     auto dbModel = new SettingsDatabaseModel(plugin->dbTabs(), this);
     m_ui->tableDatabases->setModel(dbModel);
@@ -232,8 +231,7 @@ SettingsWidgetFdoSecrets::SettingsWidgetFdoSecrets(FdoSecretsPlugin* plugin, QWi
     auto dbViewHeader = m_ui->tableDatabases->horizontalHeader();
     dbViewHeader->setSelectionMode(QAbstractItemView::NoSelection);
     dbViewHeader->setSectionsClickable(false);
-    dbViewHeader->setSectionResizeMode(SettingsDatabaseModel::ColumnFileName, QHeaderView::Stretch);
-    dbViewHeader->setSectionResizeMode(SettingsDatabaseModel::ColumnGroup, QHeaderView::Stretch);
+    dbViewHeader->setSectionResizeMode(QHeaderView::Stretch);
     dbViewHeader->setSectionResizeMode(SettingsDatabaseModel::ColumnManage, QHeaderView::ResizeToContents);
 
     // prompt the user to save settings before the sections are enabled

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -117,7 +117,9 @@ class FakeClient : public DBusClient
 {
 public:
     explicit FakeClient(DBusMgr* dbus)
-        : DBusClient(dbus, QStringLiteral("local"), 0, "fake-client")
+        : DBusClient(
+            dbus,
+            {QStringLiteral("local"), 0, true, {ProcInfo{0, 0, QStringLiteral("fake-client"), QString{}, QString{}}}})
     {
     }
 };


### PR DESCRIPTION
After a busy summer, I'm back with some more time to contribute :sunglasses:

This PR improves the overall handling of FdoSecrets showing client executable paths to the user. It does the following

- Check executable file existence as described in https://github.com/keepassxreboot/keepassxc/pull/4733#issuecomment-633679091
- Show application PID and dbus address in the client list
- When the executable file is inaccessible, depending on where the client name is shown
  * when shown inline, e.g. in notification text, where space is limited, clearly say that the path is invalid
  * when shown in auth dialog, show warning and print detailed info about the client
  * when shown in the client list, draw a warning icon

More about the auth dialog: someone in previous discussions (sorry I didn't remember exactly where) mentioned showing the process hierarchy. I liked the idea and it looks indeed cool. But I'm not sure if the function belongs to KPXC. Maybe it's better to just let the user use whatever tool already available (e.g. `pstree`) rather than duplicating the functionality.

Fixes #6459


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
### Client list
Valid exe path
![Screenshot_20210915_163242](https://user-images.githubusercontent.com/1519759/133509044-79e32ec5-70f9-43af-87e3-7c9a7c99e4b7.png)
Invalid exe path
![Screenshot_20210915_164934](https://user-images.githubusercontent.com/1519759/133509066-03a19f22-9163-47f4-bc0d-6876568d347f.png)

### Notifications

![bitmap](https://user-images.githubusercontent.com/1519759/133509580-117ba392-cbed-4f9f-9336-0d5027338f5e.png)


### Auth dialog
When the path is valid, default to collapsed mode
![image241](https://user-images.githubusercontent.com/1519759/133511879-f16ce07c-509a-4953-b64b-e648175cfdfd.png)

When the path is invalid, default to expanded mode with a warning
![image345](https://user-images.githubusercontent.com/1519759/133511887-b27bd413-89e5-4a90-bc1e-606ea6993f9c.png)





## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Refactor (significant modification to existing code)