### PR TITLE
Update cmake usage in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,10 +66,8 @@ To compile from source, open a **Terminal (Linux/MacOS)**, the **MSVC Tools Comm
 2. Navigate to the directory where you have downloaded KeePassXC and type these commands:
 
    ```
-   mkdir build
-   cd build
-   cmake -DWITH_XC_ALL=ON ..
-   make
+   cmake -S . -B build -DWITH_XC_ALL=ON
+   cmake --build build
    ```
 
 Note: These steps place the compiled KeePassXC binary inside the `./build/src/` directory.


### PR DESCRIPTION
CMake 3.14.0 released in March 2019 [1] added the command line config options `-S <source-dir>` and `-B <build-dir>` and the build argument `--build <build-dir>` [2]. These options are universally valid independent of the build system used (`make`, `nmake`, `ninja`, `MSBuild`,...), making the provided CMake commands more generic.

As reference Ubuntu 20.04 ships the CMake 3.16.3 [3] version.

It's a CMake version bump just for the used commands. I hope this would be alright

- [1] https://gitlab.kitware.com/cmake/cmake/-/tags/v3.14.0
- [2] https://cmake.org/cmake/help/v3.14/release/3.14.html#command-line
- [3] https://packages.ubuntu.com/focal/cmake

## Type of change
- ✅ Documentation (non-code change)
