### PR TITLE
Fix support for referenced URL fields

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -814,7 +814,7 @@ QList<Entry*> BrowserService::sortEntries(QList<Entry*>& entries, const QString&
     // Build map of prioritized entries
     QMultiMap<int, Entry*> priorities;
     for (auto* entry : entries) {
-        priorities.insert(sortPriority(getEntryURLs(entry), siteUrl, formUrl), entry);
+        priorities.insert(sortPriority(entry->getAllUrls(), siteUrl, formUrl), entry);
     }
 
     auto keys = priorities.uniqueKeys();
@@ -1212,21 +1212,6 @@ QSharedPointer<Database> BrowserService::selectedDatabase()
 
     // Return current database
     return getDatabase();
-}
-
-QStringList BrowserService::getEntryURLs(const Entry* entry)
-{
-    QStringList urlList;
-    urlList << entry->url();
-
-    // Handle additional URL's
-    for (const auto& key : entry->attributes()->keys()) {
-        if (key.startsWith(ADDITIONAL_URL)) {
-            urlList << entry->attributes()->value(key);
-        }
-    }
-
-    return urlList;
 }
 
 void BrowserService::hideWindow() const

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -159,7 +159,7 @@ private:
     QSharedPointer<Database> selectedDatabase();
     QString getDatabaseRootUuid();
     QString getDatabaseRecycleBinUuid();
-    QStringList getEntryURLs(const Entry* entry);
+    bool checkLegacySettings(QSharedPointer<Database> db);
     void hideWindow() const;
     void raiseWindow(const bool force = false);
     void updateWindowState();

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -372,16 +372,18 @@ QString Entry::url() const
 QStringList Entry::getAllUrls() const
 {
     QStringList urlList;
+    auto entryUrl = url();
 
-    if (!url().isEmpty()) {
-        urlList << url();
+    if (!entryUrl.isEmpty()) {
+        urlList << (EntryAttributes::matchReference(entryUrl).hasMatch() ? resolveMultiplePlaceholders(entryUrl)
+                                                                         : entryUrl);
     }
 
     for (const auto& key : m_attributes->keys()) {
         if (key.startsWith("KP2A_URL")) {
             auto additionalUrl = m_attributes->value(key);
             if (!additionalUrl.isEmpty()) {
-                urlList << additionalUrl;
+                urlList << resolveMultiplePlaceholders(additionalUrl);
             }
         }
     }

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -44,6 +44,7 @@ private slots:
     void testSearchEntries();
     void testSearchEntriesByPath();
     void testSearchEntriesByUUID();
+    void testSearchEntriesByReference();
     void testSearchEntriesWithPort();
     void testSearchEntriesWithAdditionalURLs();
     void testInvalidEntries();


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Full or partial references in the URL fields are not supported.

At first simply using `webUrl()` instead of `url()` was tried, but `resolveUrl()` can accept some invalid URL's and the tests will fail. Instead the simpler `resolveMultiplePlaceholders()` is used instead if a reference is found.

Fixes #8787

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tests added. Also did manual tests with both full and partial reference URL's.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
