### PR TITLE
Run tests with LANG=en_US.UTF-8

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,8 @@ macro(add_unit_test)
         add_test(${_test_NAME} ${_test_LAUNCHER} ${_test_NAME})
     endif(KDE4_TEST_OUTPUT STREQUAL "xml")
 
+    set_tests_properties(${_test_NAME} PROPERTIES ENVIRONMENT "LANG=en_US.UTF-8")
+
     if(NOT MSVC_IDE)   #not needed for the ide
         # if the tests are EXCLUDE_FROM_ALL, add a target "buildtests" to build all tests
         if(NOT WITH_TESTS)


### PR DESCRIPTION
On my system, I have LANG=en_GB set, which causes the following test failure:

    FAIL!  : TestCli::testInfo() Compared values are not the same
       Actual   (m_stdout->readLine())                                  : "Average password length: 11 character(s)\n"
       Expected (QByteArray("Average password length: 11 characters\n")): "Average password length: 11 characters\n"
       Loc: [tests/TestCli.cpp(876)]

And it so happens that the en_GB translation of that string has 'character(s)' where en_US has 'characters'.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
