### PR TITLE
Move socket into separate directory

### DIFF
--- a/src/browser/BrowserShared.cpp
+++ b/src/browser/BrowserShared.cpp
@@ -33,18 +33,15 @@ namespace BrowserShared
 #if defined(KEEPASSXC_DIST_SNAP)
         return QProcessEnvironment::systemEnvironment().value("SNAP_USER_COMMON") + serverName;
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-        // Use XDG_RUNTIME_DIR if available, else use /tmp.
+        // This returns XDG_RUNTIME_DIR or else a temporary subdirectory.
         QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
-        if (path.isEmpty()) {
-            path = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
-        }
 
         // Put the socket in a dedicated directory.
         // This directory will be easily mountable by sandbox containers.
         QString subPath = path + "/app/org.keepassxc.KeePassXC/";
         QDir().mkpath(subPath);
-        QString socketPath = subPath + serverName;
 
+        QString socketPath = subPath + serverName;
 #ifndef KEEPASSXC_DIST_FLATPAK
         // Create a symlink at the legacy location for backwards compatibility.
         QFile::link(socketPath, path + serverName);

--- a/src/browser/BrowserShared.cpp
+++ b/src/browser/BrowserShared.cpp
@@ -19,6 +19,7 @@
 
 #include "config-keepassx.h"
 
+#include <QDir>
 #include <QStandardPaths>
 #if defined(KEEPASSXC_DIST_SNAP)
 #include <QProcessEnvironment>
@@ -31,14 +32,25 @@ namespace BrowserShared
         const auto serverName = QStringLiteral("/org.keepassxc.KeePassXC.BrowserServer");
 #if defined(KEEPASSXC_DIST_SNAP)
         return QProcessEnvironment::systemEnvironment().value("SNAP_USER_COMMON") + serverName;
-#elif defined(KEEPASSXC_DIST_FLATPAK)
-        return QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + "/app/" + "org.keepassxc.KeePassXC"
-               + serverName;
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-        // Use XDG_RUNTIME_DIR instead of /tmp if it's available
+        // Use XDG_RUNTIME_DIR if available, else use /tmp.
         QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
-        return path.isEmpty() ? QStandardPaths::writableLocation(QStandardPaths::TempLocation) + serverName
-                              : path + serverName;
+        if (path.isEmpty()) {
+            path = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+        }
+
+        // Put the socket in a dedicated directory.
+        // This directory will be easily mountable by sandbox containers.
+        QString subPath = path + "/app/org.keepassxc.KeePassXC/";
+        QDir().mkpath(subPath);
+        QString socketPath = subPath + serverName;
+
+#ifndef KEEPASSXC_DIST_FLATPAK
+        // Create a symlink at the legacy location for backwards compatibility.
+        QFile::link(socketPath, path + serverName);
+#endif
+
+        return socketPath;
 #elif defined(Q_OS_WIN)
         // Windows uses named pipes
         return serverName + "_" + qgetenv("USERNAME");


### PR DESCRIPTION
This is mostly to ease setup and configuration with sandboxed browsers.

The socket currently existing in `$XDG_RUNTIME_DIR`. When sandboxing a
browser, it would be unsafe to mount this directory inside the sandbox.
Mounting the socket into the sandbox's filesystem is also not possible
in cases where KeePassXC is [re]started after the browser has started.

This commit moves the socket into its own isolated subdirectory, which
can be safely mounted into sandboxes. Sandbox engines can create the
directory themselves (in case the browser starts before KeePassXC). Both
Flatpak and Firejail support this configuration.

A symlink is also created, linking the previous location to the new
location. This is meant for backwards compatibility and should
eventually be dropped.

The directory can't be named `org.keepassxc.KeePassXC.BrowserServer`,
since that would collide with the symlink. Instead, the directory has
been created to match the format used for Flatpak builds, which make it
a bit less of a snowflake build, while following accepted conventions.

Fixes: https://github.com/keepassxreboot/keepassxc/issues/8018

## Testing strategy

### Backwards compatibility

Try using browser integration on an existing, working, setup. It should all work without any issues.

### For sandboxed applications

See https://github.com/keepassxreboot/keepassxc/discussions/6741#discussioncomment-1154242, without tampering with `keepassxc.local`.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)

## Notes

It might make sense to drop this bit, since now it matches the default behaviour: https://github.com/keepassxreboot/keepassxc/blob/736517f4553b443a74a420ef421b7c62695e6462/src/browser/BrowserShared.cpp#L35-L37

Not sure if it's fine to do this on the PR of it it's best to do that separately.