### PR TITLE
CLI: Add missing parameters to add/edit commands

### DIFF
--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -65,6 +65,7 @@ Add::Add()
     options.append(Generate::ExcludeCharsOption);
     options.append(Generate::ExcludeSimilarCharsOption);
     options.append(Generate::IncludeEveryGroupOption);
+    options.append(Generate::CustomCharacterSetOption);
 }
 
 int Add::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -53,6 +53,7 @@ Edit::Edit()
     options.append(Generate::ExcludeCharsOption);
     options.append(Generate::ExcludeSimilarCharsOption);
     options.append(Generate::IncludeEveryGroupOption);
+    options.append(Generate::CustomCharacterSetOption);
 }
 
 int Edit::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)


### PR DESCRIPTION
This adds the `-c` parameter to the password generator when adding/editing entries via the CLI.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
