### PR TITLE
Update system tray translation for German

### DIFF
--- a/share/translations/keepassxc_de.ts
+++ b/share/translations/keepassxc_de.ts
@@ -424,11 +424,11 @@
     </message>
     <message>
         <source>Tray icon type</source>
-        <translation>Infobbereichssymbol Typ</translation>
+        <translation>Infobereichssymbol Typ</translation>
     </message>
     <message>
         <source>Tray icon type:</source>
-        <translation>Infobbereichssymbol Typ:</translation>
+        <translation>Infobereichssymbol Typ:</translation>
     </message>
     <message>
         <source>Hide window to system tray when minimized</source>

--- a/share/translations/keepassxc_de.ts
+++ b/share/translations/keepassxc_de.ts
@@ -420,15 +420,15 @@
     </message>
     <message>
         <source>Show a system tray icon</source>
-        <translation>Taskleistensymbol anzeigen</translation>
+        <translation>Symbol im Infobereich anzeigen</translation>
     </message>
     <message>
         <source>Tray icon type</source>
-        <translation>Trayicon-Typ</translation>
+        <translation>Infobbereichssymbol Typ</translation>
     </message>
     <message>
         <source>Tray icon type:</source>
-        <translation>Tray Icon Typ:</translation>
+        <translation>Infobbereichssymbol Typ:</translation>
     </message>
     <message>
         <source>Hide window to system tray when minimized</source>


### PR DESCRIPTION
The prior translation referred to the system tray as the task bar. This made it impossible to guess what the option does, since any open window has a symbol in the task bar. It also referred to the system tray using the english term.
Most German applications use either "System Tray", which isn't a German word many people use, or "Infobereich", which is what the official Windows documentation calls it in German: https://support.microsoft.com/de-de/windows/anpassen-des-infobereichs-f%C3%BCr-taskleisten-e159e8d2-9ac5-b2bd-61c5-bb63c1d437c3


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![image](https://user-images.githubusercontent.com/24683548/215179511-404f2035-3460-4b00-8024-bc3fdd8108fa.png)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
I visually confirmed that my changes do not break the UI. I don't think there's anything else to be checked.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Localization change
