### PR TITLE
Allow KeePassXC to be built without X11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ if(UNIX AND NOT APPLE)
 endif()
 option(WITH_XC_DOCS "Enable building of documentation" ON)
 
+set(WITH_XC_X11 ON CACHE BOOL "Enable building with X11 deps")
+
 if(APPLE)
     # Perform the platform checks before applying the stricter compiler flags.
     # Otherwise the kSecAccessControlTouchIDCurrentSet deprecation warning will result in an error.
@@ -108,6 +110,11 @@ endif()
 if(NOT WITH_XC_NETWORKING AND WITH_XC_UPDATECHECK)
     message(STATUS "Disabling WITH_XC_UPDATECHECK because WITH_XC_NETWORKING is disabled")
     set(WITH_XC_UPDATECHECK OFF)
+endif()
+
+if(UNIX AND NOT APPLE AND NOT WITH_XC_X11)
+    message(STATUS "Disabling WITH_XC_AUTOTYPE because WITH_XC_X11 is disabled")
+    set(WITH_XC_AUTOTYPE OFF)
 endif()
 
 set(KEEPASSXC_VERSION_MAJOR "2")
@@ -466,7 +473,10 @@ include(CLangFormat)
 
 set(QT_COMPONENTS Core Network Concurrent Gui Svg Widgets Test LinguistTools)
 if(UNIX AND NOT APPLE)
-    find_package(Qt5 COMPONENTS ${QT_COMPONENTS} DBus X11Extras REQUIRED)
+    if(WITH_XC_X11)
+        list(APPEND QT_COMPONENTS X11Extras)
+    endif()
+    find_package(Qt5 COMPONENTS ${QT_COMPONENTS} DBus REQUIRED)
 elseif(APPLE)
     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED HINTS
             /usr/local/opt/qt/lib/cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,8 +206,11 @@ if(UNIX AND NOT APPLE)
     set(keepassx_SOURCES
             ${keepassx_SOURCES}
             gui/osutils/nixutils/ScreenLockListenerDBus.cpp
-            gui/osutils/nixutils/NixUtils.cpp
+            gui/osutils/nixutils/NixUtils.cpp)
+    if(WITH_XC_X11)
+        list(APPEND keepassx_SOURCES
             gui/osutils/nixutils/X11Funcs.cpp)
+    endif()
     qt5_add_dbus_adaptor(keepassx_SOURCES
             gui/org.keepassxc.KeePassXC.MainWindow.xml
             gui/MainWindow.h
@@ -359,7 +362,10 @@ if(HAIKU)
     target_link_libraries(keepassx_core network)
 endif()
 if(UNIX AND NOT APPLE)
-    target_link_libraries(keepassx_core Qt5::DBus Qt5::X11Extras X11)
+    target_link_libraries(keepassx_core Qt5::DBus)
+    if(WITH_XC_X11)
+        target_link_libraries(keepassx_core Qt5::X11Extras X11)
+    endif()
     include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 if(WIN32)


### PR DESCRIPTION
KeePassXC can be built without X11 (with disabled autotype) before commit 404fd941e8e5428c8fe80c78f16ff7e4fa09aff4.
Current commit is restoring this behaviour, by option WITH_XC_X11 (enabled by default)

## Testing strategy
Build with -DWITH_XC_X11=no, checking that it can be built on systems with qtx11extras and x11 not installed. After that, check that it can be started and is working properly (except autotype and capslock)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)



