### PR TITLE
Correct issues with passphrase word list 

### DIFF
--- a/share/wordlists/eff_large.wordlist
+++ b/share/wordlists/eff_large.wordlist
@@ -7742,12 +7742,12 @@ yiddish
 yield
 yin
 yippee
-yo-yo
+yes
 yodel
 yoga
 yogurt
 yonder
-yoyo
+young
 yummy
 zap
 zealous


### PR DESCRIPTION
Yo-yo and yoyo are two spelling of the same exact word, and the latter spelling is "non-standard." The former spelling is the only word with a hyphen. The replacements "yes" and "young" preserve the alphabetical order.

The EFF wordlist (5-dice list) has two words that repeat https://www.eff.org/files/2016/07/18/eff_large_wordlist.txt at 66622 and 66631. KeePassXC also uses this flawed list https://github.com/keepassxreboot/keepassxc/blob/develop/share/wordlists/eff_large.wordlist at lines 7745 and 7750.

These words are "yo-yo" and "yoyo."

Not only is this the same word with two different spellings, but the form at 7745 (yo-yo) is the only word that has a hyphen, which is usually reserved to separate words when password systems do not even allow single spaces between printable characters, which is still frightfully common.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)