### PR TITLE
Fix arrows size when expand/collapse a group

### DIFF
--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -1049,7 +1049,7 @@ namespace Phantom
         // Expected time (release): 5usecs for regular-sized arrows
         Q_NEVER_INLINE void drawArrow(QPainter* p, QRect rect, Qt::ArrowType arrowDirection, const QBrush& brush)
         {
-            const qreal ArrowBaseRatio = 0.70;
+            const qreal ArrowBaseRatio = 0.9;
             qreal irx, iry, irw, irh;
             QRectF(rect).getRect(&irx, &iry, &irw, &irh);
             if (irw < 1.0 || irh < 1.0)


### PR DESCRIPTION
Let's have the same ratio for both vertical and horizontal direction.

Fixes #8335 user interface bug.

## Screenshots
#### Classic style always has the same sizes: 
![classic-arrows](https://user-images.githubusercontent.com/121412908/217981862-3087aec7-e131-4bb6-94b4-256a3b495369.png)

#### Let's have the same sizes for custom app styles:
![fixed-arrows](https://user-images.githubusercontent.com/121412908/217981838-4fb51296-e229-4927-a9c1-1ae4a9a05988.png)
![fixed-arrows-dark](https://user-images.githubusercontent.com/121412908/217981854-d2e238b1-ba92-4ba1-aa8b-8460e2e38365.png)

#### Reducing the ratio leads to have small down arrow and big right one: `const qreal ArrowBaseRatio = 0.4`
![not-fixed-arrow](https://user-images.githubusercontent.com/121412908/217982667-c1fd5019-f2ab-4d8a-a28f-a7f2a9ced4f6.png)


## Testing strategy
- Have an entry group(s)
- Switch to all supported themes
- Verify the group tree arrows

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
