### PR TITLE
Add minimum width for QSpinBox widgets

### DIFF
--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="generalSettingsTabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabGeneral">
       <attribute name="title">
@@ -57,9 +57,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-133</y>
-            <width>564</width>
-            <height>1052</height>
+            <y>0</y>
+            <width>664</width>
+            <height>1215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="QTabWidget" name="generalSettingsTabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabGeneral">
       <attribute name="title">
@@ -57,9 +57,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>0</y>
-            <width>664</width>
-            <height>1215</height>
+            <y>-133</y>
+            <width>564</width>
+            <height>1052</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -499,6 +499,24 @@
                  <widget class="QSpinBox" name="faviconTimeoutSpinBox">
                   <property name="enabled">
                    <bool>true</bool>
+                  </property>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>120</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="baseSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
                   </property>
                   <property name="focusPolicy">
                    <enum>Qt::StrongFocus</enum>
@@ -1011,6 +1029,12 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="accessibleName">
             <string>Auto-type character typing delay milliseconds</string>
            </property>
@@ -1035,6 +1059,12 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
            </property>
            <property name="accessibleName">
             <string>Auto-type start delay milliseconds</string>

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>595</width>
-    <height>567</height>
+    <height>576</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -35,10 +35,16 @@
          <bool>false</bool>
         </property>
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="accessibleName">
          <string>Clipboard clear seconds</string>
@@ -83,10 +89,16 @@
          <bool>false</bool>
         </property>
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="accessibleName">
          <string>Touch ID inactivity reset</string>
@@ -121,10 +133,16 @@
          <bool>false</bool>
         </property>
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="accessibleName">
          <string>Database lock timeout seconds</string>
@@ -149,10 +167,16 @@
          <bool>false</bool>
         </property>
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="suffix">
          <string comment="Minutes"> min</string>

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>595</width>
-    <height>576</height>
+    <height>567</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>729</width>
-    <height>427</height>
+    <height>481</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -198,7 +198,7 @@ QProgressBar::chunk {
       <enum>QTabWidget::North</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="passwordWidget">
       <attribute name="title">
@@ -253,6 +253,18 @@ QProgressBar::chunk {
          </item>
          <item>
           <widget class="QSpinBox" name="spinBoxLength">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="accessibleName">
             <string>Password length</string>
            </property>
@@ -768,6 +780,18 @@ QProgressBar::chunk {
            </item>
            <item>
             <widget class="QSpinBox" name="spinBoxWordCount">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
              <property name="minimum">
               <number>1</number>
              </property>

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>729</width>
-    <height>481</height>
+    <height>427</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -198,7 +198,7 @@ QProgressBar::chunk {
       <enum>QTabWidget::North</enum>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="passwordWidget">
       <attribute name="title">

--- a/src/gui/TotpSetupDialog.ui
+++ b/src/gui/TotpSetupDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>249</width>
-    <height>329</height>
+    <height>278</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/gui/TotpSetupDialog.ui
+++ b/src/gui/TotpSetupDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>249</width>
-    <height>278</height>
+    <height>329</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -153,6 +153,18 @@
       </item>
       <item row="2" column="1">
        <widget class="QSpinBox" name="stepSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="accessibleName">
          <string>Time step field</string>
         </property>
@@ -179,6 +191,18 @@
       </item>
       <item row="3" column="1">
        <widget class="QSpinBox" name="digitsSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="suffix">
          <string> digits</string>
         </property>

--- a/src/gui/csvImport/CsvImportWidget.ui
+++ b/src/gui/csvImport/CsvImportWidget.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>751</width>
-        <height>684</height>
+        <width>753</width>
+        <height>615</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -725,7 +725,7 @@
              <bool>false</bool>
             </property>
             <attribute name="horizontalHeaderVisible">
-             <bool>false</bool>
+             <bool>true</bool>
             </attribute>
            </widget>
           </item>

--- a/src/gui/csvImport/CsvImportWidget.ui
+++ b/src/gui/csvImport/CsvImportWidget.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>753</width>
-        <height>615</height>
+        <width>751</width>
+        <height>684</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -601,6 +601,18 @@
              <layout class="QHBoxLayout" name="horizontalLayout">
               <item>
                <widget class="QSpinBox" name="spinBoxSkip">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>100</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="font">
                  <font>
                   <weight>50</weight>
@@ -713,7 +725,7 @@
              <bool>false</bool>
             </property>
             <attribute name="horizontalHeaderVisible">
-             <bool>true</bool>
+             <bool>false</bool>
             </attribute>
            </widget>
           </item>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.ui
@@ -14,7 +14,7 @@
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="simpleSettings">
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -326,7 +326,7 @@
             <string>Transform rounds</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignCenter</set>
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
            <property name="minimum">
             <number>1</number>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.ui
@@ -14,7 +14,7 @@
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="simpleSettings">
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -304,6 +304,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="40,40,0">
          <item>
           <widget class="QSpinBox" name="transformRoundsSpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="minimumSize">
             <size>
              <width>150</width>
@@ -320,7 +326,7 @@
             <string>Transform rounds</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignCenter</set>
            </property>
            <property name="minimum">
             <number>1</number>
@@ -361,6 +367,12 @@
        </item>
        <item row="3" column="1">
         <widget class="QSpinBox" name="memorySpinBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="minimumSize">
           <size>
            <width>150</width>
@@ -393,6 +405,12 @@
        </item>
        <item row="4" column="1">
         <widget class="QSpinBox" name="parallelismSpinBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="minimumSize">
           <size>
            <width>150</width>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
@@ -119,6 +119,18 @@
         </item>
         <item row="1" column="1">
          <widget class="QSpinBox" name="historyMaxSizeSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>Maximum size of history per entry</string>
           </property>
@@ -138,6 +150,18 @@
         </item>
         <item row="0" column="1">
          <widget class="QSpinBox" name="historyMaxItemsSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>Maximum number of history items per entry</string>
           </property>

--- a/src/gui/entry/EditEntryWidgetSSHAgent.ui
+++ b/src/gui/entry/EditEntryWidgetSSHAgent.ui
@@ -242,6 +242,18 @@
      </item>
      <item>
       <widget class="QSpinBox" name="lifetimeSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="accessibleName">
         <string>Remove key from agent after specified seconds</string>
        </property>


### PR DESCRIPTION
Greetings! It is quite likely that there is a much better way of doing this, in which case please just close this PR. I won't be offended.

Future versions (i.e. currently when compiled from git master) of the KDE Breeze style will have very wide buttons on QSpinBox widgets. For some reason, this makes them too small in KeePassXC:

![current behavior: QSpinBox is too small, value is invisible](https://i.imgur.com/fCGJBWF.png)

I have added `minimumSize` properties to all QSpinBoxes so as to avoid this behavior:

![new behavior: QSpinBox has a minimum width](https://i.imgur.com/hp4eVLI.png)

Adding a fixed value doesn't seem completely right to me, so there might be a better way. If there is, I would love to hear it.
Thank you for your consideration.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
