### PR TITLE
Set correct case for DB file path on open (fix for #7139)

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -155,11 +155,12 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
                                        const QString& password,
                                        const QString& keyfile)
 {
-    QFileInfo fileInfo(filePath);
+    QString cleanFilePath = QDir::toNativeSeparators(filePath);
+    QFileInfo fileInfo(cleanFilePath);
     QString canonicalFilePath = fileInfo.canonicalFilePath();
 
     if (canonicalFilePath.isEmpty()) {
-        emit messageGlobal(tr("Failed to open %1. It either does not exist or is not accessible.").arg(filePath),
+        emit messageGlobal(tr("Failed to open %1. It either does not exist or is not accessible.").arg(cleanFilePath),
                            MessageWidget::Error);
         return;
     }
@@ -178,10 +179,10 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
         }
     }
 
-    auto* dbWidget = new DatabaseWidget(QSharedPointer<Database>::create(filePath), this);
+    auto* dbWidget = new DatabaseWidget(QSharedPointer<Database>::create(cleanFilePath), this);
     addDatabaseTab(dbWidget, inBackground);
     dbWidget->performUnlockDatabase(password, keyfile);
-    updateLastDatabases(filePath);
+    updateLastDatabases(cleanFilePath);
 }
 
 /**
@@ -782,7 +783,7 @@ void DatabaseTabWidget::updateLastDatabases(const QString& filename)
         config()->remove(Config::LastDatabases);
     } else {
         QStringList lastDatabases = config()->get(Config::LastDatabases).toStringList();
-        lastDatabases.prepend(filename);
+        lastDatabases.prepend(QDir::toNativeSeparators(filename));
         lastDatabases.removeDuplicates();
 
         while (lastDatabases.count() > config()->get(Config::NumberOfRememberedLastDatabases).toInt()) {


### PR DESCRIPTION
Fixes #7139. On database open, if OS is Windows, find correct case for database filename by searching through database parent folder. If found, overwrite internal database file path with corrected file path so that, on database modification, database is not saved under a new name. For example, if your database is DB.kdbx and you open db.kdbx on the Windows command line, then add a new entry and save your database, DB.kdbx is maintained as the filename. Previously, DB.kdbx would be overwritten with db.kdbx on save.


## Screenshots
Old behavior:

https://user-images.githubusercontent.com/40369019/145335172-a7daf37d-e870-4bc1-8349-bbd9870056ab.mp4

New behavior:

https://user-images.githubusercontent.com/40369019/145335185-67632cff-53da-4b5c-abaa-3f2ab5c91652.mp4



## Testing strategy
I tested the change manually, as you can see in the video included above. I also ran `make test`.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
