### PR TITLE
Translate some Autotype messages for Ukrainian

### DIFF
--- a/share/translations/keepassxc_uk.ts
+++ b/share/translations/keepassxc_uk.ts
@@ -730,7 +730,7 @@ Ctrl+4 - Use Virtual Keyboard (Windows Only)&lt;/p&gt;</source>
     </message>
     <message>
         <source>Type Sequence</source>
-        <translation>Тип послідовністі</translation>
+        <translation>Тип послідовності</translation>
     </message>
     <message>
         <source>Cancel</source>

--- a/share/translations/keepassxc_uk.ts
+++ b/share/translations/keepassxc_uk.ts
@@ -612,7 +612,7 @@
     </message>
     <message>
         <source>Bracket imbalance detected, found extra { or }</source>
-        <translation type="unfinished"/>
+        <translation type="Знайдені зайві непарні дужки { або }"/>
     </message>
     <message>
         <source>Too many repetitions detected, max is %1: %2</source>
@@ -709,7 +709,7 @@
     </message>
     <message>
         <source>Double click a row to perform Auto-Type or find an entry using the search:</source>
-        <translation type="unfinished"/>
+        <translation>Клацніть двічі по запису для виконання автозаповнення або знайдіть запис через пошук</translation>
     </message>
     <message>
         <source>&lt;p&gt;You can use advanced search queries to find any entry in your open databases. The following shortcuts are useful:&lt;br/&gt;
@@ -722,15 +722,15 @@ Ctrl+4 - Use Virtual Keyboard (Windows Only)&lt;/p&gt;</source>
     </message>
     <message>
         <source>Search all open databases</source>
-        <translation type="unfinished"/>
+        <translation>Шукати в усіх відкритих сховищах</translation>
     </message>
     <message>
         <source>Search…</source>
-        <translation type="unfinished"/>
+        <translation>Шукати...</translation>
     </message>
     <message>
         <source>Type Sequence</source>
-        <translation type="unfinished"/>
+        <translation>Тип послідовністі</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -738,31 +738,31 @@ Ctrl+4 - Use Virtual Keyboard (Windows Only)&lt;/p&gt;</source>
     </message>
     <message>
         <source>Type {USERNAME}</source>
-        <translation type="unfinished"/>
+        <translation>Тип {USERNAME}</translation>
     </message>
     <message>
         <source>Type {PASSWORD}</source>
-        <translation type="unfinished"/>
+        <translation>Тип {PASSWORD}</translation>
     </message>
     <message>
         <source>Type {TOTP}</source>
-        <translation type="unfinished"/>
+        <translation>Тип {TOTP}</translation>
     </message>
     <message>
         <source>Copy Username</source>
-        <translation type="unfinished"/>
+        <translation>Скопіювати ім’я користувача</translation>
     </message>
     <message>
         <source>Copy Password</source>
-        <translation type="unfinished"/>
+        <translation>Скопіювати пароль</translation>
     </message>
     <message>
         <source>Copy TOTP</source>
-        <translation type="unfinished"/>
+        <translation>Скопіювати ТОП</translation>
     </message>
     <message>
         <source>Use Virtual Keyboard</source>
-        <translation type="unfinished"/>
+        <translation>Використати віртуальну клавіатуру</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Translated some messages on Autotype select dialog for Ukrainian language.
I am a Ukrainian native speaker and will help with translating of the rest 300+ unfinished messages.

The only concern I have is `TOTP` translation. For now I don't have idea why it was translated as `ТОП` but kept the same as already translated ones.

## Screenshots
#### Before
![Incorrect UKR tr in Autotype select](https://user-images.githubusercontent.com/121412908/218356765-6f53fe37-1ef9-478b-b9be-35cd43395705.png)


#### After
![Fixed UKR tr in Autotype select](https://user-images.githubusercontent.com/121412908/218356787-b50cc967-3d11-4a84-851c-861cdabb1514.png)


## Testing strategy
- Configure the app to use Ukraine language
- Open a db
- Trigger the Autotype function to open a select dialog
- Verify all the dialog labels


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
