### PR TITLE
Fix dark mode detection on Linux/GNOME

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -50,6 +50,7 @@ public:
     }
 
 private slots:
+    void handleColorSchemeRead(QDBusVariant value);
     void handleColorSchemeChanged(QString ns, QString key, QDBusVariant value);
 
 private:
@@ -79,6 +80,9 @@ private:
         PreferLight
     };
     ColorschemePref m_systemColorschemePref = ColorschemePref::PreferNone;
+    bool m_systemColorschemePrefExists;
+
+    void setColorScheme(QDBusVariant value);
 
     Q_DISABLE_COPY(NixUtils)
 };


### PR DESCRIPTION
The current implementation does not read the color-scheme setting at startup

Fixes #7817

## Testing strategy
Changes were tested by setting the theme using GNOME Control Center and opening KPXC to determine if used the chosen theme

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)