### PR TITLE
Implement org.freedesktop.appearance.color-scheme support on Linux

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -21,6 +21,7 @@
 #include "gui/osutils/OSUtilsBase.h"
 #include <QAbstractNativeEventFilter>
 #include <QSharedPointer>
+#include <QtDBus/QDBusVariant>
 
 class NixUtils : public OSUtilsBase, QAbstractNativeEventFilter
 {
@@ -48,6 +49,9 @@ public:
         return false;
     }
 
+private slots:
+    void handleColorSchemeChanged(QString ns, QString key, QDBusVariant value);
+
 private:
     explicit NixUtils(QObject* parent = nullptr);
     ~NixUtils() override;
@@ -65,6 +69,16 @@ private:
         uint nativeModifiers;
     };
     QHash<QString, QSharedPointer<globalShortcut>> m_globalShortcuts;
+
+    // defined as per "org.freedesktop.appearance color-scheme" spec in
+    // https://github.com/flatpak/xdg-desktop-portal/blob/d7a304a00697d7d608821253cd013f3b97ac0fb6/data/org.freedesktop.impl.portal.Settings.xml#L33-L45
+    enum ColorschemePref
+    {
+        PreferNone,
+        PreferDark,
+        PreferLight
+    };
+    ColorschemePref m_systemColorschemePref = ColorschemePref::PreferNone;
 
     Q_DISABLE_COPY(NixUtils)
 };


### PR DESCRIPTION
This finally allows us to follow the system theme without restart in a reliable and desktop-environment independent way.

This uses the new standardized `org.freedesktop.appearance.color-scheme` key to accomplish this.

The following DEs already support this in the respective version:
- KDE Plasma since version 5.24 (Released 2022-02-08)
- Gnome since version 42 (Unreleased as of now)

In addition to that, the `xdg-deskop-portal` user service needs to be running.

Relevant blog post: https://blogs.gnome.org/alexm/2021/10/04/dark-style-preference/

Properly fixes #7146 (was closed as it was basically impossible to implement this in a reliable way a few years back)

Note that if the user does not have xdg-desktop-portal or is missing support for that specific key, the previous behaviour is unchanged.

Short demo:

https://user-images.githubusercontent.com/21310755/154370506-8b46892f-37d4-4920-9b21-5b6aff6ef33c.mp4



## Type of change
- ✅ New feature (change that adds functionality)
