### PR TITLE
Add config variable for specifying a default file name for the database

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -81,6 +81,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GlobalAutoTypeRetypeTime,{QS("GlobalAutoTypeRetypeTime"), Roaming, 15}},
     {Config::FaviconDownloadTimeout,{QS("FaviconDownloadTimeout"), Roaming, 10}},
     {Config::UpdateCheckMessageShown,{QS("UpdateCheckMessageShown"), Roaming, false}},
+    {Config::DefaultDatabaseFileName,{QS("DefaultDatabaseFileName"), Roaming, {}}},
 
     {Config::LastDatabases, {QS("LastDatabases"), Local, {}}},
     {Config::LastKeyFiles, {QS("LastKeyFiles"), Local, {}}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -63,6 +63,7 @@ public:
         GlobalAutoTypeRetypeTime,
         FaviconDownloadTimeout,
         UpdateCheckMessageShown,
+        DefaultDatabaseFileName,
 
         LastDatabases,
         LastKeyFiles,

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1980,8 +1980,10 @@ bool DatabaseWidget::saveAs()
 
     QString oldFilePath = m_db->filePath();
     if (!QFileInfo::exists(oldFilePath)) {
+        QString defaultFileName = config()->get(Config::DefaultDatabaseFileName).toString();
         oldFilePath =
-            QDir::toNativeSeparators(config()->get(Config::LastDir).toString() + "/" + tr("Passwords").append(".kdbx"));
+            QDir::toNativeSeparators(config()->get(Config::LastDir).toString() + "/"
+                                     + (defaultFileName.isEmpty() ? tr("Passwords").append(".kdbx") : defaultFileName));
     }
     const QString newFilePath = fileDialog()->getSaveFileName(
         this, tr("Save database as"), oldFilePath, tr("KeePass 2 Database").append(" (*.kdbx)"), nullptr, nullptr);
@@ -2068,8 +2070,10 @@ bool DatabaseWidget::saveBackup()
     while (true) {
         QString oldFilePath = m_db->filePath();
         if (!QFileInfo::exists(oldFilePath)) {
-            oldFilePath = QDir::toNativeSeparators(config()->get(Config::LastDir).toString() + "/"
-                                                   + tr("Passwords").append(".kdbx"));
+            QString defaultFileName = config()->get(Config::DefaultDatabaseFileName).toString();
+            oldFilePath = QDir::toNativeSeparators(
+                config()->get(Config::LastDir).toString() + "/"
+                + (defaultFileName.isEmpty() ? tr("Passwords").append(".kdbx") : defaultFileName));
         }
 
         const QString newFilePath = fileDialog()->getSaveFileName(this,


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Hi!

Currently, the default file name when saving a new database is localized (e.g., `Passwords.kdbx` in English, `Mots de passe.kdbx` in French, and so on), as per [`src/gui/DatabaseWidget.cpp:1984`](https://github.com/keepassxreboot/keepassxc/blob/2.7.1/src/gui/DatabaseWidget.cpp#L1984).

However, in some cases, it might be useful to have the default file name to be locale-independent.

For instance, this is the case in [Tails](https://tails.boum.org/), which is a live system where the KeePassXC configuration is never stored: at boot time, the user's home directory is populated using fixed files in `/etc/skel`, which, among other things, include a configuration file for KeePassXC (see [here](https://gitlab.tails.boum.org/tails/tails/-/blob/5.0/config/chroot_local-includes/etc/skel/.config/keepassxc/keepassxc.ini)). This file expects that the user's database file name is `Passwords.kdbx`, so that KeePassXC will automatically open it.

However, this will not work for users using a non-English language locale: upon creating a new database, the default file name for saving it will be localized and will not be `Passwords.kdbx`. Also, Tails users may change their locale every time they log in, which makes it extremely impractical to have a file name depend on the current language locale. (This issue was reported as [\#18966](https://gitlab.tails.boum.org/tails/tails/-/issues/18966) on the Tails tracker.)

The patch in this PR proposes to address this by introducing a new configuration variable, `DefaultDatabaseFileName`, which allows one to specify a default file name for new databases. This variable isn't accessible or modifiable from the GUI, as most users wouldn't need to change it anyway. If this variable is unset, the behaviour remains unchanged: a localized version of `Passwords.kdbx` is used as the default file name. But if this variable is set to a string, this string will be used as the default file name.

This change was made to be as unobtrusive as possible: regular users will never have to use or set this variable. However, live systems such as Tails operating with fixed configuration files will be able to set this configuration variable to a fixed string, so that the default database file name is always the same, regardless of the current language locale.

An alternative to this change would be to introduce a simple boolean variable (`LocalizeDefaultDatabaseFileName`, for instance) instead, which could be set to `false` in order to disable the localization of the default file name and to always use `Passwords.kdbx`.

I felt that the `DefaultDatabaseFileName` variable allowed for more flexibility (such as choosing a totally different file name, if need be), but I'll be happy to look into this alternative option and modify my PR accordingly if you'd rather go with the boolean setting.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

Below is a screenshot of the KeePassXC window while saving a new database, localized in French and with the following line in the configuration file:
```ini
DefaultDatabaseFileName=MyCustomName.kdbx
```
![default-database-file-name](https://user-images.githubusercontent.com/79416808/167949130-0436b77e-ee76-4257-ad92-9760bb2c51e6.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

I've tested this change by creating new databases and checking which default file name was proposed by KeePassXC when saving it. I've checked that the behaviour was still the same when the variable was not set; and that, when set, the specified file name was proposed. I ran these tests under two different language locales (English and French).

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)

Thank you very much in advance!

snipfoo