### PR TITLE
cmake: emit warning if X11_Xi or X11_XTest not found

### DIFF
--- a/src/autotype/CMakeLists.txt
+++ b/src/autotype/CMakeLists.txt
@@ -1,26 +1,14 @@
 if(WITH_XC_AUTOTYPE)
     if(UNIX AND NOT APPLE AND NOT HAIKU)
-        find_package(X11)
-        find_package(Qt5X11Extras 5.2)
+        find_package(X11 REQUIRED COMPONENTS Xi XTest)
+        find_package(Qt5X11Extras 5.2 REQUIRED)
         if(PRINT_SUMMARY)
             add_feature_info(libXi X11_Xi_FOUND "The X11 Xi Protocol library is required for auto-type")
             add_feature_info(libXtst X11_XTest_FOUND "The X11 XTEST Protocol library is required for auto-type")
             add_feature_info(Qt5X11Extras Qt5X11Extras_FOUND "The Qt5X11Extras library is required for auto-type")
         endif()
 
-        # an error will be emitted by find_package above if X11 (or Qt5X11Extras) dev files were not found.
-        # X11 possibly is installed and found while X11_Xi and/or X11_XTest are not, so we emit a warning.
-        if(NOT X11_Xi_FOUND)
-            message(WARNING "The X11 Xi Protocol library is required for auto-type (try libxi-dev package)")
-        endif()
-
-        if(NOT X11_XTest_FOUND)
-            message(WARNING "The X11 XTEST Protocol library is required for auto-type (try libxtst-dev package)")
-        endif()
-
-        if(X11_FOUND AND X11_Xi_FOUND AND X11_XTest_FOUND AND Qt5X11Extras_FOUND)
-            add_subdirectory(xcb)
-        endif()
+        add_subdirectory(xcb)
     elseif(APPLE)
         add_subdirectory(mac)
     elseif(WIN32)

--- a/src/autotype/CMakeLists.txt
+++ b/src/autotype/CMakeLists.txt
@@ -8,6 +8,16 @@ if(WITH_XC_AUTOTYPE)
             add_feature_info(Qt5X11Extras Qt5X11Extras_FOUND "The Qt5X11Extras library is required for auto-type")
         endif()
 
+        # an error will be emitted by find_package above if X11 (or Qt5X11Extras) dev files were not found.
+        # X11 possibly is installed and found while X11_Xi and/or X11_XTest are not, so we emit a warning.
+        if(NOT X11_Xi_FOUND)
+            message(WARNING "The X11 Xi Protocol library is required for auto-type (try libxi-dev package)")
+        endif()
+
+        if(NOT X11_XTest_FOUND)
+            message(WARNING "The X11 XTEST Protocol library is required for auto-type (try libxtst-dev package)")
+        endif()
+
         if(X11_FOUND AND X11_Xi_FOUND AND X11_XTest_FOUND AND Qt5X11Extras_FOUND)
             add_subdirectory(xcb)
         endif()


### PR DESCRIPTION
at least on Debian, a bullseye installation, the X11 development files may be installed without the libxi-dev or the libxtest-dev packages. this leads to the autotype shared library libkeepassxc-autotype-xcb.so not being built without any complaint from cmake.

this commit makes cmake emit warning messages that shall hint anyone building themselves that autotype will not work without these libs.


## Context
Finally I wanted to start using Auto-Type, but my local builds would not provide the capability even with `WITH_XC_AUTOTYPE=ON`. After some frustrating "debugging" I found that `libkeepassxc-autotype-xcb.so` was not being built. The reason was that my Debian system was missing `libxi-dev` and `libxtst-dev`.

There is no issue in just installing these and the problem went away. My concern is that `cmake` did not complain or warn or say anything about that it would not built the autotype library due to missing development files.

I could not find what `PRINT_SUMMARY` does, so if that block is supposed to inform about this issue it did not work for me.


## Testing strategy
Manual


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)