### PR TITLE
Remove unnecessary LTR override from German translation

### DIFF
--- a/share/translations/keepassxc_de.ts
+++ b/share/translations/keepassxc_de.ts
@@ -6561,7 +6561,7 @@ Kernel: %3 %4</translation>
     </message>
     <message>
         <source>Analyze passwords for weaknesses and problems.</source>
-        <translation>Passw‭örter auf Schwächen und Probleme prüfen.</translation>
+        <translation>Passwörter auf Schwächen und Probleme prüfen.</translation>
     </message>
     <message>
         <source>Failed to open HIBP file %1: %2</source>


### PR DESCRIPTION
[CVE-2021-42574] made me look for directional overrides, i found this LTR
override lying around.

You may find the diff looks like nothing has changed, but a U+2D20 was
removed.

I hope you don't mind i added a newline at the end of the file.

[CVE-2021-42574]: https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
