### PR TITLE
Capture original regex in non-matching group when an exact match is r…

### DIFF
--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -45,18 +45,33 @@ namespace Tools
     QString envSubstitute(const QString& filepath,
                           QProcessEnvironment environment = QProcessEnvironment::systemEnvironment());
 
+    /**
+     * Escapes all characters in regex such that they do not receive any special treatment when used
+     * in a regular expression. Essentially, this function escapes any characters not in a-zA-Z0-9.
+     * @param regex The unescaped regular expression string.
+     * @return An escaped string safe to use in a regular expression.
+     */
+    QString escapeRegex(const QString& regex);
+
     enum RegexConvertOpts
     {
         DEFAULT = 0,
-        WILDCARD_UNLIMITED_MATCH = 0x1,
-        WILDCARD_SINGLE_MATCH = 0x2,
-        WILDCARD_LOGICAL_OR = 0x4,
+        WILDCARD_UNLIMITED_MATCH = 1,
+        WILDCARD_SINGLE_MATCH = 1 << 2,
+        WILDCARD_LOGICAL_OR = 1 << 3,
         WILDCARD_ALL = WILDCARD_UNLIMITED_MATCH | WILDCARD_SINGLE_MATCH | WILDCARD_LOGICAL_OR,
-        EXACT_MATCH = 0x8,
-        CASE_SENSITIVE = 0x16,
-        ESCAPE_REGEX = 0x32,
+        EXACT_MATCH = 1 << 4,
+        CASE_SENSITIVE = 1 << 5,
+        ESCAPE_REGEX = 1 << 6,
     };
 
+    /**
+     * Converts input string to a regular expression according to the options specified in opts.
+     * Note that, unless ESCAPE_REGEX is set, convertToRegex assumes a proper regular expression as input.
+     * @param string The input string. Assumed to be a proper regular expression unless ESCAPE_REGEX is set.
+     * @param opts Tools::RegexConvertOpts options the regex will be converted with.
+     * @return The regular expression built from string and opts.
+     */
     QRegularExpression convertToRegex(const QString& string, int opts = RegexConvertOpts::DEFAULT);
 
     template <typename RandomAccessIterator, typename T>

--- a/tests/TestEntrySearcher.cpp
+++ b/tests/TestEntrySearcher.cpp
@@ -224,7 +224,7 @@ void TestEntrySearcher::testSearchTermParser()
     QCOMPARE(terms.length(), 2);
 
     QCOMPARE(terms[0].field, EntrySearcher::Field::Url);
-    QCOMPARE(terms[0].regex.pattern(), QString("^.*\\.google\\.com$"));
+    QCOMPARE(terms[0].regex.pattern(), QString("^(?:.*\\.google\\.com)$"));
 
     QCOMPARE(terms[1].field, EntrySearcher::Field::Username);
     QCOMPARE(terms[1].regex.pattern(), QString("\\d+\\w{2}"));
@@ -237,7 +237,7 @@ void TestEntrySearcher::testSearchTermParser()
 
     QCOMPARE(terms[0].field, EntrySearcher::Field::AttributeValue);
     QCOMPARE(terms[0].word, QString("abc"));
-    QCOMPARE(terms[0].regex.pattern(), QString("^efg$"));
+    QCOMPARE(terms[0].regex.pattern(), QString("^(?:efg)$"));
 
     QCOMPARE(terms[1].field, EntrySearcher::Field::AttributeValue);
     QCOMPARE(terms[1].word, QString("def"));

--- a/tests/TestFdoSecrets.cpp
+++ b/tests/TestFdoSecrets.cpp
@@ -82,6 +82,11 @@ void TestFdoSecrets::testSpecialCharsInAttributeValue()
         QCOMPARE(res.count(), 1);
         QCOMPARE(res[0]->title(), QStringLiteral("titleB"));
     }
+    {
+        const auto term = Collection::attributeToTerm("testAttribute", "v|");
+        const auto res = EntrySearcher().search({term}, root.data());
+        QCOMPARE(res.count(), 0);
+    }
 }
 
 void TestFdoSecrets::testDBusPathParse()

--- a/tests/TestTools.h
+++ b/tests/TestTools.h
@@ -31,6 +31,8 @@ private slots:
     void testValidUuid();
     void testBackupFilePatternSubstitution_data();
     void testBackupFilePatternSubstitution();
+    void testEscapeRegex();
+    void testEscapeRegex_data();
     void testConvertToRegex();
     void testConvertToRegex_data();
 };


### PR DESCRIPTION
Fixes #7776.

Tools::convetToRegex pre-/appends "^"/"<span>$</span>" to the built regex if an exact match is requested. This breaks expressions such as "v|", which, instead of matching v or the empty string, matches v or the end of line after substitution: "^v|<span>$</span>" is parsed as "^(v|<span>$</span>)".

Surrounding the original regex with an non-capturing group fixes this error.

See https://pcre.org/pcre.txt Sections "Vertical Bar" and "Subpatterns".

## Testing strategy
Added test to TestFdoSecrets and TestTools.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)