### PR TITLE
FdoSecrets: allow to remember decision for future entries

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -79,10 +79,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Your decision for above entries will be remembered for the duration the requesting client is running.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
@@ -95,7 +91,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Deny All</source>
+        <source>Your decision will be remembered for the duration while both the requesting client AND KeePassXC are running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deny All &amp;&amp; Future</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow All &amp;&amp; &amp;Future</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5396,6 +5400,14 @@ We recommend you use the AppImage available on our downloads page.</source>
     </message>
     <message>
         <source>Disconnect this application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset any remembered decisions for this application</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/fdosecrets/dbus/DBusClient.h
+++ b/src/fdosecrets/dbus/DBusClient.h
@@ -159,7 +159,7 @@ namespace FdoSecrets
         /**
          * Authorize client to access all items.
          */
-        void setAllAuthorized(bool authorized = true);
+        void setAllAuthorized(AuthDecision authorized);
 
         /**
          * Forget all previous authorization.
@@ -176,7 +176,7 @@ namespace FdoSecrets
         QPointer<DBusMgr> m_dbus;
         PeerInfo m_process;
 
-        bool m_authorizedAll{false};
+        AuthDecision m_authorizedAll{AuthDecision::Undecided};
 
         QSet<QUuid> m_allowed{};
         QSet<QUuid> m_denied{};

--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -303,7 +303,7 @@ namespace FdoSecrets
                     }
                     continue;
                 }
-                // attach a temporary property so later we can get the item
+                // attach a temporary property, so later we can get the item
                 // back from the dialog's result
                 entry->setProperty(FdoSecretsBackend, QVariant::fromValue(item.data()));
                 entries << entry;
@@ -317,11 +317,11 @@ namespace FdoSecrets
             connect(ac, &AccessControlDialog::finished, ac, &AccessControlDialog::deleteLater);
             ac->open();
         } else {
-            itemUnlockFinished({});
+            itemUnlockFinished({}, AuthDecision::Undecided);
         }
     }
 
-    void UnlockPrompt::itemUnlockFinished(const QHash<Entry*, AuthDecision>& decisions)
+    void UnlockPrompt::itemUnlockFinished(const QHash<Entry*, AuthDecision>& decisions, AuthDecision forFutureEntries)
     {
         auto client = m_client.lock();
         if (!client) {
@@ -344,6 +344,9 @@ namespace FdoSecrets
             } else {
                 m_numRejected += 1;
             }
+        }
+        if (forFutureEntries != AuthDecision::Undecided) {
+            client->setAllAuthorized(forFutureEntries);
         }
         // if anything is not unlocked, treat the whole prompt as dismissed
         // so the client has a chance to handle the error

--- a/src/fdosecrets/objects/Prompt.h
+++ b/src/fdosecrets/objects/Prompt.h
@@ -169,7 +169,7 @@ namespace FdoSecrets
         QVariant currentResult() const override;
 
         void collectionUnlockFinished(bool accepted);
-        void itemUnlockFinished(const QHash<Entry*, AuthDecision>& results);
+        void itemUnlockFinished(const QHash<Entry*, AuthDecision>& results, AuthDecision forFutureEntries);
         void unlockItems();
 
         static constexpr auto FdoSecretsBackend = "FdoSecretsBackend";

--- a/src/fdosecrets/widgets/AccessControlDialog.h
+++ b/src/fdosecrets/widgets/AccessControlDialog.h
@@ -66,16 +66,16 @@ public:
     {
         Rejected,
         AllowSelected,
+        AllowAll,
         DenyAll,
     };
 
     QHash<Entry*, AuthDecision> decisions() const;
 
 signals:
-    void finished(const QHash<Entry*, AuthDecision>& results);
+    void finished(const QHash<Entry*, AuthDecision>& results, AuthDecision forFutureEntries);
 
 private slots:
-    void rememberChecked(bool checked);
     void denyEntryClicked(Entry* entry, const QModelIndex& index);
     void dialogFinished(int result);
 

--- a/src/fdosecrets/widgets/AccessControlDialog.ui
+++ b/src/fdosecrets/widgets/AccessControlDialog.ui
@@ -123,16 +123,6 @@
     </widget>
    </item>
    <item>
-    <widget class="MessageWidget" name="rememberMsg" native="true">
-     <property name="text" stdset="0">
-      <string>Your decision for above entries will be remembered for the duration the requesting client is running.</string>
-     </property>
-     <property name="closeButtonVisible" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">

--- a/tests/gui/TestGuiFdoSecrets.h
+++ b/tests/gui/TestGuiFdoSecrets.h
@@ -71,6 +71,7 @@ private slots:
     void testServiceUnlock();
     void testServiceUnlockDatabaseConcurrent();
     void testServiceUnlockItems();
+    void testServiceUnlockItemsIncludeFutureEntries();
     void testServiceLock();
     void testServiceLockConcurrent();
 
@@ -103,7 +104,7 @@ private slots:
 private:
     bool driveUnlockDialog();
     bool driveNewDatabaseWizard();
-    bool driveAccessControlDialog(bool remember = true);
+    bool driveAccessControlDialog(bool remember = true, bool includeFutureEntries = false);
     bool waitForSignal(QSignalSpy& spy, int expectedCount);
 
     void processEvents();


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
This fixes #7464 by adding an extra checkbox "Apply to all and future entries".
When checked, the decision (allow or deny) will apply to all entries including any future ones.

Note that all the "remember" we are talking about here only lasts as long as both the client and KeePassXC are running. I've updated the text to reflect this more clearly.

Also added is a new reset button in the sessions table on the settings page, to reset any saved decisions.
While at it, I also fixed distorted buttons (in the table) on the settings page.

#### Interaction with other parts of the dialog
* "Apply to all and future entries" implies "Remember". Therefore, checking it will also automatically check "Remember" and
  disable it (so the user can not accidentally uncheck it).
* the entries selection table is also disabled to make it clear that the decision is applied to all of them and it makes
  no sense to select a subset.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
https://user-images.githubusercontent.com/1519759/155861602-043adf89-41af-4ff2-9d04-37962b3b27f8.mp4


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added unit test.

To test manually:

* Open KeePassXC with the default test database `tests/data/NewDatabase.kdbx`
* Enable Secret Service Integration
* Use python `secretstorage` to check
```python
import secretstorage
conn = secretstorage.dbus_init()
coll = secretstorage.get_default_collection(conn)
assert(not coll.is_locked())

items = list(coll.get_all_items())
assert(items[0].is_locked())
assert(items[1].is_locked())

items[0].unlock()

# In the access dialog, check "Include future entries"
assert(not items[0].is_locked())
assert(not items[1].is_locked())
```




## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
