### PR TITLE
fix unexpected behavior of --lock when keepassxc is not running

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -7920,6 +7920,10 @@ Kernel: %3 %4</source>
 This options is deprecated, use --set-key-file instead.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>KeePassXC is not running. No open database to lock</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QtIOCompressor</name>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,6 +156,14 @@ int main(int argc, char** argv)
         return EXIT_SUCCESS;
     }
 
+    if (parser.isSet(lockOption)) {
+        qWarning() << QObject::tr("KeePassXC is not running. No open database to lock").toUtf8().constData();
+
+        // still return with EXIT_SUCCESS because when used within a script for ensuring that there is no unlocked
+        // keepass database (e.g. screen locking) we can consider it as successful
+        return EXIT_SUCCESS;
+    }
+
     if (!Crypto::init()) {
         QString error = QObject::tr("Fatal error while testing the cryptographic functions.");
         error.append("\n");


### PR DESCRIPTION
### status quo
currently, when keepassxc is not running, the command `keepassxc --lock` opens a new keepass window and blocks until the window is closed.

Especially in locking scripts this is rather unexpected and  I can't think of a case where someone explicitly runs keepassxc with `--lock` and wants this behaviour.


### expected
Rather --lock should always ensure, that there are no unlocked instances and exiting afterwards


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)