### PR TITLE
SSH Agent: Add support for generating SSH keys

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en">
+<TS version="2.1" language="en_US">
 <context>
     <name>AboutDialog</name>
     <message>
@@ -83,15 +83,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Your decision will be remembered for the duration while both the requesting client AND KeePassXC are running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allow Selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your decision will be remembered for the duration while both the requesting client AND KeePassXC are running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -125,6 +125,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Use both agents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>SSH_AUTH_SOCK override</source>
         <translation type="unfinished"></translation>
     </message>
@@ -152,10 +156,6 @@
         <source>SSH Agent connection is working!</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Use both agents</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidget</name>
@@ -169,6 +169,10 @@
     </message>
     <message>
         <source>Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This setting cannot be enabled when minimize on unlock is enabled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -227,10 +231,6 @@
         <source>Select backup storage directory</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>This setting cannot be enabled when minimize on unlock is enabled.</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetGeneral</name>
@@ -260,6 +260,10 @@
     </message>
     <message>
         <source>Remember previously used databases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> recent files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -415,6 +419,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show passwords in color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Use monospaced font for notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -497,14 +505,6 @@
     </message>
     <message>
         <source>Remember last typed entry for:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> recent files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show passwords in color</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -640,6 +640,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Entry does not have attribute for PICKCHARS: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invalid conversion type: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -654,10 +658,6 @@
     </message>
     <message>
         <source>Invalid placeholder: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Entry does not have attribute for PICKCHARS: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1397,6 +1397,10 @@ Backup database located at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt;p&gt;In addition to a password, you can use a secret file to enhance the security of your database. This file can be generated in your database&apos;s security settings.&lt;/p&gt;&lt;p&gt;This is &lt;strong&gt;not&lt;/strong&gt; your *.kdbx database file!&lt;br&gt;If you do not have a key file, leave this field empty.&lt;/p&gt;&lt;p&gt;Click for more information…&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Key file help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1406,6 +1410,11 @@ Backup database located at %2</source>
     </message>
     <message>
         <source>Hardware Key:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;You can use a hardware security key such as a &lt;strong&gt;YubiKey&lt;/strong&gt; or &lt;strong&gt;OnlyKey&lt;/strong&gt; with slots configured for HMAC-SHA1.&lt;/p&gt;
+&lt;p&gt;Click for more information…&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1543,15 +1552,6 @@ If you do not have a key file, please leave the field empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;In addition to a password, you can use a secret file to enhance the security of your database. This file can be generated in your database&apos;s security settings.&lt;/p&gt;&lt;p&gt;This is &lt;strong&gt;not&lt;/strong&gt; your *.kdbx database file!&lt;br&gt;If you do not have a key file, leave this field empty.&lt;/p&gt;&lt;p&gt;Click for more information…&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;You can use a hardware security key such as a &lt;strong&gt;YubiKey&lt;/strong&gt; or &lt;strong&gt;OnlyKey&lt;/strong&gt; with slots configured for HMAC-SHA1.&lt;/p&gt;
-&lt;p&gt;Click for more information…&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>authenticate to access the database</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1601,15 +1601,15 @@ If you do not have a key file, please leave the field empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Refresh database root group ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Disconnect all browsers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Forget all site-specific settings on entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refresh database root group ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2170,6 +2170,18 @@ This is definitely a bug, please report it to the developers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Export database to XML file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XML file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Writing the XML file failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Export Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2191,21 +2203,13 @@ This is definitely a bug, please report it to the developers.</source>
         <comment>Database tab name modifier</comment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Export database to XML file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>XML file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writing the XML file failed</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>DatabaseWidget</name>
+    <message>
+        <source>Searches and Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
@@ -2254,6 +2258,13 @@ This is definitely a bug, please report it to the developers.</source>
         <source>Expired entries</source>
         <translation type="unfinished"></translation>
     </message>
+    <message numerus="yes">
+        <source>Entries expiring within %1 day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
     <message>
         <source>No current database.</source>
         <translation type="unfinished"></translation>
@@ -2276,6 +2287,18 @@ This is definitely a bug, please report it to the developers.</source>
     </message>
     <message>
         <source>No Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a unique name or overwrite an existing search from the list:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2361,29 +2384,6 @@ Disable safe saves and try again?</source>
     </message>
     <message>
         <source>Could not find database file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <source>Entries expiring within %1 day(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Searches and Tags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enter a unique name or overwrite an existing search from the list:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Save Search</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2523,6 +2523,13 @@ Would you like to correct it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -2538,13 +2545,6 @@ Would you like to correct it?</source>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -2669,7 +2669,17 @@ Would you like to correct it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>+</source>
+        <comment>Add item</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remove selected window association</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>-</source>
+        <comment>Remove item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2694,16 +2704,6 @@ Would you like to correct it?</source>
     </message>
     <message>
         <source>Custom Auto-Type sequence for this window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>+</source>
-        <comment>Add item</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>-</source>
-        <comment>Remove item</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2927,19 +2927,6 @@ Would you like to correct it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>External file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browser for key file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse…</source>
-        <extracomment>Button for opening file dialog</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Attachment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2953,6 +2940,23 @@ Would you like to correct it?</source>
     </message>
     <message>
         <source>Remove from agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>External file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser for key file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browse…</source>
+        <extracomment>Button for opening file dialog</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2991,10 +2995,6 @@ Would you like to correct it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Browser Integration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3008,6 +3008,10 @@ Would you like to correct it?</source>
     </message>
     <message>
         <source>Group has unsaved changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browser Integration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3796,7 +3800,7 @@ Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notes</source>
+        <source>URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3816,7 +3820,7 @@ Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>URL</source>
+        <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3868,15 +3872,15 @@ Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Double click to copy value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Double click to copy value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4938,6 +4942,10 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5138,6 +5146,10 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Copy &amp;URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy URL to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5195,6 +5207,10 @@ Are you sure you want to continue with this file?</source>
     </message>
     <message>
         <source>Copy &amp;TOTP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Password and TOTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5294,6 +5310,14 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;XML File…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XML File…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Clear history</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5319,6 +5343,10 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
     <message>
         <source>WARNING: Your Qt version may cause KeePassXC to crash with an On-Screen Keyboard.
 We recommend you use the AppImage available on our downloads page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -5352,6 +5380,13 @@ We recommend you use the AppImage available on our downloads page.</source>
         <source>Quit KeePassXC</source>
         <translation type="unfinished"></translation>
     </message>
+    <message numerus="yes">
+        <source>%1 Entry(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
     <message>
         <source>Please present or touch your YubiKey to continue…</source>
         <translation type="unfinished"></translation>
@@ -5362,37 +5397,6 @@ We recommend you use the AppImage available on our downloads page.</source>
     </message>
     <message>
         <source>You must restart the application to apply this setting. Would you like to restart now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No Tags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 Entry(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Copy Password and TOTP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;XML File…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>XML File…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy &amp;URL</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5701,6 +5705,10 @@ We recommend you use the AppImage available on our downloads page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>AES-256/GCM is currently not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Passphrase is required to decrypt this key</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5764,8 +5772,23 @@ We recommend you use the AppImage available on our downloads page.</source>
         <source>Unexpected EOF when writing private key</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>OpenSSHKeyGenDialog</name>
     <message>
-        <source>AES-256/GCM is currently not supported</source>
+        <source>SSH Key Generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5948,6 +5971,10 @@ We recommend you use the AppImage available on our downloads page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Excluded characters: &quot;0&quot;, &quot;1&quot;, &quot;l&quot;, &quot;I&quot;, &quot;O&quot;, &quot;|&quot;, &quot;﹒&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Exclude look-alike characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6028,6 +6055,30 @@ We recommend you use the AppImage available on our downloads page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Password Quality: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Poor</source>
+        <comment>Password quality</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <comment>Password quality</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <comment>Password quality</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excellent</source>
+        <comment>Password quality</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Confirm Delete Wordlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6070,34 +6121,6 @@ Do you want to overwrite it?</source>
     </message>
     <message>
         <source>Special Characters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Password Quality: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Poor</source>
-        <comment>Password quality</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Weak</source>
-        <comment>Password quality</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Good</source>
-        <comment>Password quality</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Excellent</source>
-        <comment>Password quality</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Excluded characters: &quot;0&quot;, &quot;1&quot;, &quot;l&quot;, &quot;I&quot;, &quot;O&quot;, &quot;|&quot;, &quot;﹒&quot;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6601,11 +6624,20 @@ Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Path of the database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Target decryption time in MS for the database.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set the key file for the database.
+This options is deprecated, use --set-key-file instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6618,10 +6650,6 @@ Do you want to overwrite it?</source>
     </message>
     <message>
         <source>Create a new database.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Path of the database.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6666,6 +6694,158 @@ Do you want to overwrite it?</source>
     </message>
     <message>
         <source>Successfully created new database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unset the password for the database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unset the key file for the database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit a database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot use %1 and %2 at the same time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not change the database key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Database was not modified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Writing the database failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully edited the database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot remove password: The database does not have a password.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot remove file key: The database does not have a file key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading the new key file failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Found unexpected Key type %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot remove all the keys from a database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a database&apos;s information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UUID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cipher: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KDF: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recycle bin is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Recycle bin is not enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Database created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Last saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of expired entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unique passwords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Non-unique passwords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum password reuse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of short passwords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of weak passwords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Entries excluded from reports</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Average password length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6716,10 +6896,6 @@ Do you want to overwrite it?</source>
     </message>
     <message>
         <source>Enter new password for entry: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writing the database failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6947,106 +7123,6 @@ Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show a database&apos;s information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>UUID: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Description: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cipher: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>KDF: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Recycle bin is enabled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Recycle bin is not enabled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Database created</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Last saved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>no</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of groups</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of entries</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of expired entries</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unique passwords</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Non-unique passwords</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Maximum password reuse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of short passwords</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of weak passwords</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Entries excluded from reports</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Average password length</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 characters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Unknown command %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7215,6 +7291,10 @@ Available commands:
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show all the attributes of the entry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show the attachments of the entry.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7279,6 +7359,10 @@ Please consider generating a new key file.</source>
     </message>
     <message>
         <source>Invalid YubiKey serial %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please present or touch your YubiKey to continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7771,6 +7855,10 @@ Kernel: %3 %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>KeePassXC is not running. No open database to lock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Fatal error while testing the cryptographic functions.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7802,71 +7890,6 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Failed to sign challenge using Windows Hello.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Please present or touch your YubiKey to continue.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show all the attributes of the entry.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit a database.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not change the database key.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Database was not modified.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Successfully edited the database.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Loading the new key file failed: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unset the password for the database.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unset the key file for the database.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cannot use %1 and %2 at the same time.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cannot remove all the keys from a database.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cannot remove password: The database does not have a password.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cannot remove file key: The database does not have a file key.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Found unexpected Key type %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set the key file for the database.
-This options is deprecated, use --set-key-file instead.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>KeePassXC is not running. No open database to lock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8413,6 +8436,10 @@ This options is deprecated, use --set-key-file instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Save Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Search (%1)…</source>
         <comment>Search placeholder text, %1 is the keyboard shortcut</comment>
         <translation type="unfinished"></translation>
@@ -8423,10 +8450,6 @@ This options is deprecated, use --set-key-file instead.</source>
     </message>
     <message>
         <source>Limit search to selected group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Save Search</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8642,11 +8665,7 @@ This options is deprecated, use --set-key-file instead.</source>
 <context>
     <name>TagModel</name>
     <message>
-        <source>Expired</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Weak Passwords</source>
+        <source>Clear Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8654,7 +8673,11 @@ This options is deprecated, use --set-key-file instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clear Search</source>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weak Passwords</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -123,6 +123,7 @@ private slots:
     void removeKeyFromAgent();
     void decryptPrivateKey();
     void copyPublicKey();
+    void generatePrivateKey();
 #endif
 #ifdef WITH_XC_BROWSER
     void updateBrowserModified();
@@ -167,6 +168,7 @@ private:
     bool m_history;
 #ifdef WITH_XC_SSHAGENT
     KeeAgentSettings m_sshAgentSettings;
+    QString m_pendingPrivateKey;
 #endif
     const QScopedPointer<Ui::EditEntryWidgetMain> m_mainUi;
     const QScopedPointer<Ui::EditEntryWidgetAdvanced> m_advancedUi;

--- a/src/gui/entry/EditEntryWidgetSSHAgent.ui
+++ b/src/gui/entry/EditEntryWidgetSSHAgent.ui
@@ -118,23 +118,6 @@
       <string>Private key</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="3" column="0">
-       <widget class="QRadioButton" name="externalFileRadioButton">
-        <property name="text">
-         <string>External file</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QPushButton" name="browseButton">
-        <property name="accessibleName">
-         <string>Browser for key file</string>
-        </property>
-        <property name="text">
-         <string extracomment="Button for opening file dialog">Browse…</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QRadioButton" name="attachmentRadioButton">
         <property name="text">
@@ -145,7 +128,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="3" column="3">
        <widget class="QLineEdit" name="externalFileEdit">
         <property name="focusPolicy">
          <enum>Qt::ClickFocus</enum>
@@ -155,7 +138,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="4" column="3">
        <layout class="QHBoxLayout" name="agentActionsLayout" stretch="0,0">
         <item>
          <widget class="QPushButton" name="addToAgentButton">
@@ -173,7 +156,31 @@
         </item>
        </layout>
       </item>
-      <item row="0" column="1" colspan="2">
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="externalFileRadioButton">
+        <property name="text">
+         <string>External file</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="QPushButton" name="browseButton">
+        <property name="accessibleName">
+         <string>Browser for key file</string>
+        </property>
+        <property name="text">
+         <string extracomment="Button for opening file dialog">Browse…</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QPushButton" name="generateButton">
+        <property name="text">
+         <string>Generate</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
        <widget class="QComboBox" name="attachmentComboBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -325,7 +332,6 @@
   <tabstop>lifetimeCheckBox</tabstop>
   <tabstop>lifetimeSpinBox</tabstop>
   <tabstop>attachmentRadioButton</tabstop>
-  <tabstop>attachmentComboBox</tabstop>
   <tabstop>externalFileRadioButton</tabstop>
   <tabstop>browseButton</tabstop>
   <tabstop>addToAgentButton</tabstop>

--- a/src/sshagent/CMakeLists.txt
+++ b/src/sshagent/CMakeLists.txt
@@ -8,6 +8,8 @@ if(WITH_XC_SSHAGENT)
         BinaryStream.cpp
         KeeAgentSettings.cpp
         OpenSSHKey.cpp
+        OpenSSHKeyGen.cpp
+        OpenSSHKeyGenDialog.cpp
         SSHAgent.cpp
     )
 

--- a/src/sshagent/OpenSSHKey.h
+++ b/src/sshagent/OpenSSHKey.h
@@ -41,9 +41,11 @@ public:
     const QString fingerprint(QCryptographicHash::Algorithm algo = QCryptographicHash::Sha256) const;
     const QString comment() const;
     const QString publicKey() const;
+    const QString privateKey();
     const QString errorString() const;
 
     void setType(const QString& type);
+    void setCheck(quint32 check);
     void setPublicData(const QByteArray& data);
     void setPrivateData(const QByteArray& data);
     void setComment(const QString& comment);
@@ -70,6 +72,7 @@ private:
 
     bool extractPEM(const QByteArray& in, QByteArray& out);
 
+    quint32 m_check;
     QString m_type;
     QString m_cipherName;
     QByteArray m_cipherIV;

--- a/src/sshagent/OpenSSHKeyGen.cpp
+++ b/src/sshagent/OpenSSHKeyGen.cpp
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "OpenSSHKeyGen.h"
+#include "BinaryStream.h"
+#include "OpenSSHKey.h"
+#include "crypto/Random.h"
+
+#include <botan/ecdsa.h>
+#include <botan/ed25519.h>
+#include <botan/rsa.h>
+
+namespace OpenSSHKeyGen
+{
+    namespace
+    {
+        void bigIntToStream(const Botan::BigInt& i, BinaryStream& stream, int padding = 0)
+        {
+            QByteArray ba(i.bytes() + padding, 0);
+            i.binary_encode(reinterpret_cast<uint8_t*>(ba.data() + padding), ba.size() - padding);
+            stream.writeString(ba);
+        }
+
+        void vectorToStream(const std::vector<uint8_t>& v, BinaryStream& stream)
+        {
+            QByteArray ba(reinterpret_cast<const char*>(v.data()), v.size());
+            stream.writeString(ba);
+        }
+
+        void vectorToStream(const Botan::secure_vector<uint8_t>& v, BinaryStream& stream)
+        {
+            QByteArray ba(reinterpret_cast<const char*>(v.data()), v.size());
+            stream.writeString(ba);
+        }
+    } // namespace
+
+    bool generateRSA(OpenSSHKey& key, int bits)
+    {
+        auto rng = randomGen()->getRng();
+
+        try {
+            Botan::RSA_PrivateKey rsaKey(*rng, bits);
+
+            QByteArray publicData;
+            BinaryStream publicStream(&publicData);
+            // intentionally flipped n e -> e n
+            bigIntToStream(rsaKey.get_e(), publicStream);
+            bigIntToStream(rsaKey.get_n(), publicStream, 1);
+
+            QByteArray privateData;
+            BinaryStream privateStream(&privateData);
+            bigIntToStream(rsaKey.get_n(), privateStream, 1);
+            bigIntToStream(rsaKey.get_e(), privateStream);
+            bigIntToStream(rsaKey.get_d(), privateStream);
+            bigIntToStream(rsaKey.get_c(), privateStream, 1);
+            bigIntToStream(rsaKey.get_p(), privateStream, 1);
+            bigIntToStream(rsaKey.get_q(), privateStream, 1);
+
+            key.setType("ssh-rsa");
+            key.setCheck(randomGen()->randomUInt(std::numeric_limits<quint32>::max() - 1) + 1);
+            key.setPublicData(publicData);
+            key.setPrivateData(privateData);
+            key.setComment("id_rsa");
+            return true;
+        } catch (std::exception& e) {
+            return false;
+        }
+    }
+
+    bool generateECDSA(OpenSSHKey& key, int bits)
+    {
+        auto rng = randomGen()->getRng();
+        QString group = QString("nistp%1").arg(bits);
+
+        try {
+            Botan::EC_Group domain(QString("secp%1r1").arg(bits).toStdString());
+            Botan::ECDSA_PrivateKey ecdsaKey(*rng, domain);
+
+            QByteArray publicData;
+            BinaryStream publicStream(&publicData);
+            publicStream.writeString(group);
+            vectorToStream(ecdsaKey.public_key_bits(), publicStream);
+
+            QByteArray privateData;
+            BinaryStream privateStream(&privateData);
+            privateStream.writeString(group);
+            vectorToStream(ecdsaKey.public_key_bits(), privateStream);
+            bigIntToStream(ecdsaKey.private_value(), privateStream, 1);
+
+            key.setType("ecdsa-sha2-" + group);
+            key.setCheck(randomGen()->randomUInt(std::numeric_limits<quint32>::max() - 1) + 1);
+            key.setPublicData(publicData);
+            key.setPrivateData(privateData);
+            key.setComment("id_ecdsa");
+            return true;
+        } catch (std::exception& e) {
+            return false;
+        }
+    }
+
+    bool generateEd25519(OpenSSHKey& key)
+    {
+        auto rng = randomGen()->getRng();
+
+        try {
+            Botan::Ed25519_PrivateKey ed25519Key(*rng);
+
+            QByteArray publicData;
+            BinaryStream publicStream(&publicData);
+            vectorToStream(ed25519Key.get_public_key(), publicStream);
+
+            QByteArray privateData;
+            BinaryStream privateStream(&privateData);
+            vectorToStream(ed25519Key.get_public_key(), privateStream);
+            vectorToStream(ed25519Key.get_private_key(), privateStream);
+
+            key.setType("ssh-ed25519");
+            key.setCheck(randomGen()->randomUInt(std::numeric_limits<quint32>::max() - 1) + 1);
+            key.setPublicData(publicData);
+            key.setPrivateData(privateData);
+            key.setComment("id_ed25519");
+            return true;
+        } catch (std::exception& e) {
+            return false;
+        }
+    }
+} // namespace OpenSSHKeyGen

--- a/src/sshagent/OpenSSHKeyGen.h
+++ b/src/sshagent/OpenSSHKeyGen.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_OPENSSHKEYGEN_H
+#define KEEPASSXC_OPENSSHKEYGEN_H
+
+class OpenSSHKey;
+
+namespace OpenSSHKeyGen
+{
+    bool generateRSA(OpenSSHKey& key, int bits);
+    bool generateECDSA(OpenSSHKey& key, int bits);
+    bool generateEd25519(OpenSSHKey& key);
+} // namespace OpenSSHKeyGen
+
+#endif

--- a/src/sshagent/OpenSSHKeyGenDialog.cpp
+++ b/src/sshagent/OpenSSHKeyGenDialog.cpp
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "OpenSSHKeyGenDialog.h"
+#include "OpenSSHKey.h"
+#include "OpenSSHKeyGen.h"
+#include "gui/Icons.h"
+#include "ui_OpenSSHKeyGenDialog.h"
+#include <QHostInfo>
+#include <QProcessEnvironment>
+
+OpenSSHKeyGenDialog::OpenSSHKeyGenDialog(QWidget* parent)
+    : QDialog(parent)
+    , m_ui(new Ui::OpenSSHKeyGenDialog())
+    , m_key(nullptr)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowIcon(icons()->icon("password-generator"));
+
+    m_ui->setupUi(this);
+
+    m_ui->typeComboBox->clear();
+    m_ui->typeComboBox->addItem("Ed25519");
+    m_ui->typeComboBox->addItem("RSA");
+    m_ui->typeComboBox->addItem("ECDSA");
+
+    QString user = QProcessEnvironment::systemEnvironment().value("USER");
+    m_ui->commentLineEdit->setText(user + "@" + QHostInfo::localHostName());
+
+    connect(m_ui->typeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(typeChanged()));
+
+    typeChanged();
+}
+
+// Required for QScopedPointer
+OpenSSHKeyGenDialog::~OpenSSHKeyGenDialog()
+{
+}
+
+void OpenSSHKeyGenDialog::typeChanged()
+{
+    m_ui->bitsComboBox->clear();
+
+    if (m_ui->typeComboBox->currentText() == QString("Ed25519")) {
+        m_ui->bitsComboBox->addItem("32");
+    } else if (m_ui->typeComboBox->currentText() == QString("RSA")) {
+        m_ui->bitsComboBox->addItem("2048");
+        m_ui->bitsComboBox->addItem("3072");
+        m_ui->bitsComboBox->addItem("4096");
+        m_ui->bitsComboBox->setCurrentText("3072");
+    } else if (m_ui->typeComboBox->currentText() == QString("ECDSA")) {
+        m_ui->bitsComboBox->addItem("256");
+        m_ui->bitsComboBox->addItem("384");
+        m_ui->bitsComboBox->addItem("521");
+        m_ui->bitsComboBox->setCurrentText("256");
+    }
+}
+
+void OpenSSHKeyGenDialog::accept()
+{
+    // disable form and try to process this update before blocking in key generation
+    setEnabled(false);
+    QCoreApplication::processEvents();
+
+    int bits = m_ui->bitsComboBox->currentText().toInt();
+
+    if (m_ui->typeComboBox->currentText() == QString("Ed25519")) {
+        OpenSSHKeyGen::generateEd25519(*m_key);
+    } else if (m_ui->typeComboBox->currentText() == QString("RSA")) {
+        OpenSSHKeyGen::generateRSA(*m_key, bits);
+    } else if (m_ui->typeComboBox->currentText() == QString("ECDSA")) {
+        OpenSSHKeyGen::generateECDSA(*m_key, bits);
+    } else {
+        reject();
+        return;
+    }
+
+    m_key->setComment(m_ui->commentLineEdit->text());
+    QDialog::accept();
+}
+
+void OpenSSHKeyGenDialog::setKey(OpenSSHKey* key)
+{
+    m_key = key;
+}

--- a/src/sshagent/OpenSSHKeyGenDialog.h
+++ b/src/sshagent/OpenSSHKeyGenDialog.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2021 Team KeePassXC <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_OPENSSHKEYGENDIALOG_H
+#define KEEPASSXC_OPENSSHKEYGENDIALOG_H
+
+#include <QDialog>
+class OpenSSHKey;
+
+namespace Ui
+{
+    class OpenSSHKeyGenDialog;
+}
+
+class OpenSSHKeyGenDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit OpenSSHKeyGenDialog(QWidget* parent = nullptr);
+    ~OpenSSHKeyGenDialog() override;
+
+    void accept() override;
+    void setKey(OpenSSHKey* key);
+
+private slots:
+    void typeChanged();
+
+private:
+    QScopedPointer<Ui::OpenSSHKeyGenDialog> m_ui;
+    OpenSSHKey* m_key;
+};
+
+#endif // KEEPASSXC_OPENSSHKEYGENDIALOG_H

--- a/src/sshagent/OpenSSHKeyGenDialog.ui
+++ b/src/sshagent/OpenSSHKeyGenDialog.ui
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OpenSSHKeyGenDialog</class>
+ <widget class="QDialog" name="OpenSSHKeyGenDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>200</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>SSH Key Generator</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QComboBox" name="typeComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="typeLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="bitsLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Bits</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="commentLabel">
+     <property name="text">
+      <string>Comment</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QComboBox" name="bitsComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+     </property>
+     <property name="minimumContentsLength">
+      <number>4</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="3">
+    <widget class="QLineEdit" name="commentLineEdit"/>
+   </item>
+   <item row="2" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>OpenSSHKeyGenDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>OpenSSHKeyGenDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -254,6 +254,7 @@ void TestOpenSSHKey::testParseRSACompare()
     QCOMPARE(oldKey.type(), newKey.type());
     QCOMPARE(oldKey.fingerprint(), newKey.fingerprint());
     QCOMPARE(oldPrivateKey, newPrivateKey);
+    QCOMPARE(newKeyString, newKey.privateKey());
 }
 
 void TestOpenSSHKey::testParseECDSA256()
@@ -277,6 +278,7 @@ void TestOpenSSHKey::testParseECDSA256()
     QCOMPARE(key.type(), QString("ecdsa-sha2-nistp256"));
     QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa256@keepassxc"));
     QCOMPARE(key.fingerprint(), QString("SHA256:nwwovZmQbBeiR3GZRpK4OWHgCUE7E0wFtCN7Ng7eX5g"));
+    QCOMPARE(keyString, key.privateKey());
 }
 
 void TestOpenSSHKey::testParseECDSA384()
@@ -302,6 +304,7 @@ void TestOpenSSHKey::testParseECDSA384()
     QCOMPARE(key.type(), QString("ecdsa-sha2-nistp384"));
     QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa384@keepassxc"));
     QCOMPARE(key.fingerprint(), QString("SHA256:B5tLMG976BZ6nyi/oRUmKaTJcaEaFagEjBfOAgru0OY"));
+    QCOMPARE(keyString, key.privateKey());
 }
 
 void TestOpenSSHKey::testParseECDSA521()
@@ -328,6 +331,7 @@ void TestOpenSSHKey::testParseECDSA521()
     QCOMPARE(key.type(), QString("ecdsa-sha2-nistp521"));
     QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa521@keepassxc"));
     QCOMPARE(key.fingerprint(), QString("SHA256:m3LtA9MtZW8FN0R3vwA0AAI+YtegbggGCy3EGKWya+s"));
+    QCOMPARE(keyString, key.privateKey());
 }
 
 void TestOpenSSHKey::testDecryptOpenSSHAES256CBC()
@@ -533,6 +537,7 @@ void TestOpenSSHKey::testParseECDSASecurityKey()
     QCOMPARE(key.type(), QString("sk-ecdsa-sha2-nistp256@openssh.com"));
     QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa-sk@keepassxc"));
     QCOMPARE(key.fingerprint(), QString("SHA256:ctOtAsPMqbtumGI41o2oeWfGDah4m1ACILRj+x0gx0E"));
+    QCOMPARE(keyString, key.privateKey());
 }
 
 void TestOpenSSHKey::testParseED25519SecurityKey()
@@ -557,4 +562,5 @@ void TestOpenSSHKey::testParseED25519SecurityKey()
     QCOMPARE(key.type(), QString("sk-ssh-ed25519@openssh.com"));
     QCOMPARE(key.comment(), QString("opensshkey-test-ed25519-sk@keepassxc"));
     QCOMPARE(key.fingerprint(), QString("SHA256:PGtS5WvbnYmNqFIeRbzO6cVP9GLh8eEzENgkHp02XIA"));
+    QCOMPARE(keyString, key.privateKey());
 }

--- a/tests/TestSSHAgent.cpp
+++ b/tests/TestSSHAgent.cpp
@@ -20,6 +20,7 @@
 #include "core/Config.h"
 #include "crypto/Crypto.h"
 #include "sshagent/KeeAgentSettings.h"
+#include "sshagent/OpenSSHKeyGen.h"
 #include "sshagent/SSHAgent.h"
 
 #include <QTest>
@@ -222,6 +223,66 @@ void TestSSHAgent::testToOpenSSHKey()
     settings.toOpenSSHKey("username", "correctpassphrase", QString(), nullptr, key, false);
 
     QVERIFY(!key.publicKey().isEmpty());
+}
+
+void TestSSHAgent::testKeyGenRSA()
+{
+    SSHAgent agent;
+    agent.setEnabled(true);
+    agent.setAuthSockOverride(m_agentSocketFileName);
+
+    QVERIFY(agent.isAgentRunning());
+
+    OpenSSHKey key;
+    KeeAgentSettings settings;
+    bool keyInAgent;
+
+    QVERIFY(OpenSSHKeyGen::generateRSA(key, 2048));
+
+    QVERIFY(agent.addIdentity(key, settings, m_uuid));
+    QVERIFY(agent.checkIdentity(key, keyInAgent) && keyInAgent);
+    QVERIFY(agent.removeIdentity(key));
+    QVERIFY(agent.checkIdentity(key, keyInAgent) && !keyInAgent);
+}
+
+void TestSSHAgent::testKeyGenECDSA()
+{
+    SSHAgent agent;
+    agent.setEnabled(true);
+    agent.setAuthSockOverride(m_agentSocketFileName);
+
+    QVERIFY(agent.isAgentRunning());
+
+    OpenSSHKey key;
+    KeeAgentSettings settings;
+    bool keyInAgent;
+
+    QVERIFY(OpenSSHKeyGen::generateECDSA(key, 256));
+
+    QVERIFY(agent.addIdentity(key, settings, m_uuid));
+    QVERIFY(agent.checkIdentity(key, keyInAgent) && keyInAgent);
+    QVERIFY(agent.removeIdentity(key));
+    QVERIFY(agent.checkIdentity(key, keyInAgent) && !keyInAgent);
+}
+
+void TestSSHAgent::testKeyGenEd25519()
+{
+    SSHAgent agent;
+    agent.setEnabled(true);
+    agent.setAuthSockOverride(m_agentSocketFileName);
+
+    QVERIFY(agent.isAgentRunning());
+
+    OpenSSHKey key;
+    KeeAgentSettings settings;
+    bool keyInAgent;
+
+    QVERIFY(OpenSSHKeyGen::generateEd25519(key));
+
+    QVERIFY(agent.addIdentity(key, settings, m_uuid));
+    QVERIFY(agent.checkIdentity(key, keyInAgent) && keyInAgent);
+    QVERIFY(agent.removeIdentity(key));
+    QVERIFY(agent.checkIdentity(key, keyInAgent) && !keyInAgent);
 }
 
 void TestSSHAgent::cleanupTestCase()

--- a/tests/TestSSHAgent.h
+++ b/tests/TestSSHAgent.h
@@ -35,6 +35,9 @@ private slots:
     void testLifetimeConstraint();
     void testConfirmConstraint();
     void testToOpenSSHKey();
+    void testKeyGenRSA();
+    void testKeyGenECDSA();
+    void testKeyGenEd25519();
     void cleanupTestCase();
 
 private:


### PR DESCRIPTION
Supported key types are RSA, ECDSA and Ed25519.

Includes tests to compare writing out keys produce the exact same
private key if read from OpenSSH format and tests against ssh-agent
to ensure all no generated key is rejected.

Fixes #1761 

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
The "Generate" button has been added right next to the attachment list which pop up the dialog. Generated key will be automatically selected when you click OK.

![image](https://user-images.githubusercontent.com/106598/145630393-631d3c47-3551-413e-a445-5aad5521d4ec.png)


## Testing strategy
Tested key generation on Linux and the keys seem to work, needs more testing, though.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
