### PR TITLE
Fix new password generator closed reply with Browser Integration

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -328,9 +328,7 @@ void BrowserService::showPasswordGenerator(const QJsonObject& errorMessage, cons
         connect(m_passwordGenerator.data(),
                 &PasswordGeneratorWidget::appliedPassword,
                 m_passwordGenerator.data(),
-                [=](const QString& password) {
-                    emit passwordGenerated(password, nonce);
-                });
+                [=](const QString& password) { emit passwordGenerated(password, nonce); });
     }
 
     raiseWindow();

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 2013 Francois Ferrand
  *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -317,15 +317,20 @@ void BrowserService::showPasswordGenerator(const QJsonObject& errorMessage, cons
         m_passwordGenerator.reset(PasswordGeneratorWidget::popupGenerator());
 
         connect(m_passwordGenerator.data(), &PasswordGeneratorWidget::closed, m_passwordGenerator.data(), [=] {
+            if (!m_passwordGenerator->isPasswordGenerated()) {
+                m_browserHost->sendClientMessage(errorMessage);
+            }
+
             m_passwordGenerator.reset();
-            m_browserHost->sendClientMessage(errorMessage);
             hideWindow();
         });
 
         connect(m_passwordGenerator.data(),
                 &PasswordGeneratorWidget::appliedPassword,
                 m_passwordGenerator.data(),
-                [=](const QString& password) { emit passwordGenerated(password, nonce); });
+                [=](const QString& password) {
+                    emit passwordGenerated(password, nonce);
+                });
     }
 
     raiseWindow();

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -294,6 +294,7 @@ void PasswordGeneratorWidget::updatePasswordStrength(const QString& password)
 void PasswordGeneratorWidget::applyPassword()
 {
     saveSettings();
+    m_passwordGenerated = true;
     emit appliedPassword(m_ui->editNewPassword->text());
     emit closed();
 }
@@ -339,6 +340,11 @@ void PasswordGeneratorWidget::setPasswordVisible(bool visible)
 bool PasswordGeneratorWidget::isPasswordVisible() const
 {
     return m_ui->editNewPassword->isPasswordVisible();
+}
+
+bool PasswordGeneratorWidget::isPasswordGenerated() const
+{
+    return m_passwordGenerated;
 }
 
 void PasswordGeneratorWidget::deleteWordList()

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -53,6 +53,7 @@ public:
     void setStandaloneMode(bool standalone);
     QString getGeneratedPassword();
     bool isPasswordVisible() const;
+    bool isPasswordGenerated() const;
 
     static PasswordGeneratorWidget* popupGenerator(QWidget* parent = nullptr);
 
@@ -82,6 +83,7 @@ private slots:
 
 private:
     bool m_standalone = false;
+    bool m_passwordGenerated = false;
     int m_firstCustomWordlistIndex;
 
     void closeEvent(QCloseEvent* event);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
The password generator is sending an error reply also when password is generated.
Added a new boolean for checking that if the password was generated successfully. Disconnecting the closed event here cannot be done because it interferes with all other closed events with the popup dialog.

Fixes #7358.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
