### PR TITLE
Fix/database settings spin box bug

### DIFF
--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
@@ -53,12 +53,12 @@ void DatabaseSettingsWidgetGeneral::initialize()
         m_ui->historyMaxItemsSpinBox->setEnabled(false);
         m_ui->historyMaxItemsCheckBox->setChecked(false);
     }
-    int historyMaxSizeMiB = qRound(meta->historyMaxSize() / qreal(1048576));
+    int historyMaxSizeMiB = qRound(meta->historyMaxSize() / qreal(1024 * 1024));
     if (historyMaxSizeMiB > 0) {
         m_ui->historyMaxSizeSpinBox->setValue(historyMaxSizeMiB);
         m_ui->historyMaxSizeCheckBox->setChecked(true);
     } else {
-        m_ui->historyMaxSizeSpinBox->setValue(qRound(Metadata::DefaultHistoryMaxSize / qreal(1048576)));
+        m_ui->historyMaxSizeSpinBox->setValue(qRound(Metadata::DefaultHistoryMaxSize / qreal(1024 * 1024)));
         m_ui->historyMaxSizeSpinBox->setEnabled(false);
         m_ui->historyMaxSizeCheckBox->setChecked(false);
     }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
@@ -57,7 +57,7 @@ void DatabaseSettingsWidgetGeneral::initialize()
         m_ui->historyMaxSizeSpinBox->setValue(historyMaxSizeMiB);
         m_ui->historyMaxSizeCheckBox->setChecked(true);
     } else {
-        m_ui->historyMaxSizeSpinBox->setValue(Metadata::DefaultHistoryMaxSize);
+        m_ui->historyMaxSizeSpinBox->setValue(qRound(Metadata::DefaultHistoryMaxSize / qreal(1048576)));
         m_ui->historyMaxSizeCheckBox->setChecked(false);
     }
 }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
@@ -50,6 +50,7 @@ void DatabaseSettingsWidgetGeneral::initialize()
         m_ui->historyMaxItemsCheckBox->setChecked(true);
     } else {
         m_ui->historyMaxItemsSpinBox->setValue(Metadata::DefaultHistoryMaxItems);
+        m_ui->historyMaxItemsSpinBox->setEnabled(false);
         m_ui->historyMaxItemsCheckBox->setChecked(false);
     }
     int historyMaxSizeMiB = qRound(meta->historyMaxSize() / qreal(1048576));
@@ -58,6 +59,7 @@ void DatabaseSettingsWidgetGeneral::initialize()
         m_ui->historyMaxSizeCheckBox->setChecked(true);
     } else {
         m_ui->historyMaxSizeSpinBox->setValue(qRound(Metadata::DefaultHistoryMaxSize / qreal(1048576)));
+        m_ui->historyMaxSizeSpinBox->setEnabled(false);
         m_ui->historyMaxSizeCheckBox->setChecked(false);
     }
 }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Found a bug while adding another feature at the Database Settings widget...
The database settings for Max items history and Max history size are SpinBox enabled when loaded from metadata as disabled.
Also for Max history size, the size is ridiculously high, it says MB but the value loaded from default is in Bytes.
This pull request fixes both minor UI issues.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Before the bug when opening a database where the checkbox is unchecked:
- ❎ Default size in MB
- ❎ Enable state of SpinBox
![image](https://user-images.githubusercontent.com/15849761/218258605-6ec52f9f-7521-4113-8aec-0254bd0bff7b.png)
After the fix:
- ✅ Default size in MB
- ✅ Enable state of SpinBox
![image](https://user-images.githubusercontent.com/15849761/218258573-078fa600-ef15-43f9-90fe-e7695708b79e.png)



## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Tested on linux manually against latest release (archlinux).
Also run coverage with 100% pass


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ❎ New feature (change that adds functionality)
- ❎ Breaking change (causes existing functionality to change)
- ❎ Refactor (significant modification to existing code)
- ❎ Documentation (non-code change)
