### PR TITLE
Support numeric aware sorting on Windows and macOS

### DIFF
--- a/src/gui/SortFilterHideProxyModel.cpp
+++ b/src/gui/SortFilterHideProxyModel.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "SortFilterHideProxyModel.h"
+#include <QCollator>
 
 SortFilterHideProxyModel::SortFilterHideProxyModel(QObject* parent)
     : QSortFilterProxyModel(parent)
@@ -40,4 +41,17 @@ bool SortFilterHideProxyModel::filterAcceptsColumn(int sourceColumn, const QMode
     Q_UNUSED(sourceParent);
 
     return sourceColumn >= m_hiddenColumns.size() || !m_hiddenColumns.at(sourceColumn);
+}
+
+bool SortFilterHideProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
+{
+    auto leftData = sourceModel()->data(left, sortRole());
+    auto rightData = sourceModel()->data(right, sortRole());
+    if (leftData.type() == QVariant::String) {
+        QCollator sorter;
+        sorter.setNumericMode(true);
+        return sorter.compare(leftData.toString(), rightData.toString()) < 0;
+    }
+
+    return QSortFilterProxyModel::lessThan(left, right);
 }

--- a/src/gui/SortFilterHideProxyModel.h
+++ b/src/gui/SortFilterHideProxyModel.h
@@ -32,6 +32,7 @@ public:
 
 protected:
     bool filterAcceptsColumn(int sourceColumn, const QModelIndex& sourceParent) const override;
+    bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
     QBitArray m_hiddenColumns;


### PR DESCRIPTION
* Fix #8356 - Qt does not enable numeric aware sorting when using locale sort. Extracted both Windows and macOS locale aware sorting code and added the appropriate numeric aware flag.

Note: There is no std library way to do this so Linux is out of luck for now.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/184511186-b838b128-5e72-4dad-b03f-a223cb342cbe.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested and mac and windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
