### PR TITLE
Correct timing issue with entry level Auto-Type on some platforms

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -297,8 +297,6 @@ void AutoType::executeAutoTypeActions(const Entry* entry,
             getMainWindow()->minimizeOrHide();
         }
 #endif
-        QCoreApplication::processEvents();
-        window = m_plugin->activeWindow();
     } else {
         // Restore window state (macOS only) then raise the target window
         restoreWindowState();
@@ -311,6 +309,11 @@ void AutoType::executeAutoTypeActions(const Entry* entry,
 
     int delay = qMax(100, config()->get(Config::AutoTypeStartDelay).toInt());
     Tools::wait(delay);
+
+    // Grab the current active window after everything settles
+    if (window == 0) {
+        window = m_plugin->activeWindow();
+    }
 
     for (const auto& action : asConst(actions)) {
         if (m_plugin->activeWindow() != window) {


### PR DESCRIPTION
* Fixes #7584

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows and Linux Gnome. No functionality is changed, just when the window handle is determined.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
