### PR TITLE
clang-tidy: remove redundant access specifier

### DIFF
--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -54,7 +54,6 @@ public:
     static AutoType* instance();
     static void createTestInstance();
 
-public slots:
     void performGlobalAutoType(const QList<QSharedPointer<Database>>& dbList, const QString& search = {});
     void raiseWindow();
 
@@ -68,7 +67,6 @@ private slots:
     void startGlobalAutoType(const QString& search);
     void unloadPlugin();
 
-private:
     enum WindowState
     {
         Normal,

--- a/src/autotype/AutoTypeMatchModel.h
+++ b/src/autotype/AutoTypeMatchModel.h
@@ -56,7 +56,6 @@ private slots:
     void entryRemoved();
     void entryDataChanged(Entry* entry);
 
-private:
     void severConnections();
     void makeConnections(const Group* group);
 

--- a/src/autotype/AutoTypeMatchView.h
+++ b/src/autotype/AutoTypeMatchView.h
@@ -48,7 +48,6 @@ signals:
 protected:
     void keyPressEvent(QKeyEvent* event) override;
 
-protected slots:
     void currentChanged(const QModelIndex& current, const QModelIndex& previous) override;
 
 private:

--- a/src/autotype/AutoTypeSelectDialog.h
+++ b/src/autotype/AutoTypeSelectDialog.h
@@ -58,7 +58,6 @@ private slots:
     void activateCurrentMatch();
     void updateActionMenu(const AutoTypeMatch& match);
 
-private:
     void buildActionMenu();
     void setDelayedSearch(bool state);
 

--- a/src/autotype/PickcharsDialog.h
+++ b/src/autotype/PickcharsDialog.h
@@ -42,7 +42,7 @@ private slots:
     void upPressed();
     void downPressed();
 
-private:
+
     QSharedPointer<Ui::PickcharsDialog> m_ui;
     int m_lastSelected;
 };

--- a/src/core/CustomData.h
+++ b/src/core/CustomData.h
@@ -85,7 +85,6 @@ signals:
 private slots:
     void updateLastModified(QDateTime lastModified = {});
 
-private:
     QHash<QString, CustomDataItem> m_data;
 };
 

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -150,7 +150,6 @@ public:
 
     static Database* databaseByUuid(const QUuid& uuid);
 
-public slots:
     void markAsModified();
     void markAsClean();
     void updateCommonUsernames(int topN = 10);

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -272,7 +272,6 @@ private slots:
     void updateModifiedSinceBegin();
     void updateTotp();
 
-private:
     QString resolveMultiplePlaceholdersRecursive(const QString& str, int maxDepth) const;
     QString resolvePlaceholderRecursive(const QString& placeholder, int maxDepth) const;
     QString resolveReferencePlaceholderRecursive(const QString& placeholder, int maxDepth) const;

--- a/src/core/EntryAttachments.h
+++ b/src/core/EntryAttachments.h
@@ -64,7 +64,6 @@ signals:
 private slots:
     void attachmentFileModified(const QString& path);
 
-private:
     void disconnectAndEraseExternalFile(const QString& path);
 
     QMap<QString, QByteArray> m_attachments;

--- a/src/core/FileWatcher.h
+++ b/src/core/FileWatcher.h
@@ -44,7 +44,6 @@ public slots:
 private slots:
     void checkFileChanged();
 
-private:
     QByteArray calculateChecksum();
     bool shouldIgnoreChanges();
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -203,7 +203,6 @@ signals:
 private slots:
     void updateTimeinfo();
 
-private:
     template <class P, class V> bool set(P& property, const V& value);
 
     void setParent(Database* db);

--- a/src/core/InactivityTimer.h
+++ b/src/core/InactivityTimer.h
@@ -42,7 +42,6 @@ protected:
 private slots:
     void timeout();
 
-private:
     QTimer* m_timer;
     bool m_active;
     QMutex m_emitMutx;

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -70,7 +70,6 @@ private:
                                                            Entry* targetEntry,
                                                            Group::MergeMode mergeMethod);
 
-private:
     MergeContext m_context;
     Group::MergeMode m_mode;
 };

--- a/src/core/ModifiableObject.h
+++ b/src/core/ModifiableObject.h
@@ -26,7 +26,6 @@ class ModifiableObject : public QObject
 public:
     using QObject::QObject;
 
-public:
     /**
      * @brief check if the modified signal is enabled.
      * Note that this is NOT the same as m_emitModified.
@@ -34,7 +33,6 @@ public:
      */
     bool modifiedSignalEnabled() const;
 
-public slots:
     /**
      * @brief set whether the modified signal should be emitted from this object and all its children.
      *

--- a/src/core/PasswordGenerator.h
+++ b/src/core/PasswordGenerator.h
@@ -55,7 +55,6 @@ public:
     };
     Q_DECLARE_FLAGS(GeneratorFlags, GeneratorFlag)
 
-public:
     PasswordGenerator();
 
     void setLength(int length);

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -66,7 +66,6 @@ private slots:
     void processIncomingConnection();
     void socketReadyRead();
 
-private:
 #if defined(Q_OS_UNIX)
     /**
      * Register Unix signals such as SIGINT and SIGTERM for clean shutdown.

--- a/src/gui/ApplicationSettingsWidget.h
+++ b/src/gui/ApplicationSettingsWidget.h
@@ -65,7 +65,6 @@ private slots:
     void showExpiredEntriesOnDatabaseUnlockToggled(bool checked);
     void selectBackupDirectory();
 
-private:
     QWidget* const m_secWidget;
     QWidget* const m_generalWidget;
     const QScopedPointer<Ui::ApplicationSettingsWidgetSecurity> m_secUi;

--- a/src/gui/CategoryListWidget.h
+++ b/src/gui/CategoryListWidget.h
@@ -53,7 +53,6 @@ protected:
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
-protected slots:
     void updateCategoryScrollButtons();
     void scrollCategoriesDown();
     void scrollCategoriesUp();

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -37,7 +37,6 @@ public:
 
     static Clipboard* instance();
 
-public slots:
     void clearCopiedText();
 
 signals:
@@ -46,7 +45,6 @@ signals:
 private slots:
     void countdownTick();
 
-private:
     explicit Clipboard(QObject* parent = nullptr);
 
     static Clipboard* m_instance;

--- a/src/gui/CloneDialog.h
+++ b/src/gui/CloneDialog.h
@@ -37,7 +37,6 @@ public:
 private:
     QScopedPointer<Ui::CloneDialog> m_ui;
 
-private slots:
     void cloneEntry();
 
 protected:

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -63,7 +63,6 @@ protected:
     QString m_filename;
     bool m_retryUnlockWithEmptyPassword = false;
 
-protected slots:
     virtual void openDatabase();
     void reject();
 
@@ -75,7 +74,6 @@ private slots:
     void openHardwareKeyHelp();
     void openKeyFileHelp();
 
-private:
     bool m_pollingHardwareKey = false;
     bool m_blockQuickUnlock = false;
     QTimer m_hideTimer;

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -45,7 +45,6 @@ public:
     bool isModified(int index = -1) const;
     bool hasLockableDatabases() const;
 
-public slots:
     void lockAndSwitchToFirstUnlockedDatabase(int index = -1);
     void addDatabaseTab(const QString& filePath,
                         bool inBackground = false,
@@ -102,7 +101,6 @@ private slots:
     void handleDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
     void handleExportError(const QString& reason);
 
-private:
     QSharedPointer<Database> execNewDatabaseWizard();
     void updateLastDatabases(const QString& filename);
     bool warnOnExport();

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -255,7 +255,6 @@ private slots:
     void reloadDatabaseFile();
     void restoreGroupEntryFocus(const QUuid& groupUuid, const QUuid& EntryUuid);
 
-private:
     int addChildWidget(QWidget* w);
     void setClipboardTextAndMinimize(const QString& text);
     void processAutoOpen();

--- a/src/gui/DatabaseWidgetStateSync.h
+++ b/src/gui/DatabaseWidgetStateSync.h
@@ -30,7 +30,6 @@ public:
     explicit DatabaseWidgetStateSync(QObject* parent = nullptr);
     ~DatabaseWidgetStateSync() override;
 
-public slots:
     void setActive(DatabaseWidget* dbWidget);
     void restoreListView();
     void restoreSearchView();
@@ -41,7 +40,6 @@ private slots:
     void updateViewState();
     void sync();
 
-private:
     static QList<int> variantToIntList(const QVariant& variant);
     static QVariant intListToVariant(const QList<int>& list);
 

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -95,7 +95,6 @@ private slots:
     void updateRadioButtonCustomIcons();
     void confirmApplyIconTo(QAction* action);
 
-private:
     QMenu* createApplyIconToMenu();
 
     const QScopedPointer<Ui::EditWidgetIcons> m_ui;

--- a/src/gui/EditWidgetProperties.h
+++ b/src/gui/EditWidgetProperties.h
@@ -48,7 +48,6 @@ private slots:
     void removeSelectedPluginData();
     void toggleRemoveButton(const QItemSelection& selected);
 
-private:
     const QScopedPointer<Ui::EditWidgetProperties> m_ui;
 
     QPointer<CustomData> m_customData;

--- a/src/gui/EntryPreviewWidget.h
+++ b/src/gui/EntryPreviewWidget.h
@@ -36,7 +36,6 @@ public:
     explicit EntryPreviewWidget(QWidget* parent = nullptr);
     ~EntryPreviewWidget() override;
 
-public slots:
     void setEntry(Entry* selectedEntry);
     void setGroup(Group* selectedGroup);
     void setDatabaseMode(DatabaseWidget::Mode mode);
@@ -67,7 +66,6 @@ private slots:
     void updateTabIndexes();
     void openEntryUrl();
 
-private:
     void removeTab(QTabWidget* tabWidget, QWidget* widget);
     void setTabEnabled(QTabWidget* tabWidget, QWidget* widget, bool enabled);
 

--- a/src/gui/KMessageWidget.h
+++ b/src/gui/KMessageWidget.h
@@ -223,8 +223,7 @@ public:
      * @since 5.0
      */
     bool isShowAnimationRunning() const;
-    
-public slots:
+
     /**
      * Set the text of the message widget to @p text.
      * If the message widget is already visible, the text changes on the fly.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -146,7 +146,6 @@ private slots:
     void updateProgressBar(int percentage, QString message);
     void focusSearchWidget();
 
-private:
     static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);
 
     static const QString BaseWindowTitle;

--- a/src/gui/PasswordEdit.h
+++ b/src/gui/PasswordEdit.h
@@ -35,7 +35,6 @@ public:
     void setRepeatPartner(PasswordEdit* repeatEdit);
     bool isPasswordVisible() const;
 
-public slots:
     void setShowPassword(bool show);
     void updateRepeatStatus();
 
@@ -51,7 +50,6 @@ private slots:
     void setParentPasswordEdit(PasswordEdit* parent);
     void checkCapslockState();
 
-private:
     QPointer<QAction> m_errorAction;
     QPointer<QAction> m_correctAction;
     QPointer<QAction> m_toggleVisibleAction;

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -57,7 +57,6 @@ public:
 
     static PasswordGeneratorWidget* popupGenerator(QWidget* parent = nullptr);
 
-public slots:
     void regeneratePassword();
     void applyPassword();
     void copyPassword();
@@ -81,7 +80,6 @@ private slots:
 
     void updateGenerator();
 
-private:
     bool m_standalone = false;
     bool m_passwordGenerated = false;
     int m_firstCustomWordlistIndex;

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -76,7 +76,6 @@ private slots:
     void showSearchMenu();
     void resetSearchClearTimer();
 
-private:
     const QScopedPointer<Ui::SearchWidget> m_ui;
     PopupHelpWidget* m_helpWidget;
     QTimer* m_searchTimer;

--- a/src/gui/TotpDialog.h
+++ b/src/gui/TotpDialog.h
@@ -41,7 +41,6 @@ private Q_SLOTS:
     void updateSeconds();
     void copyToClipboard();
 
-private:
     QScopedPointer<Ui::TotpDialog> m_ui;
 
     void resetCounter();

--- a/src/gui/TotpExportSettingsDialog.h
+++ b/src/gui/TotpExportSettingsDialog.h
@@ -38,7 +38,6 @@ private slots:
     void copyToClipboard();
     void autoClose();
 
-private:
     int m_secTillClose;
     QString m_totpUri;
     QTimer* m_timer;

--- a/src/gui/TotpSetupDialog.h
+++ b/src/gui/TotpSetupDialog.h
@@ -43,7 +43,6 @@ private slots:
     void toggleCustom(bool status);
     void saveSettings();
 
-private:
     QScopedPointer<Ui::TotpSetupDialog> m_ui;
     Entry* m_entry;
 };

--- a/src/gui/URLEdit.h
+++ b/src/gui/URLEdit.h
@@ -34,7 +34,6 @@ public:
 private slots:
     void updateStylesheet();
 
-private:
     QPointer<QAction> m_errorAction;
 };
 

--- a/src/gui/WelcomeWidget.h
+++ b/src/gui/WelcomeWidget.h
@@ -50,7 +50,6 @@ protected:
 private slots:
     void openDatabaseFromFile(QListWidgetItem* item);
 
-private:
     const QScopedPointer<Ui::WelcomeWidget> m_ui;
     void removeFromLastDatabases(QListWidgetItem* item);
 };

--- a/src/gui/csvImport/CsvImportWidget.h
+++ b/src/gui/csvImport/CsvImportWidget.h
@@ -52,7 +52,6 @@ private slots:
     void setRootGroup();
     void reject();
 
-private:
     Q_DISABLE_COPY(CsvImportWidget)
     const QScopedPointer<Ui::CsvImportWidget> m_ui;
     CsvParserModel* const m_parserModel;

--- a/src/gui/csvImport/CsvImportWizard.h
+++ b/src/gui/csvImport/CsvImportWizard.h
@@ -42,7 +42,6 @@ signals:
 private slots:
     void parseFinished(bool accepted);
 
-private:
     QPointer<Database> m_db;
     CsvImportWidget* m_parse;
     QGridLayout* m_layout;

--- a/src/gui/csvImport/CsvParserModel.h
+++ b/src/gui/csvImport/CsvParserModel.h
@@ -43,7 +43,6 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
-public slots:
     void setSkippedRows(int skipped);
 
 private:

--- a/src/gui/databasekey/KeyComponentWidget.h
+++ b/src/gui/databasekey/KeyComponentWidget.h
@@ -116,7 +116,6 @@ private slots:
     void resetComponentEditWidget();
     void updateSize();
 
-private:
     bool m_isComponentAdded = false;
     Page m_previousPage = Page::AddNew;
     QPointer<QWidget> m_componentWidget;

--- a/src/gui/databasekey/KeyFileEditWidget.h
+++ b/src/gui/databasekey/KeyFileEditWidget.h
@@ -48,7 +48,6 @@ private slots:
     void createKeyFile();
     void browseKeyFile();
 
-private:
     const QScopedPointer<Ui::KeyFileEditWidget> m_compUi;
     QPointer<QWidget> m_compEditWidget;
     const QPointer<DatabaseSettingsWidget> m_parent;

--- a/src/gui/databasekey/PasswordEditWidget.h
+++ b/src/gui/databasekey/PasswordEditWidget.h
@@ -49,7 +49,6 @@ protected:
 private slots:
     void setPassword(const QString& password);
 
-private:
     const QScopedPointer<Ui::PasswordEditWidget> m_compUi;
     QPointer<QWidget> m_compEditWidget;
 };

--- a/src/gui/databasekey/YubiKeyEditWidget.h
+++ b/src/gui/databasekey/YubiKeyEditWidget.h
@@ -48,7 +48,6 @@ private slots:
     void hardwareKeyResponse(bool found);
     void pollYubikey();
 
-private:
     const QScopedPointer<Ui::YubiKeyEditWidget> m_compUi;
     QPointer<QWidget> m_compEditWidget;
     bool m_isDetected = false;

--- a/src/gui/dbsettings/DatabaseSettingsDialog.h
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.h
@@ -73,7 +73,6 @@ private slots:
     void pageChanged();
     void toggleAdvancedMode(bool advanced);
 
-private:
     enum Page
     {
         General = 0,

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.h
@@ -49,7 +49,6 @@ public:
         return false;
     }
 
-public slots:
     void initialize() override;
     void uninitialize() override;
     bool save() override;
@@ -59,7 +58,6 @@ private slots:
     void showAdditionalKeyOptions();
     void markDirty();
 
-private:
     void setAdditionalKeyOptionsVisible(bool show);
 
     // clang-format off

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.h
@@ -43,7 +43,6 @@ public:
     }
     void setAdvancedMode(bool advanced) override;
 
-public slots:
     void initialize() override;
     void uninitialize() override;
     bool save() override;
@@ -67,7 +66,6 @@ private slots:
     void activateChangeDecryptionTime();
     void markDirty();
 
-private:
     enum FormatSelection
     {
         KDBX4,

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
@@ -40,7 +40,6 @@ public:
         return false;
     }
 
-public slots:
     void initialize() override;
     void uninitialize() override;
     bool save() override;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.h
@@ -42,7 +42,6 @@ public:
         return false;
     }
 
-public slots:
     void initialize() override;
     void uninitialize() override{};
     inline bool save() override
@@ -55,7 +54,6 @@ private slots:
     void removeCustomIcon();
     void purgeUnusedCustomIcons();
 
-private:
     void populateIcons(QSharedPointer<Database> db);
     void removeSingleCustomIcon(QSharedPointer<Database> database, QModelIndex index);
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMetaDataSimple.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMetaDataSimple.h
@@ -40,7 +40,6 @@ public:
         return false;
     }
 
-public slots:
     void initialize() override;
     void uninitialize() override;
     bool save() override;

--- a/src/gui/entry/AutoTypeAssociationsModel.h
+++ b/src/gui/entry/AutoTypeAssociationsModel.h
@@ -38,7 +38,6 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
-public slots:
     void associationChange(int i);
     void associationAboutToAdd(int i);
     void associationAdd();

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -133,7 +133,6 @@ private slots:
     void updateCurrentURL();
 #endif
 
-private:
     void setupMain();
     void setupAdvanced();
     void setupIcon();

--- a/src/gui/entry/EntryAttachmentsModel.h
+++ b/src/gui/entry/EntryAttachmentsModel.h
@@ -55,7 +55,6 @@ private slots:
     void reset();
     void setReadOnly(bool readOnly);
 
-private:
     QPointer<EntryAttachments> m_entryAttachments;
     QStringList m_headers;
     bool m_readOnly = false;

--- a/src/gui/entry/EntryAttachmentsWidget.h
+++ b/src/gui/entry/EntryAttachmentsWidget.h
@@ -43,7 +43,6 @@ public:
     bool isReadOnly() const;
     bool isButtonsVisible() const;
 
-public slots:
     void linkAttachments(EntryAttachments* attachments);
     void unlinkAttachments();
     void setReadOnly(bool readOnly);
@@ -66,7 +65,6 @@ private slots:
     void updateButtonsEnabled();
     void attachmentModifiedExternally(const QString& key, const QString& filePath);
 
-private:
     bool insertAttachments(const QStringList& fileNames, QString& errorMessage);
 
     QStringList confirmAttachmentSelection(const QStringList& filenames);

--- a/src/gui/entry/EntryAttributesModel.h
+++ b/src/gui/entry/EntryAttributesModel.h
@@ -49,7 +49,6 @@ private slots:
     void aboutToReset();
     void reset();
 
-private:
     void updateAttributes();
 
     EntryAttributes* m_entryAttributes;

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -80,7 +80,6 @@ private slots:
 
     void onConfigChanged(Config::ConfigKey key);
 
-private:
     void severConnections();
     void makeConnections(const Group* group);
 

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -71,7 +71,6 @@ private slots:
     void contextMenuShortcutPressed();
     void sortIndicatorChanged(int logicalIndex, Qt::SortOrder order);
 
-private:
     void resetFixedColumns();
     bool isColumnHidden(int logicalIndex);
 

--- a/src/gui/export/ExportDialog.h
+++ b/src/gui/export/ExportDialog.h
@@ -48,7 +48,6 @@ signals:
 private slots:
     void exportDatabase();
 
-private:
     QString getStrategyName(ExportSortingStrategy strategy);
 
     QScopedPointer<Ui::ExportDialog> m_ui;

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -75,7 +75,6 @@ private slots:
     void updateBrowserModified();
 #endif
 
-private:
     void addTriStateItems(QComboBox* comboBox, bool inheritValue);
     int indexFromTriState(Group::TriState triState);
     Group::TriState triStateFromIndex(int index);

--- a/src/gui/group/GroupModel.h
+++ b/src/gui/group/GroupModel.h
@@ -51,7 +51,6 @@ private:
     QModelIndex parent(Group* group) const;
     void collectIndexesRecursively(QList<QModelIndex>& indexes, QList<Group*> groups);
 
-private slots:
     void groupDataChanged(Group* group);
     void groupAboutToRemove(Group* group);
     void groupRemoved();
@@ -60,7 +59,6 @@ private slots:
     void groupAboutToMove(Group* group, Group* toGroup, int pos);
     void groupMoved();
 
-private:
     Database* m_db;
 };
 

--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -52,7 +52,6 @@ public:
 private slots:
     void handleColorSchemeChanged(QString ns, QString key, QDBusVariant value);
 
-private:
     explicit NixUtils(QObject* parent = nullptr);
     ~NixUtils() override;
 

--- a/src/gui/reports/ReportsDialog.h
+++ b/src/gui/reports/ReportsDialog.h
@@ -71,7 +71,6 @@ private slots:
     void entryActivationSignalReceived(Entry* entry);
     void switchToMainView(bool previousDialogAccepted);
 
-private:
     QSharedPointer<Database> m_db;
     const QScopedPointer<Ui::ReportsDialog> m_ui;
     const QSharedPointer<ReportsPageHealthcheck> m_healthPage;

--- a/src/gui/reports/ReportsWidgetStatistics.h
+++ b/src/gui/reports/ReportsWidgetStatistics.h
@@ -45,7 +45,6 @@ protected:
 private slots:
     void calculateStats();
 
-private:
     QScopedPointer<Ui::ReportsWidgetStatistics> m_ui;
 
     bool m_statsCalculated = false;

--- a/src/gui/settings/SettingsWidget.h
+++ b/src/gui/settings/SettingsWidget.h
@@ -41,7 +41,6 @@ public:
     virtual void setAdvancedMode(bool advanced);
     virtual bool advancedMode() const;
 
-public slots:
     /**
      * Initialize settings widget.
      */

--- a/src/gui/tag/TagModel.h
+++ b/src/gui/tag/TagModel.h
@@ -40,7 +40,7 @@ public:
 private slots:
     void updateTagList();
 
-private:
+
     QSharedPointer<Database> m_db;
     QStringList m_tagList;
 };

--- a/src/gui/widgets/ElidedLabel.h
+++ b/src/gui/widgets/ElidedLabel.h
@@ -36,7 +36,6 @@ public:
     QString rawText() const;
     QString url() const;
 
-public slots:
     void setElideMode(Qt::TextElideMode elideMode);
     void setRawText(const QString& rawText);
     void setUrl(const QString& url);
@@ -49,8 +48,6 @@ signals:
 
 private slots:
     void updateElidedText();
-
-private:
     void resizeEvent(QResizeEvent* event) override;
 
     Qt::TextElideMode m_elideMode;

--- a/src/gui/widgets/KPToolBar.h
+++ b/src/gui/widgets/KPToolBar.h
@@ -36,7 +36,7 @@ public:
     bool isExpanded();
     bool canExpand();
 
-public slots:
+
     void setExpanded(bool state);
 
 protected:

--- a/src/gui/wizard/NewDatabaseWizardPage.h
+++ b/src/gui/wizard/NewDatabaseWizardPage.h
@@ -47,7 +47,6 @@ public:
     void initializePage() override;
     bool validatePage() override;
 
-public slots:
     void toggleAdvancedSettings();
 
 protected:

--- a/src/keeshare/KeeShare.h
+++ b/src/keeshare/KeeShare.h
@@ -79,7 +79,6 @@ signals:
 private slots:
     void handleSettingsChanged(Config::ConfigKey key);
 
-private:
     static KeeShare* m_instance;
 
     explicit KeeShare(QObject* parent);


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

