### PR TITLE
Fix crash when building history changes, add tags to history compare, fix minizip-ng compiling

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3679,6 +3679,10 @@ Error: %1</source>
         <source>Auto-Type</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EntryModel</name>

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1139,7 +1139,7 @@ QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, 
     // using format from http://keepass.info/help/base/fieldrefs.html at the time of writing
 
     QRegularExpressionMatch match = EntryAttributes::matchReference(placeholder);
-    if (!match.hasMatch()) {
+    if (!match.hasMatch() || !m_group || !m_group->database()) {
         return placeholder;
     }
 
@@ -1149,8 +1149,6 @@ QString Entry::resolveReferencePlaceholderRecursive(const QString& placeholder, 
 
     const EntryReferenceType searchInType = Entry::referenceType(searchIn);
 
-    Q_ASSERT(m_group);
-    Q_ASSERT(m_group->database());
     const Entry* refEntry = m_group->database()->rootGroup()->findEntryBySearchTerm(searchText, searchInType);
 
     if (refEntry) {

--- a/src/gui/entry/EntryHistoryModel.cpp
+++ b/src/gui/entry/EntryHistoryModel.cpp
@@ -232,7 +232,7 @@ void EntryHistoryModel::calculateHistoryModifications()
             || curr->timeInfo().expiryTime() != compare->timeInfo().expiryTime()) {
             modifiedFields << tr("Expiration");
         }
-        if (curr->totpSettingsString() != compare->totpSettingsString()) {
+        if (curr->totp() != compare->totp()) {
             modifiedFields << tr("TOTP");
         }
         if (*curr->customData() != *compare->customData()) {

--- a/src/gui/entry/EntryHistoryModel.cpp
+++ b/src/gui/entry/EntryHistoryModel.cpp
@@ -246,6 +246,9 @@ void EntryHistoryModel::calculateHistoryModifications()
             || curr->defaultAutoTypeSequence() != compare->defaultAutoTypeSequence()) {
             modifiedFields << tr("Auto-Type");
         }
+        if (curr->tags() != compare->tags()) {
+            modifiedFields << tr("Tags");
+        }
 
         m_historyModifications << modifiedFields.join(", ");
 

--- a/src/keeshare/CMakeLists.txt
+++ b/src/keeshare/CMakeLists.txt
@@ -17,6 +17,5 @@ if(WITH_XC_KEESHARE)
 
     add_library(keeshare STATIC ${keeshare_SOURCES})
     target_link_libraries(keeshare PUBLIC Qt5::Core Qt5::Widgets ${BOTAN2_LIBRARIES} ${ZLIB_LIBRARIES} PRIVATE ${MINIZIP_LIBRARIES})
-    target_include_directories(keeshare SYSTEM PRIVATE ${MINIZIP_INCLUDE_DIR})
     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 endif(WITH_XC_KEESHARE)

--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -27,7 +27,14 @@
 
 #include <QBuffer>
 #include <botan/pubkey.h>
-#include <zip.h>
+#include <minizip/zip.h>
+
+// Compatibility with minizip-ng
+#ifdef MZ_VERSION_BUILD
+#undef Z_BEST_COMPRESSION
+#define Z_BEST_COMPRESSION MZ_COMPRESS_LEVEL_BEST
+#define zipOpenNewFileInZip64 zipOpenNewFileInZip_64
+#endif
 
 namespace
 {

--- a/src/keeshare/ShareImport.cpp
+++ b/src/keeshare/ShareImport.cpp
@@ -21,7 +21,7 @@
 #include "keys/PasswordKey.h"
 
 #include <QBuffer>
-#include <unzip.h>
+#include <minizip/unzip.h>
 
 namespace
 {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
**Fix crash when building history changes**
* Replace rarely hit asserts with defined nullptr checks when replacing references without a group
* Fix #7603
* Replace TOTP history comparison with checking the actual TOTP output instead of a compiled string

**Add tags to history comparison**

**Fix compiling with minizip-ng**

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested minizip fixes on Fedora

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
