### PR TITLE
docs: Explicitly talk about SSH Agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ KeePassXC has numerous features for novice and power users alike. Our goal is to
 * Command line interface (keepassxc-cli)
 * Auto-Open databases
 * KeeShare shared databases (import, export, and synchronize)
-* SSH Agent
+* SSH Agent integration
 * FreeDesktop.org Secret Service (replace Gnome keyring, etc.)
 * Additional encryption choices: Twofish and ChaCha20
 

--- a/docs/topics/SSHAgent.adoc
+++ b/docs/topics/SSHAgent.adoc
@@ -1,9 +1,9 @@
-= KeePassXC - SSH Agent
+= KeePassXC - SSH Agent integration
 include::.sharedheader[]
 :imagesdir: ../images
 
 // tag::content[]
-== SSH Agent
+== SSH Agent integration
 SSH (Secure Shell) is a widely used remote secure shell protocol and is considered an industry standard for secure remote access to UNIX-like systems including Linux, BSDs, macOS and more recently even Windows received native support. SSH supports multiple types of authentication and the most widely used ones are either interactive keyboard input with a password or a public-key cryptography pair of keys.
 
 KeePassXC SSH Agent integration is built to manage SSH keys in a secure manner by either storing them completely within your KeePassXC database or by having only the decryption key of a key file that is stored elsewhere. SSH Agent integration _does not_ provide an agent itself but works as a client for any agent implementation that is OpenSSH compatible.


### PR DESCRIPTION
There's possible confusion that KeePassXC provides its own agent the way it's worded. Always explicitly talk about integration to make it more clear.

## Type of change
- ✅ Documentation (non-code change)
