### PR TITLE
Fix build failure with Qt5.6

### DIFF
--- a/src/gui/tag/TagView.cpp
+++ b/src/gui/tag/TagView.cpp
@@ -76,14 +76,14 @@ void TagView::contextMenuRequested(const QPoint& pos)
     if (type == TagModel::SAVED_SEARCH) {
         // Allow deleting saved searches
         QMenu menu;
-        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Search"))}, mapToGlobal(pos));
+        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Search"), nullptr)}, mapToGlobal(pos));
         if (action) {
             m_db->metadata()->deleteSavedSearch(index.data(Qt::DisplayRole).toString());
         }
     } else if (type == TagModel::TAG) {
         // Allow removing tags from all entries in a database
         QMenu menu;
-        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Tag"))}, mapToGlobal(pos));
+        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Tag"), nullptr)}, mapToGlobal(pos));
         if (action) {
             auto tag = index.data(Qt::DisplayRole).toString();
             auto ans = MessageBox::question(this,


### PR DESCRIPTION
With Qt 5.6, build fails with error below.

This is because in Qt 5.6, the 3rd argument is not optional. Starting from Qt 5.7 the default value for the 3rd argument is nullptr, so setting it to nullptr.

https://doc.qt.io/archives/qt-5.6/qaction.html#QAction-2
https://doc.qt.io/archives/qt-5.7/qaction.html#QAction-2
```
Error:
src/gui/tag/TagView.cpp:79:38: error: no matching constructor for initialization of 'QAction'
        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Search"))}, mapToGlobal(pos));
                                     ^       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Same fix could be applied to the `2.7.x` branch

## Testing strategy
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on macports builds running qt5.6


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
