### PR TITLE
Add password strength indicator to password entry fields

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1427,10 +1427,6 @@ Backup database located at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;In addition to a password, you can use a secret file to enhance the security of your database. This file can be generated in your database&apos;s security settings.&lt;/p&gt;&lt;p&gt;This is &lt;strong&gt;not&lt;/strong&gt; your *.kdbx database file!&lt;br&gt;If you do not have a key file, leave this field empty.&lt;/p&gt;&lt;p&gt;Click for more information…&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Key file help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1440,11 +1436,6 @@ Backup database located at %2</source>
     </message>
     <message>
         <source>Hardware Key:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;You can use a hardware security key such as a &lt;strong&gt;YubiKey&lt;/strong&gt; or &lt;strong&gt;OnlyKey&lt;/strong&gt; with slots configured for HMAC-SHA1.&lt;/p&gt;
-&lt;p&gt;Click for more information…&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1579,6 +1570,15 @@ If you do not have a key file, please leave the field empty.</source>
     </message>
     <message>
         <source>Select hardware key…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;In addition to a password, you can use a secret file to enhance the security of your database. This file can be generated in your database&apos;s security settings.&lt;/p&gt;&lt;p&gt;This is &lt;strong&gt;not&lt;/strong&gt; your *.kdbx database file!&lt;br&gt;If you do not have a key file, leave this field empty.&lt;/p&gt;&lt;p&gt;Click for more information…&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;You can use a hardware security key such as a &lt;strong&gt;YubiKey&lt;/strong&gt; or &lt;strong&gt;OnlyKey&lt;/strong&gt; with slots configured for HMAC-SHA1.&lt;/p&gt;
+&lt;p&gt;Click for more information…&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5750,29 +5750,6 @@ We recommend you use the AppImage available on our downloads page.</source>
     </message>
 </context>
 <context>
-    <name>PasswordEdit</name>
-    <message>
-        <source>Passwords do not match</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Passwords match so far</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Toggle Password (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generate Password (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warning: Caps Lock enabled!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>PasswordEditWidget</name>
     <message>
         <source>Enter password:</source>
@@ -5951,10 +5928,6 @@ We recommend you use the AppImage available on our downloads page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Excluded characters: &quot;0&quot;, &quot;1&quot;, &quot;l&quot;, &quot;I&quot;, &quot;O&quot;, &quot;|&quot;, &quot;﹒&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Exclude look-alike characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6081,6 +6054,57 @@ Do you want to overwrite it?</source>
     </message>
     <message>
         <source>Password Quality: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Poor</source>
+        <comment>Password quality</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <comment>Password quality</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Good</source>
+        <comment>Password quality</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excellent</source>
+        <comment>Password quality</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded characters: &quot;0&quot;, &quot;1&quot;, &quot;l&quot;, &quot;I&quot;, &quot;O&quot;, &quot;|&quot;, &quot;﹒&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PasswordWidget</name>
+    <message>
+        <source>Passwords do not match</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Passwords match so far</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Password (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generate Password (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning: Caps Lock enabled!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,7 +121,7 @@ set(keepassx_SOURCES
         gui/MessageBox.cpp
         gui/MessageWidget.cpp
         gui/OpVaultOpenWidget.cpp
-        gui/PasswordEdit.cpp
+        gui/PasswordWidget.cpp
         gui/PasswordGeneratorWidget.cpp
         gui/ApplicationSettingsWidget.cpp
         gui/Icons.cpp

--- a/src/autotype/PickcharsDialog.ui
+++ b/src/autotype/PickcharsDialog.ui
@@ -34,7 +34,7 @@
     <layout class="QGridLayout" name="charsGrid"/>
    </item>
    <item>
-    <widget class="PasswordEdit" name="selectedChars">
+    <widget class="PasswordWidget" name="selectedChars">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -74,9 +74,10 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PasswordEdit</class>
+   <class>PasswordWidget</class>
    <extends>QLineEdit</extends>
-   <header>gui/PasswordEdit.h</header>
+   <header>gui/PasswordWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -145,7 +145,7 @@
              </widget>
             </item>
             <item>
-             <widget class="PasswordEdit" name="editPassword">
+             <widget class="PasswordWidget" name="editPassword">
               <property name="accessibleName">
                <string>Password field</string>
               </property>
@@ -380,7 +380,7 @@
                    <number>0</number>
                   </property>
                   <item row="0" column="1">
-                   <widget class="PasswordEdit" name="keyFileLineEdit">
+                   <widget class="PasswordWidget" name="keyFileLineEdit">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                       <horstretch>0</horstretch>
@@ -617,9 +617,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PasswordEdit</class>
+   <class>PasswordWidget</class>
    <extends>QLineEdit</extends>
-   <header>gui/PasswordEdit.h</header>
+   <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -87,7 +87,7 @@
       </layout>
      </item>
      <item row="0" column="0">
-      <widget class="PasswordEdit" name="editNewPassword">
+      <widget class="PasswordWidget" name="editNewPassword">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
          <horstretch>0</horstretch>
@@ -990,9 +990,9 @@ QProgressBar::chunk {
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PasswordEdit</class>
+   <class>PasswordWidget</class>
    <extends>QLineEdit</extends>
-   <header>gui/PasswordEdit.h</header>
+   <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/gui/PasswordWidget.h
+++ b/src/gui/PasswordWidget.h
@@ -16,50 +16,70 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_PASSWORDEDIT_H
-#define KEEPASSX_PASSWORDEDIT_H
+#ifndef KEEPASSX_PASSWORDWIDGET_H
+#define KEEPASSX_PASSWORDWIDGET_H
 
 #include <QAction>
 #include <QLineEdit>
 #include <QPointer>
+#include <QWidget>
 
-class QDialog;
+namespace Ui
+{
+    class PasswordWidget;
+}
 
-class PasswordEdit : public QLineEdit
+class PasswordWidget : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit PasswordEdit(QWidget* parent = nullptr);
+    explicit PasswordWidget(QWidget* parent = nullptr);
+    ~PasswordWidget() override;
     void enablePasswordGenerator();
-    void setRepeatPartner(PasswordEdit* repeatEdit);
+    void setRepeatPartner(PasswordWidget* repeatEdit);
+    void setQualityVisible(bool state);
+
     bool isPasswordVisible() const;
+    QString text();
+
+signals:
+    void textChanged(QString text);
 
 public slots:
+    void setText(const QString& text);
     void setShowPassword(bool show);
-    void updateRepeatStatus();
+
+    void clear();
+    void selectAll();
+    void setReadOnly(bool state);
+    void setEchoMode(QLineEdit::EchoMode mode);
+    void setClearButtonEnabled(bool enabled);
 
 protected:
     bool event(QEvent* event) override;
 
-signals:
-    void capslockToggled(bool capslockOn);
-
 private slots:
     void autocompletePassword(const QString& password);
     void popupPasswordGenerator();
-    void setParentPasswordEdit(PasswordEdit* parent);
-    void checkCapslockState();
+    void updateRepeatStatus();
+    void updatePasswordStrength(const QString& password);
 
 private:
+    void checkCapslockState();
+    void setParentPasswordEdit(PasswordWidget* parent);
+
+    const QScopedPointer<Ui::PasswordWidget> m_ui;
+
     QPointer<QAction> m_errorAction;
     QPointer<QAction> m_correctAction;
     QPointer<QAction> m_toggleVisibleAction;
     QPointer<QAction> m_passwordGeneratorAction;
     QPointer<QAction> m_capslockAction;
-    QPointer<PasswordEdit> m_repeatPasswordEdit;
-    QPointer<PasswordEdit> m_parentPasswordEdit;
+    QPointer<PasswordWidget> m_repeatPasswordEdit;
+    QPointer<PasswordWidget> m_parentPasswordEdit;
+
     bool m_capslockState = false;
 };
 
-#endif // KEEPASSX_PASSWORDEDIT_H
+#endif // KEEPASSX_PASSWORDWIDGET_H

--- a/src/gui/PasswordWidget.ui
+++ b/src/gui/PasswordWidget.ui
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PasswordWidget</class>
+ <widget class="QWidget" name="PasswordWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>471</width>
+    <height>25</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLineEdit" name="passwordEdit"/>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="qualityProgressBar">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>4</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QProgressBar {
+              border: none;
+              background-color: transparent;
+              }
+              QProgressBar::chunk {
+              background-color: #c0392b;
+              border-radius: 1px;
+              }
+            </string>
+     </property>
+     <property name="value">
+      <number>24</number>
+     </property>
+     <property name="textVisible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>passwordEdit</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/databasekey/PasswordEditWidget.cpp
+++ b/src/gui/databasekey/PasswordEditWidget.cpp
@@ -78,6 +78,9 @@ void PasswordEditWidget::initComponentEditWidget(QWidget* widget)
     Q_UNUSED(widget);
     Q_ASSERT(m_compEditWidget);
     m_compUi->enterPasswordEdit->setFocus();
+
+    m_compUi->enterPasswordEdit->setQualityVisible(true);
+    m_compUi->repeatPasswordEdit->setQualityVisible(false);
 }
 
 void PasswordEditWidget::initComponent()

--- a/src/gui/databasekey/PasswordEditWidget.ui
+++ b/src/gui/databasekey/PasswordEditWidget.ui
@@ -31,7 +31,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="PasswordEdit" name="enterPasswordEdit">
+    <widget class="PasswordWidget" name="enterPasswordEdit">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -60,7 +60,7 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="PasswordEdit" name="repeatPasswordEdit">
+    <widget class="PasswordWidget" name="repeatPasswordEdit">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -85,9 +85,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PasswordEdit</class>
+   <class>PasswordWidget</class>
    <extends>QLineEdit</extends>
-   <header>gui/PasswordEdit.h</header>
+   <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -131,6 +131,8 @@ EditEntryWidget::EditEntryWidget(QWidget* parent)
     connect(m_iconsWidget, SIGNAL(messageEditEntryDismiss()), SLOT(hideMessage()));
 
     m_editWidgetProperties->setCustomData(m_customData.data());
+
+    m_mainUi->passwordEdit->setQualityVisible(true);
 }
 
 EditEntryWidget::~EditEntryWidget()

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -243,7 +243,7 @@
      </widget>
     </item>
     <item row="2" column="1">
-     <widget class="PasswordEdit" name="passwordEdit">
+     <widget class="PasswordWidget" name="passwordEdit">
       <property name="accessibleName">
        <string>Password field</string>
       </property>
@@ -297,15 +297,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TagsEdit</class>
-   <extends>QWidget</extends>
-   <header>gui/tag/TagsEdit.h</header>
+   <class>PasswordWidget</class>
+   <extends>QLineEdit</extends>
+   <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>PasswordEdit</class>
-   <extends>QLineEdit</extends>
-   <header>gui/PasswordEdit.h</header>
+   <class>TagsEdit</class>
+   <extends>QWidget</extends>
+   <header>gui/tag/TagsEdit.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/keeshare/group/EditGroupWidgetKeeShare.ui
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.ui
@@ -51,7 +51,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="PasswordEdit" name="passwordEdit">
+      <widget class="PasswordWidget" name="passwordEdit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -190,9 +190,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PasswordEdit</class>
+   <class>PasswordWidget</class>
    <extends>QLineEdit</extends>
-   <header>gui/PasswordEdit.h</header>
+   <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/tests/gui/TestGuiBrowser.cpp
+++ b/tests/gui/TestGuiBrowser.cpp
@@ -35,6 +35,7 @@
 #include "gui/DatabaseTabWidget.h"
 #include "gui/FileDialog.h"
 #include "gui/MessageBox.h"
+#include "gui/PasswordWidget.h"
 #include "gui/entry/EditEntryWidget.h"
 #include "gui/entry/EntryView.h"
 
@@ -90,7 +91,8 @@ void TestGuiBrowser::init()
 
     auto* databaseOpenWidget = m_tabWidget->currentDatabaseWidget()->findChild<QWidget*>("databaseOpenWidget");
     QVERIFY(databaseOpenWidget);
-    auto* editPassword = databaseOpenWidget->findChild<QLineEdit*>("editPassword");
+    auto* editPassword =
+        databaseOpenWidget->findChild<PasswordWidget*>("editPassword")->findChild<QLineEdit*>("passwordEdit");
     QVERIFY(editPassword);
     editPassword->setFocus();
 

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -33,6 +33,7 @@
 #include "gui/FileDialog.h"
 #include "gui/MainWindow.h"
 #include "gui/MessageBox.h"
+#include "gui/PasswordWidget.h"
 #include "gui/wizard/NewDatabaseWizard.h"
 #include "util/FdoSecretsProxy.h"
 #include "util/TemporaryFile.h"
@@ -1768,8 +1769,10 @@ bool TestGuiFdoSecrets::driveNewDatabaseWizard()
             COMPARE(wizard->currentId(), 2);
 
             // enter password
-            auto* passwordEdit = wizard->findChild<QLineEdit*>("enterPasswordEdit");
-            auto* passwordRepeatEdit = wizard->findChild<QLineEdit*>("repeatPasswordEdit");
+            auto* passwordEdit =
+                wizard->findChild<PasswordWidget*>("enterPasswordEdit")->findChild<QLineEdit*>("passwordEdit");
+            auto* passwordRepeatEdit =
+                wizard->findChild<PasswordWidget*>("repeatPasswordEdit")->findChild<QLineEdit*>("passwordEdit");
             VERIFY(passwordEdit);
             VERIFY(passwordRepeatEdit);
             QTest::keyClicks(passwordEdit, "test");
@@ -1797,7 +1800,7 @@ bool TestGuiFdoSecrets::driveUnlockDialog()
     processEvents();
     auto dbOpenDlg = m_tabWidget->findChild<DatabaseOpenDialog*>();
     VERIFY(dbOpenDlg);
-    auto editPassword = dbOpenDlg->findChild<QLineEdit*>("editPassword");
+    auto editPassword = dbOpenDlg->findChild<PasswordWidget*>("editPassword")->findChild<QLineEdit*>("passwordEdit");
     VERIFY(editPassword);
     editPassword->setFocus();
     QTest::keyClicks(editPassword, "a");


### PR DESCRIPTION
Fixes #7437 (partially, entry edit view only)
Fixes #5220

This change adds a password strength indicator to PasswordEditWidget (I have followed the way it is done in PasswordGeneratorWidget).

I want to contribute some code to the project and thought that this could be a good "first issue". Please be gentle ;)

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![Screenshot_20220413_120737](https://user-images.githubusercontent.com/1109854/163155485-ae9b7c2c-a3f6-4516-8a4f-aabfe54b47da.png)

![Screenshot_20220413_120832](https://user-images.githubusercontent.com/1109854/163155643-153b9fd5-5e8b-48d5-873a-6c87ce27f1fc.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Testing was quite straightforward. As far as I know, the screenshots above are the only two places where PasswordEditWidget is used. I went to the windows shown above and tried different combinations of passwords to see how the indicator behaves, trying to replicate exactly what is done in PasswordGeneratorWidget.

Both development and testing were made on Linux only.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)

## Comments
I'm basically doing the same as in PasswordGeneratorWidget so, would it be worth refactoring and making a derived class of QProgressBar? I would say it is but it is up to you, just let me know.

Thanks for the software ;)
