### PR TITLE
FdoSecrets: reject setting refs via the API

### DIFF
--- a/src/fdosecrets/README.md
+++ b/src/fdosecrets/README.md
@@ -27,13 +27,16 @@ The following attributes are exposed:
 
 In addition, all non-protected custom attributes are also exposed.
 
-## Architecture
+## Implementation
 
 * `FdoSecrets::Service` is the top level DBus service
 * There is one and only one `FdoSecrets::Collection` per opened database tab
 * Each entry under the exposed database group has a corresponding `FdoSecrets::Item` DBus object.
 
 ### Signal connections
+
+Collection here means the `Collection` object in code. Not the logical concept "collection"
+that the user interacts with.
 
 - Collections are created when a corresponding database tab opened
 - If the database is locked, a collection is still created

--- a/src/fdosecrets/README.md
+++ b/src/fdosecrets/README.md
@@ -9,8 +9,9 @@ can connect and access the exposed database in KeePassXC.
 ## Configurable settings
 
 * The user can specify if a database is exposed on DBus, and which group is exposed.
-* Whether to show desktop notification is shown when an entry is retrieved.
-* Whether to skip confirmation for entries deleted from DBus
+* Whether to show desktop notification is shown when an entry's secret is retrieved.
+* Whether to confirm for entries deleted from DBus
+* Whether to confirm each entry's access
 
 ## Implemented Attributes on Item Object
 
@@ -22,6 +23,7 @@ The following attributes are exposed:
 |UserName|The entry user name|
 |URL|The entry URL|
 |Notes|The entry notes|
+|TOTP|The TOTP code if the entry has one|
 
 In addition, all non-protected custom attributes are also exposed.
 
@@ -34,7 +36,7 @@ In addition, all non-protected custom attributes are also exposed.
 ### Signal connections
 
 - Collections are created when a corresponding database tab opened
-- If the database is locked, a collection is created
+- If the database is locked, a collection is still created
 - When the database is unlocked, collection populates its children
 - If the unlocked database's exposed group is none, collection deletes itself
 - If the database's exposed group changes, collection repopulates

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -33,7 +33,7 @@
 namespace FdoSecrets
 {
 
-    const QSet<QString> Item::ReadOnlyAttributes(QSet<QString>() << ItemAttributes::UuidKey << ItemAttributes::PathKey);
+    const QSet<QString> Item::ReadOnlyAttributes(QSet<QString>() << ItemAttributes::UuidKey << ItemAttributes::PathKey << ItemAttributes::TotpKey);
 
     static void setEntrySecret(Entry* entry, const QByteArray& data, const QString& contentType);
     static Secret getEntrySecret(Entry* entry);
@@ -110,6 +110,9 @@ namespace FdoSecrets
         // add some informative and readonly attributes
         attrs[ItemAttributes::UuidKey] = m_backend->uuidToHex();
         attrs[ItemAttributes::PathKey] = path();
+        if (m_backend->hasTotp()) {
+            attrs[ItemAttributes::TotpKey] = m_backend->totp();
+        }
         return {};
     }
 

--- a/src/fdosecrets/objects/Item.h
+++ b/src/fdosecrets/objects/Item.h
@@ -30,6 +30,7 @@ namespace FdoSecrets
     {
         constexpr const auto UuidKey = "Uuid";
         constexpr const auto PathKey = "Path";
+        constexpr const auto TotpKey = "TOTP";
     } // namespace ItemAttributes
 
     class Session;

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -41,6 +41,7 @@
 #include <QLineEdit>
 #include <QSignalSpy>
 #include <QTest>
+#include <utility>
 
 int main(int argc, char* argv[])
 {
@@ -1070,30 +1071,24 @@ void TestGuiFdoSecrets::testItemSecret()
         // first create Secret in wire format,
         // then convert to internal format and encrypt
         // finally convert encrypted internal format back to wire format to pass to SetSecret
-        wire::Secret ss;
-        ss.contentType = TEXT_PLAIN;
-        ss.value = "NewPassword";
-        ss.session = QDBusObjectPath(sess->path());
-        auto encrypted = m_clientCipher->encrypt(ss.unmarshal(m_plugin->dbus()));
-        DBUS_VERIFY(item->SetSecret(encrypted.marshal()));
-
-        COMPARE(entry->password().toUtf8(), ss.value);
+        const QByteArray expected = QByteArrayLiteral("NewPassword");
+        auto encrypted = encryptPassword(expected, TEXT_PLAIN, sess);
+        DBUS_VERIFY(item->SetSecret(encrypted));
+        COMPARE(entry->password().toUtf8(), expected);
     }
 
     // set secret with something else is saved as attachment
+    const QByteArray expected = QByteArrayLiteral("NewPasswordBinary");
     {
-        wire::Secret expected;
-        expected.contentType = APPLICATION_OCTET_STREAM;
-        expected.value = QByteArrayLiteral("NewPasswordBinary");
-        expected.session = QDBusObjectPath(sess->path());
-        DBUS_VERIFY(item->SetSecret(m_clientCipher->encrypt(expected.unmarshal(m_plugin->dbus())).marshal()));
-
+        auto encrypted = encryptPassword(expected, APPLICATION_OCTET_STREAM, sess);
+        DBUS_VERIFY(item->SetSecret(encrypted));
         COMPARE(entry->password(), QStringLiteral(""));
-
+    }
+    {
         DBUS_GET(encrypted, item->GetSecret(QDBusObjectPath(sess->path())));
         auto ss = m_clientCipher->decrypt(encrypted.unmarshal(m_plugin->dbus()));
-        COMPARE(ss.contentType, expected.contentType);
-        COMPARE(ss.value, expected.value);
+        COMPARE(ss.contentType, APPLICATION_OCTET_STREAM);
+        COMPARE(ss.value, expected);
     }
 }
 
@@ -1195,6 +1190,51 @@ void TestGuiFdoSecrets::testItemLockState()
     DBUS_COMPARE(item->locked(), false);
     DBUS_VERIFY(item->GetSecret(QDBusObjectPath(sess->path())));
     DBUS_VERIFY(item->SetSecret(encrypted));
+}
+
+void TestGuiFdoSecrets::testItemRejectSetReferenceFields()
+{
+    // expose a subgroup, entries in it should not be able to retrieve data from entries outside it
+    auto rootEntry = m_db->rootGroup()->entries().first();
+    VERIFY(rootEntry);
+    auto subgroup = m_db->rootGroup()->findGroupByPath("/Homebanking/Subgroup");
+    VERIFY(subgroup);
+    FdoSecrets::settings()->setExposedGroup(m_db, subgroup->uuid());
+    auto service = enableService();
+    VERIFY(service);
+    auto coll = getDefaultCollection(service);
+    VERIFY(coll);
+    auto item = getFirstItem(coll);
+    VERIFY(item);
+    auto sess = openSession(service, DhIetf1024Sha256Aes128CbcPkcs7::Algorithm);
+    VERIFY(sess);
+
+    const auto refText = QStringLiteral("{REF:P@T:%1}").arg(rootEntry->title());
+
+    // reject ref in label
+    {
+        auto reply = item->setLabel(refText);
+        VERIFY(reply.isFinished() && reply.isError());
+        COMPARE(reply.error().type(), QDBusError::InvalidArgs);
+    }
+    // reject ref in custom attributes
+    {
+        auto reply = item->setAttributes({{"steal", refText}});
+        VERIFY(reply.isFinished() && reply.isError());
+        COMPARE(reply.error().type(), QDBusError::InvalidArgs);
+    }
+    // reject ref in password
+    {
+        auto reply = item->SetSecret(encryptPassword(refText.toUtf8(), "text/plain", sess));
+        VERIFY(reply.isFinished() && reply.isError());
+        COMPARE(reply.error().type(), QDBusError::InvalidArgs);
+    }
+    // reject ref in content type
+    {
+        auto reply = item->SetSecret(encryptPassword("dummy", refText, sess));
+        VERIFY(reply.isFinished() && reply.isError());
+        COMPARE(reply.error().type(), QDBusError::InvalidArgs);
+    }
 }
 
 void TestGuiFdoSecrets::testAlias()
@@ -1397,6 +1437,16 @@ QSharedPointer<ItemProxy> TestGuiFdoSecrets::createItem(const QSharedPointer<Ses
     itemPath = getSignalVariantArgument<QDBusObjectPath>(args.at(1));
 
     return getProxy<ItemProxy>(itemPath);
+}
+
+FdoSecrets::wire::Secret
+TestGuiFdoSecrets::encryptPassword(QByteArray value, QString contentType, const QSharedPointer<SessionProxy>& sess)
+{
+    wire::Secret ss;
+    ss.contentType = std::move(contentType);
+    ss.value = std::move(value);
+    ss.session = QDBusObjectPath(sess->path());
+    return m_clientCipher->encrypt(ss.unmarshal(m_plugin->dbus())).marshal();
 }
 
 bool TestGuiFdoSecrets::driveAccessControlDialog(bool remember)

--- a/tests/gui/TestGuiFdoSecrets.h
+++ b/tests/gui/TestGuiFdoSecrets.h
@@ -82,6 +82,7 @@ private slots:
     void testItemSecret();
     void testItemDelete();
     void testItemLockState();
+    void testItemRejectSetReferenceFields();
 
     void testAlias();
     void testDefaultAliasAlwaysPresent();
@@ -110,6 +111,8 @@ private:
                                          const FdoSecrets::wire::StringStringMap& attr,
                                          bool replace,
                                          bool expectPrompt = false);
+    FdoSecrets::wire::Secret
+    encryptPassword(QByteArray value, QString contentType, const QSharedPointer<SessionProxy>& sess);
     template <typename Proxy> QSharedPointer<Proxy> getProxy(const QDBusObjectPath& path) const
     {
         auto ret = QSharedPointer<Proxy>{


### PR DESCRIPTION
Fixes #6802. Fixes #3992.

Check for references when setting fields calling from DBus. It still resolves references, though, so it's possible to manually create entries with references in KPXC UI.

Also added is a read-only field when reporting back attributes. This addresses the only actionable suggestion in #3992.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Add unit test

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)