### PR TITLE
Implement #5900 -- Color/hint placeholders when editing an entry

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2883,10 +2883,6 @@ Would you like to correct it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Title field</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Username:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,7 @@ set(keepassx_SOURCES
         gui/entry/EntryHistoryModel.cpp
         gui/entry/EntryModel.cpp
         gui/entry/EntryView.cpp
+        gui/entry/EntryPlaceholderTextEdit.cpp
         gui/export/ExportDialog.cpp
         gui/group/EditGroupWidget.cpp
         gui/group/GroupModel.cpp

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -35,6 +35,43 @@ const int Entry::ResolveMaximumDepth = 10;
 const QString Entry::AutoTypeSequenceUsername = "{USERNAME}{ENTER}";
 const QString Entry::AutoTypeSequencePassword = "{PASSWORD}{ENTER}";
 
+const QMap<QString, Entry::PlaceholderType> Entry::m_placeholdersMap = {
+    {QStringLiteral("{TITLE}"), Entry::PlaceholderType::Title},
+    {QStringLiteral("{USERNAME}"), Entry::PlaceholderType::UserName},
+    {QStringLiteral("{PASSWORD}"), Entry::PlaceholderType::Password},
+    {QStringLiteral("{NOTES}"), Entry::PlaceholderType::Notes},
+    {QStringLiteral("{TOTP}"), Entry::PlaceholderType::Totp},
+    {QStringLiteral("{URL}"), Entry::PlaceholderType::Url},
+    {QStringLiteral("{URL:RMVSCM}"), Entry::PlaceholderType::UrlWithoutScheme},
+    {QStringLiteral("{URL:WITHOUTSCHEME}"), Entry::PlaceholderType::UrlWithoutScheme},
+    {QStringLiteral("{URL:SCM}"), Entry::PlaceholderType::UrlScheme},
+    {QStringLiteral("{URL:SCHEME}"), Entry::PlaceholderType::UrlScheme},
+    {QStringLiteral("{URL:HOST}"), Entry::PlaceholderType::UrlHost},
+    {QStringLiteral("{URL:PORT}"), Entry::PlaceholderType::UrlPort},
+    {QStringLiteral("{URL:PATH}"), Entry::PlaceholderType::UrlPath},
+    {QStringLiteral("{URL:QUERY}"), Entry::PlaceholderType::UrlQuery},
+    {QStringLiteral("{URL:FRAGMENT}"), Entry::PlaceholderType::UrlFragment},
+    {QStringLiteral("{URL:USERINFO}"), Entry::PlaceholderType::UrlUserInfo},
+    {QStringLiteral("{URL:USERNAME}"), Entry::PlaceholderType::UrlUserName},
+    {QStringLiteral("{URL:PASSWORD}"), Entry::PlaceholderType::UrlPassword},
+    {QStringLiteral("{DT_SIMPLE}"), Entry::PlaceholderType::DateTimeSimple},
+    {QStringLiteral("{DT_YEAR}"), Entry::PlaceholderType::DateTimeYear},
+    {QStringLiteral("{DT_MONTH}"), Entry::PlaceholderType::DateTimeMonth},
+    {QStringLiteral("{DT_DAY}"), Entry::PlaceholderType::DateTimeDay},
+    {QStringLiteral("{DT_HOUR}"), Entry::PlaceholderType::DateTimeHour},
+    {QStringLiteral("{DT_MINUTE}"), Entry::PlaceholderType::DateTimeMinute},
+    {QStringLiteral("{DT_SECOND}"), Entry::PlaceholderType::DateTimeSecond},
+    {QStringLiteral("{DT_UTC_SIMPLE}"), Entry::PlaceholderType::DateTimeUtcSimple},
+    {QStringLiteral("{DT_UTC_YEAR}"), Entry::PlaceholderType::DateTimeUtcYear},
+    {QStringLiteral("{DT_UTC_MONTH}"), Entry::PlaceholderType::DateTimeUtcMonth},
+    {QStringLiteral("{DT_UTC_DAY}"), Entry::PlaceholderType::DateTimeUtcDay},
+    {QStringLiteral("{DT_UTC_HOUR}"), Entry::PlaceholderType::DateTimeUtcHour},
+    {QStringLiteral("{DT_UTC_MINUTE}"), Entry::PlaceholderType::DateTimeUtcMinute},
+    {QStringLiteral("{DT_UTC_SECOND}"), Entry::PlaceholderType::DateTimeUtcSecond},
+    {QStringLiteral("{DB_DIR}"), Entry::PlaceholderType::DbDir}
+};
+
+
 Entry::Entry()
     : m_attributes(new EntryAttributes(this))
     , m_attachments(new EntryAttachments(this))
@@ -1344,43 +1381,18 @@ Entry::PlaceholderType Entry::placeholderType(const QString& placeholder) const
     if (placeholder.startsWith(QLatin1Literal("{REF:"))) {
         return PlaceholderType::Reference;
     }
+    return m_placeholdersMap.value(placeholder.toUpper(), PlaceholderType::Unknown);
+}
 
-    static const QMap<QString, PlaceholderType> placeholders{
-        {QStringLiteral("{TITLE}"), PlaceholderType::Title},
-        {QStringLiteral("{USERNAME}"), PlaceholderType::UserName},
-        {QStringLiteral("{PASSWORD}"), PlaceholderType::Password},
-        {QStringLiteral("{NOTES}"), PlaceholderType::Notes},
-        {QStringLiteral("{TOTP}"), PlaceholderType::Totp},
-        {QStringLiteral("{URL}"), PlaceholderType::Url},
-        {QStringLiteral("{URL:RMVSCM}"), PlaceholderType::UrlWithoutScheme},
-        {QStringLiteral("{URL:WITHOUTSCHEME}"), PlaceholderType::UrlWithoutScheme},
-        {QStringLiteral("{URL:SCM}"), PlaceholderType::UrlScheme},
-        {QStringLiteral("{URL:SCHEME}"), PlaceholderType::UrlScheme},
-        {QStringLiteral("{URL:HOST}"), PlaceholderType::UrlHost},
-        {QStringLiteral("{URL:PORT}"), PlaceholderType::UrlPort},
-        {QStringLiteral("{URL:PATH}"), PlaceholderType::UrlPath},
-        {QStringLiteral("{URL:QUERY}"), PlaceholderType::UrlQuery},
-        {QStringLiteral("{URL:FRAGMENT}"), PlaceholderType::UrlFragment},
-        {QStringLiteral("{URL:USERINFO}"), PlaceholderType::UrlUserInfo},
-        {QStringLiteral("{URL:USERNAME}"), PlaceholderType::UrlUserName},
-        {QStringLiteral("{URL:PASSWORD}"), PlaceholderType::UrlPassword},
-        {QStringLiteral("{DT_SIMPLE}"), PlaceholderType::DateTimeSimple},
-        {QStringLiteral("{DT_YEAR}"), PlaceholderType::DateTimeYear},
-        {QStringLiteral("{DT_MONTH}"), PlaceholderType::DateTimeMonth},
-        {QStringLiteral("{DT_DAY}"), PlaceholderType::DateTimeDay},
-        {QStringLiteral("{DT_HOUR}"), PlaceholderType::DateTimeHour},
-        {QStringLiteral("{DT_MINUTE}"), PlaceholderType::DateTimeMinute},
-        {QStringLiteral("{DT_SECOND}"), PlaceholderType::DateTimeSecond},
-        {QStringLiteral("{DT_UTC_SIMPLE}"), PlaceholderType::DateTimeUtcSimple},
-        {QStringLiteral("{DT_UTC_YEAR}"), PlaceholderType::DateTimeUtcYear},
-        {QStringLiteral("{DT_UTC_MONTH}"), PlaceholderType::DateTimeUtcMonth},
-        {QStringLiteral("{DT_UTC_DAY}"), PlaceholderType::DateTimeUtcDay},
-        {QStringLiteral("{DT_UTC_HOUR}"), PlaceholderType::DateTimeUtcHour},
-        {QStringLiteral("{DT_UTC_MINUTE}"), PlaceholderType::DateTimeUtcMinute},
-        {QStringLiteral("{DT_UTC_SECOND}"), PlaceholderType::DateTimeUtcSecond},
-        {QStringLiteral("{DB_DIR}"), PlaceholderType::DbDir}};
-
-    return placeholders.value(placeholder.toUpper(), PlaceholderType::Unknown);
+QStringList Entry::placeholdersList()
+{
+    QStringList types;
+    QMap<QString, Entry::PlaceholderType>::const_iterator i = m_placeholdersMap.constBegin();
+    while (i != m_placeholdersMap.constEnd()) {
+        types.append(i.key());
+        ++i;
+    }
+    return types;
 }
 
 QString Entry::resolveUrl(const QString& url) const

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -68,9 +68,7 @@ const QMap<QString, Entry::PlaceholderType> Entry::m_placeholdersMap = {
     {QStringLiteral("{DT_UTC_HOUR}"), Entry::PlaceholderType::DateTimeUtcHour},
     {QStringLiteral("{DT_UTC_MINUTE}"), Entry::PlaceholderType::DateTimeUtcMinute},
     {QStringLiteral("{DT_UTC_SECOND}"), Entry::PlaceholderType::DateTimeUtcSecond},
-    {QStringLiteral("{DB_DIR}"), Entry::PlaceholderType::DbDir}
-};
-
+    {QStringLiteral("{DB_DIR}"), Entry::PlaceholderType::DbDir}};
 
 Entry::Entry()
     : m_attributes(new EntryAttributes(this))

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -224,6 +224,9 @@ public:
     static const QString AutoTypeSequenceUsername;
     static const QString AutoTypeSequencePassword;
 
+    static QStringList placeholdersList();
+    static EntryReferenceType referenceType(const QString& referenceStr);
+
     /**
      * Creates a duplicate of this entry except that the returned entry isn't
      * part of any group.
@@ -279,7 +282,6 @@ private:
     QString referenceFieldValue(EntryReferenceType referenceType) const;
 
     static QString buildReference(const QUuid& uuid, const QString& field);
-    static EntryReferenceType referenceType(const QString& referenceStr);
 
     template <class T> bool set(T& property, const T& value);
 
@@ -295,6 +297,8 @@ private:
     bool m_modifiedSinceBegin;
     QPointer<Group> m_group;
     bool m_updateTimeinfo;
+
+    static const QMap<QString, PlaceholderType> m_placeholdersMap;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Entry::CloneFlags)

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -436,6 +436,8 @@ void EditEntryWidget::setupHistory()
 void EditEntryWidget::setupEntryUpdate()
 {
     // Entry tab
+    connect(m_mainUi->titleEdit, SIGNAL(accepted()), this, SLOT(acceptEntry()));
+    connect(m_mainUi->titleEdit, SIGNAL(canceled()), this, SLOT(cancel()));
     connect(m_mainUi->titleEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
     connect(m_mainUi->usernameComboBox->lineEdit(), SIGNAL(textChanged(QString)), this, SLOT(setModified()));
     connect(m_mainUi->passwordEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
@@ -819,6 +821,7 @@ void EditEntryWidget::loadEntry(Entry* entry,
     m_db = std::move(database);
     m_create = create;
     m_history = history;
+    m_mainUi->titleEdit->setEntry(m_entry);
 
     connect(m_entry, &Entry::modified, this, [this] { m_entryModifiedTimer.start(); });
 
@@ -890,7 +893,6 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_autoTypeUi->windowTitleCombo->lineEdit()->setReadOnly(m_history);
     m_autoTypeUi->windowSequenceEdit->setReadOnly(m_history);
     m_historyWidget->setEnabled(!m_history);
-
     m_mainUi->titleEdit->setText(entry->title());
     m_mainUi->usernameComboBox->lineEdit()->setText(entry->username());
     m_mainUi->urlEdit->setText(entry->url());
@@ -1157,7 +1159,8 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
     entry->attributes()->copyCustomKeysFrom(m_entryAttributes);
     entry->attachments()->copyDataFrom(m_attachments.data());
     entry->customData()->copyDataFrom(m_customData.data());
-    entry->setTitle(m_mainUi->titleEdit->text().replace(newLineRegex, " "));
+    entry->setTitle(m_mainUi->titleEdit->toPlainText().replace(newLineRegex, " "));
+
     entry->setUsername(m_mainUi->usernameComboBox->lineEdit()->text().replace(newLineRegex, " "));
     entry->setUrl(m_mainUi->urlEdit->text().replace(newLineRegex, " "));
     entry->setPassword(m_mainUi->passwordEdit->text());

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -821,7 +821,7 @@ void EditEntryWidget::loadEntry(Entry* entry,
     m_db = std::move(database);
     m_create = create;
     m_history = history;
-    m_mainUi->titleEdit->setEntry(m_entry);
+    m_mainUi->titleEdit->setEntry(m_entry, m_entry->title());
 
     connect(m_entry, &Entry::modified, this, [this] { m_entryModifiedTimer.start(); });
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1159,7 +1159,7 @@ void EditEntryWidget::updateEntryData(Entry* entry) const
     entry->attributes()->copyCustomKeysFrom(m_entryAttributes);
     entry->attachments()->copyDataFrom(m_attachments.data());
     entry->customData()->copyDataFrom(m_customData.data());
-    entry->setTitle(m_mainUi->titleEdit->toPlainText().replace(newLineRegex, " "));
+    entry->setTitle(m_mainUi->titleEdit->text().replace(newLineRegex, " "));
 
     entry->setUsername(m_mainUi->usernameComboBox->lineEdit()->text().replace(newLineRegex, " "));
     entry->setUrl(m_mainUi->urlEdit->text().replace(newLineRegex, " "));

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -56,80 +56,37 @@
     <property name="verticalSpacing">
      <number>8</number>
     </property>
-    <item row="7" column="1">
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QPlainTextEdit" name="notesEdit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>1</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>100</height>
-         </size>
-        </property>
-        <property name="accessibleName">
-         <string>Notes field</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="notesHint">
-        <property name="visible">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Toggle the checkbox to reveal the notes section.</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignTop</set>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item row="1" column="1">
-     <widget class="QComboBox" name="usernameComboBox">
-      <property name="accessibleName">
-       <string>Username field</string>
+    <item row="2" column="0">
+     <widget class="QLabel" name="usernameLabel">
+      <property name="text">
+       <string>Username:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
     </item>
-    <item row="7" column="0">
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QCheckBox" name="notesEnabled">
-        <property name="toolTip">
-         <string>Toggle notes visible</string>
-        </property>
-        <property name="accessibleName">
-         <string>Toggle notes visible</string>
-        </property>
-        <property name="text">
-         <string>Notes:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
+    <item row="0" column="0">
+     <widget class="QLabel" name="titleLabel">
+      <property name="text">
+       <string>Title:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
     </item>
     <item row="6" column="1">
+     <widget class="TagsEdit" name="tagsList" native="true">
+      <property name="focusPolicy">
+       <enum>Qt::StrongFocus</enum>
+      </property>
+      <property name="accessibleName">
+       <string>Tags list</string>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="1">
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="spacing">
        <number>8</number>
@@ -168,17 +125,43 @@
       </item>
      </layout>
     </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="passwordLabel">
-      <property name="text">
-       <string>Password:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
+    <item row="8" column="1">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QPlainTextEdit" name="notesEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>1</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>100</height>
+         </size>
+        </property>
+        <property name="accessibleName">
+         <string>Notes field</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="notesHint">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Toggle the checkbox to reveal the notes section.</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignTop</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
-    <item row="3" column="0">
+    <item row="4" column="0">
      <widget class="QLabel" name="urlLabel">
       <property name="text">
        <string>URL:</string>
@@ -188,7 +171,14 @@
       </property>
      </widget>
     </item>
-    <item row="3" column="1">
+    <item row="2" column="1">
+     <widget class="QComboBox" name="usernameComboBox">
+      <property name="accessibleName">
+       <string>Username field</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
      <layout class="QHBoxLayout" name="horizontalLayout_6">
       <property name="spacing">
        <number>8</number>
@@ -215,34 +205,57 @@
       </item>
      </layout>
     </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="titleLabel">
+    <item row="6" column="0">
+     <widget class="QLabel" name="tagsLabel">
       <property name="text">
-       <string>Title:</string>
+       <string>Tags:</string>
       </property>
       <property name="alignment">
        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
     </item>
-    <item row="0" column="1">
-     <widget class="QLineEdit" name="titleEdit">
-      <property name="accessibleName">
-       <string>Title field</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="usernameLabel">
+    <item row="3" column="0">
+     <widget class="QLabel" name="passwordLabel">
       <property name="text">
-       <string>Username:</string>
+       <string>Password:</string>
       </property>
       <property name="alignment">
        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
     </item>
-    <item row="2" column="1">
+    <item row="8" column="0">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="notesEnabled">
+        <property name="toolTip">
+         <string>Toggle notes visible</string>
+        </property>
+        <property name="accessibleName">
+         <string>Toggle notes visible</string>
+        </property>
+        <property name="text">
+         <string>Notes:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item row="3" column="1">
      <widget class="PasswordWidget" name="passwordEdit">
       <property name="accessibleName">
        <string>Password field</string>
@@ -252,7 +265,7 @@
       </property>
      </widget>
     </item>
-    <item row="6" column="0">
+    <item row="7" column="0">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="spacing">
        <number>0</number>
@@ -272,23 +285,25 @@
       </item>
      </layout>
     </item>
-    <item row="5" column="0">
-     <widget class="QLabel" name="tagsLabel">
-      <property name="text">
-       <string>Tags:</string>
+    <item row="0" column="1">
+     <widget class="EntryPlaceholderTextEdit" name="titleEdit">
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>30</height>
+       </size>
       </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
       </property>
-     </widget>
-    </item>
-    <item row="5" column="1">
-     <widget class="TagsEdit" name="tagsList" native="true">
-      <property name="focusPolicy">
-       <enum>Qt::StrongFocus</enum>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
       </property>
-      <property name="accessibleName">
-       <string>Tags list</string>
+      <property name="verticalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="horizontalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
       </property>
      </widget>
     </item>
@@ -314,9 +329,13 @@
    <header>gui/URLEdit.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>EntryPlaceholderTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header>gui/entry/EntryPlaceholderTextEdit.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>titleEdit</tabstop>
   <tabstop>usernameComboBox</tabstop>
   <tabstop>passwordEdit</tabstop>
   <tabstop>urlEdit</tabstop>

--- a/src/gui/entry/EntryPlaceholderTextEdit.cpp
+++ b/src/gui/entry/EntryPlaceholderTextEdit.cpp
@@ -238,11 +238,11 @@ void EntryPlaceholderTextEdit::applyAutoCompletion(QString placeholderName)
     redrawPlaceHolders();
 }
 
-void EntryPlaceholderTextEdit::setEntry(Entry* e)
+void EntryPlaceholderTextEdit::setEntry(Entry* e, const QString& text)
 {
     if (!e) return;
     m_entry = e;
-    setText(e->title());
+    setText(text);
     redrawPlaceHolders();
 }
 
@@ -306,9 +306,9 @@ void EntryPlaceholderTextEdit::redrawPlaceHolders()
     QTextCursor cur{textCursor()};
     const int originalPos = cur.position();
     QStringList replacedList;
-    QString styledTitle = toPlainText().replace(" ", "&nbsp;"); // 2 consecutive spaces do not display in HTML
+    QString styledText = toPlainText().replace(" ", "&nbsp;"); // 2 consecutive spaces do not display in HTML
     QRegularExpression rx("{[^}{]+}");
-    QRegularExpressionMatchIterator i = rx.globalMatch(styledTitle);
+    QRegularExpressionMatchIterator i = rx.globalMatch(styledText);
     while (i.hasNext())
     {
         QRegularExpressionMatch match = i.next();
@@ -322,13 +322,13 @@ void EntryPlaceholderTextEdit::redrawPlaceHolders()
         if (!replacedList.contains(placeholder) && substitution != placeholder) {
             const bool isSubstitutionInvalid = substitution.isEmpty() || substitution=="-1";
             const QString styledPh = ph.getStyledString(isSubstitutionInvalid);
-            styledTitle.replace(placeholder, styledPh);
+            styledText.replace(placeholder, styledPh);
             replacedList << placeholder;
         }
     }
     if (replacedList.size() > 0)
     {
-        setHtml(styledTitle);
+        setHtml(styledText);
         cur.setPosition(originalPos);
         setTextCursor(cur);
     }

--- a/src/gui/entry/EntryPlaceholderTextEdit.cpp
+++ b/src/gui/entry/EntryPlaceholderTextEdit.cpp
@@ -1,0 +1,373 @@
+#include "EntryPlaceholderTextEdit.h"
+
+#include <QCoreApplication>
+#include <QtGlobal>
+#include <QKeyEvent>
+#include <QMenu>
+#include <QListWidget>
+#include <QStringList>
+#include <QRegularExpression>
+
+#include "core/Entry.h"
+#include "gui/Icons.h"
+
+
+EntryPlaceholder::EntryPlaceholder(const QString& placeholder)
+    : m_fullText(placeholder)
+{
+    QString ph = placeholder;
+    // Remove brackets
+    if (!ph.isEmpty())
+    {
+        if (ph[0]=='{') {
+            ph = ph.mid(1);
+        }
+        if (ph[ph.size()-1]=='}') {
+            ph = ph.mid(0, ph.size()-1);
+        }
+    }
+    // Parse placeholder parts
+    const QStringList parts = ph.split(QLatin1Char(':'), Qt::SkipEmptyParts);
+    const int sz = parts.size();
+    if (sz==1) {
+        // simple placeholder
+        m_value = parts[0];
+    }
+    else if (sz==2) {
+        // key-value pair placeholder (URL or S placeholders)
+        m_key = parts[0];
+        m_value = parts[1];
+    }
+    else if (sz==3) {
+        // REF placeholder only
+        m_key = parts[0];
+        m_value = parts[2];
+        const QStringList crossRef = parts[1].split(QLatin1Char('@'), Qt::SkipEmptyParts);
+        if (crossRef.size()==2) {
+            m_crossReferenceField = crossRef[0];
+            m_crossReferenceSearchIn = crossRef[1];
+        }
+    }
+}
+
+// Colorize the placeholder using Qt HTML format:
+// * set to bold if valid
+// * set to RED colour if valid but the target value is empty
+// * not formatted if invalid
+QString EntryPlaceholder::getStyledString(const bool emptyTargetValue) const
+{
+    QString htmlTag{"<"};
+    htmlTag.append(emptyTargetValue ? "span" : "b").append(emptyTargetValue ? " style=\"color:red\"" : "").append(">");
+    htmlTag.append("{");
+
+    if (m_key.isEmpty()) {
+        htmlTag.append(m_value);
+    }
+    else if (m_key=="S" || m_key=="URL") {
+        htmlTag.append(m_key+":"+m_value);
+    }
+    else if (m_key=="REF") {
+        htmlTag.append(m_key+":"+m_crossReferenceField+"@"+m_crossReferenceSearchIn+":"+m_value);
+    }
+
+    htmlTag.append("}").append("</").append(emptyTargetValue ? "span" : "b").append(">");
+    return htmlTag;
+}
+
+EntryPlaceholderCompletionPopup::EntryPlaceholderCompletionPopup(QWidget* parent)
+    : QWidget(parent)
+{
+    // Setup autocompletion popup
+    setAttribute(Qt::WA_QuitOnClose, false);
+    setFixedSize(150,200);
+    setWindowFlags(Qt::FramelessWindowHint | Qt::Tool);
+    setWindowModality(Qt::NonModal);
+
+    QStringList placeholders = Entry::placeholdersList();
+    placeholders.append("{REF:}");
+    placeholders.append("{S:}");
+    m_autoCompletionList = new QListWidget(this);
+    for (const QString& placeholder : placeholders) {
+        const QString phName = placeholder.mid(1, placeholder.size()-2);
+        m_autoCompletionPlaceholdersList.append(phName);
+        new QListWidgetItem(phName, m_autoCompletionList);
+    }
+    m_autoCompletionList->setCurrentRow(0);
+    m_autoCompletionList->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_autoCompletionList->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+
+    connect(m_autoCompletionList, &QListWidget::itemActivated, this, &EntryPlaceholderCompletionPopup::itemActivated);
+    connect(m_autoCompletionList, &QListWidget::itemClicked, this, &EntryPlaceholderCompletionPopup::itemClicked);
+}
+
+// triggers when a placeholder in the auto-complete popup is selected (with keyboard, in most cases with ENTER key)
+void EntryPlaceholderCompletionPopup::itemActivated(QListWidgetItem* item)
+{
+    emit autoCompletionChoiceSelected(item->text());
+}
+
+// triggers when a placeholder in the auto-complete popup is selected (with mouse click)
+void EntryPlaceholderCompletionPopup::itemClicked(QListWidgetItem* item)
+{
+    emit autoCompletionChoiceSelected(item->text());
+}
+
+void EntryPlaceholderCompletionPopup::populateCompletionChoices(const QString& filter)
+{
+    if (isHidden()) return;
+    m_autoCompletionList->clear();
+
+    if (!filter.endsWith(":")) {
+        for (const QString& placeholder : m_autoCompletionPlaceholdersList) {
+            if (filter.isEmpty() || filter=="{" || placeholder.startsWith(filter.mid(1))) {
+                new QListWidgetItem(placeholder, m_autoCompletionList);
+            }
+        }
+    }
+    if (count()==0) {
+        hide();
+    }
+}
+
+int EntryPlaceholderCompletionPopup::count() const
+{
+    return m_autoCompletionList->count();
+}
+
+int EntryPlaceholderCompletionPopup::getCurrentItemIndex() const
+{
+    return m_autoCompletionList->currentRow();
+}
+
+QString EntryPlaceholderCompletionPopup::getCurrentItemText() const
+{
+    const auto item = m_autoCompletionList->currentItem();
+    return item ? item->text() : "";
+}
+
+void EntryPlaceholderCompletionPopup::setCurrentIndex(const int idx) const
+{
+    m_autoCompletionList->setCurrentRow(idx);
+}
+
+// returns whether the placeholder under the cursor matches any item in the auto-complete list
+bool EntryPlaceholderCompletionPopup::matchAutoComplete(const QString& placeholder) const
+{
+    for (const QString& item : m_autoCompletionPlaceholdersList) {
+        if (item.startsWith(placeholder)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Custom text edit to display HTML colored text
+EntryPlaceholderTextEdit::EntryPlaceholderTextEdit(QWidget* parent)
+    : QTextEdit(parent)
+    , m_entry(nullptr)
+    , m_autoCompletionPopup(new EntryPlaceholderCompletionPopup(this))
+{
+    setFocusPolicy(Qt::StrongFocus);
+    setTabChangesFocus(true);
+    setFixedHeight(32);
+    viewport()->setCursor(Qt::IBeamCursor);
+
+    connect(this, SIGNAL(cursorPositionChanged()), SLOT(trackCursorPosition()));
+    connect(m_autoCompletionPopup, &EntryPlaceholderCompletionPopup::autoCompletionChoiceSelected, this, &EntryPlaceholderTextEdit::applyAutoCompletion);
+}
+
+// triggers each time the cursor position changes (not the mouse cursor position, the TEXT cursor position)
+void EntryPlaceholderTextEdit::trackCursorPosition()
+{
+    const int pos = textCursor().position();
+    const QString txtBefore = toPlainText().mid(0, pos);
+    const QString txtAfter = toPlainText().mid(pos, -1);
+    const QString placeholderPreCursor = getPlaceholderBeforeCursor();
+    QChar lastCharBefore = txtBefore.isEmpty() ? QChar() : txtBefore[txtBefore.size()-1];
+    QChar firstCharAfter = txtAfter.isEmpty() ? QChar() : txtAfter[0];
+
+    // Check whether the auto-complete popup needs to move, or to be hidden/shown
+    if (!txtBefore.isEmpty()) {
+        auto pt = cursorRect().bottomLeft();
+        pt.setY(pt.y() + 7);
+        pt.setX(pt.x() + 5);
+
+        if (lastCharBefore=='{') {
+            m_autoCompletionPopup->move( mapToGlobal(pt) );
+            m_autoCompletionPopup->show();
+        }
+        else if (lastCharBefore=='}' || firstCharAfter=='{') {
+            m_autoCompletionPopup->hide();
+            return;
+        }
+        else if (placeholderPreCursor.size()>0) {
+            const bool phIsValid = m_autoCompletionPopup->matchAutoComplete(placeholderPreCursor.mid(1, -1));
+            if (phIsValid) {
+                m_autoCompletionPopup->move( mapToGlobal(pt) );
+                m_autoCompletionPopup->show();
+            }
+        }
+    }
+
+    m_autoCompletionPopup->populateCompletionChoices(placeholderPreCursor);
+}
+
+void EntryPlaceholderTextEdit::applyAutoCompletion(QString placeholderName)
+{
+    m_autoCompletionPopup->hide();
+    const QString placeholderPreCursor = getPlaceholderBeforeCursor();
+    QString placeholderPostCursor = getPlaceholderAfterCursor();
+    QString placeholder = placeholderName.append("}");
+    const bool replaceExistingPlaceholder = !placeholderPostCursor.endsWith(" ");
+    if (!replaceExistingPlaceholder) {
+        placeholderPostCursor.chop(1);
+        placeholder.append(" ");
+    }
+
+    QTextCursor cur{textCursor()};
+    const int pos = cur.position();
+    const int startPos = pos + 1 /* for the { char */ - placeholderPreCursor.size();
+    const int nbCharsToReplace = placeholderPreCursor.size() + placeholderPostCursor.size();
+    const int newCursorPos = pos + 1 /* for the } char */ - placeholderPreCursor.size() + placeholderName.size() + (replaceExistingPlaceholder ? 1 : 0) /* for the extra space */;
+
+    QString txt = toPlainText();
+    txt.replace(startPos, nbCharsToReplace, placeholder);
+    setText(txt);
+    cur.setPosition(newCursorPos);
+    setTextCursor(cur);
+    redrawPlaceHolders();
+}
+
+void EntryPlaceholderTextEdit::setEntry(Entry* e)
+{
+    if (!e) return;
+    m_entry = e;
+    setText(e->title());
+    redrawPlaceHolders();
+}
+
+void EntryPlaceholderTextEdit::keyPressEvent(QKeyEvent* e)
+{
+    const QString currentAutoCompleteItemText = m_autoCompletionPopup->getCurrentItemText();
+    const int currentAutoCompleteItemIndex = m_autoCompletionPopup->getCurrentItemIndex();
+    const int key = e->key();
+
+    if (key == Qt::Key_Enter || key == Qt::Key_Return) {
+        if (m_autoCompletionPopup->isHidden()) {
+            emit accepted();
+        }
+        else {
+            applyAutoCompletion(currentAutoCompleteItemText);
+        }
+        return;
+    }
+    if (key == Qt::Key_Up) {
+        const int idx = currentAutoCompleteItemIndex;
+        if (idx > 0)
+        {
+            m_autoCompletionPopup->setCurrentIndex(idx-1);
+        }
+        return;
+    }
+    if (key == Qt::Key_Down) {
+        const int idx = currentAutoCompleteItemIndex;
+        if (idx < m_autoCompletionPopup->count()-1)
+        {
+            m_autoCompletionPopup->setCurrentIndex(idx+1);
+        }
+        return;
+    }
+    if (key == Qt::Key_Tab) {
+        if (!m_autoCompletionPopup->isHidden())
+        {
+            applyAutoCompletion(currentAutoCompleteItemText);
+        }
+        return;
+    }
+    if (key == Qt::Key_Escape) {
+        if (!m_autoCompletionPopup->isHidden())
+        {
+            m_autoCompletionPopup->hide();
+        }
+        else {
+            emit canceled();
+        }
+        return;
+    }
+    QTextEdit::keyPressEvent(e);
+    emit textChanged(toPlainText());
+    redrawPlaceHolders();
+}
+
+// Do not use paintEvent, because we are modifying the text (HTML content)
+void EntryPlaceholderTextEdit::redrawPlaceHolders()
+{
+    if (!m_entry) return;
+    QTextCursor cur{textCursor()};
+    const int originalPos = cur.position();
+    QStringList replacedList;
+    QString styledTitle = toPlainText().replace(" ", "&nbsp;"); // 2 consecutive spaces do not display in HTML
+    QRegularExpression rx("{[^}{]+}");
+    QRegularExpressionMatchIterator i = rx.globalMatch(styledTitle);
+    while (i.hasNext())
+    {
+        QRegularExpressionMatch match = i.next();
+        EntryPlaceholder ph{match.captured()};
+        const QString placeholder = ph.getString();
+        const auto phType = m_entry->placeholderType(placeholder);
+        if (phType==Entry::PlaceholderType::NotPlaceholder || phType==Entry::PlaceholderType::Unknown) {
+            continue;
+        }
+        QString substitution = m_entry->resolvePlaceholder(placeholder);
+        if (!replacedList.contains(placeholder) && substitution != placeholder) {
+            const bool isSubstitutionInvalid = substitution.isEmpty() || substitution=="-1";
+            const QString styledPh = ph.getStyledString(isSubstitutionInvalid);
+            styledTitle.replace(placeholder, styledPh);
+            replacedList << placeholder;
+        }
+    }
+    if (replacedList.size() > 0)
+    {
+        setHtml(styledTitle);
+        cur.setPosition(originalPos);
+        setTextCursor(cur);
+    }
+}
+
+QString EntryPlaceholderTextEdit::getPlaceholderBeforeCursor() const
+{
+    const int pos = textCursor().position();
+    const QString txtBefore = toPlainText().mid(0, pos);
+
+    if (pos>0) {
+        for (int i=txtBefore.size()-1; i>=0; --i)
+        {
+            if (txtBefore[i]=='{')
+            {
+                return txtBefore.mid(i, pos-1);
+            }
+        }
+    }
+    return "";
+}
+
+QString EntryPlaceholderTextEdit::getPlaceholderAfterCursor() const
+{
+    const int pos = textCursor().position();
+    const QString txtAfter = toPlainText().mid(pos, -1);
+
+    if (txtAfter.size() > 0) {
+        if (txtAfter[0]==" ") {
+            return "";
+        }
+        for (int i=0; i<=txtAfter.size(); ++i)
+        {
+            if (txtAfter[i]=='{' || txtAfter[i]=='}')
+            {
+                return txtAfter.mid(0, i);
+            }
+        }
+    }
+    return "";
+}
+

--- a/src/gui/entry/EntryPlaceholderTextEdit.cpp
+++ b/src/gui/entry/EntryPlaceholderTextEdit.cpp
@@ -1,49 +1,45 @@
 #include "EntryPlaceholderTextEdit.h"
 
 #include <QCoreApplication>
-#include <QtGlobal>
 #include <QKeyEvent>
-#include <QMenu>
 #include <QListWidget>
-#include <QStringList>
+#include <QMenu>
 #include <QRegularExpression>
+#include <QStringList>
+#include <QtGlobal>
 
 #include "core/Entry.h"
 #include "gui/Icons.h"
-
 
 EntryPlaceholder::EntryPlaceholder(const QString& placeholder)
     : m_fullText(placeholder)
 {
     QString ph = placeholder;
     // Remove brackets
-    if (!ph.isEmpty())
-    {
-        if (ph[0]=='{') {
+    if (!ph.isEmpty()) {
+        if (ph[0] == '{') {
             ph = ph.mid(1);
         }
-        if (ph[ph.size()-1]=='}') {
-            ph = ph.mid(0, ph.size()-1);
+        if (ph[ph.size() - 1] == '}') {
+            ph = ph.mid(0, ph.size() - 1);
         }
     }
     // Parse placeholder parts
     const QStringList parts = ph.split(QLatin1Char(':'), QString::SplitBehavior::SkipEmptyParts);
     const int sz = parts.size();
-    if (sz==1) {
+    if (sz == 1) {
         // simple placeholder
         m_value = parts[0];
-    }
-    else if (sz==2) {
+    } else if (sz == 2) {
         // key-value pair placeholder (URL or S placeholders)
         m_key = parts[0];
         m_value = parts[1];
-    }
-    else if (sz==3) {
+    } else if (sz == 3) {
         // REF placeholder only
         m_key = parts[0];
         m_value = parts[2];
         const QStringList crossRef = parts[1].split(QLatin1Char('@'), QString::SplitBehavior::SkipEmptyParts);
-        if (crossRef.size()==2) {
+        if (crossRef.size() == 2) {
             m_crossReferenceField = crossRef[0];
             m_crossReferenceSearchIn = crossRef[1];
         }
@@ -62,12 +58,10 @@ QString EntryPlaceholder::getStyledString(const bool emptyTargetValue) const
 
     if (m_key.isEmpty()) {
         htmlTag.append(m_value);
-    }
-    else if (m_key=="S" || m_key=="URL") {
-        htmlTag.append(m_key+":"+m_value);
-    }
-    else if (m_key=="REF") {
-        htmlTag.append(m_key+":"+m_crossReferenceField+"@"+m_crossReferenceSearchIn+":"+m_value);
+    } else if (m_key == "S" || m_key == "URL") {
+        htmlTag.append(m_key + ":" + m_value);
+    } else if (m_key == "REF") {
+        htmlTag.append(m_key + ":" + m_crossReferenceField + "@" + m_crossReferenceSearchIn + ":" + m_value);
     }
 
     htmlTag.append("}").append("</").append(emptyTargetValue ? "span" : "b").append(">");
@@ -79,7 +73,7 @@ EntryPlaceholderCompletionPopup::EntryPlaceholderCompletionPopup(QWidget* parent
 {
     // Setup autocompletion popup
     setAttribute(Qt::WA_QuitOnClose, false);
-    setFixedSize(150,200);
+    setFixedSize(150, 200);
     setWindowFlags(Qt::FramelessWindowHint | Qt::Tool);
     setWindowModality(Qt::NonModal);
 
@@ -88,7 +82,7 @@ EntryPlaceholderCompletionPopup::EntryPlaceholderCompletionPopup(QWidget* parent
     placeholders.append("{S:}");
     m_autoCompletionList = new QListWidget(this);
     for (const QString& placeholder : placeholders) {
-        const QString phName = placeholder.mid(1, placeholder.size()-2);
+        const QString phName = placeholder.mid(1, placeholder.size() - 2);
         m_autoCompletionPlaceholdersList.append(phName);
         new QListWidgetItem(phName, m_autoCompletionList);
     }
@@ -114,17 +108,18 @@ void EntryPlaceholderCompletionPopup::itemClicked(QListWidgetItem* item)
 
 void EntryPlaceholderCompletionPopup::populateCompletionChoices(const QString& filter)
 {
-    if (isHidden()) return;
+    if (isHidden())
+        return;
     m_autoCompletionList->clear();
 
     if (!filter.endsWith(":")) {
         for (const QString& placeholder : m_autoCompletionPlaceholdersList) {
-            if (filter.isEmpty() || filter=="{" || placeholder.startsWith(filter.mid(1))) {
+            if (filter.isEmpty() || filter == "{" || placeholder.startsWith(filter.mid(1))) {
                 new QListWidgetItem(placeholder, m_autoCompletionList);
             }
         }
     }
-    if (count()==0) {
+    if (count() == 0) {
         hide();
     }
 }
@@ -173,7 +168,10 @@ EntryPlaceholderTextEdit::EntryPlaceholderTextEdit(QWidget* parent)
     viewport()->setCursor(Qt::IBeamCursor);
 
     connect(this, SIGNAL(cursorPositionChanged()), SLOT(trackCursorPosition()));
-    connect(m_autoCompletionPopup, &EntryPlaceholderCompletionPopup::autoCompletionChoiceSelected, this, &EntryPlaceholderTextEdit::applyAutoCompletion);
+    connect(m_autoCompletionPopup,
+            &EntryPlaceholderCompletionPopup::autoCompletionChoiceSelected,
+            this,
+            &EntryPlaceholderTextEdit::applyAutoCompletion);
 }
 
 // triggers each time the cursor position changes (not the mouse cursor position, the TEXT cursor position)
@@ -183,7 +181,7 @@ void EntryPlaceholderTextEdit::trackCursorPosition()
     const QString txtBefore = toPlainText().mid(0, pos);
     const QString txtAfter = toPlainText().mid(pos, -1);
     const QString placeholderPreCursor = getPlaceholderBeforeCursor();
-    QChar lastCharBefore = txtBefore.isEmpty() ? QChar() : txtBefore[txtBefore.size()-1];
+    QChar lastCharBefore = txtBefore.isEmpty() ? QChar() : txtBefore[txtBefore.size() - 1];
     QChar firstCharAfter = txtAfter.isEmpty() ? QChar() : txtAfter[0];
 
     // Check whether the auto-complete popup needs to move, or to be hidden/shown
@@ -192,18 +190,16 @@ void EntryPlaceholderTextEdit::trackCursorPosition()
         pt.setY(pt.y() + 7);
         pt.setX(pt.x() + 5);
 
-        if (lastCharBefore=='{') {
-            m_autoCompletionPopup->move( mapToGlobal(pt) );
+        if (lastCharBefore == '{') {
+            m_autoCompletionPopup->move(mapToGlobal(pt));
             m_autoCompletionPopup->show();
-        }
-        else if (lastCharBefore=='}' || firstCharAfter=='{') {
+        } else if (lastCharBefore == '}' || firstCharAfter == '{') {
             m_autoCompletionPopup->hide();
             return;
-        }
-        else if (placeholderPreCursor.size()>0) {
+        } else if (placeholderPreCursor.size() > 0) {
             const bool phIsValid = m_autoCompletionPopup->matchAutoComplete(placeholderPreCursor.mid(1, -1));
             if (phIsValid) {
-                m_autoCompletionPopup->move( mapToGlobal(pt) );
+                m_autoCompletionPopup->move(mapToGlobal(pt));
                 m_autoCompletionPopup->show();
             }
         }
@@ -228,7 +224,8 @@ void EntryPlaceholderTextEdit::applyAutoCompletion(QString placeholderName)
     const int pos = cur.position();
     const int startPos = pos + 1 /* for the { char */ - placeholderPreCursor.size();
     const int nbCharsToReplace = placeholderPreCursor.size() + placeholderPostCursor.size();
-    const int newCursorPos = pos + 1 /* for the } char */ - placeholderPreCursor.size() + placeholderName.size() + (replaceExistingPlaceholder ? 1 : 0) /* for the extra space */;
+    const int newCursorPos = pos + 1 /* for the } char */ - placeholderPreCursor.size() + placeholderName.size()
+                             + (replaceExistingPlaceholder ? 1 : 0) /* for the extra space */;
 
     QString txt = toPlainText();
     txt.replace(startPos, nbCharsToReplace, placeholder);
@@ -240,7 +237,8 @@ void EntryPlaceholderTextEdit::applyAutoCompletion(QString placeholderName)
 
 void EntryPlaceholderTextEdit::setEntry(Entry* e, const QString& text)
 {
-    if (!e) return;
+    if (!e)
+        return;
     m_entry = e;
     setText(text);
     redrawPlaceHolders();
@@ -255,41 +253,35 @@ void EntryPlaceholderTextEdit::keyPressEvent(QKeyEvent* e)
     if (key == Qt::Key_Enter || key == Qt::Key_Return) {
         if (m_autoCompletionPopup->isHidden()) {
             emit accepted();
-        }
-        else {
+        } else {
             applyAutoCompletion(currentAutoCompleteItemText);
         }
         return;
     }
     if (key == Qt::Key_Up) {
         const int idx = currentAutoCompleteItemIndex;
-        if (idx > 0)
-        {
-            m_autoCompletionPopup->setCurrentIndex(idx-1);
+        if (idx > 0) {
+            m_autoCompletionPopup->setCurrentIndex(idx - 1);
         }
         return;
     }
     if (key == Qt::Key_Down) {
         const int idx = currentAutoCompleteItemIndex;
-        if (idx < m_autoCompletionPopup->count()-1)
-        {
-            m_autoCompletionPopup->setCurrentIndex(idx+1);
+        if (idx < m_autoCompletionPopup->count() - 1) {
+            m_autoCompletionPopup->setCurrentIndex(idx + 1);
         }
         return;
     }
     if (key == Qt::Key_Tab) {
-        if (!m_autoCompletionPopup->isHidden())
-        {
+        if (!m_autoCompletionPopup->isHidden()) {
             applyAutoCompletion(currentAutoCompleteItemText);
         }
         return;
     }
     if (key == Qt::Key_Escape) {
-        if (!m_autoCompletionPopup->isHidden())
-        {
+        if (!m_autoCompletionPopup->isHidden()) {
             m_autoCompletionPopup->hide();
-        }
-        else {
+        } else {
             emit canceled();
         }
         return;
@@ -302,32 +294,31 @@ void EntryPlaceholderTextEdit::keyPressEvent(QKeyEvent* e)
 // Do not use paintEvent, because we are modifying the text (HTML content)
 void EntryPlaceholderTextEdit::redrawPlaceHolders()
 {
-    if (!m_entry) return;
+    if (!m_entry)
+        return;
     QTextCursor cur{textCursor()};
     const int originalPos = cur.position();
     QStringList replacedList;
     QString styledText = toPlainText().replace(" ", "&nbsp;"); // 2 consecutive spaces do not display in HTML
     QRegularExpression rx("{[^}{]+}");
     QRegularExpressionMatchIterator i = rx.globalMatch(styledText);
-    while (i.hasNext())
-    {
+    while (i.hasNext()) {
         QRegularExpressionMatch match = i.next();
         EntryPlaceholder ph{match.captured()};
         const QString placeholder = ph.getString();
         const auto phType = m_entry->placeholderType(placeholder);
-        if (phType==Entry::PlaceholderType::NotPlaceholder || phType==Entry::PlaceholderType::Unknown) {
+        if (phType == Entry::PlaceholderType::NotPlaceholder || phType == Entry::PlaceholderType::Unknown) {
             continue;
         }
         QString substitution = m_entry->resolvePlaceholder(placeholder);
         if (!replacedList.contains(placeholder) && substitution != placeholder) {
-            const bool isSubstitutionInvalid = substitution.isEmpty() || substitution=="-1";
+            const bool isSubstitutionInvalid = substitution.isEmpty() || substitution == "-1";
             const QString styledPh = ph.getStyledString(isSubstitutionInvalid);
             styledText.replace(placeholder, styledPh);
             replacedList << placeholder;
         }
     }
-    if (replacedList.size() > 0)
-    {
+    if (replacedList.size() > 0) {
         setHtml(styledText);
         cur.setPosition(originalPos);
         setTextCursor(cur);
@@ -339,12 +330,10 @@ QString EntryPlaceholderTextEdit::getPlaceholderBeforeCursor() const
     const int pos = textCursor().position();
     const QString txtBefore = toPlainText().mid(0, pos);
 
-    if (pos>0) {
-        for (int i=txtBefore.size()-1; i>=0; --i)
-        {
-            if (txtBefore[i]=='{')
-            {
-                return txtBefore.mid(i, pos-1);
+    if (pos > 0) {
+        for (int i = txtBefore.size() - 1; i >= 0; --i) {
+            if (txtBefore[i] == '{') {
+                return txtBefore.mid(i, pos - 1);
             }
         }
     }
@@ -357,17 +346,14 @@ QString EntryPlaceholderTextEdit::getPlaceholderAfterCursor() const
     const QString txtAfter = toPlainText().mid(pos, -1);
 
     if (txtAfter.size() > 0) {
-        if (txtAfter[0]==" ") {
+        if (txtAfter[0] == " ") {
             return "";
         }
-        for (int i=0; i<=txtAfter.size(); ++i)
-        {
-            if (txtAfter[i]=='{' || txtAfter[i]=='}')
-            {
+        for (int i = 0; i <= txtAfter.size(); ++i) {
+            if (txtAfter[i] == '{' || txtAfter[i] == '}') {
                 return txtAfter.mid(0, i);
             }
         }
     }
     return "";
 }
-

--- a/src/gui/entry/EntryPlaceholderTextEdit.cpp
+++ b/src/gui/entry/EntryPlaceholderTextEdit.cpp
@@ -27,7 +27,7 @@ EntryPlaceholder::EntryPlaceholder(const QString& placeholder)
         }
     }
     // Parse placeholder parts
-    const QStringList parts = ph.split(QLatin1Char(':'), Qt::SkipEmptyParts);
+    const QStringList parts = ph.split(QLatin1Char(':'), QString::SplitBehavior::SkipEmptyParts);
     const int sz = parts.size();
     if (sz==1) {
         // simple placeholder
@@ -42,7 +42,7 @@ EntryPlaceholder::EntryPlaceholder(const QString& placeholder)
         // REF placeholder only
         m_key = parts[0];
         m_value = parts[2];
-        const QStringList crossRef = parts[1].split(QLatin1Char('@'), Qt::SkipEmptyParts);
+        const QStringList crossRef = parts[1].split(QLatin1Char('@'), QString::SplitBehavior::SkipEmptyParts);
         if (crossRef.size()==2) {
             m_crossReferenceField = crossRef[0];
             m_crossReferenceSearchIn = crossRef[1];

--- a/src/gui/entry/EntryPlaceholderTextEdit.h
+++ b/src/gui/entry/EntryPlaceholderTextEdit.h
@@ -89,7 +89,7 @@ class EntryPlaceholderTextEdit : public QTextEdit
 public:
     explicit EntryPlaceholderTextEdit(QWidget* parent);
 
-    void setEntry(Entry* e);
+    void setEntry(Entry* e, const QString& text);
 
 signals:
     void textChanged(QString newContent);

--- a/src/gui/entry/EntryPlaceholderTextEdit.h
+++ b/src/gui/entry/EntryPlaceholderTextEdit.h
@@ -90,6 +90,7 @@ public:
     explicit EntryPlaceholderTextEdit(QWidget* parent);
 
     void setEntry(Entry* e, const QString& text);
+    QString text() const { return toPlainText(); }
 
 signals:
     void textChanged(QString newContent);

--- a/src/gui/entry/EntryPlaceholderTextEdit.h
+++ b/src/gui/entry/EntryPlaceholderTextEdit.h
@@ -1,0 +1,115 @@
+/*
+  MIT License
+
+  Copyright (c) 2022 KeePassXC Team <team@keepassxc.org>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#pragma once
+
+#include <QTextEdit>
+
+class Entry;
+class QListWidget;
+class QListWidgetItem;
+
+
+struct EntryPlaceholder
+{
+    EntryPlaceholder(const QString& placeholder);
+
+    QString getString() const { return m_fullText; }
+    QString getStyledString(const bool emptyTargetValue) const;
+    QString getKey() const { return m_key; }
+    QString getValue() const { return m_value; }
+    QString getRefField() const { return m_crossReferenceField; }
+    QString getRefSearchIn() const { return m_crossReferenceSearchIn; }
+
+private:
+    QString m_fullText;
+    QString m_key;
+    QString m_value;
+    QString m_crossReferenceField;
+    QString m_crossReferenceSearchIn;
+};
+
+
+class EntryPlaceholderCompletionPopup : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit EntryPlaceholderCompletionPopup(QWidget* parent);
+
+    int count() const;
+    int getCurrentItemIndex() const;
+    QString getCurrentItemText() const;
+
+    void setCurrentIndex(const int idx) const;
+    void populateCompletionChoices(const QString& filter);
+
+    bool matchAutoComplete(const QString& placeholder) const;
+
+signals:
+    void autoCompletionChoiceSelected(QString choice);
+
+private slots:
+    void itemActivated(QListWidgetItem* item);
+    void itemClicked(QListWidgetItem* item);
+
+private:
+    QListWidget* m_autoCompletionList;
+    QStringList m_autoCompletionPlaceholdersList;
+
+    Q_DISABLE_COPY(EntryPlaceholderCompletionPopup)
+};
+
+
+class EntryPlaceholderTextEdit : public QTextEdit
+{
+    Q_OBJECT
+
+public:
+    explicit EntryPlaceholderTextEdit(QWidget* parent);
+
+    void setEntry(Entry* e);
+
+signals:
+    void textChanged(QString newContent);
+    void accepted();
+    void canceled();
+
+protected:
+    virtual void keyPressEvent(QKeyEvent *e) override;
+
+private slots:
+    void trackCursorPosition();
+    void applyAutoCompletion(QString placeholderName);
+
+private:
+    Entry* m_entry;
+    EntryPlaceholderCompletionPopup* m_autoCompletionPopup;
+
+    void redrawPlaceHolders();
+    QString getPlaceholderBeforeCursor() const;
+    QString getPlaceholderAfterCursor() const;
+
+    Q_DISABLE_COPY(EntryPlaceholderTextEdit)
+};

--- a/src/gui/entry/EntryPlaceholderTextEdit.h
+++ b/src/gui/entry/EntryPlaceholderTextEdit.h
@@ -30,17 +30,31 @@ class Entry;
 class QListWidget;
 class QListWidgetItem;
 
-
 struct EntryPlaceholder
 {
     EntryPlaceholder(const QString& placeholder);
 
-    QString getString() const { return m_fullText; }
+    QString getString() const
+    {
+        return m_fullText;
+    }
     QString getStyledString(const bool emptyTargetValue) const;
-    QString getKey() const { return m_key; }
-    QString getValue() const { return m_value; }
-    QString getRefField() const { return m_crossReferenceField; }
-    QString getRefSearchIn() const { return m_crossReferenceSearchIn; }
+    QString getKey() const
+    {
+        return m_key;
+    }
+    QString getValue() const
+    {
+        return m_value;
+    }
+    QString getRefField() const
+    {
+        return m_crossReferenceField;
+    }
+    QString getRefSearchIn() const
+    {
+        return m_crossReferenceSearchIn;
+    }
 
 private:
     QString m_fullText;
@@ -49,7 +63,6 @@ private:
     QString m_crossReferenceField;
     QString m_crossReferenceSearchIn;
 };
-
 
 class EntryPlaceholderCompletionPopup : public QWidget
 {
@@ -81,7 +94,6 @@ private:
     Q_DISABLE_COPY(EntryPlaceholderCompletionPopup)
 };
 
-
 class EntryPlaceholderTextEdit : public QTextEdit
 {
     Q_OBJECT
@@ -90,7 +102,10 @@ public:
     explicit EntryPlaceholderTextEdit(QWidget* parent);
 
     void setEntry(Entry* e, const QString& text);
-    QString text() const { return toPlainText(); }
+    QString text() const
+    {
+        return toPlainText();
+    }
 
 signals:
     void textChanged(QString newContent);
@@ -98,7 +113,7 @@ signals:
     void canceled();
 
 protected:
-    virtual void keyPressEvent(QKeyEvent *e) override;
+    virtual void keyPressEvent(QKeyEvent* e) override;
 
 private slots:
     void trackCursorPosition();


### PR DESCRIPTION
Implement #5900, points 1, 2 and 3.

## Notes
* There is an issue with the field not being rendered when the Entry is opened. A keyboard key has to be pressed in order for the colours to apply. I have tried various things (update(), viewport->update(), QApp:processEvents(), reRender()...) but couldn't figure it out.
* I did not implement the tooltips as discussed in #5900, the colours/bold format already conveys this information, so I've omitted tooltips to keep the PR simple. This can be added easily later of course.
* QTextEdit does not have any addAction() method like QLineEdit does... so adding a button at the end of the field (to toggle the placeholder content/target values) will need to be done with a sub-layout. I figured this is not worth the effort for now, as we said we should keep this as simple as possible for now. Should be very easy to add though.


## Screenshots
![Screenshot_20220606_084205](https://user-images.githubusercontent.com/105943093/172118336-d1b9188f-c741-4eba-b4c8-1ee035389b5c.png)


## Testing strategy
Tested manually (GUI) as this is a visual/graphical improvement feature. 


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
