### PR TITLE
Several improvements to tags editing

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -192,7 +192,7 @@ QString Entry::tags() const
 
 QStringList Entry::tagList() const
 {
-    static QRegExp rx("(\\ |\\,|\\t|\\;)");
+    static QRegExp rx("(\\,|\\t|\\;)");
     auto taglist = tags().split(rx, QString::SkipEmptyParts);
     std::sort(taglist.begin(), taglist.end());
     return taglist;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -441,6 +441,7 @@ void EditEntryWidget::setupEntryUpdate()
 #ifdef WITH_XC_NETWORKING
     connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), this, SLOT(updateFaviconButtonEnable(QString)));
 #endif
+    connect(m_mainUi->tagsList, SIGNAL(tagsEdited()), this, SLOT(setModified()));
     connect(m_mainUi->expireCheck, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
     connect(m_mainUi->expireDatePicker, SIGNAL(dateTimeChanged(QDateTime)), this, SLOT(setModified()));
     connect(m_mainUi->notesEdit, SIGNAL(textChanged()), this, SLOT(setModified()));

--- a/src/gui/tag/TagsEdit.cpp
+++ b/src/gui/tag/TagsEdit.cpp
@@ -25,6 +25,7 @@
 #include "TagsEdit.h"
 #include "gui/MainWindow.h"
 #include <QApplication>
+#include <QClipboard>
 #include <QCompleter>
 #include <QDebug>
 #include <QPainter>
@@ -701,6 +702,7 @@ void TagsEdit::mousePressEvent(QMouseEvent* event)
             if (i <= impl->editing_index) {
                 --impl->editing_index;
             }
+            emit tagsEdited();
             found = true;
             break;
         }
@@ -797,6 +799,15 @@ void TagsEdit::keyPressEvent(QKeyEvent* event)
     } else if (event == QKeySequence::SelectNextChar) {
         impl->moveCursor(impl->text_layout.nextCursorPosition(impl->cursor), true);
         event->accept();
+    } else if (event == QKeySequence::Paste) {
+        auto clipboard = QApplication::clipboard();
+        if (clipboard) {
+            for (auto tagtext : clipboard->text().split(",")) {
+                impl->currentText().insert(impl->cursor, tagtext);
+                impl->editNewTag(impl->editing_index + 1);
+            }
+        }
+        event->accept();
     } else {
         switch (event->key()) {
         case Qt::Key_Left:
@@ -839,7 +850,10 @@ void TagsEdit::keyPressEvent(QKeyEvent* event)
             }
             event->accept();
             break;
-        case Qt::Key_Space:
+        case Qt::Key_Return:
+        case Qt::Key_Enter:
+        case Qt::Key_Comma:
+        case Qt::Key_Semicolon:
             if (!impl->currentText().isEmpty()) {
                 impl->editNewTag(impl->editing_index + 1);
             }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -107,6 +107,8 @@ void TestGui::init()
     config()->set(Config::GUI_ShowTrayIcon, true);
     // Disable the update check first time alert
     config()->set(Config::UpdateCheckMessageShown, true);
+    // Disable quick unlock
+    config()->set(Config::Security_QuickUnlock, false);
 
     // Copy the test database file to the temporary file
     auto origFilePath = QDir(KEEPASSX_TEST_DATA_DIR).absoluteFilePath("NewDatabase.kdbx");
@@ -451,15 +453,15 @@ void TestGui::testEditEntry()
     // Test tags
     auto* tags = editEntryWidget->findChild<TagsEdit*>("tagsList");
     QTest::keyClicks(tags, "_tag1");
-    QTest::keyClick(tags, Qt::Key_Space);
+    QTest::keyClick(tags, Qt::Key_Return);
     QCOMPARE(tags->tags().last(), QString("_tag1"));
-    QTest::keyClick(tags, Qt::Key_Space);
-    QTest::keyClicks(tags, "_tag2"); // adds another tag
-    QCOMPARE(tags->tags().last(), QString("_tag2"));
+    QTest::keyClicks(tags, "tag 2"); // adds another tag
+    QTest::keyClick(tags, Qt::Key_Return);
+    QCOMPARE(tags->tags().last(), QString("tag 2"));
     QTest::keyClick(tags, Qt::Key_Backspace); // Back into editing last tag
-    QTest::keyClicks(tags, "gers");
-    QTest::keyClick(tags, Qt::Key_Space);
-    QCOMPARE(tags->tags().last(), QString("_taggers"));
+    QTest::keyClicks(tags, "_is!awesome");
+    QTest::keyClick(tags, Qt::Key_Return);
+    QCOMPARE(tags->tags().last(), QString("tag 2_is!awesome"));
 
     // Test entry colors (simulate choosing a color)
     editEntryWidget->setCurrentPage(1);


### PR DESCRIPTION
* Fix #7602 - Allow spaces in tag names
* Fix #7528 - Allow pasting text into the tags field. Text is split by comma creating tags for each section of text. If there are no commas then the pasted text becomes a tag.
* Fix tags editing not causing the entry to be marked as modified.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on windows.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
