### PR TITLE
entry preview: blend background of tags when inactive

### DIFF
--- a/src/gui/styles/dark/darkstyle.qss
+++ b/src/gui/styles/dark/darkstyle.qss
@@ -1,10 +1,12 @@
 DatabaseWidget:!active, GroupView:!active,
-EntryPreviewWidget QLineEdit:!active, EntryPreviewWidget QTextEdit:!active {
+EntryPreviewWidget QLineEdit:!active, EntryPreviewWidget QTextEdit:!active,
+EntryPreviewWidget TagsEdit:!active {
     background-color: #404042;
 }
 
 DatabaseWidget:disabled, GroupView:disabled,
-EntryPreviewWidget QLineEdit:disabled, EntryPreviewWidget QTextEdit:disabled {
+EntryPreviewWidget QLineEdit:disabled, EntryPreviewWidget QTextEdit:disabled,
+EntryPreviewWidget TagsEdit:disabled {
     background-color: #424242;
 }
 

--- a/src/gui/styles/light/lightstyle.qss
+++ b/src/gui/styles/light/lightstyle.qss
@@ -1,10 +1,12 @@
 DatabaseWidget:!active, GroupView:!active,
-EntryPreviewWidget QLineEdit:!active, EntryPreviewWidget QTextEdit:!active {
+EntryPreviewWidget QLineEdit:!active, EntryPreviewWidget QTextEdit:!active,
+EntryPreviewWidget TagsEdit:!active {
     background-color: #FCFCFC;
 }
 
 DatabaseWidget:disabled, GroupView:disabled,
-EntryPreviewWidget QLineEdit:disabled, EntryPreviewWidget QTextEdit:disabled {
+EntryPreviewWidget QLineEdit:disabled, EntryPreviewWidget QTextEdit:disabled,
+EntryPreviewWidget TagsEdit:disabled {
     background-color: #EDEDED;
 }
 


### PR DESCRIPTION
The background color of the list of tags in the entry preview pane is mismatched with the background if the window is not active. This happens with both light and dark themes, but is much more visible/annoying when using the darfk theme.

## Screenshots
![tags_background](https://user-images.githubusercontent.com/3578416/154992860-3fd571f0-990e-40bc-80e4-46c10695c642.png)

## Testing strategy
Optical inspection after building with this fix included.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
