### PR TITLE
Allow specifing database backup paths.

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -215,6 +215,10 @@
         <source>Monochrome</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select backup storage directory</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetGeneral</name>
@@ -438,6 +442,22 @@
     </message>
     <message>
         <source>Directly write to database file (dangerous)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backup destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specifies the database backup file location. Occurences of &quot;{DB_FILENAME}&quot; are replaced with the filename of the saved database without extension. {TIME:&lt;format&gt;} is replaced with the backup time, see https://doc.qt.io/qt-5/qdatetime.html#toString. &lt;format&gt; defaults to format string &quot;dd_MM_yyyy_hh-mm-ss&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>{DB_FILENAME}.old.kdbx</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -121,7 +121,7 @@ int Add::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<Q
     }
 
     QString errorMessage;
-    if (!database->save(Database::Atomic, false, &errorMessage)) {
+    if (!database->save(Database::Atomic, QString(), &errorMessage)) {
         err << QObject::tr("Writing the database failed %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/AddGroup.cpp
+++ b/src/cli/AddGroup.cpp
@@ -63,7 +63,7 @@ int AddGroup::executeWithDatabase(QSharedPointer<Database> database, QSharedPoin
     newGroup->setParent(parentGroup);
 
     QString errorMessage;
-    if (!database->save(Database::Atomic, false, &errorMessage)) {
+    if (!database->save(Database::Atomic, QString(), &errorMessage)) {
         err << QObject::tr("Writing the database failed %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Create.cpp
+++ b/src/cli/Create.cpp
@@ -165,7 +165,7 @@ int Create::execute(const QStringList& arguments)
     }
 
     QString errorMessage;
-    if (!db->saveAs(databaseFilename, Database::Atomic, false, &errorMessage)) {
+    if (!db->saveAs(databaseFilename, Database::Atomic, QString(), &errorMessage)) {
         err << QObject::tr("Failed to save the database: %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -126,7 +126,7 @@ int Edit::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     entry->endUpdate();
 
     QString errorMessage;
-    if (!database->save(Database::Atomic, false, &errorMessage)) {
+    if (!database->save(Database::Atomic, QString(), &errorMessage)) {
         err << QObject::tr("Writing the database failed: %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -75,7 +75,7 @@ int Import::execute(const QStringList& arguments)
         return EXIT_FAILURE;
     }
 
-    if (!db->saveAs(dbPath, Database::Atomic, false, &errorMessage)) {
+    if (!db->saveAs(dbPath, Database::Atomic, QString(), &errorMessage)) {
         err << QObject::tr("Failed to save the database: %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -95,7 +95,7 @@ int Merge::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer
 
     if (!changeList.isEmpty() && !parser->isSet(Merge::DryRunOption)) {
         QString errorMessage;
-        if (!database->save(Database::Atomic, false, &errorMessage)) {
+        if (!database->save(Database::Atomic, QString(), &errorMessage)) {
             err << QObject::tr("Unable to save database to file : %1").arg(errorMessage) << endl;
             return EXIT_FAILURE;
         }

--- a/src/cli/Move.cpp
+++ b/src/cli/Move.cpp
@@ -65,7 +65,7 @@ int Move::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     entry->endUpdate();
 
     QString errorMessage;
-    if (!database->save(Database::Atomic, false, &errorMessage)) {
+    if (!database->save(Database::Atomic, QString(), &errorMessage)) {
         err << QObject::tr("Writing the database failed %1.").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -53,7 +53,7 @@ int Remove::executeWithDatabase(QSharedPointer<Database> database, QSharedPointe
     };
 
     QString errorMessage;
-    if (!database->save(Database::Atomic, false, &errorMessage)) {
+    if (!database->save(Database::Atomic, QString(), &errorMessage)) {
         err << QObject::tr("Unable to save database to file: %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/cli/RemoveGroup.cpp
+++ b/src/cli/RemoveGroup.cpp
@@ -63,7 +63,7 @@ int RemoveGroup::executeWithDatabase(QSharedPointer<Database> database, QSharedP
     };
 
     QString errorMessage;
-    if (!database->save(Database::Atomic, false, &errorMessage)) {
+    if (!database->save(Database::Atomic, QString(), &errorMessage)) {
         err << QObject::tr("Unable to save database to file: %1").arg(errorMessage) << endl;
         return EXIT_FAILURE;
     }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -61,6 +61,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::AutoSaveOnExit,{QS("AutoSaveOnExit"), Roaming, true}},
     {Config::AutoSaveNonDataChanges,{QS("AutoSaveNonDataChanges"), Roaming, true}},
     {Config::BackupBeforeSave,{QS("BackupBeforeSave"), Roaming, false}},
+    {Config::BackupFilePathPattern,{QS("BackupFilePathPattern"), Roaming, QString("{DB_FILENAME}.old.kdbx")}},
     {Config::UseAtomicSaves,{QS("UseAtomicSaves"), Roaming, true}},
     {Config::UseDirectWriteSaves,{QS("UseDirectWriteSaves"), Local, false}},
     {Config::SearchLimitGroup,{QS("SearchLimitGroup"), Roaming, false}},
@@ -227,6 +228,11 @@ QVariant Config::get(ConfigKey key)
         return m_localSettings->value(cfg.name, defaultValue);
     }
     return m_settings->value(cfg.name, defaultValue);
+}
+
+QVariant Config::getDefault(Config::ConfigKey key)
+{
+    return configStrings[key].defaultValue;
 }
 
 bool Config::hasAccessError()

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -43,6 +43,7 @@ public:
         AutoSaveOnExit,
         AutoSaveNonDataChanges,
         BackupBeforeSave,
+        BackupFilePathPattern,
         UseAtomicSaves,
         UseDirectWriteSaves,
         SearchLimitGroup,
@@ -195,6 +196,7 @@ public:
 
     ~Config() override;
     QVariant get(ConfigKey key);
+    QVariant getDefault(ConfigKey key);
     QString getFileName();
     void set(ConfigKey key, const QVariant& value);
     void remove(ConfigKey key);

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -79,8 +79,11 @@ public:
               QSharedPointer<const CompositeKey> key,
               QString* error = nullptr,
               bool readOnly = false);
-    bool save(SaveAction action = Atomic, bool backup = false, QString* error = nullptr);
-    bool saveAs(const QString& filePath, SaveAction action = Atomic, bool backup = false, QString* error = nullptr);
+    bool save(SaveAction action = Atomic, const QString& backupFilePath = QString(), QString* error = nullptr);
+    bool saveAs(const QString& filePath,
+                SaveAction action = Atomic,
+                const QString& backupFilePath = QString(),
+                QString* error = nullptr);
     bool extract(QByteArray&, QString* error = nullptr);
     bool import(const QString& xmlExportPath, QString* error = nullptr);
 
@@ -203,9 +206,9 @@ private:
     void createRecycleBin();
 
     bool writeDatabase(QIODevice* device, QString* error = nullptr);
-    bool backupDatabase(const QString& filePath);
-    bool restoreDatabase(const QString& filePath);
-    bool performSave(const QString& filePath, SaveAction flags, bool backup, QString* error);
+    bool backupDatabase(const QString& filePath, const QString& destinationFilePath);
+    bool restoreDatabase(const QString& filePath, const QString& fromBackupFilePath);
+    bool performSave(const QString& filePath, SaveAction flags, const QString& backupFilePath, QString* error);
     void startModifiedTimer();
     void stopModifiedTimer();
 

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -21,6 +21,7 @@
 
 #include "core/Global.h"
 
+#include <QDateTime>
 #include <QProcessEnvironment>
 
 class QIODevice;
@@ -75,6 +76,11 @@ namespace Tools
     }
 
     QVariantMap qo2qvm(const QObject* object, const QStringList& ignoredProperties = {"objectName"});
+
+    QString substituteBackupFilePathPattern(QString pattern,
+                                            const QString& databasePath,
+                                            QDateTime date = QDateTime::currentDateTime(),
+                                            int maxSubstitutions = 100);
 } // namespace Tools
 
 #endif // KEEPASSX_TOOLS_H

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -21,7 +21,6 @@
 
 #include "core/Global.h"
 
-#include <QDateTime>
 #include <QProcessEnvironment>
 
 class QIODevice;
@@ -77,10 +76,7 @@ namespace Tools
 
     QVariantMap qo2qvm(const QObject* object, const QStringList& ignoredProperties = {"objectName"});
 
-    QString substituteBackupFilePathPattern(QString pattern,
-                                            const QString& databasePath,
-                                            QDateTime date = QDateTime::currentDateTime(),
-                                            int maxSubstitutions = 100);
+    QString substituteBackupFilePath(QString pattern, const QString& databasePath);
 } // namespace Tools
 
 #endif // KEEPASSX_TOOLS_H

--- a/src/gui/ApplicationSettingsWidget.h
+++ b/src/gui/ApplicationSettingsWidget.h
@@ -62,6 +62,7 @@ private slots:
     void systrayToggled(bool checked);
     void rememberDatabasesToggled(bool checked);
     void checkUpdatesToggled(bool checked);
+    void selectBackupDirectory();
 
 private:
     QWidget* const m_secWidget;

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -58,8 +58,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>581</width>
-            <height>924</height>
+            <width>664</width>
+            <height>1215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -277,6 +277,52 @@
                  <string>Backup database file before saving</string>
                 </property>
                </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <item>
+                 <widget class="QLabel" name="label">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Backup destination</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>backupFilePath</cstring>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="backupFilePath">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="toolTip">
+                   <string>Specifies the database backup file location. Occurences of &quot;{DB_FILENAME}&quot; are replaced with the filename of the saved database without extension. {TIME:&lt;format&gt;} is replaced with the backup time, see https://doc.qt.io/qt-5/qdatetime.html#toString. &lt;format&gt; defaults to format string &quot;dd_MM_yyyy_hh-mm-ss&quot;.</string>
+                  </property>
+                  <property name="placeholderText">
+                   <string>{DB_FILENAME}.old.kdbx</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="backupFilePathPicker">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="text">
+                   <string>Choose...</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_5"/>
               </item>
               <item>
                <widget class="QCheckBox" name="useAlternativeSaveCheckBox">

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1889,7 +1889,7 @@ bool DatabaseWidget::performSave(QString& errorMessage, const QString& fileName)
         }
 
         QFileInfo dbFileInfo(m_db->filePath());
-        backupFilePath = Tools::substituteBackupFilePathPattern(backupFilePath, dbFileInfo.canonicalFilePath());
+        backupFilePath = Tools::substituteBackupFilePath(backupFilePath, dbFileInfo.canonicalFilePath());
         if (!backupFilePath.isNull()) {
             // Note that we cannot guarantee that backupFilePath is actually a valid filename. QT currently provides
             // no function for this. Moreover, we don't check if backupFilePath is a file and not a directory.

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -27,6 +27,7 @@
 #include <QProcess>
 #include <QSplitter>
 #include <QTextEdit>
+#include <core/Tools.h>
 
 #include "autotype/AutoType.h"
 #include "core/EntrySearcher.h"
@@ -1879,11 +1880,31 @@ bool DatabaseWidget::performSave(QString& errorMessage, const QString& fileName)
         }
     }
 
+    QString backupFilePath;
+    if (config()->get(Config::BackupBeforeSave).toBool()) {
+        backupFilePath = config()->get(Config::BackupFilePathPattern).toString();
+        // Fall back to default
+        if (backupFilePath.isEmpty()) {
+            backupFilePath = config()->getDefault(Config::BackupFilePathPattern).toString();
+        }
+
+        QFileInfo dbFileInfo(m_db->filePath());
+        backupFilePath = Tools::substituteBackupFilePathPattern(backupFilePath, dbFileInfo.canonicalFilePath());
+        if (!backupFilePath.isNull()) {
+            // Note that we cannot guarantee that backupFilePath is actually a valid filename. QT currently provides
+            // no function for this. Moreover, we don't check if backupFilePath is a file and not a directory.
+            // If this isn't the case, just let the backup fail.
+            if (QDir::isRelativePath(backupFilePath)) {
+                backupFilePath = QDir::cleanPath(dbFileInfo.absolutePath() + QDir::separator() + backupFilePath);
+            }
+        }
+    }
+
     bool ok;
     if (fileName.isEmpty()) {
-        ok = m_db->save(saveAction, config()->get(Config::BackupBeforeSave).toBool(), &errorMessage);
+        ok = m_db->save(saveAction, backupFilePath, &errorMessage);
     } else {
-        ok = m_db->saveAs(fileName, saveAction, config()->get(Config::BackupBeforeSave).toBool(), &errorMessage);
+        ok = m_db->saveAs(fileName, saveAction, backupFilePath, &errorMessage);
     }
 
     // Return control

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -75,29 +75,26 @@ void TestDatabase::testSave()
     // Test safe saves
     db->metadata()->setName("test");
     QVERIFY(db->isModified());
-    QVERIFY2(db->save(Database::Atomic, false, &error), error.toLatin1());
+    QVERIFY2(db->save(Database::Atomic, QString(), &error), error.toLatin1());
     QVERIFY(!db->isModified());
 
     // Test temp-file saves
     db->metadata()->setName("test2");
-    QVERIFY2(db->save(Database::TempFile, false, &error), error.toLatin1());
+    QVERIFY2(db->save(Database::TempFile, QString(), &error), error.toLatin1());
     QVERIFY(!db->isModified());
 
     // Test direct-write saves
     db->metadata()->setName("test3");
-    QVERIFY2(db->save(Database::DirectWrite, false, &error), error.toLatin1());
+    QVERIFY2(db->save(Database::DirectWrite, QString(), &error), error.toLatin1());
     QVERIFY(!db->isModified());
 
     // Test save backups
+    TemporaryFile backupFile;
+    auto backupFilePath = backupFile.fileName();
     db->metadata()->setName("test4");
-    QVERIFY2(db->save(Database::Atomic, true, &error), error.toLatin1());
+    QVERIFY2(db->save(Database::Atomic, backupFilePath, &error), error.toLatin1());
     QVERIFY(!db->isModified());
 
-    // Confirm backup exists and then delete it
-    auto re = QRegularExpression("(\\.[^.]+)$");
-    auto match = re.match(tempFile.fileName());
-    auto backupFilePath = tempFile.fileName();
-    backupFilePath = backupFilePath.replace(re, "") + ".old" + match.captured(1);
     QVERIFY(QFile::exists(backupFilePath));
     QFile::remove(backupFilePath);
     QVERIFY(!QFile::exists(backupFilePath));
@@ -123,7 +120,7 @@ void TestDatabase::testSignals()
     QTRY_COMPARE(spyModified.count(), 1);
 
     QSignalSpy spySaved(db.data(), SIGNAL(databaseSaved()));
-    QVERIFY(db->save(Database::Atomic, false, &error));
+    QVERIFY(db->save(Database::Atomic, QString(), &error));
     QCOMPARE(spySaved.count(), 1);
 
     // Short delay to allow file system settling to reduce test failures

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -17,6 +17,8 @@
 
 #include "TestTools.h"
 
+#include "core/Clock.h"
+
 #include <QTest>
 
 QTEST_GUILESS_MAIN(TestTools)
@@ -113,63 +115,50 @@ void TestTools::testBackupFilePatternSubstitution_data()
 {
     QTest::addColumn<QString>("pattern");
     QTest::addColumn<QString>("dbFilePath");
-    QTest::addColumn<QDateTime>("date");
-    QTest::addColumn<int>("maxSubstitutions");
     QTest::addColumn<QString>("expectedSubstitution");
 
     static const auto DEFAULT_DB_FILE_NAME = QStringLiteral("KeePassXC");
     static const auto DEFAULT_DB_FILE_PATH = QStringLiteral("/tmp/") + DEFAULT_DB_FILE_NAME + QStringLiteral(".kdbx");
-    static const auto NOW = QDateTime::currentDateTime();
+    static const auto NOW = Clock::currentDateTime();
     auto DEFAULT_FORMATTED_TIME = NOW.toString("dd_MM_yyyy_hh-mm-ss");
 
-    QTest::newRow("Null pattern") << QString() << DEFAULT_DB_FILE_PATH << NOW << 100 << QString();
-    QTest::newRow("Empty pattern") << QString("") << DEFAULT_DB_FILE_PATH << NOW << 100 << QString("");
-    QTest::newRow("Null database path") << "valid_pattern" << QString() << NOW << 100 << QString();
-    QTest::newRow("Empty database path") << "valid_pattern" << QString("") << NOW << 100 << QString();
-    QTest::newRow("Unclosed/invalid pattern") << "{DB_FILENAME" << DEFAULT_DB_FILE_PATH << NOW << 100 << "{DB_FILENAME";
-    QTest::newRow("Unknown pattern") << "{NO_MATCH}" << DEFAULT_DB_FILE_PATH << NOW << 100 << "{NO_MATCH}";
+    QTest::newRow("Null pattern") << QString() << DEFAULT_DB_FILE_PATH << QString();
+    QTest::newRow("Empty pattern") << QString("") << DEFAULT_DB_FILE_PATH << QString("");
+    QTest::newRow("Null database path") << "valid_pattern" << QString() << QString();
+    QTest::newRow("Empty database path") << "valid_pattern" << QString("") << QString();
+    QTest::newRow("Unclosed/invalid pattern") << "{DB_FILENAME" << DEFAULT_DB_FILE_PATH << "{DB_FILENAME";
+    QTest::newRow("Unknown pattern") << "{NO_MATCH}" << DEFAULT_DB_FILE_PATH << "{NO_MATCH}";
     QTest::newRow("Do not replace escaped patterns (filename)")
-        << "\\{DB_FILENAME\\}" << DEFAULT_DB_FILE_PATH << NOW << 100 << "{DB_FILENAME}";
+        << "\\{DB_FILENAME\\}" << DEFAULT_DB_FILE_PATH << "{DB_FILENAME}";
     QTest::newRow("Do not replace escaped patterns (time)")
-        << "\\{TIME:dd.MM.yyyy\\}" << DEFAULT_DB_FILE_PATH << NOW << 100 << "{TIME:dd.MM.yyyy}";
+        << "\\{TIME:dd.MM.yyyy\\}" << DEFAULT_DB_FILE_PATH << "{TIME:dd.MM.yyyy}";
     QTest::newRow("Multiple patterns should be replaced")
-        << "{DB_FILENAME} {TIME} {DB_FILENAME}" << DEFAULT_DB_FILE_PATH << NOW << 100
+        << "{DB_FILENAME} {TIME} {DB_FILENAME}" << DEFAULT_DB_FILE_PATH
         << DEFAULT_DB_FILE_NAME + QStringLiteral(" ") + DEFAULT_FORMATTED_TIME + QStringLiteral(" ")
                + DEFAULT_DB_FILE_NAME;
-    QTest::newRow("Default time pattern") << "{TIME}" << DEFAULT_DB_FILE_PATH << NOW << 100 << DEFAULT_FORMATTED_TIME;
+    QTest::newRow("Default time pattern") << "{TIME}" << DEFAULT_DB_FILE_PATH << DEFAULT_FORMATTED_TIME;
     QTest::newRow("Default time pattern (empty formatter)")
-        << "{TIME:}" << DEFAULT_DB_FILE_PATH << NOW << 100 << DEFAULT_FORMATTED_TIME;
-    QTest::newRow("Custom time pattern") << "{TIME:dd-ss}" << DEFAULT_DB_FILE_PATH << NOW << 100
-                                         << NOW.toString("dd-ss");
-    QTest::newRow("Invalid custom time pattern")
-        << "{TIME:dd/-ss}" << DEFAULT_DB_FILE_PATH << NOW << 100 << NOW.toString("dd/-ss");
-    QTest::newRow("Recursive substitution")
-        << "{TIME:'{TIME}'}" << DEFAULT_DB_FILE_PATH << NOW << 100 << DEFAULT_FORMATTED_TIME;
-    QTest::newRow("Substitution limit is respected")
-        << "{TIME} {TIME} {TIME}" << DEFAULT_DB_FILE_PATH << NOW << 2
-        << DEFAULT_FORMATTED_TIME + QStringLiteral(" ") + DEFAULT_FORMATTED_TIME + QStringLiteral(" {TIME}");
-    QTest::newRow("Substitution limit is respected (recursive)")
-        << "{TIME} {TIME} {TIME:'{TIME}'}" << DEFAULT_DB_FILE_PATH << NOW << 3
-        << DEFAULT_FORMATTED_TIME + QStringLiteral(" ") + DEFAULT_FORMATTED_TIME + QStringLiteral(" {TIME}");
+        << "{TIME:}" << DEFAULT_DB_FILE_PATH << DEFAULT_FORMATTED_TIME;
+    QTest::newRow("Custom time pattern") << "{TIME:dd-ss}" << DEFAULT_DB_FILE_PATH << NOW.toString("dd-ss");
+    QTest::newRow("Invalid custom time pattern") << "{TIME:dd/-ss}" << DEFAULT_DB_FILE_PATH << NOW.toString("dd/-ss");
+    QTest::newRow("Recursive substitution") << "{TIME:'{TIME}'}" << DEFAULT_DB_FILE_PATH << DEFAULT_FORMATTED_TIME;
     QTest::newRow("{DB_FILENAME} substitution")
-        << "some {DB_FILENAME} thing" << DEFAULT_DB_FILE_PATH << NOW << 100
+        << "some {DB_FILENAME} thing" << DEFAULT_DB_FILE_PATH
         << QStringLiteral("some ") + DEFAULT_DB_FILE_NAME + QStringLiteral(" thing");
-    QTest::newRow("{DB_FILENAME} substitution with multiple extensions")
-        << "some {DB_FILENAME} thing"
-        << "/tmp/KeePassXC.kdbx.ext" << NOW << 100 << "some KeePassXC.kdbx thing";
+    QTest::newRow("{DB_FILENAME} substitution with multiple extensions") << "some {DB_FILENAME} thing"
+                                                                         << "/tmp/KeePassXC.kdbx.ext"
+                                                                         << "some KeePassXC.kdbx thing";
     // Not relevant right now, added test anyway
-    QTest::newRow("There should be no substitution loops")
-        << "{DB_FILENAME}"
-        << "{TIME:'{DB_FILENAME}'}.ext" << NOW << 100 << "{DB_FILENAME}";
+    QTest::newRow("There should be no substitution loops") << "{DB_FILENAME}"
+                                                           << "{TIME:'{DB_FILENAME}'}.ext"
+                                                           << "{DB_FILENAME}";
 }
 
 void TestTools::testBackupFilePatternSubstitution()
 {
     QFETCH(QString, pattern);
     QFETCH(QString, dbFilePath);
-    QFETCH(QDateTime, date);
-    QFETCH(int, maxSubstitutions);
     QFETCH(QString, expectedSubstitution);
 
-    QCOMPARE(Tools::substituteBackupFilePathPattern(pattern, dbFilePath, date, maxSubstitutions), expectedSubstitution);
+    QCOMPARE(Tools::substituteBackupFilePath(pattern, dbFilePath), expectedSubstitution);
 }

--- a/tests/TestTools.h
+++ b/tests/TestTools.h
@@ -29,6 +29,8 @@ private slots:
     void testIsBase64();
     void testEnvSubstitute();
     void testValidUuid();
+    void testBackupFilePatternSubstitution_data();
+    void testBackupFilePatternSubstitution();
 };
 
 #endif // KEEPASSX_TESTTOOLS_H

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -69,8 +69,8 @@ private slots:
 
 private:
     void addCannedEntries();
-    void checkDatabase(const QString& dbFileName, const QString& expectedDbName);
-    void checkDatabase(QString dbFileName = {});
+    void checkDatabase(const QString& filePath, const QString& expectedDbName);
+    void checkDatabase(const QString& filePath = {});
     void triggerAction(const QString& name);
     void dragAndDropGroup(const QModelIndex& sourceIndex,
                           const QModelIndex& targetIndex,

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -57,6 +57,8 @@ private slots:
     void testSaveAs();
     void testSaveBackup();
     void testSave();
+    void testSaveBackupPath();
+    void testSaveBackupPath_data();
     void testDatabaseSettings();
     void testKeePass1Import();
     void testDatabaseLocking();
@@ -67,7 +69,8 @@ private slots:
 
 private:
     void addCannedEntries();
-    void checkDatabase(QString dbFileName = "");
+    void checkDatabase(const QString& dbFileName, const QString& expectedDbName);
+    void checkDatabase(QString dbFileName = {});
     void triggerAction(const QString& name);
     void dragAndDropGroup(const QModelIndex& sourceIndex,
                           const QModelIndex& targetIndex,


### PR DESCRIPTION
Resolves #3279.

Allow to specify a custom backup location & filename. The filename may contain patterns "{DB_NAME}" and "{TIME:xxx}" which will be replaced with the database name and the current time, formatted according to "xxx", respectively.

The backup path can be relative or absolute. The former creates the backup relative to the database file.

The following changes have been made:
- `backupDatabase()` now takes a destination file path as argument
- Propagated method signature changes to `saveAs`, `save` and `performSave` functions
- Added a `getDefault(key)` method to `Config`. This returns the default value.
- Added new config keys `backupFileNamePattern` and `backupFilePath`
- Added textfields to `ApplicationSettingsWidget` accordingly

## Limitations/open issues (please comment)
- Old databases are not removed when the backup location changes. I believe this is out of scope and should not be the responsibility of keepassxc. Especially since there is no way to handle relative paths properly if this is required.
- A section on the structure of `backupFileNamePattern` needs to created. Or do you think it suffices to explain it in a tooltip?

## Screenshots
![image](https://user-images.githubusercontent.com/42714034/136691539-2abe9d2b-df77-49d5-8ea9-4db1bb477207.png)

## Testing strategy
Modified database backup unit test accordingly.

## Type of change
- ✅ New feature (change that adds functionality)
