### PR TITLE
Respect user icon theme in classical mode

### DIFF
--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -189,7 +189,11 @@ QIcon Icons::icon(const QString& name, bool recolor, const QColor& overrideColor
     //
     // See issue #4963: https://github.com/keepassxreboot/keepassxc/issues/4963
     // and qt5ct issue #80: https://sourceforge.net/p/qt5ct/tickets/80/
-    QIcon::setThemeName("application");
+    if (config()->get(Config::GUI_ApplicationTheme) == QVariant::fromValue<QString>("classic")) {
+        QIcon::setFallbackThemeName("application");
+    } else {
+        QIcon::setThemeName("application");
+    }
 #endif
 
     QString cacheName =
@@ -201,7 +205,7 @@ QIcon Icons::icon(const QString& name, bool recolor, const QColor& overrideColor
     }
 
     icon = QIcon::fromTheme(name);
-    if (recolor) {
+    if (recolor && config()->get(Config::GUI_ApplicationTheme) != QVariant::fromValue<QString>("classic")) {
         icon = QIcon(new AdaptiveIconEngine(icon, overrideColor));
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
         icon.setIsMask(true);
@@ -224,7 +228,11 @@ Icons* Icons::instance()
 
         Q_INIT_RESOURCE(icons);
         QIcon::setThemeSearchPaths(QStringList{":/icons"} << QIcon::themeSearchPaths());
-        QIcon::setThemeName("application");
+        if (config()->get(Config::GUI_ApplicationTheme) == QVariant::fromValue<QString>("classic")) {
+            QIcon::setFallbackThemeName("application");
+        } else {
+            QIcon::setThemeName("application");
+        }
     }
 
     return m_instance;


### PR DESCRIPTION
If users opt in to use their system theme, their icon theme is not respected.

As solution, set the "application" theme as fallback theme in QIcon and
disable recoloring if classical mode is enabled. This way users can provide
custom icons via themes. If an icon is not found in the current user theme,
the icon from KeePassXC's "application" theme is used.

This behavior could be further improved by renaming some custom icons
like "group-new" to their system name, e.g. "folder-new", or by adding an alternative system icon name.

This change needs at least QT 5.12 to compile.

## Testing strategy
Starting KeePassXC and switching between light, dark and classical mode. Observe that icons do not change in light and dark mode, and change to system icons in classical mode if they exist in user theme. This is the case e.g. for the "open database" icon.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
