### PR TITLE
Support sorting HTML export

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2218,14 +2218,6 @@ This is definitely a bug, please report it to the developers.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Export database to HTML file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>HTML file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Writing the HTML file failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3834,6 +3826,47 @@ Would you like to overwrite the existing attachment?</source>
     <message>
         <source>Reset to defaults</source>
         <translation>Reset to defaults</translation>
+    </message>
+</context>
+<context>
+    <name>ExportDialog</name>
+    <message>
+        <source>Export options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You are about to export your database to an unencrypted file.
+This will leave your passwords and sensitive information vulnerable!
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export database to HTML file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTML file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>database order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name (ascending)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>name (descending)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sort entries by...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,7 @@ set(keepassx_SOURCES
         gui/entry/EntryHistoryModel.cpp
         gui/entry/EntryModel.cpp
         gui/entry/EntryView.cpp
+        gui/export/ExportDialog.cpp
         gui/group/EditGroupWidget.cpp
         gui/group/GroupModel.cpp
         gui/group/GroupView.cpp

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -100,6 +100,7 @@ private slots:
     void emitActiveDatabaseChanged();
     void emitDatabaseLockChanged();
     void handleDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
+    void handleExportError(const QString& reason);
 
 private:
     QSharedPointer<Database> execNewDatabaseWizard();

--- a/src/gui/HtmlExporter.h
+++ b/src/gui/HtmlExporter.h
@@ -28,12 +28,22 @@ class QIODevice;
 class HtmlExporter
 {
 public:
-    bool exportDatabase(const QString& filename, const QSharedPointer<const Database>& db);
+    bool exportDatabase(const QString& filename,
+                        const QSharedPointer<const Database>& db,
+                        bool sorted = true,
+                        bool ascending = true);
     QString errorString() const;
 
 private:
-    bool exportDatabase(QIODevice* device, const QSharedPointer<const Database>& db);
-    bool writeGroup(QIODevice& device, const Group& group, QString path = QString());
+    bool exportDatabase(QIODevice* device,
+                        const QSharedPointer<const Database>& db,
+                        bool sorted = true,
+                        bool ascending = true);
+    bool writeGroup(QIODevice& device,
+                    const Group& group,
+                    QString path = QString(),
+                    bool sorted = true,
+                    bool ascending = true);
 
     QString m_error;
 };

--- a/src/gui/export/ExportDialog.cpp
+++ b/src/gui/export/ExportDialog.cpp
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ExportDialog.h"
+#include "ui_ExportDialog.h"
+
+#include "gui/FileDialog.h"
+#include "gui/HtmlExporter.h"
+
+ExportDialog::ExportDialog(QSharedPointer<const Database> db, DatabaseTabWidget* parent)
+    : QDialog(parent)
+    , m_ui(new Ui::ExportDialog())
+    , m_db(std::move(db))
+{
+    m_ui->setupUi(this);
+
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(close()));
+    connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(exportDatabase()));
+
+    m_ui->sortingStrategy->addItem(getStrategyName(BY_NAME_ASC), BY_NAME_ASC);
+    m_ui->sortingStrategy->addItem(getStrategyName(BY_NAME_DESC), BY_NAME_DESC);
+    m_ui->sortingStrategy->addItem(getStrategyName(BY_DATABASE_ORDER), BY_DATABASE_ORDER);
+
+    m_ui->messageWidget->setCloseButtonVisible(false);
+    m_ui->messageWidget->setAutoHideTimeout(-1);
+    m_ui->messageWidget->showMessage(tr("You are about to export your database to an unencrypted file.\n"
+                                        "This will leave your passwords and sensitive information vulnerable!\n"),
+                                     MessageWidget::Warning);
+}
+
+ExportDialog::~ExportDialog()
+{
+}
+
+QString ExportDialog::getStrategyName(ExportSortingStrategy strategy)
+{
+    switch (strategy) {
+    case ExportSortingStrategy::BY_DATABASE_ORDER:
+        return tr("database order");
+    case ExportSortingStrategy::BY_NAME_ASC:
+        return tr("name (ascending)");
+    case ExportSortingStrategy::BY_NAME_DESC:
+        return tr("name (descending)");
+    }
+    return tr("unknown");
+}
+
+void ExportDialog::exportDatabase()
+{
+    auto sortBy = m_ui->sortingStrategy->currentData().toInt();
+    bool ascendingOrder = sortBy == ExportSortingStrategy::BY_NAME_ASC;
+
+    const QString fileName = fileDialog()->getSaveFileName(
+        this, tr("Export database to HTML file"), FileDialog::getLastDir("html"), tr("HTML file").append(" (*.html)"));
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    FileDialog::saveLastDir("html", fileName, true);
+
+    HtmlExporter htmlExporter;
+    if (!htmlExporter.exportDatabase(
+            fileName, m_db, sortBy != ExportSortingStrategy::BY_DATABASE_ORDER, ascendingOrder)) {
+        emit exportFailed(htmlExporter.errorString());
+        reject();
+    }
+
+    accept();
+}

--- a/src/gui/export/ExportDialog.h
+++ b/src/gui/export/ExportDialog.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_EXPORTDIALOG_H
+#define KEEPASSXC_EXPORTDIALOG_H
+
+#include "core/Database.h"
+#include "gui/DatabaseTabWidget.h"
+#include <QDialog>
+
+namespace Ui
+{
+    class ExportDialog;
+}
+
+class ExportDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ExportDialog(QSharedPointer<const Database> db, DatabaseTabWidget* parent = nullptr);
+    ~ExportDialog() override;
+
+    enum ExportSortingStrategy
+    {
+        BY_DATABASE_ORDER = 0,
+        BY_NAME_ASC = 1,
+        BY_NAME_DESC = 2
+    };
+
+signals:
+    void exportFailed(QString reason);
+
+private slots:
+    void exportDatabase();
+
+private:
+    QString getStrategyName(ExportSortingStrategy strategy);
+
+    QScopedPointer<Ui::ExportDialog> m_ui;
+    QSharedPointer<const Database> m_db;
+};
+
+#endif // KEEPASSXC_EXPORTDIALOG_H

--- a/src/gui/export/ExportDialog.ui
+++ b/src/gui/export/ExportDialog.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExportDialog</class>
+ <widget class="QDialog" name="ExportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>186</width>
+    <height>164</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Export options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="MessageWidget" name="messageWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="sortingStrategyLabel">
+     <property name="text">
+      <string>Sort entries by...</string>
+     </property>
+     <property name="buddy">
+      <cstring>sortingStrategy</cstring>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="sortingStrategy">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MessageWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/MessageWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Resolved #6164.

- Implement sorting support in HtmlExporter
- Add ExportDialog class and UI, which allows to configure export options.

## Screenshots

Current integration:
![kpx1](https://user-images.githubusercontent.com/42714034/135755196-8236fd5f-11a8-4394-8b92-0e184186f626.png)

The export dialog:
![kpx2](https://user-images.githubusercontent.com/42714034/135755190-7ac81281-510f-429e-a1ea-ce33fbc1c751.png)

Export in descending order:
![descending-order](https://user-images.githubusercontent.com/42714034/135755093-3c65e6d5-bd99-457c-b515-5caa97aaa170.png)
Export in ascending order:
![ascending-order](https://user-images.githubusercontent.com/42714034/135755088-b9e95e67-cfb2-4030-bcb7-611a6a9c55f2.png)
Export in database order:
![database-order](https://user-images.githubusercontent.com/42714034/135755091-398c8355-92e2-4d36-94b4-d5c1665c2d70.png)

## Testing strategy
Test on local databases.



## Type of change
- ✅ New feature (change that adds functionality)
- Implements feature request #6164 

## Open issues
- The "ascending" option has no effect when database order is selected. Should the checkbox be disabled in that case or should we remove the "database order" option? I think it probably only causes confusion anyway.
- How about testing? I'd propose to compare the generated .html files to expected output on a test database. I'd reuse the ones in tests/data/*.kdbx for this purpose.

## Discussion / Future work

### Common Exporter Interfance
Both CSV & HTML Exporter share a lot of functionality, especially if we want to include support for sorting, exporting only specific groups, etc. in the future. This should also make implementing new exporters easier. I think we should address this issue and refactor in a future PR. 
- Common Exporter Dialog
- Move Enum to Exporter