### PR TITLE
Fix use of modifiers under macOS

### DIFF
--- a/src/autotype/mac/AutoTypeMac.h
+++ b/src/autotype/mac/AutoTypeMac.h
@@ -45,7 +45,7 @@ public:
     bool raiseOwnWindow() override;
 
     void sendChar(const QChar& ch, bool isKeyDown);
-    void sendKey(Qt::Key key, bool isKeyDown, Qt::KeyboardModifiers modifiers);
+    void sendKey(Qt::Key key, bool isKeyDown, Qt::KeyboardModifiers modifiers = 0);
 
 private:
     static int windowLayer(CFDictionaryRef window);


### PR DESCRIPTION
* Fix #6463
This fixes use of {CLEARFIELD} and also use of modifiers in general. For example the sequence `+a` would output lowercase a prior to this PR and after outputs the expected upper case A.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested extensively on macOS

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
