### PR TITLE
Auto-Type: Allow retyping with automatic relock

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -476,6 +476,18 @@
         <source>will expire within </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source> s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <translation type="unfinished">Re-lock previously locked database after performing Auto-Type</translation>
+    </message>
+    <message>
+        <source>Remember last typed entry for:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetSecurity</name>
@@ -519,10 +531,6 @@
     <message>
         <source>Lock databases after minimizing the window</source>
         <translation>Lock databases after minimizing the window</translation>
-    </message>
-    <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
-        <translation>Re-lock previously locked database after performing Auto-Type</translation>
     </message>
     <message>
         <source>Hide passwords in the entry preview panel</source>

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -21,6 +21,7 @@
 
 #include <QMutex>
 #include <QObject>
+#include <QTimer>
 #include <QWidget>
 
 #include "AutoTypeMatch.h"
@@ -61,6 +62,7 @@ signals:
     void globalAutoTypeTriggered(const QString& search);
     void autotypePerformed();
     void autotypeRejected();
+    void autotypeRetypeTimeout();
 
 private slots:
     void startGlobalAutoType(const QString& search);
@@ -98,7 +100,7 @@ private:
     WindowState m_windowState;
     WId m_windowForGlobal;
     AutoTypeMatch m_lastMatch;
-    qint64 m_lastMatchTime;
+    QTimer m_lastMatchRetypeTimer;
 
     Q_DISABLE_COPY(AutoType)
 };

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -78,6 +78,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::AutoTypeHideExpiredEntry,{QS("AutoTypeHideExpiredEntry"), Roaming, false}},
     {Config::GlobalAutoTypeKey,{QS("GlobalAutoTypeKey"), Roaming, 0}},
     {Config::GlobalAutoTypeModifiers,{QS("GlobalAutoTypeModifiers"), Roaming, 0}},
+    {Config::GlobalAutoTypeRetypeTime,{QS("GlobalAutoTypeRetypeTime"), Roaming, 15}},
     {Config::FaviconDownloadTimeout,{QS("FaviconDownloadTimeout"), Roaming, 10}},
     {Config::UpdateCheckMessageShown,{QS("UpdateCheckMessageShown"), Roaming, false}},
     {Config::UseTouchID,{QS("UseTouchID"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -60,6 +60,7 @@ public:
         AutoTypeHideExpiredEntry,
         GlobalAutoTypeKey,
         GlobalAutoTypeModifiers,
+        GlobalAutoTypeRetypeTime,
         FaviconDownloadTimeout,
         UpdateCheckMessageShown,
         UseTouchID,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -260,6 +260,7 @@ void ApplicationSettingsWidget::loadSettings()
     showExpiredEntriesOnDatabaseUnlockToggled(m_generalUi->showExpiredEntriesOnDatabaseUnlockCheckBox->isChecked());
 
     m_generalUi->autoTypeAskCheckBox->setChecked(config()->get(Config::Security_AutoTypeAsk).toBool());
+    m_generalUi->autoTypeRelockDatabaseCheckBox->setChecked(config()->get(Config::Security_RelockAutoType).toBool());
 
     if (autoType()->isAvailable()) {
         m_globalAutoTypeKey = static_cast<Qt::Key>(config()->get(Config::GlobalAutoTypeKey).toInt());
@@ -268,6 +269,7 @@ void ApplicationSettingsWidget::loadSettings()
         if (m_globalAutoTypeKey > 0 && m_globalAutoTypeModifiers > 0) {
             m_generalUi->autoTypeShortcutWidget->setShortcut(m_globalAutoTypeKey, m_globalAutoTypeModifiers);
         }
+        m_generalUi->autoTypeRetypeTimeSpinBox->setValue(config()->get(Config::GlobalAutoTypeRetypeTime).toInt());
         m_generalUi->autoTypeShortcutWidget->setAttribute(Qt::WA_MacShowFocusRect, true);
         m_generalUi->autoTypeDelaySpinBox->setValue(config()->get(Config::AutoTypeDelay).toInt());
         m_generalUi->autoTypeStartDelaySpinBox->setValue(config()->get(Config::AutoTypeStartDelay).toInt());
@@ -297,7 +299,6 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->lockDatabaseMinimizeCheckBox->setChecked(config()->get(Config::Security_LockDatabaseMinimize).toBool());
     m_secUi->lockDatabaseOnScreenLockCheckBox->setChecked(
         config()->get(Config::Security_LockDatabaseScreenLock).toBool());
-    m_secUi->relockDatabaseAutoTypeCheckBox->setChecked(config()->get(Config::Security_RelockAutoType).toBool());
     m_secUi->fallbackToSearch->setChecked(config()->get(Config::Security_IconDownloadFallback).toBool());
 
     m_secUi->passwordsHiddenCheckBox->setChecked(config()->get(Config::Security_PasswordsHidden).toBool());
@@ -392,11 +393,13 @@ void ApplicationSettingsWidget::saveSettings()
                   m_generalUi->showExpiredEntriesOnDatabaseUnlockOffsetSpinBox->value());
 
     config()->set(Config::Security_AutoTypeAsk, m_generalUi->autoTypeAskCheckBox->isChecked());
+    config()->set(Config::Security_RelockAutoType, m_generalUi->autoTypeRelockDatabaseCheckBox->isChecked());
 
     if (autoType()->isAvailable()) {
         config()->set(Config::GlobalAutoTypeKey, m_generalUi->autoTypeShortcutWidget->key());
         config()->set(Config::GlobalAutoTypeModifiers,
                       static_cast<int>(m_generalUi->autoTypeShortcutWidget->modifiers()));
+        config()->set(Config::GlobalAutoTypeRetypeTime, m_generalUi->autoTypeRetypeTimeSpinBox->value());
         config()->set(Config::AutoTypeDelay, m_generalUi->autoTypeDelaySpinBox->value());
         config()->set(Config::AutoTypeStartDelay, m_generalUi->autoTypeStartDelaySpinBox->value());
     }
@@ -410,7 +413,6 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::Security_LockDatabaseIdleSeconds, m_secUi->lockDatabaseIdleSpinBox->value());
     config()->set(Config::Security_LockDatabaseMinimize, m_secUi->lockDatabaseMinimizeCheckBox->isChecked());
     config()->set(Config::Security_LockDatabaseScreenLock, m_secUi->lockDatabaseOnScreenLockCheckBox->isChecked());
-    config()->set(Config::Security_RelockAutoType, m_secUi->relockDatabaseAutoTypeCheckBox->isChecked());
     config()->set(Config::Security_IconDownloadFallback, m_secUi->fallbackToSearch->isChecked());
 
     config()->set(Config::Security_PasswordsHidden, m_secUi->passwordsHiddenCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -266,11 +266,14 @@
                   <property name="accessibleName">
                    <string>On database unlock, show entries that </string>
                   </property>
-                  <property name="prefix">
-                   <string>will expire within </string>
+                  <property name="specialValueText">
+                   <string>are expired</string>
                   </property>
                   <property name="suffix">
                    <string> days</string>
+                  </property>
+                  <property name="prefix">
+                   <string>will expire within </string>
                   </property>
                   <property name="minimum">
                    <number>0</number>
@@ -280,9 +283,6 @@
                   </property>
                   <property name="value">
                    <number>0</number>
-                  </property>
-                  <property name="specialValueText">
-                   <string>are expired</string>
                   </property>
                  </widget>
                 </item>
@@ -1021,6 +1021,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="autoTypeRelockDatabaseCheckBox">
+         <property name="text">
+          <string>Re-lock previously locked database after performing Auto-Type</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_4">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -1045,57 +1052,32 @@
           <number>8</number>
          </property>
          <item row="2" column="0">
-          <widget class="QLabel" name="autoTypeDelayLabel">
+          <widget class="QLabel" name="autoTypeStartDelayLabel">
            <property name="text">
-            <string>Auto-Type typing delay:</string>
+            <string>Auto-Type start delay:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
-            <cstring>autoTypeDelaySpinBox</cstring>
+            <cstring>autoTypeStartDelaySpinBox</cstring>
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="ShortcutWidget" name="autoTypeShortcutWidget">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+         <item row="0" column="0">
+          <widget class="QLabel" name="autoTypeShortcutLabel">
+           <property name="text">
+            <string>Global Auto-Type shortcut:</string>
            </property>
-           <property name="accessibleName">
-            <string>Global auto-type shortcut</string>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="buddy">
+            <cstring>autoTypeShortcutWidget</cstring>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QSpinBox" name="autoTypeDelaySpinBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="accessibleName">
-            <string>Auto-type character typing delay milliseconds</string>
-           </property>
-           <property name="suffix">
-            <string comment="Milliseconds"> ms</string>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="maximum">
-            <number>1000</number>
-           </property>
-           <property name="value">
-            <number>25</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
           <widget class="QSpinBox" name="autoTypeStartDelaySpinBox">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1126,29 +1108,16 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="autoTypeShortcutLabel">
+         <item row="3" column="0">
+          <widget class="QLabel" name="autoTypeDelayLabel">
            <property name="text">
-            <string>Global Auto-Type shortcut:</string>
+            <string>Auto-Type typing delay:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
-            <cstring>autoTypeShortcutWidget</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="autoTypeStartDelayLabel">
-           <property name="text">
-            <string>Auto-Type start delay:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="buddy">
-            <cstring>autoTypeStartDelaySpinBox</cstring>
+            <cstring>autoTypeDelaySpinBox</cstring>
            </property>
           </widget>
          </item>
@@ -1164,6 +1133,67 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item row="0" column="1">
+          <widget class="ShortcutWidget" name="autoTypeShortcutWidget">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="accessibleName">
+            <string>Global auto-type shortcut</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QSpinBox" name="autoTypeDelaySpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="accessibleName">
+            <string>Auto-type character typing delay milliseconds</string>
+           </property>
+           <property name="suffix">
+            <string comment="Milliseconds"> ms</string>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>25</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="autoTypeRetypeLabel">
+           <property name="text">
+            <string>Remember last typed entry for:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="autoTypeRetypeTimeSpinBox">
+           <property name="suffix">
+            <string> s</string>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>60</number>
+           </property>
+           <property name="value">
+            <number>15</number>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -216,13 +216,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="relockDatabaseAutoTypeCheckBox">
-        <property name="text">
-         <string>Re-lock previously locked database after performing Auto-Type</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QCheckBox" name="passwordsRepeatVisibleCheckBox">
         <property name="text">
          <string>Require password repeat when it is visible</string>
@@ -320,7 +313,6 @@
   <tabstop>lockDatabaseOnScreenLockCheckBox</tabstop>
   <tabstop>touchIDResetOnScreenLockCheckBox</tabstop>
   <tabstop>lockDatabaseMinimizeCheckBox</tabstop>
-  <tabstop>relockDatabaseAutoTypeCheckBox</tabstop>
   <tabstop>passwordsRepeatVisibleCheckBox</tabstop>
   <tabstop>passwordsHiddenCheckBox</tabstop>
   <tabstop>passwordShowDotsCheckBox</tabstop>

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -52,7 +52,7 @@ DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
     connect(this, SIGNAL(activeDatabaseChanged(DatabaseWidget*)),
             m_dbWidgetStateSync, SLOT(setActive(DatabaseWidget*)));
     connect(autoType(), SIGNAL(globalAutoTypeTriggered(const QString&)), SLOT(performGlobalAutoType(const QString&)));
-    connect(autoType(), SIGNAL(autotypePerformed()), SLOT(relockPendingDatabase()));
+    connect(autoType(), SIGNAL(autotypeRetypeTimeout()), SLOT(relockPendingDatabase()));
     connect(autoType(), SIGNAL(autotypeRejected()), SLOT(relockPendingDatabase()));
     connect(m_databaseOpenDialog.data(), &DatabaseOpenDialog::dialogFinished,
             this, &DatabaseTabWidget::handleDatabaseUnlockDialogFinished);


### PR DESCRIPTION
If relock after performing Auto-Type is enabled it will wait until specified timeout before doing so.
    
Retype time is now configurable and is decreased from the old hardcoded 30 seconds down to 15 seconds to keep the default a bit more secure while still allowing the user to set it higher for their liking.
    
To restore old behavior the user can set retype time to 0 which will make the database relock instantly.
    
Auto-Type relock setting relocated to Auto-Type tab to group it better with the other Auto-Type settings.

Qt Designer botched the settings UI file a bit, sorry.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
New setting:
![image](https://user-images.githubusercontent.com/106598/154828362-9f19beb1-5a96-4903-84f1-1ad849e32e28.png)



## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually on Linux. Tested that relocking with a timer while having the Auto-Type dialog open also closes it correctly (rejecting the dialog).


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)

