### PR TITLE
Browser: second fix for linked socket path

### DIFF
--- a/src/browser/BrowserShared.cpp
+++ b/src/browser/BrowserShared.cpp
@@ -38,14 +38,15 @@ namespace BrowserShared
 
         // Put the socket in a dedicated directory.
         // This directory will be easily mountable by sandbox containers.
-        QString subPath = path + "/app/org.keepassxc.KeePassXC/";
+        QString subPath = path + "/app/org.keepassxc.KeePassXC";
         QDir().mkpath(subPath);
 
         QString socketPath = subPath + serverName;
 #ifndef KEEPASSXC_DIST_FLATPAK
-        QFile::remove(socketPath);
         // Create a symlink at the legacy location for backwards compatibility.
-        QFile::link(socketPath, path + serverName);
+        const auto origSocketPath = path + serverName;
+        QFile::remove(origSocketPath);
+        QFile::link(socketPath, origSocketPath);
 #endif
 
         return socketPath;


### PR DESCRIPTION
* Fix #8702

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Ubuntu with 2.70 upgraded to this commit

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)