### PR TITLE
Set password hint on BSD, fill selection on macOS again

### DIFF
--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -55,7 +55,6 @@ void Clipboard::setText(const QString& text, bool clear)
     mime->setText(text);
 #ifdef Q_OS_MACOS
     mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());
-    clipboard->setMimeData(mime, QClipboard::Clipboard);
 #else
 #ifdef Q_OS_UNIX
     mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
@@ -63,12 +62,11 @@ void Clipboard::setText(const QString& text, bool clear)
 #ifdef Q_OS_WIN
     mime->setData("ExcludeClipboardContentFromMonitorProcessing", QByteArrayLiteral("1"));
 #endif
-    clipboard->setMimeData(mime, QClipboard::Clipboard);
-
     if (clipboard->supportsSelection()) {
         clipboard->setMimeData(mime, QClipboard::Selection);
     }
 #endif
+    clipboard->setMimeData(mime, QClipboard::Clipboard);
 
     if (clear) {
         m_lastCopied = text;

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -58,7 +58,7 @@ void Clipboard::setText(const QString& text, bool clear)
     clipboard->setMimeData(mime, QClipboard::Clipboard);
 #else
     mime->setText(text);
-#ifdef Q_OS_LINUX
+#ifdef Q_OS_UNIX
     mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
 #endif
 #ifdef Q_OS_WIN

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -61,11 +61,9 @@ void Clipboard::setText(const QString& text, bool clear)
     mime->setData("ExcludeClipboardContentFromMonitorProcessing", QByteArrayLiteral("1"));
 #endif
 
-#if !defined(Q_OS_MACOS)
     if (clipboard->supportsSelection()) {
         clipboard->setMimeData(mime, QClipboard::Selection);
     }
-#endif
     clipboard->setMimeData(mime, QClipboard::Clipboard);
 
     if (clear) {

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -52,12 +52,11 @@ void Clipboard::setText(const QString& text, bool clear)
     }
 
     auto* mime = new QMimeData;
-#ifdef Q_OS_MACOS
     mime->setText(text);
+#ifdef Q_OS_MACOS
     mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());
     clipboard->setMimeData(mime, QClipboard::Clipboard);
 #else
-    mime->setText(text);
 #ifdef Q_OS_UNIX
     mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
 #endif

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -53,15 +53,15 @@ void Clipboard::setText(const QString& text, bool clear)
 
     auto* mime = new QMimeData;
     mime->setText(text);
-#ifdef Q_OS_MACOS
+#if defined(Q_OS_MACOS)
     mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());
-#else
-#ifdef Q_OS_UNIX
+#elif defined(Q_OS_UNIX)
     mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
-#endif
-#ifdef Q_OS_WIN
+#elif defined(Q_OS_WIN)
     mime->setData("ExcludeClipboardContentFromMonitorProcessing", QByteArrayLiteral("1"));
 #endif
+
+#if !defined(Q_OS_MACOS)
     if (clipboard->supportsSelection()) {
         clipboard->setMimeData(mime, QClipboard::Selection);
     }


### PR DESCRIPTION
- Set x-kde-passwordManagerHint on BSD
- Hoist mime handling out of Q_OS_* macros
- Defer filling clipboard
- Simplify Q_OS_* macro logic
- Fill selction on macOS again

## Testing strategy
Tested on OpenBSD/amd64 7.2-current with `keepassxc-2.7.4p1-browser` and `copyq-6.3.2`.
This PR makes passwords copied from KeePassXC no longer appear in CopyQ (after adding a command that ignores values containing the password hint).

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Refactor (significant modification to existing code)
