### PR TITLE
Improve entry preview panel

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3890,6 +3890,10 @@ Error: %1</source>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Double click to copy value</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EntryURLModel</name>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -642,19 +642,19 @@ void DatabaseWidget::copyPassword()
     bool clearClipboard = config()->get(Config::Security_ClearClipboard).toBool();
 
     auto plainTextEdit = qobject_cast<QPlainTextEdit*>(focusWidget());
-    if (plainTextEdit) {
+    if (plainTextEdit && plainTextEdit->textCursor().hasSelection()) {
         clipboard()->setText(plainTextEdit->textCursor().selectedText(), clearClipboard);
         return;
     }
 
     auto label = qobject_cast<QLabel*>(focusWidget());
-    if (label) {
+    if (label && label->hasSelectedText()) {
         clipboard()->setText(label->selectedText(), clearClipboard);
         return;
     }
 
     auto textEdit = qobject_cast<QTextEdit*>(focusWidget());
-    if (textEdit) {
+    if (textEdit && textEdit->textCursor().hasSelection()) {
         clipboard()->setText(textEdit->textCursor().selectedText(), clearClipboard);
         return;
     }

--- a/src/gui/EntryPreviewWidget.ui
+++ b/src/gui/EntryPreviewWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>481</width>
+    <width>508</width>
     <height>257</height>
    </rect>
   </property>
@@ -195,7 +195,7 @@
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
             <widget class="QWidget" name="entryGeneralWidget" native="true">
-             <layout class="QGridLayout" name="gridLayout">
+             <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,1">
               <property name="leftMargin">
                <number>0</number>
               </property>
@@ -455,19 +455,6 @@
                  <size>
                   <width>10</width>
                   <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="4" column="0">
-               <spacer name="verticalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
                  </size>
                 </property>
                </spacer>
@@ -751,13 +738,16 @@
            <item>
             <widget class="QTreeWidget" name="entryAutotypeTree">
              <property name="focusPolicy">
-              <enum>Qt::ClickFocus</enum>
+              <enum>Qt::NoFocus</enum>
              </property>
              <property name="frameShadow">
               <enum>QFrame::Sunken</enum>
              </property>
              <property name="showDropIndicator" stdset="0">
               <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::NoSelection</enum>
              </property>
              <property name="rootIsDecorated">
               <bool>true</bool>
@@ -897,7 +887,7 @@
           <layout class="QVBoxLayout" name="verticalLayout_8">
            <item>
             <widget class="QWidget" name="groupGeneralWidget" native="true">
-             <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
+             <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,1">
               <property name="leftMargin">
                <number>0</number>
               </property>


### PR DESCRIPTION
* Fix #7811 - Notes height no longer truncated
* Fix #7949 - Improve copying attribute value to clipboard in entry preview
* Fix #7898 - Prevent copying url when copy password selected after clicking url in preview pane
* Fix #7982 - Double clicking hidden attributes in preview pane copies the value instead of ●●●●●●

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/166162225-b975cfe9-48db-40a8-b6c6-8be6e99fafdf.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
