### PR TITLE
Fix check for malloc_usable_size()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,7 +522,7 @@ if(UNIX)
             HAVE_MALLOC_H)
 
     check_cxx_source_compiles("#include <malloc.h>
-    int main() { malloc_usable_size(NULL, 0); return 0; }"
+    int main() { malloc_usable_size(NULL); return 0; }"
             HAVE_MALLOC_USABLE_SIZE)
 
     check_cxx_source_compiles("#include <sys/resource.h>


### PR DESCRIPTION
The CMake compilation check for malloc_usable_size() was broken.

This is probably a permanent fix for #4207.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )



## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)