### PR TITLE
Add 'Copy URL' action into Entry context menu

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -5138,10 +5138,6 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;URL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Copy URL to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5393,6 +5389,10 @@ We recommend you use the AppImage available on our downloads page.</source>
     </message>
     <message>
         <source>XML File…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy &amp;URL</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -128,6 +128,7 @@ MainWindow::MainWindow()
     m_entryContextMenu->setSeparatorsCollapsible(true);
     m_entryContextMenu->addAction(m_ui->actionEntryCopyUsername);
     m_entryContextMenu->addAction(m_ui->actionEntryCopyPassword);
+    m_entryContextMenu->addAction(m_ui->actionEntryCopyURL);
     m_entryContextMenu->addAction(m_ui->menuEntryCopyAttribute->menuAction());
     m_entryContextMenu->addAction(m_ui->menuEntryTotp->menuAction());
     m_entryContextMenu->addAction(m_ui->menuTags->menuAction());

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -216,7 +216,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <property name="contextMenuPolicy">
@@ -246,11 +246,6 @@
      <addaction name="actionExportCsv"/>
      <addaction name="actionExportHtml"/>
      <addaction name="actionExportXML"/>
-    </widget>
-    <widget class="QMenu" name="menu_Quit">
-     <property name="title">
-      <string>&amp;Quit</string>
-     </property>
     </widget>
     <addaction name="actionDatabaseNew"/>
     <addaction name="actionDatabaseOpen"/>
@@ -306,7 +301,6 @@
       <string>Copy Att&amp;ribute</string>
      </property>
      <addaction name="actionEntryCopyTitle"/>
-     <addaction name="actionEntryCopyURL"/>
      <addaction name="actionEntryCopyNotes"/>
      <addaction name="separator"/>
     </widget>
@@ -338,6 +332,7 @@
     <addaction name="separator"/>
     <addaction name="actionEntryCopyUsername"/>
     <addaction name="actionEntryCopyPassword"/>
+    <addaction name="actionEntryCopyURL"/>
     <addaction name="menuEntryCopyAttribute"/>
     <addaction name="menuEntryTotp"/>
     <addaction name="menuTags"/>
@@ -818,7 +813,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>&amp;URL</string>
+    <string>Copy &amp;URL</string>
    </property>
    <property name="toolTip">
     <string>Copy URL to clipboard</string>
@@ -895,7 +890,7 @@
     <string>Copy &amp;TOTP</string>
    </property>
   </action>
-    <action name="actionEntryCopyPasswordTotp">
+  <action name="actionEntryCopyPasswordTotp">
    <property name="text">
     <string>Copy Password and TOTP</string>
    </property>


### PR DESCRIPTION
Fixes #7377 feature request to add `Copy URL` action into Entry context menu.
Added already existent action.
Also renamed the existent action from `URL` to `Copy URL` to be in the same style as `Copy Username` and `Copy Password` actions.

## Screenshots
#### When an entry has some URL:
![entry-context-menu-with-copy-url](https://user-images.githubusercontent.com/121412908/213633432-9585a5e8-1455-4e8e-9714-3eb056d32da5.png)

#### When an entry does not have URL:
![entry-context-menu-with-copy-url-disabled](https://user-images.githubusercontent.com/121412908/213634078-ae2d66f1-7382-49f2-84fc-9084cbe70e52.png)

## Testing strategy
Tested on Ubuntu 22.04.1 LTS
- Open a database -> select any entry with URL -> make sure you have enabled `Copy URL` action -> click on it -> paste the copied URL in an editor -> verify it.
- Open a database -> select any entry without URL -> make sure you have disabled `Copy URL` action.

## Type of change
- ✅ New feature (change that adds functionality)
