### PR TITLE
Reduce indentation of GroupView

### DIFF
--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -60,6 +60,10 @@ GroupView::GroupView(Database* db, QWidget* parent)
     setDefaultDropAction(Qt::MoveAction);
     setVisible(!config()->get(Config::GUI_HideGroupsPanel).toBool());
 
+    if (config()->get(Config::GUI_CompactMode).toBool()) {
+        setIndentation(indentation() / 2);
+    }
+
     connect(config(), &Config::changed, this, [this](Config::ConfigKey key) {
         if (key == Config::GUI_HideGroupsPanel) {
             setVisible(!config()->get(Config::GUI_HideGroupsPanel).toBool());


### PR DESCRIPTION
Fixes #7124 by reducing GroupView padding from 20px to 5px. This is the simplest way to implement the change, but I'm not sure it's ideal. I was considering making the indentation configurable in the application settings. Would that be a better option?

## Screenshots
Current:

![Screenshot from 2021-12-02 22-12-52](https://user-images.githubusercontent.com/40369019/144538851-9b28828a-7f5f-44fc-91c7-cd0e75d8b6b8.png)


Reduced indentation:

![Screenshot from 2021-12-02 22-13-28](https://user-images.githubusercontent.com/40369019/144538863-234f1a55-9904-4e64-9646-09f16a05cdbd.png)


## Testing strategy
I visually checked the change as well as manually running `make test` on both the develop branch and my branch. The results between the two branches were identical:

![Screenshot from 2021-12-02 22-09-14](https://user-images.githubusercontent.com/40369019/144538690-74baee82-189d-4395-b806-831978ff1fbb.png)


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
