### PR TITLE
[CLI] Add Option to show all attributes (Show command)

### DIFF
--- a/docs/man/keepassxc-cli.1.adoc
+++ b/docs/man/keepassxc-cli.1.adoc
@@ -16,7 +16,7 @@
 
 = keepassxc-cli(1)
 KeePassXC Team <team@keepassxc.org>
-:docdate: 2020-08-31
+:docdate: 2022-08-20
 :doctype: manpage
 :mansource: KeePassXC {revnumber}
 :manmanual: General Commands Manual
@@ -251,6 +251,9 @@ The same password generation options as documented for the generate command can 
   This option can be specified more than once, with each attribute shown one-per-line in the given order.
   If no attributes are specified and *-t* is not specified, a summary of the default attributes is given.
   Protected attributes will be displayed in clear text if specified explicitly by this option.
+
+*--all*::
+  Show all the attributes of the entry.
 
 *-s*, *--show-protected*::
   Shows the protected attributes in clear text.

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -7812,6 +7812,10 @@ Kernel: %3 %4</source>
         <source>Please present or touch your YubiKey to continue.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show all the attributes of the entry.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QtIOCompressor</name>

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -32,6 +32,9 @@ const QCommandLineOption Show::ProtectedAttributesOption =
                                      << "show-protected",
                        QObject::tr("Show the protected attributes in clear text."));
 
+const QCommandLineOption Show::AllAttributesOption =
+    QCommandLineOption(QStringList() << "all", QObject::tr("Show all the attributes of the entry."));
+
 const QCommandLineOption Show::AttachmentsOption =
     QCommandLineOption(QStringList() << "show-attachments", QObject::tr("Show the attachments of the entry."));
 
@@ -51,6 +54,7 @@ Show::Show()
     options.append(Show::TotpOption);
     options.append(Show::AttributesOption);
     options.append(Show::ProtectedAttributesOption);
+    options.append(Show::AllAttributesOption);
     options.append(Show::AttachmentsOption);
     positionalArguments.append({QString("entry"), QObject::tr("Name of the entry to show."), QString("")});
 }
@@ -64,6 +68,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     const QString& entryPath = args.at(1);
     bool showTotp = parser->isSet(Show::TotpOption);
     bool showProtectedAttributes = parser->isSet(Show::ProtectedAttributesOption);
+    bool showAllAttributes = parser->isSet(Show::AllAttributesOption);
     QStringList attributes = parser->values(Show::AttributesOption);
 
     Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
@@ -77,9 +82,24 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         return EXIT_FAILURE;
     }
 
-    // If no attributes specified, output the default attribute set.
-    bool showDefaultAttributes = attributes.isEmpty() && !showTotp;
-    if (showDefaultAttributes) {
+    bool attributesWereSpecified = true;
+    if (showAllAttributes) {
+        attributesWereSpecified = false;
+        attributes = EntryAttributes::DefaultAttributes;
+        for (QString fieldName : Utils::EntryFieldNames) {
+            attributes.append(fieldName);
+        }
+        // Adding the custom attributes after the default attributes so that
+        // the default attributes are always shown first.
+        for (QString attributeName : entry->attributes()->keys()) {
+            if (EntryAttributes::DefaultAttributes.contains(attributeName)) {
+                continue;
+            }
+            attributes.append(attributeName);
+        }
+    } else if (attributes.isEmpty() && !showTotp) {
+        // If no attributes are specified, output the default attribute set.
+        attributesWereSpecified = false;
         attributes = EntryAttributes::DefaultAttributes;
         for (QString fieldName : Utils::EntryFieldNames) {
             attributes.append(fieldName);
@@ -90,7 +110,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     bool encounteredError = false;
     for (const QString& attributeName : asConst(attributes)) {
         if (Utils::EntryFieldNames.contains(attributeName)) {
-            if (showDefaultAttributes) {
+            if (!attributesWereSpecified) {
                 out << attributeName << ": ";
             }
             out << Utils::getTopLevelField(entry, attributeName) << endl;
@@ -110,10 +130,10 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
             continue;
         }
         QString canonicalName = attrs[0];
-        if (showDefaultAttributes) {
+        if (!attributesWereSpecified) {
             out << canonicalName << ": ";
         }
-        if (entry->attributes()->isProtected(canonicalName) && showDefaultAttributes && !showProtectedAttributes) {
+        if (entry->attributes()->isProtected(canonicalName) && !attributesWereSpecified && !showProtectedAttributes) {
             out << "PROTECTED" << endl;
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << endl;

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -28,6 +28,7 @@ public:
     int executeWithDatabase(QSharedPointer<Database> db, QSharedPointer<QCommandLineParser> parser) override;
 
     static const QCommandLineOption TotpOption;
+    static const QCommandLineOption AllAttributesOption;
     static const QCommandLineOption AttributesOption;
     static const QCommandLineOption ProtectedAttributesOption;
     static const QCommandLineOption AttachmentsOption;

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -2049,6 +2049,21 @@ void TestCli::testShow()
     execCmd(showCmd, {"show", m_dbFile->fileName(), "-a", "Testattribute1", "/Sample Entry"});
     QCOMPARE(m_stdout->readAll(), QByteArray());
     QVERIFY(m_stderr->readAll().contains("ERROR: attribute Testattribute1 is ambiguous"));
+
+    setInput("a");
+    execCmd(showCmd, {"show", "--all", m_dbFile->fileName(), "/Sample Entry"});
+    QCOMPARE(m_stdout->readAll(),
+             QByteArray("Title: Sample Entry\n"
+                        "UserName: User Name\n"
+                        "Password: PROTECTED\n"
+                        "URL: http://www.somesite.com/\n"
+                        "Notes: Notes\n"
+                        "Uuid: {9f4544c2-ab00-c74a-8a1a-6eaf26cf57e9}\n"
+                        "Tags: \n"
+                        "TOTP Seed: PROTECTED\n"
+                        "TOTP Settings: 30;6\n"
+                        "TestAttribute1: b\n"
+                        "testattribute1: a\n"));
 }
 
 void TestCli::testInvalidDbFiles()


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc/issues/8243

I renamed the `showDefaultAttributes` variable to `attributesWereSpecified` to make it more explicit what the variable is used for.

## Testing strategy
Unit tests

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
