### PR TITLE
fix compilation on macOS when clang<9 & Qt<5.12

### DIFF
--- a/src/core/Alloc.cpp
+++ b/src/core/Alloc.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <botan/mem_ops.h>
+#include <cstdlib>
 #if defined(Q_OS_MACOS)
 #include <malloc/malloc.h>
 #elif defined(Q_OS_FREEBSD)

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -139,6 +139,7 @@
 //
 - (bool) isStatusBarDark
 {
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101000
     if (@available(macOS 10.17, *)) {
         // This is an ugly hack, but I couldn't find a way to access QTrayIcon's NSStatusItem.
         NSStatusItem* dummy = [[NSStatusBar systemStatusBar] statusItemWithLength:0];
@@ -146,6 +147,7 @@
         [[NSStatusBar systemStatusBar] removeStatusItem:dummy];
         return [appearance containsString:@"dark"];
     }
+#endif
 
     return [self isDarkMode];
 }

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -168,9 +168,13 @@
 //
 - (bool) enableAccessibility
 {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1090
     // Request accessibility permissions for Auto-Type type on behalf of the user
     NSDictionary* opts = @{static_cast<id>(kAXTrustedCheckOptionPrompt): @YES};
     return AXIsProcessTrustedWithOptions(static_cast<CFDictionaryRef>(opts));
+#else
+    return YES;
+#endif
 }
 
 //

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -60,7 +60,7 @@
 - (void) didDeactivateApplicationObserver:(NSNotification*) notification
 {
     NSDictionary* userInfo = notification.userInfo;
-    NSRunningApplication* app = userInfo[NSWorkspaceApplicationKey];
+    NSRunningApplication* app = [userInfo objectForKey:NSWorkspaceApplicationKey];
 
     if (app.processIdentifier != [self ownProcessId]) {
         self.lastActiveApplication = app;
@@ -182,6 +182,7 @@
 //
 - (bool) enableScreenRecording
 {
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
     if (@available(macOS 10.15, *)) {
         // Request screen recording permission on macOS 10.15+
         // This is necessary to get the current window title
@@ -199,6 +200,7 @@
             return NO;
         }
     }
+#endif
     return YES;
 }
 

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -26,7 +26,10 @@
 #include <QWindow>
 
 #include <ApplicationServices/ApplicationServices.h>
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
 #include <CoreGraphics/CGEventSource.h>
+#endif
 
 #define INVALID_KEYCODE 0xFFFF
 
@@ -138,7 +141,11 @@ void MacUtils::setLaunchAtStartup(bool enable)
 
 bool MacUtils::isCapslockEnabled()
 {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
     return (CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState) & kCGEventFlagMaskAlphaShift) != 0;
+#else
+    return false;
+#endif
 }
 
 /**

--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -41,7 +41,9 @@
 
 #ifdef Q_OS_MACOS
 #include <QMainWindow>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
 #include <QOperatingSystemVersion>
+#endif
 #endif
 
 #include "gui/Icons.h"
@@ -279,16 +281,22 @@ namespace Phantom
 #ifdef Q_OS_MACOS
             QColor tabBarBase(const QPalette& pal)
             {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 10) && QT_VERSION < QT_VERSION_CHECK(5, 13, 0)                               \
+    || QT_VERSION >= QT_VERSION_CHECK(5, 15, 1)
                 if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur) {
                     return hack_isLightPalette(pal) ? QRgb(0xD4D4D4) : QRgb(0x2A2A2A);
                 }
+#endif
                 return hack_isLightPalette(pal) ? QRgb(0xDD1D1D1) : QRgb(0x252525);
             }
             QColor tabBarBaseInactive(const QPalette& pal)
             {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 10) && QT_VERSION < QT_VERSION_CHECK(5, 13, 0)                               \
+    || QT_VERSION >= QT_VERSION_CHECK(5, 15, 1)
                 if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur) {
                     return hack_isLightPalette(pal) ? QRgb(0xF5F5F5) : QRgb(0x2D2D2D);
                 }
+#endif
                 return hack_isLightPalette(pal) ? QRgb(0xF4F4F4) : QRgb(0x282828);
             }
 #endif

--- a/src/touchid/TouchID.mm
+++ b/src/touchid/TouchID.mm
@@ -95,6 +95,7 @@ bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKe
     // prepare adding secure entry to the macOS KeyChain
     CFErrorRef error = NULL;
     SecAccessControlRef sacObject;
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
     if (@available(macOS 10.15, *)) {
         // kSecAccessControlWatch is only available for macOS 10.15 and later
         sacObject = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
@@ -102,11 +103,14 @@ bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKe
                                                     kSecAccessControlOr | kSecAccessControlBiometryCurrentSet | kSecAccessControlWatch,
                                                     &error);
     } else {
+#endif
         sacObject = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
                                                     kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
                                                     kSecAccessControlTouchIDCurrentSet, // depr: kSecAccessControlBiometryCurrentSet,
                                                     &error);
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
     }
+#endif
 
 
     if (sacObject == NULL || error != NULL) {
@@ -234,11 +238,15 @@ bool TouchID::isAvailable()
         LAContext* context = [[LAContext alloc] init];
 
         LAPolicy policyCode;
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
         if (@available(macOS 10.15, *)) {
             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometricsOrWatch;
         } else {
+#endif
             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
         }
+#endif
 
         bool canAuthenticate = [context canEvaluatePolicy:policyCode error:nil];
         [context release];
@@ -274,11 +282,15 @@ bool TouchID::authenticate(const QString& message) const
         NSString* authMessage = msg.toNSString(); // autoreleased
 
         LAPolicy policyCode;
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
         if (@available(macOS 10.15, *)) {
             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometricsOrWatch;
         } else {
+#endif
             policyCode = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
         }
+#endif
 
         [context evaluatePolicy:policyCode
                 localizedReason:authMessage reply:^(BOOL success, NSError* error) {


### PR DESCRIPTION
1. The code uses `@available` syntax which is new in clang 9
This prevents compilation on older version of macOS that don't
use this version. For example on El Capitan.
This fix will allow to compile on such older systems.


2. The code uses 'QOperatingSystemVersion::MacOSBigSur' which doesn't exist
in some versions (it has been backported to Qt 5.12.10+ & 5.15.1+ only).
On older macos systems like El Capitan the last supported
version of Qt is 5.11
This will fix compilation issue on such older systems and on systems
running with Qt not supporting QOperatingSystemVersion::MacOSBigSur
Compilation error was:
error: no member named 'MacOSBigSur' in 'QOperatingSystemVersion'

3. More details for the other changes are in the commit messages

## Testing strategy
Checked compilation on El Capitan (through macports)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
