### PR TITLE
Retain quick unlock if Hardware Key is missing

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -312,16 +312,14 @@ void DatabaseOpenWidget::openDatabase()
 
         setUserInteractionLock(false);
 
-        // Reset quick unlock for the current database
-        if (isOnQuickUnlockScreen()) {
-            resetQuickUnlock();
-        }
-
         m_retryUnlockWithEmptyPassword = false;
         m_ui->messageWidget->showMessage(error, MessageWidget::MessageType::Error);
-        // Focus on the password field and select the input for easy retry
-        m_ui->editPassword->selectAll();
-        m_ui->editPassword->setFocus();
+
+        if (!isOnQuickUnlockScreen()) {
+            // Focus on the password field and select the input for easy retry
+            m_ui->editPassword->selectAll();
+            m_ui->editPassword->setFocus();
+        }
     }
 }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
* The hardware key missing error message is properly shown and the user can try to Quick Unlock again after plugging in or tapping the hardware key in time.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/157756109-603ebccb-cd42-4395-b24c-a23179676928.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested with Yubikey

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)