### PR TITLE
Fix crash while downloading favicon

### DIFF
--- a/src/gui/IconDownloaderDialog.cpp
+++ b/src/gui/IconDownloaderDialog.cpp
@@ -185,7 +185,7 @@ void IconDownloaderDialog::updateTable(const QString& url, const QString& messag
 void IconDownloaderDialog::abortDownloads()
 {
     for (auto* downloader : m_activeDownloaders) {
-        delete downloader;
+        downloader->deleteLater();
     }
     m_activeDownloaders.clear();
     updateProgressBar();


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Fixes #7103 

When I'm debugging, I find that it always crashes on this line.

https://github.com/keepassxreboot/keepassxc/blob/20db504c3af80a5765afa66824dc3e69c1a0bb59/src/gui/IconDownloaderDialog.cpp#L188

So I modified the code.

```cpp
for (auto*& downloader : m_activeDownloaders) {
     downloader->deleteLater();
     downloader = nullptr;
}
```

Then I compiled and tested on Windows and the program no longer crashes.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

