### PR TITLE
chore: remove unused functions

### DIFF
--- a/src/autotype/AutoTypeMatchModel.cpp
+++ b/src/autotype/AutoTypeMatchModel.cpp
@@ -38,13 +38,6 @@ AutoTypeMatch AutoTypeMatchModel::matchFromIndex(const QModelIndex& index) const
     return m_matches.at(index.row());
 }
 
-QModelIndex AutoTypeMatchModel::indexFromMatch(const AutoTypeMatch& match) const
-{
-    int row = m_matches.indexOf(match);
-    Q_ASSERT(row != -1);
-    return index(row, 1);
-}
-
 QModelIndex AutoTypeMatchModel::closestIndexFromMatch(const AutoTypeMatch& match) const
 {
     int row = -1;

--- a/src/autotype/AutoTypeMatchModel.h
+++ b/src/autotype/AutoTypeMatchModel.h
@@ -41,7 +41,6 @@ public:
 
     explicit AutoTypeMatchModel(QObject* parent = nullptr);
     AutoTypeMatch matchFromIndex(const QModelIndex& index) const;
-    QModelIndex indexFromMatch(const AutoTypeMatch& match) const;
     QModelIndex closestIndexFromMatch(const AutoTypeMatch& match) const;
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/src/core/Clock.cpp
+++ b/src/core/Clock.cpp
@@ -63,11 +63,6 @@ QDateTime Clock::parse(const QString& text, Qt::DateFormat format)
     return QDateTime::fromString(text, format);
 }
 
-QDateTime Clock::parse(const QString& text, const QString& format)
-{
-    return QDateTime::fromString(text, format);
-}
-
 Clock::~Clock()
 {
 }

--- a/src/core/Clock.cpp
+++ b/src/core/Clock.cpp
@@ -53,19 +53,9 @@ QDateTime Clock::datetimeUtc(int year, int month, int day, int hour, int min, in
     return QDateTime(QDate(year, month, day), QTime(hour, min, second), Qt::UTC);
 }
 
-QDateTime Clock::datetime(int year, int month, int day, int hour, int min, int second)
-{
-    return QDateTime(QDate(year, month, day), QTime(hour, min, second), Qt::LocalTime);
-}
-
 QDateTime Clock::datetimeUtc(qint64 msecSinceEpoch)
 {
     return QDateTime::fromMSecsSinceEpoch(msecSinceEpoch, Qt::UTC);
-}
-
-QDateTime Clock::datetime(qint64 msecSinceEpoch)
-{
-    return QDateTime::fromMSecsSinceEpoch(msecSinceEpoch, Qt::LocalTime);
 }
 
 QDateTime Clock::parse(const QString& text, Qt::DateFormat format)

--- a/src/core/Clock.h
+++ b/src/core/Clock.h
@@ -37,7 +37,6 @@ public:
     static QDateTime datetimeUtc(qint64 msecSinceEpoch);
 
     static QDateTime parse(const QString& text, Qt::DateFormat format = Qt::TextDate);
-    static QDateTime parse(const QString& text, const QString& format);
 
     virtual ~Clock();
 

--- a/src/core/Clock.h
+++ b/src/core/Clock.h
@@ -33,10 +33,8 @@ public:
     static QDateTime serialized(const QDateTime& dateTime);
 
     static QDateTime datetimeUtc(int year, int month, int day, int hour, int min, int second);
-    static QDateTime datetime(int year, int month, int day, int hour, int min, int second);
 
     static QDateTime datetimeUtc(qint64 msecSinceEpoch);
-    static QDateTime datetime(qint64 msecSinceEpoch);
 
     static QDateTime parse(const QString& text, Qt::DateFormat format = Qt::TextDate);
     static QDateTime parse(const QString& text, const QString& format);

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -105,28 +105,6 @@ void CustomData::remove(const QString& key)
     emit removed(key);
 }
 
-void CustomData::rename(const QString& oldKey, const QString& newKey)
-{
-    const bool containsOldKey = m_data.contains(oldKey);
-    const bool containsNewKey = m_data.contains(newKey);
-    Q_ASSERT(containsOldKey && !containsNewKey);
-    if (!containsOldKey || containsNewKey) {
-        return;
-    }
-
-    CustomDataItem data = m_data.value(oldKey);
-
-    emit aboutToRename(oldKey, newKey);
-
-    m_data.remove(oldKey);
-    data.lastModified = Clock::currentDateTimeUtc();
-    m_data.insert(newKey, data);
-
-    updateLastModified();
-    emitModified();
-    emit renamed(oldKey, newKey);
-}
-
 void CustomData::copyDataFrom(const CustomData* other)
 {
     if (*this == *other) {

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -158,11 +158,6 @@ QDateTime CustomData::lastModified() const
     return modified;
 }
 
-QDateTime CustomData::lastModified(const QString& key) const
-{
-    return m_data.value(key).lastModified;
-}
-
 void CustomData::updateLastModified(QDateTime lastModified)
 {
     if (m_data.isEmpty() || (m_data.size() == 1 && m_data.contains(LastModified))) {

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -64,16 +64,6 @@ bool CustomData::contains(const QString& key) const
     return m_data.contains(key);
 }
 
-bool CustomData::containsValue(const QString& value) const
-{
-    for (auto i = m_data.constBegin(); i != m_data.constEnd(); ++i) {
-        if (i.value().value == value) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void CustomData::set(const QString& key, CustomDataItem item)
 {
     bool addAttribute = !m_data.contains(key);

--- a/src/core/CustomData.h
+++ b/src/core/CustomData.h
@@ -48,7 +48,6 @@ public:
     const CustomDataItem& item(const QString& key) const;
     bool contains(const QString& key) const;
     QDateTime lastModified() const;
-    QDateTime lastModified(const QString& key) const;
     bool isProtected(const QString& key) const;
     void set(const QString& key, CustomDataItem item);
     void set(const QString& key, const QString& value, const QDateTime& lastModified = {});

--- a/src/core/CustomData.h
+++ b/src/core/CustomData.h
@@ -47,7 +47,6 @@ public:
     QString value(const QString& key) const;
     const CustomDataItem& item(const QString& key) const;
     bool contains(const QString& key) const;
-    bool containsValue(const QString& value) const;
     QDateTime lastModified() const;
     QDateTime lastModified(const QString& key) const;
     bool isProtected(const QString& key) const;

--- a/src/core/CustomData.h
+++ b/src/core/CustomData.h
@@ -52,7 +52,6 @@ public:
     void set(const QString& key, CustomDataItem item);
     void set(const QString& key, const QString& value, const QDateTime& lastModified = {});
     void remove(const QString& key);
-    void rename(const QString& oldKey, const QString& newKey);
     void clear();
     bool isEmpty() const;
     int size() const;

--- a/src/core/EntrySearcher.cpp
+++ b/src/core/EntrySearcher.cpp
@@ -83,19 +83,6 @@ QList<Entry*> EntrySearcher::repeat(const Group* baseGroup, bool forceSearch)
 }
 
 /**
- * Search provided entries by the provided search terms
- *
- * @param searchTerms search terms
- * @param entries list of entries to include in the search
- * @return list of entries that match the search terms
- */
-QList<Entry*> EntrySearcher::searchEntries(const QList<SearchTerm>& searchTerms, const QList<Entry*>& entries)
-{
-    m_searchTerms = searchTerms;
-    return repeatEntries(entries);
-}
-
-/**
  * Search provided entries by parsing the search string
  * for search terms.
  *

--- a/src/core/EntrySearcher.cpp
+++ b/src/core/EntrySearcher.cpp
@@ -136,11 +136,6 @@ void EntrySearcher::setCaseSensitive(bool state)
     m_caseSensitive = state;
 }
 
-bool EntrySearcher::isCaseSensitive() const
-{
-    return m_caseSensitive;
-}
-
 bool EntrySearcher::searchEntryImpl(const Entry* entry)
 {
     // Pre-load in case they are needed

--- a/src/core/EntrySearcher.h
+++ b/src/core/EntrySearcher.h
@@ -58,7 +58,6 @@ public:
     QList<Entry*> search(const QString& searchString, const Group* baseGroup, bool forceSearch = false);
     QList<Entry*> repeat(const Group* baseGroup, bool forceSearch = false);
 
-    QList<Entry*> searchEntries(const QList<SearchTerm>& searchTerms, const QList<Entry*>& entries);
     QList<Entry*> searchEntries(const QString& searchString, const QList<Entry*>& entries);
     QList<Entry*> repeatEntries(const QList<Entry*>& entries);
 

--- a/src/core/EntrySearcher.h
+++ b/src/core/EntrySearcher.h
@@ -63,7 +63,6 @@ public:
     QList<Entry*> repeatEntries(const QList<Entry*>& entries);
 
     void setCaseSensitive(bool state);
-    bool isCaseSensitive() const;
 
 private:
     bool searchEntryImpl(const Entry* entry);

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -52,11 +52,6 @@ void Merger::setForcedMergeMode(Group::MergeMode mode)
     m_mode = mode;
 }
 
-void Merger::resetForcedMergeMode()
-{
-    m_mode = Group::Default;
-}
-
 QStringList Merger::merge()
 {
     // Order of merge steps is important - it is possible that we

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -30,7 +30,6 @@ public:
     Merger(const Database* sourceDb, Database* targetDb);
     Merger(const Group* sourceGroup, Group* targetGroup);
     void setForcedMergeMode(Group::MergeMode mode);
-    void resetForcedMergeMode();
     QStringList merge();
 
 private:

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -105,11 +105,6 @@ void Metadata::setUpdateDatetime(bool value)
     m_updateDatetime = value;
 }
 
-void Metadata::copyAttributesFrom(const Metadata* other)
-{
-    m_data = other->m_data;
-}
-
 QString Metadata::generator() const
 {
     return m_data.generator;

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -154,15 +154,6 @@ public:
     void addSavedSearch(const QString& name, const QString& searchtext);
     void deleteSavedSearch(const QString& name);
     QVariantMap savedSearches();
-    /*
-     * Copy all attributes from other except:
-     * - Group pointers/uuids
-     * - Database key changed date
-     * - Custom icons
-     * - Custom fields
-     * - Settings changed date
-     */
-    void copyAttributesFrom(const Metadata* other);
 
 private:
     template <class P, class V> bool set(P& property, const V& value);

--- a/src/format/KdbxReader.cpp
+++ b/src/format/KdbxReader.cpp
@@ -105,11 +105,6 @@ QString KdbxReader::errorString() const
     return m_errorStr;
 }
 
-KeePass2::ProtectedStreamAlgo KdbxReader::protectedStreamAlgo() const
-{
-    return m_irsAlgo;
-}
-
 /**
  * @param data stream cipher UUID as bytes
  */

--- a/src/format/KdbxReader.h
+++ b/src/format/KdbxReader.h
@@ -45,8 +45,6 @@ public:
     bool hasError() const;
     QString errorString() const;
 
-    KeePass2::ProtectedStreamAlgo protectedStreamAlgo() const;
-
 protected:
     /**
      * Concrete reader implementation for reading database from device.

--- a/src/format/KdbxXmlReader.cpp
+++ b/src/format/KdbxXmlReader.cpp
@@ -157,11 +157,6 @@ void KdbxXmlReader::readDatabase(QIODevice* device, Database* db, KeePass2Random
     }
 }
 
-bool KdbxXmlReader::strictMode() const
-{
-    return m_strictMode;
-}
-
 void KdbxXmlReader::setStrictMode(bool strictMode)
 {
     m_strictMode = strictMode;

--- a/src/format/KdbxXmlReader.h
+++ b/src/format/KdbxXmlReader.h
@@ -51,7 +51,6 @@ public:
 
     QByteArray headerHash() const;
 
-    bool strictMode() const;
     void setStrictMode(bool strictMode);
 
 protected:

--- a/src/format/KdbxXmlWriter.cpp
+++ b/src/format/KdbxXmlWriter.cpp
@@ -567,16 +567,6 @@ void KdbxXmlWriter::writeTriState(const QString& qualifiedName, Group::TriState 
     writeString(qualifiedName, value);
 }
 
-QString KdbxXmlWriter::colorPartToString(int value)
-{
-    QString str = QString::number(value, 16).toUpper();
-    if (str.length() == 1) {
-        str.prepend("0");
-    }
-
-    return str;
-}
-
 QString KdbxXmlWriter::stripInvalidXml10Chars(QString str)
 {
     for (int i = str.size() - 1; i >= 0; i--) {

--- a/src/format/KdbxXmlWriter.cpp
+++ b/src/format/KdbxXmlWriter.cpp
@@ -608,12 +608,3 @@ void KdbxXmlWriter::disableInnerStreamProtection(bool disable)
 {
     m_innerStreamProtectionDisabled = disable;
 }
-
-/**
- * @return true if inner stream protection is disabled and protected
- *         fields will be saved in plaintext
- */
-bool KdbxXmlWriter::innerStreamProtectionDisabled() const
-{
-    return m_innerStreamProtectionDisabled;
-}

--- a/src/format/KdbxXmlWriter.h
+++ b/src/format/KdbxXmlWriter.h
@@ -72,7 +72,6 @@ private:
     void writeUuid(const QString& qualifiedName, const Entry* entry);
     void writeBinary(const QString& qualifiedName, const QByteArray& ba);
     void writeTriState(const QString& qualifiedName, Group::TriState triState);
-    QString colorPartToString(int value);
     QString stripInvalidXml10Chars(QString str);
 
     void raiseError(const QString& errorMessage);

--- a/src/format/KdbxXmlWriter.h
+++ b/src/format/KdbxXmlWriter.h
@@ -38,7 +38,6 @@ public:
                        const QByteArray& headerHash = QByteArray());
     void writeDatabase(const QString& filename, Database* db);
     void disableInnerStreamProtection(bool disable);
-    bool innerStreamProtectionDisabled() const;
     bool hasError();
     QString errorString();
 

--- a/src/gui/CategoryListWidget.cpp
+++ b/src/gui/CategoryListWidget.cpp
@@ -97,11 +97,6 @@ void CategoryListWidget::setCategoryHidden(int index, bool hidden)
     m_ui->categoryList->item(index)->setHidden(hidden);
 }
 
-bool CategoryListWidget::isCategoryHidden(int index)
-{
-    return m_ui->categoryList->item(index)->isHidden();
-}
-
 void CategoryListWidget::showEvent(QShowEvent* event)
 {
     QWidget::showEvent(event);

--- a/src/gui/CategoryListWidget.cpp
+++ b/src/gui/CategoryListWidget.cpp
@@ -77,11 +77,6 @@ int CategoryListWidget::addCategory(const QString& labelText, const QIcon& icon)
     return m_ui->categoryList->count() - 1;
 }
 
-void CategoryListWidget::removeCategory(int index)
-{
-    m_ui->categoryList->removeItemWidget(m_ui->categoryList->item(index));
-}
-
 int CategoryListWidget::currentCategory()
 {
     return m_ui->categoryList->currentRow();

--- a/src/gui/CategoryListWidget.h
+++ b/src/gui/CategoryListWidget.h
@@ -41,7 +41,6 @@ public:
     void setCurrentCategory(int index);
     int addCategory(const QString& labelText, const QIcon& icon);
     void setCategoryHidden(int index, bool hidden);
-    bool isCategoryHidden(int index);
     void removeCategory(int index);
 
 signals:

--- a/src/gui/CategoryListWidget.h
+++ b/src/gui/CategoryListWidget.h
@@ -41,7 +41,6 @@ public:
     void setCurrentCategory(int index);
     int addCategory(const QString& labelText, const QIcon& icon);
     void setCategoryHidden(int index, bool hidden);
-    void removeCategory(int index);
 
 signals:
     void categoryChanged(int index);

--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -136,11 +136,6 @@ void EditWidget::setReadOnly(bool readOnly)
     }
 }
 
-bool EditWidget::readOnly() const
-{
-    return m_readOnly;
-}
-
 void EditWidget::setModified(bool state)
 {
     m_modified = state;

--- a/src/gui/EditWidget.h
+++ b/src/gui/EditWidget.h
@@ -48,7 +48,6 @@ public:
     void setHeadline(const QString& text);
     QLabel* headlineLabel();
     void setReadOnly(bool readOnly);
-    bool readOnly() const;
     void enableApplyButton(bool enabled);
     void showApplyButton(bool state);
     virtual bool isModified() const;

--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -135,11 +135,6 @@ void FileDialog::setNextFileName(const QString& fileName)
     m_nextFileName = fileName;
 }
 
-void FileDialog::setNextDirectory(const QString& path)
-{
-    m_nextDirName = path;
-}
-
 void FileDialog::saveLastDir(const QString& role, const QString& path, bool sensitive)
 {
     auto lastDirs = config()->get(Config::LastDir).toHash();

--- a/src/gui/FileDialog.h
+++ b/src/gui/FileDialog.h
@@ -53,7 +53,6 @@ public:
      * Bypasses the selection process and returns the provided filename/directory immediately (for testing)
      */
     void setNextFileName(const QString& fileName);
-    void setNextDirectory(const QString& path);
 
     static void saveLastDir(const QString& role, const QString& path, bool sensitive = false);
     static QString getLastDir(const QString& role, const QString& defaultDir = QDir::homePath());

--- a/src/gui/MessageWidget.cpp
+++ b/src/gui/MessageWidget.cpp
@@ -41,11 +41,6 @@ void MessageWidget::setAnimate(bool state)
     m_animate = state;
 }
 
-int MessageWidget::autoHideTimeout() const
-{
-    return m_autoHideTimeout;
-}
-
 void MessageWidget::showMessage(const QString& text, MessageWidget::MessageType type)
 {
     showMessage(text, type, m_autoHideTimeout);

--- a/src/gui/MessageWidget.h
+++ b/src/gui/MessageWidget.h
@@ -30,8 +30,6 @@ class MessageWidget : public KMessageWidget
 public:
     explicit MessageWidget(QWidget* parent = nullptr);
 
-    int autoHideTimeout() const;
-
     static const int DefaultAutoHideTimeout;
     static const int LongAutoHideTimeout;
     static const int DisableAutoHide;

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -54,11 +54,6 @@ public:
         editPage->assign(widget);
     }
 
-    QWidget* getWidget()
-    {
-        return widget;
-    }
-
 private:
     QSharedPointer<IEditGroupPage> editPage;
     QWidget* widget;

--- a/src/gui/reports/ReportsWidget.cpp
+++ b/src/gui/reports/ReportsWidget.cpp
@@ -37,8 +37,3 @@ void ReportsWidget::load(QSharedPointer<Database> db)
     m_db = std::move(db);
     initialize();
 }
-
-const QSharedPointer<Database> ReportsWidget::getDatabase() const
-{
-    return m_db;
-}

--- a/src/gui/reports/ReportsWidget.h
+++ b/src/gui/reports/ReportsWidget.h
@@ -36,8 +36,6 @@ public:
 
     virtual void load(QSharedPointer<Database> db);
 
-    const QSharedPointer<Database> getDatabase() const;
-
 signals:
     /**
      * Can be emitted to indicate size changes and allow parents widgets to adjust properly.

--- a/src/gui/styles/base/phantomcolor.cpp
+++ b/src/gui/styles/base/phantomcolor.cpp
@@ -404,14 +404,6 @@ namespace Phantom
         return {r_, g_, b_};
     }
 
-    QColor lerpQColor(const QColor& x, const QColor& y, qreal a)
-    {
-        Rgb x_ = rgb_of_qcolor(x);
-        Rgb y_ = rgb_of_qcolor(y);
-        Rgb z = Rgb::lerp(x_, y_, a);
-        return qcolor_of_rgb(z.r, z.g, z.b);
-    }
-
     Rgb Rgb::lerp(const Rgb& x, const Rgb& y, qreal a)
     {
         Rgb z;

--- a/src/gui/styles/base/phantomcolor.h
+++ b/src/gui/styles/base/phantomcolor.h
@@ -113,11 +113,6 @@ namespace Phantom
         return (1.0 - a) * x + a * y;
     }
 
-    // Linearly interpolate two QColors after trasnforming them to linear color
-    // space, treating the QColor values as if they were in sRGB space. The
-    // returned QColor is converted back to sRGB space.
-    QColor lerpQColor(const QColor& x, const QColor& y, qreal a);
-
     Hsl Rgb::toHsl() const
     {
         return hsl_of_rgb(r, g, b);

--- a/src/gui/widgets/PopupHelpWidget.cpp
+++ b/src/gui/widgets/PopupHelpWidget.cpp
@@ -42,14 +42,6 @@ PopupHelpWidget::~PopupHelpWidget()
     parentWidget()->removeEventFilter(this);
 }
 
-void PopupHelpWidget::setOffset(const QPoint& offset)
-{
-    m_offset = offset;
-    if (isVisible()) {
-        alignWithParent();
-    }
-}
-
 void PopupHelpWidget::setPosition(Qt::Corner corner)
 {
     m_corner = corner;

--- a/src/gui/widgets/PopupHelpWidget.cpp
+++ b/src/gui/widgets/PopupHelpWidget.cpp
@@ -42,14 +42,6 @@ PopupHelpWidget::~PopupHelpWidget()
     parentWidget()->removeEventFilter(this);
 }
 
-void PopupHelpWidget::setPosition(Qt::Corner corner)
-{
-    m_corner = corner;
-    if (isVisible()) {
-        alignWithParent();
-    }
-}
-
 bool PopupHelpWidget::eventFilter(QObject* obj, QEvent* event)
 {
     if (isVisible()) {

--- a/src/gui/widgets/PopupHelpWidget.h
+++ b/src/gui/widgets/PopupHelpWidget.h
@@ -28,8 +28,6 @@ public:
     explicit PopupHelpWidget(QWidget* parent);
     ~PopupHelpWidget() override;
 
-    void setPosition(Qt::Corner corner);
-
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
     void showEvent(QShowEvent* event) override;

--- a/src/gui/widgets/PopupHelpWidget.h
+++ b/src/gui/widgets/PopupHelpWidget.h
@@ -28,7 +28,6 @@ public:
     explicit PopupHelpWidget(QWidget* parent);
     ~PopupHelpWidget() override;
 
-    void setOffset(const QPoint& offset);
     void setPosition(Qt::Corner corner);
 
 protected:

--- a/src/keys/ChallengeResponseKey.cpp
+++ b/src/keys/ChallengeResponseKey.cpp
@@ -38,11 +38,6 @@ void ChallengeResponseKey::setRawKey(const QByteArray&)
     // Nothing to do here
 }
 
-YubiKeySlot ChallengeResponseKey::slotData() const
-{
-    return m_keySlot;
-}
-
 QString ChallengeResponseKey::error() const
 {
     return m_error;

--- a/src/keys/ChallengeResponseKey.h
+++ b/src/keys/ChallengeResponseKey.h
@@ -30,7 +30,6 @@ public:
 
     QByteArray rawKey() const override;
     void setRawKey(const QByteArray&) override;
-    YubiKeySlot slotData() const;
 
     virtual bool challenge(const QByteArray& challenge);
     QString error() const;

--- a/src/keys/PasswordKey.cpp
+++ b/src/keys/PasswordKey.cpp
@@ -64,13 +64,6 @@ void PasswordKey::setPassword(const QString& password)
     setRawKey(CryptoHash::hash(password.toUtf8(), CryptoHash::Sha256));
 }
 
-QSharedPointer<PasswordKey> PasswordKey::fromRawKey(const QByteArray& rawKey)
-{
-    auto result = QSharedPointer<PasswordKey>::create();
-    result->setRawKey(rawKey);
-    return result;
-}
-
 QByteArray PasswordKey::serialize() const
 {
     QByteArray data;

--- a/src/keys/PasswordKey.h
+++ b/src/keys/PasswordKey.h
@@ -36,8 +36,6 @@ public:
     void setRawKey(const QByteArray& data) override;
     void setPassword(const QString& password);
 
-    static QSharedPointer<PasswordKey> fromRawKey(const QByteArray& rawKey);
-
     QByteArray serialize() const override;
     void deserialize(const QByteArray& data) override;
 

--- a/src/streams/qtiocompressor.cpp
+++ b/src/streams/qtiocompressor.cpp
@@ -286,16 +286,6 @@ void QtIOCompressor::setStreamFormat(StreamFormat format)
 }
 
 /*!
-    Returns the format set on the compressed stream.
-    \sa QtIOCompressor::StreamFormat
-*/
-QtIOCompressor::StreamFormat QtIOCompressor::streamFormat() const
-{
-    Q_D(const QtIOCompressor);
-    return d->streamFormat;
-}
-
-/*!
     \reimp
 */
 bool QtIOCompressor::isSequential() const

--- a/src/streams/qtiocompressor.cpp
+++ b/src/streams/qtiocompressor.cpp
@@ -296,14 +296,6 @@ QtIOCompressor::StreamFormat QtIOCompressor::streamFormat() const
 }
 
 /*!
-    Returns true if the zlib library in use supports the gzip format, false otherwise.
-*/
-bool QtIOCompressor::isGzipSupported()
-{
-    return checkGzipSupport(zlibVersion());
-}
-
-/*!
     \reimp
 */
 bool QtIOCompressor::isSequential() const

--- a/src/streams/qtiocompressor.h
+++ b/src/streams/qtiocompressor.h
@@ -58,7 +58,6 @@ enum StreamFormat { ZlibFormat, GzipFormat, RawZipFormat };
     QtIOCompressor(QIODevice *device, int compressionLevel = 6, int bufferSize = 65500);
     ~QtIOCompressor() override;
     void setStreamFormat(StreamFormat format);
-    StreamFormat streamFormat() const;
     bool isSequential() const override;
     bool open(OpenMode mode) override;
     void close() override;

--- a/src/streams/qtiocompressor.h
+++ b/src/streams/qtiocompressor.h
@@ -59,7 +59,6 @@ enum StreamFormat { ZlibFormat, GzipFormat, RawZipFormat };
     ~QtIOCompressor() override;
     void setStreamFormat(StreamFormat format);
     StreamFormat streamFormat() const;
-    static bool isGzipSupported();
     bool isSequential() const override;
     bool open(OpenMode mode) override;
     void close() override;

--- a/src/totp/totp.cpp
+++ b/src/totp/totp.cpp
@@ -249,15 +249,6 @@ QString Totp::generateTotp(const QSharedPointer<Totp::Settings>& settings, const
     return retval;
 }
 
-QList<QPair<QString, QString>> Totp::supportedEncoders()
-{
-    QList<QPair<QString, QString>> encoders;
-    for (auto& encoder : totpEncoders) {
-        encoders << QPair<QString, QString>(encoder.name, encoder.shortName);
-    }
-    return encoders;
-}
-
 QList<QPair<QString, Totp::Algorithm>> Totp::supportedAlgorithms()
 {
     QList<QPair<QString, Algorithm>> algorithms;

--- a/src/totp/totp.h
+++ b/src/totp/totp.h
@@ -86,7 +86,6 @@ namespace Totp
 
     QString generateTotp(const QSharedPointer<Totp::Settings>& settings, const quint64 time = 0ull);
 
-    QList<QPair<QString, QString>> supportedEncoders();
     QList<QPair<QString, Algorithm>> supportedAlgorithms();
 
     Encoder& defaultEncoder();


### PR DESCRIPTION
This PR removes unused functions and class methods.

I ran keepassxc through [xunused](https://github.com/mgehre/xunused), manually inspected the results to remove false positives, and then removed the code that seems to actually be unused.

One note: some of the unused code was accessors for Qt properties, e.g. places where a QObject had

```c++
void setFoo(int foo);
int foo() const;
```

and `foo()` was unused. I'm happy to re-add these if you want to keep getter / setter symmetry for Qt properties.

## Testing strategy

The pre-existing ctest suite.

There are no custom instructions here since this PR only removes code.

## Type of change

- ✅ Refactor (significant modification to existing code)
