### PR TITLE
Auto-Type: PICKCHARS can specify attribute and ignore BEEP

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -644,6 +644,10 @@
         <source>Invalid placeholder: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Entry does not have attribute for PICKCHARS: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoTypeAssociationsModel</name>

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -647,13 +647,26 @@ AutoType::parseSequence(const QString& entrySequence, const Entry* entry, QStrin
             for (const auto& ch : totp) {
                 actions << QSharedPointer<AutoTypeKey>::create(ch);
             }
-        } else if (placeholder == "pickchars") {
-            // Ignore this if we are syntax checking
+        } else if (placeholder.startsWith("pickchars")) {
+            // Reset to the original capture to preserve case
+            placeholder = match.captured(3);
+
+            auto attribute = EntryAttributes::PasswordKey;
+            if (placeholder.contains(":")) {
+                attribute = placeholder.section(":", 1);
+                if (!entry->attributes()->hasKey(attribute)) {
+                    error = tr("Entry does not have attribute for PICKCHARS: %1").arg(attribute);
+                    return {};
+                }
+            }
+
+            // Bail out if we are just syntax checking
             if (syntaxOnly) {
                 continue;
             }
-            // Show pickchars dialog for entry's password
-            auto password = entry->resolvePlaceholder(entry->password());
+
+            // Show pickchars dialog for the desired attribute
+            auto password = entry->resolvePlaceholder(entry->attribute(attribute));
             if (!password.isEmpty()) {
                 PickcharsDialog pickcharsDialog(password);
                 if (pickcharsDialog.exec() == QDialog::Accepted && !pickcharsDialog.selectedChars().isEmpty()) {
@@ -746,8 +759,8 @@ AutoType::parseSequence(const QString& entrySequence, const Entry* entry, QStrin
                 mode = AutoTypeExecutor::Mode::VIRTUAL;
             }
             actions << QSharedPointer<AutoTypeMode>::create(mode);
-        } else if (placeholder == "beep" || placeholder.startsWith("vkey") || placeholder.startsWith("appactivate")
-                   || placeholder.startsWith("c:")) {
+        } else if (placeholder.startsWith("beep") || placeholder.startsWith("vkey")
+                   || placeholder.startsWith("appactivate") || placeholder.startsWith("c:")) {
             // Ignore these commands
         } else {
             // Attempt to resolve an entry attribute

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -337,7 +337,7 @@ void TestAutoType::testAutoTypeSyntaxChecks()
     QVERIFY2(AutoType::verifyAutoTypeSyntax("{S:FOO}{S:HELLO WORLD}", entry, error), error.toLatin1());
     QVERIFY2(!AutoType::verifyAutoTypeSyntax("{S:SPECIAL_TOKEN{}}", entry, error), error.toLatin1());
 
-    QVERIFY2(!AutoType::verifyAutoTypeSyntax("{BEEP 3 3}", entry, error), error.toLatin1());
+    QVERIFY2(AutoType::verifyAutoTypeSyntax("{BEEP 3 3}", entry, error), error.toLatin1());
     QVERIFY2(AutoType::verifyAutoTypeSyntax("{BEEP 3}", entry, error), error.toLatin1());
 
     QVERIFY2(AutoType::verifyAutoTypeSyntax("{VKEY 0x01}", entry, error), error.toLatin1());


### PR DESCRIPTION
* Fix #7726 - Ignore BEEP Auto-Type token when it includes spaces and numbers as well
* Close #8103 - Allow specifying specific attribute to use with PICKCHARS. If none specified, it defaults to Password.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
