### PR TITLE
Translation error: Polish: Fixing contextual mistake

### DIFF
--- a/share/translations/keepassxc_pl.ts
+++ b/share/translations/keepassxc_pl.ts
@@ -6157,7 +6157,7 @@ Czy chcesz ją nadpisać?</translation>
     </message>
     <message>
         <source>Empty</source>
-        <translation>Pusty</translation>
+        <translation>Opróżnij</translation>
     </message>
     <message>
         <source>Remove</source>


### PR DESCRIPTION
"Empty" can be translated as "Pusty" in context of something simply being empty, but it should be translated as "Opróżnij" when used in a context of taking action of emptying something, which would be the case here.