### PR TITLE
Normalize path (slashes to be precise) when opening a database or saving the last used database paths (Fixes #7821)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -21,8 +21,8 @@
 
 #include <QCloseEvent>
 #include <QDesktopServices>
-#include <QFileInfo>
 #include <QDir>
+#include <QFileInfo>
 #include <QList>
 #include <QMimeData>
 #include <QShortcut>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1388,7 +1388,7 @@ bool MainWindow::saveLastDatabases()
         QStringList openDatabases;
         for (int i = 0; i < m_ui->tabWidget->count(); ++i) {
             auto dbWidget = m_ui->tabWidget->databaseWidgetFromIndex(i);
-            openDatabases.append(dbWidget->database()->filePath());
+            openDatabases.append(QDir::toNativeSeparators(dbWidget->database()->filePath()));
         }
 
         config()->set(Config::LastOpenedDatabases, openDatabases);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -22,6 +22,7 @@
 #include <QCloseEvent>
 #include <QDesktopServices>
 #include <QFileInfo>
+#include <QDir>
 #include <QList>
 #include <QMimeData>
 #include <QShortcut>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 
 #include <QCommandLineParser>
 #include <QFile>
+#include <QDir>
 #include <QWindow>
 
 #include "cli/Utils.h"
@@ -180,7 +181,7 @@ int main(int argc, char** argv)
         }
 
         if (!filename.isEmpty() && QFile::exists(filename) && !filename.endsWith(".json", Qt::CaseInsensitive)) {
-            mainWindow.openDatabase(filename, password, parser.value(keyfileOption));
+            mainWindow.openDatabase(QDir::toNativeSeparators(filename), password, parser.value(keyfileOption));
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,8 +17,8 @@
  */
 
 #include <QCommandLineParser>
-#include <QFile>
 #include <QDir>
+#include <QFile>
 #include <QWindow>
 
 #include "cli/Utils.h"


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )

This PR fixes the funny behavior described in issue #7821.

To summarize, depending on how you load a database in Windows, you will find the path (to the database) twice in the `Recent Databases` menu entry. The only difference between the two entries would be the slashes.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

As I don't have a windows environment to test this small change, I don't really know how to test it for windows (because it is a windows only bug). So my question here is, how do you test your code for linux and windows?

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)