### PR TITLE
Auto-Type: Remember previous selected global match

### DIFF
--- a/docs/topics/AutoType.adoc
+++ b/docs/topics/AutoType.adoc
@@ -65,7 +65,7 @@ image::autotype_entry_sequences.png[]
 === Performing Global Auto-Type
 The global Auto-Type keyboard shortcut is used when you have focus on the window you want to type into. To make use of this feature, you must have previously configured an Auto-Type hotkey.
 
-When you press the global Auto-Type hotkey, KeePassXC searches all unlocked databases for entries that match the focused window title. The Auto-Type selection dialog will appear in the following circumstances: there are no matches found, there are multiple matches found, or the setting "Always ask before performing Auto-Type" is enabled.
+When you press the global Auto-Type hotkey, KeePassXC searches all unlocked databases for entries that match the focused window title. The Auto-Type selection dialog will appear in the following circumstances: there are no matches found, there are multiple matches found, or the setting "Always ask before performing Auto-Type" is enabled. The selection is remembered for a short while to help retype with the same entry in quick succession.
 
 .Auto-Type sequence selection
 image::autotype_selection_dialog.png[,70%]

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -23,6 +23,8 @@
 #include <QObject>
 #include <QWidget>
 
+#include "AutoTypeMatch.h"
+
 class AutoTypeAction;
 class AutoTypeExecutor;
 class AutoTypePlatformInterface;
@@ -95,6 +97,8 @@ private:
     QString m_windowTitleForGlobal;
     WindowState m_windowState;
     WId m_windowForGlobal;
+    AutoTypeMatch m_lastMatch;
+    qint64 m_lastMatchTime;
 
     Q_DISABLE_COPY(AutoType)
 };

--- a/src/autotype/AutoTypeMatchModel.cpp
+++ b/src/autotype/AutoTypeMatchModel.cpp
@@ -45,6 +45,24 @@ QModelIndex AutoTypeMatchModel::indexFromMatch(const AutoTypeMatch& match) const
     return index(row, 1);
 }
 
+QModelIndex AutoTypeMatchModel::closestIndexFromMatch(const AutoTypeMatch& match) const
+{
+    int row = -1;
+
+    for (int i = m_matches.size() - 1; i >= 0; --i) {
+        const auto& currentMatch = m_matches.at(i);
+        if (currentMatch.first == match.first) {
+            row = i;
+
+            if (currentMatch.second == match.second) {
+                break;
+            }
+        }
+    }
+
+    return (row > -1) ? index(row, 1) : QModelIndex();
+}
+
 void AutoTypeMatchModel::setMatchList(const QList<AutoTypeMatch>& matches)
 {
     beginResetModel();

--- a/src/autotype/AutoTypeMatchModel.h
+++ b/src/autotype/AutoTypeMatchModel.h
@@ -42,6 +42,7 @@ public:
     explicit AutoTypeMatchModel(QObject* parent = nullptr);
     AutoTypeMatch matchFromIndex(const QModelIndex& index) const;
     QModelIndex indexFromMatch(const AutoTypeMatch& match) const;
+    QModelIndex closestIndexFromMatch(const AutoTypeMatch& match) const;
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/src/autotype/AutoTypeMatchView.cpp
+++ b/src/autotype/AutoTypeMatchView.cpp
@@ -18,6 +18,7 @@
 
 #include "AutoTypeMatchView.h"
 #include "AutoTypeMatchModel.h"
+#include "core/Entry.h"
 
 #include <QHeaderView>
 #include <QKeyEvent>
@@ -78,21 +79,36 @@ void AutoTypeMatchView::keyPressEvent(QKeyEvent* event)
     }
 }
 
-void AutoTypeMatchView::setMatchList(const QList<AutoTypeMatch>& matches, bool selectFirst)
+void AutoTypeMatchView::setMatchList(const QList<AutoTypeMatch>& matches)
 {
     m_model->setMatchList(matches);
     m_sortModel->setFilterWildcard({});
 
     horizontalHeader()->resizeSections(QHeaderView::ResizeToContents);
 
-    if (selectFirst) {
-        selectionModel()->setCurrentIndex(m_sortModel->index(0, 0),
+    selectionModel()->clear();
+    emit currentMatchChanged(currentMatch());
+}
+
+void AutoTypeMatchView::selectFirstMatch()
+{
+    selectionModel()->setCurrentIndex(m_sortModel->index(0, 0),
+                                      QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    emit currentMatchChanged(currentMatch());
+}
+
+bool AutoTypeMatchView::selectMatch(const AutoTypeMatch& match)
+{
+    QModelIndex index = m_model->closestIndexFromMatch(match);
+
+    if (index.isValid()) {
+        selectionModel()->setCurrentIndex(m_sortModel->mapFromSource(index),
                                           QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
-    } else {
-        selectionModel()->clear();
+        emit currentMatchChanged(currentMatch());
+        return true;
     }
 
-    emit currentMatchChanged(currentMatch());
+    return false;
 }
 
 void AutoTypeMatchView::filterList(const QString& filter)

--- a/src/autotype/AutoTypeMatchView.h
+++ b/src/autotype/AutoTypeMatchView.h
@@ -35,7 +35,9 @@ public:
     explicit AutoTypeMatchView(QWidget* parent = nullptr);
     AutoTypeMatch currentMatch();
     AutoTypeMatch matchFromIndex(const QModelIndex& index);
-    void setMatchList(const QList<AutoTypeMatch>& matches, bool selectFirst);
+    void setMatchList(const QList<AutoTypeMatch>& matches);
+    void selectFirstMatch();
+    bool selectMatch(const AutoTypeMatch& match);
     void filterList(const QString& filter);
     void moveSelection(int offset);
 

--- a/src/autotype/AutoTypeSelectDialog.h
+++ b/src/autotype/AutoTypeSelectDialog.h
@@ -39,7 +39,9 @@ public:
     explicit AutoTypeSelectDialog(QWidget* parent = nullptr);
     ~AutoTypeSelectDialog() override;
 
-    void setMatches(const QList<AutoTypeMatch>& matchList, const QList<QSharedPointer<Database>>& dbs);
+    void setMatches(const QList<AutoTypeMatch>& matchList,
+                    const QList<QSharedPointer<Database>>& dbs,
+                    const AutoTypeMatch& lastMatch);
     void setSearchString(const QString& search);
 
 signals:
@@ -63,6 +65,7 @@ private:
 
     QList<QSharedPointer<Database>> m_dbs;
     QList<AutoTypeMatch> m_matches;
+    AutoTypeMatch m_lastMatch;
     QTimer m_searchTimer;
     QPointer<QMenu> m_actionMenu;
 


### PR DESCRIPTION
This makes using multi-stage login forms slightly easier as you can avoid typing the search terms multiple times. The last match is invalidated after 30 seconds which should be plenty if you are going through a login form.

Inspired by https://github.com/keepassxreboot/keepassxc/pull/5864#issuecomment-968916483 to avoid needing a complex sequence in the first place.

## Testing strategy
Manually on Linux.

## Type of change
- ✅ New feature (change that adds functionality)
