### PR TITLE
Update eff_large.wordlist

### DIFF
--- a/share/wordlists/eff_large.wordlist
+++ b/share/wordlists/eff_large.wordlist
@@ -2006,8 +2006,8 @@ drizzly
 drone
 drool
 droop
-drop-down
-dropbox
+drop-in
+dropforge
 dropkick
 droplet
 dropout
@@ -2102,11 +2102,11 @@ eaten
 eatery
 eating
 eats
-ebay
+eaves
 ebony
 ebook
-ecard
-eccentric
+echelon
+echidna
 echo
 eclair
 eclipse
@@ -2684,8 +2684,8 @@ footpad
 footpath
 footprint
 footrest
-footsie
-footsore
+footstool
+footway
 footwear
 footwork
 fossil
@@ -2928,7 +2928,7 @@ goldmine
 goldsmith
 golf
 goliath
-gonad
+golly
 gondola
 gone
 gong
@@ -2937,8 +2937,8 @@ gooey
 goofball
 goofiness
 goofy
-google
-goon
+gooseneck
+goosey
 gopher
 gore
 gorged
@@ -3028,6 +3028,7 @@ groom
 groove
 grooving
 groovy
+grouch
 ground
 grouped
 grout
@@ -3137,7 +3138,7 @@ hangover
 hangup
 hankering
 hankie
-hanky
+hanoi
 haphazard
 happening
 happier
@@ -3146,9 +3147,10 @@ happily
 happiness
 happy
 harbor
-hardcopy
+hardback
+hardball
 hardcover
-harddisk
+hardedge
 hardened
 hardener
 hardening
@@ -3410,10 +3412,10 @@ impurity
 iodine
 iodize
 ion
-ipad
-iphone
-ipod
-irate
+iota
+ire
+iridium
+iris
 irk
 iron
 irregular
@@ -3423,7 +3425,7 @@ irritably
 irritant
 irritate
 islamic
-islamist
+island
 isolated
 isolating
 isolation
@@ -3576,7 +3578,7 @@ kite
 kitten
 kitty
 kiwi
-kleenex
+knack
 knapsack
 knee
 knelt
@@ -3661,7 +3663,7 @@ leggings
 legible
 legibly
 legislate
-lego
+legitimate
 legroom
 legume
 legwarmer
@@ -3876,7 +3878,7 @@ marshland
 marshy
 marsupial
 marvelous
-marxism
+marzipan
 mascot
 masculine
 mashed
@@ -5912,7 +5914,7 @@ shun
 shush
 shut
 shy
-siamese
+sial
 siberian
 sibling
 siding
@@ -6608,6 +6610,7 @@ swimmer
 swimming
 swimsuit
 swimwear
+swindle
 swinging
 swipe
 swirl
@@ -7720,7 +7723,7 @@ wrongful
 wrongly
 wrongness
 wrought
-xbox
+xenon
 xerox
 yahoo
 yam
@@ -7747,7 +7750,7 @@ yodel
 yoga
 yogurt
 yonder
-yoyo
+young
 yummy
 zap
 zealous


### PR DESCRIPTION
1. Replaces words removed by pull 6914 <https://github.com/keepassxreboot/keepassxc/pull/6914/files/23b9e35de9a605bd9f6c6ea90e39a3ef9a55761f> for possible offense. This restores the total word count.

Add replacement: grope -> . . . -> grouch

Change: hardcopy -> hardcopy -> hardback

Replace: hardcore -> . . . -> hardball

(I couldn't see "hardcopy" as a single word in American dictionaries from the turn of the century. It's too much of a neologism [and if we can't have "hardcore," then there's nothing else I can fit in that gap]. I had to remove another word to allow the addition of two new words here to preserve ordering. It's also an improvement because "hardcopy" is not a single word in dictionaries older than a decade or so.)

Add replacement: swinger -> . . . -> swindle

2. Yo-yo and yoyo are two spelling of the same exact word, and the latter spelling is "non-standard."

Keeping: yo-yo (t-shirt is the another hyphenated word and I can't find a suitable candidate for either without creating several conflicts on the long wordlist. Felt-tip stays as well.)

Change: yoyo -> young

3.  Word repetition: two spellings of same word hankie.

Keeping: hankie (as the "correct" spelling because "hanky" is more common in "hanky-panky").

Change: hanky -> hanoi

(The other option was to insert "hansom" between "hanky" and "haphazard," but "handsome" is a homophone because the "d" became silent many years ago.)

4. Changed brand names to regular nouns:

dropbox -> dropforge

ebay -> eaves

google -> goosey as in "loosey-goosey" (the real word is "googol," anyhow)

This necessitated changing goon -> gooseneck

ipad -> iota

iphone -> ire

ipod -> iridium

This necessitated irate -> iris

kleenex -> knack (the word "tissue" exists)

lego -> legitimate

xbox -> xenon (which sounds like x box or x-box, too)

Keeping: xerox (now genericized like aspirin and describes a specific process)

5. Replaced non-standard words around "drop" and the brand name in there

drop-down -> drop-in

ebook -> (genericized like "email")

ecard -> echelon

This necessitated eccentric -> echidna

harddisk -> hardedge (Hardedge is an art style. Hard disk is always two words or else is abbreviated as HDD for hard disk drive)

6. Replaced flirtatious activity

footsie -> footstool

Which necessitated making footsore -> footway

7. Potentially sensitive anatomy

gonad -> golly

siamese -> siam (Siamese = Thai, but "twins" is also on the list and "Siamese" could precede "twins," which is slur for conjoined twins. Siam = Thailand)

8. Politically sensitive

islamist -> island (An Islamist is someone who wants to enforce political Islam on all with a literal and conservative interpretation of the Qu'ran. It does not mean Muslim.)

marxism ->  marzipan (I'm a big old lefty, myself, but I need to be consistent)

********

These necessitated a couple changes to nearby words where a drop-in replacement word did not exist, which required shifting neighboring words slightly.

Alphabetical order preserved and total word count should match EFF's modified and the original Diceware list. No breaking changes.

## Note

Condenses multiple pull requests

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)