### PR TITLE
Don't rely on AppleInterfaceStyle for theme switching

### DIFF
--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -69,29 +69,21 @@
                         change:(NSDictionary<NSKeyValueChangeKey,id> *)change
                        context:(void *)context
 {
-    Q_UNUSED(object);
-    Q_UNUSED(change);
-    Q_UNUSED(context);
+    Q_UNUSED(object)
+    Q_UNUSED(change)
+    Q_UNUSED(context)
     if ([keyPath isEqualToString:@"effectiveAppearance"]) {
-        //
-        // Light / dark theme toggled
-        //
         if (m_appkit) {
 
-            void (^emitBlock)(void) = ^
-            {
+            void (^emitBlock)(void) = ^{
                 emit m_appkit->interfaceThemeChanged();
             };
 
-#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101000
-            if(@available(macOS 11.0, *))
-            {
+            if(@available(macOS 11.0, *)) {
                 // Not sure why exactly this call is needed, but Apple sample code uses it so it's best to use it here too
                 [NSApp.effectiveAppearance performAsCurrentDrawingAppearance:emitBlock];
             }
-            else
-#endif
-            {
+            else {
                 emitBlock();
             }
         }

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -38,10 +38,7 @@
                                                                 name:NSWorkspaceSessionDidResignActiveNotification
                                                                 object:nil];
 
-        [[NSDistributedNotificationCenter defaultCenter] addObserver:self
-                                                            selector:@selector(interfaceThemeChanged:)
-                                                                name:@"AppleInterfaceThemeChangedNotification"
-                                                              object:nil];
+        [NSApp addObserver:self forKeyPath:@"effectiveAppearance" options:NSKeyValueObservingOptionNew context:nil];
 
         // Unfortunately, there is no notification for a wallpaper change, which affects
         // the status bar colour on macOS Big Sur, but we can at least subscribe to this.
@@ -67,14 +64,37 @@
     }
 }
 
-//
-// Light / dark theme toggled
-//
-- (void) interfaceThemeChanged:(NSNotification*) notification
+- (void) observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey,id> *)change
+                       context:(void *)context
 {
-    Q_UNUSED(notification);
-    if (m_appkit) {
-        emit m_appkit->interfaceThemeChanged();
+    Q_UNUSED(object);
+    Q_UNUSED(change);
+    Q_UNUSED(context);
+    if ([keyPath isEqualToString:@"effectiveAppearance"]) {
+        //
+        // Light / dark theme toggled
+        //
+        if (m_appkit) {
+
+            void (^emitBlock)(void) = ^
+            {
+                emit m_appkit->interfaceThemeChanged();
+            };
+
+#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101000
+            if(@available(macOS 11.0, *))
+            {
+                // Not sure why exactly this call is needed, but Apple sample code uses it so it's best to use it here too
+                [NSApp.effectiveAppearance performAsCurrentDrawingAppearance:emitBlock];
+            }
+            else
+#endif
+            {
+                emitBlock();
+            }
+        }
     }
 }
 
@@ -127,10 +147,7 @@
 //
 - (bool) isDarkMode
 {
-    NSDictionary* dict = [[NSUserDefaults standardUserDefaults] persistentDomainForName:NSGlobalDomain];
-    id style = [dict objectForKey:@"AppleInterfaceStyle"];
-    return ( style && [style isKindOfClass:[NSString class]]
-             && NSOrderedSame == [style caseInsensitiveCompare:@"dark"] );
+    return [NSApp.effectiveAppearance.name isEqualToString:NSAppearanceNameDarkAqua];
 }
 
 


### PR DESCRIPTION
Fixes #7615

I discovered that in very specific conditions (when interface style is on automatic and the switch happens while the Mac is turned off, as outlined in the original issue), the `AppleInterfaceStyle` preference value in `.GlobalPreferences` is wrong. I worked around this issue by instead relying on the proper system API to get the appearance state.

Additionally there was a second issue, originally the code was registering for the `AppleInterfaceThemeChangedNotification` to know when the appearance changed, unfortunately this event fires before the system API returns the new appearance state, so I had to switch it to registering a KVO on the `effectiveAppearance` property as done in [Apple sample code](https://developer.apple.com/documentation/uikit/appearance_customization/supporting_dark_mode_in_your_interface?language=objc).


## Screenshots
Before:
![before](https://user-images.githubusercontent.com/18235760/197339236-0dad5d3e-94e7-4ec0-a2b7-ef6fb23984ce.png)

After:
![after](https://user-images.githubusercontent.com/18235760/197339252-4d73e598-b3b2-4c54-a2f7-d6cdabe90963.png)


## Testing strategy
Reproduce the specific conditions outlined above and open the old build and the build with this change after another (you will see one looks wrong and one looks right). Instead of reproducing the conditions (very time consuming), you can also manually give the `AppleInterfaceStyle` key the wrong value: `defaults write NSGlobalDomain AppleInterfaceStyle -string "<Dark/Light>"`. (Note that you have to use defaults, manually writing this key using a plist editor does not work).

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
