### PR TITLE
Select the clone instead of the original after cloning an entry

### DIFF
--- a/src/gui/CloneDialog.cpp
+++ b/src/gui/CloneDialog.cpp
@@ -18,8 +18,6 @@
 #include "CloneDialog.h"
 #include "ui_CloneDialog.h"
 
-#include "config-keepassx.h"
-
 CloneDialog::CloneDialog(DatabaseWidget* parent, Database* db, Entry* entry)
     : QDialog(parent)
     , m_ui(new Ui::CloneDialog())
@@ -29,8 +27,9 @@ CloneDialog::CloneDialog(DatabaseWidget* parent, Database* db, Entry* entry)
     m_parent = parent;
 
     m_ui->setupUi(this);
-    this->setFixedSize(this->sizeHint());
 
+    window()->layout()->setSizeConstraint(QLayout::SetFixedSize);
+    setWindowFlag(Qt::WindowContextHelpButtonHint, false);
     setAttribute(Qt::WA_DeleteOnClose);
 
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(close()));
@@ -54,10 +53,10 @@ void CloneDialog::cloneEntry()
         flags |= Entry::CloneIncludeHistory;
     }
 
-    Entry* entry = m_entry->clone(flags);
+    auto entry = m_entry->clone(flags);
     entry->setGroup(m_entry->group());
 
-    m_parent->refreshSearch();
+    emit entryCloned(entry);
     close();
 }
 

--- a/src/gui/CloneDialog.h
+++ b/src/gui/CloneDialog.h
@@ -34,6 +34,9 @@ public:
     explicit CloneDialog(DatabaseWidget* parent = nullptr, Database* db = nullptr, Entry* entry = nullptr);
     ~CloneDialog() override;
 
+signals:
+    void entryCloned(Entry* clone);
+
 private:
     QScopedPointer<Ui::CloneDialog> m_ui;
 

--- a/src/gui/CloneDialog.ui
+++ b/src/gui/CloneDialog.ui
@@ -6,54 +6,56 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>347</width>
-    <height>136</height>
+    <width>319</width>
+    <height>132</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Clone Entry Options</string>
   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="titleClone">
-       <property name="text">
-        <string>Append ' - Clone' to title</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="referencesClone">
-       <property name="text">
-        <string>Replace username and password with references</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="historyClone">
-       <property name="text">
-        <string>Copy history</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QCheckBox" name="titleClone">
+     <property name="text">
+      <string>Append ' - Clone' to title</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="referencesClone">
+     <property name="text">
+      <string>Replace username and password with references</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="historyClone">
+     <property name="text">
+      <string>Copy history</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>6</height>
       </size>
      </property>
     </spacer>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -447,6 +447,11 @@ void DatabaseWidget::cloneEntry()
     }
 
     auto cloneDialog = new CloneDialog(this, m_db.data(), currentEntry);
+    connect(cloneDialog, &CloneDialog::entryCloned, this, [this](auto entry) {
+        refreshSearch();
+        m_entryView->setCurrentEntry(entry);
+    });
+
     cloneDialog->show();
 }
 
@@ -1399,7 +1404,10 @@ void DatabaseWidget::performUnlockDatabase(const QString& password, const QStrin
 void DatabaseWidget::refreshSearch()
 {
     if (isSearchActive()) {
+        auto selectedEntry = m_entryView->currentEntry();
         search(m_lastSearchText);
+        // Re-select the previous entry if it is still in the search
+        m_entryView->setCurrentEntry(selectedEntry);
     }
 }
 

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -50,8 +50,10 @@ Entry* EntryModel::entryFromIndex(const QModelIndex& index) const
 QModelIndex EntryModel::indexFromEntry(Entry* entry) const
 {
     int row = m_entries.indexOf(entry);
-    Q_ASSERT(row != -1);
-    return index(row, 1);
+    if (row >= 0) {
+        return index(row, 1);
+    }
+    return {};
 }
 
 void EntryModel::setGroup(Group* group)

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -279,8 +279,11 @@ int EntryView::numberOfSelectedEntries()
 
 void EntryView::setCurrentEntry(Entry* entry)
 {
-    selectionModel()->setCurrentIndex(m_sortModel->mapFromSource(m_model->indexFromEntry(entry)),
-                                      QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    auto index = m_model->indexFromEntry(entry);
+    if (index.isValid()) {
+        selectionModel()->setCurrentIndex(m_sortModel->mapFromSource(index),
+                                          QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    }
 }
 
 Entry* EntryView::entryFromIndex(const QModelIndex& index)

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1230,6 +1230,7 @@ void TestGui::testCloneEntry()
     Entry* entryClone = entryView->entryFromIndex(entryView->model()->index(1, 1));
     QVERIFY(entryOrg->uuid() != entryClone->uuid());
     QCOMPARE(entryClone->title(), entryOrg->title() + QString(" - Clone"));
+    QVERIFY(m_dbWidget->currentSelectedEntry()->uuid() == entryClone->uuid());
 }
 
 void TestGui::testEntryPlaceholders()


### PR DESCRIPTION
After cloning an entry, it is the clone that needs to be edited, but KeePassXC currently keeps the selection at the original.  This PR makes it select the clone so the user can edit the newly created entry right away by hitting the return key.


## Testing strategy
A test assertion is included.  However, testgui fails with segfault in my environment (macOS Ventura) with or without my change, so I haven't confirmed it works.


## Type of change
- ✅ New feature (change that adds functionality)
