### PR TITLE
Fix OPVault import when there are multiple OTP fields

### DIFF
--- a/src/format/OpVaultReaderSections.cpp
+++ b/src/format/OpVaultReaderSections.cpp
@@ -84,7 +84,16 @@ void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionNam
     auto kind = field["k"].toString();
 
     if (attrName.startsWith("TOTP_")) {
-        if (attrValue.startsWith("otpauth://")) {
+        if (entry->hasTotp()) {
+            // Store multiple TOTP definitions as additional otp attributes
+            int i = 0;
+            QString name("otp");
+            auto attributes = entry->attributes()->keys();
+            while (attributes.contains(name)) {
+                name = QString("otp_%1").arg(++i);
+            }
+            entry->attributes()->set(name, attrValue);
+        } else if (attrValue.startsWith("otpauth://")) {
             QUrlQuery query(attrValue);
             // at least as of 1Password 7, they don't append the digits= and period= which totp.cpp requires
             if (!query.hasQueryItem("digits")) {


### PR DESCRIPTION
* Fix #8371 - store multiple OTP fields as `otp_#` instead of silently discarding them.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added test case

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
