### PR TITLE
Fix crash when using Windows Hello in a Remote Desktop session

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1495,10 +1495,6 @@ To prevent this error from appearing, you must go to &quot;Database Settings / S
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to authenticate with Windows Hello</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Failed to authenticate with Touch ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1553,6 +1549,10 @@ If you do not have a key file, please leave the field empty.</source>
     </message>
     <message>
         <source>authenticate to access the database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to authenticate with Windows Hello: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -339,7 +339,12 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::buildDatabaseKey()
 #ifdef Q_CC_MSVC
         if (!getWindowsHello()->getKey(m_filename, keyData)) {
             // Failed to retrieve Quick Unlock data
-            m_ui->messageWidget->showMessage(tr("Failed to authenticate with Windows Hello"), MessageWidget::Error);
+            auto error = getWindowsHello()->errorString();
+            if (!error.isEmpty()) {
+                m_ui->messageWidget->showMessage(tr("Failed to authenticate with Windows Hello: %1").arg(error),
+                                                 MessageWidget::Error);
+                resetQuickUnlock();
+            }
             return {};
         }
 #elif defined(Q_OS_MACOS)


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Summary: This change fixes #7890 by catching a previously uncaught exception, and adds fallback behaviour when quick-unlock fails.

Windows Hello can suddenly become unavailable with a permission denied exception. According to https://github.com/keepassxreboot/keepassxc/issues/7890#issuecomment-1099221593:

1. Unlock a database with Windows Hello enabled
2. Lock the database
3. Connect to the machine in a remote desktop session
4. Attempt to use Windows Hello to unlock the database by clicking the big button with the fingerprint icon

Note that this might not be the only way to trigger this. For example, one could disable Windows Hello and probably end up with the same crash.

So far I've been calling this "Windows Hello", but I'm not too familiar with the Windows APIs, so I'm not sure if `KeyCredentialManager.RequestCreateAsync Method` is technically Windows Hello. In any case, it comes up as a crash in the Windows Hello flow. It crashes because of an uncaught exception being returned, and it seems the error is by design because of extra restrictions Microsoft wanted to place on remote desktop sessions.

In the second commit, I made a quick attempt to improve the overall experience by falling back to the other unlock methods if quick unlock fails for any reason. This is a bigger change than just preventing the crash, so I'm open to feedback, including simply removing the second commit from this PR if it's contentious. This fallback behaviour I implemented was suggested in the original issue report and I think it's sensible.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![image](https://user-images.githubusercontent.com/1320418/213322851-3a132980-ea4e-4c1b-bf8a-eecb9ec98719.png)
Clicking "Unlock Database" in a remote desktop session used to crash, now it doesn't.


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

I tested this by using the reproduction steps in the linked issue #7890, using a real RDP session. I first reliably reproduced the crash on an unmodified build, and then verified that my fix stopped the crashes.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
