### PR TITLE
Fix realpath error on macOS 13

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -883,7 +883,6 @@ build() {
         fi
     fi
 
-    OUTPUT_DIR="$(realpath "$OUTPUT_DIR")"
     if  ! ${build_snapshot} && [ -d "$OUTPUT_DIR" ]; then
         exitError "Output dir '${OUTPUT_DIR}' already exists."
     fi
@@ -892,6 +891,7 @@ build() {
     if ! mkdir -p "$OUTPUT_DIR"; then
         exitError "Failed to create output directory!"
     fi
+    OUTPUT_DIR="$(realpath "$OUTPUT_DIR")"
 
     if ${build_source_tarball}; then
         logInfo "Creating source tarball..."


### PR DESCRIPTION
realpath did not exist on macOS 12 and lower, so we used to fall back to our own version. macOS 13 now ships with realpath, but it behaves differently than the Linux version and errors out if used on a non-existent path.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

