### PR TITLE
Colored passwords in the preview pane

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -503,6 +503,10 @@
         <source> recent files</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show passwords in color</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetSecurity</name>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -105,6 +105,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_HideUsernames, {QS("GUI/HideUsernames"), Roaming, false}},
     {Config::GUI_HidePasswords, {QS("GUI/HidePasswords"), Roaming, true}},
     {Config::GUI_AdvancedSettings, {QS("GUI/AdvancedSettings"), Roaming, false}},
+    {Config::GUI_ColorPasswords, {QS("GUI/ColorPasswords"), Roaming, false}},
     {Config::GUI_MonospaceNotes, {QS("GUI/MonospaceNotes"), Roaming, false}},
     {Config::GUI_ApplicationTheme, {QS("GUI/ApplicationTheme"), Roaming, QS("auto")}},
     {Config::GUI_CompactMode, {QS("GUI/CompactMode"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -86,6 +86,7 @@ public:
         GUI_HideUsernames,
         GUI_HidePasswords,
         GUI_AdvancedSettings,
+        GUI_ColorPasswords,
         GUI_MonospaceNotes,
         GUI_ApplicationTheme,
         GUI_CompactMode,

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -183,6 +183,7 @@ void Application::applyTheme()
         auto* s = new LightStyle;
         setPalette(s->standardPalette());
         setStyle(s);
+        m_darkTheme = false;
     } else if (appTheme == "dark") {
         auto* s = new DarkStyle;
         setPalette(s->standardPalette());
@@ -191,7 +192,9 @@ void Application::applyTheme()
     } else {
         // Classic mode, don't check for dark theme on Windows
         // because Qt 5.x does not support it
-#ifndef Q_OS_WIN
+#if defined(Q_OS_WIN)
+        m_darkTheme = false;
+#else
         m_darkTheme = osUtils->isDarkMode();
 #endif
         QFile stylesheetFile(":/styles/base/classicstyle.qss");

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -239,6 +239,7 @@ void ApplicationSettingsWidget::loadSettings()
 
     m_generalUi->toolbarMovableCheckBox->setChecked(config()->get(Config::GUI_MovableToolbar).toBool());
     m_generalUi->monospaceNotesCheckBox->setChecked(config()->get(Config::GUI_MonospaceNotes).toBool());
+    m_generalUi->colorPasswordsCheckBox->setChecked(config()->get(Config::GUI_ColorPasswords).toBool());
 
     m_generalUi->toolButtonStyleComboBox->clear();
     m_generalUi->toolButtonStyleComboBox->addItem(tr("Icon only"), Qt::ToolButtonIconOnly);
@@ -383,6 +384,7 @@ void ApplicationSettingsWidget::saveSettings()
 
     config()->set(Config::GUI_MovableToolbar, m_generalUi->toolbarMovableCheckBox->isChecked());
     config()->set(Config::GUI_MonospaceNotes, m_generalUi->monospaceNotesCheckBox->isChecked());
+    config()->set(Config::GUI_ColorPasswords, m_generalUi->colorPasswordsCheckBox->isChecked());
 
     config()->set(Config::GUI_ToolButtonStyle, m_generalUi->toolButtonStyleComboBox->currentData().toString());
 

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -767,6 +767,13 @@
                </layout>
               </item>
               <item>
+               <widget class="QCheckBox" name="colorPasswordsCheckBox">
+                <property name="text">
+                 <string>Show passwords in color</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="monospaceNotesCheckBox">
                 <property name="text">
                  <string>Use monospaced font for notes</string>

--- a/src/gui/EntryPreviewWidget.ui
+++ b/src/gui/EntryPreviewWidget.ui
@@ -315,24 +315,42 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLineEdit" name="entryPasswordLabel">
+                 <widget class="QTextEdit" name="entryPasswordLabel">
                   <property name="minimumSize">
                    <size>
                     <width>150</width>
                     <height>0</height>
                    </size>
                   </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>30</height>
+                   </size>
+                  </property>
                   <property name="focusPolicy">
                    <enum>Qt::ClickFocus</enum>
                   </property>
-                  <property name="text">
-                   <string notr="true">password</string>
+                  <property name="frameShape">
+                   <enum>QFrame::NoFrame</enum>
                   </property>
-                  <property name="frame">
+                  <property name="frameShadow">
+                   <enum>QFrame::Plain</enum>
+                  </property>
+                  <property name="lineWidth">
+                   <number>0</number>
+                  </property>
+                  <property name="verticalScrollBarPolicy">
+                   <enum>Qt::ScrollBarAlwaysOff</enum>
+                  </property>
+                  <property name="tabChangesFocus">
+                   <bool>true</bool>
+                  </property>
+                  <property name="undoRedoEnabled">
                    <bool>false</bool>
                   </property>
-                  <property name="dragEnabled">
-                   <bool>true</bool>
+                  <property name="lineWrapMode">
+                   <enum>QTextEdit::NoWrap</enum>
                   </property>
                   <property name="readOnly">
                    <bool>true</bool>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

In the entry preview pane, the password is now displayed with in multiple colours (digits in blue, upper-case letters in red, etc). The idea and the color scheme are taken from the iOS app "Strongbox".

A checkbox was added to section "General -> User Interface" of the settings dialog to turn color display off.

Fixes #4099 

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![Screenshot from 2021-10-26 16-56-18](https://user-images.githubusercontent.com/25565229/139558536-df871fd7-7a44-4368-8727-ecb1c04bcec1.png)

![Screenshot from 2021-10-26 16-57-46](https://user-images.githubusercontent.com/25565229/139558542-f6084205-ef43-40d3-84ab-217c3e5958d1.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Tested manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
