### PR TITLE
SSH Agent: Show correct error messages in main window

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -666,11 +666,14 @@ void DatabaseWidget::addToAgent()
         return;
     }
 
+    SSHAgent* agent = SSHAgent::instance();
     OpenSSHKey key;
     if (settings.toOpenSSHKey(currentEntry, key, true)) {
-        SSHAgent::instance()->addIdentity(key, settings, database()->uuid());
+        if (!agent->addIdentity(key, settings, database()->uuid())) {
+            m_messageWidget->showMessage(agent->errorString(), MessageWidget::Error);
+        }
     } else {
-        m_messageWidget->showMessage(key.errorString(), MessageWidget::Error);
+        m_messageWidget->showMessage(settings.errorString(), MessageWidget::Error);
     }
 }
 
@@ -687,11 +690,14 @@ void DatabaseWidget::removeFromAgent()
         return;
     }
 
+    SSHAgent* agent = SSHAgent::instance();
     OpenSSHKey key;
     if (settings.toOpenSSHKey(currentEntry, key, false)) {
-        SSHAgent::instance()->removeIdentity(key);
+        if (!agent->removeIdentity(key)) {
+            m_messageWidget->showMessage(agent->errorString(), MessageWidget::Error);
+        }
     } else {
-        m_messageWidget->showMessage(key.errorString(), MessageWidget::Error);
+        m_messageWidget->showMessage(settings.errorString(), MessageWidget::Error);
     }
 }
 #endif


### PR DESCRIPTION
Fixes #7152

The error checking code for main window agent operations were completely off and 100% useless, like the author of the code.

I said I'll disable the context menu but it looks a bit heavy to actually do all of the checks at that point. This fixes the error message, though.

## Testing strategy
Adding and removing a key with attachment type selected but the attachment left empty.. Shouldn't require much more.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
