### PR TITLE
Show expired entries on DB unlock

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -460,6 +460,22 @@
         <source>{DB_FILENAME}.old.kdbx</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>On database unlock, show entries that </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>are expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>will expire within </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetSecurity</name>
@@ -2383,6 +2399,14 @@ Disable safe saves and try again?</translation>
     </message>
     <message>
         <source>Database Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expired entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Entries expiring within %1 days</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -111,6 +111,8 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_CheckForUpdates, {QS("GUI/CheckForUpdates"), Roaming, true}},
     {Config::GUI_CheckForUpdatesNextCheck, {QS("GUI/CheckForUpdatesNextCheck"), Local, 0}},
     {Config::GUI_CheckForUpdatesIncludeBetas, {QS("GUI/CheckForUpdatesIncludeBetas"), Roaming, false}},
+    {Config::GUI_ShowExpiredEntriesOnDatabaseUnlock, {QS("GUI/ShowExpiredEntriesOnDatabaseUnlock"), Roaming, true}},
+    {Config::GUI_ShowExpiredEntriesOnDatabaseUnlockOffsetDays, {QS("GUI/ShowExpiredEntriesOnDatabaseUnlockOffsetDays"), Roaming, 3}},
 
     {Config::GUI_MainWindowGeometry, {QS("GUI/MainWindowGeometry"), Local, {}}},
     {Config::GUI_MainWindowState, {QS("GUI/MainWindowState"), Local, {}}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -91,6 +91,8 @@ public:
         GUI_CompactMode,
         GUI_CheckForUpdates,
         GUI_CheckForUpdatesIncludeBetas,
+        GUI_ShowExpiredEntriesOnDatabaseUnlock,
+        GUI_ShowExpiredEntriesOnDatabaseUnlockOffsetDays,
 
         GUI_MainWindowGeometry,
         GUI_MainWindowState,

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -441,7 +441,12 @@ int Entry::size() const
 
 bool Entry::isExpired() const
 {
-    return m_data.timeInfo.expires() && m_data.timeInfo.expiryTime() < Clock::currentDateTimeUtc();
+    return willExpireInDays(0);
+}
+
+bool Entry::willExpireInDays(int days) const
+{
+    return m_data.timeInfo.expires() && m_data.timeInfo.expiryTime() < Clock::currentDateTime().addDays(days);
 }
 
 bool Entry::isRecycled() const

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -121,6 +121,7 @@ public:
 
     bool hasTotp() const;
     bool isExpired() const;
+    bool willExpireInDays(int days) const;
     bool isRecycled() const;
     bool isAttributeReference(const QString& key) const;
     bool isAttributeReferenceOf(const QString& key, const QUuid& uuid) const;

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -120,6 +120,8 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
     connect(m_generalUi->backupBeforeSaveCheckBox, SIGNAL(toggled(bool)),
             m_generalUi->backupFilePathPicker, SLOT(setEnabled(bool)));
     connect(m_generalUi->backupFilePathPicker, SIGNAL(pressed()), SLOT(selectBackupDirectory()));
+    connect(m_generalUi->showExpiredEntriesOnDatabaseUnlockCheckBox, SIGNAL(toggled(bool)),
+            SLOT(showExpiredEntriesOnDatabaseUnlockToggled(bool)));
 
     connect(m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)),
             m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));
@@ -251,6 +253,12 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->checkForUpdatesIncludeBetasCheckBox->setChecked(
         config()->get(Config::GUI_CheckForUpdatesIncludeBetas).toBool());
 
+    m_generalUi->showExpiredEntriesOnDatabaseUnlockCheckBox->setChecked(
+        config()->get(Config::GUI_ShowExpiredEntriesOnDatabaseUnlock).toBool());
+    m_generalUi->showExpiredEntriesOnDatabaseUnlockOffsetSpinBox->setValue(
+        config()->get(Config::GUI_ShowExpiredEntriesOnDatabaseUnlockOffsetDays).toInt());
+    showExpiredEntriesOnDatabaseUnlockToggled(m_generalUi->showExpiredEntriesOnDatabaseUnlockCheckBox->isChecked());
+
     m_generalUi->autoTypeAskCheckBox->setChecked(config()->get(Config::Security_AutoTypeAsk).toBool());
 
     if (autoType()->isAvailable()) {
@@ -377,6 +385,11 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::GUI_CheckForUpdates, m_generalUi->checkForUpdatesOnStartupCheckBox->isChecked());
     config()->set(Config::GUI_CheckForUpdatesIncludeBetas,
                   m_generalUi->checkForUpdatesIncludeBetasCheckBox->isChecked());
+
+    config()->set(Config::GUI_ShowExpiredEntriesOnDatabaseUnlock,
+                  m_generalUi->showExpiredEntriesOnDatabaseUnlockCheckBox->isChecked());
+    config()->set(Config::GUI_ShowExpiredEntriesOnDatabaseUnlockOffsetDays,
+                  m_generalUi->showExpiredEntriesOnDatabaseUnlockOffsetSpinBox->value());
 
     config()->set(Config::Security_AutoTypeAsk, m_generalUi->autoTypeAskCheckBox->isChecked());
 
@@ -518,6 +531,11 @@ void ApplicationSettingsWidget::rememberDatabasesToggled(bool checked)
 void ApplicationSettingsWidget::checkUpdatesToggled(bool checked)
 {
     m_generalUi->checkForUpdatesIncludeBetasCheckBox->setEnabled(checked);
+}
+
+void ApplicationSettingsWidget::showExpiredEntriesOnDatabaseUnlockToggled(bool checked)
+{
+    m_generalUi->showExpiredEntriesOnDatabaseUnlockOffsetSpinBox->setEnabled(checked);
 }
 
 void ApplicationSettingsWidget::selectBackupDirectory()

--- a/src/gui/ApplicationSettingsWidget.h
+++ b/src/gui/ApplicationSettingsWidget.h
@@ -62,6 +62,7 @@ private slots:
     void systrayToggled(bool checked);
     void rememberDatabasesToggled(bool checked);
     void checkUpdatesToggled(bool checked);
+    void showExpiredEntriesOnDatabaseUnlockToggled(bool checked);
     void selectBackupDirectory();
 
 private:

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -234,6 +234,73 @@
                 </item>
                </layout>
               </item>
+              <item>
+               <layout class="QGridLayout" name="showExpiredEntriesSubLayout">
+                <property name="sizeConstraint">
+                 <enum>QLayout::SetMaximumSize</enum>
+                </property>
+                <property name="spacing">
+                 <number>6</number>
+                </property>
+                <item row="0" column="0">
+                 <widget class="QCheckBox" name="showExpiredEntriesOnDatabaseUnlockCheckBox">
+                  <property name="text">
+                   <string>On database unlock, show entries that </string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QSpinBox" name="showExpiredEntriesOnDatabaseUnlockOffsetSpinBox">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::StrongFocus</enum>
+                  </property>
+                  <property name="accessibleName">
+                   <string>On database unlock, show entries that </string>
+                  </property>
+                  <property name="prefix">
+                   <string>will expire within </string>
+                  </property>
+                  <property name="suffix">
+                   <string> days</string>
+                  </property>
+                  <property name="minimum">
+                   <number>0</number>
+                  </property>
+                  <property name="maximum">
+                   <number>30</number>
+                  </property>
+                  <property name="value">
+                   <number>0</number>
+                  </property>
+                  <property name="specialValueText">
+                   <string>are expired</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="2">
+                 <spacer name="showExpiredEntriesSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
              </layout>
             </widget>
            </item>
@@ -1138,6 +1205,8 @@
   <tabstop>rememberLastKeyFilesCheckBox</tabstop>
   <tabstop>checkForUpdatesOnStartupCheckBox</tabstop>
   <tabstop>checkForUpdatesIncludeBetasCheckBox</tabstop>
+  <tabstop>showExpiredEntriesOnDatabaseUnlockCheckBox</tabstop>
+  <tabstop>showExpiredEntriesOnDatabaseUnlockOffsetSpinBox</tabstop>
   <tabstop>autoSaveAfterEveryChangeCheckBox</tabstop>
   <tabstop>autoSaveOnExitCheckBox</tabstop>
   <tabstop>autoSaveNonDataChangesCheckBox</tabstop>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes https://github.com/keepassxreboot/keepassxc/issues/4624. I implemented it the way I described in the above linked issue:

> I like the way the original KeePass does this. Whenever the database is unlocked,
it groups together all expired entries into a temporary, "virtual" group, which is displayed by default, so you see all your expired entries. If you navigate away to another group, the virtual group disappears, and the application behaves as normal from that point on.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
New option:
![image](https://user-images.githubusercontent.com/26036493/149640214-3b934b3b-ece9-48ab-a1e9-184de331ce55.png)

After DB unlock, option disabled:
![image](https://user-images.githubusercontent.com/26036493/149640232-b117f133-43a1-4e97-b2bb-f33c376e97c0.png)

After DB unlock, option enabled:
![image](https://user-images.githubusercontent.com/26036493/149640243-49a19ace-a41d-466b-bed3-86475b26e27e.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual testing:
 * Created expired entries in many groups (child groups too)
 * Verified that all expired entries appear on DB unlock, except the ones where "exclude from database reports" is ticked
 * Verified that nothing appears when there are no expired entries
 * Verified that nothing appears when the option is disabled

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
