### PR TITLE
Replacements for removed words (and preserve ordering)

### DIFF
--- a/share/wordlists/eff_large.wordlist
+++ b/share/wordlists/eff_large.wordlist
@@ -3028,6 +3028,7 @@ groom
 groove
 grooving
 groovy
+grouch
 ground
 grouped
 grout
@@ -3146,7 +3147,8 @@ happily
 happiness
 happy
 harbor
-hardcopy
+hardball
+hardboard
 hardcover
 harddisk
 hardened
@@ -6608,6 +6610,7 @@ swimmer
 swimming
 swimsuit
 swimwear
+swindle
 swinging
 swipe
 swirl


### PR DESCRIPTION
This undoes the change to word count and numbering after the removal of three words that some could deem offensive <https://github.com/keepassxreboot/keepassxc/pull/6914>.

Replacing removed words to preserve total word order and alphabetical ordering.

Add replacement: grope -> . . . -> grouch

Change: hardcopy -> hardcopy -> hardball

Replace: hardcore -> . . . -> hardboard

(I couldn't see "hardcopy" as a single word in American dictionaries from the turn of the century. It's too much of a neologism [and if we can't have "hardcore," then there's nothing else I can fit in that gap]. I had to remove another word to allow the addition of two new words here to preserve ordering. It's also an improvement because "hardcopy" is not a single word in dictionaries older than a decade or so.)

Add replacement: swinger -> . . . -> swindle

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
