### PR TITLE
Allow picking tags from completion menu with keyboard

### DIFF
--- a/src/gui/tag/TagsEdit.cpp
+++ b/src/gui/tag/TagsEdit.cpp
@@ -413,9 +413,9 @@ struct TagsEdit::Impl
     void setupCompleter()
     {
         completer->setWidget(ifce);
-        connect(completer.get(), static_cast<void (QCompleter::*)(QString const&)>(&QCompleter::activated), [this](QString const& text) {
-            currentText(text);
-        });
+        connect(completer.get(),
+                static_cast<void (QCompleter::*)(QString const&)>(&QCompleter::activated),
+                [this](QString const& text) { currentText(text); });
     }
 
     QVector<QTextLayout::FormatRange> formatting() const
@@ -861,10 +861,16 @@ void TagsEdit::keyPressEvent(QKeyEvent* event)
         case Qt::Key_Enter:
         case Qt::Key_Comma:
         case Qt::Key_Semicolon:
+            // If completer is visible, accept the selection or hide if no selection
+            if (impl->completer->popup()->isVisible() && impl->completer->popup()->selectionModel()->hasSelection()) {
+                break;
+            }
+
+            // Make existing text into a tag
             if (!impl->currentText().isEmpty()) {
                 impl->editNewTag(impl->editing_index + 1);
+                event->accept();
             }
-            event->accept();
             break;
         default:
             unknown = true;


### PR DESCRIPTION
* Also fixes the hiding and display of the completion menu to be more natural and less annoying.
* Fixes #7939

_note: I accidently committed this directly to develop and pushed, this PR just adds it to the record for 2.7.2_

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
