### PR TITLE
Download favicon in the background after credential add

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -364,11 +364,13 @@ QJsonObject BrowserAction::handleSetLogin(const QJsonObject& json, const QString
     const QString uuid = decrypted.value("uuid").toString();
     const QString group = decrypted.value("group").toString();
     const QString groupUuid = decrypted.value("groupUuid").toString();
+    const QString downloadFavicon = decrypted.value("downloadFavicon").toString();
     const QString realm;
 
     bool result = true;
     if (uuid.isEmpty()) {
-        browserService()->addEntry(id, login, password, url, submitUrl, realm, group, groupUuid);
+        auto dlFavicon = !downloadFavicon.isEmpty() && downloadFavicon.compare(TRUE_STR) == 0;
+        browserService()->addEntry(id, login, password, url, submitUrl, realm, group, groupUuid, dlFavicon);
     } else {
         if (!Tools::isValidUuid(uuid)) {
             return getErrorReply(action, ERROR_KEEPASS_NO_VALID_UUID_PROVIDED);

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -494,6 +494,7 @@ void BrowserService::addEntry(const QString& dbid,
                               const QString& realm,
                               const QString& group,
                               const QString& groupUuid,
+                              const bool downloadFavicon,
                               const QSharedPointer<Database>& selectedDb)
 {
     // TODO: select database based on this key id
@@ -537,6 +538,10 @@ void BrowserService::addEntry(const QString& dbid,
         config.setRealm(realm);
     }
     config.save(entry);
+
+    if (downloadFavicon && m_currentDatabaseWidget) {
+        m_currentDatabaseWidget->downloadFaviconInBackground(entry);
+    }
 }
 
 bool BrowserService::updateEntry(const QString& dbid,

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -67,6 +67,7 @@ public:
                   const QString& realm,
                   const QString& group,
                   const QString& groupUuid,
+                  const bool downloadFavicon,
                   const QSharedPointer<Database>& selectedDb = {});
     bool updateEntry(const QString& dbid,
                      const QString& uuid,

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
  * Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ * Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -794,15 +794,30 @@ void DatabaseWidget::downloadAllFavicons()
 #endif
 }
 
-void DatabaseWidget::performIconDownloads(const QList<Entry*>& entries, bool force)
+void DatabaseWidget::downloadFaviconInBackground(Entry* entry)
+{
+#ifdef WITH_XC_NETWORKING
+    performIconDownloads({entry}, true, true);
+#else
+    Q_UNUSED(entry);
+#endif
+}
+
+void DatabaseWidget::performIconDownloads(const QList<Entry*>& entries, bool force, bool downloadInBackground)
 {
 #ifdef WITH_XC_NETWORKING
     auto* iconDownloaderDialog = new IconDownloaderDialog(this);
     connect(this, SIGNAL(databaseLockRequested()), iconDownloaderDialog, SLOT(close()));
-    iconDownloaderDialog->downloadFavicons(m_db, entries, force);
+
+    if (downloadInBackground && entries.count() > 0) {
+        iconDownloaderDialog->downloadFaviconInBackground(m_db, entries.first());
+    } else {
+        iconDownloaderDialog->downloadFavicons(m_db, entries, force);
+    }
 #else
     Q_UNUSED(entries);
     Q_UNUSED(force);
+    Q_UNUSED(downloadInBackground);
 #endif
 }
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -193,6 +193,7 @@ public slots:
     void openUrl();
     void downloadSelectedFavicons();
     void downloadAllFavicons();
+    void downloadFaviconInBackground(Entry* entry);
     void openUrlForEntry(Entry* entry);
     void createGroup();
     void cloneGroup();
@@ -259,7 +260,7 @@ private:
     void setClipboardTextAndMinimize(const QString& text);
     void processAutoOpen();
     void openDatabaseFromEntry(const Entry* entry, bool inBackground = true);
-    void performIconDownloads(const QList<Entry*>& entries, bool force = false);
+    void performIconDownloads(const QList<Entry*>& entries, bool force = false, bool downloadInBackground = false);
     bool performSave(QString& errorMessage, const QString& fileName = {});
 
     QSharedPointer<Database> m_db;

--- a/src/gui/IconDownloaderDialog.h
+++ b/src/gui/IconDownloaderDialog.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -42,6 +42,7 @@ public:
     ~IconDownloaderDialog() override;
 
     void downloadFavicons(const QSharedPointer<Database>& database, const QList<Entry*>& entries, bool force = false);
+    void downloadFaviconInBackground(const QSharedPointer<Database>& database, Entry* entry);
 
 private slots:
     void downloadFinished(const QString& url, const QImage& icon);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Downloads a favicon in the background if set by https://github.com/keepassxreboot/keepassxc-browser/pull/1472.
The feature is only available via the browser extension.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
