### PR TITLE
Revert DatabaseOpenDialog to be always on top on Linux

### DIFF
--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -36,6 +36,10 @@ DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
 {
     setWindowTitle(tr("Unlock Database - KeePassXC"));
     setWindowFlags(Qt::Dialog);
+#ifdef Q_OS_LINUX
+    // Linux requires this to overcome some Desktop Environments (also no Quick Unlock)
+    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+#endif
     // block input to the main window/application while the dialog is open
     setWindowModality(Qt::ApplicationModal);
 #ifdef Q_OS_WIN


### PR DESCRIPTION
Fixes regression due to issues with dialogs appearing above other windows on some Linux Desktop Envs.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
