### PR TITLE
Remove WITH_GUI_TESTS exclusion for CLI tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -236,11 +236,9 @@ if(WITH_XC_BROWSER)
         LIBS ${TEST_LIBRARIES})
 endif()
 
+add_unit_test(NAME testcli SOURCES TestCli.cpp
+        LIBS testsupport cli ${TEST_LIBRARIES})
 
 if(WITH_GUI_TESTS)
-    # CLI clip tests need X environment on Linux
-    add_unit_test(NAME testcli SOURCES TestCli.cpp
-            LIBS testsupport cli ${TEST_LIBRARIES})
-
     add_subdirectory(gui)
 endif(WITH_GUI_TESTS)

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -437,6 +437,10 @@ void TestCli::testAnalyze()
 
 void TestCli::testClip()
 {
+    if (QProcessEnvironment::systemEnvironment().contains("WAYLAND_DISPLAY")) {
+        QSKIP("Clip test skipped due to QClipboard and Wayland issues on Linux");
+    }
+
     QClipboard* clipboard = QGuiApplication::clipboard();
     clipboard->clear();
 
@@ -448,10 +452,6 @@ void TestCli::testClip()
     setInput("a");
     execCmd(clipCmd, {"clip", m_dbFile->fileName(), "/Sample Entry", "0"});
     QString errorOutput(m_stderr->readAll());
-
-    if (QProcessEnvironment::systemEnvironment().contains("WAYLAND_DISPLAY")) {
-        QSKIP("Clip test skipped due to QClipboard and Wayland issues");
-    }
 
     if (errorOutput.contains("Unable to start program")
         || errorOutput.contains("No program defined for clipboard manipulation")) {


### PR DESCRIPTION
Apparently this exclusion was only relevant for Linux
systems not running X, which was already handled dynamically
in the testClip function. The CLI tests will now run by default
will all the other core tests.

## Testing strategy
unit tests :wink: 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Tests