### PR TITLE
Add Ctrl+Tab shortcut to cycle databases in unlock dialog

### DIFF
--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -59,11 +59,22 @@ DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
     setLayout(layout);
     setMinimumWidth(700);
 
-    // set up Ctrl+PageUp and Ctrl+PageDown shortcuts to cycle tabs
+    // set up Ctrl+PageUp / Ctrl+PageDown and Ctrl+Tab / Ctrl+Shift+Tab shortcuts to cycle tabs
+    // Ctrl+Tab is broken on Mac, so use Alt (i.e. the Option key) - https://bugreports.qt.io/browse/QTBUG-8596
+    auto dbTabModifier = Qt::CTRL;
+#ifdef Q_OS_MACOS
+    dbTabModifier = Qt::ALT;
+#endif
     auto* shortcut = new QShortcut(Qt::CTRL + Qt::Key_PageUp, this);
     shortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(shortcut, &QShortcut::activated, this, [this]() { selectTabOffset(-1); });
+    shortcut = new QShortcut(dbTabModifier + Qt::Key_Tab, this);
+    shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(shortcut, &QShortcut::activated, this, [this]() { selectTabOffset(-1); });
     shortcut = new QShortcut(Qt::CTRL + Qt::Key_PageDown, this);
+    shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(shortcut, &QShortcut::activated, this, [this]() { selectTabOffset(1); });
+    shortcut = new QShortcut(dbTabModifier + Qt::SHIFT + Qt::Key_Tab, this);
     shortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(shortcut, &QShortcut::activated, this, [this]() { selectTabOffset(1); });
 }


### PR DESCRIPTION
The main window has both `Ctrl+PageUp` / `Ctrl+PageDown` and `Ctrl+Tab / Ctrl+Shift+Tab` shortcuts to cycle the database tabs. When in PR #5427 the abbility to select any open database in the unlock dialog was introduced, only the `Ctrl+PageUp` / `Ctrl+PageDown` shortcuts were added. This commit adds the `Ctrl+Tab / Ctrl+Shift+Tab` shortcuts to the unlock diaglog to fix this inconsistent UI behaviour.

## Screenshots

None.


## Testing strategy

I was able to compile and run the application.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )

- ✅ New feature (change that adds functionality)
