### PR TITLE
Fix crash on macOS when unlocking database

### DIFF
--- a/src/touchid/TouchID.mm
+++ b/src/touchid/TouchID.mm
@@ -31,7 +31,11 @@ inline std::string StatusToErrorMessage(OSStatus status)
       return std::to_string(status);
    }
 
-   std::string result(CFStringGetCStringPtr(text, kCFStringEncodingUTF8));
+   auto msg = CFStringGetCStringPtr(text, kCFStringEncodingUTF8);
+   std::string result;
+   if (msg) {
+       result = msg;
+   }
    CFRelease(text);
    return result;
 }


### PR DESCRIPTION
* Fix #8639

This only affects macOS 13+ due to the use of nullptr when initializing std::string.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested by forcing the use of TouchID code, still needs to be tested in a signed build to ensure all code paths are clean. 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
