### PR TITLE
Better handling of "Lock on Minimize" setting

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -227,6 +227,10 @@
         <source>Select backup storage directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This setting cannot be enabled when minimize on unlock is enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetGeneral</name>

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -134,6 +134,15 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
             m_secUi->lockDatabaseIdleSpinBox, SLOT(setEnabled(bool)));
     // clang-format on
 
+    connect(m_generalUi->minimizeAfterUnlockCheckBox, &QCheckBox::toggled, this, [this](bool state) {
+        if (state) {
+            m_secUi->lockDatabaseMinimizeCheckBox->setChecked(false);
+        }
+        m_secUi->lockDatabaseMinimizeCheckBox->setToolTip(
+            state ? tr("This setting cannot be enabled when minimize on unlock is enabled.") : "");
+        m_secUi->lockDatabaseMinimizeCheckBox->setEnabled(!state);
+    });
+
     // Disable mouse wheel grab when scrolling
     // This prevents combo box and spinner values from changing without explicit focus
     auto mouseWheelFilter = new MouseWheelEventFilter(this);
@@ -295,7 +304,8 @@ void ApplicationSettingsWidget::loadSettings()
 
     m_secUi->lockDatabaseIdleCheckBox->setChecked(config()->get(Config::Security_LockDatabaseIdle).toBool());
     m_secUi->lockDatabaseIdleSpinBox->setValue(config()->get(Config::Security_LockDatabaseIdleSeconds).toInt());
-    m_secUi->lockDatabaseMinimizeCheckBox->setChecked(config()->get(Config::Security_LockDatabaseMinimize).toBool());
+    m_secUi->lockDatabaseMinimizeCheckBox->setChecked(m_secUi->lockDatabaseMinimizeCheckBox->isEnabled()
+                                                      && config()->get(Config::Security_LockDatabaseMinimize).toBool());
     m_secUi->lockDatabaseOnScreenLockCheckBox->setChecked(
         config()->get(Config::Security_LockDatabaseScreenLock).toBool());
     m_secUi->fallbackToSearch->setChecked(config()->get(Config::Security_IconDownloadFallback).toBool());

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -34,6 +34,7 @@ class Clipboard : public QObject
 
 public:
     void setText(const QString& text, bool clear = true);
+    int secondsToClear();
 
     static Clipboard* instance();
 
@@ -51,8 +52,10 @@ private:
 
     static Clipboard* m_instance;
 
+    void sendCountdownStatus();
+
     QTimer* m_timer;
-    int m_secondsElapsed = 0;
+    int m_secondsToClear = 0;
 
 #ifdef Q_OS_MACOS
     // This object lives for the whole program lifetime and we cannot delete it on exit,

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -63,6 +63,9 @@ DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
 #ifdef Q_OS_MACOS
     connect(macUtils(), SIGNAL(lockDatabases()), SLOT(lockDatabases()));
 #endif
+
+    m_lockDelayTimer.setSingleShot(true);
+    connect(&m_lockDelayTimer, &QTimer::timeout, this, [this] { lockDatabases(); });
 }
 
 DatabaseTabWidget::~DatabaseTabWidget()
@@ -647,6 +650,18 @@ bool DatabaseTabWidget::lockDatabases()
     }
 
     return numLocked == c;
+}
+
+void DatabaseTabWidget::lockDatabasesDelayed()
+{
+    // Delay at least 1 second and up to 20 seconds depending on clipboard state.
+    // This allows for Auto-Type, Browser Extension, and clipboard to function
+    // even with "Lock on Minimize" setting enabled.
+    int lockDelay = qBound(1, clipboard()->secondsToClear(), 20);
+    m_lockDelayTimer.setInterval(lockDelay * 1000);
+    if (!m_lockDelayTimer.isActive()) {
+        m_lockDelayTimer.start();
+    }
 }
 
 /**

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -22,6 +22,7 @@
 #include "gui/MessageWidget.h"
 
 #include <QTabWidget>
+#include <QTimer>
 
 class Database;
 class DatabaseWidget;
@@ -72,6 +73,7 @@ public slots:
     void exportToHtml();
 
     bool lockDatabases();
+    void lockDatabasesDelayed();
     void closeDatabaseFromSender();
     void unlockDatabaseInDialog(DatabaseWidget* dbWidget, DatabaseOpenDialog::Intent intent);
     void unlockDatabaseInDialog(DatabaseWidget* dbWidget, DatabaseOpenDialog::Intent intent, const QString& filePath);
@@ -112,6 +114,7 @@ private:
     QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
     QPointer<DatabaseWidget> m_dbWidgetPendingLock;
     QPointer<DatabaseOpenDialog> m_databaseOpenDialog;
+    QTimer m_lockDelayTimer;
 };
 
 #endif // KEEPASSX_DATABASETABWIDGET_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1326,7 +1326,7 @@ void MainWindow::changeEvent(QEvent* event)
         }
 
         if (config()->get(Config::Security_LockDatabaseMinimize).toBool()) {
-            m_ui->tabWidget->lockDatabases();
+            m_ui->tabWidget->lockDatabasesDelayed();
         }
     } else {
         QMainWindow::changeEvent(event);
@@ -1674,7 +1674,7 @@ void MainWindow::hideWindow()
     }
 
     if (config()->get(Config::Security_LockDatabaseMinimize).toBool()) {
-        m_ui->tabWidget->lockDatabases();
+        m_ui->tabWidget->lockDatabasesDelayed();
     }
 }
 


### PR DESCRIPTION
* Fix #1090 - delay locking databases after minimize to allow for clipboard use, Auto-Type use, and browser integration use.

* Fix #6757 - prevent setting both minimize on unlock and lock on minimize settings at the same time.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
