### PR TITLE
Add support for retrieving credentials when non-connected database is active

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -264,8 +264,9 @@ QJsonObject BrowserAction::handleTestAssociate(const QJsonObject& json, const QS
         return getErrorReply(action, ERROR_KEEPASS_DATABASE_NOT_OPENED);
     }
 
-    const QString key = browserService()->getKey(id);
-    if (key.isEmpty() || key.compare(responseKey) != 0) {
+    const auto keyResponse = browserService()->getKey(id);
+    if (keyResponse.second.isEmpty()) {
+        m_associated = false;
         return getErrorReply(action, ERROR_KEEPASS_ASSOCIATION_FAILED);
     }
 
@@ -275,6 +276,7 @@ QJsonObject BrowserAction::handleTestAssociate(const QJsonObject& json, const QS
     QJsonObject message = buildMessage(newNonce);
     message["hash"] = hash;
     message["id"] = id;
+    message["associated"] = keyResponse.first ? TRUE_STR : FALSE_STR;
 
     return buildResponse(action, message, newNonce);
 }

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -393,12 +393,12 @@ QString BrowserService::storeKey(const QString& key)
 
 QPair<bool, QString> BrowserService::getKey(const QString& id)
 {
-    auto db = getDatabase();
-    if (!db) {
+    auto currentDatabase = getDatabase();
+    if (!currentDatabase) {
         return {};
     }
 
-    const auto currentHash = db->metadata()->customData()->value(CustomData::BrowserKeyPrefix + id);
+    const auto currentHash = currentDatabase->metadata()->customData()->value(CustomData::BrowserKeyPrefix + id);
     const auto isAssociated = !currentHash.isEmpty();
     auto result = qMakePair(isAssociated, currentHash);
 

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 2013 Francois Ferrand
  *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -45,7 +45,7 @@ public:
 
     void setEnabled(bool enabled);
 
-    QString getKey(const QString& id);
+    QPair<bool, QString> getKey(const QString& id);
     QString storeKey(const QString& key);
     QString getDatabaseHash(bool legacy = false);
 


### PR DESCRIPTION
Current implementation does not allow retrieving credentials from a connected database if a non-connected database is on the active tab. The behavior is changed so that if "Search for all databases" option is enabled, all connected databases are returned on `geyKey()` and the matching hash is returned, instead of just checking the current active database.

An extra parameter `associated` is added to the JSON for browser extension because `test-associate` now returns `true` even if the active database is not  connected. The new parameters allows a backwards compatible way to check if the active database is truly associated with the extension.

Browser side PR coming soon.

Fixes #7269.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
