### PR TITLE
Fix detection of hardware keys in keepassxc-cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,9 @@ macro(check_add_gcc_compiler_flag FLAG)
 endmacro(check_add_gcc_compiler_flag)
 
 add_definitions(-DQT_NO_EXCEPTIONS -DQT_STRICT_ITERATORS -DQT_NO_CAST_TO_ASCII)
+if(NOT IS_DEBUG_BUILD)
+    add_definitions(-DQT_NO_DEBUG_OUTPUT)
+endif()
 
 if(WITH_APP_BUNDLE)
     add_definitions(-DWITH_APP_BUNDLE)

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -7234,10 +7234,6 @@ Please consider generating a new key file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please present or touch your YubiKey to continue…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Enter password to encrypt database (optional): </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7758,6 +7754,10 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Failed to sign challenge using Windows Hello.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please present or touch your YubiKey to continue.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -404,7 +404,6 @@ void AutoType::startGlobalAutoType(const QString& search)
                 tr("KeePassXC requires the Accessibility and Screen Recorder permission in order to perform global "
                    "Auto-Type. Screen Recording is necessary to use the window title to find entries. If you "
                    "already granted permission, you may have to restart KeePassXC."));
-            qDebug() << "Oh noes macOS.";
             return;
         }
     }

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -313,7 +313,7 @@ namespace Utils
             // Other platforms understand UTF-8
             if (clipProcess->write(text.toUtf8()) == -1) {
 #endif
-                qDebug("Unable to write to process : %s", qPrintable(clipProcess->errorString()));
+                qWarning("Unable to write to process : %s", qPrintable(clipProcess->errorString()));
             }
             clipProcess->waitForBytesWritten();
             clipProcess->closeWriteChannel();

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -167,14 +167,14 @@ namespace Utils
                 }
             }
 
-            auto conn = QObject::connect(YubiKey::instance(), &YubiKey::userInteractionRequest, [&] {
-                err << QObject::tr("Please present or touch your YubiKey to continue…") << "\n\n" << flush;
+            QObject::connect(YubiKey::instance(), &YubiKey::userInteractionRequest, [&] {
+                err << QObject::tr("Please present or touch your YubiKey to continue.") << "\n\n" << flush;
             });
 
             auto key = QSharedPointer<ChallengeResponseKey>(new ChallengeResponseKey({serial, slot}));
             compositeKey->addChallengeResponseKey(key);
 
-            QObject::disconnect(conn);
+            YubiKey::instance()->findValidKeys();
         }
 #else
         Q_UNUSED(yubiKeySlot);

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -66,8 +66,6 @@ QStringList Merger::merge()
     changes << mergeDeletions(m_context);
     changes << mergeMetadata(m_context);
 
-    // qDebug("Merged %s", qPrintable(changes.join("\n\t")));
-
     // At this point we have a list of changes we may want to show the user
     if (!changes.isEmpty()) {
         m_context.m_targetDb->markAsModified();

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -456,7 +456,7 @@ void DatabaseOpenWidget::pollHardwareKey()
     m_ui->hardwareKeyProgress->setVisible(true);
     m_pollingHardwareKey = true;
 
-    YubiKey::instance()->findValidKeys();
+    YubiKey::instance()->findValidKeysAsync();
 }
 
 void DatabaseOpenWidget::hardwareKeyResponse(bool found)

--- a/src/gui/databasekey/YubiKeyEditWidget.cpp
+++ b/src/gui/databasekey/YubiKeyEditWidget.cpp
@@ -122,7 +122,7 @@ void YubiKeyEditWidget::pollYubikey()
     m_compUi->comboChallengeResponse->setEnabled(false);
     m_compUi->yubikeyProgress->setVisible(true);
 
-    YubiKey::instance()->findValidKeys();
+    YubiKey::instance()->findValidKeysAsync();
 #endif
 }
 

--- a/src/keys/drivers/YubiKey.h
+++ b/src/keys/drivers/YubiKey.h
@@ -46,7 +46,8 @@ public:
     static YubiKey* instance();
     bool isInitialized();
 
-    void findValidKeys();
+    bool findValidKeys();
+    void findValidKeysAsync();
 
     QList<YubiKeySlot> foundKeys();
     QString getDisplayName(YubiKeySlot slot);
@@ -84,8 +85,6 @@ private:
     QTimer m_interactionTimer;
     bool m_initialized = false;
     QString m_error;
-    int m_interfaces_detect_completed = -1;
-    bool m_interfaces_detect_found = false;
     QMutex m_interfaces_detect_mutex;
 
     Q_DISABLE_COPY(YubiKey)

--- a/src/keys/drivers/YubiKeyInterface.cpp
+++ b/src/keys/drivers/YubiKeyInterface.cpp
@@ -37,6 +37,11 @@ QMultiMap<unsigned int, QPair<int, QString>> YubiKeyInterface::foundKeys()
 
 bool YubiKeyInterface::hasFoundKey(YubiKeySlot slot)
 {
+    // A serial number of 0 implies use the first key
+    if (slot.first == 0 && !m_foundKeys.isEmpty()) {
+        return true;
+    }
+
     for (const auto& key : m_foundKeys.values(slot.first)) {
         if (slot.second == key.first) {
             return true;

--- a/src/keys/drivers/YubiKeyInterface.h
+++ b/src/keys/drivers/YubiKeyInterface.h
@@ -36,7 +36,7 @@ public:
     bool hasFoundKey(YubiKeySlot slot);
     QString getDisplayName(YubiKeySlot slot);
 
-    virtual void findValidKeys() = 0;
+    virtual bool findValidKeys() = 0;
     virtual YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) = 0;
     virtual bool testChallenge(YubiKeySlot slot, bool* wouldBlock) = 0;

--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -197,7 +197,7 @@ namespace
                             rv = SCardBeginTransaction(handle);
                         }
 #endif
-                        qDebug("Smardcard was reset and had to be reconnected");
+                        qDebug("Smartcard was reset and had to be reconnected");
                     } else {
                         // This does not mean that the payload returned SCARD_S_SUCCESS
                         //  just that the card was not reset during communication.
@@ -208,7 +208,7 @@ namespace
                 }
                 if (i == 0) {
                     rv = SCARD_W_RESET_CARD;
-                    qDebug("Smardcard was reset and failed to reconnect after 3 tries");
+                    qDebug("Smartcard was reset and failed to reconnect after 3 tries");
                 }
             }
         }

--- a/src/keys/drivers/YubiKeyInterfacePCSC.h
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.h
@@ -50,7 +50,7 @@ class YubiKeyInterfacePCSC : public YubiKeyInterface
 public:
     static YubiKeyInterfacePCSC* instance();
 
-    void findValidKeys() override;
+    bool findValidKeys() override;
 
     YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) override;

--- a/src/keys/drivers/YubiKeyInterfaceUSB.h
+++ b/src/keys/drivers/YubiKeyInterfaceUSB.h
@@ -33,7 +33,7 @@ class YubiKeyInterfaceUSB : public YubiKeyInterface
 public:
     static YubiKeyInterfaceUSB* instance();
 
-    void findValidKeys() override;
+    bool findValidKeys() override;
 
     YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) override;

--- a/src/keys/drivers/YubiKeyStub.cpp
+++ b/src/keys/drivers/YubiKeyStub.cpp
@@ -38,7 +38,12 @@ bool YubiKey::isInitialized()
     return false;
 }
 
-void YubiKey::findValidKeys()
+bool YubiKey::findValidKeys()
+{
+    return false;
+}
+
+void YubiKey::findValidKeysAsync()
 {
 }
 

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -2075,10 +2075,6 @@ void TestCli::testYubiKeyOption()
 
     YubiKey::instance()->findValidKeys();
 
-    // Wait for the hardware to respond
-    QSignalSpy detected(YubiKey::instance(), SIGNAL(detectComplete(bool)));
-    QTRY_VERIFY_WITH_TIMEOUT(detected.count() > 0, 2000);
-
     auto keys = YubiKey::instance()->foundKeys();
     if (keys.isEmpty()) {
         QSKIP("No YubiKey devices were detected.");
@@ -2094,7 +2090,7 @@ void TestCli::testYubiKeyOption()
     for (auto key : keys) {
         if (YubiKey::instance()->testChallenge(key, &wouldBlock) && !wouldBlock) {
             YubiKey::instance()->challenge(key, challenge, response);
-            if (std::memcmp(response.data(), expected.data(), expected.size())) {
+            if (std::memcmp(response.data(), expected.data(), expected.size()) == 0) {
                 pKey = key;
                 break;
             }
@@ -2110,7 +2106,11 @@ void TestCli::testYubiKeyOption()
     Add addCmd;
 
     setInput("a");
-    execCmd(listCmd, {"ls", "-y", "2", m_yubiKeyProtectedDbFile->fileName()});
+    execCmd(listCmd,
+            {"ls",
+             "-y",
+             QString("%1:%2").arg(QString::number(pKey.second), QString::number(pKey.first)),
+             m_yubiKeyProtectedDbFile->fileName()});
     m_stderr->readLine(); // skip password prompt
     QCOMPARE(m_stderr->readAll(), QByteArray());
     QCOMPARE(m_stdout->readAll(),

--- a/tests/TestYkChallengeResponseKey.cpp
+++ b/tests/TestYkChallengeResponseKey.cpp
@@ -43,10 +43,6 @@ void TestYubiKeyChallengeResponse::testDetectDevices()
 {
     YubiKey::instance()->findValidKeys();
 
-    // Wait for the hardware to respond
-    QSignalSpy detected(YubiKey::instance(), SIGNAL(detectComplete(bool)));
-    QTRY_VERIFY_WITH_TIMEOUT(detected.count() > 0, 2000);
-
     // Look at the information retrieved from the key(s)
     for (auto key : YubiKey::instance()->foundKeys()) {
         auto displayName = YubiKey::instance()->getDisplayName(key);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
* Split calls to finding hardware keys into sync and async methods. This has the side effect of simplifying the code.
* Check for keys before performing challenge/response if no keys have been found previously.
* Correct timeout of user interaction message to interact with the hardware key.
* Correct error in TestCli::testYubiKeyOption

While I was at it, I also disabled debug messages in release builds.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested with both GUI and CLI using interaction required and passive modes on YubiKey.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)