### PR TITLE
Translate Cipher and KDF strings

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -7892,6 +7892,14 @@ Kernel: %3 %4</source>
         <source>Failed to sign challenge using Windows Hello.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid Cipher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid KDF</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QtIOCompressor</name>

--- a/src/cli/DatabaseInfo.cpp
+++ b/src/cli/DatabaseInfo.cpp
@@ -39,8 +39,8 @@ int DatabaseInfo::executeWithDatabase(QSharedPointer<Database> database, QShared
     out << QObject::tr("Name: ") << database->metadata()->name() << endl;
     out << QObject::tr("Description: ") << database->metadata()->description() << endl;
     for (auto& cipher : asConst(KeePass2::CIPHERS)) {
-        if (cipher.first == database->cipher()) {
-            out << QObject::tr("Cipher: ") << cipher.second << endl;
+        if (cipher == database->cipher()) {
+            out << QObject::tr("Cipher: ") << KeePass2::cipherToString(cipher) << endl;
         }
     }
     out << QObject::tr("KDF: ") << database->kdf()->toString() << endl;

--- a/src/format/KeePass2.cpp
+++ b/src/format/KeePass2.cpp
@@ -47,16 +47,12 @@ const QString KeePass2::KDFPARAM_ARGON2_VERSION("V");
 const QString KeePass2::KDFPARAM_ARGON2_SECRET("K");
 const QString KeePass2::KDFPARAM_ARGON2_ASSOCDATA("A");
 
-const QList<QPair<QUuid, QString>> KeePass2::CIPHERS{
-    qMakePair(KeePass2::CIPHER_AES256, QObject::tr("AES 256-bit")),
-    qMakePair(KeePass2::CIPHER_TWOFISH, QObject::tr("Twofish 256-bit")),
-    qMakePair(KeePass2::CIPHER_CHACHA20, QObject::tr("ChaCha20 256-bit"))};
+const QList<QUuid> KeePass2::CIPHERS{KeePass2::CIPHER_AES256, KeePass2::CIPHER_TWOFISH, KeePass2::CIPHER_CHACHA20};
 
-const QList<QPair<QUuid, QString>> KeePass2::KDFS{
-    qMakePair(KeePass2::KDF_ARGON2D, QObject::tr("Argon2d (KDBX 4 – recommended)")),
-    qMakePair(KeePass2::KDF_ARGON2ID, QObject::tr("Argon2id (KDBX 4)")),
-    qMakePair(KeePass2::KDF_AES_KDBX4, QObject::tr("AES-KDF (KDBX 4)")),
-    qMakePair(KeePass2::KDF_AES_KDBX3, QObject::tr("AES-KDF (KDBX 3)"))};
+const QList<QUuid> KeePass2::KDFS{KeePass2::KDF_ARGON2D,
+                                  KeePass2::KDF_ARGON2ID,
+                                  KeePass2::KDF_AES_KDBX4,
+                                  KeePass2::KDF_AES_KDBX3};
 
 QByteArray KeePass2::hmacKey(const QByteArray& masterSeed, const QByteArray& transformedMasterKey)
 {
@@ -132,4 +128,30 @@ KeePass2::ProtectedStreamAlgo KeePass2::idToProtectedStreamAlgo(quint32 id)
     default:
         return KeePass2::ProtectedStreamAlgo::InvalidProtectedStreamAlgo;
     }
+}
+
+QString KeePass2::cipherToString(QUuid cipherUuid)
+{
+    if (cipherUuid == KeePass2::CIPHER_AES256) {
+        return QObject::tr("AES 256-bit");
+    } else if (cipherUuid == KeePass2::CIPHER_TWOFISH) {
+        return QObject::tr("Twofish 256-bit");
+    } else if (cipherUuid == KeePass2::CIPHER_CHACHA20) {
+        return QObject::tr("ChaCha20 256-bit");
+    }
+    return QObject::tr("Invalid Cipher");
+}
+
+QString KeePass2::kdfToString(QUuid kdfUuid)
+{
+    if (kdfUuid == KeePass2::KDF_ARGON2D) {
+        return QObject::tr("Argon2d (KDBX 4 – recommended)");
+    } else if (kdfUuid == KeePass2::KDF_ARGON2ID) {
+        return QObject::tr("Argon2id (KDBX 4)");
+    } else if (kdfUuid == KeePass2::KDF_AES_KDBX4) {
+        return QObject::tr("AES-KDF (KDBX 4)");
+    } else if (kdfUuid == KDF_AES_KDBX3) {
+        return QObject::tr("AES-KDF (KDBX 3)");
+    }
+    return QObject::tr("Invalid KDF");
 }

--- a/src/format/KeePass2.h
+++ b/src/format/KeePass2.h
@@ -26,7 +26,6 @@ class Kdf;
 
 namespace KeePass2
 {
-
     constexpr quint32 SIGNATURE_1 = 0x9AA2D903;
     constexpr quint32 SIGNATURE_2 = 0xB54BFB67;
 
@@ -67,8 +66,8 @@ namespace KeePass2
     extern const QString KDFPARAM_ARGON2_SECRET;
     extern const QString KDFPARAM_ARGON2_ASSOCDATA;
 
-    extern const QList<QPair<QUuid, QString>> CIPHERS;
-    extern const QList<QPair<QUuid, QString>> KDFS;
+    extern const QList<QUuid> CIPHERS;
+    extern const QList<QUuid> KDFS;
 
     enum class HeaderFieldID
     {
@@ -130,7 +129,8 @@ namespace KeePass2
     QVariantMap kdfToParameters(const QSharedPointer<Kdf>& kdf);
     QSharedPointer<Kdf> uuidToKdf(const QUuid& uuid);
     ProtectedStreamAlgo idToProtectedStreamAlgo(quint32 id);
-
+    QString cipherToString(QUuid cipherUuid);
+    QString kdfToString(QUuid kdfUuid);
 } // namespace KeePass2
 
 #endif // KEEPASSX_KEEPASS2_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
@@ -141,7 +141,7 @@ void DatabaseSettingsWidgetEncryption::setupAlgorithmComboBox()
 {
     m_ui->algorithmComboBox->clear();
     for (auto& cipher : asConst(KeePass2::CIPHERS)) {
-        m_ui->algorithmComboBox->addItem(cipher.second.toUtf8(), cipher.first.toByteArray());
+        m_ui->algorithmComboBox->addItem(KeePass2::cipherToString(cipher), cipher.toByteArray());
     }
     int cipherIndex = m_ui->algorithmComboBox->findData(m_db->cipher().toByteArray());
     if (cipherIndex > -1) {
@@ -155,8 +155,8 @@ void DatabaseSettingsWidgetEncryption::setupKdfComboBox(bool enableKdbx3)
     bool block = m_ui->kdfComboBox->blockSignals(true);
     m_ui->kdfComboBox->clear();
     for (auto& kdf : asConst(KeePass2::KDFS)) {
-        if (kdf.first != KeePass2::KDF_AES_KDBX3 or enableKdbx3) {
-            m_ui->kdfComboBox->addItem(kdf.second.toUtf8(), kdf.first.toByteArray());
+        if (kdf != KeePass2::KDF_AES_KDBX3 or enableKdbx3) {
+            m_ui->kdfComboBox->addItem(KeePass2::kdfToString(kdf), kdf.toByteArray());
         }
     }
     m_ui->kdfComboBox->blockSignals(block);


### PR DESCRIPTION
* Fix #8952 - move translations for Cipher and KDF strings into evaluated code instead of globally defined code. The strings were being baked prior to the language being set resulting in only english being displayed.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested by setting alternate language and ensuring the translations showed.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
