### PR TITLE
feature/AutoTypeFromTrayIcon - Draft needs guidance see Tests

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1413,6 +1413,7 @@ void MainWindow::updateTrayIcon()
             actionToggle->setIcon(icons()->icon("keepassxc-monochrome-dark"));
 
             menu->addAction(m_ui->actionLockAllDatabases);
+            menu->addAction(m_ui->actionEntryAutoType);
 
 #ifdef Q_OS_MACOS
             auto actionQuit = new QAction(tr("Quit KeePassXC"), menu);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
AutoType from toolbar, assures that as user, you know where password would be auto typed.

If user also sets the “Config::Security_AutoTypeAsk” then he is 100% sure that current field he is focused at, is where the password would be typed, and focus would not be changed
due to manually changing to the KPXC app and back

[NOTE]: # ( Explain large or complex code modifications. )
N/A
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
N/A

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![Screen Shot 2022-01-19 at 12 56 35 PM](https://user-images.githubusercontent.com/8200598/150116893-aaa9f486-9b45-4e7e-a59a-8a6979e94914.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
### Test succeeded
1. Security_AutoTypeAsk on
1.1 Autotype from KPXC window
1.2 Autotype from KPXC toolbar
2 Security_AutoTypeAsk OFF, and KPXC minimized or hidden
2.1 Autotype from KPXC window
2.2 Autotype from KPXC toolbar
### Test Failed, needs guidance, not sure how to procceed
3.  Security_AutoTypeAsk OFF, and KPXC visible or not hidden
- Open application A and activate it's window
- Open application B and activate window
- AutoType from toolbar
- Unexpected result - it will AutoType in to A

(A walk-around might be always hide KPXC in the ```DatabaseWidget::performAutoType```,  
but there is allot of of this window management logic already in this function)

[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
