### PR TITLE
Fix syntax issue & add a missing header

### DIFF
--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -27,7 +27,7 @@ const QString CustomData::BrowserLegacyKeyPrefix = QStringLiteral("Public Key: "
 const QString CustomData::ExcludeFromReportsLegacy = QStringLiteral("KnownBad");
 
 // Fallback item for return by reference
-static const CustomData::CustomDataItem NULL_ITEM;
+static const CustomData::CustomDataItem NULL_ITEM{};
 
 CustomData::CustomData(QObject* parent)
     : ModifiableObject(parent)

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -29,7 +29,7 @@ const int Metadata::DefaultHistoryMaxItems = 10;
 const int Metadata::DefaultHistoryMaxSize = 6 * 1024 * 1024;
 
 // Fallback icon for return by reference
-static const Metadata::CustomIconData NULL_ICON;
+static const Metadata::CustomIconData NULL_ICON{};
 
 Metadata::Metadata(QObject* parent)
     : ModifiableObject(parent)

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -20,6 +20,7 @@
 #include "core/Clock.h"
 
 #include <QTest>
+#include <QUuid>
 
 QTEST_GUILESS_MAIN(TestTools)
 


### PR DESCRIPTION
* Fix syntax to prevent compilation issue: fixes build failure with AppleClang 7 & 8.
* Add missing QUuid header: fixes compilation issue with LLVM clang 9, possibly also due to an old QT5

## Testing strategy
Tested on MacPorts

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
