### PR TITLE
Emit database changed signal when locking a single database

### DIFF
--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -202,6 +202,7 @@ void DatabaseTabWidget::lockAndSwitchToFirstUnlockedDatabase(int index)
         for (int i = 0, c = count(); i < c; ++i) {
             if (!databaseWidgetFromIndex(i)->isLocked()) {
                 setCurrentIndex(i);
+                emitActiveDatabaseChanged();
                 return;
             }
         }


### PR DESCRIPTION
Steps to reproduce:
- Open two databases
- Lock only one of them
- KeePassXC switches to the next open database but the database changed signal is never emitted
- Database state does not update to the browser extension

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
