### PR TITLE
cmake: Check for PIE support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,12 @@ elseif(KEEPASSXC_DIST_TYPE STREQUAL "Other")
     unset(KEEPASSXC_DIST)
 endif()
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14.0")
+    cmake_policy(SET CMP0083 NEW)
+    include(CheckPIESupported)
+    check_pie_supported()
+endif()
+
 # Create position independent code for shared libraries and executables
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 


### PR DESCRIPTION
Check for PIE support during configure stage of cmake

## Testing strategy

Search `CMakeCache.txt` for `CMAKE_CXX_LINK_PIE_SUPPORTED`.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)