### PR TITLE
Remove old --pw / --parent-window option from man page

### DIFF
--- a/docs/man/keepassxc.1.adoc
+++ b/docs/man/keepassxc.1.adoc
@@ -49,9 +49,6 @@ Your wallet works offline and requires no Internet connection.
 *--pw-stdin*::
   Read password of the database from stdin.
 
-*--pw*, *--parent-window* <__handle__>::
-  Parent window handle.
-
 *--debug-info*::
   Displays debugging information.
 


### PR DESCRIPTION
This was removed from the code in 9886b1075fbddca0d4ef564c1bb481afcc199c3f

## Type of change
- ✅ Documentation (non-code change)
