### PR TITLE
Clean up code coverage reporting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,20 +385,13 @@ endif(WITH_TESTS)
 if(WITH_COVERAGE)
     # Include code coverage, use with -DCMAKE_BUILD_TYPE=Debug
     include(CodeCoverage)
-    set(COVERAGE_EXCLUDES
-            "\\(.+/\\)?tests/.\\*"
-            "\\(.+/\\)?build/.\\*"
-            "\\(.+/\\)?thirdparty/.\\*"
-            "\\(.+/\\)?CMakeFiles/.\\*"
-            "src/main.cpp"
-            ".\\*/moc_\\[^/\\]+\\.cpp"
-            ".\\*/ui_\\[^/\\]+\\.h"
-            ".\\*/\\[^/\\]+_autogen/.\\*"
-            "\\(.+/\\)?zxcvbn/.\\*"
-            "/Applications/.\\*"
-            "/opt/.\\*")
     append_coverage_compiler_flags()
 
+    set(COVERAGE_EXCLUDES
+            "'^(.+/)?(thirdparty|zxcvbn)/.*'"
+            "'^(.+/)?main\\.cpp$$'"
+            "'^(.+/)?cli/keepassxc-cli\\.cpp$$'"
+            "'^(.+/)?proxy/keepassxc-proxy\\.cpp$$'")
     if(WITH_COVERAGE AND CMAKE_COMPILER_IS_CLANGXX)
         set(MAIN_BINARIES
                 "$<TARGET_FILE:${PROGNAME}>"
@@ -406,14 +399,13 @@ if(WITH_COVERAGE)
                 "$<TARGET_FILE:keepassxc-proxy>")
         setup_target_for_coverage_llvm(
                 NAME coverage
-                EXECUTABLE $(MAKE) test
                 BINARY ${MAIN_BINARIES}
-                SOURCES ${CMAKE_SOURCE_DIR}/src
+                SOURCES_ROOT ${CMAKE_SOURCE_DIR}/src
         )
     else()
         setup_target_for_coverage_gcovr(
                 NAME coverage
-                EXECUTABLE $(MAKE) test
+                SOURCES_ROOT ${CMAKE_SOURCE_DIR}/src
         )
     endif()
 endif()

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -2,5 +2,7 @@ coverage:
   range: 60..80
   round: nearest
   precision: 2
+fixes:
+  - "*/src/::"
 comment:
   require_changes: true


### PR DESCRIPTION
CTest is now run directly and `make coverage` (like `make test`) now expects you to run `make` beforehand, which is more flexible for the user. This patch also reduces clutter by properly excluding unwanted files and reduces the number of explicit exlusion regexes that are required.

Gcov reports are still confusing and report very low branch coverage (which is picked up by Codecov, unfortunately), but the llvm-cov reports are nice and clean now.

The updated codecov.yaml fixes mapping issues between files in the report and the repository.

Seems like these changes now also fix coverage report generation on our CI.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)