### PR TITLE
thirdparty/ykcore: link against libpthread

### DIFF
--- a/src/thirdparty/ykcore/CMakeLists.txt
+++ b/src/thirdparty/ykcore/CMakeLists.txt
@@ -27,13 +27,15 @@ if(WIN32)
 elseif(UNIX AND NOT APPLE)
     target_sources(ykcore PRIVATE ykcore_libusb-1.0.c)
 
+    find_package(Threads REQUIRED)
+
     find_library(LIBUSB_LIBRARY NAMES usb-1.0)
     find_path(LIBUSB_INCLUDE_DIR NAMES libusb.h PATH_SUFFIXES "libusb-1.0" "libusb")
     if(NOT LIBUSB_LIBRARY OR NOT LIBUSB_INCLUDE_DIR)
         message(FATAL_ERROR "libusb-1.0 dev package required, but not found")
     endif()
 
-    target_link_libraries(ykcore PRIVATE ${LIBUSB_LIBRARY})
+    target_link_libraries(ykcore PRIVATE Threads::Threads ${LIBUSB_LIBRARY})
     target_include_directories(ykcore PRIVATE ${LIBUSB_INCLUDE_DIR})
     target_compile_definitions(ykcore PRIVATE _GNU_SOURCE)
 elseif(APPLE)


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

keepassxc failed to link ykcore library due to missing `-pthread` flag.

## Build Log
```
<...>
[382/549] Linking CXX executable src/keepassxc
FAILED: src/keepassxc 
: && /usr/lib/ccache/bin/g++ -DNDEBUG -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -Og -ggdb3    -fdebug-prefix-map=/builddir/keepassxc-2.7.1=. -fno-common -Wall -Wextra -Wundef -Wpointer-arith -Wno-long-long -Wformat=2 -Wmissing-format-attribute -fvisibility=hidden -fvisibility-inlines-hidden -fstack-protector-strong -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Werror=format-security -Wcast-align -fsized-deallocation -Wno-deprecated-declarations -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -Wl,--no-add-needed -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro,-z,now -pie   -Wl,--export-dynamic -rdynamic  -fPIE -pie src/CMakeFiles/keepassxc.dir/keepassxc_autogen/mocs_compilation.cpp.o src/CMakeFiles/keepassxc.dir/main.cpp.o -o src/keepassxc  src/libkeepassx_core.a  src/libautotype.a  src/browser/libkeepassxcbrowser.a  src/qrcode/libqrcode.a  /usr/lib/libQt5Svg.so.5.15.2  /usr/lib/libqrencode.so  src/fdosecrets/libfdosecrets.a  /usr/lib/libQt5Concurrent.so.5.15.2  /usr/lib64/libpcsclite.so  src/libzxcvbn.a  /usr/lib/libargon2.so  src/thirdparty/ykcore/libykcore.a  /usr/lib/libusb-1.0.so  src/sshagent/libsshagent.a  /usr/lib/libQt5Network.so.5.15.2  src/keeshare/libkeeshare.a  /usr/lib/libQt5Widgets.so.5.15.2  /usr/lib/libbotan-2.so  /usr/lib/libz.so  /usr/lib/libminizip.so  /usr/lib/libQt5DBus.so.5.15.2  /usr/lib/libQt5X11Extras.so.5.15.2  /usr/lib/libQt5Gui.so.5.15.2  /usr/lib/libQt5Core.so.5.15.2  -lX11 && :
/usr/bin/ld: src/thirdparty/ykcore/libykcore.a(ykcore.c.o): undefined reference to symbol 'pthread_setspecific@@GLIBC_2.2.5'
/usr/bin/ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
<...>
```

## Testing strategy
Build for Void Linux
```
# consult https://github.com/void-linux/void-packages/tree/da6b404aa293c3df6de54a2c8827e010dab54f42#foreign 
git clone https://github.com/void-linux/void-packages/ && cd void-packages
# modify `srcpkgs/keepassxc/template` to build keepassxc-2.7.1
./xbps-src pkg keepassxc 
```

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)