### PR TITLE
Fix entry preview resetting when focusing out of entry view

### DIFF
--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -200,12 +200,6 @@ void EntryView::focusInEvent(QFocusEvent* event)
     QTreeView::focusInEvent(event);
 }
 
-void EntryView::focusOutEvent(QFocusEvent* event)
-{
-    emit entrySelectionChanged(nullptr);
-    QTreeView::focusOutEvent(event);
-}
-
 void EntryView::displayGroup(Group* group)
 {
     m_model->setGroup(group);

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -59,7 +59,6 @@ signals:
 protected:
     void keyPressEvent(QKeyEvent* event) override;
     void focusInEvent(QFocusEvent* event) override;
-    void focusOutEvent(QFocusEvent* event) override;
     void showEvent(QShowEvent* event) override;
 
 private slots:


### PR DESCRIPTION
* Fixes #7061
* This bug impacts linux only when clicking in the preview panel.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested fix on Ubuntu Linux. Also tested for any regressions on Windows, none found.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
