### PR TITLE
Increase entropy required for a "good" rating to 75.

### DIFF
--- a/src/core/PasswordHealth.cpp
+++ b/src/core/PasswordHealth.cpp
@@ -101,7 +101,7 @@ PasswordHealth::Quality PasswordHealth::quality() const
         return Quality::Bad;
     } else if (m_score < 40) {
         return Quality::Poor;
-    } else if (m_score < 65) {
+    } else if (m_score < 75) {
         return Quality::Weak;
     } else if (m_score < 100) {
         return Quality::Good;
@@ -160,8 +160,8 @@ QSharedPointer<PasswordHealth> HealthChecker::evaluate(const Entry* entry) const
 
         // Don't allow re-used passwords to be considered "good"
         // no matter how great their entropy is.
-        if (health->score() > 64) {
-            health->setScore(64);
+        if (health->score() > 74) {
+            health->setScore(74);
         }
     }
 
@@ -181,8 +181,8 @@ QSharedPointer<PasswordHealth> HealthChecker::evaluate(const Entry* entry) const
             // reduce the score by 2 points for every day that
             // we get closer to expiry. days<=0 has already
             // been handled above ("isExpired()").
-            if (health->score() > 60) {
-                health->setScore(60);
+            if (health->score() > 70) {
+                health->setScore(70);
             }
 
             health->adjustScore((30 - days) * -2);


### PR DESCRIPTION
Raise the bits of entropy required to classify as a "good" password to 75. Fixes #8519.

I'd propose to properly separate m_score and m_entropy logic: currently, m_score is initialized with the entropy and "points" are then deducted based on password reuse and expiry date. I think it would be more straightforward to set the score independent of entropy, implement different quality thresholds for both values and return the minimum quality class reached.