### PR TITLE
Fix keepass-cr-recovery

### DIFF
--- a/utils/keepassxc-cr-recovery/main.go
+++ b/utils/keepassxc-cr-recovery/main.go
@@ -169,6 +169,14 @@ func main() {
 		log.Fatalf("couldn't read challenge: %s", err)
 	}
 
+	if len(challenge) < 64 {
+		padd := make([]byte, 64-len(challenge))
+		for i, _ := range padd {
+			padd[i] = byte(64-len(challenge))
+		}
+		challenge = append(challenge[:], padd[:]...)
+	}
+
 	mac := hmac.New(sha1.New, secret)
 	mac.Write(challenge)
 


### PR DESCRIPTION
keepass-cr-recovery used the challenge unpadded, add padding as in
https://github.com/keepassxreboot/keepassxc/blob/develop/src/keys/drivers/YubiKeyInterfaceUSB.cpp\#L291
https://github.com/keepassxreboot/keepassxc/blob/develop/src/keys/drivers/YubiKeyInterfacePCSC.cpp\#L747

Closes #4744

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)