### PR TITLE
Add master password inactivity timer

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -37,6 +37,7 @@
 namespace
 {
     constexpr int clearFormsDelay = 30000;
+    constexpr int inputInactivityDelay = 60000;
 }
 
 DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
@@ -55,6 +56,14 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
         m_ui->editPassword->setText("");
         m_ui->editPassword->setShowPassword(false);
     });
+
+    m_inputInactivityTimer.setInterval(inputInactivityDelay);
+    connect(&m_inputInactivityTimer, &QTimer::timeout, this, [this] {
+        // Reset the password field after not receiving user input for a set time
+        m_ui->editPassword->setText("");
+        m_ui->editPassword->setShowPassword(false);
+    });
+    connect(m_ui->editPassword, &QLineEdit::textEdited, this, [this] { m_inputInactivityTimer.start(); });
 
     QFont font;
     font.setPointSize(font.pointSize() + 4);

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -38,7 +38,7 @@ namespace
 {
     constexpr int clearFormsDelay = 30000;
     constexpr int inputInactivityDelay = 60000;
-}
+} // namespace
 
 DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     : DialogyWidget(parent)

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -74,6 +74,7 @@ private slots:
 private:
     bool m_pollingHardwareKey = false;
     QTimer m_hideTimer;
+    QTimer m_inputInactivityTimer;
 
     Q_DISABLE_COPY(DatabaseOpenWidget)
 };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

I created a new timer that clears the master password field when the user doesn't update it after one minute. Fixes #6817 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
I verified if it works on a linux and windows machine and also I runned all the tests.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
