### PR TITLE
When exporting csv files, transform slashes within group names into b…

### DIFF
--- a/src/format/CsvExporter.cpp
+++ b/src/format/CsvExporter.cpp
@@ -79,7 +79,7 @@ QString CsvExporter::exportGroup(const Group* group, QString groupPath)
     if (!groupPath.isEmpty()) {
         groupPath.append("/");
     }
-    groupPath.append(group->name());
+    groupPath.append(group->name().replace("/", "\\"));
 
     const QList<Entry*>& entryList = group->entries();
     for (const Entry* entry : entryList) {

--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -322,7 +322,8 @@ Group* CsvImportWidget::splitGroups(const QString& label)
         groupList.removeFirst();
     }
 
-    for (const QString& groupName : groupList) {
+    for (QString& groupName : groupList) {
+        groupName.replace("\\","/");
         Group* children = hasChildren(current, groupName);
         if (children == nullptr) {
             auto brandNew = new Group();


### PR DESCRIPTION

- Fixes #8235 
- When exporting csv files, transform slashes within group names into back slashes and transform it back to slashes when importing. This avoids the creation of sub groups on import.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
Tested that this fixes the bug and causes no regressions.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
