### PR TITLE
[CLI] Add and Edit attributes of an entry 

### DIFF
--- a/docs/man/keepassxc-cli.1.adoc
+++ b/docs/man/keepassxc-cli.1.adoc
@@ -195,6 +195,20 @@ The same password generation options as documented for the generate command can 
 *--notes* <__notes__>::
   Specifies the notes of the entry.
 
+*-a*, *--attribute* <__attribute__>::
+  Specifies the attribute of the entry.
+
+*-A*, *--attribute-value* <__attribute_value__>::
+  Specifies value of the new attribute for the entry.
+  Value must be base64 encoded.
+
+*-P*, *--protect*::
+  Protect value of the new attribute for the entry.
+
+*--unprotect*::
+  Unprotect value of the attribute for the entry.
+  By default new attributes are not protected.
+
 *-p*, *--password-prompt*::
   Uses a password prompt for the entry's password.
 

--- a/src/cli/Add.h
+++ b/src/cli/Add.h
@@ -31,6 +31,9 @@ public:
     static const QCommandLineOption UrlOption;
     static const QCommandLineOption NotesOption;
     static const QCommandLineOption PasswordPromptOption;
+    static const QCommandLineOption AttributeOption;
+    static const QCommandLineOption AttributeValueOption;
+    static const QCommandLineOption AttributeProtectOption;
     static const QCommandLineOption GenerateOption;
 };
 

--- a/src/cli/Edit.h
+++ b/src/cli/Edit.h
@@ -27,6 +27,7 @@ public:
     int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
 
     static const QCommandLineOption TitleOption;
+    static const QCommandLineOption AttributeUnprotectOption;
 };
 
 #endif // KEEPASSXC_EDIT_H


### PR DESCRIPTION
Closes #9212

# Lack of add or edit attribute in the entry 



## Testing strategy
### some password for a new database
read -s PK
### create a new database
printf "%s\n%s\n" "$PW" "$PW" | keepassxc-cli db-create -p test.kdbx
### create group
printf "%s\n" "$PW" | keepassxc-cli mkdir -q test.kdbx a
### create entry 'e1' in group 'a' with empty unprotected attribute 'custom'
printf "%s\n%s\n" "$PW" "$PW" | keepassxc-cli add -q -u test --url 'http://example.net' -p -a custom test.kdbx a/e1
### create entry 'e2' in group 'a' with unprotected attribute 'custom' with attribute's value 'custom value'
printf "%s\n%s\n" "$PW" "$PW" | keepassxc-cli add -q -u test --url 'http://example.net' -p -a custom -A $( echo -n "custom value" | base64 -w 0) test.kdbx a/e2
### create entry 'e3' in group 'a' with protected attribute 'custom' with attribute's value 'custom value'
printf "%s\n%s\n" "$PW" "$PW" | keepassxc-cli add -q -u test --url 'http://example.net' -p -a custom -A $( echo -n "custom value" | base64 -w 0) -P test.kdbx a/e3
### create empty unprotected attribute 'custom2' in a/e1
printf "%s\n" "$PW" | keepassxc-cli edit -q -a custom2 test.kdbx a/e1
### create empty protected attribute 'custom3' in a/e1
printf "%s\n" "$PW" | keepassxc-cli edit -q -a custom3 -P test.kdbx a/e1
### set attribute 'custom3' in a/e1 to be unprotected
printf "%s\n" "$PW" | keepassxc-cli edit -q -a custom3 --unprotect test.kdbx a/e1
### set value of attribute  'custom3' in a/e1
printf "%s\n" "$PW" | keepassxc-cli edit -q -a custom3 -A $( echo -n "custom value" | base64 -w 0) test.kdbx a/e1
### show things
printf "%s\n" "$PW" | keepassxc-cli ls -q test.kdbx a
printf "%s\n" "$PW" | keepassxc-cli show -q -s -a custom test.kdbx a/e1
printf "%s\n" "$PW" | keepassxc-cli show -q -s -a custom test.kdbx a/e2
printf "%s\n" "$PW" | keepassxc-cli show -q -s -a custom test.kdbx a/e3
printf "%s\n" "$PW" | keepassxc-cli show -q -a custom2 test.kdbx a/e1
printf "%s\n" "$PW" | keepassxc-cli show -q -a custom3 test.kdbx a/e1
In edit command if atribute exists and some option like -P,--unprotect or -A is not used, appropriately attribute's protection  and attribute's value remain unchanged. So It is possible to use -a and any option from ( -A, -P, --unprotect ) in any combination.
Add command hasn't option --unprotect, because default action is unprotect - you only set protection with -P option. Of course, -P and --unprotect cann't bu used together.
Only one attribute can be added or edited at once. If you have more than one attributes and entry does not exists, you can(not must) add first with add command, then use edit command to add rest. If entry exist, use edit command to add all attributes.

