### PR TITLE
Add 12 hours expiration preset

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2537,10 +2537,6 @@ Would you like to correct it?</source>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Tomorrow</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
@@ -2557,6 +2553,13 @@ Would you like to correct it?</source>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>

--- a/src/core/TimeDelta.cpp
+++ b/src/core/TimeDelta.cpp
@@ -21,36 +21,51 @@
 
 QDateTime operator+(const QDateTime& dateTime, const TimeDelta& delta)
 {
-    return dateTime.addDays(delta.getDays()).addMonths(delta.getMonths()).addYears(delta.getYears());
+    return dateTime.addSecs(delta.getHours() * 3600)
+        .addDays(delta.getDays())
+        .addMonths(delta.getMonths())
+        .addYears(delta.getYears());
+}
+
+TimeDelta TimeDelta::fromHours(int hours)
+{
+    return TimeDelta(hours, 0, 0, 0);
 }
 
 TimeDelta TimeDelta::fromDays(int days)
 {
-    return TimeDelta(days, 0, 0);
+    return TimeDelta(0, days, 0, 0);
 }
 
 TimeDelta TimeDelta::fromMonths(int months)
 {
-    return TimeDelta(0, months, 0);
+    return TimeDelta(0, 0, months, 0);
 }
 
 TimeDelta TimeDelta::fromYears(int years)
 {
-    return TimeDelta(0, 0, years);
+    return TimeDelta(0, 0, 0, years);
 }
 
 TimeDelta::TimeDelta()
-    : m_days(0)
+    : m_hours(0)
+    , m_days(0)
     , m_months(0)
     , m_years(0)
 {
 }
 
-TimeDelta::TimeDelta(int days, int months, int years)
-    : m_days(days)
+TimeDelta::TimeDelta(int hours, int days, int months, int years)
+    : m_hours(hours)
+    , m_days(days)
     , m_months(months)
     , m_years(years)
 {
+}
+
+int TimeDelta::getHours() const
+{
+    return m_hours;
 }
 
 int TimeDelta::getDays() const

--- a/src/core/TimeDelta.h
+++ b/src/core/TimeDelta.h
@@ -28,18 +28,21 @@ QDateTime operator+(const QDateTime& dateTime, const TimeDelta& delta);
 class TimeDelta
 {
 public:
+    static TimeDelta fromHours(int hours);
     static TimeDelta fromDays(int days);
     static TimeDelta fromMonths(int months);
     static TimeDelta fromYears(int years);
 
     TimeDelta();
-    TimeDelta(int days, int months, int years);
+    TimeDelta(int hours, int days, int months, int years);
 
+    int getHours() const;
     int getDays() const;
     int getMonths() const;
     int getYears() const;
 
 private:
+    int m_hours;
     int m_days;
     int m_months;
     int m_years;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1574,7 +1574,8 @@ void EditEntryWidget::deleteAllHistoryEntries()
 QMenu* EditEntryWidget::createPresetsMenu()
 {
     auto* expirePresetsMenu = new QMenu(this);
-    expirePresetsMenu->addAction(tr("Tomorrow"))->setData(QVariant::fromValue(TimeDelta::fromDays(1)));
+    expirePresetsMenu->addAction(tr("%n hour(s)", nullptr, 12))->setData(QVariant::fromValue(TimeDelta::fromHours(12)));
+    expirePresetsMenu->addAction(tr("%n hour(s)", nullptr, 24))->setData(QVariant::fromValue(TimeDelta::fromHours(24)));
     expirePresetsMenu->addSeparator();
     expirePresetsMenu->addAction(tr("%n week(s)", nullptr, 1))->setData(QVariant::fromValue(TimeDelta::fromDays(7)));
     expirePresetsMenu->addAction(tr("%n week(s)", nullptr, 2))->setData(QVariant::fromValue(TimeDelta::fromDays(14)));


### PR DESCRIPTION
This adds a 12 hours expiration preset to the list of expiration presets and renames the "Tomorrow" preset to "24 hours". Fixes #7369 (ignoring the request to allow custom presets, which would be covered by #4896).

## Screenshots
![image](https://user-images.githubusercontent.com/3578416/160998728-efd0921c-937f-4051-9d99-178b029f67d2.png)

## Testing strategy
Manual, see screenshot.

## Type of change
- ✅ New feature (change that adds functionality)