### PR TITLE
bump the delay for clip timeout tests

### DIFF
--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -687,7 +687,7 @@ void TestCli::testClip()
     // clang-format on
 
     QTRY_COMPARE(clipboard->text(), QString("Password"));
-    QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(""), 2000);
+    QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(""), 3000);
 
     future.waitForFinished();
 
@@ -698,7 +698,7 @@ void TestCli::testClip()
                                QStringList{"clip", m_dbFile->fileName(), "/Sample Entry", "1", "-t"});
 
     QTRY_VERIFY(isTotp(clipboard->text()));
-    QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(""), 2000);
+    QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(""), 3000);
 
     future.waitForFinished();
 


### PR DESCRIPTION
The clip tests are flaky on Windows, probably because of how the scheduling works between the two tasks. This should reduce the number of flakes.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
