### PR TITLE
Fix crash in Group Edit after enabling Browser Integration

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3085,10 +3085,6 @@ Would you like to correct it?</source>
 <context>
     <name>EditGroupWidgetBrowser</name>
     <message>
-        <source>Edit Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>These settings affect to the group&apos;s behaviour with the browser extension.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -72,6 +72,8 @@ private slots:
     void save();
     void cancel();
 #ifdef WITH_XC_BROWSER
+    void initializeBrowserPage();
+    void setupBrowserModifiedTracking();
     void updateBrowserModified();
 #endif
 
@@ -89,7 +91,7 @@ private:
 #ifdef WITH_XC_BROWSER
     bool m_browserSettingsChanged;
     const QScopedPointer<Ui::EditGroupWidgetBrowser> m_browserUi;
-    QPointer<QScrollArea> m_browserWidget;
+    QWidget* const m_browserWidget;
 #endif
 
     QScopedPointer<Group> m_temporaryGroup;

--- a/src/gui/group/EditGroupWidgetBrowser.ui
+++ b/src/gui/group/EditGroupWidgetBrowser.ui
@@ -1,34 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>EditGroupWidgetBrowser</class>
- <widget class="QScrollArea" name="EditGroupWidgetBrowser">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>539</width>
-    <height>523</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Edit Group</string>
-  </property>
-  <property name="frameShape">
-   <enum>QFrame::NoFrame</enum>
-  </property>
-  <property name="frameShadow">
-   <enum>QFrame::Plain</enum>
-  </property>
-  <property name="horizontalScrollBarPolicy">
-   <enum>Qt::ScrollBarAlwaysOff</enum>
-  </property>
-  <property name="sizeAdjustPolicy">
-   <enum>QAbstractScrollArea::AdjustToContents</enum>
-  </property>
-  <property name="widgetResizable">
-   <bool>true</bool>
-  </property>
-  <widget class="QWidget" name="container">
+ <widget class="QWidget" name="EditGroupWidgetBrowser">
    <property name="geometry">
     <rect>
      <x>0</x>
@@ -59,127 +32,126 @@
     </item>
     <item>
      <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,1" columnstretch="0,1" rowminimumheight="0,0,0,1">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>10</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <property name="horizontalSpacing">
-       <number>10</number>
-      </property>
-      <property name="verticalSpacing">
-       <number>8</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="browserIntegrationHideEntriesLabel">
-        <property name="text">
-         <string>Hide entries from browser extension:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="browserIntegrationHideEntriesComboBox">
-        <property name="accessibleName">
-         <string>Hide entries from browser extension toggle for this and sub groups</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="browserIntegrationSkipAutoSubmitLabel">
-        <property name="text">
-         <string>Skip Auto-Submit for entries:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="browserIntegrationSkipAutoSubmitComboBox">
-        <property name="accessibleName">
-         <string>Skip Auto-Submit toggle for this and sub groups</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="browserIntegrationOnlyHttpAuthLabel">
-        <property name="text">
-         <string>Use entries only with HTTP Basic Auth:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="browserIntegrationOnlyHttpAuthComboBox">
-        <property name="accessibleName">
-         <string>Only HTTP Auth toggle for this and sub groups</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="browserIntegrationNotHttpAuthLabel">
-        <property name="text">
-         <string>Do not use entries with HTTP Basic Auth:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="browserIntegrationNotHttpAuthComboBox">
-        <property name="accessibleName">
-         <string>Do not use HTTP Auth toggle for this and sub groups</string>
-        </property>
-       </widget>
-      </item>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>10</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="horizontalSpacing">
+       <number>10</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>8</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="browserIntegrationHideEntriesLabel">
+        <property name="text">
+         <string>Hide entries from browser extension:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="browserIntegrationHideEntriesComboBox">
+        <property name="accessibleName">
+         <string>Hide entries from browser extension toggle for this and sub groups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="browserIntegrationSkipAutoSubmitLabel">
+        <property name="text">
+         <string>Skip Auto-Submit for entries:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="browserIntegrationSkipAutoSubmitComboBox">
+        <property name="accessibleName">
+         <string>Skip Auto-Submit toggle for this and sub groups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="browserIntegrationOnlyHttpAuthLabel">
+        <property name="text">
+         <string>Use entries only with HTTP Basic Auth:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="browserIntegrationOnlyHttpAuthComboBox">
+        <property name="accessibleName">
+         <string>Only HTTP Auth toggle for this and sub groups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="browserIntegrationNotHttpAuthLabel">
+        <property name="text">
+         <string>Do not use entries with HTTP Basic Auth:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="browserIntegrationNotHttpAuthComboBox">
+        <property name="accessibleName">
+         <string>Do not use HTTP Auth toggle for this and sub groups</string>
+        </property>
+       </widget>
+      </item>
       <item row="4" column="0">
-       <widget class="QLabel" name="browserIntegrationOmitWwwLabel">
-        <property name="text">
-         <string>Omit WWW subdomain from matching:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="browserIntegrationOmitWwwCombobox">
-        <property name="accessibleName">
-         <string>Omit WWW subdomain from matching toggle for this and sub groups</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <spacer name="verticalSpacer_1">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </item>
+       <widget class="QLabel" name="browserIntegrationOmitWwwLabel">
+        <property name="text">
+         <string>Omit WWW subdomain from matching:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="browserIntegrationOmitWwwCombobox">
+        <property name="accessibleName">
+         <string>Omit WWW subdomain from matching toggle for this and sub groups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <spacer name="verticalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
    </layout>
   </widget>
- </widget>
  <tabstops>
   <tabstop>browserIntegrationHideEntriesComboBox</tabstop>
   <tabstop>browserIntegrationSkipAutoSubmitComboBox</tabstop>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
If Browser Integration is disabled when KeePassXC is started, and then enabled, Group Edit crashes because the Browser Integration group page is not created. Currently it is only done in the class constructor.
It needs to be created only once, thus the check for `nullptr` instead of `hasPage()`.

Also hides the page from Group Edit if Browser Integration is disabled. The page shouldn't be no longer visible.

Fixes #8775.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
