### PR TITLE
Implement "Overwrite attachment" confirmation dialog.

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3533,6 +3533,15 @@ Do you want to save the changes to your database?</source>
 Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Confirm Overwrite Attachment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attachment &quot;%1&quot; already exists. 
+Would you like to overwrite the existing attachment?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EntryAttributesModel</name>

--- a/src/gui/entry/EntryAttachmentsWidget.h
+++ b/src/gui/entry/EntryAttachmentsWidget.h
@@ -69,7 +69,7 @@ private slots:
 private:
     bool insertAttachments(const QStringList& fileNames, QString& errorMessage);
 
-    QStringList confirmLargeAttachments(const QStringList& filenames);
+    QStringList confirmAttachmentSelection(const QStringList& filenames);
 
     bool eventFilter(QObject* watched, QEvent* event) override;
 


### PR DESCRIPTION
Fixes #7054.

Adds a confirmation dialog if adding a file attachment to an entry would cause an existing attachment to be overwritten.


## Screenshots
![The dialog](https://user-images.githubusercontent.com/42714034/138600798-2019fe0b-31a6-4e6f-be38-aef154c5c9ce.png)


## Testing strategy
Tested with a test database.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
