### PR TITLE
Word repetition: two spellings of same word hankie

### DIFF
--- a/share/wordlists/eff_large.wordlist
+++ b/share/wordlists/eff_large.wordlist
@@ -3137,8 +3137,8 @@ hangover
 hangup
 hankering
 hankie
-hanky
-haphazard
+hapless
+haploid
 happening
 happier
 happiest


### PR DESCRIPTION
Word repetition: two spellings of same word hankie.

- keeping "hankie" as the "correct" spelling (because "hanky" is more common in "hanky-panky")

- hanky -> hapless

- haphazard -> haploid

(The other option was to insert "hansom" between "hanky" and "haphazard," but "handsome" is a homophone because the "d" became silent many years ago. There are proper noun options like Hannibal, Hanoi, and Hanover.)

This preserves the ordering and is a non-breaking change.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)