### PR TITLE
Add setting for number of recent files

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -495,6 +495,10 @@
         <source>Remember last typed entry for:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source> recent files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetSecurity</name>

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -191,6 +191,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->singleInstanceCheckBox->setChecked(config()->get(Config::SingleInstance).toBool());
     m_generalUi->launchAtStartup->setChecked(osUtils->isLaunchAtStartupEnabled());
     m_generalUi->rememberLastDatabasesCheckBox->setChecked(config()->get(Config::RememberLastDatabases).toBool());
+    m_generalUi->rememberLastDatabasesSpinbox->setValue(config()->get(Config::NumberOfRememberedLastDatabases).toInt());
     m_generalUi->rememberLastKeyFilesCheckBox->setChecked(config()->get(Config::RememberLastKeyFiles).toBool());
     m_generalUi->openPreviousDatabasesOnStartupCheckBox->setChecked(
         config()->get(Config::OpenPreviousDatabasesOnStartup).toBool());
@@ -336,6 +337,7 @@ void ApplicationSettingsWidget::saveSettings()
 
     config()->set(Config::SingleInstance, m_generalUi->singleInstanceCheckBox->isChecked());
     config()->set(Config::RememberLastDatabases, m_generalUi->rememberLastDatabasesCheckBox->isChecked());
+    config()->set(Config::NumberOfRememberedLastDatabases, m_generalUi->rememberLastDatabasesSpinbox->value());
     config()->set(Config::RememberLastKeyFiles, m_generalUi->rememberLastKeyFilesCheckBox->isChecked());
     config()->set(Config::OpenPreviousDatabasesOnStartup,
                   m_generalUi->openPreviousDatabasesOnStartupCheckBox->isChecked());
@@ -520,6 +522,7 @@ void ApplicationSettingsWidget::rememberDatabasesToggled(bool checked)
         m_generalUi->openPreviousDatabasesOnStartupCheckBox->setChecked(false);
     }
 
+    m_generalUi->rememberLastDatabasesSpinbox->setEnabled(checked);
     m_generalUi->rememberLastKeyFilesCheckBox->setEnabled(checked);
     m_generalUi->openPreviousDatabasesOnStartupCheckBox->setEnabled(checked);
 }

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -113,14 +113,47 @@
                </widget>
               </item>
               <item>
-               <widget class="QCheckBox" name="rememberLastDatabasesCheckBox">
-                <property name="text">
-                 <string>Remember previously used databases</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
+               <layout class="QHBoxLayout" name="horizontalLayout_6">
+                <item>
+                 <widget class="QCheckBox" name="rememberLastDatabasesCheckBox">
+                  <property name="text">
+                   <string>Remember previously used databases</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="rememberLastDatabasesSpinbox">
+                  <property name="suffix">
+                   <string> recent files</string>
+                  </property>
+                  <property name="minimum">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <number>25</number>
+                  </property>
+                  <property name="value">
+                   <number>5</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_9">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
               </item>
               <item>
                <layout class="QHBoxLayout" name="rememberDbSubLayout_2">
@@ -1231,6 +1264,7 @@
   <tabstop>systrayMinimizeOnStartup</tabstop>
   <tabstop>minimizeAfterUnlockCheckBox</tabstop>
   <tabstop>rememberLastDatabasesCheckBox</tabstop>
+  <tabstop>rememberLastDatabasesSpinbox</tabstop>
   <tabstop>openPreviousDatabasesOnStartupCheckBox</tabstop>
   <tabstop>rememberLastKeyFilesCheckBox</tabstop>
   <tabstop>checkForUpdatesOnStartupCheckBox</tabstop>
@@ -1240,8 +1274,12 @@
   <tabstop>autoSaveAfterEveryChangeCheckBox</tabstop>
   <tabstop>autoSaveOnExitCheckBox</tabstop>
   <tabstop>autoSaveNonDataChangesCheckBox</tabstop>
+  <tabstop>autoReloadOnChangeCheckBox</tabstop>
   <tabstop>backupBeforeSaveCheckBox</tabstop>
+  <tabstop>backupFilePath</tabstop>
+  <tabstop>backupFilePathPicker</tabstop>
   <tabstop>useAlternativeSaveCheckBox</tabstop>
+  <tabstop>alternativeSaveComboBox</tabstop>
   <tabstop>useGroupIconOnEntryCreationCheckBox</tabstop>
   <tabstop>minimizeOnOpenUrlCheckBox</tabstop>
   <tabstop>hideWindowOnCopyCheckBox</tabstop>
@@ -1250,8 +1288,8 @@
   <tabstop>faviconTimeoutSpinBox</tabstop>
   <tabstop>languageComboBox</tabstop>
   <tabstop>toolButtonStyleComboBox</tabstop>
-  <tabstop>monospaceNotesCheckBox</tabstop>
   <tabstop>toolbarMovableCheckBox</tabstop>
+  <tabstop>monospaceNotesCheckBox</tabstop>
   <tabstop>minimizeOnCloseCheckBox</tabstop>
   <tabstop>systrayShowCheckBox</tabstop>
   <tabstop>trayIconAppearance</tabstop>
@@ -1260,7 +1298,10 @@
   <tabstop>autoTypeEntryTitleMatchCheckBox</tabstop>
   <tabstop>autoTypeEntryURLMatchCheckBox</tabstop>
   <tabstop>autoTypeAskCheckBox</tabstop>
+  <tabstop>autoTypeHideExpiredEntryCheckBox</tabstop>
+  <tabstop>autoTypeRelockDatabaseCheckBox</tabstop>
   <tabstop>autoTypeShortcutWidget</tabstop>
+  <tabstop>autoTypeRetypeTimeSpinBox</tabstop>
   <tabstop>autoTypeStartDelaySpinBox</tabstop>
   <tabstop>autoTypeDelaySpinBox</tabstop>
  </tabstops>


### PR DESCRIPTION
* Expose setting to limit the number of recent files. Default is still 5, can be set from 1 to 25.
* Also fix tab order on settings page

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/177211985-d97dc90a-6f2a-4778-aeff-79ebe8bc3423.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested locally

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
