### PR TITLE
Fix Ctrl+Tab shortcut to cycle databases in unlock dialog

### DIFF
--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -68,13 +68,13 @@ DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
     auto* shortcut = new QShortcut(Qt::CTRL + Qt::Key_PageUp, this);
     shortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(shortcut, &QShortcut::activated, this, [this]() { selectTabOffset(-1); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_Tab, this);
+    shortcut = new QShortcut(dbTabModifier + Qt::SHIFT + Qt::Key_Tab, this);
     shortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(shortcut, &QShortcut::activated, this, [this]() { selectTabOffset(-1); });
     shortcut = new QShortcut(Qt::CTRL + Qt::Key_PageDown, this);
     shortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(shortcut, &QShortcut::activated, this, [this]() { selectTabOffset(1); });
-    shortcut = new QShortcut(dbTabModifier + Qt::SHIFT + Qt::Key_Tab, this);
+    shortcut = new QShortcut(dbTabModifier + Qt::Key_Tab, this);
     shortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(shortcut, &QShortcut::activated, this, [this]() { selectTabOffset(1); });
 }


### PR DESCRIPTION
When in PR #8168 the ability to cycle through the databases in the unlock dialogue was extended to include the `Ctrl+Tab / Ctrl+Shift+Tab` shortcuts, it mixed up the direction. At the moment `Ctrl+Tab` selects the previous database when customarily it should select the next entry. This was my mistake.

This commit changes the direction of cycling through databases in the unlock dialogue with `Ctrl+Tab / Ctrl+Shift+Tab` fixing my original commit.

## Screenshots

None.


## Testing strategy
I was able to compile and run the application.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

