### PR TITLE
Fix Windows Hello bugs

### DIFF
--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -209,12 +209,6 @@ bool Application::event(QEvent* event)
         emit openFile(static_cast<QFileOpenEvent*>(event)->file());
         return true;
     }
-#ifdef Q_OS_MACOS
-    // restore main window when clicking on the docker icon
-    else if (event->type() == QEvent::ApplicationActivate) {
-        emit applicationActivated();
-    }
-#endif
 
     return QApplication::event(event);
 }


### PR DESCRIPTION
* Fix #7977 - wrap key signing request in try/catch block to prevent crashes on some machines.
* Fix #8120 - try 3 times to bring Windows Hello prompt to front. This may be necessary on older machines that are slow to bring up the prompt window.

Also remove defunct code on macOS to prevent window focus issues.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows and macOS

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
