### PR TITLE
SSH Agent: Fix Windows agent selection, radio buttons

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -152,6 +152,10 @@
         <source>SSH Agent connection is working!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use both agents</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidget</name>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -170,7 +170,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     // SSHAgent
     {Config::SSHAgent_Enabled, {QS("SSHAgent/Enabled"), Roaming, false}},
     {Config::SSHAgent_UseOpenSSH, {QS("SSHAgent/UseOpenSSH"), Roaming, false}},
-    {Config::SSHAgent_UsePageant, {QS("SSHAgent/UsePageant"), Roaming, false} },
+    {Config::SSHAgent_UsePageant, {QS("SSHAgent/UsePageant"), Roaming, true} },
     {Config::SSHAgent_AuthSockOverride, {QS("SSHAgent/AuthSockOverride"), Local, {}}},
     {Config::SSHAgent_SecurityKeyProviderOverride, {QS("SSHAgent/SecurityKeyProviderOverride"), Local, {}}},
 

--- a/src/sshagent/AgentSettingsWidget.cpp
+++ b/src/sshagent/AgentSettingsWidget.cpp
@@ -26,8 +26,9 @@ AgentSettingsWidget::AgentSettingsWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
 #ifndef Q_OS_WIN
-    m_ui->usePageantCheckBox->setVisible(false);
-    m_ui->useOpenSSHCheckBox->setVisible(false);
+    m_ui->usePageantRadioButton->setVisible(false);
+    m_ui->useOpenSSHRadioButton->setVisible(false);
+    m_ui->useBothRadioButton->setVisible(false);
 #else
     m_ui->sshAuthSockWidget->setVisible(false);
 #endif
@@ -47,8 +48,9 @@ void AgentSettingsWidget::loadSettings()
 
     m_ui->enableSSHAgentCheckBox->setChecked(sshAgentEnabled);
 #ifdef Q_OS_WIN
-    m_ui->usePageantCheckBox->setChecked(sshAgent()->usePageant());
-    m_ui->useOpenSSHCheckBox->setChecked(sshAgent()->useOpenSSH());
+    m_ui->usePageantRadioButton->setChecked(sshAgent()->usePageant());
+    m_ui->useOpenSSHRadioButton->setChecked(sshAgent()->useOpenSSH());
+    m_ui->useBothRadioButton->setChecked(sshAgent()->usePageant() && sshAgent()->useOpenSSH());
     sshAgentEnabled = sshAgentEnabled && (sshAgent()->usePageant() || sshAgent()->useOpenSSH());
 #else
     auto sshAuthSock = sshAgent()->socketPath(false);
@@ -93,8 +95,8 @@ void AgentSettingsWidget::saveSettings()
     auto sshSecurityKeyProviderOverride = m_ui->sshSecurityKeyProviderOverrideEdit->text();
     sshAgent()->setSecurityKeyProviderOverride(sshSecurityKeyProviderOverride);
 #ifdef Q_OS_WIN
-    sshAgent()->setUsePageant(m_ui->usePageantCheckBox->isChecked());
-    sshAgent()->setUseOpenSSH(m_ui->useOpenSSHCheckBox->isChecked());
+    sshAgent()->setUsePageant(m_ui->usePageantRadioButton->isChecked() || m_ui->useBothRadioButton->isChecked());
+    sshAgent()->setUseOpenSSH(m_ui->useOpenSSHRadioButton->isChecked() || m_ui->useBothRadioButton->isChecked());
 #endif
     sshAgent()->setEnabled(m_ui->enableSSHAgentCheckBox->isChecked());
 }

--- a/src/sshagent/AgentSettingsWidget.ui
+++ b/src/sshagent/AgentSettingsWidget.ui
@@ -72,17 +72,24 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-	  <item>
-       <widget class="QCheckBox" name="usePageantCheckBox">
+      <item>
+       <widget class="QRadioButton" name="usePageantRadioButton">
         <property name="text">
          <string>Use Pageant</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="useOpenSSHCheckBox">
+       <widget class="QRadioButton" name="useOpenSSHRadioButton">
         <property name="text">
          <string>Use OpenSSH</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="useBothRadioButton">
+        <property name="text">
+         <string>Use both agents</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
When we added support for having multiple agents enabled at the same time on Windows the unfortunate default was that no agents were enabled. This is really confusing.

Now Pageant is (again) the default and you can't create a combination that would have integration enabled but no agents.

Partially helps with #7473 but this also adds a new translation string, unfortunately.


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/106598/161365084-74335f33-e1b6-4a6f-bd0a-6b5566ffa53e.png)


## Testing strategy
Quickly by hand that all positions of the radio selection were correctly saved to config file and that on first launch Pageant was selected.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

