### PR TITLE
Fix extra hideWindow() call after retrieving credentials

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -524,7 +524,6 @@ void BrowserService::sendCredentialsToClient(QList<Entry*>& allowedEntries,
 
     m_browserHost->sendClientMessage(
         socket, browserMessageBuilder()->buildResponse("get-logins", message, incrementedNonce, publicKey, secretKey));
-    hideWindow();
 }
 
 void BrowserService::showPasswordGenerator(QLocalSocket* socket,


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
At least with macOS this extra call sometimes causes the actual browser window to hide instead of KeePassXC after the extension has retrieved the credentials. If the Access Confirm Dialog has been already shown, `hideWindow()` is already called earlier.

PR with the incorrect change: https://github.com/keepassxreboot/keepassxc/pull/8273

This is easy to reproduce with the following steps:
1. Have some third application window open, KeePassXC in the background
2. Go to some login page with your main browser window where the extension retrieves the credentials
3. The main browser window gets hidden after retrieval, activating the third application's window

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
