### PR TITLE
Fix autotype menu entries on Windows

### DIFF
--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -35,6 +35,14 @@
 #include "gui/Clipboard.h"
 #include "gui/Icons.h"
 
+const auto MENU_FIELD_PROP_NAME = "menu_field";
+enum MENU_FIELD
+{
+    USERNAME = 1,
+    PASSWORD,
+    TOTP,
+};
+
 AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     : QDialog(parent)
     , m_ui(new Ui::AutoTypeSelectDialog())
@@ -260,14 +268,22 @@ void AutoTypeSelectDialog::updateActionMenu(const AutoTypeMatch& match)
     bool hasPassword = !match.first->password().isEmpty();
     bool hasTotp = match.first->hasTotp();
 
-    auto actions = m_actionMenu->actions();
-    Q_ASSERT(actions.size() >= 6);
-    actions[0]->setEnabled(hasUsername);
-    actions[1]->setEnabled(hasPassword);
-    actions[2]->setEnabled(hasTotp);
-    actions[3]->setEnabled(hasUsername);
-    actions[4]->setEnabled(hasPassword);
-    actions[5]->setEnabled(hasTotp);
+    for (auto action : m_actionMenu->actions()) {
+        auto prop = action->property(MENU_FIELD_PROP_NAME);
+        if (prop.isValid()) {
+            switch (prop.toInt()) {
+            case MENU_FIELD::USERNAME:
+                action->setEnabled(hasUsername);
+                break;
+            case MENU_FIELD::PASSWORD:
+                action->setEnabled(hasPassword);
+                break;
+            case MENU_FIELD::TOTP:
+                action->setEnabled(hasTotp);
+                break;
+            }
+        }
+    }
 }
 
 void AutoTypeSelectDialog::buildActionMenu()
@@ -282,15 +298,12 @@ void AutoTypeSelectDialog::buildActionMenu()
     m_actionMenu->addAction(typeUsernameAction);
     m_actionMenu->addAction(typePasswordAction);
     m_actionMenu->addAction(typeTotpAction);
-#ifdef Q_OS_WIN
-    auto typeVirtualAction = new QAction(icons()->icon("auto-type"), tr("Use Virtual Keyboard"));
-    m_actionMenu->addAction(typeVirtualAction);
-#endif
     m_actionMenu->addAction(copyUsernameAction);
     m_actionMenu->addAction(copyPasswordAction);
     m_actionMenu->addAction(copyTotpAction);
 
     typeUsernameAction->setShortcut(Qt::CTRL + Qt::Key_1);
+    typeUsernameAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::USERNAME);
     connect(typeUsernameAction, &QAction::triggered, this, [&] {
         auto match = m_ui->view->currentMatch();
         match.second = "{USERNAME}";
@@ -298,6 +311,7 @@ void AutoTypeSelectDialog::buildActionMenu()
     });
 
     typePasswordAction->setShortcut(Qt::CTRL + Qt::Key_2);
+    typePasswordAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::PASSWORD);
     connect(typePasswordAction, &QAction::triggered, this, [&] {
         auto match = m_ui->view->currentMatch();
         match.second = "{PASSWORD}";
@@ -305,6 +319,7 @@ void AutoTypeSelectDialog::buildActionMenu()
     });
 
     typeTotpAction->setShortcut(Qt::CTRL + Qt::Key_3);
+    typeTotpAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::TOTP);
     connect(typeTotpAction, &QAction::triggered, this, [&] {
         auto match = m_ui->view->currentMatch();
         match.second = "{TOTP}";
@@ -312,6 +327,8 @@ void AutoTypeSelectDialog::buildActionMenu()
     });
 
 #ifdef Q_OS_WIN
+    auto typeVirtualAction = new QAction(icons()->icon("auto-type"), tr("Use Virtual Keyboard"));
+    m_actionMenu->insertAction(copyUsernameAction, typeVirtualAction);
     typeVirtualAction->setShortcut(Qt::CTRL + Qt::Key_4);
     connect(typeVirtualAction, &QAction::triggered, this, [&] {
         m_virtualMode = true;
@@ -330,6 +347,7 @@ void AutoTypeSelectDialog::buildActionMenu()
 #endif
 #endif
 
+    copyUsernameAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::USERNAME);
     connect(copyUsernameAction, &QAction::triggered, this, [&] {
         auto entry = m_ui->view->currentMatch().first;
         if (entry) {
@@ -337,6 +355,8 @@ void AutoTypeSelectDialog::buildActionMenu()
             reject();
         }
     });
+
+    copyPasswordAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::PASSWORD);
     connect(copyPasswordAction, &QAction::triggered, this, [&] {
         auto entry = m_ui->view->currentMatch().first;
         if (entry) {
@@ -344,6 +364,8 @@ void AutoTypeSelectDialog::buildActionMenu()
             reject();
         }
     });
+
+    copyTotpAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::TOTP);
     connect(copyTotpAction, &QAction::triggered, this, [&] {
         auto entry = m_ui->view->currentMatch().first;
         if (entry) {


### PR DESCRIPTION
The addition of the "Use Virtual Keyboard" menu entry from commit 8a7eb3695087c94f78b9c93676f6d36597f407c2 on Windows broke the enabling/disabling of the "Copy *" autotype menu entries due to incorrect hard-coded indices. Fixed by replacing the indexing with a custom property on each action to identify when it should be enabled/disabled.


## Testing strategy
On Windows, confirmed that the correct menu entries are enabled/disabled for the different combinations of username/password/totp.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
