### PR TITLE
Wait for hardware key when using --pw-stdin

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -181,7 +181,11 @@ void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
 {
     m_ui->editPassword->setText(pw);
     m_ui->keyFileLineEdit->setText(keyFile);
-    openDatabase();
+    if (m_pollingHardwareKey) {
+        m_openDatabaseAfterHardwareKeyResponse = true;
+    } else {
+        openDatabase();
+    }
 }
 
 void DatabaseOpenWidget::openDatabase()
@@ -454,6 +458,11 @@ void DatabaseOpenWidget::hardwareKeyResponse(bool found)
 
     m_ui->challengeResponseCombo->setCurrentIndex(selectedIndex);
     m_ui->challengeResponseCombo->setEnabled(true);
+
+    if (m_openDatabaseAfterHardwareKeyResponse) {
+        m_openDatabaseAfterHardwareKeyResponse = false;
+        openDatabase();
+    }
 }
 
 void DatabaseOpenWidget::openHardwareKeyHelp()

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -73,6 +73,7 @@ private slots:
 
 private:
     bool m_pollingHardwareKey = false;
+    bool m_openDatabaseAfterHardwareKeyResponse = false;
     QTimer m_hideTimer;
 
     Q_DISABLE_COPY(DatabaseOpenWidget)


### PR DESCRIPTION
This fixes the following behavior: When starting the application with a hardware-key-protected database file as an argument and providing the password via stdin, the application will try to open the database without the hardware key, even if the database was last opened with this key.
Example command:
```
echo test | keepassxc test.kdbx --pw-stdin 
```
When starting the application as described above, `DatabaseOpenWidget::load` already starts polling for hardware keys in order to pre-select the last one used. This change introduces the following behavior: Before trying to open a database that has last been opened with a hardware key, we wait until polling is complete and the last-used hardware key has been selected and then open the database.

## Screenshots
Before: The application instantly tries to open the database while also polling for hardware keys.
![image](https://user-images.githubusercontent.com/1208506/152692097-16e26989-a725-4129-b5db-aaa4cf84a31a.png)

After: The application logs right into the database.

## Testing strategy

- Start the application with a database file and `--pw-stdin` as arguments for hardware-key-protected and non-hardware-key-protected database files.
- Start the application without arguments and open both kinds of databases.
- Lock and unlock both kinds of databases.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
