### PR TITLE
Allow user to purge old history entries

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2133,6 +2133,49 @@ This action is not reversible.</source>
             <numerusform></numerusform>
         </translation>
     </message>
+    <message>
+        <source>History Cleanup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No old history entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Old history entries removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Removed %n old history entry(s) from the database</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove all but the single latest history item from each entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all history items from each entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove history items older than</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>from each entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Perform Cleanup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All history entries are younger than the specified age.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetMetaDataSimple</name>
@@ -8583,6 +8626,44 @@ Kernel: %3 %4</source>
     <message>
         <source>Weak Passwords</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TimeDeltaUI</name>
+    <message numerus="yes">
+        <source>hour(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>day(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>week(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>month(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>year(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/share/translations/keepassxc_en_US.ts
+++ b/share/translations/keepassxc_en_US.ts
@@ -8522,6 +8522,44 @@ Kernel: %3 %4</translation>
     </message>
 </context>
 <context>
+    <name>TimeDeltaUI</name>
+    <message numerus="yes">
+        <source>hour(s)</source>
+        <translation>
+            <numerusform>hour</numerusform>
+            <numerusform>hours</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>day(s)</source>
+        <translation>
+            <numerusform>day</numerusform>
+            <numerusform>days</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>week(s)</source>
+        <translation>
+            <numerusform>week</numerusform>
+            <numerusform>weeks</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>month(s)</source>
+        <translation>
+            <numerusform>month</numerusform>
+            <numerusform>months</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>year(s)</source>
+        <translation>
+            <numerusform>year</numerusform>
+            <numerusform>years</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
     <name>TotpDialog</name>
     <message>
         <source>Timed Password</source>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(keepassx_SOURCES
         core/Resources.cpp
         core/SignalMultiplexer.cpp
         core/TimeDelta.cpp
+        core/TimeDeltaUI.cpp
         core/TimeInfo.cpp
         core/Tools.cpp
         core/Translator.cpp

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -755,10 +755,10 @@ void Entry::addHistoryItem(Entry* entry)
     emitModified();
 }
 
-void Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
+int Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
 {
     if (historyEntries.isEmpty()) {
-        return;
+        return 0;
     }
 
     for (Entry* entry : historyEntries) {
@@ -771,6 +771,8 @@ void Entry::removeHistoryItems(const QList<Entry*>& historyEntries)
     }
 
     emitModified();
+
+    return historyEntries.length();
 }
 
 void Entry::truncateHistory()

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -161,7 +161,7 @@ public:
     QList<Entry*> historyItems();
     const QList<Entry*>& historyItems() const;
     void addHistoryItem(Entry* entry);
-    void removeHistoryItems(const QList<Entry*>& historyEntries);
+    int removeHistoryItems(const QList<Entry*>& historyEntries);
     void truncateHistory();
 
     bool equals(const Entry* other, CompareItemOptions options = CompareItemDefault) const;

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -24,7 +24,9 @@
 
 #include <QApplication>
 #include <QCryptographicHash>
+#include <algorithm>
 
+const int Metadata::DefaultMaintenanceHistoryDays = 365;
 const int Metadata::DefaultHistoryMaxItems = 10;
 const int Metadata::DefaultHistoryMaxSize = 6 * 1024 * 1024;
 
@@ -43,7 +45,7 @@ Metadata::Metadata(QObject* parent)
 void Metadata::init()
 {
     m_data.generator = QStringLiteral("KeePassXC");
-    m_data.maintenanceHistoryDays = 365;
+    m_data.maintenanceHistoryDays = DefaultMaintenanceHistoryDays;
     m_data.masterKeyChangeRec = -1;
     m_data.masterKeyChangeForce = -1;
     m_data.historyMaxItems = DefaultHistoryMaxItems;
@@ -314,7 +316,9 @@ void Metadata::setDefaultUserNameChanged(const QDateTime& value)
 
 void Metadata::setMaintenanceHistoryDays(int value)
 {
-    set(m_data.maintenanceHistoryDays, value);
+    // KeePass2 has a hardcoded maximum of 3650 days.
+    // for compatibility we make sure not to use bigger numbers.
+    set(m_data.maintenanceHistoryDays, std::min(value, 3650));
 }
 
 void Metadata::setColor(const QString& value)

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -111,6 +111,7 @@ public:
     CustomData* customData();
     const CustomData* customData() const;
 
+    static const int DefaultMaintenanceHistoryDays;
     static const int DefaultHistoryMaxItems;
     static const int DefaultHistoryMaxSize;
 

--- a/src/core/TimeDelta.cpp
+++ b/src/core/TimeDelta.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "TimeDelta.h"
+#include "Clock.h"
 
 #include <QDateTime>
 
@@ -81,4 +82,11 @@ int TimeDelta::getMonths() const
 int TimeDelta::getYears() const
 {
     return m_years;
+}
+
+int TimeDelta::toDays() const
+{
+    QDateTime now = Clock::currentDateTime();
+    QDateTime future = now + *this;
+    return now.daysTo(future);
 }

--- a/src/core/TimeDelta.h
+++ b/src/core/TimeDelta.h
@@ -41,6 +41,8 @@ public:
     int getMonths() const;
     int getYears() const;
 
+    int toDays() const;
+
 private:
     int m_hours;
     int m_days;

--- a/src/core/TimeDeltaUI.cpp
+++ b/src/core/TimeDeltaUI.cpp
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TimeDeltaUI.h"
+
+#include <QSpinBox>
+#include <QComboBox>
+#include <QtGlobal>
+
+TimeDeltaUI::UnitTexts TimeDeltaUI::s_unitTexts = {
+    { Unit::Hours, QT_TR_N_NOOP("hour(s)") },
+    { Unit::Days, QT_TR_N_NOOP("day(s)") },
+    { Unit::Weeks, QT_TR_N_NOOP("week(s)") },
+    { Unit::Months, QT_TR_N_NOOP("month(s)") },
+    { Unit::Years, QT_TR_N_NOOP("year(s)") }
+};
+
+TimeDeltaUI::TimeDeltaUI(QSpinBox* valueSpinBox, QComboBox* unitComboBox)
+    : m_valueSpinBox(valueSpinBox)
+    , m_unitComboBox(unitComboBox)
+{
+    connect(m_valueSpinBox, SIGNAL(valueChanged(int)), SLOT(valueChanged(int)));
+}
+
+void TimeDeltaUI::initialize(int value, Unit initialUnit)
+{
+    bool blocked = m_unitComboBox->blockSignals(true);
+    m_unitComboBox->clear();
+    for (const auto& elm : s_unitTexts) {
+        auto unit = tr(elm.second, nullptr, value);
+        m_unitComboBox->addItem(unit, elm.first);
+    }
+    auto idx = m_unitComboBox->findData(initialUnit);
+    m_unitComboBox->setCurrentIndex(idx);
+    m_unitComboBox->blockSignals(blocked);
+    m_unitComboBox->setSizeAdjustPolicy(QComboBox::SizeAdjustPolicy::AdjustToContents);
+
+    m_valueSpinBox->setValue(value);
+}
+
+TimeDelta TimeDeltaUI::toTimeDelta()
+{
+    int value = m_valueSpinBox->value();
+    auto unit = m_unitComboBox->currentData();
+
+    if (Unit::Hours == unit) {
+        return TimeDelta::fromHours(value);
+    }
+
+    if (Unit::Days == unit) {
+        return TimeDelta::fromDays(value);
+    }
+
+    if (Unit::Weeks == unit) {
+        return TimeDelta::fromDays(value * 7);
+    }
+
+    if (Unit::Months == unit) {
+        return TimeDelta::fromMonths(value);
+    }
+
+    if (Unit::Years == unit) {
+        return TimeDelta::fromYears(value);
+    }
+
+    Q_ASSERT(false);
+    return TimeDelta::fromHours(0);
+}
+
+void TimeDeltaUI::valueChanged(int value) {
+    // re-translate all units to fix the plural if the new value requires it
+    for (const auto& elm : s_unitTexts) {
+        auto idx = m_unitComboBox->findData(elm.first);
+        Q_ASSERT(idx >= 0);
+        auto unit = tr(elm.second, nullptr, value);
+        m_unitComboBox->setItemText(idx, unit);
+    }
+}

--- a/src/core/TimeDeltaUI.h
+++ b/src/core/TimeDeltaUI.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TIMEDELTAUI_H
+#define KEEPASSXC_TIMEDELTAUI_H
+
+#include <QObject>
+#include <map>
+#include "TimeDelta.h"
+
+class QSpinBox;
+class QComboBox;
+
+class TimeDeltaUI : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum Unit { Hours, Days, Weeks, Months, Years };
+
+    TimeDeltaUI() = delete;
+    TimeDeltaUI(QSpinBox* valueSpinBox, QComboBox* unitComboBox);
+
+    void initialize(int value, Unit initialUnit);
+    TimeDelta toTimeDelta();
+
+private slots:
+    void valueChanged(int value);
+
+private:
+    using UnitTexts = std::map<Unit, const char*>;
+    static UnitTexts s_unitTexts;
+
+    QSpinBox* m_valueSpinBox;
+    QComboBox* m_unitComboBox;
+};
+
+#endif // KEEPASSXC_TIMEDELTAUI_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.h
@@ -20,6 +20,9 @@
 
 #include "DatabaseSettingsWidget.h"
 
+#include "core/TimeDeltaUI.h"
+#include <QScopedPointer>
+
 class QItemSelection;
 class CustomIconModel;
 class Database;
@@ -54,6 +57,7 @@ private slots:
     void selectionChanged();
     void removeCustomIcon();
     void purgeUnusedCustomIcons();
+    void cleanupHistory();
 
 private:
     void populateIcons(QSharedPointer<Database> db);
@@ -65,6 +69,7 @@ protected:
 private:
     CustomIconModel* const m_customIconModel;
     uint64_t m_deletionDecision;
+    QScopedPointer<TimeDeltaUI> m_historyCleanupAge;
 };
 
 #endif // KEEPASSXC_DATABASESETTINGSWIDGETMAINTENANCE_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.ui
@@ -36,7 +36,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="customIconsGroupBox">
      <property name="title">
       <string>Manage Custom Icons</string>
      </property>
@@ -97,6 +97,96 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="historyCleanupGroupBox">
+     <property name="title">
+      <string>History Cleanup</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0">
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="0">
+         <widget class="QRadioButton" name="radioButtonAllHistory">
+          <property name="text">
+           <string>Remove all history items from each entry</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">historyCleanupButtonGroup</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QRadioButton" name="radioButtonAllButLatest">
+          <property name="text">
+           <string>Remove all but the single latest history item from each entry</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">historyCleanupButtonGroup</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QRadioButton" name="radioButtonMaxAge">
+            <property name="text">
+             <string>Remove history items older than</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">historyCleanupButtonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="historyCleanupSpinBox">
+            <property name="suffix">
+             <string/>
+            </property>
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="maximum">
+             <number>3650</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="historyCleanupComboBox"/>
+          </item>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>from each entry</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="5" column="0">
+         <widget class="QPushButton" name="historyCleanupButton">
+          <property name="text">
+           <string>Perform Cleanup</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -113,4 +203,7 @@
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="historyCleanupButtonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
the database maintenance widget is complemented with a section that allows the user to clean up old history entries. the age of history entries to be removed is configurable. respective entries are searched for and removed with the click of a button.  message boxes inform about whether or not and if so how many entries were removed from the database.

Fixes #7550.

This implementation leans on the implementation in KeePass2. I was going to add a line to the database settings general tab alongside the "Max. history items" and "Max. history size" settings. That would either require a custom, i.e., incompatible, metadata datum, or would use the existing metadata datum in an incompatible way (KeePassXC would truncate history according to this setting at any chance it gets while the respective entries are only removed by KeePass2 by the click of a button).

## Screenshots
![image](https://user-images.githubusercontent.com/3578416/161442473-5660c783-784c-4cb4-83d3-f8da0848c4ed.png)
![image](https://user-images.githubusercontent.com/3578416/161442487-bd713566-e9c3-40b4-9e15-37e915fa29fa.png)
![image](https://user-images.githubusercontent.com/3578416/161442513-b9755b19-8167-4d26-9359-97cac95498ff.png)


## Testing strategy
Manual


## Type of change
- ✅ New feature (change that adds functionality)
