### PR TITLE
Add CFBundleVersion, fixes #8454

### DIFF
--- a/share/macosx/Info.plist.cmake
+++ b/share/macosx/Info.plist.cmake
@@ -22,6 +22,8 @@
   <string>${PROJECT_NAME}</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
+  <key>CFBundleVersion</key>
+  <string>${KEEPASSXC_VERSION}</string>
   <key>CFBundleShortVersionString</key>
   <string>${KEEPASSXC_VERSION}</string>
   <key>CFBundleSignature</key>


### PR DESCRIPTION
Adds the missing CFBundleVersion to the macOS bundle plist file.

Fixes #8454

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
