### PR TITLE
Fix styling of database tag view in main window

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -5314,10 +5314,6 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Groups Panel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Preview Panel</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -93,7 +93,6 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_Language, {QS("GUI/Language"), Roaming, QS("system")}},
     {Config::GUI_HideToolbar, {QS("GUI/HideToolbar"), Roaming, false}},
     {Config::GUI_MovableToolbar, {QS("GUI/MovableToolbar"), Roaming, false}},
-    {Config::GUI_HideGroupsPanel, {QS("GUI/HideGroupsPanel"), Roaming, false}},
     {Config::GUI_HidePreviewPanel, {QS("GUI/HidePreviewPanel"), Roaming, false}},
     {Config::GUI_AlwaysOnTop, {QS("GUI/GUI_AlwaysOnTop"), Local, false}},
     {Config::GUI_ToolButtonStyle, {QS("GUI/ToolButtonStyle"), Roaming, Qt::ToolButtonIconOnly}},
@@ -365,6 +364,7 @@ static const QHash<QString, Config::ConfigKey> deprecationMap = {
     {QS("GUI/DarkTrayIcon"), Config::Deleted},
 
     // 2.7.0
+    {QS("GUI/HideGroupsPanel"), Config::Deleted},
     {QS("LastAttachmentDir"), Config::Deleted},
     {QS("KeeShare/LastDir"), Config::Deleted},
     {QS("KeeShare/LastKeyDir"), Config::Deleted},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -74,7 +74,6 @@ public:
         GUI_Language,
         GUI_HideToolbar,
         GUI_MovableToolbar,
-        GUI_HideGroupsPanel,
         GUI_HidePreviewPanel,
         GUI_AlwaysOnTop,
         GUI_ToolButtonStyle,

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -99,6 +99,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
 
     // Setup tags view and place under groups
     auto tagModel = new TagModel(m_db);
+    m_tagView->setObjectName("tagView");
     m_tagView->setModel(tagModel);
     m_tagView->setFrameStyle(QFrame::NoFrame);
     m_tagView->setSelectionMode(QListView::SingleSelection);
@@ -111,9 +112,11 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     auto tagsLayout = new QVBoxLayout();
     auto tagsTitle = new QLabel(tr("Database Tags"));
     tagsTitle->setProperty("title", true);
+    tagsWidget->setObjectName("tagWidget");
     tagsWidget->setLayout(tagsLayout);
     tagsLayout->addWidget(tagsTitle);
     tagsLayout->addWidget(m_tagView);
+    tagsLayout->setMargin(0);
 
     m_groupSplitter->setOrientation(Qt::Vertical);
     m_groupSplitter->setChildrenCollapsible(true);
@@ -133,7 +136,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     rightHandSideWidget->setLayout(rightHandSideVBox);
     m_entryView = new EntryView(rightHandSideWidget);
 
-    m_mainSplitter->setChildrenCollapsible(false);
+    m_mainSplitter->setChildrenCollapsible(true);
     m_mainSplitter->addWidget(m_groupSplitter);
     m_mainSplitter->addWidget(rightHandSideWidget);
     m_mainSplitter->setStretchFactor(0, 30);
@@ -1728,6 +1731,7 @@ void DatabaseWidget::reloadDatabaseFile()
     // Lock out interactions
     m_entryView->setDisabled(true);
     m_groupView->setDisabled(true);
+    m_tagView->setDisabled(true);
     QApplication::processEvents();
 
     QString error;
@@ -1773,6 +1777,7 @@ void DatabaseWidget::reloadDatabaseFile()
     // Return control
     m_entryView->setDisabled(false);
     m_groupView->setDisabled(false);
+    m_tagView->setDisabled(false);
 }
 
 int DatabaseWidget::numberOfSelectedEntries() const

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1910,11 +1910,6 @@ void MainWindow::initViewMenu()
         applySettingsChanges();
     });
 
-    m_ui->actionShowGroupsPanel->setChecked(!config()->get(Config::GUI_HideGroupsPanel).toBool());
-    connect(m_ui->actionShowGroupsPanel, &QAction::toggled, this, [](bool checked) {
-        config()->set(Config::GUI_HideGroupsPanel, !checked);
-    });
-
     m_ui->actionShowPreviewPanel->setChecked(!config()->get(Config::GUI_HidePreviewPanel).toBool());
     connect(m_ui->actionShowPreviewPanel, &QAction::toggled, this, [](bool checked) {
         config()->set(Config::GUI_HidePreviewPanel, !checked);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -377,7 +377,6 @@
     <addaction name="menuTheme"/>
     <addaction name="actionCompactMode"/>
     <addaction name="actionAlwaysOnTop"/>
-    <addaction name="actionShowGroupsPanel"/>
     <addaction name="actionShowPreviewPanel"/>
     <addaction name="actionShowToolbar"/>
     <addaction name="actionHideUsernames"/>
@@ -1003,17 +1002,6 @@
    </property>
    <property name="text">
     <string>Show Toolbar</string>
-   </property>
-  </action>
-  <action name="actionShowGroupsPanel">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Show Groups Panel</string>
    </property>
   </action>
   <action name="actionShowPreviewPanel">

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -58,13 +58,6 @@ GroupView::GroupView(Database* db, QWidget* parent)
     viewport()->setAcceptDrops(true);
     setDropIndicatorShown(true);
     setDefaultDropAction(Qt::MoveAction);
-    setVisible(!config()->get(Config::GUI_HideGroupsPanel).toBool());
-
-    connect(config(), &Config::changed, this, [this](Config::ConfigKey key) {
-        if (key == Config::GUI_HideGroupsPanel) {
-            setVisible(!config()->get(Config::GUI_HideGroupsPanel).toBool());
-        }
-    });
 }
 
 void GroupView::contextMenuShortcutPressed()

--- a/src/gui/styles/base/basestyle.qss
+++ b/src/gui/styles/base/basestyle.qss
@@ -25,12 +25,14 @@ QCheckBox, QRadioButton {
     spacing: 10px;
 }
 
-DatabaseWidget, GroupView {
+DatabaseWidget, DatabaseWidget #groupView, DatabaseWidget #tagView {
     background-color: palette(window);
     border: none;
 }
 
-EntryPreviewWidget QLineEdit, EntryPreviewWidget QTextEdit {
+EntryPreviewWidget QLineEdit, EntryPreviewWidget QTextEdit,
+EntryPreviewWidget TagsEdit
+{
     background-color: palette(window);
     border: none;
 }


### PR DESCRIPTION
* Fix a bunch of styling issues with the tags interface
* Also allow collapsing the entire left splitter instead of a dedicated option to hide the group view.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
**BEFORE:**
![image](https://user-images.githubusercontent.com/2809491/154819103-44b97cf3-d8be-49ec-905e-15ff4647661d.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/2809491/154819039-d6b1fe3a-31f6-4bdd-8d94-274dd1c4ec44.png)

![image](https://user-images.githubusercontent.com/2809491/154819040-c054acab-cd80-4425-8d8d-597a4c77c8c6.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested using light and dark themes

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
