### PR TITLE
Fix Auto-Type gui guard for tests

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -335,7 +335,9 @@ void AutoType::executeAutoTypeActions(const Entry* entry,
             }
 
             if (!result.canRetry() || i == max_retries) {
-                MessageBox::critical(getMainWindow(), tr("Auto-Type Error"), result.errorString());
+                if (getMainWindow()) {
+                    MessageBox::critical(getMainWindow(), tr("Auto-Type Error"), result.errorString());
+                }
                 emit autotypeRejected();
                 m_inAutoType.unlock();
                 return;


### PR DESCRIPTION
Prevent showing gui error dialogs when no gui is present. This can occur during auto-type tests.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
This came up from one of our linux distribution partners running across test failures.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
