### PR TITLE
Fix deleting existing socket file before making a new symbolic link

### DIFF
--- a/src/browser/BrowserShared.cpp
+++ b/src/browser/BrowserShared.cpp
@@ -43,6 +43,7 @@ namespace BrowserShared
 
         QString socketPath = subPath + serverName;
 #ifndef KEEPASSXC_DIST_FLATPAK
+        QFile::remove(socketPath);
         // Create a symlink at the legacy location for backwards compatibility.
         QFile::link(socketPath, path + serverName);
 #endif


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Removes the old socket before making a new symbolic link. Qt's function does not force it, and it does nothing if the target file already exists. Introduced in https://github.com/keepassxreboot/keepassxc/pull/8030.

Fixes #8634.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
