### PR TITLE
FdoSecrets: do not share entry <-> item property by multiple unlock prompts

### DIFF
--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -297,15 +297,15 @@ namespace FdoSecrets
                     continue;
                 }
                 auto entry = item->backend();
-                if (client->itemKnown(entry->uuid())) {
-                    if (!client->itemAuthorized(entry->uuid())) {
+                auto uuid = entry->uuid();
+                if (client->itemKnown(uuid)) {
+                    if (!client->itemAuthorized(uuid)) {
                         m_numRejected += 1;
                     }
+                    // Already saw this entry
                     continue;
                 }
-                // attach a temporary property, so later we can get the item
-                // back from the dialog's result
-                entry->setProperty(FdoSecretsBackend, QVariant::fromValue(item.data()));
+                m_entryToItems[uuid] = item.data();
                 entries << entry;
             }
         }
@@ -331,15 +331,17 @@ namespace FdoSecrets
         }
         for (auto it = decisions.constBegin(); it != decisions.constEnd(); ++it) {
             auto entry = it.key();
+            auto uuid = entry->uuid();
             // get back the corresponding item
-            auto item = entry->property(FdoSecretsBackend).value<Item*>();
-            entry->setProperty(FdoSecretsBackend, {});
-            Q_ASSERT(item);
+            auto item = m_entryToItems.value(uuid);
+            if (!item) {
+                continue;
+            }
 
             // set auth
-            client->setItemAuthorized(entry->uuid(), it.value());
+            client->setItemAuthorized(uuid, it.value());
 
-            if (client->itemAuthorized(entry->uuid())) {
+            if (client->itemAuthorized(uuid)) {
                 m_unlocked += item->objectPath();
             } else {
                 m_numRejected += 1;

--- a/src/fdosecrets/objects/Prompt.h
+++ b/src/fdosecrets/objects/Prompt.h
@@ -172,10 +172,10 @@ namespace FdoSecrets
         void itemUnlockFinished(const QHash<Entry*, AuthDecision>& results, AuthDecision forFutureEntries);
         void unlockItems();
 
-        static constexpr auto FdoSecretsBackend = "FdoSecretsBackend";
-
         QList<QPointer<Collection>> m_collections;
         QHash<Collection*, QList<QPointer<Item>>> m_items;
+        QHash<QUuid, Item*> m_entryToItems;
+
         QList<QDBusObjectPath> m_unlocked;
         int m_numRejected = 0;
 


### PR DESCRIPTION
Fixes #7753

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually. Existing unit tests pass.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)