### PR TITLE
Implement autosave timer.

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -441,11 +441,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically save the database every X seconds</source>
+        <source>Automatically save the database every X minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seconds</source>
+        <source>Minutes</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -440,6 +440,14 @@
         <source>Directly write to database file (dangerous)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Automatically save the database every X seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetSecurity</name>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -59,6 +59,8 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::AutoSaveAfterEveryChange,{QS("AutoSaveAfterEveryChange"), Roaming, true}},
     {Config::AutoReloadOnChange,{QS("AutoReloadOnChange"), Roaming, true}},
     {Config::AutoSaveOnExit,{QS("AutoSaveOnExit"), Roaming, true}},
+    {Config::AutoSaveTimerEnabled,{QS("AutoSaveTimerEnabled"), Roaming, true}},
+    {Config::AutoSaveInterval,{QS("AutoSaveInterval"), Roaming, 10*1000}}, // Autosave every 5 minutes by default
     {Config::AutoSaveNonDataChanges,{QS("AutoSaveNonDataChanges"), Roaming, true}},
     {Config::BackupBeforeSave,{QS("BackupBeforeSave"), Roaming, false}},
     {Config::UseAtomicSaves,{QS("UseAtomicSaves"), Roaming, true}},

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -59,8 +59,8 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::AutoSaveAfterEveryChange,{QS("AutoSaveAfterEveryChange"), Roaming, true}},
     {Config::AutoReloadOnChange,{QS("AutoReloadOnChange"), Roaming, true}},
     {Config::AutoSaveOnExit,{QS("AutoSaveOnExit"), Roaming, true}},
-    {Config::AutoSaveTimerEnabled,{QS("AutoSaveTimerEnabled"), Roaming, true}},
-    {Config::AutoSaveInterval,{QS("AutoSaveInterval"), Roaming, 10*1000}}, // Autosave every 5 minutes by default
+    {Config::AutoSaveTimerEnabled,{QS("AutoSaveTimerEnabled"), Roaming, false}},
+    {Config::AutoSaveInterval,{QS("AutoSaveInterval"), Roaming, 5*60*1000}}, // Autosave every 5 minutes by default
     {Config::AutoSaveNonDataChanges,{QS("AutoSaveNonDataChanges"), Roaming, true}},
     {Config::BackupBeforeSave,{QS("BackupBeforeSave"), Roaming, false}},
     {Config::UseAtomicSaves,{QS("UseAtomicSaves"), Roaming, true}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -42,6 +42,8 @@ public:
         AutoReloadOnChange,
         AutoSaveOnExit,
         AutoSaveNonDataChanges,
+        AutoSaveTimerEnabled,
+        AutoSaveInterval,
         BackupBeforeSave,
         UseAtomicSaves,
         UseDirectWriteSaves,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -113,7 +113,12 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
             m_generalUi->alternativeSaveComboBox, SLOT(setEnabled(bool)));
 
     connect(m_generalUi->enableAutoSaveTimerCheckBox, SIGNAL(toggled(bool)), m_generalUi->autoSaveIntervalSpinBox, SLOT(setEnabled(bool)));
-    m_generalUi->autoSaveIntervalSpinBox->setRange(1, static_cast<int>(std::min(std::chrono::milliseconds::max().count(), static_cast<long>(std::numeric_limits<int>::max()))));
+    auto max_ms = std::chrono::milliseconds::max().count();
+    if(max_ms > std::numeric_limits<int>::max()) {
+        m_generalUi->autoSaveIntervalSpinBox->setRange(1, std::numeric_limits<int>::max());
+    } else {
+        m_generalUi->autoSaveIntervalSpinBox->setRange(1, static_cast<int>(max_ms));
+    }
 
     connect(m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)),
             m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -112,6 +112,9 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
     connect(m_generalUi->useAlternativeSaveCheckBox, SIGNAL(toggled(bool)),
             m_generalUi->alternativeSaveComboBox, SLOT(setEnabled(bool)));
 
+    connect(m_generalUi->enableAutoSaveTimerCheckBox, SIGNAL(toggled(bool)), m_generalUi->autoSaveIntervalSpinBox, SLOT(setEnabled(bool)));
+    m_generalUi->autoSaveIntervalSpinBox->setRange(1, static_cast<int>(std::min(std::chrono::milliseconds::max().count(), static_cast<long>(std::numeric_limits<int>::max()))));
+
     connect(m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)),
             m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));
     connect(m_secUi->clearSearchCheckBox, SIGNAL(toggled(bool)),
@@ -186,6 +189,8 @@ void ApplicationSettingsWidget::loadSettings()
         config()->get(Config::OpenPreviousDatabasesOnStartup).toBool());
     m_generalUi->autoSaveAfterEveryChangeCheckBox->setChecked(config()->get(Config::AutoSaveAfterEveryChange).toBool());
     m_generalUi->autoSaveOnExitCheckBox->setChecked(config()->get(Config::AutoSaveOnExit).toBool());
+    m_generalUi->enableAutoSaveTimerCheckBox->setChecked(config()->get(Config::AutoSaveTimerEnabled).toBool());
+    m_generalUi->autoSaveIntervalSpinBox->setValue(config()->get(Config::AutoSaveInterval).toInt() / 1000);
     m_generalUi->autoSaveNonDataChangesCheckBox->setChecked(config()->get(Config::AutoSaveNonDataChanges).toBool());
     m_generalUi->backupBeforeSaveCheckBox->setChecked(config()->get(Config::BackupBeforeSave).toBool());
     m_generalUi->useAlternativeSaveCheckBox->setChecked(!config()->get(Config::UseAtomicSaves).toBool());
@@ -324,6 +329,8 @@ void ApplicationSettingsWidget::saveSettings()
                   m_generalUi->openPreviousDatabasesOnStartupCheckBox->isChecked());
     config()->set(Config::AutoSaveAfterEveryChange, m_generalUi->autoSaveAfterEveryChangeCheckBox->isChecked());
     config()->set(Config::AutoSaveOnExit, m_generalUi->autoSaveOnExitCheckBox->isChecked());
+    config()->set(Config::AutoSaveTimerEnabled, m_generalUi->enableAutoSaveTimerCheckBox->isChecked());
+    config()->set(Config::AutoSaveInterval, m_generalUi->autoSaveIntervalSpinBox->value() * 1000);
     config()->set(Config::AutoSaveNonDataChanges, m_generalUi->autoSaveNonDataChangesCheckBox->isChecked());
     config()->set(Config::BackupBeforeSave, m_generalUi->backupBeforeSaveCheckBox->isChecked());
     config()->set(Config::UseAtomicSaves, !m_generalUi->useAlternativeSaveCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -195,7 +195,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->autoSaveAfterEveryChangeCheckBox->setChecked(config()->get(Config::AutoSaveAfterEveryChange).toBool());
     m_generalUi->autoSaveOnExitCheckBox->setChecked(config()->get(Config::AutoSaveOnExit).toBool());
     m_generalUi->enableAutoSaveTimerCheckBox->setChecked(config()->get(Config::AutoSaveTimerEnabled).toBool());
-    m_generalUi->autoSaveIntervalSpinBox->setValue(config()->get(Config::AutoSaveInterval).toInt() / 1000);
+    m_generalUi->autoSaveIntervalSpinBox->setValue(config()->get(Config::AutoSaveInterval).toInt() / (1000 * 60));
     m_generalUi->autoSaveNonDataChangesCheckBox->setChecked(config()->get(Config::AutoSaveNonDataChanges).toBool());
     m_generalUi->backupBeforeSaveCheckBox->setChecked(config()->get(Config::BackupBeforeSave).toBool());
     m_generalUi->useAlternativeSaveCheckBox->setChecked(!config()->get(Config::UseAtomicSaves).toBool());
@@ -335,7 +335,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::AutoSaveAfterEveryChange, m_generalUi->autoSaveAfterEveryChangeCheckBox->isChecked());
     config()->set(Config::AutoSaveOnExit, m_generalUi->autoSaveOnExitCheckBox->isChecked());
     config()->set(Config::AutoSaveTimerEnabled, m_generalUi->enableAutoSaveTimerCheckBox->isChecked());
-    config()->set(Config::AutoSaveInterval, m_generalUi->autoSaveIntervalSpinBox->value() * 1000);
+    config()->set(Config::AutoSaveInterval, m_generalUi->autoSaveIntervalSpinBox->value() * (1000 * 60));
     config()->set(Config::AutoSaveNonDataChanges, m_generalUi->autoSaveNonDataChangesCheckBox->isChecked());
     config()->set(Config::BackupBeforeSave, m_generalUi->backupBeforeSaveCheckBox->isChecked());
     config()->set(Config::UseAtomicSaves, !m_generalUi->useAlternativeSaveCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -274,7 +274,7 @@
               <item>
                <widget class="QCheckBox" name="enableAutoSaveTimerCheckBox">
                 <property name="text">
-                 <string>Automatically save the database every X seconds</string>
+                 <string>Automatically save the database every X minutes</string>
                 </property>
                </widget>
               </item>
@@ -311,14 +311,14 @@
                    <number>10000</number>
                   </property>
                   <property name="value">
-                   <number>300</number>
+                   <number>5</number>
                   </property>
                  </widget>
                 </item>
                 <item>
                  <widget class="QLabel" name="label">
                   <property name="text">
-                   <string>Seconds</string>
+                   <string>Minutes</string>
                   </property>
                   <property name="buddy">
                    <cstring>autoSaveIntervalSpinBox</cstring>

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -58,8 +58,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>581</width>
-            <height>924</height>
+            <width>620</width>
+            <height>1168</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -244,6 +244,13 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_5">
               <item>
+               <widget class="QCheckBox" name="autoReloadOnChangeCheckBox">
+                <property name="text">
+                 <string>Automatically reload the database when modified externally</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="autoSaveAfterEveryChangeCheckBox">
                 <property name="text">
                  <string>Automatically save after every change</string>
@@ -265,11 +272,73 @@
                </widget>
               </item>
               <item>
-               <widget class="QCheckBox" name="autoReloadOnChangeCheckBox">
+               <widget class="QCheckBox" name="enableAutoSaveTimerCheckBox">
                 <property name="text">
-                 <string>Automatically reload the database when modified externally</string>
+                 <string>Automatically save the database every X seconds</string>
                 </property>
                </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <item>
+                 <spacer name="horizontalSpacer_9">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>30</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="autoSaveIntervalSpinBox">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="minimum">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <number>10000</number>
+                  </property>
+                  <property name="value">
+                   <number>300</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label">
+                  <property name="text">
+                   <string>Seconds</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>autoSaveIntervalSpinBox</cstring>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_10">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
               </item>
               <item>
                <widget class="QCheckBox" name="backupBeforeSaveCheckBox">

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -2093,7 +2093,7 @@ void DatabaseWidget::onAutosaveTriggered()
 }
 void DatabaseWidget::resetAutosaveTimer()
 {
-    if(config()->get(Config::AutoSaveTimerEnabled).toBool()) {
+    if (config()->get(Config::AutoSaveTimerEnabled).toBool()) {
         // We do not create a one-shot timer here on purpose. The timer is reset only on successful saves,
         // hence, we would not restart upon failure.
         m_autosaveTimer.start(config()->get(Config::AutoSaveInterval).toInt());
@@ -2104,7 +2104,7 @@ void DatabaseWidget::resetAutosaveTimer()
 
 void DatabaseWidget::onConfigChanged(Config::ConfigKey key)
 {
-    if(key == Config::AutoSaveInterval || key == Config::AutoSaveTimerEnabled) {
+    if (key == Config::AutoSaveInterval || key == Config::AutoSaveTimerEnabled) {
         resetAutosaveTimer();
     }
 }

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -251,6 +251,8 @@ private slots:
     // Database autoreload slots
     void reloadDatabaseFile();
     void restoreGroupEntryFocus(const QUuid& groupUuid, const QUuid& EntryUuid);
+    // Autosave
+    void onAutosaveTriggered();
 
 private:
     int addChildWidget(QWidget* w);
@@ -259,6 +261,8 @@ private:
     void openDatabaseFromEntry(const Entry* entry, bool inBackground = true);
     void performIconDownloads(const QList<Entry*>& entries, bool force = false);
     bool performSave(QString& errorMessage, const QString& fileName = {});
+    void resetAutosaveTimer();
+    void onConfigChanged(Config::ConfigKey);
 
     QSharedPointer<Database> m_db;
 
@@ -289,6 +293,8 @@ private:
     QUuid m_entryBeforeLock;
 
     int m_saveAttempts;
+
+    QTimer m_autosaveTimer;
 
     // Search state
     QScopedPointer<EntrySearcher> m_entrySearcher;


### PR DESCRIPTION
Resolves #4152.

Adds a timer that automatically saves currently opened databases every X seconds. The interval length is configurable (seconds). Each database has a separate timer, but the interval is configured globally. Saves triggered externally (i.e., by the user or other auto save mechanisms) reset the timer.  

## Screenshots
![image](https://user-images.githubusercontent.com/42714034/136697290-1a40e436-9e38-44ad-b6a7-2e456efe2345.png)

## Testing strategy
Tested manually with QDebug() and several test databases.

## Limitations: (Comment please)
- Auto saves may be missed when saving is disabled, the database is locked, or the saving operation fails. The current behavior is to ignore these and simply retry the next time the timer is triggered. Another option could be to retry earlier.

## Type of change
- ✅ New feature (change that adds functionality)