### PR TITLE
Fix crash when application is unfocused during saves

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -213,6 +213,7 @@ void DatabaseOpenWidget::clearForms()
     m_ui->editPassword->setShowPassword(false);
     m_ui->keyFileLineEdit->clear();
     m_ui->keyFileLineEdit->setShowPassword(false);
+    m_ui->keyFileLineEdit->setClearButtonEnabled(true);
     m_ui->challengeResponseCombo->clear();
     m_ui->centralStack->setCurrentIndex(0);
     m_db.reset();
@@ -440,12 +441,6 @@ void DatabaseOpenWidget::browseKeyFile()
     if (!filename.isEmpty()) {
         m_ui->keyFileLineEdit->setText(filename);
     }
-}
-
-void DatabaseOpenWidget::clearKeyFileText()
-{
-    m_ui->keyFileLineEdit->clear();
-    m_ui->keyFileLineEdit->setShowPassword(false);
 }
 
 void DatabaseOpenWidget::pollHardwareKey()

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -70,7 +70,6 @@ protected slots:
 
 private slots:
     void browseKeyFile();
-    void clearKeyFileText();
     void pollHardwareKey();
     void hardwareKeyResponse(bool found);
     void openHardwareKeyHelp();

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -145,12 +145,12 @@
              </widget>
             </item>
             <item>
-             <widget class="PasswordWidget" name="editPassword">
+             <widget class="PasswordWidget" name="editPassword" native="true">
+              <property name="focusPolicy">
+               <enum>Qt::StrongFocus</enum>
+              </property>
               <property name="accessibleName">
                <string>Password field</string>
-              </property>
-              <property name="echoMode">
-               <enum>QLineEdit::Password</enum>
               </property>
              </widget>
             </item>
@@ -380,21 +380,18 @@
                    <number>0</number>
                   </property>
                   <item row="0" column="1">
-                   <widget class="PasswordWidget" name="keyFileLineEdit">
+                   <widget class="PasswordWidget" name="keyFileLineEdit" native="true">
                     <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
                     </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
                     <property name="accessibleName">
                      <string>Key file to unlock the database</string>
-                    </property>
-                    <property name="echoMode">
-                     <enum>QLineEdit::Password</enum>
-                    </property>
-                    <property name="clearButtonEnabled">
-                     <bool>true</bool>
                     </property>
                    </widget>
                   </item>
@@ -463,6 +460,9 @@
               </property>
               <item alignment="Qt::AlignRight">
                <widget class="QDialogButtonBox" name="buttonBox">
+                <property name="focusPolicy">
+                 <enum>Qt::StrongFocus</enum>
+                </property>
                 <property name="standardButtons">
                  <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
                 </property>
@@ -618,7 +618,7 @@
  <customwidgets>
   <customwidget>
    <class>PasswordWidget</class>
-   <extends>QLineEdit</extends>
+   <extends>QWidget</extends>
    <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -76,9 +76,11 @@ void DatabaseTabWidget::toggleTabbar()
 {
     if (count() > 1) {
         tabBar()->show();
+        setFocusPolicy(Qt::StrongFocus);
         emit tabVisibilityChanged(true);
     } else {
         tabBar()->hide();
+        setFocusPolicy(Qt::NoFocus);
         emit tabVisibilityChanged(false);
     }
 }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1640,7 +1640,7 @@ bool DatabaseWidget::focusNextPrevChild(bool next)
     // Find the next visible element in the sequence and set the focus
     while (idx >= 0 && idx < sequence.size()) {
         widget = sequence[idx];
-        if (widget && widget->isVisible() && widget->height() > 0 && widget->width() > 0) {
+        if (widget && widget->isVisible() && widget->isEnabled() && widget->height() > 0 && widget->width() > 0) {
             widget->setFocus();
             return widget;
         }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1619,13 +1619,18 @@ bool DatabaseWidget::focusNextPrevChild(bool next)
     // [parent] <-> GroupView <-> TagView <-> EntryView <-> EntryPreview <-> [parent]
     QList<QWidget*> sequence = {m_groupView, m_tagView, m_entryView, m_previewView};
     auto widget = qApp->focusWidget();
+    if (!widget) {
+        return QStackedWidget::focusNextPrevChild(next);
+    }
 
+    // Find the nearest parent widget in the sequence list
     int idx;
     do {
         idx = sequence.indexOf(widget);
         widget = widget->parentWidget();
     } while (idx == -1 && widget);
 
+    // Determine next/previous or wrap around
     if (idx == -1) {
         idx = next ? 0 : sequence.size() - 1;
     } else {
@@ -1635,7 +1640,7 @@ bool DatabaseWidget::focusNextPrevChild(bool next)
     // Find the next visible element in the sequence and set the focus
     while (idx >= 0 && idx < sequence.size()) {
         widget = sequence[idx];
-        if (widget->isVisible() && widget->height() > 0 && widget->width() > 0) {
+        if (widget && widget->isVisible() && widget->height() > 0 && widget->width() > 0) {
             widget->setFocus();
             return widget;
         }

--- a/src/gui/EditWidget.ui
+++ b/src/gui/EditWidget.ui
@@ -66,10 +66,16 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
       <widget class="QStackedWidget" name="stackedWidget">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="currentIndex">
         <number>-1</number>
        </property>
@@ -84,6 +90,9 @@
      </property>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="standardButtons">
         <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
@@ -107,6 +116,11 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>categoryList</tabstop>
+  <tabstop>stackedWidget</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -87,9 +87,9 @@
       </layout>
      </item>
      <item row="0" column="0">
-      <widget class="PasswordWidget" name="editNewPassword">
+      <widget class="PasswordWidget" name="editNewPassword" native="true">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -99,6 +99,9 @@
          <width>450</width>
          <height>0</height>
         </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
        <property name="accessibleName">
         <string>Generated password</string>
@@ -991,7 +994,7 @@ QProgressBar::chunk {
  <customwidgets>
   <customwidget>
    <class>PasswordWidget</class>
-   <extends>QLineEdit</extends>
+   <extends>QWidget</extends>
    <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>

--- a/src/gui/databasekey/PasswordEditWidget.ui
+++ b/src/gui/databasekey/PasswordEditWidget.ui
@@ -31,9 +31,9 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="PasswordWidget" name="enterPasswordEdit">
+    <widget class="PasswordWidget" name="enterPasswordEdit" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -44,11 +44,11 @@
        <height>0</height>
       </size>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
      <property name="accessibleName">
       <string>Password field</string>
-     </property>
-     <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
      </property>
     </widget>
    </item>
@@ -60,9 +60,9 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="PasswordWidget" name="repeatPasswordEdit">
+    <widget class="PasswordWidget" name="repeatPasswordEdit" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -73,11 +73,11 @@
        <height>0</height>
       </size>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
      <property name="accessibleName">
       <string>Repeat password field</string>
-     </property>
-     <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
      </property>
     </widget>
    </item>
@@ -86,7 +86,7 @@
  <customwidgets>
   <customwidget>
    <class>PasswordWidget</class>
-   <extends>QLineEdit</extends>
+   <extends>QWidget</extends>
    <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>

--- a/src/gui/entry/EditEntryWidgetMain.ui
+++ b/src/gui/entry/EditEntryWidgetMain.ui
@@ -243,12 +243,12 @@
      </widget>
     </item>
     <item row="2" column="1">
-     <widget class="PasswordWidget" name="passwordEdit">
+     <widget class="PasswordWidget" name="passwordEdit" native="true">
+      <property name="focusPolicy">
+       <enum>Qt::StrongFocus</enum>
+      </property>
       <property name="accessibleName">
        <string>Password field</string>
-      </property>
-      <property name="echoMode">
-       <enum>QLineEdit::Password</enum>
       </property>
      </widget>
     </item>
@@ -297,12 +297,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PasswordWidget</class>
-   <extends>QLineEdit</extends>
-   <header>gui/PasswordWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>TagsEdit</class>
    <extends>QWidget</extends>
    <header>gui/tag/TagsEdit.h</header>
@@ -312,6 +306,12 @@
    <class>URLEdit</class>
    <extends>QLineEdit</extends>
    <header>gui/URLEdit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PasswordWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/keeshare/group/EditGroupWidgetKeeShare.ui
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.ui
@@ -51,9 +51,9 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="PasswordWidget" name="passwordEdit">
+      <widget class="PasswordWidget" name="passwordEdit" native="true">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -64,11 +64,11 @@
          <height>0</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
        <property name="accessibleName">
         <string>Password field</string>
-       </property>
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
        </property>
       </widget>
      </item>
@@ -191,7 +191,7 @@
  <customwidgets>
   <customwidget>
    <class>PasswordWidget</class>
-   <extends>QLineEdit</extends>
+   <extends>QWidget</extends>
    <header>gui/PasswordWidget.h</header>
    <container>1</container>
   </customwidget>


### PR DESCRIPTION
* Fix #8504

Also Fix Focus Traps!
* Fix focus issues with new PasswordWidget
* Fix focus wrapping when DatabaseTabWidget is not showing the tab bar
* Fix focus wrapping in EditWidget views to move between category list and contents. This is not a perfect fix, but Qt has a mind of its own with these complex widgets. This will be fixed in future Ui improvements that move away from the category widget.


[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
