### PR TITLE
TestKdbx4Format: use MockClock

### DIFF
--- a/tests/TestKdbx4.cpp
+++ b/tests/TestKdbx4.cpp
@@ -27,6 +27,7 @@
 #include "keys/FileKey.h"
 #include "keys/PasswordKey.h"
 #include "mock/MockChallengeResponseKey.h"
+#include "mock/MockClock.h"
 #include <QTest>
 
 int main(int argc, char* argv[])
@@ -113,6 +114,17 @@ void TestKdbx4AesKdf::initTestCaseImpl()
 }
 
 Q_DECLARE_METATYPE(QUuid)
+
+void TestKdbx4Format::init()
+{
+    MockClock::setup(new MockClock());
+}
+
+void TestKdbx4Format::cleanup()
+{
+    MockClock::teardown();
+}
+
 void TestKdbx4Format::testFormat400()
 {
     QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/Format400.kdbx");

--- a/tests/TestKdbx4.h
+++ b/tests/TestKdbx4.h
@@ -56,6 +56,8 @@ class TestKdbx4Format : public QObject
     Q_OBJECT
 
 private slots:
+    void init();
+    void cleanup();
     void testFormat400();
     void testFormat400Upgrade();
     void testFormat400Upgrade_data();


### PR DESCRIPTION
Otherwise, assertions in `TestKdbx4::testCustomData()` may fail on rare occasions, because the customData in a cloned entry won't be identical to its original, because of its potentially-updated LastModified property.

Originally noticed in https://github.com/keepassxreboot/keepassxc/pull/7783#issuecomment-1101404487.

## Testing strategy

`ctest -R testkdbx4` succeeds even when a sleep statement is inserted before [this line](https://github.com/keepassxreboot/keepassxc/blob/9bf61bfc5cd3ad60f8c7301d6f5f443d80333887/tests/TestKdbx4.cpp#L470). Without the change in this PR, that consistently fails.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
