### PR TITLE
Add missing greater-than symbol in the password generator UI

### DIFF
--- a/src/core/PasswordGenerator.cpp
+++ b/src/core/PasswordGenerator.cpp
@@ -214,7 +214,7 @@ QVector<PasswordGroup> PasswordGenerator::passwordGroups() const
     if (m_classes & Math) {
         PasswordGroup group;
 
-        // !*+-<=>?
+        // !*+<=>?
         group.append(33);
         group.append(42);
         group.append(43);

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -492,7 +492,7 @@ QProgressBar::chunk {
                  <string>Math Symbols</string>
                 </property>
                 <property name="text">
-                 <string notr="true">&lt; * + ! ? =</string>
+                 <string notr="true">&lt; &gt; * + ! ? =</string>
                 </property>
                 <property name="checkable">
                  <bool>true</bool>


### PR DESCRIPTION
Make the password generator widget also show the greater-than sign. Without this change, the display is wrong, because a character may be selected during password generation even though users think that they have not selected it.

This change does not affect strings that need translation.

See commit message for more details.

## Testing strategy
I have tested the changes by recompiling KeePassXC 2.7.1 with the patch. The result was as expected: the greater-than sign is now also displayed on the checkable push button where it belongs.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)