### PR TITLE
FdoSecrets: skip entries in recycle bin when searching

### DIFF
--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -107,6 +107,9 @@ namespace FdoSecrets
         DatabaseWidget* backend() const;
         QString backendFilePath() const;
         Service* service() const;
+        /**
+         * similar to Group::isRecycled, but we also return true when the group itself is the recycle bin
+         */
         bool inRecycleBin(Group* group) const;
         bool inRecycleBin(Entry* entry) const;
 

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -258,12 +258,13 @@ namespace FdoSecrets
             }
             // item locked state already covers its collection's locked state
             for (const auto& item : asConst(items)) {
-                bool l;
-                ret = item->locked(client, l);
+                Q_ASSERT(item);
+                bool itemLocked;
+                ret = item->locked(client, itemLocked);
                 if (ret.err()) {
                     return ret;
                 }
-                if (l) {
+                if (itemLocked) {
                     locked.append(item);
                 } else {
                     unlocked.append(item);

--- a/tests/gui/TestGuiFdoSecrets.h
+++ b/tests/gui/TestGuiFdoSecrets.h
@@ -97,6 +97,7 @@ private slots:
 
     void testExposeSubgroup();
     void testModifyingExposedGroup();
+    void testNoExposeRecycleBin();
 
     void testHiddenFilename();
     void testDuplicateName();


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

When the recycle bin is under the exposed group, searching will return entries in the recycle bin.

fix #7933, replaces #7850


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added unit test


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
