### PR TITLE
Point INSTALL.md checkout reference to `latest` tag

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,10 +57,10 @@ To compile from source, open a **Terminal (Linux/MacOS)**, the **MSVC Tools Comm
    git pull
    ```
 
-   For a stable build, it is recommended to check out the master branch.
+   For a stable build, it is recommended to check out the main branch.
 
    ```
-   git checkout master
+   git checkout main
    ```
 
 2. Navigate to the directory where you have downloaded KeePassXC and type these commands:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,10 +57,10 @@ To compile from source, open a **Terminal (Linux/MacOS)**, the **MSVC Tools Comm
    git pull
    ```
 
-   For a stable build, it is recommended to check out the main branch.
+   For a stable build, it is recommended to check out the `latest` branch.
 
    ```
-   git checkout main
+   git checkout latest
    ```
 
 2. Navigate to the directory where you have downloaded KeePassXC and type these commands:


### PR DESCRIPTION
INSTALL.md now correctly references branch main instead of now nonexistent master branch

Fix https://github.com/keepassxreboot/keepassxc/issues/8224

## Type of change
- ✅ Documentation (non-code change)
