### PR TITLE
revise strings labeling history limit settings

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1968,15 +1968,7 @@ If you keep this number, your database will not be protected from brute force at
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max. history items:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Maximum size of history per entry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max. history size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2006,6 +1998,35 @@ This action is not reversible.</source>
     </message>
     <message>
         <source> (old)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When saving this setting or editing an entry
+the oldest history items of an entry will be
+removed such that only the specified amount
+of entries remain at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit the amount of history items per entry to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When saving this setting or editing an entry
+the oldest history items of an entry will be
+removed such that the remaining history items
+add up to the specified amount at most.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit the total size of history items per entry to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move entries to a recycle bin group
+instead of deleting them from the database.
+Entries deleted from the recycle bin are
+removed from the database.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
@@ -100,20 +100,26 @@
         <item row="0" column="0">
          <widget class="QCheckBox" name="historyMaxItemsCheckBox">
           <property name="toolTip">
-           <string>Maximum number of history items per entry</string>
+           <string>When saving this setting or editing an entry
+the oldest history items of an entry will be
+removed such that only the specified amount
+of entries remain at most.</string>
           </property>
           <property name="text">
-           <string>Max. history items:</string>
+           <string>Limit the amount of history items per entry to:</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
          <widget class="QCheckBox" name="historyMaxSizeCheckBox">
           <property name="toolTip">
-           <string>Maximum size of history per entry</string>
+           <string>When saving this setting or editing an entry
+the oldest history items of an entry will be
+removed such that the remaining history items
+add up to the specified amount at most.</string>
           </property>
           <property name="text">
-           <string>Max. history size:</string>
+           <string>Limit the total size of history items per entry to:</string>
           </property>
          </widget>
         </item>
@@ -151,6 +157,12 @@
         </item>
         <item row="2" column="0">
          <widget class="QCheckBox" name="recycleBinEnabledCheckBox">
+          <property name="toolTip">
+           <string>Move entries to a recycle bin group
+instead of deleting them from the database.
+Entries deleted from the recycle bin are
+removed from the database.</string>
+          </property>
           <property name="text">
            <string>Use recycle bin</string>
           </property>


### PR DESCRIPTION
As per https://github.com/keepassxreboot/keepassxc/issues/7618#issuecomment-1087443237. The labels for the history limit settings were not explaining well what they do. The respective tooltips were extended to convey even more information.

A tooltip for the recycle bin setting was added as well, even though the concept of a recycle bin is well established.

## Screenshots
![limit_amount](https://user-images.githubusercontent.com/3578416/161565643-a505f8d8-5557-4aa6-9c69-86004ce79d23.png)
![limit_size](https://user-images.githubusercontent.com/3578416/161565651-7c8bc6e2-7f4e-4ba1-a4ff-6d5ac9ee40c9.png)
![recycle_bin](https://user-images.githubusercontent.com/3578416/161565661-de790c46-eeb1-44b9-81e6-70f3e3150c28.png)

## Testing strategy
Manual.

## Type of change
- ✅ Bug fix
