### PR TITLE
Auto-Type: Map ASCII dead keys on Linux

### DIFF
--- a/src/autotype/xcb/AutoTypeXCB.h
+++ b/src/autotype/xcb/AutoTypeXCB.h
@@ -61,7 +61,7 @@ private:
     bool RemapKeycode(KeySym keysym);
     void SendKeyEvent(unsigned keycode, bool press);
     void SendModifiers(unsigned int mask, bool press);
-    bool GetKeycode(KeySym keysym, int* keycode, int* group, unsigned int* mask);
+    bool GetKeycode(KeySym keysym, int* keycode, int* group, unsigned int* mask, bool* repeat);
 
     static int MyErrorHandler(Display* my_dpy, XErrorEvent* event);
 


### PR DESCRIPTION
Special handling of ASCII keys that are common in passwords that may be dead on the current keyboard layout and prevents going to keysym emulation fallback.

I know the nested loops look awful, sorry.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Helps with #7610 but does not fix the keysym emulation issue.

## Testing strategy
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

