### PR TITLE
fix compilation of TagsEdit.cpp

### DIFF
--- a/src/gui/tag/TagsEdit.cpp
+++ b/src/gui/tag/TagsEdit.cpp
@@ -411,7 +411,7 @@ struct TagsEdit::Impl
     void setupCompleter()
     {
         completer->setWidget(ifce);
-        connect(completer.get(), qOverload<QString const&>(&QCompleter::activated), [this](QString const& text) {
+        connect(completer.get(), static_cast<void (QCompleter::*)(QString const&)>(&QCompleter::activated), [this](QString const& text) {
             currentText(text);
         });
     }


### PR DESCRIPTION
qOverload appeared with qt5.7

Reported error:
keepassxc-2.7.0-src/src/gui/tag/TagsEdit.cpp:414:34: error: use of undeclared identifier 'qOverload'
        connect(completer.get(), qOverload<QString const&>(&QCompleter::activated), [this](QString const& text) {
                                 ^


## Testing strategy
- Tested the new code on Qt 5.11 with the condition set to < Qt 5.12. Haven't found anything abnormal in the GUI.
- Will report back as soon as tested on Qt 5.6 (likely today)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

