### PR TITLE
Fix various typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -897,7 +897,7 @@
 - Compare window title to entry URLs #556
 - Implemented inline error messages #162
 - Ignore group expansion and other minor changes when making database "dirty" #464
-- Updated license and copyright information on souce files #632
+- Updated license and copyright information on source files #632
 - Added contributors list to about dialog #629
 
 ## 2.1.4 (2017-04-09)

--- a/cmake/KPXCMacDeployHelpers.cmake
+++ b/cmake/KPXCMacDeployHelpers.cmake
@@ -1,5 +1,5 @@
 # Running macdeployqt on a POST_BUILD copied binaries is pointless when using CPack because
-# the copied binaries will be overriden by the corresponding install(TARGETS) commands.
+# the copied binaries will be overridden by the corresponding install(TARGETS) commands.
 # That's why we run macdeployqt using install(CODE) on the already installed binaries.
 # The precondition is that all install(TARGETS) calls have to be called before this function is
 # called.

--- a/share/linux/org.keepassxc.KeePassXC.appdata.xml
+++ b/share/linux/org.keepassxc.KeePassXC.appdata.xml
@@ -941,7 +941,7 @@
                     <li>Compare window title to entry URLs [#556]</li>
                     <li>Implemented inline error messages [#162]</li>
                     <li>Ignore group expansion and other minor changes when making database "dirty" [#464]</li>
-                    <li>Updated license and copyright information on souce files [#632]</li>
+                    <li>Updated license and copyright information on source files [#632]</li>
                     <li>Added contributors list to about dialog [#629]</li>
                 </ul>
             </description>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -532,5 +532,5 @@ if(WIN32)
 endif()
 
 # The install commands in this subdirectory will be executed after all the install commands in the
-# current scope are ran. It is required for correct functtioning of macdeployqt.
+# current scope are ran. It is required for correct functioning of macdeployqt.
 add_subdirectory(post_install)

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -356,7 +356,7 @@ void AutoType::executeAutoTypeActions(const Entry* entry,
 
 /**
  * Single Autotype entry-point function
- * Look up the Auto-Type sequence for the given entry then perfom Auto-Type in the active window
+ * Look up the Auto-Type sequence for the given entry then perform Auto-Type in the active window
  */
 void AutoType::performAutoType(const Entry* entry)
 {
@@ -372,7 +372,7 @@ void AutoType::performAutoType(const Entry* entry)
 
 /**
  * Extra Autotype entry-point function
- * Perfom Auto-Type of the directly specified sequence in the active window
+ * Perform Auto-Type of the directly specified sequence in the active window
  */
 void AutoType::performAutoTypeWithSequence(const Entry* entry, const QString& sequence)
 {

--- a/src/cli/DatabaseCreate.cpp
+++ b/src/cli/DatabaseCreate.cpp
@@ -149,7 +149,7 @@ QSharedPointer<Database> DatabaseCreate::initializeDatabaseFromOptions(const QSh
  * If a key file is specified but it can't be loaded, the function will
  * fail.
  *
- * If the database is being saved in a non existant directory, the
+ * If the database is being saved in a non existent directory, the
  * function will fail.
  *
  * @return EXIT_SUCCESS on success, or EXIT_FAILURE on failure

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -28,7 +28,7 @@
  * A password can be specified to encrypt the database.
  * If none is specified the function will fail.
  *
- * If the database is being saved in a non existant directory, the
+ * If the database is being saved in a non existent directory, the
  * function will fail.
  *
  * @return EXIT_SUCCESS on success, or EXIT_FAILURE on failure

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -413,7 +413,7 @@ namespace Utils
      *
      * @param path Path to the key file to be loaded
      * @param fileKey Resulting fileKey
-     * @return true if the key file was loaded succesfully
+     * @return true if the key file was loaded successfully
      */
     bool loadFileKey(const QString& path, QSharedPointer<FileKey>& fileKey)
     {

--- a/src/core/AsyncTask.h
+++ b/src/core/AsyncTask.h
@@ -64,7 +64,7 @@ namespace AsyncTask
      *
      * @param task std::function object to run
      * @param context QObject responsible for calling this function
-     * @param callback std::function object to run after the task completess
+     * @param callback std::function object to run after the task completes
      */
     template <typename FunctionObject, typename FunctionObject2>
     void runThenCallback(FunctionObject task, QObject* context, FunctionObject2 callback)

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -346,7 +346,7 @@ bool Database::performSave(const QString& filePath, SaveAction action, const QSt
                 tempFile.setAutoRemove(false);
                 QFile::setPermissions(filePath, perms);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-                // Retain orginal creation time
+                // Retain original creation time
                 tempFile.setFileTime(createTime, QFile::FileBirthTime);
 #endif
                 return true;

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -43,7 +43,7 @@ public:
         KeepLocal, // merge history forcing local as top regardless of age
         KeepRemote, // merge history forcing remote as top regardless of age
         KeepNewer, // merge history
-        Synchronize, // merge history keeping most recent as top entry and appling deletions
+        Synchronize, // merge history keeping most recent as top entry and applying deletions
     };
 
     enum CloneFlag

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -331,7 +331,7 @@ void DatabaseTabWidget::importOpVaultDatabase()
  * Attempt to close the current database and remove its tab afterwards.
  *
  * @param index index of the database tab to close
- * @return true if database was closed successully
+ * @return true if database was closed successfully
  */
 bool DatabaseTabWidget::closeCurrentDatabaseTab()
 {
@@ -342,7 +342,7 @@ bool DatabaseTabWidget::closeCurrentDatabaseTab()
  * Attempt to close the database tab that sent the close request.
  *
  * @param index index of the database tab to close
- * @return true if database was closed successully
+ * @return true if database was closed successfully
  */
 bool DatabaseTabWidget::closeDatabaseTabFromSender()
 {
@@ -353,7 +353,7 @@ bool DatabaseTabWidget::closeDatabaseTabFromSender()
  * Attempt to close a database and remove its tab afterwards.
  *
  * @param index index of the database tab to close
- * @return true if database was closed successully
+ * @return true if database was closed successfully
  */
 bool DatabaseTabWidget::closeDatabaseTab(int index)
 {
@@ -364,7 +364,7 @@ bool DatabaseTabWidget::closeDatabaseTab(int index)
  * Attempt to close a database and remove its tab afterwards.
  *
  * @param dbWidget \link DatabaseWidget to close
- * @return true if database was closed successully
+ * @return true if database was closed successfully
  */
 bool DatabaseTabWidget::closeDatabaseTab(DatabaseWidget* dbWidget)
 {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -745,7 +745,7 @@ void MainWindow::appExit()
 
 /**
  * Returns if application was built with hardware key support.
- * Intented to be used by 3rd-party applications using DBus.
+ * Intended to be used by 3rd-party applications using DBus.
  *
  * @return True if built with hardware key support, false otherwise
  */
@@ -761,7 +761,7 @@ bool MainWindow::isHardwareKeySupported()
 /**
  * Refreshes list of hardware keys known.
  * Triggers the DatabaseOpenWidget to automatically select the key last used for a database if found.
- * Intented to be used by 3rd-party applications using DBus.
+ * Intended to be used by 3rd-party applications using DBus.
  *
  * @return True if any key was found, false otherwise or if application lacks hardware key support
  */

--- a/src/gui/reports/ReportsWidgetHibp.cpp
+++ b/src/gui/reports/ReportsWidgetHibp.cpp
@@ -133,7 +133,7 @@ void ReportsWidgetHibp::makeHibpTable()
         }
     }
 
-    // Sort decending by the number the password has been exposed
+    // Sort descending by the number the password has been exposed
     qSort(items.begin(), items.end(), [](QPair<Entry*, int>& lhs, QPair<Entry*, int>& rhs) {
         return lhs.second > rhs.second;
     });

--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -173,7 +173,7 @@ ShareObserver::Result ShareExport::intoContainer(const QString& resolvedPath,
 
         KeePass2Writer writer;
         if (!writer.writeDatabase(&buffer, targetDb.data())) {
-            qWarning("Serializing export dabase failed: %s.", writer.errorString().toLatin1().data());
+            qWarning("Serializing export database failed: %s.", writer.errorString().toLatin1().data());
             return {reference.path, ShareObserver::Result::Error, writer.errorString()};
         }
 
@@ -202,7 +202,7 @@ ShareObserver::Result ShareExport::intoContainer(const QString& resolvedPath,
     } else {
         QString error;
         if (!targetDb->saveAs(resolvedPath, Database::Atomic, {}, &error)) {
-            qWarning("Exporting dabase failed: %s.", error.toLatin1().data());
+            qWarning("Exporting database failed: %s.", error.toLatin1().data());
             return {resolvedPath, ShareObserver::Result::Error, error};
         }
     }

--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -107,7 +107,7 @@ namespace
         rv = SCardListReaders(context, nullptr, mszReaders, &dwReaders);
         if (rv == SCARD_S_SUCCESS) {
             char* readhead = mszReaders;
-            // Names are seperated by a null byte
+            // Names are separated by a null byte
             // The list is terminated by two null bytes
             while (*readhead != '\0') {
                 QString reader = QString::fromUtf8(readhead);
@@ -563,7 +563,7 @@ bool YubiKeyInterfacePCSC::findValidKeys()
                                &dwActiveProtocol);
 
         if (rv == SCARD_S_SUCCESS) {
-            // Read the potocol and the ATR record
+            // Read the protocol and the ATR record
             char pbReader[MAX_READERNAME] = {0};
             SCUINT dwReaderLen = sizeof(pbReader);
             SCUINT dwState = 0;
@@ -683,7 +683,7 @@ YubiKeyInterfacePCSC::challenge(YubiKeySlot slot, const QByteArray& challenge, B
                So we wait for the user to re-present it to clear the time-out
                This condition usually only happens when the key times out after
                the initial key listing, because performTestChallenge implicitly
-               resets the key (see commnt above) */
+               resets the key (see comment above) */
             if (ret == YubiKey::ChallengeResult::YCR_SUCCESS) {
                 emit challengeCompleted();
                 m_mutex.unlock();
@@ -728,7 +728,7 @@ YubiKey::ChallengeResult YubiKeyInterfacePCSC::performChallenge(void* key,
      * configurations even work, some docs say avoid it.
      *
      * In fact, the Yubikey always assumes the last byte (nr. 64)
-     * and all bytes of the same value preceeding it to be padding.
+     * and all bytes of the same value preceding it to be padding.
      * This does not conform fully to PKCS7, because the the actual value
      * of the padding bytes is ignored.
      */

--- a/src/post_install/CMakeLists.txt
+++ b/src/post_install/CMakeLists.txt
@@ -1,5 +1,5 @@
 # The install commands in this subdirectory will be executed after all the install commands in the
-# current scope are ran. It is required for correct functtioning of macdeployqt.
+# current scope are ran. It is required for correct functioning of macdeployqt.
 
 if(APPLE AND WITH_APP_BUNDLE)
     # Run macdeloyqt on the main app and any extra binaries and plugins as specified by the

--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -433,7 +433,7 @@ bool SSHAgent::listIdentities(QList<QSharedPointer<OpenSSHKey>>& list)
  * Check if this identity is loaded in the SSH Agent.
  *
  * @param key identity to remove
- * @param loaded is the key laoded
+ * @param loaded is the key loaded
  * @return true on success
  */
 bool SSHAgent::checkIdentity(const OpenSSHKey& key, bool& loaded)

--- a/src/touchid/TouchID.mm
+++ b/src/touchid/TouchID.mm
@@ -110,7 +110,7 @@ bool TouchID::storeKey(const QString& databasePath, const QByteArray& passwordKe
 
     SymmetricCipher aes256Encrypt;
     if (!aes256Encrypt.init(SymmetricCipher::Aes256_GCM, SymmetricCipher::Encrypt, randomKey, randomIV)) {
-        debug("TouchID::storeKey - AES initialisation falied");
+        debug("TouchID::storeKey - AES initialisation failed");
         return false;
     }
 

--- a/src/zxcvbn/zxcvbn.c
+++ b/src/zxcvbn/zxcvbn.c
@@ -60,7 +60,7 @@
 
 /* Additional entropy to add when password is made of multiple matches. Use different
  * amounts depending on whether the match is at the end of the password, or in the
- * middle. If the match is at the begining then there is no additional entropy.
+ * middle. If the match is at the beginning then there is no additional entropy.
  */
 #define MULTI_END_ADDITION 1.0
 #define MULTI_MID_ADDITION 1.75
@@ -169,7 +169,7 @@ static ZxcMatch_t *AllocMatch()
 static void AddResult(ZxcMatch_t **HeadRef, ZxcMatch_t *Nu, int MaxLen)
 {
     /* Adjust the entropy to be used for calculations depending on whether the passed match is
-     * at the begining, middle or end of the password
+     * at the beginning, middle or end of the password
      */
     if (Nu->Begin)
     {
@@ -546,7 +546,7 @@ static void AddLeetChr(uint8_t c, int IsLeet, uint8_t *Leeted, uint8_t *UnLeet)
 
 /**********************************************************************************
  * Given details of a word match, update it with the entropy (as natural log of
- * number of possiblities)
+ * number of possibilities)
  */
 static void DictionaryEntropy(ZxcMatch_t *m, DictMatchInfo_t *Extra, const uint8_t *Pwd)
 {
@@ -1370,7 +1370,7 @@ static void RepeatMatch(ZxcMatch_t **Result, const uint8_t *Passwd, int Start, i
     int Len, i;
     uint8_t c;
     Passwd += Start;
-    /* Remember first char and the count its occurances */
+    /* Remember first char and the count its occurrences */
     c = *Passwd;
     for(Len = 1; (Len < MaxLen) && (c == Passwd[Len]); ++Len)
     { }
@@ -1533,9 +1533,9 @@ static void SequenceMatch(ZxcMatch_t **Result, const uint8_t *Passwd, int Start,
 
 /**********************************************************************************
  * Matching a password is treated as a problem of finding the minimum distance
- * between two vertexes in a graph. This is solved using Dijkstra's algorithm.
+ * between two vertices in a graph. This is solved using Dijkstra's algorithm.
  *
- * There  are a series of nodes (or vertexes in graph terminology) which correspond
+ * There  are a series of nodes (or vertices in graph terminology) which correspond
  * to points between each character of the password. Also there is a start node
  * before the first character and an end node after the last character.
  *
@@ -1546,7 +1546,7 @@ static void SequenceMatch(ZxcMatch_t **Result, const uint8_t *Passwd, int Start,
  * end node.
  *
  * Dijkstra's algorithm finds the combination of these part matches (or paths)
- * which gives the lowest entropy (or smallest distance) from begining to end
+ * which gives the lowest entropy (or smallest distance) from beginning to end
  * of the password. 
  */
 

--- a/src/zxcvbn/zxcvbn.h
+++ b/src/zxcvbn/zxcvbn.h
@@ -68,7 +68,7 @@ typedef enum
 /* Linked list of information returned in the Info arg to ZxcvbnMatch */
 struct ZxcMatch
 {
-    int             Begin;   /* Char position of begining of match */
+    int             Begin;   /* Char position of beginning of match */
     int             Length;  /* Number of chars in the match */
     double          Entrpy;  /* The entropy of the match */
     double          MltEnpy; /* Entropy with additional allowance for multipart password */
@@ -85,13 +85,13 @@ extern "C" {
 #ifdef USE_DICT_FILE
 
 /**********************************************************************************
- * Read the dictionnary data from the given file. Returns 1 if OK, 0 if error.
+ * Read the dictionary data from the given file. Returns 1 if OK, 0 if error.
  * Called once at program startup.
  */
 int ZxcvbnInit(const char *);
 
 /**********************************************************************************
- * Free the dictionnary data after use. Called once at program shutdown.
+ * Free the dictionary data after use. Called once at program shutdown.
  */
 void ZxcvbnUnInit();
 
@@ -107,7 +107,7 @@ void ZxcvbnUnInit();
  * The main password matching function. May be called multiple times.
  * The parameters are:
  *  Passwd      The password to be tested. Null terminated string.
- *  UserDict    User supplied dictionary words to be considered particulary bad. Passed
+ *  UserDict    User supplied dictionary words to be considered particularly bad. Passed
  *               as a pointer to array of string pointers, with null last entry (like
  *               the argv parameter to main()). May be null or point to empty array when
  *               there are no user dictionary words.

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -115,7 +115,7 @@ void TestEntry::testClone()
     QScopedPointer<Entry> entryCloneRename(entryOrg->clone(Entry::CloneRenameTitle));
     QCOMPARE(entryCloneRename->uuid(), entryOrg->uuid());
     QCOMPARE(entryCloneRename->title(), QString("New Title - Clone"));
-    // Cloning should not modify time info unless explicity requested
+    // Cloning should not modify time info unless explicitly requested
     QCOMPARE(entryCloneRename->timeInfo(), entryOrg->timeInfo());
 
     QScopedPointer<Entry> entryCloneResetTime(entryOrg->clone(Entry::CloneResetTimeInfo));

--- a/tests/TestFdoSecrets.cpp
+++ b/tests/TestFdoSecrets.cpp
@@ -69,7 +69,7 @@ void TestFdoSecrets::testSpecialCharsInAttributeValue()
     e2->setTitle("titleB");
     e2->attributes()->set("testAttribute", "Abc:*+.-");
 
-    // search for custom entries via programatic API
+    // search for custom entries via programmatic API
     {
         const auto term = Collection::attributeToTerm("testAttribute", "OAuth::[test.name@gmail.com]");
         const auto res = EntrySearcher().search({term}, root.data());

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -79,7 +79,7 @@ void TestMerge::testMergeIntoNew()
 }
 
 /**
- * Merging when no changes occured should not
+ * Merging when no changes occurred should not
  * have any side effect.
  */
 void TestMerge::testMergeNoChanges()

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -418,7 +418,7 @@ void TestGuiFdoSecrets::testServiceSearchBlockingUnlockMultiple()
     VERIFY(service);
 
     // when there are multiple locked databases,
-    // repeatly show the dialog until there is at least one unlocked collection
+    // repeatedly show the dialog until there is at least one unlocked collection
     FdoSecrets::settings()->setUnlockBeforeSearch(true);
 
     // when only unlocking the one with no exposed group, a second dialog is shown


### PR DESCRIPTION
Found via `codespell -q3 -S *.ai,*.ts,./src/thirdparty,./share/translations -L ans,commend,doubleclick,keypair,searchin,te`