### PR TITLE
Fix crash when trying to close database during unlock

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <QCheckBox>
+#include <QCloseEvent>
 #include <QDesktopServices>
 #include <QFont>
 
@@ -166,6 +167,11 @@ void DatabaseOpenWidget::hideEvent(QHideEvent* event)
     if (!isVisible()) {
         m_hideTimer.start();
     }
+}
+
+bool DatabaseOpenWidget::unlockingDatabase()
+{
+    return m_unlockingDatabase;
 }
 
 void DatabaseOpenWidget::load(const QString& filename)
@@ -522,6 +528,7 @@ void DatabaseOpenWidget::setUserInteractionLock(bool state)
         }
         m_ui->centralStack->setEnabled(true);
     }
+    m_unlockingDatabase = state;
 }
 
 bool DatabaseOpenWidget::isOnQuickUnlockScreen()

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -46,6 +46,7 @@ public:
     void enterKey(const QString& pw, const QString& keyFile);
     QSharedPointer<Database> database();
     void resetQuickUnlock();
+    bool unlockingDatabase();
 
 signals:
     void dialogFinished(bool accepted);
@@ -78,6 +79,7 @@ private slots:
 private:
     bool m_pollingHardwareKey = false;
     bool m_blockQuickUnlock = false;
+    bool m_unlockingDatabase = false;
     QTimer m_hideTimer;
 
     Q_DISABLE_COPY(DatabaseOpenWidget)

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1565,12 +1565,12 @@ Group* DatabaseWidget::currentGroup() const
 
 void DatabaseWidget::closeEvent(QCloseEvent* event)
 {
-    if (!isLocked() && !lock()) {
+    if (!lock() || m_databaseOpenWidget->unlockingDatabase()) {
         event->ignore();
         return;
     }
-    m_databaseOpenWidget->resetQuickUnlock();
 
+    m_databaseOpenWidget->resetQuickUnlock();
     event->accept();
 }
 


### PR DESCRIPTION
* Fix #7239 - prevent closing the database widget if the open dialog is still unlocking the database. This problem became slightly worse with quick unlock.

With this fix, if the user tries to close the database during unlock we will just ignore that request.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
