### PR TITLE
Fix broken browser integration since #6899

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -324,7 +324,7 @@ namespace Tools
         }
 
         const auto uuid = hexToUuid(uuidStr);
-        if (uuid.isNull() || uuid.version() == QUuid::VerUnknown) {
+        if (uuid.isNull()) {
             return false;
         }
 

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -48,7 +48,7 @@ void TestTools::testHumanReadableFileSize()
 void TestTools::testIsHex()
 {
     QVERIFY(Tools::isHex("0123456789abcdefABCDEF"));
-    QVERIFY(not Tools::isHex(QByteArray("0xnothex")));
+    QVERIFY(!Tools::isHex(QByteArray("0xnothex")));
 }
 
 void TestTools::testIsBase64()
@@ -59,9 +59,9 @@ void TestTools::testIsBase64()
     QVERIFY(Tools::isBase64(QByteArray("abcd9876MN==")));
     QVERIFY(Tools::isBase64(QByteArray("abcd9876DEFGhijkMNO=")));
     QVERIFY(Tools::isBase64(QByteArray("abcd987/DEFGh+jk/NO=")));
-    QVERIFY(not Tools::isBase64(QByteArray("abcd123==")));
-    QVERIFY(not Tools::isBase64(QByteArray("abc_")));
-    QVERIFY(not Tools::isBase64(QByteArray("123")));
+    QVERIFY(!Tools::isBase64(QByteArray("abcd123==")));
+    QVERIFY(!Tools::isBase64(QByteArray("abc_")));
+    QVERIFY(!Tools::isBase64(QByteArray("123")));
 }
 
 void TestTools::testEnvSubstitute()
@@ -103,8 +103,8 @@ void TestTools::testValidUuid()
      * UUIDs are simply random 16-byte strings. Such older entries should be
      * accepted as well. */
     QVERIFY(Tools::isValidUuid(nonRfc4122Uuid));
-    QVERIFY(not Tools::isValidUuid(emptyUuid));
-    QVERIFY(not Tools::isValidUuid(shortUuid));
-    QVERIFY(not Tools::isValidUuid(longUuid));
-    QVERIFY(not Tools::isValidUuid(nonHexUuid));
+    QVERIFY(!Tools::isValidUuid(emptyUuid));
+    QVERIFY(!Tools::isValidUuid(shortUuid));
+    QVERIFY(!Tools::isValidUuid(longUuid));
+    QVERIFY(!Tools::isValidUuid(nonHexUuid));
 }

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -92,14 +92,17 @@ void TestTools::testEnvSubstitute()
 void TestTools::testValidUuid()
 {
     auto validUuid = Tools::uuidToHex(QUuid::createUuid());
-    auto nonValidUuid = "1234567890abcdef1234567890abcdef";
+    auto nonRfc4122Uuid = "1234567890abcdef1234567890abcdef";
     auto emptyUuid = QString();
     auto shortUuid = validUuid.left(10);
     auto longUuid = validUuid + "baddata";
     auto nonHexUuid = Tools::uuidToHex(QUuid::createUuid()).replace(0, 1, 'p');
 
     QVERIFY(Tools::isValidUuid(validUuid));
-    QVERIFY(not Tools::isValidUuid(nonValidUuid));
+    /* Before https://github.com/keepassxreboot/keepassxc/pull/1770/, entry
+     * UUIDs are simply random 16-byte strings. Such older entries should be
+     * accepted as well. */
+    QVERIFY(Tools::isValidUuid(nonRfc4122Uuid));
     QVERIFY(not Tools::isValidUuid(emptyUuid));
     QVERIFY(not Tools::isValidUuid(shortUuid));
     QVERIFY(not Tools::isValidUuid(longUuid));


### PR DESCRIPTION
This patch fixes a regression from
https://github.com/keepassxreboot/keepassxc/pull/6899.

Before https://github.com/keepassxreboot/keepassxc/pull/1770, entry
UUIDs are simply random 16-byte strings. On the other hand, since
PR #6899, only RFC4122 UUIDs with a valid version are accepted. As a
result, browser actions passing a UUID (ex: get_totp) are rejected with
"No valid UUID provided" for older entries.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
N/A

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual using old entries with TOTP set up

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
