### PR TITLE
Auto-Type: Only match non-empty associations

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -656,6 +656,10 @@
         <source>Default sequence</source>
         <translation>Default sequence</translation>
     </message>
+    <message>
+        <source>(empty)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoTypeMatchModel</name>

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -328,7 +328,7 @@ QList<QString> Entry::autoTypeSequences(const QString& windowTitle) const
     const auto assocList = autoTypeAssociations()->getAll();
     for (const auto& assoc : assocList) {
         auto window = resolveMultiplePlaceholders(assoc.window);
-        if (windowMatches(window)) {
+        if (!assoc.window.isEmpty() && windowMatches(window)) {
             if (!assoc.sequence.isEmpty()) {
                 sequenceList << assoc.sequence;
             } else {

--- a/src/gui/entry/AutoTypeAssociationsModel.cpp
+++ b/src/gui/entry/AutoTypeAssociationsModel.cpp
@@ -92,6 +92,9 @@ QVariant AutoTypeAssociationsModel::data(const QModelIndex& index, int role) con
     if (role == Qt::DisplayRole) {
         if (index.column() == 0) {
             QString window = m_autoTypeAssociations->get(index.row()).window;
+            if (window.isEmpty()) {
+                return tr("(empty)");
+            }
             if (m_entry) {
                 window = m_entry->maskPasswordPlaceholders(window);
                 window = m_entry->resolveMultiplePlaceholders(window);


### PR DESCRIPTION
Previously empty associations matched any window but since you can use a wildcard (*) if you specifically want that this change makes it possible to define multiple sequences for the global search if you need to.

Additionally show empty associations in the list as "(empty)" to better differentiate between rows if no title is set.

This trivial change makes #6869 possible without touching the dialog code.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/106598/152745259-ad9264d8-089c-476f-bce5-b28d7771ba9a.png)
![image](https://user-images.githubusercontent.com/106598/152745317-87d269ee-e38d-4f42-bdf6-42a1af7a9e96.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually on Linux.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)