### PR TITLE
Change "open" to "Open" in Windows context menu

### DIFF
--- a/share/windows/wix-patch.xml
+++ b/share/windows/wix-patch.xml
@@ -3,7 +3,7 @@
   <CPackWiXFragment Id="CM_CP_KeePassXC.exe">
     <ProgId Id="KeePassXC.kdbx" Description="KeePass Password Database" Icon="CM_FP_KeePassXC.exe" IconIndex="1">
       <Extension Id="kdbx" ContentType="application/x-keepass2">
-        <Verb Id="open" Command="open" TargetFile="CM_FP_KeePassXC.exe" Argument="&quot;%1&quot;"/>
+        <Verb Id="open" Command="Open" TargetFile="CM_FP_KeePassXC.exe" Argument="&quot;%1&quot;"/>
       </Extension>
     </ProgId>
   </CPackWiXFragment>


### PR DESCRIPTION
On Windows context menu items start with a capital letter, so change `open` to say `Open` for consistency with the OS and other software.

## Screenshots

Before:
![before](https://user-images.githubusercontent.com/4525736/154816958-830b557b-215c-4fa0-9ef7-4282600e1185.png)

After:
![after](https://user-images.githubusercontent.com/4525736/154816978-57b0e640-ea67-447a-a012-05ebba00e616.png)

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
