### PR TITLE
Add `.mm` files to translation update

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -1411,8 +1411,8 @@ i18n() {
         if ! command -v $LUPDATE > /dev/null; then
             LUPDATE=lupdate
         fi
-        $LUPDATE -no-ui-lines -disable-heuristic similartext -locations none -no-obsolete src \
-            -ts share/translations/keepassxc_en.ts $@
+        $LUPDATE -no-ui-lines -disable-heuristic similartext -locations none -extensions c,cpp,h,js,mm,qrc,ui \
+            -no-obsolete src -ts share/translations/keepassxc_en.ts $@
 
         return 0
     fi

--- a/release-tool.ps1
+++ b/release-tool.ps1
@@ -284,7 +284,7 @@ if ($Merge) {
     # Update translation files
     Write-Host "Updating source translation file..."
     Invoke-Cmd "lupdate" "-no-ui-lines -disable-heuristic similartext -locations none", `
-        "-no-obsolete ./src -ts share/translations/keepassxc_en.ts"
+        "-extensions c,cpp,h,js,mm,qrc,ui -no-obsolete ./src -ts share/translations/keepassxc_en.ts"
 
     Write-Host "Pulling updated translations from Transifex..."
     Invoke-Cmd "tx" "pull -af --minimum-perc=60 --parallel -r keepassxc.share-translations-keepassxc-en-ts--develop"

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1597,6 +1597,10 @@ If you do not have a key file, please leave the field empty.</source>
 &lt;p&gt;Click for more information…&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>authenticate to access the database</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingWidgetMetaData</name>


### PR DESCRIPTION
I found an untranslated string in the Touch ID prompt (see below). Localisation is [already implemented](https://github.com/keepassxreboot/keepassxc/blob/2583cc4aa4fe5c05639d48ee579925af0ff170ce/src/touchid/TouchID.mm#L219), the string is just missing from the translations file. `release-tool i18n lupdate` did not catch it either. 

Explicitly specifying the extensions for `lupdate` to search fixes this.

## Screenshots

<img width="402" src="https://user-images.githubusercontent.com/6024426/204058451-c9b3abc0-21a2-4664-a506-34dcef8af233.png">

## Testing strategy

I called `lupdate` again; no strings have vanished and the one missing string has appeared:

```
$ ./release-tool i18n lupdate
KeePassXC Release Preparation Helper
Copyright (C) 2021 KeePassXC Team <https://keepassxc.org/>

[ INFO ] Updating source translation file...
Scanning directory 'src'...
Updating 'share/translations/keepassxc_en.ts'...
    Found 2098 source text(s) (1 new and 2097 already existing)
```
I haven't tested my changes to the PowerShell script yet.



## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
