### PR TITLE
Fix wrong horizontal QR code resizing

### DIFF
--- a/src/gui/SquareSvgWidget.cpp
+++ b/src/gui/SquareSvgWidget.cpp
@@ -16,6 +16,14 @@
  */
 
 #include "SquareSvgWidget.h"
+#include <QResizeEvent>
+
+SquareSvgWidget::SquareSvgWidget(QWidget* parent)
+    : QSvgWidget(parent)
+{
+    Q_ASSERT(parent);
+    setObjectName("squareSvgWidget");
+}
 
 bool SquareSvgWidget::hasHeightForWidth() const
 {
@@ -25,4 +33,25 @@ bool SquareSvgWidget::hasHeightForWidth() const
 int SquareSvgWidget::heightForWidth(int width) const
 {
     return width;
+}
+
+// The overridden logic allows to keep the SVG image as square and centered by width and height.
+void SquareSvgWidget::resizeEvent(QResizeEvent*)
+{
+    QWidget* pWidget = parentWidget();
+    Q_ASSERT(pWidget);
+    if (pWidget) {
+        auto containerRect = pWidget->contentsRect();
+
+        auto containerWidth = containerRect.width();
+        auto containerHeight = containerRect.height();
+
+        auto squareSize = qMin(containerWidth, containerHeight);
+        auto halfSquareSize = squareSize >> 1;
+
+        auto startX = (containerWidth >> 1) - halfSquareSize;
+        auto startY = (containerHeight >> 1) - halfSquareSize;
+
+        setGeometry(startX, startY, squareSize, squareSize);
+    }
 }

--- a/src/gui/SquareSvgWidget.h
+++ b/src/gui/SquareSvgWidget.h
@@ -23,11 +23,13 @@
 class SquareSvgWidget : public QSvgWidget
 {
 public:
-    SquareSvgWidget() = default;
+    explicit SquareSvgWidget(QWidget* parent);
     ~SquareSvgWidget() override = default;
 
     bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
+
+    void resizeEvent(QResizeEvent* event) override;
 };
 
 #endif // KEEPASSX_SquareSvgWidget_H

--- a/src/gui/TotpExportSettingsDialog.cpp
+++ b/src/gui/TotpExportSettingsDialog.cpp
@@ -29,24 +29,28 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QShortcut>
+#include <QStackedWidget>
 
 TotpExportSettingsDialog::TotpExportSettingsDialog(DatabaseWidget* parent, Entry* entry)
     : QDialog(parent)
     , m_timer(new QTimer(this))
     , m_verticalLayout(new QVBoxLayout())
-    , m_totpSvgWidget(new SquareSvgWidget())
+    , m_totpSvgContainerWidget(new QStackedWidget())
+    , m_totpSvgWidget(new SquareSvgWidget(m_totpSvgContainerWidget))
     , m_countDown(new QLabel())
     , m_warningLabel(new QLabel())
     , m_buttonBox(new QDialogButtonBox(QDialogButtonBox::Close | QDialogButtonBox::Ok))
 {
+    setObjectName("entryQrCodeWidget");
+    m_totpSvgContainerWidget->addWidget(m_totpSvgWidget);
+
     m_verticalLayout->addWidget(m_warningLabel);
     m_verticalLayout->addItem(new QSpacerItem(0, 0));
-
-    m_verticalLayout->addStretch(0);
-    m_verticalLayout->addWidget(m_totpSvgWidget);
-    m_verticalLayout->addStretch(0);
+    m_verticalLayout->addWidget(m_totpSvgContainerWidget);
     m_verticalLayout->addWidget(m_countDown);
     m_verticalLayout->addWidget(m_buttonBox);
+
+    m_verticalLayout->setAlignment(m_buttonBox, Qt::AlignBottom);
 
     setLayout(m_verticalLayout);
     setAttribute(Qt::WA_DeleteOnClose);

--- a/src/gui/TotpExportSettingsDialog.h
+++ b/src/gui/TotpExportSettingsDialog.h
@@ -44,6 +44,7 @@ private:
     QTimer* m_timer;
 
     QVBoxLayout* m_verticalLayout;
+    QStackedWidget* m_totpSvgContainerWidget;
     SquareSvgWidget* m_totpSvgWidget;
     QLabel* m_countDown;
     QLabel* m_warningLabel;

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -895,12 +895,27 @@ void TestGui::testTotp()
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
 
+    // Test the TOTP value
     triggerAction("actionEntryTotp");
 
     auto* totpDialog = m_dbWidget->findChild<TotpDialog*>("TotpDialog");
     auto* totpLabel = totpDialog->findChild<QLabel*>("totpLabel");
 
     QCOMPARE(totpLabel->text().replace(" ", ""), entry->totp());
+    QTest::keyClick(totpDialog, Qt::Key_Escape);
+
+    // Test the QR code
+    triggerAction("actionEntryTotpQRCode");
+    auto* qrCodeDialog = m_mainWindow->findChild<QDialog*>("entryQrCodeWidget");
+    QVERIFY(qrCodeDialog);
+    QVERIFY(qrCodeDialog->isVisible());
+    auto* qrCodeWidget = qrCodeDialog->findChild<QWidget*>("squareSvgWidget");
+    QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Initial QR code is not square");
+
+    // Test the QR code window resizing, make the dialog bigger.
+    qrCodeDialog->setFixedSize(800, 600);
+    QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Resized QR code is not square");
+    QTest::keyClick(qrCodeDialog, Qt::Key_Escape);
 }
 
 void TestGui::testSearch()


### PR DESCRIPTION
Fixes #8944 issue when the QR code was wrongly resized horizontally

## Screenshots (have dummy QR codes based on `AAAA` key).
### Before
![stratched-qr-code](https://user-images.githubusercontent.com/121412908/214471029-dc0d7636-5724-45dd-932a-72dec7f13b56.png)

### After
![fixed-qr-code-centered](https://user-images.githubusercontent.com/121412908/214471054-d3f5ffb1-9ea5-43f9-989a-7f1a6a062354.png)

## Testing strategy
- Have an entry with defined TOTP.
- Open the QR code window and try to stretch it.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)