### PR TITLE
Pass database locked/unlocked status even with Search In All Opened Databases option enabled

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1428,8 +1428,7 @@ void BrowserService::databaseUnlocked(DatabaseWidget* dbWidget)
 
 void BrowserService::activeDatabaseChanged(DatabaseWidget* dbWidget)
 {
-    // Only emit these signals when we are not searching in all databases
-    if (dbWidget && !browserSettings()->searchInAllDatabases()) {
+    if (dbWidget) {
         if (dbWidget->isLocked()) {
             databaseLocked(dbWidget);
         } else {


### PR DESCRIPTION
Reverts a bad fix made in https://github.com/keepassxreboot/keepassxc/pull/4660. Originally it was made to fix showing Access Confirm Dialog at database change, but it seems to work OK with the latest extension. This "fix" failed to pass database status to the extension, causing missing icon state updates.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Manually:
- Enable "Search in all databases" in KeePassXC
- Without this fix, icons are not updated in the extension when switching between databases, no matter if it's locked, not connected etc.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
