### PR TITLE
Fix potential deadlock in UI when saving

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1747,8 +1747,8 @@ bool DatabaseWidget::lock()
 
 void DatabaseWidget::reloadDatabaseFile()
 {
-    // Ignore reload if we are locked or currently editing an entry or group
-    if (!m_db || isLocked() || isEntryEditActive() || isGroupEditActive()) {
+    // Ignore reload if we are locked, saving, or currently editing an entry or group
+    if (!m_db || isLocked() || isEntryEditActive() || isGroupEditActive() || isSaving()) {
         return;
     }
 


### PR DESCRIPTION
This was noted as a problem in several issues and it finally occurred to me and I traced it to the fact that a timing issue sometimes allowed the file watcher to trigger a "file changed" alert right when saving starts. I fixed this by moving where the mutex lock is made for saving and preventing database reload during a save operation.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tried to replicate the problem and could not with the fixes in place.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
