### PR TITLE
Fix CLI output when using clip with the -t flag

### DIFF
--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -116,6 +116,7 @@ int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
             return EXIT_FAILURE;
         }
 
+        selectedAttribute = "totp";
         found = true;
         value = entry->totp();
     } else {

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -666,6 +666,7 @@ void TestCli::testClip()
     setInput("a");
     execCmd(clipCmd, {"clip", m_dbFile->fileName(), "/Sample Entry", "0", "--totp"});
     QTRY_VERIFY(isTotp(clipboard->text()));
+    QCOMPARE(m_stdout->readLine(), QByteArray("Entry's \"totp\" attribute copied to the clipboard!\n"));
 
     // Test Unicode
     setInput("a");


### PR DESCRIPTION
if you use the CLI with -t/--totp flag, the program prints out: "Entry's "password" attribute copied to the clipboard!"
expected output is "Entry's "totp" attribute copied to the clipboard!" the same when you run with -a totp


- ✅ Bug fix (non-breaking change that fixes an issue)
