### PR TITLE
AES-256/GCM fixes

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -5823,6 +5823,10 @@ We recommend you use the AppImage available on our downloads page.</source>
         <source>Unexpected EOF when writing private key</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>AES-256/GCM is currently not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PasswordEditWidget</name>

--- a/src/crypto/SymmetricCipher.cpp
+++ b/src/crypto/SymmetricCipher.cpp
@@ -267,3 +267,22 @@ int SymmetricCipher::blockSize(Mode mode)
         return 0;
     }
 }
+
+int SymmetricCipher::ivSize(Mode mode)
+{
+    switch (mode) {
+    case Aes128_CBC:
+    case Aes256_CBC:
+    case Aes128_CTR:
+    case Aes256_CTR:
+    case Twofish_CBC:
+        return 16;
+    case Aes256_GCM:
+        return 12;
+    case Salsa20:
+    case ChaCha20:
+        return 8;
+    default:
+        return 0;
+    }
+}

--- a/src/crypto/SymmetricCipher.cpp
+++ b/src/crypto/SymmetricCipher.cpp
@@ -176,7 +176,7 @@ SymmetricCipher::Mode SymmetricCipher::stringToMode(const QString& cipher)
         return Aes128_CTR;
     } else if (cipher.compare("aes-256-ctr", cs) == 0 || cipher.compare("aes256-ctr", cs) == 0) {
         return Aes256_CTR;
-    } else if (cipher.compare("aes-256-gcm", cs) == 0 || cipher.compare("aes256-gcm", cs) == 0) {
+    } else if (cipher.compare("aes-256-gcm", cs) == 0 || cipher.startsWith("aes256-gcm", cs)) {
         return Aes256_GCM;
     } else if (cipher.startsWith("twofish", cs)) {
         return Twofish_CBC;

--- a/src/crypto/SymmetricCipher.cpp
+++ b/src/crypto/SymmetricCipher.cpp
@@ -176,7 +176,7 @@ SymmetricCipher::Mode SymmetricCipher::stringToMode(const QString& cipher)
         return Aes128_CTR;
     } else if (cipher.compare("aes-256-ctr", cs) == 0 || cipher.compare("aes256-ctr", cs) == 0) {
         return Aes256_CTR;
-    } else if (cipher.compare("aes-256-gcm", cs) == 0 || cipher.startsWith("aes256-gcm", cs)) {
+    } else if (cipher.compare("aes-256-gcm", cs) == 0 || cipher.compare("aes256-gcm", cs) == 0) {
         return Aes256_GCM;
     } else if (cipher.startsWith("twofish", cs)) {
         return Twofish_CBC;

--- a/src/crypto/SymmetricCipher.h
+++ b/src/crypto/SymmetricCipher.h
@@ -70,6 +70,7 @@ public:
     static int defaultIvSize(Mode mode);
     static int keySize(Mode mode);
     static int blockSize(Mode mode);
+    static int ivSize(Mode mode);
 
 private:
     static QString modeToString(const Mode mode);

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -30,6 +30,7 @@
 const QString OpenSSHKey::TYPE_DSA_PRIVATE = "DSA PRIVATE KEY";
 const QString OpenSSHKey::TYPE_RSA_PRIVATE = "RSA PRIVATE KEY";
 const QString OpenSSHKey::TYPE_OPENSSH_PRIVATE = "OPENSSH PRIVATE KEY";
+const QString OpenSSHKey::OPENSSH_CIPHER_SUFFIX = "@openssh.com";
 
 OpenSSHKey::OpenSSHKey(QObject* parent)
     : QObject(parent)
@@ -310,9 +311,13 @@ bool OpenSSHKey::openKey(const QString& passphrase)
     QByteArray rawData = m_rawData;
 
     if (m_cipherName != "none") {
-        auto cipherMode = SymmetricCipher::stringToMode(m_cipherName);
+        QString l_cipherName(m_cipherName);
+        if (l_cipherName.endsWith(OPENSSH_CIPHER_SUFFIX)) {
+            l_cipherName.chop(OPENSSH_CIPHER_SUFFIX.length());
+        }
+        auto cipherMode = SymmetricCipher::stringToMode(l_cipherName);
         if (cipherMode == SymmetricCipher::InvalidMode) {
-            m_error = tr("Unknown cipher: %1").arg(m_cipherName);
+            m_error = tr("Unknown cipher: %1").arg(l_cipherName);
             return false;
         } else if (cipherMode == SymmetricCipher::Aes256_GCM) {
             m_error = tr("AES-256/GCM is currently not supported");

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -312,7 +312,9 @@ bool OpenSSHKey::openKey(const QString& passphrase)
 
     if (m_cipherName != "none") {
         QString l_cipherName(m_cipherName);
-        l_cipherName.remove(OPENSSH_CIPHER_SUFFIX);
+        if (l_cipherName.endsWith(OPENSSH_CIPHER_SUFFIX)) {
+            l_cipherName.remove(OPENSSH_CIPHER_SUFFIX);
+        }
         auto cipherMode = SymmetricCipher::stringToMode(l_cipherName);
         if (cipherMode == SymmetricCipher::InvalidMode) {
             m_error = tr("Unknown cipher: %1").arg(l_cipherName);

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -312,9 +312,7 @@ bool OpenSSHKey::openKey(const QString& passphrase)
 
     if (m_cipherName != "none") {
         QString l_cipherName(m_cipherName);
-        if (l_cipherName.endsWith(OPENSSH_CIPHER_SUFFIX)) {
-            l_cipherName.chop(OPENSSH_CIPHER_SUFFIX.length());
-        }
+        l_cipherName.remove(OPENSSH_CIPHER_SUFFIX);
         auto cipherMode = SymmetricCipher::stringToMode(l_cipherName);
         if (cipherMode == SymmetricCipher::InvalidMode) {
             m_error = tr("Unknown cipher: %1").arg(l_cipherName);

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -325,7 +325,7 @@ bool OpenSSHKey::openKey(const QString& passphrase)
             }
 
             int keySize = cipher->keySize(cipherMode);
-            int blockSize = 16;
+            int ivSize = cipher->ivSize(cipherMode);
 
             BinaryStream optionStream(&m_kdfOptions);
 
@@ -335,7 +335,7 @@ bool OpenSSHKey::openKey(const QString& passphrase)
             optionStream.readString(salt);
             optionStream.read(rounds);
 
-            QByteArray decryptKey(keySize + blockSize, '\0');
+            QByteArray decryptKey(keySize + ivSize, '\0');
             try {
                 auto baPass = passphrase.toUtf8();
                 auto pwhash = Botan::PasswordHashFamily::create_or_throw("Bcrypt-PBKDF")->from_iterations(rounds);
@@ -351,7 +351,7 @@ bool OpenSSHKey::openKey(const QString& passphrase)
             }
 
             keyData = decryptKey.left(keySize);
-            ivData = decryptKey.right(blockSize);
+            ivData = decryptKey.right(ivSize);
         } else if (m_kdfName == "md5") {
             if (m_cipherIV.length() < 8) {
                 m_error = tr("Cipher IV is too short for MD5 kdf");

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -314,6 +314,9 @@ bool OpenSSHKey::openKey(const QString& passphrase)
         if (cipherMode == SymmetricCipher::InvalidMode) {
             m_error = tr("Unknown cipher: %1").arg(m_cipherName);
             return false;
+        } else if (cipherMode == SymmetricCipher::Aes256_GCM) {
+            m_error = tr("AES-256/GCM is currently not supported");
+            return false;
         }
 
         QByteArray keyData, ivData;

--- a/src/sshagent/OpenSSHKey.h
+++ b/src/sshagent/OpenSSHKey.h
@@ -58,6 +58,7 @@ public:
     static const QString TYPE_DSA_PRIVATE;
     static const QString TYPE_RSA_PRIVATE;
     static const QString TYPE_OPENSSH_PRIVATE;
+    static const QString OPENSSH_CIPHER_SUFFIX;
 
 private:
     enum KeyPart


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Correct detection of aes256-gcm cipher. OpenSSH includes an `@openssh.com` at the end of the cipher name, similar to ChaCha20.

Use IV Size when deriving the encryption key instead of Block Size. While this is is the same value for the other AES modes, it is different for AES-256/GCM and for ChaCha20.

Disable aes256-gcm algorithm with an explicit message. Decryption is currently broken pending changes to the botan library.

See #8964

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Ran
```
cmake -DWITH_GUI_TESTS=on -DWITH_XC_ALL=on ../
make
make test
```
to validate that there were no regressions.

Manually tested changes with test password database + ssh key.
```
ssh-keygen -t ed25519 -Z aes256-gcm@openssh.com -f test -N test
```

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
