### PR TITLE
Fix capture of whiptail's exit status

### DIFF
--- a/utils/keepassxc-snap-helper.sh
+++ b/utils/keepassxc-snap-helper.sh
@@ -122,9 +122,10 @@ BROWSER=$(whiptail \
             "7" "Microsoft Edge" \
             3>&1 1>&2 2>&3)
 
+exitstatus=$?
+
 clear
 
-exitstatus=$?
 if [[ $exitstatus == 0 ]]; then
     # Configure settings for the chosen browser
     case $BROWSER in


### PR DESCRIPTION
The exit status of `whiptail` was masked by the subsequent call to
`clear`.

This correct the capture of whiptail's exit status so that pressing the
`[Cancel]` button can be correctly detected by the script.

Fixes #7830