### PR TITLE
Hardware keys: Add VivoKey and DT token ATRs

### DIFF
--- a/src/keys/drivers/YubiKeyInterfacePCSC.h
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.h
@@ -106,7 +106,10 @@ private:
              "\x3B\xFD\x13\x00\x00\x81\x31\xFE\x45\x41\x37\x30\x30\x36\x43\x47\x20\x32\x34\x32\x52\x31\xD6"),
          "YubiKey NEO (token)"},
         // Other tokens implementing the Yubikey challenge-response protocol
-        {QByteArrayLiteral("\x3B\x80\x80\x01\x01"), "Fidesmo Card 2.0"}};
+        {QByteArrayLiteral("\x3B\x80\x80\x01\x01"), "Fidesmo Card 2.0"},
+        {QByteArrayLiteral("\x3B\x8A\x80\x01\x00\x31\xC1\x73\xC8\x40\x00\x00\x90\x00\x90"), "VivoKey Apex"},
+        {QByteArrayLiteral("\x3B\x8D\x80\x01\x00\x31\xC1\x73\xC8\x40\x00\x52\xA5\x10\x00\x90\x00\x70"),
+         "Dangerous Things FlexSecure"}};
 };
 
 #endif // KEEPASSX_YUBIKEY_INTERFACE_PCSC_H


### PR DESCRIPTION
This adds the ATRs of the VivoKey Apex and the Dangerous Things FlexSecure tokens, in order to display a human-readable name instead of "Unknown Key". It is a small change adding two entries to a string map. These tokens are NFC-only.

As projected in #6895 (#6766), more hardware tokens than the YubiKey implement the Yubico-style HMAC-SHA1 protocol.

## Testing strategy
Compiled on Linux and tested with the mentioned tokens.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
