### PR TITLE
Add --minimize flag

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -7273,6 +7273,10 @@ Please consider generating a new key file.</source>
         <source>%1 (invalid executable path)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Start application minimized or minimize existing running application</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QtIOCompressor</name>

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -307,9 +307,8 @@ void Application::socketReadyRead()
     quint32 id;
     in >> id;
 
-    // TODO: move constants to enum
     switch (id) {
-    case 1:
+    case IpcMessages::OPEN_DATABASE:
         in >> fileNames;
         for (const QString& fileName : asConst(fileNames)) {
             const QFileInfo fInfo(fileName);
@@ -319,7 +318,7 @@ void Application::socketReadyRead()
         }
 
         break;
-    case 2:
+    case IpcMessages::LOCK_DATABASE:
         getMainWindow()->lockAllDatabases();
         break;
     }
@@ -355,7 +354,7 @@ bool Application::sendFileNamesToRunningInstance(const QStringList& fileNames)
     QDataStream out(&data, QIODevice::WriteOnly);
     out.setVersion(QDataStream::Qt_5_0);
     out << quint32(0); // reserve space for block size
-    out << quint32(1); // ID for file name send. TODO: move to enum
+    out << quint32(IpcMessages::OPEN_DATABASE);
     out << fileNames; // send file names to be opened
     out.device()->seek(0);
     out << quint32(data.size() - sizeof(quint32)); // replace the previous constant 0 with block size
@@ -387,7 +386,7 @@ bool Application::sendLockToInstance()
     QDataStream out(&data, QIODevice::WriteOnly);
     out.setVersion(QDataStream::Qt_5_0);
     out << quint32(0); // reserve space for block size
-    out << quint32(2); // ID for database lock. TODO: move to enum
+    out << quint32(IpcMessages::LOCK_DATABASE);
     out.device()->seek(0);
     out << quint32(data.size() - sizeof(quint32)); // replace the previous constant 0 with block size
 

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -50,6 +50,7 @@ public:
 
     bool sendFileNamesToRunningInstance(const QStringList& fileNames);
     bool sendLockToInstance();
+    bool sendMinimize();
 
     void restart();
 
@@ -84,7 +85,8 @@ private:
 
     enum IpcMessages {
         OPEN_DATABASE = 1,
-        LOCK_DATABASE = 2
+        LOCK_DATABASE = 2,
+        MINIMIZE
     };
 };
 

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -83,7 +83,8 @@ private:
     QLocalServer m_lockServer;
     QString m_socketName;
 
-    enum IpcMessages {
+    enum IpcMessages
+    {
         OPEN_DATABASE = 1,
         LOCK_DATABASE = 2,
         MINIMIZE

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -81,6 +81,11 @@ private:
     QLockFile* m_lockFile;
     QLocalServer m_lockServer;
     QString m_socketName;
+
+    enum IpcMessages {
+        OPEN_DATABASE = 1,
+        LOCK_DATABASE = 2
+    };
 };
 
 #define kpxcApp qobject_cast<Application*>(Application::instance())

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -90,7 +90,8 @@ MainWindow* getMainWindow()
 }
 
 MainWindow::MainWindow(bool startMinimized)
-    : m_ui(new Ui::MainWindow()), m_startMinimized(startMinimized)
+    : m_ui(new Ui::MainWindow())
+    , m_startMinimized(startMinimized)
 {
     g_MainWindow = this;
 
@@ -1729,7 +1730,7 @@ void MainWindow::hideYubiKeyPopup()
 void MainWindow::bringToFront()
 {
     ensurePolished();
-    if(m_startMinimized) {
+    if (m_startMinimized) {
         setWindowState(Qt::WindowMinimized);
         showMinimized();
     } else {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -89,8 +89,8 @@ MainWindow* getMainWindow()
     return g_MainWindow;
 }
 
-MainWindow::MainWindow()
-    : m_ui(new Ui::MainWindow())
+MainWindow::MainWindow(bool startMinimized)
+    : m_ui(new Ui::MainWindow()), m_startMinimized(startMinimized)
 {
     g_MainWindow = this;
 
@@ -1729,10 +1729,15 @@ void MainWindow::hideYubiKeyPopup()
 void MainWindow::bringToFront()
 {
     ensurePolished();
-    setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
-    show();
-    raise();
-    activateWindow();
+    if(m_startMinimized) {
+        setWindowState(Qt::WindowMinimized);
+        showMinimized();
+    } else {
+        setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+        show();
+        raise();
+        activateWindow();
+    }
 }
 
 void MainWindow::handleScreenLock()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -47,7 +47,7 @@ class MainWindow : public QMainWindow
 #endif
 
 public:
-    MainWindow();
+    MainWindow(bool startMinimized);
     ~MainWindow();
 
     QList<DatabaseWidget*> getOpenDatabases();
@@ -192,6 +192,7 @@ private:
     QTimer m_updateCheckTimer;
     QTimer m_trayIconTriggerTimer;
     QSystemTrayIcon::ActivationReason m_trayIconTriggerReason;
+    bool m_startMinimized = false;
 
     friend class MainWindowEventFilter;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,7 +74,8 @@ int main(int argc, char** argv)
     QCommandLineOption pwstdinOption("pw-stdin", QObject::tr("read password of the database from stdin"));
     QCommandLineOption allowScreenCaptureOption("allow-screencapture",
                                                 QObject::tr("allow app screen recordering and screenshots"));
-    QCommandLineOption minimizeOption("minimize", QObject::tr("Start application minimized or minimize existing running application"));
+    QCommandLineOption minimizeOption(
+        "minimize", QObject::tr("Start application minimized or minimize existing running application"));
 
     QCommandLineOption helpOption = parser.addHelpOption();
     QCommandLineOption versionOption = parser.addVersionOption();
@@ -122,7 +123,7 @@ int main(int argc, char** argv)
                 qWarning() << QObject::tr("Database failed to lock.").toUtf8().constData();
                 return EXIT_FAILURE;
             }
-        } else if(parser.isSet(minimizeOption)) {
+        } else if (parser.isSet(minimizeOption)) {
             app.sendMinimize();
         } else {
             if (!fileNames.isEmpty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,7 @@ int main(int argc, char** argv)
     QCommandLineOption pwstdinOption("pw-stdin", QObject::tr("read password of the database from stdin"));
     QCommandLineOption allowScreenCaptureOption("allow-screencapture",
                                                 QObject::tr("allow app screen recordering and screenshots"));
+    QCommandLineOption minimizeOption("minimize", QObject::tr("Start application minimized or minimize existing running application"));
 
     QCommandLineOption helpOption = parser.addHelpOption();
     QCommandLineOption versionOption = parser.addVersionOption();
@@ -84,6 +85,7 @@ int main(int argc, char** argv)
     parser.addOption(keyfileOption);
     parser.addOption(pwstdinOption);
     parser.addOption(debugInfoOption);
+    parser.addOption(minimizeOption);
 
     if (osUtils->canPreventScreenCapture()) {
         parser.addOption(allowScreenCaptureOption);
@@ -120,6 +122,8 @@ int main(int argc, char** argv)
                 qWarning() << QObject::tr("Database failed to lock.").toUtf8().constData();
                 return EXIT_FAILURE;
             }
+        } else if(parser.isSet(minimizeOption)) {
+            app.sendMinimize();
         } else {
             if (!fileNames.isEmpty()) {
                 app.sendFileNamesToRunningInstance(fileNames);
@@ -147,7 +151,7 @@ int main(int argc, char** argv)
 
     Application::bootstrap();
 
-    MainWindow mainWindow;
+    MainWindow mainWindow(parser.isSet(minimizeOption));
 
 #ifndef QT_DEBUG
     // Disable screen capture if capable and not explicitly allowed

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -100,7 +100,7 @@ void TestGui::initTestCase()
 
     Application::bootstrap();
 
-    m_mainWindow.reset(new MainWindow());
+    m_mainWindow.reset(new MainWindow(false));
     m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
     m_mainWindow->show();
     m_mainWindow->resize(1024, 768);

--- a/tests/gui/TestGuiBrowser.cpp
+++ b/tests/gui/TestGuiBrowser.cpp
@@ -70,7 +70,7 @@ void TestGuiBrowser::initTestCase()
     // Disable the update check first time alert
     config()->set(Config::UpdateCheckMessageShown, true);
 
-    m_mainWindow.reset(new MainWindow());
+    m_mainWindow.reset(new MainWindow(false));
     m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
     m_mainWindow->show();
 }

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -147,7 +147,7 @@ void TestGuiFdoSecrets::initTestCase()
 
     Application::bootstrap();
 
-    m_mainWindow.reset(new MainWindow());
+    m_mainWindow.reset(new MainWindow(false));
     m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
     VERIFY(m_tabWidget);
     m_plugin = FdoSecretsPlugin::getPlugin();


### PR DESCRIPTION
# Add minimize flag

It does one of two things:
 - if keepassxc is NOT running, it starts a new instances but
   hides/minimizes it.
- if it is already running that instance is sent an IPC message to
    hide/minimize it.
    
Fixes #4507


## Testing strategy
`Application::isAlreadyRunning()` in debug mode allows infinite instances which disables the check in main.cpp `if(app.isAlreadyRunning())`. I just removed that part.

Then the testing strategy was:
```sh
$ build/src/keepassxc &
# keepass starts and is visible
$ build/src/keepassxc --minimize
# first instance is hidden, no second instance running
$ pkill keepassxc
$ build/src/keepassxc --minimize &
# new instance starts, hides itself
```

## Type of change
- ✅ New feature (change that adds functionality)
