### PR TITLE
cmake: Removed unneeded --no-add-needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,9 +310,9 @@ check_add_gcc_compiler_flag("-Wcast-align")
 
 if(UNIX AND NOT APPLE)
     check_add_gcc_compiler_flag("-Qunused-arguments")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-add-needed -Wl,--as-needed -Wl,--no-undefined")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--as-needed -Wl,--no-undefined")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro,-z,now -pie")
-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-add-needed -Wl,--as-needed")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--as-needed")
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,relro,-z,now")
 endif()
 


### PR DESCRIPTION
--no-add-needed is a deprecated alias for --no-copy-dt-needed-entries since 2009
(https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=ddbb8a31d5f6d13c91a416e13f6ad11ac6604102).
--no-copy-dt-needed-entries has been the default in GNU ld since 2011. ld.lld
14.0.0 does not accept --no-add-needed.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
