### PR TITLE
Browser: Option to select original or referenced entry for password update

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1045,6 +1045,10 @@ Do you want to overwrite the passkey in %1 - %2?</source>
         <source>Register</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Do you want to update the information in %1 - %2?&lt;br&gt;&lt;br&gt;The selected entry is a reference of &quot;%3&quot;.&lt;br&gt;Select Overwrite to change password to the current referenced entry.&lt;br&gt;Select Save to change the password of the original entry.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BrowserSettingsWidget</name>
@@ -1646,10 +1650,6 @@ To prevent this error from appearing, you must go to &quot;Database Settings / S
     </message>
     <message>
         <source>Cannot use database file as key file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>authenticate to access the database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -928,37 +928,69 @@ bool BrowserService::updateEntry(const EntryParameters& entryParameters, const Q
         return true;
     }
 
-    // Check if the entry password is a reference. If so, update the original entry instead
-    while (entry->attributes()->isReference(EntryAttributes::PasswordKey)) {
-        const QUuid referenceUuid = entry->attributes()->referenceUuid(EntryAttributes::PasswordKey);
-        if (!referenceUuid.isNull()) {
-            entry = db->rootGroup()->findEntryByUuid(referenceUuid);
-            if (!entry) {
-                return false;
-            }
-        }
-    }
-
     auto username = entry->username();
     if (username.isEmpty()) {
         return false;
     }
 
+    // Get the original entry if the password is a reference
+    Entry* originalEntry = nullptr;
+    while (entry->attributes()->isReference(EntryAttributes::PasswordKey)) {
+        const QUuid referenceUuid = entry->attributes()->referenceUuid(EntryAttributes::PasswordKey);
+        if (!referenceUuid.isNull()) {
+            originalEntry = db->rootGroup()->findEntryByUuid(referenceUuid);
+            break;
+        }
+    }
+
+    const auto isEntryPasswordChanged =
+        !originalEntry && entry->password().compare(entryParameters.password, Qt::CaseSensitive) != 0;
+    const auto isReferencePasswordChanged =
+        originalEntry && originalEntry->password().compare(entryParameters.password, Qt::CaseSensitive) != 0;
+    const auto isPasswordChanged = isEntryPasswordChanged || isReferencePasswordChanged;
+
     bool result = false;
-    if (username.compare(entryParameters.login, Qt::CaseSensitive) != 0
-        || entry->password().compare(entryParameters.password, Qt::CaseSensitive) != 0) {
+    if (username.compare(entryParameters.login, Qt::CaseSensitive) != 0 || isPasswordChanged) {
         MessageBox::Button dialogResult = MessageBox::No;
-        if (!browserSettings()->alwaysAllowUpdate()) {
+
+        if (entry->attributes()->isReference(EntryAttributes::UserNameKey)) {
+            username = !originalEntry ? entry->resolvePlaceholder(entry->username()) : originalEntry->username();
+        }
+
+        if (!browserSettings()->alwaysAllowUpdate() && isEntryPasswordChanged) {
             raiseWindow();
             dialogResult = MessageBox::question(m_currentDatabaseWidget,
                                                 tr("KeePassXC - Update Entry"),
                                                 tr("Do you want to update the information in %1 - %2?")
                                                     .arg(QUrl(entryParameters.siteUrl).host(), username),
                                                 MessageBox::Save | MessageBox::Cancel,
-                                                MessageBox::Cancel);
+                                                MessageBox::Cancel,
+                                                MessageBox::Raise);
+        } else if (isReferencePasswordChanged) {
+            raiseWindow();
+            dialogResult =
+                MessageBox::question(nullptr,
+                                     tr("KeePassXC: Update Entry"),
+                                     tr("Do you want to update the information in %1 - %2?<br><br>"
+                                        "The selected entry is a reference of \"%3\".<br>"
+                                        "Select Overwrite to change password to the current referenced entry.<br>"
+                                        "Select Save to change the password of the original entry.")
+                                         .arg(QUrl(entryParameters.siteUrl).host(),
+                                              username,
+                                              originalEntry ? originalEntry->title() : entry->title()),
+                                     MessageBox::Save | MessageBox::Cancel | MessageBox::Overwrite,
+                                     MessageBox::Cancel,
+                                     MessageBox::Raise);
+
+            // Make the save to the original entry
+            if (dialogResult == MessageBox::Save) {
+                entry = originalEntry;
+            }
         }
 
-        if (browserSettings()->alwaysAllowUpdate() || dialogResult == MessageBox::Save) {
+        if (entry
+            && (browserSettings()->alwaysAllowUpdate() || dialogResult == MessageBox::Save
+                || dialogResult == MessageBox::Overwrite)) {
             entry->beginUpdate();
             if (!entry->attributes()->isReference(EntryAttributes::UserNameKey)) {
                 entry->setUsername(entryParameters.login);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Detects if the current password is a reference. In that case an extra option is displayed for the user: a possibility to override the password from the original entry (which affects all referenced entries), or just save the new password directly to the selected entry dispite the reference.

TODO: The message box sentence could be improved.

Fixes #8003

[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. A good way to test was described in the issue:
1. Have one account A with username, password for site A
2. Create two more accounts B and C for sites B and C, referencing the password of account A
3. Log in the site C with a different password
4. Accept request to update account C(!)
5. Learn that not account C was updated, but the password of account A


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
