### PR TITLE
FDO Secrets GUI separation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -359,7 +359,7 @@ configure_file(git-info.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/git-info.h)
 # Core Library Definition
 add_library(keepassxc_core STATIC ${core_SOURCES})
 set_target_properties(keepassxc_core PROPERTIES COMPILE_DEFINITIONS KEEPASSX_BUILDING_CORE)
-target_link_libraries(keepassxc_core 
+target_link_libraries(keepassxc_core
         ${qrcode_LIB}
         Qt5::Core
         Qt5::Concurrent

--- a/src/fdosecrets/CMakeLists.txt
+++ b/src/fdosecrets/CMakeLists.txt
@@ -2,8 +2,11 @@ if(WITH_XC_FDOSECRETS)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
     add_library(fdosecrets STATIC
-        # app settings page
         FdoSecretsPlugin.cpp
+        FdoSecretsPluginGUI.cpp
+
+        # app settings page
+        FdoSecretsSettingsPage.cpp
         widgets/SettingsModels.cpp
         widgets/SettingsWidgetFdoSecrets.cpp
         widgets/RowButtonHelper.cpp

--- a/src/fdosecrets/CMakeLists.txt
+++ b/src/fdosecrets/CMakeLists.txt
@@ -20,7 +20,7 @@ if(WITH_XC_FDOSECRETS)
         # setting storage
         FdoSecretsSettings.cpp
 
-        # dbus objects
+        # D-Bus objects
         dbus/DBusClient.cpp
         dbus/DBusMgr.cpp
         dbus/DBusDispatch.cpp

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -56,7 +56,7 @@ public:
     FdoSecrets::Service* serviceInstance() const;
 
     /**
-     * @brief The dbus manager instance
+     * @brief The D-Bus manager instance
      * @return
      */
     const QSharedPointer<FdoSecrets::DBusMgr>& dbus() const;

--- a/src/fdosecrets/FdoSecretsPlugin.h
+++ b/src/fdosecrets/FdoSecretsPlugin.h
@@ -18,39 +18,35 @@
 #ifndef KEEPASSXC_FDOSECRETSPLUGIN_H
 #define KEEPASSXC_FDOSECRETSPLUGIN_H
 
-#include "gui/ApplicationSettingsWidget.h"
-#include "gui/Icons.h"
-
+#include "core/Global.h"
 #include <QPointer>
 
-class DatabaseTabWidget;
+class Database;
+class Entry;
+class FdoSecretsPluginRequestHandler;
 
 namespace FdoSecrets
 {
-    class Service;
+    class Collection;
+    class DBusClient;
     class DBusMgr;
+    class Service;
+    class UnlockPrompt;
+    class PromptBase;
 } // namespace FdoSecrets
 
-class FdoSecretsPlugin : public QObject, public ISettingsPage
+class FdoSecretsPlugin : public QObject
 {
     Q_OBJECT
+
+    friend class FdoSecrets::Collection;
+    friend class FdoSecrets::Service;
+    friend class FdoSecrets::UnlockPrompt;
+    friend class FdoSecrets::PromptBase;
+
 public:
-    explicit FdoSecretsPlugin(DatabaseTabWidget* tabWidget);
+    FdoSecretsPlugin(QObject* parent);
     ~FdoSecretsPlugin() override = default;
-
-    QString name() override
-    {
-        return QObject::tr("Secret Service Integration");
-    }
-
-    QIcon icon() override
-    {
-        return icons()->icon("freedesktop");
-    }
-
-    QWidget* createWidget() override;
-    void loadSettings(QWidget* widget) override;
-    void saveSettings(QWidget* widget) override;
 
     void updateServiceState();
 
@@ -60,38 +56,53 @@ public:
     FdoSecrets::Service* serviceInstance() const;
 
     /**
-     * @return The db tabs widget, containing opened databases. Can be nullptr.
-     */
-    DatabaseTabWidget* dbTabs() const;
-
-    /**
      * @brief The dbus manager instance
      * @return
      */
     const QSharedPointer<FdoSecrets::DBusMgr>& dbus() const;
 
-    // TODO: Only used for testing. Need to split service functions away from settings page.
-    static FdoSecretsPlugin* getPlugin();
-
 public slots:
-    void emitRequestSwitchToDatabases();
     void emitRequestShowNotification(const QString& msg, const QString& title = {});
 
+    void registerDatabase(const QString& name);
+    void unregisterDatabase(const QString& name);
+
+    void databaseLocked(const QString& name);
+    void databaseUnlocked(const QString& name, QSharedPointer<Database> db);
+
     /**
-     * @brief Show error in the GUI
+     * @brief Show error in the UI
      * @param msg
      */
     void emitError(const QString& msg);
 
 signals:
     void error(const QString& msg);
-    void requestSwitchToDatabases();
     void requestShowNotification(const QString& msg, const QString& title, int msTimeoutHint);
     void secretServiceStarted();
     void secretServiceStopped();
 
 private:
-    QPointer<DatabaseTabWidget> m_dbTabs;
+    virtual size_t requestEntriesRemove(const QSharedPointer<FdoSecrets::DBusClient>& client,
+                                        const QString& name,
+                                        const QList<Entry*>& entries,
+                                        bool permanent) const = 0;
+
+    virtual bool requestEntriesUnlock(const QSharedPointer<FdoSecrets::DBusClient>& client,
+                                      const QString& windowId,
+                                      const QList<Entry*>& entries,
+                                      QHash<Entry*, AuthDecision>& decisions,
+                                      AuthDecision& forFutureEntries) const = 0;
+
+    virtual bool doLockDatabase(const QSharedPointer<FdoSecrets::DBusClient>& client, const QString& name) = 0;
+    virtual bool doUnlockDatabase(const QSharedPointer<FdoSecrets::DBusClient>& client, const QString& name) = 0;
+
+    virtual bool requestUnlockAnyDatabase(const QSharedPointer<FdoSecrets::DBusClient>& client) const = 0;
+    virtual QString requestNewDatabase(const QSharedPointer<FdoSecrets::DBusClient>& client) = 0;
+
+    virtual QString overrideMessageBoxParent(const QString& windowId) const = 0;
+
+private:
     QSharedPointer<FdoSecrets::DBusMgr> m_dbus;
     QSharedPointer<FdoSecrets::Service> m_secretService;
 };

--- a/src/fdosecrets/FdoSecretsPluginGUI.cpp
+++ b/src/fdosecrets/FdoSecretsPluginGUI.cpp
@@ -1,0 +1,349 @@
+/*
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "FdoSecretsPluginGUI.h"
+
+#include <QWindow>
+
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "fdosecrets/FdoSecretsSettings.h"
+#include "fdosecrets/dbus/DBusClient.h"
+#include "fdosecrets/objects/Collection.h"
+#include "fdosecrets/objects/Service.h"
+#include "fdosecrets/widgets/AccessControlDialog.h"
+#include "gui/DatabaseTabWidget.h"
+#include "gui/DatabaseWidget.h"
+#include "gui/GuiTools.h"
+#include "gui/MessageBox.h"
+
+FdoSecretsPluginGUI::FdoSecretsPluginGUI(DatabaseTabWidget* databases)
+    : FdoSecretsPlugin{databases}
+    , m_databases{databases}
+    , m_lockingDb{}
+    , m_unlockingDb{}
+{
+    // Don't connect signals until service is enabled
+    connect(this, &FdoSecretsPlugin::secretServiceStarted, this, [this]() {
+        // Connect to new database signal
+        connect(m_databases, &DatabaseTabWidget::databaseOpened, this, &FdoSecretsPluginGUI::databaseTabOpened);
+
+        // Populate/Clear the database when lock state changes
+        connect(m_databases, &DatabaseTabWidget::databaseUnlocked, this, [this](DatabaseWidget* dbWidget) {
+            auto db = dbWidget->database();
+            auto name = getDatabaseName(db);
+            if (FdoSecrets::settings()->exposedGroup(db.data()).isNull()) {
+                return;
+            }
+
+            Q_ASSERT(m_nameToWidget.value(name) == dbWidget);
+            databaseUnlocked(name, db);
+        });
+
+        connect(m_databases, &DatabaseTabWidget::databaseLocked, this, [this](DatabaseWidget* dbWidget) {
+            databaseLocked(getDatabaseName(dbWidget->database()));
+        });
+
+        // Make default alias track current activated database
+        connect(m_databases, &DatabaseTabWidget::activeDatabaseChanged, this, [this](DatabaseWidget* dbWidget) {
+            if (dbWidget) {
+                auto db = dbWidget->database();
+                if (FdoSecrets::settings()->exposedGroup(db.data()).isNull()) {
+                    return;
+                }
+
+                serviceInstance()->setAlias("default", getDatabaseName(db));
+            }
+        });
+
+        // Clear the local state when collection deletes
+        connect(serviceInstance(), &FdoSecrets::Service::collectionDeleted, this, [this](FdoSecrets::Collection* coll) {
+            if (!FdoSecrets::settings()->exposedGroup(coll->backend()).isNull()) {
+                m_databases->closeDatabaseTab(m_nameToWidget.value(coll->name()));
+            }
+
+            m_nameToWidget.remove(coll->name());
+        });
+
+        // Add existing database tabs
+        for (int idx = 0; idx < m_databases->count(); ++idx) {
+            auto dbWidget = m_databases->databaseWidgetFromIndex(idx);
+            databaseTabOpened(dbWidget);
+        }
+    });
+
+    // Clear local state when service stops
+    connect(this, &FdoSecretsPlugin::secretServiceStopped, this, [this]() {
+        m_databases->disconnect(this);
+        for (int idx = 0; idx < m_databases->count(); ++idx) {
+            m_databases->databaseWidgetFromIndex(idx)->disconnect(this);
+        }
+
+        m_nameToWidget.clear();
+    });
+}
+
+void FdoSecretsPluginGUI::registerDatabase(const QString& name, DatabaseWidget* dbWidget)
+{
+    Q_ASSERT(!name.isEmpty());
+    Q_ASSERT(m_nameToWidget.value(name) == nullptr);
+    m_nameToWidget[name] = dbWidget;
+    FdoSecretsPlugin::registerDatabase(name);
+
+    // If the db is already unlocked we won't get additional signal
+    if (!dbWidget->isLocked()) {
+        databaseUnlocked(name, dbWidget->database());
+    }
+}
+
+void FdoSecretsPluginGUI::unregisterDatabase(const QString& name)
+{
+    Q_ASSERT(!name.isEmpty());
+    Q_ASSERT(m_nameToWidget.value(name));
+    FdoSecretsPlugin::unregisterDatabase(name);
+    m_nameToWidget.remove(name);
+}
+
+void FdoSecretsPluginGUI::databaseTabOpened(DatabaseWidget* dbWidget)
+{
+    // The Collection will monitor the database's exposed group.
+    // When the Collection finds that no exposed group, it will delete itself.
+    // Thus, the plugin also needs to monitor it and recreate the collection if the user changes
+    // from no exposed to exposed something.
+    connect(dbWidget, &DatabaseWidget::databaseReplaced, this, [this, dbWidget]() {
+        monitorDatabaseExposedGroup(dbWidget);
+    });
+
+    if (!dbWidget->isLocked()) {
+        monitorDatabaseExposedGroup(dbWidget);
+    }
+
+    // No exposed group, no point in registering as it will remove itself immediately anyway
+    if (!dbWidget->isLocked() && FdoSecrets::settings()->exposedGroup(dbWidget->database().data()).isNull()) {
+        return;
+    }
+
+    registerDatabase(getDatabaseName(dbWidget->database()), dbWidget);
+
+    // Reload Collection when database is replaced
+    connect(dbWidget,
+            &DatabaseWidget::databaseReplaced,
+            this,
+            [this, dbWidget](QSharedPointer<Database> oldDb, QSharedPointer<Database> newDb) {
+                Q_ASSERT(oldDb != newDb);
+                auto oldName = getDatabaseName(oldDb);
+                auto newName = getDatabaseName(newDb);
+                if (oldName != newName) {
+                    unregisterDatabase(oldName);
+                    registerDatabase(newName, dbWidget);
+                } else {
+                    // If the db is already unlocked we won't get additional signal
+                    if (!dbWidget->isLocked()) {
+                        databaseUnlocked(newName, dbWidget->database());
+                    }
+                }
+            });
+
+    // Unregister on close
+    connect(dbWidget, &DatabaseWidget::closeRequest, this, [this, dbWidget]() {
+        unregisterDatabase(getDatabaseName(dbWidget->database()));
+    });
+
+    // Reload Collection on file path changed
+    connect(dbWidget,
+            &DatabaseWidget::databaseFilePathChanged,
+            this,
+            [this, dbWidget](const QString& oldPath, const QString&) {
+                unregisterDatabase(QFileInfo(oldPath).completeBaseName());
+                registerDatabase(getDatabaseName(dbWidget->database()), dbWidget);
+            });
+}
+
+size_t FdoSecretsPluginGUI::requestEntriesRemove(const QSharedPointer<FdoSecrets::DBusClient>&,
+                                                 const QString& name,
+                                                 const QList<Entry*>& entries,
+                                                 bool permanent) const
+{
+    DatabaseWidget* dbWidget = m_nameToWidget.value(name);
+    if (!dbWidget) {
+        return 0;
+    }
+
+    if (FdoSecrets::settings()->confirmDeleteItem() && !GuiTools::confirmDeleteEntries(dbWidget, entries, permanent)) {
+        return 0;
+    }
+
+    return GuiTools::deleteEntriesResolveReferences(dbWidget, entries, permanent);
+}
+
+bool FdoSecretsPluginGUI::requestEntriesUnlock(const QSharedPointer<FdoSecrets::DBusClient>& client,
+                                               const QString& windowId,
+                                               const QList<Entry*>& entries,
+                                               QHash<Entry*, AuthDecision>& decisions,
+                                               AuthDecision& forFutureEntries) const
+{
+    QString app = QObject::tr("%1 (PID: %2)").arg(client->name()).arg(client->pid());
+    auto ac = new AccessControlDialog(findWindow(windowId), entries, app, client->processInfo(), AuthOption::Remember);
+    QObject::connect(ac,
+                     &AccessControlDialog::finished,
+                     [&](const QHash<Entry*, AuthDecision>& dialogDecisions, AuthDecision dialogForFutureEntries) {
+                         decisions = dialogDecisions;
+                         forFutureEntries = dialogForFutureEntries;
+                     });
+    ac->exec();
+    ac->deleteLater();
+    return true;
+}
+
+bool FdoSecretsPluginGUI::doLockDatabase(const QSharedPointer<FdoSecrets::DBusClient>&, const QString& name)
+{
+    DatabaseWidget* dbWidget = m_nameToWidget.value(name);
+    if (!dbWidget) {
+        return false;
+    }
+
+    // return immediately if the db is already locked
+    if (dbWidget->isLocked()) {
+        return true;
+    }
+
+    // Prevent multiple dialogs on the same database
+    if (m_lockingDb.contains(dbWidget)) {
+        return true;
+    }
+
+    m_lockingDb.insert(dbWidget);
+    bool ret = dbWidget->lock();
+    m_lockingDb.remove(dbWidget);
+    return ret;
+}
+
+bool FdoSecretsPluginGUI::doUnlockDatabase(const QSharedPointer<FdoSecrets::DBusClient>&, const QString& name)
+{
+    DatabaseWidget* dbWidget = m_nameToWidget.value(name);
+    if (!dbWidget) {
+        return false;
+    }
+
+    // return immediately if the db is already unlocked
+    if (!dbWidget->isLocked()) {
+        return true;
+    }
+
+    // Prevent multiple dialogs on the same database
+    if (!m_unlockingDb.contains(dbWidget)) {
+        m_unlockingDb.insert(dbWidget);
+        m_databases->unlockDatabaseInDialog(dbWidget, DatabaseOpenDialog::Intent::None);
+    }
+
+    QEventLoop loop;
+    bool wasAccepted = false;
+    QObject::connect(m_databases,
+                     &DatabaseTabWidget::databaseUnlockDialogFinished,
+                     &loop,
+                     [&](bool accepted, DatabaseWidget* unlocked) {
+                         if (unlocked == dbWidget) {
+                             wasAccepted = accepted;
+                             m_unlockingDb.remove(dbWidget);
+                             loop.quit();
+                         }
+                     });
+
+    loop.exec();
+    return wasAccepted;
+}
+
+bool FdoSecretsPluginGUI::requestUnlockAnyDatabase(const QSharedPointer<FdoSecrets::DBusClient>&) const
+{
+    m_databases->unlockAnyDatabaseInDialog(DatabaseOpenDialog::Intent::None);
+    QEventLoop loop;
+    bool wasAccepted = false;
+    QObject::connect(m_databases, &DatabaseTabWidget::databaseUnlockDialogFinished, &loop, [&](bool accepted) {
+        wasAccepted = accepted;
+        loop.quit();
+    });
+
+    loop.exec();
+    return wasAccepted;
+}
+
+QString FdoSecretsPluginGUI::requestNewDatabase(const QSharedPointer<FdoSecrets::DBusClient>&)
+{
+    auto dbWidget = m_databases->newDatabase();
+    if (!dbWidget) {
+        return {};
+    }
+
+    // database created through D-Bus will be exposed to D-Bus by default
+    auto db = dbWidget->database();
+    FdoSecrets::settings()->setExposedGroup(db.data(), db->rootGroup()->uuid());
+    return getDatabaseName(db);
+}
+
+QString FdoSecretsPluginGUI::overrideMessageBoxParent(const QString& windowId) const
+{
+    QString oldParentWindowId = {};
+
+    if (MessageBox::m_overrideParent && MessageBox::m_overrideParent->winId()) {
+        oldParentWindowId = QString::number(MessageBox::m_overrideParent->winId());
+    }
+
+    MessageBox::m_overrideParent = findWindow(windowId);
+    return oldParentWindowId;
+}
+
+QWindow* FdoSecretsPluginGUI::findWindow(const QString& windowId) const
+{
+    // find parent window, or nullptr if not found
+    bool ok = false;
+    WId wid = windowId.toULongLong(&ok, 0);
+    QWindow* parent = nullptr;
+    if (ok) {
+        parent = QWindow::fromWinId(wid);
+    }
+    if (parent) {
+        // parent is not the child of any object, so make sure it gets deleted at some point
+        QObject::connect(this, &QObject::destroyed, parent, &QObject::deleteLater);
+    }
+    return parent;
+}
+
+QString FdoSecretsPluginGUI::getDatabaseName(const QSharedPointer<Database>& db) const
+{
+    if (db->canonicalFilePath().isEmpty()) {
+        // This is a newly created db without saving to file,
+        // but we have to give a name, which is used to register D-Bus path.
+        // We use database name for this purpose. For simplicity, we don't monitor the name change.
+        // So the D-Bus object path is not updated if the db name changes.
+        // This should not be a problem because once the database gets saved,
+        // the D-Bus path will be updated to use filename and everything back to normal.
+        return db->metadata()->name();
+    }
+
+    return db->canonicalFilePath();
+}
+
+void FdoSecretsPluginGUI::monitorDatabaseExposedGroup(DatabaseWidget* dbWidget)
+{
+    Q_ASSERT(dbWidget->database());
+    connect(dbWidget->database()->metadata()->customData(), &CustomData::modified, this, [this, dbWidget]() {
+        if (!FdoSecrets::settings()->exposedGroup(dbWidget->database().data()).isNull()
+            && !m_nameToWidget.value(getDatabaseName(dbWidget->database()))) {
+            databaseTabOpened(dbWidget);
+        }
+    });
+}

--- a/src/fdosecrets/FdoSecretsPluginGUI.h
+++ b/src/fdosecrets/FdoSecretsPluginGUI.h
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_FDOSECRETSPLUGINGUI_H
+#define KEEPASSXC_FDOSECRETSPLUGINGUI_H
+
+#include "fdosecrets/FdoSecretsPlugin.h"
+
+#include <QSet>
+
+class DatabaseTabWidget;
+class DatabaseWidget;
+class Database;
+class QWindow;
+
+class FdoSecretsPluginGUI : public FdoSecretsPlugin
+{
+
+public:
+    FdoSecretsPluginGUI(DatabaseTabWidget* databases);
+    ~FdoSecretsPluginGUI() override = default;
+
+private slots:
+    void registerDatabase(const QString& name, DatabaseWidget* dbWidget);
+    void unregisterDatabase(const QString& name);
+
+    void databaseTabOpened(DatabaseWidget* dbWidget);
+
+private:
+    size_t requestEntriesRemove(const QSharedPointer<FdoSecrets::DBusClient>& client,
+                                const QString& name,
+                                const QList<Entry*>& entries,
+                                bool permanent) const override;
+
+    bool requestEntriesUnlock(const QSharedPointer<FdoSecrets::DBusClient>& client,
+                              const QString& windowId,
+                              const QList<Entry*>& entries,
+                              QHash<Entry*, AuthDecision>& decisions,
+                              AuthDecision& forFutureEntries) const override;
+
+    bool doLockDatabase(const QSharedPointer<FdoSecrets::DBusClient>& client, const QString& name) override;
+    bool doUnlockDatabase(const QSharedPointer<FdoSecrets::DBusClient>& client, const QString& name) override;
+    bool requestUnlockAnyDatabase(const QSharedPointer<FdoSecrets::DBusClient>& client) const override;
+    QString requestNewDatabase(const QSharedPointer<FdoSecrets::DBusClient>& client) override;
+    QString overrideMessageBoxParent(const QString& windowId) const override;
+    QWindow* findWindow(const QString& windowId) const;
+
+    QString getDatabaseName(const QSharedPointer<Database>& db) const;
+    void monitorDatabaseExposedGroup(DatabaseWidget* dbWidget);
+
+private:
+    QHash<QString, DatabaseWidget*> m_nameToWidget;
+    DatabaseTabWidget* m_databases;
+    QSet<const DatabaseWidget*> m_lockingDb; // list of dbs being locked
+    QSet<const DatabaseWidget*> m_unlockingDb; // list of dbs being unlocked
+};
+
+#endif // KEEPASSXC_FDOSECRETSPLUGINGUI_H

--- a/src/fdosecrets/FdoSecretsSettings.cpp
+++ b/src/fdosecrets/FdoSecretsSettings.cpp
@@ -84,16 +84,6 @@ namespace FdoSecrets
         config()->set(Config::FdoSecrets_UnlockBeforeSearch, unlockBeforeSearch);
     }
 
-    QUuid FdoSecretsSettings::exposedGroup(const QSharedPointer<Database>& db) const
-    {
-        return exposedGroup(db.data());
-    }
-
-    void FdoSecretsSettings::setExposedGroup(const QSharedPointer<Database>& db, const QUuid& group)
-    {
-        setExposedGroup(db.data(), group);
-    }
-
     QUuid FdoSecretsSettings::exposedGroup(Database* db) const
     {
         return {db->metadata()->customData()->value(CustomData::FdoSecretsExposedGroup)};

--- a/src/fdosecrets/FdoSecretsSettings.h
+++ b/src/fdosecrets/FdoSecretsSettings.h
@@ -48,9 +48,6 @@ namespace FdoSecrets
         void setUnlockBeforeSearch(bool unlockBeforeSearch);
 
         // Per db settings
-
-        QUuid exposedGroup(const QSharedPointer<Database>& db) const;
-        void setExposedGroup(const QSharedPointer<Database>& db, const QUuid& group);
         QUuid exposedGroup(Database* db) const;
         void setExposedGroup(Database* db, const QUuid& group);
 

--- a/src/fdosecrets/FdoSecretsSettingsPage.cpp
+++ b/src/fdosecrets/FdoSecretsSettingsPage.cpp
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "FdoSecretsSettingsPage.h"
+
+#include "FdoSecretsPlugin.h"
+#include "fdosecrets/widgets/SettingsWidgetFdoSecrets.h"
+
+#include "gui/DatabaseTabWidget.h"
+#include "gui/DatabaseWidget.h"
+
+FdoSecretsSettingsPage::FdoSecretsSettingsPage(FdoSecretsPlugin* plugin, DatabaseTabWidget* dbTabs)
+    : QObject{plugin}
+    , m_plugin{plugin}
+    , m_dbTabs{dbTabs}
+{
+}
+
+QWidget* FdoSecretsSettingsPage::createWidget()
+{
+    return new SettingsWidgetFdoSecrets(m_plugin, this);
+}
+
+void FdoSecretsSettingsPage::loadSettings(QWidget* widget)
+{
+    qobject_cast<SettingsWidgetFdoSecrets*>(widget)->loadSettings();
+}
+
+void FdoSecretsSettingsPage::saveSettings(QWidget* widget)
+{
+    qobject_cast<SettingsWidgetFdoSecrets*>(widget)->saveSettings();
+}
+
+void FdoSecretsSettingsPage::unlockDatabaseInDialog(DatabaseWidget* dbWidget)
+{
+    Q_ASSERT(dbWidget);
+    // return immediately if the db is already unlocked
+    if (dbWidget && !dbWidget->isLocked()) {
+        return;
+    }
+
+    // actually show the dialog
+    m_dbTabs->unlockDatabaseInDialog(dbWidget, DatabaseOpenDialog::Intent::None);
+}
+
+void FdoSecretsSettingsPage::switchToDatabaseSettings(DatabaseWidget* dbWidget)
+{
+    if (dbWidget->isLocked()) {
+        return;
+    }
+    // switch selected to current
+    m_dbTabs->setCurrentWidget(dbWidget);
+    m_dbTabs->showDatabaseSettings();
+
+    // open settings (switch from app settings to m_dbTabs)
+    emit requestSwitchToDatabases();
+}

--- a/src/fdosecrets/FdoSecretsSettingsPage.h
+++ b/src/fdosecrets/FdoSecretsSettingsPage.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_FDOSECRETSSETTINGSPAGE_H
+#define KEEPASSXC_FDOSECRETSSETTINGSPAGE_H
+
+#include "gui/ApplicationSettingsWidget.h"
+#include "gui/Icons.h"
+
+class DatabaseWidget;
+class DatabaseTabWidget;
+class FdoSecretsPlugin;
+
+class FdoSecretsSettingsPage : public QObject, public ISettingsPage
+{
+    Q_OBJECT
+
+public:
+    FdoSecretsSettingsPage(FdoSecretsPlugin* plugin, DatabaseTabWidget* dbTabs);
+    ~FdoSecretsSettingsPage() override = default;
+
+    QString name() override
+    {
+        return QObject::tr("Secret Service Integration");
+    }
+
+    QIcon icon() override
+    {
+        return icons()->icon("freedesktop");
+    }
+
+    DatabaseTabWidget* dbTabs() const
+    {
+        return m_dbTabs;
+    }
+
+    QWidget* createWidget() override;
+    void loadSettings(QWidget* widget) override;
+    void saveSettings(QWidget* widget) override;
+
+    void unlockDatabaseInDialog(DatabaseWidget* dbWidget);
+    void switchToDatabaseSettings(DatabaseWidget* dbWidget);
+
+signals:
+    void requestSwitchToDatabases();
+
+private:
+    FdoSecretsPlugin* m_plugin;
+    DatabaseTabWidget* m_dbTabs;
+};
+
+#endif // KEEPASSXC_FDOSECRETSSETTINGSPAGE_H

--- a/src/fdosecrets/README.md
+++ b/src/fdosecrets/README.md
@@ -1,16 +1,16 @@
 # Freedesktop.org Secret Storage Spec Server Side API
 
 This plugin implements the [Secret Storage specification][secrets] version 0.2. While running KeePassXC, it acts as a
-Secret Service server, registered on DBus, so clients like seahorse, python-secretstorage, or other implementations
+Secret Service server, registered on D-Bus, so clients like seahorse, python-secretstorage, or other implementations
 can connect and access the exposed database in KeePassXC.
 
 [secrets]: (https://www.freedesktop.org/wiki/Specifications/secret-storage-spec/)
 
 ## Configurable settings
 
-* The user can specify if a database is exposed on DBus, and which group is exposed.
+* The user can specify if a database is exposed on D-Bus, and which group is exposed.
 * Whether to show desktop notification is shown when an entry's secret is retrieved.
-* Whether to confirm for entries deleted from DBus
+* Whether to confirm for entries deleted from D-Bus
 * Whether to confirm each entry's access
 
 ## Implemented Attributes on Item Object
@@ -29,9 +29,9 @@ In addition, all non-protected custom attributes are also exposed.
 
 ## Implementation
 
-* `FdoSecrets::Service` is the top level DBus service
+* `FdoSecrets::Service` is the top level D-Bus service
 * There is one and only one `FdoSecrets::Collection` per opened database tab
-* Each entry under the exposed database group has a corresponding `FdoSecrets::Item` DBus object.
+* Each entry under the exposed database group has a corresponding `FdoSecrets::Item` D-Bus object.
 
 ### Signal connections
 

--- a/src/fdosecrets/dbus/DBusClient.cpp
+++ b/src/fdosecrets/dbus/DBusClient.cpp
@@ -63,7 +63,7 @@ namespace FdoSecrets
     {
         auto exePath = m_process.exePath();
         if (exePath.isEmpty()) {
-            return QObject::tr("unknown executable (DBus address %1)").arg(m_process.address);
+            return QObject::tr("unknown executable (D-Bus address %1)").arg(m_process.address);
         }
         if (!m_process.valid) {
             return QObject::tr("%1 (invalid executable path)").arg(exePath);

--- a/src/fdosecrets/dbus/DBusClient.h
+++ b/src/fdosecrets/dbus/DBusClient.h
@@ -44,12 +44,12 @@ namespace FdoSecrets
 
     /**
      * Contains info representing a process.
-     * This can be obtained by DBusMgr::serviceInfo given a dbus address.
+     * This can be obtained by DBusMgr::serviceInfo given a D-Bus address.
      */
     struct PeerInfo
     {
         /**
-         * @brief DBus address
+         * @brief D-Bus address
          */
         QString address;
 
@@ -82,10 +82,10 @@ namespace FdoSecrets
 
     /**
      * Represent a client that has made requests to our service. A client is identified by its
-     * DBus address, which is guaranteed to be unique by the DBus protocol.
+     * D-Bus address, which is guaranteed to be unique by the D-Bus protocol.
      *
      * An object of this class is created on the first request and destroyed
-     * when the client address vanishes from the bus. DBus guarantees that the
+     * when the client address vanishes from the bus. D-Bus guarantees that the
      * client address is not reused.
      *
      * One client may have multiple `Session`s with our service, and this class
@@ -110,7 +110,7 @@ namespace FdoSecrets
         QString name() const;
 
         /**
-         * @return The unique DBus address of the client
+         * @return The unique D-Bus address of the client
          */
         QString address() const
         {

--- a/src/fdosecrets/dbus/DBusDispatch.cpp
+++ b/src/fdosecrets/dbus/DBusDispatch.cpp
@@ -95,7 +95,7 @@ namespace FdoSecrets
                 continue;
             }
 
-            // map from function name to dbus name
+            // map from function name to D-Bus name
             auto member = camelToPascal(mm.name());
             // also "remove" => "Delete" due to c++ keyword restriction
             if (member == "Remove") {
@@ -132,7 +132,7 @@ namespace FdoSecrets
                     md.outputTypes.append(id);
                     auto paramData = typeToWireType(id);
                     if (paramData.signature.isEmpty()) {
-                        qDebug() << "Internal error: unhandled new output type for dbus signature" << paramType;
+                        qDebug() << "Internal error: unhandled new output type for D-Bus signature" << paramType;
                         valid = false;
                         break;
                     }
@@ -149,7 +149,7 @@ namespace FdoSecrets
                 }
                 auto sig = typeToWireType(id).signature;
                 if (sig.isEmpty()) {
-                    qDebug() << "Internal error: unhandled new parameter type for dbus signature" << paramType;
+                    qDebug() << "Internal error: unhandled new parameter type for D-Bus signature" << paramType;
                     valid = false;
                     break;
                 }

--- a/src/fdosecrets/dbus/DBusMgr.cpp
+++ b/src/fdosecrets/dbus/DBusMgr.cpp
@@ -232,7 +232,7 @@ namespace FdoSecrets
 
     void DBusMgr::populateMethodCache()
     {
-        // these are the methods we expose on DBus
+        // these are the methods we expose on D-Bus
         populateMethodCache(Service::staticMetaObject);
         populateMethodCache(Collection::staticMetaObject);
         populateMethodCache(Item::staticMetaObject);
@@ -296,8 +296,8 @@ namespace FdoSecrets
     {
         bool ok = m_conn.send(reply);
         if (!ok) {
-            qDebug() << "Failed to send on DBus:" << reply;
-            emit error(tr("Failed to send reply on DBus"));
+            qDebug() << "Failed to send on D-Bus:" << reply;
+            emit error(tr("Failed to send reply on D-Bus"));
         }
         return ok;
     }
@@ -423,16 +423,16 @@ namespace FdoSecrets
     {
         if (!m_conn.registerService(DBUS_SERVICE_SECRET)) {
             const auto existing = reportExistingService();
-            qDebug() << "Failed to register DBus service at " << DBUS_SERVICE_SECRET;
+            qDebug() << "Failed to register D-Bus service at " << DBUS_SERVICE_SECRET;
             qDebug() << existing;
-            emit error(tr("Failed to register DBus service at %1.<br/>").arg(DBUS_SERVICE_SECRET) + existing);
+            emit error(tr("Failed to register D-Bus service at %1.<br/>").arg(DBUS_SERVICE_SECRET) + existing);
             return false;
         }
         connect(service, &DBusObject::destroyed, this, [this]() { m_conn.unregisterService(DBUS_SERVICE_SECRET); });
 
         if (!registerObject(DBUS_PATH_SECRETS, service)) {
-            qDebug() << "Failed to register service on DBus at path" << DBUS_PATH_SECRETS;
-            emit error(tr("Failed to register service on DBus at path '%1'").arg(DBUS_PATH_SECRETS));
+            qDebug() << "Failed to register service on D-Bus at path" << DBUS_PATH_SECRETS;
+            emit error(tr("Failed to register service on D-Bus at path '%1'").arg(DBUS_PATH_SECRETS));
             return false;
         }
 
@@ -453,8 +453,8 @@ namespace FdoSecrets
             path = DBUS_PATH_TEMPLATE_COLLECTION.arg(DBUS_PATH_SECRETS, name);
 
             if (!registerObject(path, coll)) {
-                qDebug() << "Failed to register database on DBus under name" << name;
-                emit error(tr("Failed to register database on DBus under the name '%1'").arg(name));
+                qDebug() << "Failed to register database on D-Bus under name" << name;
+                emit error(tr("Failed to register database on D-Bus under the name '%1'").arg(name));
                 return false;
             }
         }
@@ -469,7 +469,7 @@ namespace FdoSecrets
     {
         auto path = DBUS_PATH_TEMPLATE_SESSION.arg(DBUS_PATH_SECRETS, sess->id());
         if (!registerObject(path, sess)) {
-            emit error(tr("Failed to register session on DBus at path '%1'").arg(path));
+            emit error(tr("Failed to register session on D-Bus at path '%1'").arg(path));
             return false;
         }
         return true;
@@ -479,7 +479,7 @@ namespace FdoSecrets
     {
         auto path = DBUS_PATH_TEMPLATE_ITEM.arg(item->collection()->objectPath().path(), item->backend()->uuidToHex());
         if (!registerObject(path, item)) {
-            emit error(tr("Failed to register item on DBus at path '%1'").arg(path));
+            emit error(tr("Failed to register item on D-Bus at path '%1'").arg(path));
             return false;
         }
 
@@ -492,7 +492,7 @@ namespace FdoSecrets
     {
         auto path = DBUS_PATH_TEMPLATE_PROMPT.arg(DBUS_PATH_SECRETS, Tools::uuidToHex(QUuid::createUuid()));
         if (!registerObject(path, prompt)) {
-            emit error(tr("Failed to register prompt object on DBus at path '%1'").arg(path));
+            emit error(tr("Failed to register prompt object on D-Bus at path '%1'").arg(path));
             return false;
         }
 
@@ -514,8 +514,8 @@ namespace FdoSecrets
     {
         auto path = DBUS_PATH_TEMPLATE_ALIAS.arg(DBUS_PATH_SECRETS, alias);
         if (!registerObject(path, coll, false)) {
-            qDebug() << "Failed to register database on DBus under alias" << alias;
-            // usually this is reported back directly on dbus, so no need to show in UI
+            qDebug() << "Failed to register database on D-Bus under alias" << alias;
+            // usually this is reported back directly on D-Bus, so no need to show in UI
             return false;
         }
         // alias signals are handled together with collections' primary path in emitCollection*

--- a/src/fdosecrets/dbus/DBusMgr.h
+++ b/src/fdosecrets/dbus/DBusMgr.h
@@ -39,17 +39,17 @@ namespace FdoSecrets
     class DBusResult;
 
     /**
-     * DBusMgr takes care of the interaction between dbus and business logic objects (DBusObject). It handles the
+     * DBusMgr takes care of the interaction between D-Bus and business logic objects (DBusObject). It handles the
      * following
      * - Registering/unregistering service name
      * - Registering/unregistering paths
-     * - Relay signals from DBusObject to dbus
-     * - Manage per-client states, mapping from dbus caller address to Client
-     * - Deliver method calls from dbus to DBusObject
+     * - Relay signals from DBusObject to D-Bus
+     * - Manage per-client states, mapping from D-Bus caller address to Client
+     * - Deliver method calls from D-Bus to DBusObject
      *
      * Special note in implementation of method delivery:
      * There are two sets of vocabulary classes in use for method delivery.
-     * The Qt DBus system uses QDBusVariant/QDBusObjectPath and other primitive types in QDBusMessage::arguments(),
+     * The Qt D-Bus system uses QDBusVariant/QDBusObjectPath and other primitive types in QDBusMessage::arguments(),
      * i.e. the on-the-wire types.
      * The DBusObject invokable methods uses QVariant/DBusObject* and other primitive types in parameters (parameter
      * types). FdoSecrets::typeToWireType establishes the mapping from parameter types to on-the-wire types. The
@@ -64,7 +64,7 @@ namespace FdoSecrets
      * by DBusObject
      *   * prepare output argument storage
      *   * call the method
-     *   * convert types to what Qt DBus expects
+     *   * convert types to what Qt D-Bus expects
      *
      * The MethodData is pre-computed using Qt meta object system by finding methods with signature matching a certain
      * pattern:
@@ -82,7 +82,7 @@ namespace FdoSecrets
         explicit DBusMgr();
 
         /**
-         * @brief Must be called after all dbus types are registered
+         * @brief Must be called after all D-Bus types are registered
          */
         void populateMethodCache();
 
@@ -107,7 +107,7 @@ namespace FdoSecrets
          */
         QString reportExistingService() const;
 
-        // expose on dbus and handle signals
+        // expose on D-Bus and handle signals
         bool registerObject(Service* service);
         bool registerObject(Collection* coll);
         bool registerObject(Session* sess);
@@ -312,7 +312,7 @@ namespace FdoSecrets
         void removeClient(DBusClient* client);
 
         QDBusServiceWatcher m_watcher{};
-        // mapping from the unique dbus peer address to client object
+        // mapping from the unique D-Bus peer address to client object
         QHash<QString, DBusClientPtr> m_clients{};
 
         DBusClientPtr m_overrideClient;

--- a/src/fdosecrets/dbus/DBusObject.h
+++ b/src/fdosecrets/dbus/DBusObject.h
@@ -34,7 +34,7 @@ namespace FdoSecrets
     class Service;
 
     /**
-     * @brief A common base class for all dbus-exposed objects.
+     * @brief A common base class for all D-Bus-exposed objects.
      */
     class DBusObject : public QObject
     {
@@ -72,7 +72,7 @@ namespace FdoSecrets
     };
 
     /**
-     * @brief A dbus error or not
+     * @brief A D-Bus error or not
      */
     class DBusResult : public QString
     {
@@ -104,7 +104,7 @@ namespace FdoSecrets
     };
 
     /**
-     * Encode the string value to a DBus object path safe representation,
+     * Encode the string value to a D-Bus object path safe representation,
      * using a schema similar to URI encoding, but with percentage(%) replaced with
      * underscore(_). All characters except [A-Za-z0-9] are encoded. For non-ascii
      * characters, UTF-8 encoding is first applied and each of the resulting byte

--- a/src/fdosecrets/dbus/DBusTypes.h
+++ b/src/fdosecrets/dbus/DBusTypes.h
@@ -27,7 +27,7 @@ namespace FdoSecrets
     struct Secret;
     class DBusMgr;
 
-    // types used directly in Qt DBus system
+    // types used directly in Qt D-Bus system
     namespace wire
     {
         struct Secret
@@ -87,7 +87,7 @@ namespace FdoSecrets
     };
 
     /**
-     * @brief Convert parameter type to on-the-wire type and associated dbus signature.
+     * @brief Convert parameter type to on-the-wire type and associated D-Bus signature.
      * This is NOT a generic version, and only handles types used in org.freedesktop.secrets
      * @param id
      * @return ParamData

--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -426,7 +426,7 @@ namespace FdoSecrets
 
         emit collectionAboutToDelete();
 
-        // remove from dbus early
+        // remove from D-Bus early
         dbus()->unregisterObject(this);
 
         // cleanup connection on Database

--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -17,48 +17,45 @@
 
 #include "Collection.h"
 
+#include "fdosecrets/FdoSecretsPlugin.h"
 #include "fdosecrets/FdoSecretsSettings.h"
 #include "fdosecrets/objects/Item.h"
 #include "fdosecrets/objects/Prompt.h"
 #include "fdosecrets/objects/Service.h"
 
+#include "core/Database.h"
+#include "core/Group.h"
+#include "core/Metadata.h"
 #include "core/Tools.h"
-#include "gui/DatabaseWidget.h"
-#include "gui/GuiTools.h"
 
 #include <QEventLoop>
 #include <QFileInfo>
 
 namespace FdoSecrets
 {
-    Collection* Collection::Create(Service* parent, DatabaseWidget* backend)
+    Collection* Collection::Create(Service* parent, const QString& name)
     {
-        return new Collection(parent, backend);
+        QScopedPointer<Collection> res{new Collection(parent, name)};
+        if (!res->dbus()->registerObject(res.data())) {
+            return nullptr;
+        }
+
+        return res.take();
     }
 
-    Collection::Collection(Service* parent, DatabaseWidget* backend)
+    Collection::Collection(Service* parent, const QString& name)
         : DBusObject(parent)
-        , m_backend(backend)
-        , m_exposedGroup(nullptr)
+        , m_backend()
+        , m_name{name}
+        , m_exposedGroup()
+        , m_items{}
+        , m_entryToItem{}
     {
-        // whenever the file path or the database object itself change, we do a full reload.
-        connect(backend, &DatabaseWidget::databaseFilePathChanged, this, &Collection::reloadBackendOrDelete);
-        connect(backend, &DatabaseWidget::databaseReplaced, this, &Collection::reloadBackendOrDelete);
-
-        // also remember to clear/populate the database when lock state changes.
-        connect(backend, &DatabaseWidget::databaseUnlocked, this, &Collection::onDatabaseLockChanged);
-        connect(backend, &DatabaseWidget::databaseLocked, this, &Collection::onDatabaseLockChanged);
-
-        // get notified whenever unlock db dialog finishes
-        connect(parent, &Service::doneUnlockDatabaseInDialog, this, [this](bool accepted, DatabaseWidget* dbWidget) {
-            if (!dbWidget || dbWidget != m_backend) {
-                return;
-            }
-            emit doneUnlockCollection(accepted);
-        });
     }
 
-    bool Collection::reloadBackend()
+    Collection::~Collection() = default;
+
+    void Collection::reloadBackend()
     {
         Q_ASSERT(m_backend);
 
@@ -69,49 +66,22 @@ namespace FdoSecrets
             m_items.first()->removeFromDBus();
         }
         cleanupConnections();
-        dbus()->unregisterObject(this);
-
-        // make sure we have updated copy of the filepath, which is used to identify the database.
-        m_backendPath = m_backend->database()->canonicalFilePath();
-
-        // register the object, handling potentially duplicated name
-        if (!dbus()->registerObject(this)) {
-            return false;
-        }
-
-        // populate contents after expose on dbus, because items rely on parent's dbus object path
-        if (!backendLocked()) {
-            populateContents();
-        } else {
-            cleanupConnections();
-        }
+        populateContents();
 
         emit collectionChanged();
-        return true;
-    }
-
-    void Collection::reloadBackendOrDelete()
-    {
-        if (!reloadBackend()) {
-            removeFromDBus();
-        }
     }
 
     DBusResult Collection::ensureBackend() const
     {
         if (!m_backend) {
-            return DBusResult(DBUS_ERROR_SECRET_NO_SUCH_OBJECT);
-        }
-        return {};
-    }
-
-    DBusResult Collection::ensureUnlocked() const
-    {
-        if (backendLocked()) {
             return DBusResult(DBUS_ERROR_SECRET_IS_LOCKED);
         }
         return {};
     }
+
+    /**
+     * D-Bus Properties
+     */
 
     DBusResult Collection::items(QList<Item*>& items) const
     {
@@ -130,11 +100,12 @@ namespace FdoSecrets
             return ret;
         }
 
-        if (backendLocked()) {
+        if (!m_backend) {
             label = name();
         } else {
-            label = m_backend->database()->metadata()->name();
+            label = m_backend->metadata()->name();
         }
+
         return {};
     }
 
@@ -144,22 +115,14 @@ namespace FdoSecrets
         if (ret.err()) {
             return ret;
         }
-        ret = ensureUnlocked();
-        if (ret.err()) {
-            return ret;
-        }
 
-        m_backend->database()->metadata()->setName(label);
+        m_backend->metadata()->setName(label);
         return {};
     }
 
     DBusResult Collection::locked(bool& locked) const
     {
-        auto ret = ensureBackend();
-        if (ret.err()) {
-            return ret;
-        }
-        locked = backendLocked();
+        locked = !m_backend;
         return {};
     }
 
@@ -169,12 +132,7 @@ namespace FdoSecrets
         if (ret.err()) {
             return ret;
         }
-        ret = ensureUnlocked();
-        if (ret.err()) {
-            return ret;
-        }
-        created = static_cast<qulonglong>(
-            m_backend->database()->rootGroup()->timeInfo().creationTime().toMSecsSinceEpoch() / 1000);
+        created = static_cast<qulonglong>(m_backend->rootGroup()->timeInfo().creationTime().toMSecsSinceEpoch() / 1000);
 
         return {};
     }
@@ -185,16 +143,16 @@ namespace FdoSecrets
         if (ret.err()) {
             return ret;
         }
-        ret = ensureUnlocked();
-        if (ret.err()) {
-            return ret;
-        }
         // FIXME: there seems not to have a global modified time.
         // Use a more accurate time, considering all metadata, group, entry.
-        modified = static_cast<qulonglong>(
-            m_backend->database()->rootGroup()->timeInfo().lastModificationTime().toMSecsSinceEpoch() / 1000);
+        modified = static_cast<qulonglong>(m_backend->rootGroup()->timeInfo().lastModificationTime().toMSecsSinceEpoch()
+                                           / 1000);
         return {};
     }
+
+    /**
+     * D-Bus Methods
+     */
 
     DBusResult Collection::remove(PromptBase*& prompt)
     {
@@ -217,13 +175,6 @@ namespace FdoSecrets
         auto ret = ensureBackend();
         if (ret.err()) {
             return ret;
-        }
-
-        if (backendLocked()) {
-            // searchItems should work, whether `this` is locked or not.
-            // however, we can't search items the same way as in gnome-keying,
-            // because there's no database at all when locked.
-            return {};
         }
 
         // shortcut logic for Uuid/Path attributes, as they can uniquely identify an item.
@@ -294,11 +245,6 @@ namespace FdoSecrets
                                       Item*& item,
                                       PromptBase*& prompt)
     {
-        auto ret = ensureBackend();
-        if (ret.err()) {
-            return ret;
-        }
-
         item = nullptr;
 
         prompt = PromptBase::Create<CreateItemPrompt>(service(), this, properties, secret, replace);
@@ -320,84 +266,6 @@ namespace FdoSecrets
         return {};
     }
 
-    const QSet<QString> Collection::aliases() const
-    {
-        return m_aliases;
-    }
-
-    DBusResult Collection::addAlias(QString alias)
-    {
-        auto ret = ensureBackend();
-        if (ret.err()) {
-            return ret;
-        }
-
-        alias = encodePath(alias);
-
-        if (m_aliases.contains(alias)) {
-            return {};
-        }
-
-        emit aliasAboutToAdd(alias);
-
-        if (dbus()->registerAlias(this, alias)) {
-            m_aliases.insert(alias);
-            emit aliasAdded(alias);
-        } else {
-            return QDBusError::InvalidObjectPath;
-        }
-
-        return {};
-    }
-
-    DBusResult Collection::removeAlias(QString alias)
-    {
-        auto ret = ensureBackend();
-        if (ret.err()) {
-            return ret;
-        }
-
-        alias = encodePath(alias);
-
-        if (!m_aliases.contains(alias)) {
-            return {};
-        }
-
-        dbus()->unregisterAlias(alias);
-        m_aliases.remove(alias);
-        emit aliasRemoved(alias);
-
-        return {};
-    }
-
-    QString Collection::name() const
-    {
-        if (m_backendPath.isEmpty()) {
-            // This is a newly created db without saving to file,
-            // but we have to give a name, which is used to register dbus path.
-            // We use database name for this purpose. For simplicity, we don't monitor the name change.
-            // So the dbus object path is not updated if the db name changes.
-            // This should not be a problem because once the database gets saved,
-            // the dbus path will be updated to use filename and everything back to normal.
-            return m_backend->database()->metadata()->name();
-        }
-        return QFileInfo(m_backendPath).completeBaseName();
-    }
-
-    DatabaseWidget* Collection::backend() const
-    {
-        return m_backend;
-    }
-
-    void Collection::onDatabaseLockChanged()
-    {
-        if (!reloadBackend()) {
-            removeFromDBus();
-            return;
-        }
-        emit collectionLockChanged(backendLocked());
-    }
-
     void Collection::populateContents()
     {
         if (!m_backend) {
@@ -406,8 +274,8 @@ namespace FdoSecrets
 
         // we have an unlocked db
 
-        auto newUuid = FdoSecrets::settings()->exposedGroup(m_backend->database());
-        auto newGroup = m_backend->database()->rootGroup()->findGroupByUuid(newUuid);
+        auto newUuid = FdoSecrets::settings()->exposedGroup(m_backend.data());
+        auto newGroup = m_backend->rootGroup()->findGroupByUuid(newUuid);
         if (!newGroup || newGroup->isRecycled()) {
             // no exposed group, delete self
             removeFromDBus();
@@ -425,89 +293,74 @@ namespace FdoSecrets
         // signal should be first emitted, and we will clean up connection in reloadDatabase,
         // so this handler won't be triggered.
         connect(m_exposedGroup.data(), &Group::groupAboutToRemove, this, [this](Group* toBeRemoved) {
-            if (backendLocked()) {
+            if (!m_backend) {
                 return;
             }
-            auto db = m_backend->database();
-            if (toBeRemoved->database() != db) {
+
+            Q_ASSERT(toBeRemoved->database() == m_backend);
+            if (toBeRemoved->database() != m_backend) {
                 // should not happen, but anyway.
                 // somehow our current database has been changed, and the old group is being deleted
                 // possibly logic changes in replaceDatabase.
                 return;
             }
-            auto uuid = FdoSecrets::settings()->exposedGroup(db);
-            auto exposedGroup = db->rootGroup()->findGroupByUuid(uuid);
+            auto uuid = FdoSecrets::settings()->exposedGroup(m_backend.data());
+            auto exposedGroup = m_backend->rootGroup()->findGroupByUuid(uuid);
             if (toBeRemoved == exposedGroup) {
                 // reset the exposed group to none
-                FdoSecrets::settings()->setExposedGroup(db, {});
+                FdoSecrets::settings()->setExposedGroup(m_backend.data(), {});
             }
         });
         // Another possibility is the group being moved to recycle bin.
         connect(m_exposedGroup.data(), &Group::modified, this, [this]() {
             if (m_exposedGroup->isRecycled()) {
                 // reset the exposed group to none
-                FdoSecrets::settings()->setExposedGroup(m_backend->database().data(), {});
+                FdoSecrets::settings()->setExposedGroup(m_backend.data(), {});
             }
         });
 
         // Monitor exposed group settings
-        connect(m_backend->database()->metadata()->customData(), &CustomData::modified, this, [this]() {
-            if (!m_exposedGroup || backendLocked()) {
+        connect(m_backend->metadata()->customData(), &CustomData::modified, this, [this]() {
+            if (!m_exposedGroup || !m_backend) {
                 return;
             }
-            if (m_exposedGroup->uuid() == FdoSecrets::settings()->exposedGroup(m_backend->database())) {
+            if (m_exposedGroup->uuid() == FdoSecrets::settings()->exposedGroup(m_backend.data())) {
                 // no change
                 return;
             }
-            onDatabaseExposedGroupChanged();
+            reloadBackend();
         });
 
         // Add items for existing entry
         const auto entries = m_exposedGroup->entriesRecursive(false);
         for (const auto& entry : entries) {
-            onEntryAdded(entry, false);
+            onEntryAdded(entry);
         }
 
         // Do not connect to Database::modified signal because we only want signals for the subset under m_exposedGroup
-        connect(m_backend->database()->metadata(), &Metadata::modified, this, &Collection::collectionChanged);
+        connect(m_backend->metadata(), &Metadata::modified, this, &Collection::collectionChanged);
         connectGroupSignalRecursive(m_exposedGroup);
     }
 
-    void Collection::onDatabaseExposedGroupChanged()
-    {
-        // delete all items
-        // this has to be done because the backend is actually still there
-        // just we don't expose them
-        for (const auto& item : asConst(m_items)) {
-            item->removeFromDBus();
-        }
-
-        // repopulate
-        if (!backendLocked()) {
-            populateContents();
-        }
-    }
-
-    void Collection::onEntryAdded(Entry* entry, bool emitSignal)
+    Item* Collection::onEntryAdded(Entry* entry)
     {
         if (entry->isRecycled()) {
-            return;
+            return nullptr;
         }
 
-        auto item = Item::Create(this, entry);
+        auto item = m_entryToItem.value(entry);
+        // Entry already has corresponding Item
+        if (item) {
+            return item;
+        }
+
+        item = Item::Create(this, entry);
         if (!item) {
-            return;
+            return nullptr;
         }
 
         m_items << item;
         m_entryToItem[entry] = item;
-
-        // forward delete signals
-        connect(entry->group(), &Group::entryAboutToRemove, item, [item](Entry* toBeRemoved) {
-            if (item->backend() == toBeRemoved) {
-                item->removeFromDBus();
-            }
-        });
 
         // relay signals
         connect(item, &Item::itemChanged, this, [this, item]() { emit itemChanged(item); });
@@ -517,9 +370,7 @@ namespace FdoSecrets
             emit itemDeleted(item);
         });
 
-        if (emitSignal) {
-            emit itemCreated(item);
-        }
+        return item;
     }
 
     void Collection::connectGroupSignalRecursive(Group* group)
@@ -529,7 +380,11 @@ namespace FdoSecrets
         }
 
         connect(group, &Group::modified, this, &Collection::collectionChanged);
-        connect(group, &Group::entryAdded, this, [this](Entry* entry) { onEntryAdded(entry, true); });
+        connect(group, &Group::entryAdded, this, [this](Entry* entry) {
+            if (Item* item = onEntryAdded(entry)) {
+                emit itemCreated(item);
+            }
+        });
 
         const auto children = group->children();
         for (const auto& cg : children) {
@@ -537,37 +392,34 @@ namespace FdoSecrets
         }
     }
 
-    Service* Collection::service() const
+    FdoSecretsPlugin* Collection::plugin() const
     {
-        return qobject_cast<Service*>(parent());
+        return service()->plugin();
     }
 
-    bool Collection::doLock()
+    bool Collection::doLock(const DBusClientPtr& client) const
     {
-        Q_ASSERT(m_backend);
+        // Already locked
+        if (!m_backend) {
+            return true;
+        }
 
-        // do not call m_backend->lock() directly
-        // let the service handle locking which handles concurrent calls
-        return service()->doLockDatabase(m_backend);
+        return plugin()->doLockDatabase(client, m_name);
     }
 
-    void Collection::doUnlock()
+    bool Collection::doUnlock(const DBusClientPtr& client) const
     {
-        Q_ASSERT(m_backend);
+        // Already unlocked
+        if (m_backend) {
+            return true;
+        }
 
-        return service()->doUnlockDatabaseInDialog(m_backend);
-    }
-
-    bool Collection::doDelete()
-    {
-        Q_ASSERT(m_backend);
-
-        return service()->doCloseDatabase(m_backend);
+        return plugin()->doUnlockDatabase(client, m_name);
     }
 
     void Collection::removeFromDBus()
     {
-        if (!m_backend) {
+        if (!m_backend && !m_exposedGroup) {
             // I'm already deleted
             return;
         }
@@ -577,41 +429,38 @@ namespace FdoSecrets
         // remove from dbus early
         dbus()->unregisterObject(this);
 
-        // remove alias manually to trigger signal
-        for (const auto& a : aliases()) {
-            removeAlias(a).okOrDie();
-        }
-
         // cleanup connection on Database
         cleanupConnections();
-        // cleanup connection on Backend itself
-        m_backend->disconnect(this);
+
+        // items will be removed automatically as they are children objects
+        m_items.clear();
+
         parent()->disconnect(this);
 
         m_exposedGroup = nullptr;
 
-        // reset backend and delete self
+        // reset database and delete self
         m_backend = nullptr;
-        deleteLater();
 
-        // items will be removed automatically as they are children objects
+        deleteLater();
     }
 
     void Collection::cleanupConnections()
     {
-        m_backend->database()->metadata()->customData()->disconnect(this);
+        if (m_backend && m_backend->metadata() && m_backend->metadata()->customData()) {
+            m_backend->metadata()->customData()->disconnect(this);
+        }
+
         if (m_exposedGroup) {
             for (const auto group : m_exposedGroup->groupsRecursive(true)) {
                 group->disconnect(this);
             }
         }
-
-        m_items.clear();
     }
 
-    QString Collection::backendFilePath() const
+    QString Collection::dbusName() const
     {
-        return m_backendPath;
+        return QFileInfo(m_name).completeBaseName();
     }
 
     Group* Collection::exposedRootGroup() const
@@ -619,23 +468,13 @@ namespace FdoSecrets
         return m_exposedGroup;
     }
 
-    bool Collection::backendLocked() const
+    bool Collection::doDeleteItem(const DBusClientPtr& client, const Item* item) const
     {
-        return !m_backend || !m_backend->database()->isInitialized() || m_backend->isLocked();
-    }
+        Q_ASSERT(m_backend);
 
-    bool Collection::doDeleteEntry(Entry* entry)
-    {
-        // Confirm entry removal before moving forward
-        bool permanent = entry->isRecycled() || !m_backend->database()->metadata()->recycleBinEnabled();
-        if (FdoSecrets::settings()->confirmDeleteItem()
-            && !GuiTools::confirmDeleteEntries(m_backend, {entry}, permanent)) {
-            return false;
-        }
-
-        auto num = GuiTools::deleteEntriesResolveReferences(m_backend, {entry}, permanent);
-
-        return num != 0;
+        auto entry = item->backend();
+        bool permanent = entry->isRecycled() || !m_backend->metadata()->recycleBinEnabled();
+        return plugin()->requestEntriesRemove(client, m_name, {entry}, permanent);
     }
 
     Group* Collection::findCreateGroupByPath(const QString& groupPath)
@@ -682,7 +521,7 @@ namespace FdoSecrets
         auto* entry = new Entry();
         entry->setUuid(QUuid::createUuid());
         entry->setTitle(itemName);
-        entry->setUsername(m_backend->database()->metadata()->defaultUserName());
+        entry->setUsername(m_backend->metadata()->defaultUserName());
         group->applyGroupIconOnCreateTo(entry);
 
         entry->setGroup(group);
@@ -691,9 +530,27 @@ namespace FdoSecrets
         client->setItemAuthorized(entry->uuid(), AuthDecision::Allowed);
 
         // when creation finishes in backend, we will already have item
-        auto created = m_entryToItem.value(entry, nullptr);
-
+        auto created = m_entryToItem.value(entry);
         return created;
+    }
+
+    void Collection::databaseLocked()
+    {
+        if (!m_backend) {
+            return;
+        }
+
+        m_backend = nullptr;
+        emit collectionChanged();
+        emit collectionLockChanged(false);
+    }
+
+    void Collection::databaseUnlocked(QSharedPointer<Database> db)
+    {
+        Q_ASSERT(!m_backend);
+        m_backend = db;
+        reloadBackend();
+        emit collectionLockChanged(true);
     }
 
 } // namespace FdoSecrets

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -24,8 +24,8 @@
 #include "core/EntrySearcher.h"
 
 class Database;
-class DatabaseWidget;
 class Entry;
+class FdoSecretsPlugin;
 class Group;
 
 namespace FdoSecrets
@@ -38,19 +38,23 @@ namespace FdoSecrets
         Q_OBJECT
         Q_CLASSINFO("D-Bus Interface", DBUS_INTERFACE_SECRET_COLLECTION_LITERAL)
 
-        explicit Collection(Service* parent, DatabaseWidget* backend);
+        explicit Collection(Service* parent, const QString& name);
 
     public:
         /**
          * @brief Create a new instance of `Collection`
          * @param parent the owning Service
-         * @param backend the widget containing the database
+         * @param name the collection name
          * @return pointer to created instance, or nullptr when error happens.
          * This may be caused by
          *   - DBus path registration error
-         *   - database has no exposed group
          */
-        static Collection* Create(Service* parent, DatabaseWidget* backend);
+        static Collection* Create(Service* parent, const QString& name);
+        ~Collection() override;
+
+        /**
+         * D-Bus Properties
+         */
 
         Q_INVOKABLE DBUS_PROPERTY DBusResult items(QList<Item*>& items) const;
 
@@ -63,6 +67,9 @@ namespace FdoSecrets
 
         Q_INVOKABLE DBUS_PROPERTY DBusResult modified(qulonglong& modified) const;
 
+        /**
+         * D-Bus Methods
+         */
         Q_INVOKABLE DBusResult remove(PromptBase*& prompt);
         Q_INVOKABLE DBusResult searchItems(const DBusClientPtr& client,
                                            const StringStringMap& attributes,
@@ -71,6 +78,9 @@ namespace FdoSecrets
         createItem(const QVariantMap& properties, const Secret& secret, bool replace, Item*& item, PromptBase*& prompt);
 
     signals:
+        /**
+         * D-Bus Signals
+         */
         void itemCreated(Item* item);
         void itemDeleted(Item* item);
         void itemChanged(Item* item);
@@ -79,84 +89,68 @@ namespace FdoSecrets
         void collectionAboutToDelete();
         void collectionLockChanged(bool newLocked);
 
-        void aliasAboutToAdd(const QString& alias);
-        void aliasAdded(const QString& alias);
-        void aliasRemoved(const QString& alias);
-
-        void doneUnlockCollection(bool accepted);
-
     public:
+        // For setting multiple properties at once
         DBusResult setProperties(const QVariantMap& properties);
-
-        bool isValid() const
-        {
-            return backend();
-        }
-
-        DBusResult removeAlias(QString alias);
-        DBusResult addAlias(QString alias);
-        const QSet<QString> aliases() const;
 
         /**
          * A human readable name of the collection, available even if the db is locked
          * @return
          */
-        QString name() const;
+        QString name() const
+        {
+            return m_name;
+        }
 
+        QString dbusName() const;
         Group* exposedRootGroup() const;
-        DatabaseWidget* backend() const;
-        QString backendFilePath() const;
-        Service* service() const;
+        Database* backend() const
+        {
+            return m_backend.data();
+        }
+
+        // Access to ancestors
+        Service* service() const
+        {
+            return qobject_cast<Service*>(parent());
+        }
+        FdoSecretsPlugin* plugin() const;
 
         static EntrySearcher::SearchTerm attributeToTerm(const QString& key, const QString& value);
 
     public slots:
         // expose some methods for Prompt to use
+        bool doLock(const DBusClientPtr& client) const;
+        bool doUnlock(const DBusClientPtr& client) const;
 
-        bool doLock();
-        // actually only closes database tab in KPXC
-        bool doDelete();
-        // Async, finish signal doneUnlockCollection
-        void doUnlock();
+        bool doDeleteItem(const DBusClientPtr& client, const Item* item) const;
 
-        bool doDeleteEntry(Entry* entry);
         Item* doNewItem(const DBusClientPtr& client, QString itemPath);
 
         // Only delete from dbus, will remove self. Do not affect database in KPXC
         void removeFromDBus();
 
-        // force reload info from backend, potentially delete self
-        bool reloadBackend();
+        void reloadBackend();
 
-    private slots:
-        void onDatabaseLockChanged();
-        void onDatabaseExposedGroupChanged();
-
-        // calls reloadBackend, delete self when error
-        void reloadBackendOrDelete();
+        void databaseLocked();
+        void databaseUnlocked(QSharedPointer<Database> db);
 
     private:
+        friend class LockCollectionsPrompt;
+        friend class UnlockPrompt;
         friend class DeleteCollectionPrompt;
-        friend class CreateCollectionPrompt;
+        friend class CreateItemPrompt;
 
-        void onEntryAdded(Entry* entry, bool emitSignal);
+        Item* onEntryAdded(Entry* entry);
         void populateContents();
         void connectGroupSignalRecursive(Group* group);
         void cleanupConnections();
-
-        bool backendLocked() const;
 
         /**
          * Check if the backend is a valid object, send error reply if not.
          * @return true if the backend is valid.
          */
         DBusResult ensureBackend() const;
-
-        /**
-         * Ensure the database is unlocked, send error reply if locked.
-         * @return true if the database is locked
-         */
-        DBusResult ensureUnlocked() const;
 
         /**
          * Like mkdir -p, find or create the group by path, under m_exposedGroup
@@ -166,11 +160,12 @@ namespace FdoSecrets
         Group* findCreateGroupByPath(const QString& groupPath);
 
     private:
-        QPointer<DatabaseWidget> m_backend;
-        QString m_backendPath;
+        QSharedPointer<Database> m_backend;
+
+        QString m_name;
+
         QPointer<Group> m_exposedGroup;
 
-        QSet<QString> m_aliases;
         QList<Item*> m_items;
         QMap<const Entry*, Item*> m_entryToItem;
     };

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -47,7 +47,7 @@ namespace FdoSecrets
          * @param name the collection name
          * @return pointer to created instance, or nullptr when error happens.
          * This may be caused by
-         *   - DBus path registration error
+         *   - D-Bus path registration error
          */
         static Collection* Create(Service* parent, const QString& name);
         ~Collection() override;
@@ -127,7 +127,7 @@ namespace FdoSecrets
 
         Item* doNewItem(const DBusClientPtr& client, QString itemPath);
 
-        // Only delete from dbus, will remove self. Do not affect database in KPXC
+        // Only delete from D-Bus, will remove self. Do not affect database in KPXC
         void removeFromDBus();
 
         void reloadBackend();

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -74,7 +74,19 @@ namespace FdoSecrets
         , m_backend(backend)
     {
         connect(m_backend, &Entry::modified, this, &Item::itemChanged);
+        // Remove from dbus when deleted
+        connect(m_backend->group(), &Group::entryAboutToRemove, this, [this](Entry* toBeRemoved) {
+            if (m_backend == toBeRemoved) {
+                removeFromDBus();
+            }
+        });
     }
+
+    Item::~Item() = default;
+
+    /**
+     * D-Bus Properties
+     */
 
     DBusResult Item::locked(const DBusClientPtr& client, bool& locked) const
     {
@@ -232,6 +244,10 @@ namespace FdoSecrets
         return {};
     }
 
+    /**
+     * D-Bus Methods
+     */
+
     DBusResult Item::remove(PromptBase*& prompt)
     {
         auto ret = ensureBackend();
@@ -249,9 +265,8 @@ namespace FdoSecrets
     {
         auto ret = getSecretNoNotification(client, session, secret);
         if (ret.ok()) {
-            service()->plugin()->emitRequestShowNotification(
-                tr(R"(Entry "%1" from database "%2" was used by %3)")
-                    .arg(m_backend->title(), collection()->name(), client->name()));
+            plugin()->emitRequestShowNotification(tr(R"(Entry "%1" from database "%2" was used by %3)")
+                                                      .arg(m_backend->title(), collection()->name(), client->name()));
         }
         return ret;
     }
@@ -331,11 +346,6 @@ namespace FdoSecrets
         return {};
     }
 
-    Collection* Item::collection() const
-    {
-        return qobject_cast<Collection*>(parent());
-    }
-
     DBusResult Item::ensureBackend() const
     {
         if (!m_backend) {
@@ -362,11 +372,11 @@ namespace FdoSecrets
         return m_backend;
     }
 
-    bool Item::doDelete()
+    bool Item::doDelete(const DBusClientPtr& client) const
     {
         Q_ASSERT(m_backend);
 
-        return collection()->doDeleteEntry(m_backend);
+        return collection()->doDeleteItem(client, this);
     }
 
     void Item::removeFromDBus()
@@ -378,6 +388,8 @@ namespace FdoSecrets
         // before the current Item is deleted in the event loop.
         dbus()->unregisterObject(this);
 
+        m_backend->group()->disconnect(this);
+
         m_backend = nullptr;
         deleteLater();
     }
@@ -385,6 +397,11 @@ namespace FdoSecrets
     Service* Item::service() const
     {
         return collection()->service();
+    }
+
+    FdoSecretsPlugin* Item::plugin() const
+    {
+        return service()->plugin();
     }
 
     QString Item::path() const
@@ -404,6 +421,10 @@ namespace FdoSecrets
 
         return pathComponents.join('/');
     }
+
+    /**
+     * Helper functions
+     */
 
     DBusResult setEntrySecret(Entry* entry, const QByteArray& data, const QString& contentType)
     {

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -74,7 +74,7 @@ namespace FdoSecrets
         , m_backend(backend)
     {
         connect(m_backend, &Entry::modified, this, &Item::itemChanged);
-        // Remove from dbus when deleted
+        // Remove from D-Bus when deleted
         connect(m_backend->group(), &Group::entryAboutToRemove, this, [this](Entry* toBeRemoved) {
             if (m_backend == toBeRemoved) {
                 removeFromDBus();
@@ -384,7 +384,7 @@ namespace FdoSecrets
         emit itemAboutToDelete();
 
         // Unregister current path early, do not rely on deleteLater's call to destructor
-        // as in case of Entry moving between groups, new Item will be created at the same DBus path
+        // as in case of Entry moving between groups, new Item will be created at the same D-Bus path
         // before the current Item is deleted in the event loop.
         dbus()->unregisterObject(this);
 

--- a/src/fdosecrets/objects/Item.h
+++ b/src/fdosecrets/objects/Item.h
@@ -22,6 +22,7 @@
 #include "fdosecrets/dbus/DBusObject.h"
 
 class Entry;
+class FdoSecretsPlugin;
 
 namespace FdoSecrets
 {
@@ -33,9 +34,10 @@ namespace FdoSecrets
         constexpr const auto TotpKey = "TOTP";
     } // namespace ItemAttributes
 
-    class Session;
     class Collection;
     class PromptBase;
+    class Service;
+    class Session;
 
     class Item : public DBusObject
     {
@@ -54,6 +56,11 @@ namespace FdoSecrets
          *   - DBus path registration error
          */
         static Item* Create(Collection* parent, Entry* backend);
+        ~Item() override;
+
+        /**
+         * D-Bus Properties
+         */
 
         Q_INVOKABLE DBUS_PROPERTY DBusResult locked(const DBusClientPtr& client, bool& locked) const;
 
@@ -67,6 +74,10 @@ namespace FdoSecrets
 
         Q_INVOKABLE DBUS_PROPERTY DBusResult modified(qulonglong& modified) const;
 
+        /**
+         * D-Bus Methods
+         */
+
         Q_INVOKABLE DBusResult remove(PromptBase*& prompt);
         Q_INVOKABLE DBusResult getSecret(const DBusClientPtr& client, Session* session, Secret& secret);
         Q_INVOKABLE DBusResult setSecret(const DBusClientPtr& client, const Secret& secret);
@@ -78,12 +89,20 @@ namespace FdoSecrets
     public:
         static const QSet<QString> ReadOnlyAttributes;
 
+        // Helper for Service::getSecrets
         DBusResult getSecretNoNotification(const DBusClientPtr& client, Session* session, Secret& secret) const;
+        // For setting multiple properties at once
         DBusResult setProperties(const QVariantMap& properties);
 
         Entry* backend() const;
-        Collection* collection() const;
+
+        // Access to ancestors
+        Collection* collection() const
+        {
+            return qobject_cast<Collection*>(parent());
+        }
         Service* service() const;
+        FdoSecretsPlugin* plugin() const;
 
         /**
          * Compute the entry path relative to the exposed group
@@ -93,7 +112,7 @@ namespace FdoSecrets
 
     public slots:
         // will actually delete the entry in KPXC
-        bool doDelete();
+        bool doDelete(const DBusClientPtr& client) const;
 
         // Only delete from dbus, will remove self. Do not affect database in KPXC
         void removeFromDBus();
@@ -101,7 +120,7 @@ namespace FdoSecrets
     private slots:
         /**
          * Check if the backend is a valid object, send error reply if not.
-         * @return No error if the backend is valid.
+         * @return No error if the entry is valid.
          */
         DBusResult ensureBackend() const;
 
@@ -110,6 +129,9 @@ namespace FdoSecrets
          * @return true if the database is locked
          */
         DBusResult ensureUnlocked() const;
+
+    private:
+        friend class DeleteItemPrompt;
 
     private:
         QPointer<Entry> m_backend;

--- a/src/fdosecrets/objects/Item.h
+++ b/src/fdosecrets/objects/Item.h
@@ -53,7 +53,7 @@ namespace FdoSecrets
          * @param backend the `Entry` containing the data
          * @return pointer to newly created Item, or nullptr if error
          * This may be caused by
-         *   - DBus path registration error
+         *   - D-Bus path registration error
          */
         static Item* Create(Collection* parent, Entry* backend);
         ~Item() override;
@@ -114,7 +114,7 @@ namespace FdoSecrets
         // will actually delete the entry in KPXC
         bool doDelete(const DBusClientPtr& client) const;
 
-        // Only delete from dbus, will remove self. Do not affect database in KPXC
+        // Only delete from D-Bus, will remove self. Do not affect database in KPXC
         void removeFromDBus();
 
     private slots:

--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -107,7 +107,7 @@ namespace FdoSecrets
         OverrideParentWindow override(this, windowId);
 
         if (m_collection) {
-            // Collection removal is just disconnecting it from dbus.
+            // Collection removal is just disconnecting it from D-Bus.
             // GUI then reacts with potentially closing the database.
             m_collection->removeFromDBus();
         }

--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -17,49 +17,40 @@
 
 #include "Prompt.h"
 
+#include "fdosecrets/FdoSecretsPlugin.h"
 #include "fdosecrets/objects/Collection.h"
 #include "fdosecrets/objects/Item.h"
 #include "fdosecrets/objects/Service.h"
 #include "fdosecrets/objects/Session.h"
-#include "fdosecrets/widgets/AccessControlDialog.h"
 
 #include "FdoSecretsSettings.h"
 #include "core/Entry.h"
-#include "gui/MessageBox.h"
 
 #include <QThread>
 #include <QTimer>
-#include <QWindow>
 
 namespace FdoSecrets
 {
-    const PromptResult PromptResult::Pending{PromptResult::AsyncPending};
-
     PromptBase::PromptBase(Service* parent)
         : DBusObject(parent)
     {
         connect(this, &PromptBase::completed, this, &PromptBase::deleteLater);
     }
 
-    QWindow* PromptBase::findWindow(const QString& windowId)
-    {
-        // find parent window, or nullptr if not found
-        bool ok = false;
-        WId wid = windowId.toULongLong(&ok, 0);
-        QWindow* parent = nullptr;
-        if (ok) {
-            parent = QWindow::fromWinId(wid);
-        }
-        if (parent) {
-            // parent is not the child of any object, so make sure it gets deleted at some point
-            QObject::connect(this, &QObject::destroyed, parent, &QObject::deleteLater);
-        }
-        return parent;
-    }
-
     Service* PromptBase::service() const
     {
         return qobject_cast<Service*>(parent());
+    }
+
+    PromptBase::OverrideParentWindow::OverrideParentWindow(PromptBase* prompt, const QString& newParentWindowId)
+        : m_prompt(prompt)
+        , m_oldParentWindowId(prompt->service()->plugin()->overrideMessageBoxParent(newParentWindowId))
+    {
+    }
+
+    PromptBase::OverrideParentWindow::~OverrideParentWindow()
+    {
+        m_prompt->service()->plugin()->overrideMessageBoxParent(m_oldParentWindowId);
     }
 
     DBusResult PromptBase::prompt(const DBusClientPtr& client, const QString& windowId)
@@ -78,20 +69,25 @@ namespace FdoSecrets
             if (!c) {
                 return;
             }
+
             if (m_signalSent) {
                 return;
             }
+
             auto res = promptSync(c, windowId);
-            if (!res.isPending()) {
-                finishPrompt(res.isDismiss());
+            if (m_signalSent) {
+                return;
             }
+            m_signalSent = true;
+            emit completed(!res.ok(), currentResult());
         });
         return {};
     }
 
     DBusResult PromptBase::dismiss()
     {
-        finishPrompt(true);
+        m_signalSent = true;
+        emit completed(true, currentResult());
         return {};
     }
 
@@ -100,31 +96,22 @@ namespace FdoSecrets
         return "";
     }
 
-    void PromptBase::finishPrompt(bool dismissed)
-    {
-        if (m_signalSent) {
-            return;
-        }
-        m_signalSent = true;
-        emit completed(dismissed, currentResult());
-    }
-
     DeleteCollectionPrompt::DeleteCollectionPrompt(Service* parent, Collection* coll)
         : PromptBase(parent)
         , m_collection(coll)
     {
     }
 
-    PromptResult DeleteCollectionPrompt::promptSync(const DBusClientPtr&, const QString& windowId)
+    DBusResult DeleteCollectionPrompt::promptSync(const DBusClientPtr&, const QString& windowId)
     {
-        MessageBox::OverrideParent override(findWindow(windowId));
+        OverrideParentWindow override(this, windowId);
 
-        // if m_collection is already gone then treat as deletion accepted
-        auto accepted = true;
         if (m_collection) {
-            accepted = m_collection->doDelete();
+            // Collection removal is just disconnecting it from dbus.
+            // GUI then reacts with potentially closing the database.
+            m_collection->removeFromDBus();
         }
-        return PromptResult::accepted(accepted);
+        return {};
     }
 
     CreateCollectionPrompt::CreateCollectionPrompt(Service* parent, QVariantMap properties, QString alias)
@@ -139,9 +126,9 @@ namespace FdoSecrets
         return QVariant::fromValue(DBusMgr::objectPathSafe(m_coll));
     }
 
-    PromptResult CreateCollectionPrompt::promptSync(const DBusClientPtr&, const QString& windowId)
+    DBusResult CreateCollectionPrompt::promptSync(const DBusClientPtr& client, const QString& windowId)
     {
-        MessageBox::OverrideParent override(findWindow(windowId));
+        OverrideParentWindow override(this, windowId);
 
         bool created = false;
         // collection with the alias may be created since the prompt was created
@@ -149,13 +136,15 @@ namespace FdoSecrets
         if (ret.err()) {
             return ret;
         }
+
         if (!m_coll) {
             created = true;
-            m_coll = service()->doNewDatabase();
+            m_coll = service()->doNewDatabase(client);
             if (!m_coll) {
-                return PromptResult::accepted(false);
+                return {QDBusError::AccessDenied};
             }
         }
+
         ret = m_coll->setProperties(m_properties);
         if (ret.err()) {
             if (created) {
@@ -164,7 +153,7 @@ namespace FdoSecrets
             return ret;
         }
         if (!m_alias.isEmpty()) {
-            ret = m_coll->addAlias(m_alias);
+            ret = service()->setAlias(m_alias, m_coll);
             if (ret.err()) {
                 if (created) {
                     m_coll->removeFromDBus();
@@ -190,19 +179,19 @@ namespace FdoSecrets
         return QVariant::fromValue(m_locked);
     }
 
-    PromptResult LockCollectionsPrompt::promptSync(const DBusClientPtr&, const QString& windowId)
+    DBusResult LockCollectionsPrompt::promptSync(const DBusClientPtr& client, const QString& windowId)
     {
-        MessageBox::OverrideParent override(findWindow(windowId));
+        OverrideParentWindow override(this, windowId);
 
         for (const auto& c : asConst(m_collections)) {
             if (c) {
-                auto accepted = c->doLock();
+                auto accepted = c->doLock(client);
                 if (accepted) {
                     m_locked << c->objectPath();
                 }
             }
         }
-        return PromptResult::accepted(m_locked.size() == m_collections.size());
+        return {m_locked.size() == m_collections.size() ? QDBusError::NoError : QDBusError::AccessDenied};
     }
 
     UnlockPrompt::UnlockPrompt(Service* parent, const QSet<Collection*>& colls, const QSet<Item*>& items)
@@ -222,71 +211,22 @@ namespace FdoSecrets
         return QVariant::fromValue(m_unlocked);
     }
 
-    PromptResult UnlockPrompt::promptSync(const DBusClientPtr& client, const QString& windowId)
+    DBusResult UnlockPrompt::promptSync(const DBusClientPtr& client, const QString& windowId)
     {
-        MessageBox::OverrideParent override(findWindow(windowId));
-
-        // for use in unlockItems
-        m_windowId = windowId;
-        m_client = client;
+        OverrideParentWindow override(this, windowId);
 
         // first unlock any collections
-        bool waitingForCollections = false;
         for (const auto& c : asConst(m_collections)) {
             if (c) {
-                connect(c, &Collection::doneUnlockCollection, this, &UnlockPrompt::collectionUnlockFinished);
-                // doUnlock is nonblocking, execution will continue in collectionUnlockFinished
-                // it is ok to call doUnlock multiple times before it's actually unlocked by the user
-                c->doUnlock();
-                waitingForCollections = true;
+                bool accepted = c->doUnlock(client);
+                if (accepted) {
+                    m_unlocked << c->objectPath();
+                } else {
+                    m_numRejected += 1;
+                    // no longer need to unlock the item if its containing collection didn't unlock.
+                    m_items.remove(c);
+                }
             }
-        }
-
-        // unlock items directly if no collection unlocking pending
-        // o.w. doing it in collectionUnlockFinished
-        if (!waitingForCollections) {
-            unlockItems();
-        }
-
-        return PromptResult::Pending;
-    }
-
-    void UnlockPrompt::collectionUnlockFinished(bool accepted)
-    {
-        auto coll = qobject_cast<Collection*>(sender());
-        if (!coll) {
-            return;
-        }
-
-        // one shot
-        coll->disconnect(this);
-
-        if (!m_collections.contains(coll)) {
-            // should not happen
-            return;
-        }
-
-        if (accepted) {
-            m_unlocked << coll->objectPath();
-        } else {
-            m_numRejected += 1;
-            // no longer need to unlock the item if its containing collection didn't unlock.
-            m_items.remove(coll);
-        }
-
-        // if we got response for all collections
-        if (m_numRejected + m_unlocked.size() == m_collections.size()) {
-            // next step is to unlock items
-            unlockItems();
-        }
-    }
-
-    void UnlockPrompt::unlockItems()
-    {
-        auto client = m_client.lock();
-        if (!client) {
-            // client already gone
-            return;
         }
 
         // flatten to list of entries
@@ -310,50 +250,40 @@ namespace FdoSecrets
                 entries << entry;
             }
         }
+
         if (!entries.isEmpty()) {
-            QString app = tr("%1 (PID: %2)").arg(client->name()).arg(client->pid());
-            auto ac = new AccessControlDialog(
-                findWindow(m_windowId), entries, app, client->processInfo(), AuthOption::Remember);
-            connect(ac, &AccessControlDialog::finished, this, &UnlockPrompt::itemUnlockFinished);
-            connect(ac, &AccessControlDialog::finished, ac, &AccessControlDialog::deleteLater);
-            ac->open();
-        } else {
-            itemUnlockFinished({}, AuthDecision::Undecided);
-        }
-    }
-
-    void UnlockPrompt::itemUnlockFinished(const QHash<Entry*, AuthDecision>& decisions, AuthDecision forFutureEntries)
-    {
-        auto client = m_client.lock();
-        if (!client) {
-            // client already gone
-            qDebug() << "DBus client gone before item unlocking finish";
-            return;
-        }
-        for (auto it = decisions.constBegin(); it != decisions.constEnd(); ++it) {
-            auto entry = it.key();
-            auto uuid = entry->uuid();
-            // get back the corresponding item
-            auto item = m_entryToItems.value(uuid);
-            if (!item) {
-                continue;
+            QHash<Entry*, AuthDecision> decisions{};
+            AuthDecision forFutureEntries{};
+            if (!service()->plugin()->requestEntriesUnlock(client, windowId, entries, decisions, forFutureEntries)) {
+                return {QDBusError::InternalError};
             }
 
-            // set auth
-            client->setItemAuthorized(uuid, it.value());
+            for (auto it = decisions.constBegin(); it != decisions.constEnd(); ++it) {
+                auto entry = it.key();
+                auto uuid = entry->uuid();
+                // get back the corresponding item
+                auto item = m_entryToItems.value(uuid);
+                if (!item) {
+                    continue;
+                }
 
-            if (client->itemAuthorized(uuid)) {
-                m_unlocked += item->objectPath();
-            } else {
-                m_numRejected += 1;
+                // set auth
+                client->setItemAuthorized(uuid, it.value());
+
+                if (client->itemAuthorized(uuid)) {
+                    m_unlocked += item->objectPath();
+                } else {
+                    m_numRejected += 1;
+                }
+            }
+            if (forFutureEntries != AuthDecision::Undecided) {
+                client->setAllAuthorized(forFutureEntries);
             }
         }
-        if (forFutureEntries != AuthDecision::Undecided) {
-            client->setAllAuthorized(forFutureEntries);
-        }
+
         // if anything is not unlocked, treat the whole prompt as dismissed
         // so the client has a chance to handle the error
-        finishPrompt(m_numRejected > 0);
+        return {!m_numRejected ? QDBusError::NoError : QDBusError::AccessDenied};
     }
 
     DeleteItemPrompt::DeleteItemPrompt(Service* parent, Item* item)
@@ -362,16 +292,16 @@ namespace FdoSecrets
     {
     }
 
-    PromptResult DeleteItemPrompt::promptSync(const DBusClientPtr&, const QString& windowId)
+    DBusResult DeleteItemPrompt::promptSync(const DBusClientPtr& client, const QString& windowId)
     {
-        MessageBox::OverrideParent override(findWindow(windowId));
+        OverrideParentWindow override(this, windowId);
 
         // if m_item is gone, assume it's already deleted
         bool deleted = true;
         if (m_item) {
-            deleted = m_item->doDelete();
+            deleted = m_item->doDelete(client);
         }
-        return PromptResult::accepted(deleted);
+        return {deleted ? QDBusError::NoError : QDBusError::AccessDenied};
     }
 
     CreateItemPrompt::CreateItemPrompt(Service* parent,
@@ -384,9 +314,7 @@ namespace FdoSecrets
         , m_properties(std::move(properties))
         , m_secret(std::move(secret))
         , m_replace(replace)
-        , m_item(nullptr)
-        // session aliveness also need to be tracked, for potential use later in updateItem
-        , m_sess(m_secret.session)
+        , m_item{nullptr}
     {
     }
 
@@ -395,53 +323,34 @@ namespace FdoSecrets
         return QVariant::fromValue(DBusMgr::objectPathSafe(m_item));
     }
 
-    PromptResult CreateItemPrompt::promptSync(const DBusClientPtr& client, const QString& windowId)
+    DBusResult CreateItemPrompt::promptSync(const DBusClientPtr& client, const QString& windowId)
     {
         if (!m_coll) {
-            return PromptResult::accepted(false);
+            return DBusResult{DBUS_ERROR_SECRET_NO_SUCH_OBJECT};
         }
-
-        // save a weak reference to the client which may be used asynchronously later
-        m_client = client;
 
         // give the user a chance to unlock the collection
         // UnlockPrompt will handle the case of collection already unlocked
         auto prompt = PromptBase::Create<UnlockPrompt>(service(), QSet<Collection*>{m_coll.data()}, QSet<Item*>{});
         if (!prompt) {
-            return DBusResult{QDBusError::InternalError};
+            return {QDBusError::InternalError};
         }
-        // postpone anything after the prompt
-        connect(prompt, &PromptBase::completed, this, [this, windowId](bool dismissed) {
-            if (dismissed) {
-                finishPrompt(dismissed);
-            } else {
-                auto res = createItem(windowId);
-                if (res.err()) {
-                    qWarning() << "FdoSecrets:" << res;
-                    finishPrompt(true);
-                }
-            }
-        });
 
-        auto ret = prompt->prompt(client, windowId);
+        auto ret = prompt->promptSync(client, windowId);
         if (ret.err()) {
             return ret;
         }
-        return PromptResult::Pending;
+
+        auto res = createItem(client, windowId);
+        if (res.err()) {
+            qWarning() << "FdoSecrets:" << res;
+        }
+
+        return {res.ok() ? QDBusError::NoError : QDBusError::InternalError};
     }
 
-    DBusResult CreateItemPrompt::createItem(const QString& windowId)
+    DBusResult CreateItemPrompt::createItem(const DBusClientPtr& client, const QString& windowId)
     {
-        auto client = m_client.lock();
-        if (!client) {
-            // client already gone
-            return {};
-        }
-
-        if (!m_coll) {
-            return DBusResult{DBUS_ERROR_SECRET_NO_SUCH_OBJECT};
-        }
-
         // get itemPath to create item and
         // try to find an existing item using attributes
         QString itemPath{};
@@ -481,51 +390,19 @@ namespace FdoSecrets
         if (!prompt) {
             return DBusResult{QDBusError::InternalError};
         }
-        // postpone anything after the confirmation
-        connect(prompt, &PromptBase::completed, this, [this](bool dismissed) {
-            if (dismissed) {
-                finishPrompt(dismissed);
-            } else {
-                auto res = updateItem();
-                if (res.err()) {
-                    qWarning() << "FdoSecrets:" << res;
-                    finishPrompt(true);
-                }
-            }
-        });
 
-        auto ret = prompt->prompt(client, windowId);
+        auto ret = prompt->promptSync(client, windowId);
         if (ret.err()) {
             return ret;
         }
-        return {};
-    }
 
-    DBusResult CreateItemPrompt::updateItem()
-    {
-        auto client = m_client.lock();
-        if (!client) {
-            // client already gone
-            return {};
-        }
-
-        if (!m_sess || m_sess != m_secret.session) {
-            return DBusResult(DBUS_ERROR_SECRET_NO_SESSION);
-        }
-        if (!m_item) {
-            return {};
-        }
-        auto ret = m_item->setProperties(m_properties);
+        ret = m_item->setProperties(m_properties);
         if (ret.err()) {
             return ret;
         }
+
         ret = m_item->setSecret(client, m_secret);
-        if (ret.err()) {
-            return ret;
-        }
-
-        // finally can finish the prompt without dismissing it
-        finishPrompt(false);
-        return {};
+        return ret;
     }
+
 } // namespace FdoSecrets

--- a/src/fdosecrets/objects/Session.h
+++ b/src/fdosecrets/objects/Session.h
@@ -38,7 +38,7 @@ namespace FdoSecrets
          * @param parent the owning Service
          * @return pointer to newly created Session, or nullptr if error
          * This may be caused by
-         *   - DBus path registration error
+         *   - D-Bus path registration error
          */
         static Session* Create(QSharedPointer<CipherPair> cipher, const QString& peer, Service* parent);
 

--- a/src/fdosecrets/widgets/DatabaseSettingsWidgetFdoSecrets.cpp
+++ b/src/fdosecrets/widgets/DatabaseSettingsWidgetFdoSecrets.cpp
@@ -122,7 +122,7 @@ void DatabaseSettingsWidgetFdoSecrets::loadSettings(QSharedPointer<Database> db)
         recycleBin = m_db->metadata()->recycleBin();
     }
 
-    auto group = m_db->rootGroup()->findGroupByUuid(FdoSecrets::settings()->exposedGroup(m_db));
+    auto group = m_db->rootGroup()->findGroupByUuid(FdoSecrets::settings()->exposedGroup(m_db.data()));
     if (!group || group->isRecycled() || (recycleBin && group->uuid() == recycleBin->uuid())) {
         m_ui->radioDonotExpose->setChecked(true);
     } else {
@@ -157,7 +157,7 @@ void DatabaseSettingsWidgetFdoSecrets::saveSettings()
     }
     }
 
-    FdoSecrets::settings()->setExposedGroup(m_db, exposedGroup);
+    FdoSecrets::settings()->setExposedGroup(m_db.data(), exposedGroup);
 }
 
 void DatabaseSettingsWidgetFdoSecrets::settingsWarning()

--- a/src/fdosecrets/widgets/SettingsModels.cpp
+++ b/src/fdosecrets/widgets/SettingsModels.cpp
@@ -141,7 +141,7 @@ namespace FdoSecrets
             }
         }
         auto db = dbWidget->database();
-        auto group = db->rootGroup()->findGroupByUuid(FdoSecrets::settings()->exposedGroup(db));
+        auto group = db->rootGroup()->findGroupByUuid(FdoSecrets::settings()->exposedGroup(db.data()));
         if (group) {
             switch (role) {
             case Qt::DisplayRole:

--- a/src/fdosecrets/widgets/SettingsModels.h
+++ b/src/fdosecrets/widgets/SettingsModels.h
@@ -93,7 +93,7 @@ namespace FdoSecrets
         static constexpr const char* ColumnNames[] = {
             QT_TRANSLATE_NOOP("SettingsClientModel", "Application"),
             QT_TRANSLATE_NOOP("SettingsClientModel", "PID"),
-            QT_TRANSLATE_NOOP("SettingsClientModel", "DBus Address"),
+            QT_TRANSLATE_NOOP("SettingsClientModel", "D-Bus Address"),
             QT_TRANSLATE_NOOP("SettingsClientModel", "Manage"),
         };
 

--- a/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.h
+++ b/src/fdosecrets/widgets/SettingsWidgetFdoSecrets.h
@@ -25,6 +25,8 @@
 class QAbstractItemView;
 
 class FdoSecretsPlugin;
+class FdoSecretsSettingsPage;
+class DatabaseWidget;
 
 namespace Ui
 {
@@ -34,7 +36,9 @@ class SettingsWidgetFdoSecrets : public QWidget
 {
     Q_OBJECT
 public:
-    explicit SettingsWidgetFdoSecrets(FdoSecretsPlugin* plugin, QWidget* parent = nullptr);
+    explicit SettingsWidgetFdoSecrets(FdoSecretsPlugin* plugin,
+                                      FdoSecretsSettingsPage* page,
+                                      QWidget* parent = nullptr);
     ~SettingsWidgetFdoSecrets() override;
 
 public slots:
@@ -52,6 +56,7 @@ protected:
 private:
     QScopedPointer<Ui::SettingsWidgetFdoSecrets> m_ui;
     FdoSecretsPlugin* m_plugin;
+    FdoSecretsSettingsPage* m_page;
     QTimer m_checkTimer;
 };
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -63,7 +63,8 @@
 #endif
 
 #ifdef WITH_XC_FDOSECRETS
-#include "fdosecrets/FdoSecretsPlugin.h"
+#include "fdosecrets/FdoSecretsPluginGUI.h"
+#include "fdosecrets/FdoSecretsSettingsPage.h"
 #endif
 
 #ifdef WITH_XC_YUBIKEY
@@ -218,12 +219,14 @@ MainWindow::MainWindow()
 #endif
 
 #ifdef WITH_XC_FDOSECRETS
-    auto fdoSS = new FdoSecretsPlugin(m_ui->tabWidget);
+    auto fdoSS = new FdoSecretsPluginGUI(m_ui->tabWidget);
     connect(fdoSS, &FdoSecretsPlugin::error, this, &MainWindow::showErrorMessage);
-    connect(fdoSS, &FdoSecretsPlugin::requestSwitchToDatabases, this, &MainWindow::switchToDatabases);
     connect(fdoSS, &FdoSecretsPlugin::requestShowNotification, this, &MainWindow::displayDesktopNotification);
     fdoSS->updateServiceState();
-    m_ui->settingsWidget->addSettingsPage(fdoSS);
+
+    auto fdoSSP = new FdoSecretsSettingsPage(fdoSS, m_ui->tabWidget);
+    connect(fdoSSP, &FdoSecretsSettingsPage::requestSwitchToDatabases, this, &MainWindow::switchToDatabases);
+    m_ui->settingsWidget->addSettingsPage(fdoSSP);
 #endif
 
 #ifdef WITH_XC_YUBIKEY

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -722,7 +722,7 @@ void MainWindow::appExit()
 
 /**
  * Returns if application was built with hardware key support.
- * Intended to be used by 3rd-party applications using DBus.
+ * Intended to be used by 3rd-party applications using D-Bus.
  *
  * @return True if built with hardware key support, false otherwise
  */
@@ -738,7 +738,7 @@ bool MainWindow::isHardwareKeySupported()
 /**
  * Refreshes list of hardware keys known.
  * Triggers the DatabaseOpenWidget to automatically select the key last used for a database if found.
- * Intended to be used by 3rd-party applications using DBus.
+ * Intended to be used by 3rd-party applications using D-Bus.
  *
  * @return True if any key was found, false otherwise or if application lacks hardware key support
  */

--- a/src/gui/MessageBox.cpp
+++ b/src/gui/MessageBox.cpp
@@ -189,14 +189,3 @@ void MessageBox::setNextAnswer(MessageBox::Button button)
 {
     m_nextAnswer = button;
 }
-
-MessageBox::OverrideParent::OverrideParent(QWindow* newParent)
-    : m_oldParent(MessageBox::m_overrideParent)
-{
-    MessageBox::m_overrideParent = newParent;
-}
-
-MessageBox::OverrideParent::~OverrideParent()
-{
-    MessageBox::m_overrideParent = m_oldParent;
-}

--- a/src/gui/MessageBox.h
+++ b/src/gui/MessageBox.h
@@ -24,6 +24,8 @@
 
 class MessageBox
 {
+    friend class FdoSecretsPluginGUI;
+
 public:
     enum Button : uint64_t
     {
@@ -104,16 +106,6 @@ public:
                            Button defaultButton = MessageBox::Cancel,
                            Action action = MessageBox::None,
                            QCheckBox* checkbox = nullptr);
-
-    class OverrideParent
-    {
-    public:
-        explicit OverrideParent(QWindow* newParent);
-        ~OverrideParent();
-
-    private:
-        QWindow* m_oldParent;
-    };
 
 private:
     static QWindow* m_overrideParent;

--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -41,13 +41,13 @@ void GroupModel::changeDatabase(Database* newDb)
     m_db = newDb;
 
     // clang-format off
-    connect(m_db, SIGNAL(groupDataChanged(Group*)), SLOT(groupDataChanged(Group*)));
-    connect(m_db, SIGNAL(groupAboutToAdd(Group*,int)), SLOT(groupAboutToAdd(Group*,int)));
-    connect(m_db, SIGNAL(groupAdded()), SLOT(groupAdded()));
-    connect(m_db, SIGNAL(groupAboutToRemove(Group*)), SLOT(groupAboutToRemove(Group*)));
-    connect(m_db, SIGNAL(groupRemoved()), SLOT(groupRemoved()));
-    connect(m_db, SIGNAL(groupAboutToMove(Group*,Group*,int)), SLOT(groupAboutToMove(Group*,Group*,int)));
-    connect(m_db, SIGNAL(groupMoved()), SLOT(groupMoved()));
+    connect(m_db, SIGNAL(groupDataChanged(Group*)), this, SLOT(groupDataChanged(Group*)));
+    connect(m_db, SIGNAL(groupAboutToAdd(Group*,int)), this, SLOT(groupAboutToAdd(Group*,int)));
+    connect(m_db, SIGNAL(groupAdded()), this, SLOT(groupAdded()));
+    connect(m_db, SIGNAL(groupAboutToRemove(Group*)), this, SLOT(groupAboutToRemove(Group*)));
+    connect(m_db, SIGNAL(groupRemoved()), this, SLOT(groupRemoved()));
+    connect(m_db, SIGNAL(groupAboutToMove(Group*,Group*,int)), this, SLOT(groupAboutToMove(Group*,Group*,int)));
+    connect(m_db, SIGNAL(groupMoved()), this, SLOT(groupMoved()));
     // clang-format on
 
     endResetModel();

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -197,7 +197,7 @@ void NixUtils::setLaunchAtStartup(bool enable)
                                   SLOT(launchAtStartupRequested(uint, QVariantMap)));
 
     if (!res) {
-        qDebug() << "DBus Error: could not connect to org.freedesktop.portal.Request";
+        qDebug() << "D-Bus Error: could not connect to org.freedesktop.portal.Request";
     }
 #endif
 }
@@ -205,7 +205,7 @@ void NixUtils::setLaunchAtStartup(bool enable)
 void NixUtils::launchAtStartupRequested(uint response, const QVariantMap& results)
 {
     if (response > 0) {
-        qDebug() << "DBus Error: the request to autostart was cancelled.";
+        qDebug() << "D-Bus Error: the request to autostart was cancelled.";
         return;
     }
 

--- a/src/quickunlock/Polkit.cpp
+++ b/src/quickunlock/Polkit.cpp
@@ -49,7 +49,7 @@ Polkit::Polkit()
     PolkitSubject::registerMetaType();
     PolkitAuthorizationResults::registerMetaType();
 
-    /* Note we explicitly use our own dbus path here, as the ::systemBus() method could be overridden
+    /* Note we explicitly use our own D-Bus path here, as the ::systemBus() method could be overridden
        through an environment variable to return an alternative bus path. This bus could have an application
        pretending to be polkit running on it, which could approve every authentication request
 
@@ -61,14 +61,14 @@ Polkit::Polkit()
 
     m_available = bus.isConnected();
     if (!m_available) {
-        qDebug() << "polkit: Failed to connect to system dbus (this may be due to a non-standard dbus path)";
+        qDebug() << "polkit: Failed to connect to system D-Bus (this may be due to a non-standard D-Bus path)";
         return;
     }
 
     m_available = bus.interface()->isServiceRegistered(polkit_service);
 
     if (!m_available) {
-        qDebug() << "polkit: Polkit is not registered on dbus";
+        qDebug() << "polkit: Polkit is not registered on D-Bus";
         return;
     }
 

--- a/tests/TestFdoSecrets.cpp
+++ b/tests/TestFdoSecrets.cpp
@@ -21,6 +21,7 @@
 #include "core/Group.h"
 #include "crypto/Random.h"
 #include "fdosecrets/objects/Collection.h"
+#include "fdosecrets/objects/Service.h"
 #include "fdosecrets/objects/SessionCipher.h"
 
 #include <QTest>

--- a/tests/gui/TestGuiFdoSecrets.h
+++ b/tests/gui/TestGuiFdoSecrets.h
@@ -30,7 +30,7 @@ class Database;
 class DatabaseTabWidget;
 class DatabaseWidget;
 class TemporaryFile;
-class FdoSecretsPlugin;
+class FdoSecretsPluginGUI;
 namespace FdoSecrets
 {
     class Service;
@@ -150,7 +150,7 @@ private:
     QPointer<DatabaseWidget> m_dbWidget;
     QSharedPointer<Database> m_db;
 
-    QPointer<FdoSecretsPlugin> m_plugin;
+    QPointer<FdoSecretsPluginGUI> m_plugin;
     QSharedPointer<FdoSecrets::DBusClient> m_client;
 
     QScopedPointer<FdoSecrets::DhIetf1024Sha256Aes128CbcPkcs7> m_clientCipher;


### PR DESCRIPTION
I'm trying to run KeePassXC headless with CLI mode.
But I also like to keep using Freedesktop.org Secret Service integration as my keyring provider for various other applications on the remote to access secrets I keep in the database.
Unfortunately current fdosecrets implementation is heavily dependent on GUI and is not supported in CLI mode.

This PR is a first part of trying to make fdosecrets work with CLI. It only focuses on separating fdosecrets internals from GUI, which I think is worth even of itself?
To that end I moved all the methods that directly depended on GUI to the top-level `FdoSecretsPluginGUI` implementation using virtual methods (allowing to later make `FdoSecretsPluginCLI` that will replace those methods with CLI supporting versions).
Since the plugin relied heavily on GUI objects (`DatabaseWidget` and `DatabaseTabWidget`) it turned into quite a big refactoring while trying to move them out :cold_sweat:, we'll see how it goes.


Other notable things:

* GUI dependent functions were changed to be blocking to avoid chaining sockets/signals/adding `loop.exec()` in random places just to fetch the actually needed values out of UI responses (essentially moved `loop.exec()`s into them wherever necessary), this also simplified D-Bus Prompts making them all synchronous as well.
* Because they depended on GUI logic patterns, some Prompts tests needed adjustments. But similar logic was already present in other cases so this just normalized their handling across the fdosecrets GUI tests.
* In `src/Gui/group/GroupModel.cpp` I had to add the links to the group model object in `QObject::connect` as otherwise the signals links could outlive the objects and throw errors (caught randomly during testing). And similar in some other `QObject::connect`s.
* And I couldn't help myself and normalized D-Bus name everywhere I found it :sweat_smile:


## Screenshots
N/A


## Testing strategy
1. I run all the tests for the test suite, they seem to work (though some needed updates because of change in prompts implementation)
2. Running with these edits for last few months without any issues (though my use cases probably aren't any near exhaustive)


## Type of change
- ✅ Refactor (significant modification to existing code)
