### PR TITLE
Enable "-fsized-deallocation" iif deallocation functions are really present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,18 @@ endif()
 add_gcc_compiler_cflags("-std=c99")
 add_gcc_compiler_cxxflags("-std=c++11")
 
-check_add_gcc_compiler_flag("-fsized-deallocation" CXX)
+check_cxx_compiler_flag("-fsized-deallocation" CXX_HAS_fsized_deallocation)
+if(CXX_HAS_fsized_deallocation)
+    # Do additional check: the deallocation functions must be there too.
+    set(CMAKE_REQUIRED_FLAGS "-fsized-deallocation")
+    check_cxx_source_compiles("#include <new>
+        int main() { void * ptr = nullptr; std::size_t size = 1; ::operator delete(ptr, size); }"
+        HAVE_DEALLOCATION_FUNCTIONS)
+    if(HAVE_DEALLOCATION_FUNCTIONS)
+        check_add_gcc_compiler_flag("-fsized-deallocation" CXX)
+    endif()
+    unset(CMAKE_REQUIRED_FLAGS)
+endif()
 
 if(APPLE AND CMAKE_COMPILER_IS_CLANGXX)
     add_gcc_compiler_cxxflags("-stdlib=libc++")


### PR DESCRIPTION
On some systems, although "-fsized-deallocation" compiler flag is there,
compilation will fail because some deallocation functions are missing.
Typically '`operator delete ( void* ptr, std::size_t sz )`' is missing on some
macOS systems.

This will check their presence.

On macOS we can have this case when using a compiler that supports the flag,
while the OS doesn't have all the deallocation functions. Typically,
::operator delete(ptr, size) appeared in macOS 10.12

Reported error was:
error: call to unavailable function 'operator delete': introduced in macOS 10.12

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
Tested on macos 10.13 (which reports _found_ as expected) & 10.11 (which reports _missing_ as expected)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
