### PR TITLE
Make selected text copyable instead of copying password (fix for #7059)

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -24,6 +24,7 @@
 #include <QDesktopServices>
 #include <QHostInfo>
 #include <QKeyEvent>
+#include <QPlainTextEdit>
 #include <QProcess>
 #include <QSplitter>
 #include <QTextEdit>
@@ -591,11 +592,26 @@ void DatabaseWidget::copyUsername()
 
 void DatabaseWidget::copyPassword()
 {
-    // QTextEdit does not properly trap Ctrl+C copy shortcut
-    // if a text edit has focus pass the copy operation to it
+    // Some platforms do not properly trap Ctrl+C copy shortcut
+    // if a text edit or label has focus pass the copy operation to it
+
+    bool clearClipboard = config()->get(Config::Security_ClearClipboard).toBool();
+
+    auto plainTextEdit = qobject_cast<QPlainTextEdit*>(focusWidget());
+    if (plainTextEdit) {
+        clipboard()->setText(plainTextEdit->textCursor().selectedText(), clearClipboard);
+        return;
+    }
+
+    auto label = qobject_cast<QLabel*>(focusWidget());
+    if (label) {
+        clipboard()->setText(label->selectedText(), clearClipboard);
+        return;
+    }
+
     auto textEdit = qobject_cast<QTextEdit*>(focusWidget());
     if (textEdit) {
-        textEdit->copy();
+        clipboard()->setText(textEdit->textCursor().selectedText(), clearClipboard);
         return;
     }
 


### PR DESCRIPTION
Fixes #7059. Checks whether the fingerprint, comment, or public key widgets of the SSH Agent tab in the Edit Entry screen are selected when a copy event occurs. If they are, the relevant selected text is copied, otherwise falls back to the current behavior of copying the password. The clipboard is cleared after the timeout if the usual setting is enabled. Below is a short video demonstration of the new behavior. Previously, none of the text mentioned above could be copied using the copy shortcut. The password would be copied instead.


## Screenshots
https://user-images.githubusercontent.com/40369019/144961908-12ed5f16-941d-4d75-9324-77c6ac7c96a4.mp4


## Testing strategy
I tested the change manually, as you can see in the video included above. I also ran `make test` locally and got the same results on my branch as the develop branch.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
