### PR TITLE
Fix use of WITH_XC_X11 build flag

### DIFF
--- a/src/config-keepassx.h.cmake
+++ b/src/config-keepassx.h.cmake
@@ -21,6 +21,7 @@
 #cmakedefine WITH_XC_UPDATECHECK
 #cmakedefine WITH_XC_FDOSECRETS
 #cmakedefine WITH_XC_DOCS
+#cmakedefine WITH_XC_X11
 
 #cmakedefine KEEPASSXC_BUILD_TYPE "@KEEPASSXC_BUILD_TYPE@"
 #cmakedefine KEEPASSXC_BUILD_TYPE_RELEASE

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -17,6 +17,8 @@
 
 #include "NixUtils.h"
 
+#include "config-keepassx.h"
+
 #include <QApplication>
 #include <QDBusInterface>
 #include <QDir>
@@ -24,7 +26,7 @@
 #include <QStandardPaths>
 #include <QStyle>
 #include <QTextStream>
-#ifdef WITH_XC_AUTOTYPE
+#ifdef WITH_XC_X11
 #include <QX11Info>
 
 #include <qpa/qplatformnativeinterface.h>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
This is a pre-release bug and very bad, would have broken use of global auto-type shortcut for every linux user. 

Fixes #8501

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Linux build

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
