### PR TITLE
Autotype: fix text selection for clear_field step on Mac

### DIFF
--- a/src/autotype/mac/AutoTypeMac.cpp
+++ b/src/autotype/mac/AutoTypeMac.cpp
@@ -267,8 +267,8 @@ AutoTypeAction::Result AutoTypeExecutorMac::execType(const AutoTypeKey* action)
 AutoTypeAction::Result AutoTypeExecutorMac::execClearField(const AutoTypeClearField* action)
 {
     Q_UNUSED(action);
-    execType(new AutoTypeKey(Qt::Key_Up, Qt::ControlModifier));
-    execType(new AutoTypeKey(Qt::Key_Down, Qt::ControlModifier | Qt::ShiftModifier));
+    execType(new AutoTypeKey(Qt::Key_Left, Qt::ControlModifier));
+    execType(new AutoTypeKey(Qt::Key_Right, Qt::ControlModifier | Qt::ShiftModifier));
     execType(new AutoTypeKey(Qt::Key_Backspace));
     return AutoTypeAction::Result::Ok();
 }


### PR DESCRIPTION
- Changed the key combination for clear field auto type function on Mac environment.
- Fixes #9029 bug,

## Screenshots
The previous key combination `Ctrl` + `Up` is assigned to show the virtual workspaces:
<img width="976" alt="Screen Shot 2023-02-04 at 23 07 56" src="https://user-images.githubusercontent.com/121412908/216806450-2a74d308-8837-4409-9dd7-d3ebae424ef8.png">

## Testing strategy
- Do the same steps as descibed in the bug description: #9029.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
