### PR TITLE
fix compilation on Qt < 5.12

### DIFF
--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -279,16 +279,20 @@ namespace Phantom
 #ifdef Q_OS_MACOS
             QColor tabBarBase(const QPalette& pal)
             {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
                 if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur) {
                     return hack_isLightPalette(pal) ? QRgb(0xD4D4D4) : QRgb(0x2A2A2A);
                 }
+#endif
                 return hack_isLightPalette(pal) ? QRgb(0xDD1D1D1) : QRgb(0x252525);
             }
             QColor tabBarBaseInactive(const QPalette& pal)
             {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
                 if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur) {
                     return hack_isLightPalette(pal) ? QRgb(0xF5F5F5) : QRgb(0x2D2D2D);
                 }
+#endif
                 return hack_isLightPalette(pal) ? QRgb(0xF4F4F4) : QRgb(0x282828);
             }
 #endif


### PR DESCRIPTION
The code uses  `QOperatingSystemVersion::MacOSBigSur` which doesn't exist in older
versions of Qt (it has been backported down to Qt 5.12). On older macos systems like
El Capitan the last supported version of Qt is 5.11.

This will fix compilation issue on such older systems

Compilation error was:
error: no member named 'MacOSBigSur' in 'QOperatingSystemVersion'

## Testing strategy
Checked compilation on El Capitan (through macports)

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
