### PR TITLE
Add keyboard shortcuts for app and database settings

### DIFF
--- a/docs/topics/KeyboardShortcuts.adoc
+++ b/docs/topics/KeyboardShortcuts.adoc
@@ -9,12 +9,15 @@ NOTE: On macOS please substitute `Ctrl` with `Cmd` (aka `⌘`).
 |===
 |Action                       | Keyboard Shortcut
 
+|Settings                     | Ctrl + ,
 |Open Database                | Ctrl + O
 |Save Database                | Ctrl + S
 |Save Database As             | Ctrl + Shift + S
 |New Database                 | Ctrl + Shift + N
 |Close Database               | Ctrl + W ; Ctrl + F4
 |Lock All Databases           | Ctrl + L
+|Database Settings            | Ctrl + Shift + ,
+|Database Reports             | Ctrl + Shift + R
 |Quit                         | Ctrl + Q
 |New Entry                    | Ctrl + N
 |Edit Entry                   | Enter ; Ctrl + E

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -269,6 +269,9 @@ MainWindow::MainWindow()
     setShortcut(m_ui->actionDatabaseSave, QKeySequence::Save, Qt::CTRL + Qt::Key_S);
     setShortcut(m_ui->actionDatabaseSaveAs, QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S);
     setShortcut(m_ui->actionDatabaseClose, QKeySequence::Close, Qt::CTRL + Qt::Key_W);
+    m_ui->actionDatabaseSettings->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Comma);
+    m_ui->actionReports->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_R);
+    setShortcut(m_ui->actionSettings, QKeySequence::Preferences, Qt::CTRL + Qt::Key_Comma);
     m_ui->actionLockDatabase->setShortcut(Qt::CTRL + Qt::Key_L);
     m_ui->actionLockAllDatabases->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_L);
     setShortcut(m_ui->actionQuit, QKeySequence::Quit, Qt::CTRL + Qt::Key_Q);


### PR DESCRIPTION
Fixes #8923 request to support the `Ctrl+,` shortcut on Linux.

Add the registration of `Ctrl+,` shortcut as the standard `Preferences` key. Refer [the QT doc](https://doc.qt.io/qt-5/qkeysequence.html) for details.

## Screenshots
![tool-menu-with-added-shortcut](https://user-images.githubusercontent.com/121412908/213376381-589438d3-d5f4-4c31-ac02-fdfa49073450.png)

## Testing strategy
Tested manually on Ubuntu 22.04.1 LTS.

## Type of change
- ✅ New feature
- ✅ Documentation