### PR TITLE
Fix file dialog not appearing on snap build

### DIFF
--- a/src/core/Bootstrap.cpp
+++ b/src/core/Bootstrap.cpp
@@ -89,7 +89,9 @@ namespace Bootstrap
         success = success && (setrlimit(RLIMIT_CORE, &limit) == 0);
 #endif
 
-#if defined(HAVE_PR_SET_DUMPABLE)
+// NOTE: Dumps cannot be disabled for snap builds as it prevents desktop portals from working
+//       See https://github.com/keepassxreboot/keepassxc/issues/7607#issuecomment-1109005206
+#if defined(HAVE_PR_SET_DUMPABLE) && !defined(KEEPASSXC_DIST_SNAP)
         success = success && (prctl(PR_SET_DUMPABLE, 0) == 0);
 #endif
 


### PR DESCRIPTION
Fix #7607 - Don't disable core dumps when building for snap distribution. Doing so will not allow the xdg-desktop-portal from opening the file dialog. This is because the portal attempts to call entries from /proc/[pid]/xxxx which are restricted to root when core dumps are disabled.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
This fix is already deployed in a custom built snap package. Users have reported success.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
