### PR TITLE
Asynchronous Browser Access Request dialog

### DIFF
--- a/src/browser/BrowserAccessControlDialog.h
+++ b/src/browser/BrowserAccessControlDialog.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2013 Francois Ferrand
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -37,17 +37,34 @@ public:
     explicit BrowserAccessControlDialog(QWidget* parent = nullptr);
     ~BrowserAccessControlDialog() override;
 
-    void setItems(const QList<Entry*>& items, const QString& urlString, bool httpAuth);
+    void setItems(const QList<Entry*>& entriesToConfirm,
+                  const QList<Entry*>& allowedEntries,
+                  const QString& urlString,
+                  bool httpAuth);
     bool remember() const;
+    bool entriesAccepted() const;
 
     QList<QTableWidgetItem*> getSelectedEntries() const;
     QList<QTableWidgetItem*> getNonSelectedEntries() const;
 
 signals:
     void disableAccess(QTableWidgetItem* item);
+    void acceptEntries(QList<QTableWidgetItem*> items, QList<Entry*> entriesToConfirm, QList<Entry*> allowedEntries);
+    void rejectEntries(QList<QTableWidgetItem*> items, QList<Entry*> entriesToConfirm);
+    void closed();
+
+public slots:
+    void acceptSelections();
+    void rejectSelections();
+
+private:
+    void closeEvent(QCloseEvent* event) override;
 
 private:
     QScopedPointer<Ui::BrowserAccessControlDialog> m_ui;
+    QList<Entry*> m_entriesToConfirm;
+    QList<Entry*> m_allowedEntries;
+    bool m_entriesAccepted;
 };
 
 #endif // BROWSERACCESSCONTROLDIALOG_H

--- a/src/browser/BrowserAccessControlDialog.ui
+++ b/src/browser/BrowserAccessControlDialog.ui
@@ -97,7 +97,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cancelButton">
+      <widget class="QPushButton" name="denyButton">
        <property name="text">
         <string>Deny All</string>
        </property>

--- a/src/browser/BrowserAction.h
+++ b/src/browser/BrowserAction.h
@@ -37,7 +37,7 @@ private:
     QJsonObject handleGetDatabaseHash(const QJsonObject& json, const QString& action);
     QJsonObject handleAssociate(const QJsonObject& json, const QString& action);
     QJsonObject handleTestAssociate(const QJsonObject& json, const QString& action);
-    QJsonObject handleGetLogins(const QJsonObject& json, const QString& action);
+    QJsonObject handleGetLogins(QLocalSocket* socket, const QJsonObject& json, const QString& action);
     QJsonObject handleGeneratePassword(QLocalSocket* socket, const QJsonObject& json, const QString& action);
     QJsonObject handleSetLogin(const QJsonObject& json, const QString& action);
     QJsonObject handleLockDatabase(const QJsonObject& json, const QString& action);

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 2013 Francois Ferrand
  *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
 #ifndef BROWSERSERVICE_H
 #define BROWSERSERVICE_H
 
+#include "BrowserAccessControlDialog.h"
 #include "core/Entry.h"
 #include "gui/PasswordGeneratorWidget.h"
 
@@ -64,12 +65,13 @@ public:
                                const QString& secretKey);
     void sendPassword(QLocalSocket* socket, const QJsonObject& message);
     bool isPasswordGeneratorRequested() const;
+    bool isAccessConfirmRequested() const;
 
     void addEntry(const QString& dbid,
                   const QString& login,
                   const QString& password,
-                  const QString& siteUrlStr,
-                  const QString& formUrlStr,
+                  const QString& siteUrl,
+                  const QString& formUrl,
                   const QString& realm,
                   const QString& group,
                   const QString& groupUuid,
@@ -79,17 +81,21 @@ public:
                      const QString& uuid,
                      const QString& login,
                      const QString& password,
-                     const QString& siteUrlStr,
-                     const QString& formUrlStr);
+                     const QString& siteUrl,
+                     const QString& formUrl);
     bool deleteEntry(const QString& uuid);
-
-    QJsonArray findMatchingEntries(const QString& dbid,
-                                   const QString& siteUrlStr,
-                                   const QString& formUrlStr,
-                                   const QString& realm,
-                                   const StringPairList& keyList,
-                                   const bool httpAuth = false);
-
+    void findEntries(QLocalSocket* socket,
+                     const QString& nonce,
+                     const QString& publicKey,
+                     const QString& secretKey,
+                     const QString& dbid,
+                     const QString& hash,
+                     const QString& requestId,
+                     const QString& siteUrl,
+                     const QString& formUrl,
+                     const QString& realm,
+                     const StringPairList& keyList,
+                     const bool httpAuth = false);
     void requestGlobalAutoType(const QString& search);
     static void convertAttributesToCustomData(QSharedPointer<Database> db);
 
@@ -132,13 +138,32 @@ private:
     QList<Entry*> searchEntries(const QSharedPointer<Database>& db, const QString& siteUrl, const QString& formUrl);
     QList<Entry*> searchEntries(const QString& siteUrl, const QString& formUrl, const StringPairList& keyList);
     QList<Entry*> sortEntries(QList<Entry*>& pwEntries, const QString& siteUrl, const QString& formUrl);
-    QList<Entry*> confirmEntries(QList<Entry*>& pwEntriesToConfirm,
-                                 const QString& siteUrl,
-                                 const QString& siteHost,
-                                 const QString& formUrl,
-                                 const QString& realm,
-                                 const bool httpAuth);
+    void confirmEntries(QLocalSocket* socket,
+                        const QString& incrementedNonce,
+                        const QString& publicKey,
+                        const QString& secretKey,
+                        const QString& id,
+                        const QString& hash,
+                        const QString& requestId,
+                        QList<Entry*>& allowedEntries,
+                        QList<Entry*>& entriesToConfirm,
+                        const QString& siteUrl,
+                        const QString& siteHost,
+                        const QString& formUrl,
+                        const QString& realm,
+                        const bool httpAuth);
+    void sendCredentialsToClient(QList<Entry*>& allowedEntries,
+                                 QLocalSocket* socket,
+                                 const QString& incrementedNonce,
+                                 const QString& publicKey,
+                                 const QString& secretKey,
+                                 const QString& hash,
+                                 const QString& id,
+                                 const QString siteUrl,
+                                 const QString& formUrl);
     QJsonObject prepareEntry(const Entry* entry);
+    void allowEntry(Entry* entry, const QString& siteHost, const QString& formUrl, const QString& realm);
+    void denyEntry(Entry* entry, const QString& siteHost, const QString& formUrl, const QString& realm);
     QJsonArray getChildrenFromGroup(Group* group);
     Access checkAccess(const Entry* entry, const QString& siteHost, const QString& formHost, const QString& realm);
     Group* getDefaultEntryGroup(const QSharedPointer<Database>& selectedDb = {});
@@ -171,14 +196,15 @@ private:
     QPointer<BrowserHost> m_browserHost;
     QHash<QString, QSharedPointer<BrowserAction>> m_browserClients;
 
-    bool m_dialogActive;
     bool m_bringToFrontRequested;
     bool m_passwordGeneratorRequested;
+    bool m_accessConfirmRequested;
     WindowState m_prevWindowState;
     QUuid m_keepassBrowserUUID;
 
     QPointer<DatabaseWidget> m_currentDatabaseWidget;
     QScopedPointer<PasswordGeneratorWidget> m_passwordGenerator;
+    QScopedPointer<BrowserAccessControlDialog> m_accessControlDialog;
 
     Q_DISABLE_COPY(BrowserService);
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Modifies the Access Control Dialog to work asynchronously, similar to the new Password Generator popup. The old/current implementation can break message sync between KeePassXC and the extension if another request for the dialog is retrieved. This can be only fixed when database is locked and reopened, which is not very user friendly.

This PR fixes the following issues:
-  When another dialog request is sent, an error is returned to the extension. The dialog must be closed before further intercation with browser is possible.
- Fixes the message sync with browser extension when multiple access requests are retrieved.
- Fixes the message sync if user switches tab to another page when the dialog is visible.
- Fixes accessing the dialog (and message sync) when using multiple browsers and one of them requests the dialog.

Fixes #5765.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Needs https://github.com/keepassxreboot/keepassxc-browser/pull/1684 for testing.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
