### PR TITLE
Feature/increase number of remembered last databases

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -53,7 +53,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     // General
     {Config::SingleInstance,{QS("SingleInstance"), Roaming, true}},
     {Config::RememberLastDatabases,{QS("RememberLastDatabases"), Roaming, true}},
-    {Config::NumberOfRememberedLastDatabases,{QS("NumberOfRememberedLastDatabases"), Roaming, 5}},
+    {Config::NumberOfRememberedLastDatabases,{QS("NumberOfRememberedLastDatabases"), Roaming, 20}},
     {Config::RememberLastKeyFiles,{QS("RememberLastKeyFiles"), Roaming, true}},
     {Config::OpenPreviousDatabasesOnStartup,{QS("OpenPreviousDatabasesOnStartup"), Roaming, true}},
     {Config::AutoSaveAfterEveryChange,{QS("AutoSaveAfterEveryChange"), Roaming, true}},

--- a/src/gui/WelcomeWidget.ui
+++ b/src/gui/WelcomeWidget.ui
@@ -182,7 +182,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>110</height>
+       <height>220</height>
       </size>
      </property>
      <property name="accessibleName">


### PR DESCRIPTION
I have many databases in different places, I spend time researching my databases. Increasing the number of last database saves time to reopen a recurring database.

## Screenshots
![image](https://user-images.githubusercontent.com/2263103/177003056-de6b4a77-3e5d-4f8a-aee4-246b95cd4da3.png)


## Testing strategy
Just create and open more than 5 databases to see this feature


## Type of change
- ✅ New feature (change that adds functionality)