### PR TITLE
Fix display of passwords in preview panel

### DIFF
--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -250,6 +250,8 @@ void EntryPreviewWidget::setUsernameVisible(bool state)
 
 void EntryPreviewWidget::setPasswordVisible(bool state)
 {
+    m_ui->entryPasswordLabel->setFont(Font::fixedFont());
+
     const QString password = m_currentEntry->resolveMultiplePlaceholders(m_currentEntry->password());
     if (state) {
         if (config()->get(Config::GUI_ColorPasswords).toBool()) {
@@ -268,7 +270,7 @@ void EntryPreviewWidget::setPasswordVisible(bool state)
             m_ui->entryPasswordLabel->setHtml(html);
         } else {
             // No color
-            m_ui->entryPasswordLabel->setPlainText(password.toHtmlEscaped());
+            m_ui->entryPasswordLabel->setPlainText(password);
         }
     } else if (password.isEmpty() && !config()->get(Config::Security_PasswordEmptyPlaceholder).toBool()) {
         m_ui->entryPasswordLabel->setPlainText("");
@@ -276,7 +278,6 @@ void EntryPreviewWidget::setPasswordVisible(bool state)
         m_ui->entryPasswordLabel->setPlainText(QString("\u25cf").repeated(6));
     }
 
-    m_ui->entryPasswordLabel->setFont(Font::fixedFont());
     m_ui->togglePasswordButton->setIcon(icons()->onOffIcon("password-show", state));
 }
 


### PR DESCRIPTION
* Fix #8627 - don't HTML escape plain text...
* Fix #8624 - ensure use of monospace font when displaying passwords in preview panel

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Confirmed using GammaRay that the font was set to Consolas (Microsoft monospace).

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/2809491/197515191-9c234bc4-1631-495c-9e8e-ccf39f9d3a56.png)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
