### PR TITLE
cmake: add new macOS default location for QT discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,14 +479,14 @@ if(UNIX AND NOT APPLE)
     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} DBus REQUIRED)
 elseif(APPLE)
     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED HINTS
-            /usr/local/opt/qt/lib/cmake
-            /usr/local/Cellar/qt/*/lib/cmake
-            /opt/homebrew/opt/qt/lib/cmake
+            /usr/local/opt/qt@5/lib/cmake
+            /usr/local/Cellar/qt@5/*/lib/cmake
+            /opt/homebrew/opt/qt@5/lib/cmake
             ENV PATH)
     find_package(Qt5 COMPONENTS MacExtras HINTS
-            /usr/local/opt/qt/lib/cmake
-            /usr/local/Cellar/qt/*/lib/cmake
-            /opt/homebrew/opt/qt/lib/cmake
+            /usr/local/opt/qt@5/lib/cmake
+            /usr/local/Cellar/qt@5/*/lib/cmake
+            /opt/homebrew/opt/qt@5/lib/cmake
             ENV PATH)
 else()
     find_package(Qt5 COMPONENTS ${QT_COMPONENTS} REQUIRED)
@@ -497,6 +497,10 @@ if(Qt5Core_VERSION VERSION_LESS "5.2.0")
 endif()
 
 get_filename_component(Qt5_PREFIX ${Qt5_DIR}/../../.. REALPATH)
+if(APPLE)
+    # Add includes under Qt5 Prefix in case Qt6 is also installed
+    include_directories(SYSTEM ${Qt5_PREFIX}/include)
+endif()
 
 # Process moc automatically
 set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
The [build & install instructions](https://github.com/keepassxreboot/keepassxc/blob/develop/INSTALL.md) for macOS say that using [Homebrew to install the dependencies](https://github.com/keepassxreboot/keepassxc/wiki/Set-up-Build-Environment-on-macOS) is enough and the build process will then work without additional setup.

However, QT5 as offered by Homebrew is versioned since March 2021 and the default, non-suffixed path points to QT6 (if installed). New installations of qt5/qt@5 have a suffixed path that should be used instead.

There's an explanation for using `-DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake` but I'd argue this only applies to non-default setups and shouldn't be required for newly setup development environments.

Technically I would think that removing the non-suffixed paths is feasible (and a good idea for better reproducibility) as well but I don't want to break existing setups. I suppose that's something to be done during #7774 ?

## Screenshots
n/a

## Testing strategy
Following the [build & install instructions](https://github.com/keepassxreboot/keepassxc/blob/develop/INSTALL.md) from a clean state.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
