### PR TITLE
Add filename to window title

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1119,16 +1119,20 @@ void MainWindow::updateWindowTitle()
     }
 
     QString windowTitle;
+    QString filePath = QString("");
+    if (tabWidgetIndex >= 0) {
+        filePath = m_ui->tabWidget->databaseWidgetFromIndex(tabWidgetIndex)->database()->filePath();
+    }
     if (customWindowTitlePart.isEmpty()) {
         windowTitle = BaseWindowTitle;
     } else {
-        windowTitle = QString("%1[*] - %2").arg(customWindowTitlePart, BaseWindowTitle);
+        windowTitle = QString("%1[*] - %2 - %3").arg(customWindowTitlePart, filePath, BaseWindowTitle);
     }
 
     if (customWindowTitlePart.isEmpty() || stackedWidgetIndex == 1) {
         setWindowFilePath("");
     } else {
-        setWindowFilePath(m_ui->tabWidget->databaseWidgetFromIndex(tabWidgetIndex)->database()->filePath());
+        setWindowFilePath(filePath);
     }
 
     setWindowTitle(windowTitle);


### PR DESCRIPTION
# Add file name in window title.
Since different database files could have the same db name, it is better to show db filename


## Screenshots
Before the change, after db is open:
```Shell
MyPass0 - KeepassXC
```
After:
```Shell
MyPass0 - my_pass0-20220101.kdbx - KeepassXC
```

## Testing strategy
[NOTE]: # Run the code and see the result


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)


This is a minor modification.
