### PR TITLE
Add support for Microsoft Edge

### DIFF
--- a/utils/keepassxc-snap-helper.sh
+++ b/utils/keepassxc-snap-helper.sh
@@ -52,7 +52,8 @@ JSON_CHROME=$(cat << EOF
     "type": "stdio",
     "allowed_origins": [
         "chrome-extension://iopaggbpplllidnfmcghoonnokmjoicf/",
-        "chrome-extension://oboonakemofpalcgghocfoadofidjkkk/"
+        "chrome-extension://oboonakemofpalcgghocfoadofidjkkk/",
+        "chrome-extension://pdffhmdngciaglkoonimfcmckehcpafo/"
     ]
 }
 EOF
@@ -99,6 +100,11 @@ setupTorBrowser() {
     INSTALL_DIR="${BASE_DIR}/.tor-browser/app/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts"
 }
 
+setupEdge() {
+    JSON_OUT=${JSON_CHROME}
+    INSTALL_DIR="${BASE_DIR}/.config/microsoft-edge/NativeMessagingHosts"
+}
+
 # --------------------------------
 # Start of script
 # --------------------------------
@@ -113,6 +119,7 @@ BROWSER=$(whiptail \
             "4" "Vivaldi" \
             "5" "Brave" \
             "6" "Tor Browser" \
+            "7" "Microsoft Edge" \
             3>&1 1>&2 2>&3)
 
 clear
@@ -127,6 +134,7 @@ if [[ $exitstatus == 0 ]]; then
         4) setupVivaldi ;;
         5) setupBrave ;;
         6) setupTorBrowser ;;
+        7) setupEdge ;;
     esac
 
     # Install the JSON file


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Microsoft Edge can now also be installed in Linux. This small change adds support to the snap helper to correctly recognize it and install the JSON with proxy information.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Used the modified helper script with MS Edge, and successfully connected to a database with KeepassXC-Browser.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
