### PR TITLE
autostart: Linux: Exec= filename not absolute path

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -128,15 +128,15 @@ void NixUtils::setLaunchAtStartup(bool enable)
 
         const QString appImagePath = QString::fromLocal8Bit(qgetenv("APPIMAGE"));
         const bool isAppImage = !appImagePath.isNull() && QFile::exists(appImagePath);
-        const QString executeablePath = isAppImage ? appImagePath : QApplication::applicationFilePath();
+        const QString executeablePathOrName = isAppImage ? appImagePath : QApplication::applicationName().toLower();
 
         QTextStream stream(&desktopFile);
         stream.setCodec("UTF-8");
         stream << QStringLiteral("[Desktop Entry]") << '\n'
                << QStringLiteral("Name=") << QApplication::applicationDisplayName() << '\n'
                << QStringLiteral("GenericName=") << tr("Password Manager") << '\n'
-               << QStringLiteral("Exec=") << executeablePath << '\n'
-               << QStringLiteral("TryExec=") << executeablePath << '\n'
+               << QStringLiteral("Exec=") << executeablePathOrName << '\n'
+               << QStringLiteral("TryExec=") << executeablePathOrName << '\n'
                << QStringLiteral("Icon=") << QApplication::applicationName().toLower() << '\n'
                << QStringLiteral("StartupWMClass=keepassxc") << '\n'
                << QStringLiteral("StartupNotify=true") << '\n'


### PR DESCRIPTION
Systems like NixOS install software under unique paths, so persisting
the absolute file path in the generated .desktop file when enabling
autostart will eventually point at an outdated or nonexistent program.

Another possible issue with using Qt's `applicationFilePath()` is that
the final program's basename (`argv[0]`) might not be the same as what
the user initially executed to start KeePassXC.

Use the file name and thus rely on `PATH` lookup just like the static
.desktop file does to lift those issues and defer execution logic
(`PATH` lookup, wrapper scripts, etc.) to the operating system.

## Testing strategy
Applied this patch to NixOS nixpkgs and inspected the resulting
`~/.config/autostart/org.keepassxc.KeePassXC.desktop` file.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
