### PR TITLE
Skip "StatusIndicator" window in Auto-Type window list

### DIFF
--- a/src/autotype/mac/AutoTypeMac.h
+++ b/src/autotype/mac/AutoTypeMac.h
@@ -49,7 +49,7 @@ public:
 
 private:
     static int windowLayer(CFDictionaryRef window);
-    static QString windowTitle(CFDictionaryRef window);
+    static QString windowStringProperty(CFDictionaryRef window, CFStringRef propertyRef);
 };
 
 class AutoTypeExecutorMac : public AutoTypeExecutor


### PR DESCRIPTION
Starting with macOS 12.2, when the audio recording indicator is shown, the "Window Server" process injects a "StatusIndicator" window into the list of active windows, which messes with Auto-Type's window title matching. This window has an Alpha value of 1 (so technically, it is not invisible), and it is always in front of all other windows. Hence, the only way to skip it is by title and owner name.

Fixes #7418

This fix should be backported to 2.7.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

