### PR TITLE
Fix segfault on accessing items in the DBus vault. Discard all items that are nullptr.

### DIFF
--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -259,14 +259,16 @@ namespace FdoSecrets
             // item locked state already covers its collection's locked state
             for (const auto& item : asConst(items)) {
                 bool l;
-                ret = item->locked(client, l);
-                if (ret.err()) {
-                    return ret;
-                }
-                if (l) {
-                    locked.append(item);
-                } else {
-                    unlocked.append(item);
+                if (item) {
+                    ret = item->locked(client, l);
+                    if (ret.err()) {
+                        return ret;
+                    }
+                    if (l) {
+                        locked.append(item);
+                    } else {
+                        unlocked.append(item);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Discards all items from the loop which are `nullptr`.  I doubt this isn't really fixing the root issue, but afterall it works. Root of issue probably in https://github.com/keepassxreboot/keepassxc/commit/a31c5ba006198f2fdadfd6c4f587cfed602c81c6
~~Fixes: #7731~~

## Testing strategy
Tests run manually and tested manually.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

@michaelk83