### PR TITLE
Fix print exported html

### DIFF
--- a/src/gui/HtmlExporter.cpp
+++ b/src/gui/HtmlExporter.cpp
@@ -231,7 +231,7 @@ bool HtmlExporter::writeGroup(QIODevice& device, const Group& group, QString pat
     }
 
     // Begin the table for the entries in this group
-    auto table = QString("<table width=\"100%\">");
+    auto table = QString("<table width=\"80%\">");
 
     auto entries = group.entries();
     if (sorted) {


### PR DESCRIPTION
Fix #7769 by adjusting the html table width.

## Screenshots
The generated html page looks fine now:
![FixedHtmlPage1](https://user-images.githubusercontent.com/121412908/212236702-95da9e05-4644-4834-ac00-cecc33346791.png)

The print preview page looks fine now:
![FixedPrintPage1](https://user-images.githubusercontent.com/121412908/212236722-5bb84fc5-2e4e-440b-8749-dc07fbce6f40.png)

## Testing strategy
### Manual testing
- Created a test database with an entry with long notes (I took some paragraph from a wikipedia page).
- Exported the database into HTML page.
- Opened the generated html page by Firefox, Brave browsers.
- Made sure the formatting is good.

### Unit testing
- Not applicable

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)