### PR TITLE
Add simple detection of timestamp resolution for CSV files

### DIFF
--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -225,18 +225,29 @@ void CsvImportWidget::writeDatabase()
         if (m_parserModel->data(m_parserModel->index(r, 8)).isValid()) {
             auto datetime = m_parserModel->data(m_parserModel->index(r, 8)).toString();
             if (datetime.contains(QRegularExpression("^\\d+$"))) {
-                timeInfo.setLastModificationTime(Clock::datetimeUtc(datetime.toLongLong() * 1000));
+                auto t = datetime.toLongLong();
+                if (t <= INT32_MAX) {
+                    t *= 1000;
+                }
+                auto lastModified = Clock::datetimeUtc(t);
+                timeInfo.setLastModificationTime(lastModified);
+                timeInfo.setLastAccessTime(lastModified);
             } else {
                 auto lastModified = QDateTime::fromString(datetime, Qt::ISODate);
                 if (lastModified.isValid()) {
                     timeInfo.setLastModificationTime(lastModified);
+                    timeInfo.setLastAccessTime(lastModified);
                 }
             }
         }
         if (m_parserModel->data(m_parserModel->index(r, 9)).isValid()) {
             auto datetime = m_parserModel->data(m_parserModel->index(r, 9)).toString();
             if (datetime.contains(QRegularExpression("^\\d+$"))) {
-                timeInfo.setCreationTime(Clock::datetimeUtc(datetime.toLongLong() * 1000));
+                auto t = datetime.toLongLong();
+                if (t <= INT32_MAX) {
+                    t *= 1000;
+                }
+                timeInfo.setCreationTime(Clock::datetimeUtc(t));
             } else {
                 auto created = QDateTime::fromString(datetime, Qt::ISODate);
                 if (created.isValid()) {


### PR DESCRIPTION
## Summary

Fixes #6498 

## Screenshots
N/A

## Testing strategy
- Created a record in Firefox password manager
  ![Firefox password manager](https://user-images.githubusercontent.com/17182159/144594855-3755caa6-8440-4aea-bea0-68b0ee6e6bd2.png)
- Exported passwords in Firefox, then imported [logins.csv file](https://github.com/keepassxreboot/keepassxc/files/7649215/test.csv) I got in stable (dark themed) and my snapshot (light themed) and compared the results.
  ![Properties in stable](https://user-images.githubusercontent.com/17182159/144595532-20b71efc-5e66-4987-8cef-2335fded5895.png)
  ![Properties in snapshot](https://user-images.githubusercontent.com/17182159/144595313-0cd8bc72-2cdb-4713-8822-59fbe152443a.png)

Also:
- Imported my existing *.csv file from Firefox, works fine
- Run tests included with the code, all passed

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
