### PR TITLE
Bugfix #8743 run enable over the page on custom sequence selection

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -234,8 +234,7 @@ void EditEntryWidget::setupAutoType()
 
     // clang-format off
     connect(m_autoTypeUi->enableButton, SIGNAL(toggled(bool)), SLOT(updateAutoTypeEnabled()));
-    connect(m_autoTypeUi->customSequenceButton, SIGNAL(toggled(bool)),
-            m_autoTypeUi->sequenceEdit, SLOT(setEnabled(bool)));
+    connect(m_autoTypeUi->customSequenceButton, &QRadioButton::toggled, this, &EditEntryWidget::updateAutoTypeEnabled);
     connect(m_autoTypeUi->openHelpButton, SIGNAL(clicked()), SLOT(openAutotypeHelp()));
     connect(m_autoTypeUi->customWindowSequenceButton, SIGNAL(toggled(bool)),
             m_autoTypeUi->windowSequenceEdit, SLOT(setEnabled(bool)));


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
This change update the help button of autotype edition when the user selects custom sequence

[NOTE]: # ( Explain large or complex code modifications. )
I used qt5 new connect syntax instead of old one used just aside because it's better on many points and I didn't any guideline that is against, but I didn't dare refactor the other connect, so there is kind of incoherence in code.

[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes #8743 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
- Edit an entry in opened database
- Go to the Autotype tab
- Click on custom sequence button
- Help button should be enabled


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
