### PR TITLE
Fix newlines when copying from DatabaseWidget

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -28,6 +28,7 @@
 #include <QPlainTextEdit>
 #include <QProcess>
 #include <QSplitter>
+#include <QTextDocumentFragment>
 #include <QTextEdit>
 #include <core/Tools.h>
 
@@ -638,7 +639,7 @@ void DatabaseWidget::copyPassword()
 
     auto textEdit = qobject_cast<QTextEdit*>(focusWidget());
     if (textEdit && textEdit->textCursor().hasSelection()) {
-        clipboard()->setText(textEdit->textCursor().selectedText(), clearClipboard);
+        clipboard()->setText(textEdit->textCursor().selection().toPlainText(), clearClipboard);
         return;
     }
 


### PR DESCRIPTION
Fixes #8469
Newlines are no longer replaced with paragraph separators when copying notes from DatabaseWidget.

## Testing strategy
Tested in Windows 11 using WSL


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

