### PR TITLE
Allow colon in tags and sort alphabetically

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -192,8 +192,10 @@ QString Entry::tags() const
 
 QStringList Entry::tagList() const
 {
-    static QRegExp rx("(\\ |\\,|\\.|\\:|\\t|\\;)");
-    return tags().split(rx, QString::SkipEmptyParts);
+    static QRegExp rx("(\\ |\\,|\\t|\\;)");
+    auto taglist = tags().split(rx, QString::SkipEmptyParts);
+    std::sort(taglist.begin(), taglist.end());
+    return taglist;
 }
 
 const TimeInfo& Entry::timeInfo() const


### PR DESCRIPTION
* Fix #7489 - allow colon and period in tag names
* Fix #7490 - sort tags alphabetically

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested visually

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)