### PR TITLE
Browser feature: Add omit WWW subdomain group option

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3088,6 +3088,14 @@ Would you like to correct it?</source>
         <source>Do not use HTTP Auth toggle for this and sub groups</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Omit WWW subdomain from matching:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Omit WWW subdomain from matching toggle for this and sub groups</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EditGroupWidgetKeeShare</name>

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -99,6 +99,7 @@ public:
     static const QString OPTION_HIDE_ENTRY;
     static const QString OPTION_ONLY_HTTP_AUTH;
     static const QString OPTION_NOT_HTTP_AUTH;
+    static const QString OPTION_OMIT_WWW;
     static const QString ADDITIONAL_URL;
 
 signals:
@@ -128,26 +129,29 @@ private:
         Hidden
     };
 
-    QList<Entry*>
-    searchEntries(const QSharedPointer<Database>& db, const QString& siteUrlStr, const QString& formUrlStr);
-    QList<Entry*> searchEntries(const QString& siteUrlStr, const QString& formUrlStr, const StringPairList& keyList);
-    QList<Entry*> sortEntries(QList<Entry*>& pwEntries, const QString& siteUrlStr, const QString& formUrlStr);
+    QList<Entry*> searchEntries(const QSharedPointer<Database>& db, const QString& siteUrl, const QString& formUrl);
+    QList<Entry*> searchEntries(const QString& siteUrl, const QString& formUrl, const StringPairList& keyList);
+    QList<Entry*> sortEntries(QList<Entry*>& pwEntries, const QString& siteUrl, const QString& formUrl);
     QList<Entry*> confirmEntries(QList<Entry*>& pwEntriesToConfirm,
-                                 const QString& siteUrlStr,
+                                 const QString& siteUrl,
                                  const QString& siteHost,
-                                 const QString& formUrlStr,
+                                 const QString& formUrl,
                                  const QString& realm,
                                  const bool httpAuth);
     QJsonObject prepareEntry(const Entry* entry);
     QJsonArray getChildrenFromGroup(Group* group);
     Access checkAccess(const Entry* entry, const QString& siteHost, const QString& formHost, const QString& realm);
     Group* getDefaultEntryGroup(const QSharedPointer<Database>& selectedDb = {});
-    int sortPriority(const QStringList& urls, const QString& siteUrlStr, const QString& formUrlStr);
+    int sortPriority(const QStringList& urls, const QString& siteUrl, const QString& formUrl);
     bool schemeFound(const QString& url);
     bool isIpAddress(const QString& host) const;
     bool removeFirstDomain(QString& hostname);
-    bool handleEntry(Entry* entry, const QString& url, const QString& submitUrl);
-    bool handleURL(const QString& entryUrl, const QString& siteUrlStr, const QString& formUrlStr);
+    bool
+    shouldIncludeEntry(Entry* entry, const QString& url, const QString& submitUrl, const bool omitWwwSubdomain = false);
+    bool handleURL(const QString& entryUrl,
+                   const QString& siteUrl,
+                   const QString& formUrl,
+                   const bool omitWwwSubdomain = false);
     QString getTopLevelDomainFromUrl(const QString& url) const;
     QString baseDomain(const QString& hostname) const;
     QSharedPointer<Database> getDatabase();

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -219,6 +219,7 @@ void EditGroupWidget::loadGroup(Group* group, bool create, const QSharedPointer<
         auto inheritSkipSubmit = false;
         auto inheritOnlyHttp = false;
         auto inheritNoHttp = false;
+        auto inheritOmitWww = false;
 
         auto parent = group->parentGroup();
         if (parent) {
@@ -226,12 +227,14 @@ void EditGroupWidget::loadGroup(Group* group, bool create, const QSharedPointer<
             inheritSkipSubmit = parent->resolveCustomDataTriState(BrowserService::OPTION_SKIP_AUTO_SUBMIT);
             inheritOnlyHttp = parent->resolveCustomDataTriState(BrowserService::OPTION_ONLY_HTTP_AUTH);
             inheritNoHttp = parent->resolveCustomDataTriState(BrowserService::OPTION_NOT_HTTP_AUTH);
+            inheritOmitWww = parent->resolveCustomDataTriState(BrowserService::OPTION_OMIT_WWW);
         }
 
         addTriStateItems(m_browserUi->browserIntegrationHideEntriesComboBox, inheritHideEntries);
         addTriStateItems(m_browserUi->browserIntegrationSkipAutoSubmitComboBox, inheritSkipSubmit);
         addTriStateItems(m_browserUi->browserIntegrationOnlyHttpAuthComboBox, inheritOnlyHttp);
         addTriStateItems(m_browserUi->browserIntegrationNotHttpAuthComboBox, inheritNoHttp);
+        addTriStateItems(m_browserUi->browserIntegrationOmitWwwCombobox, inheritOmitWww);
 
         m_browserUi->browserIntegrationHideEntriesComboBox->setCurrentIndex(
             indexFromTriState(group->resolveCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY, false)));
@@ -241,6 +244,8 @@ void EditGroupWidget::loadGroup(Group* group, bool create, const QSharedPointer<
             indexFromTriState(group->resolveCustomDataTriState(BrowserService::OPTION_ONLY_HTTP_AUTH, false)));
         m_browserUi->browserIntegrationNotHttpAuthComboBox->setCurrentIndex(
             indexFromTriState(group->resolveCustomDataTriState(BrowserService::OPTION_NOT_HTTP_AUTH, false)));
+        m_browserUi->browserIntegrationOmitWwwCombobox->setCurrentIndex(
+            indexFromTriState(group->resolveCustomDataTriState(BrowserService::OPTION_OMIT_WWW, false)));
     }
 #endif
 
@@ -309,6 +314,9 @@ void EditGroupWidget::apply()
         m_temporaryGroup->setCustomDataTriState(
             BrowserService::OPTION_NOT_HTTP_AUTH,
             triStateFromIndex(m_browserUi->browserIntegrationNotHttpAuthComboBox->currentIndex()));
+        m_temporaryGroup->setCustomDataTriState(
+            BrowserService::OPTION_OMIT_WWW,
+            triStateFromIndex(m_browserUi->browserIntegrationOmitWwwCombobox->currentIndex()));
     }
 #endif
 

--- a/src/gui/group/EditGroupWidgetBrowser.ui
+++ b/src/gui/group/EditGroupWidgetBrowser.ui
@@ -145,7 +145,24 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="4" column="0">
+       <widget class="QLabel" name="browserIntegrationOmitWwwLabel">
+        <property name="text">
+         <string>Omit WWW subdomain from matching:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="browserIntegrationOmitWwwCombobox">
+        <property name="accessibleName">
+         <string>Omit WWW subdomain from matching toggle for this and sub groups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
        <spacer name="verticalSpacer_1">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -168,6 +185,7 @@
   <tabstop>browserIntegrationSkipAutoSubmitComboBox</tabstop>
   <tabstop>browserIntegrationOnlyHttpAuthComboBox</tabstop>
   <tabstop>browserIntegrationNotHttpAuthComboBox</tabstop>
+  <tabstop>browserIntegrationOmitWwwCombobox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -281,7 +281,7 @@ void TestBrowser::compareEntriesByPath(QSharedPointer<Database> db, QList<Entry*
     for (Entry* entry : entries) {
         QString testUrl = "keepassxc://by-path/" + path + entry->title();
         /* Look for an entry with that path. First using handleEntry, then through the search */
-        QCOMPARE(m_browserService->handleEntry(entry, testUrl, ""), true);
+        QCOMPARE(m_browserService->shouldIncludeEntry(entry, testUrl, ""), true);
         auto result = m_browserService->searchEntries(db, testUrl, "");
         QCOMPARE(result.length(), 1);
         QCOMPARE(result[0], entry);
@@ -311,7 +311,7 @@ void TestBrowser::testSearchEntriesByUUID()
     for (Entry* entry : entries) {
         QString testUrl = "keepassxc://by-uuid/" + entry->uuidToHex();
         /* Look for an entry with that UUID. First using handleEntry, then through the search */
-        QCOMPARE(m_browserService->handleEntry(entry, testUrl, ""), true);
+        QCOMPARE(m_browserService->shouldIncludeEntry(entry, testUrl, ""), true);
         auto result = m_browserService->searchEntries(db, testUrl, "");
         QCOMPARE(result.length(), 1);
         QCOMPARE(result[0], entry);
@@ -329,7 +329,7 @@ void TestBrowser::testSearchEntriesByUUID()
         QString testUrl = "keepassxc://by-uuid/" + uuid;
 
         for (Entry* entry : entries) {
-            QCOMPARE(m_browserService->handleEntry(entry, testUrl, ""), false);
+            QCOMPARE(m_browserService->shouldIncludeEntry(entry, testUrl, ""), false);
         }
 
         auto result = m_browserService->searchEntries(db, testUrl, "");
@@ -436,6 +436,16 @@ void TestBrowser::testSubdomainsAndPaths()
     QCOMPARE(result.length(), 4);
     QCOMPARE(result[0]->url(), QString("https://www.github.com/login/page.xml"));
     QCOMPARE(result[1]->url(), QString("https://github.com")); // Accepts any subdomain
+    QCOMPARE(result[2]->url(), QString("http://www.github.com"));
+    QCOMPARE(result[3]->url(), QString("www.github.com/"));
+
+    // With www subdomain omitted
+    root->setCustomDataTriState(BrowserService::OPTION_OMIT_WWW, Group::Enable);
+    result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
+    root->setCustomDataTriState(BrowserService::OPTION_OMIT_WWW, Group::Inherit);
+    QCOMPARE(result.length(), 4);
+    QCOMPARE(result[0]->url(), QString("https://www.github.com/login/page.xml"));
+    QCOMPARE(result[1]->url(), QString("https://github.com"));
     QCOMPARE(result[2]->url(), QString("http://www.github.com"));
     QCOMPARE(result[3]->url(), QString("www.github.com/"));
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds a new group option "Omit WWW subdomain from matching" that ignores the common subdomain from all entries during matching.
This option is also useful when importing credentials from other password managers.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually + automatic tests added.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
