### PR TITLE
PasswordGenerator.adoc: fix list indices

### DIFF
--- a/docs/topics/PasswordGenerator.adoc
+++ b/docs/topics/PasswordGenerator.adoc
@@ -40,7 +40,7 @@ Word Count slider.
 3. In the Word Separator field, enter a character, word, number, or space that you want to use as a separator between the words in your passphrase.
 4. _(Optional)_ You can choose a word case between lower, upper, and title case options.
 5. _(Optional)_ You can also load your own custom word lists. Click the plus sign button to the right of the wordlist selection dialog to choose a custom word list. You can download alternative lists from the https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases[EFF's Website] or from https://github.com/redacted/XKCD-password-generator#additional-languages[GitHub].
-4. Click the Regenerate button (Ctrl + R) to generate a new random passphrase.
-5. Click the Clipboard button (Ctrl + C) to copy the passphrase to the clipboard.
+6. Click the Regenerate button (Ctrl + R) to generate a new random passphrase.
+7. Click the Clipboard button (Ctrl + C) to copy the passphrase to the clipboard.
 // end::advanced[]
 // end::content[]


### PR DESCRIPTION
`asciidoctor` warns about this during the build:

```
asciidoctor: WARNING: topics/PasswordGenerator.adoc: line 42: list item index: expected 6, got 4
asciidoctor: WARNING: topics/PasswordGenerator.adoc: line 43: list item index: expected 7, got 5
```

## Type of change

- ✅ Documentation (non-code change)
