### PR TITLE
bump to the C++17 standard in the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,8 +311,8 @@ if(UNIX AND NOT APPLE)
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,relro,-z,now")
 endif()
 
-add_gcc_compiler_cflags("-std=c99")
-add_gcc_compiler_cxxflags("-std=c++11")
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 17)
 
 check_add_gcc_compiler_flag("-fsized-deallocation" CXX)
 


### PR DESCRIPTION
Bumping the C++ version to C++17. No reason not to do it, as first mentioned in [this discussion](https://github.com/keepassxreboot/keepassxc/pull/6487#issuecomment-848828636). Asked @droidmonkey again before adding the changes.

## Testing strategy
Tested locally, the CI will test it further.

## Type of change
- ✅ New feature (change that adds functionality)
