### PR TITLE
Fix various bugs when returning credentials

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -240,6 +240,7 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
     entryParameters.dbid = id;
     entryParameters.hash = browserRequest.hash;
     entryParameters.siteUrl = siteUrl;
+    entryParameters.formUrl = formUrl;
     entryParameters.httpAuth = httpAuth;
 
     bool accepted = false;

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -247,7 +247,8 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
         return getErrorReply(action, ERROR_KEEPASS_NO_LOGINS_FOUND);
     }
 
-    const Parameters params{{"count", result.second.count()}, {"entries", result.second}, {"hash", browserRequest.hash}, {"id", id}};
+    const Parameters params{
+        {"count", result.second.count()}, {"entries", result.second}, {"hash", browserRequest.hash}, {"id", id}};
     return buildResponse(action, browserRequest.incrementedNonce, params);
 }
 

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -242,12 +242,12 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
     entryParameters.siteUrl = siteUrl;
     entryParameters.formUrl = formUrl;
 
-    const auto users = browserService()->findEntries(entryParameters, keyList, httpAuth);
-    if (users.isEmpty()) {
+    const auto result = browserService()->findEntries(entryParameters, keyList, httpAuth);
+    if (!result.first) {
         return getErrorReply(action, ERROR_KEEPASS_NO_LOGINS_FOUND);
     }
 
-    const Parameters params{{"count", users.count()}, {"entries", users}, {"hash", browserRequest.hash}, {"id", id}};
+    const Parameters params{{"count", result.second.count()}, {"entries", result.second}, {"hash", browserRequest.hash}, {"id", id}};
     return buildResponse(action, browserRequest.incrementedNonce, params);
 }
 

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -240,15 +240,16 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
     entryParameters.dbid = id;
     entryParameters.hash = browserRequest.hash;
     entryParameters.siteUrl = siteUrl;
-    entryParameters.formUrl = formUrl;
+    entryParameters.httpAuth = httpAuth;
 
-    const auto result = browserService()->findEntries(entryParameters, keyList, httpAuth);
-    if (!result.first) {
+    bool accepted = false;
+    const auto entries = browserService()->findEntries(entryParameters, keyList, &accepted);
+    if (!accepted) {
         return getErrorReply(action, ERROR_KEEPASS_NO_LOGINS_FOUND);
     }
 
     const Parameters params{
-        {"count", result.second.count()}, {"entries", result.second}, {"hash", browserRequest.hash}, {"id", id}};
+        {"count", entries.count()}, {"entries", entries}, {"hash", browserRequest.hash}, {"id", id}};
     return buildResponse(action, browserRequest.incrementedNonce, params);
 }
 

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -243,9 +243,9 @@ QJsonObject BrowserAction::handleGetLogins(const QJsonObject& json, const QStrin
     entryParameters.formUrl = formUrl;
     entryParameters.httpAuth = httpAuth;
 
-    bool accepted = false;
-    const auto entries = browserService()->findEntries(entryParameters, keyList, &accepted);
-    if (!accepted) {
+    bool entriesFound = false;
+    const auto entries = browserService()->findEntries(entryParameters, keyList, &entriesFound);
+    if (!entriesFound) {
         return getErrorReply(action, ERROR_KEEPASS_NO_LOGINS_FOUND);
     }
 

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -371,8 +371,7 @@ BrowserService::findEntries(const EntryParameters& entryParameters, const String
     }
 
     // Confirm entries
-    auto selectedEntriesToConfirm =
-        confirmEntries(entriesToConfirm, entryParameters, siteHost, formHost, httpAuth);
+    auto selectedEntriesToConfirm = confirmEntries(entriesToConfirm, entryParameters, siteHost, formHost, httpAuth);
     if (!selectedEntriesToConfirm.isEmpty()) {
         allowedEntries.append(selectedEntriesToConfirm);
     }

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -318,7 +318,7 @@ QJsonArray
 BrowserService::findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* entriesFound)
 {
     if (entriesFound) {
-       *entriesFound = false;
+        *entriesFound = false;
     }
 
     const bool alwaysAllowAccess = browserSettings()->alwaysAllowAccess();

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -317,6 +317,11 @@ QString BrowserService::getCurrentTotp(const QString& uuid)
 QJsonArray
 BrowserService::findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* accepted)
 {
+    if (accepted == nullptr) {
+        return {};
+    }
+
+    *accepted = false;
     const bool alwaysAllowAccess = browserSettings()->alwaysAllowAccess();
     const bool ignoreHttpAuth = browserSettings()->httpAuthPermission();
     const QString siteHost = QUrl(entryParameters.siteUrl).host();

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -419,12 +419,17 @@ QList<Entry*> BrowserService::confirmEntries(QList<Entry*>& pwEntriesToConfirm,
 
     QList<Entry*> allowedEntries;
     auto ret = accessControlDialog.exec();
-    if (ret == QDialog::Accepted) {
-        for (auto item : accessControlDialog.getSelectedEntries()) {
-            auto entry = pwEntriesToConfirm[item->row()];
-            if (accessControlDialog.remember()) {
+    for (auto item : accessControlDialog.getSelectedEntries()) {
+        auto entry = pwEntriesToConfirm[item->row()];
+        if (accessControlDialog.remember()) {
+            if (ret == QDialog::Accepted) {
                 allowEntry(entry, siteHost, formUrl, entryParameters.realm);
+            } else {
+                denyEntry(entry, siteHost, formUrl, entryParameters.realm);
             }
+        }
+
+        if (ret == QDialog::Accepted) {
             allowedEntries.append(entry);
         }
     }

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -315,13 +315,12 @@ QString BrowserService::getCurrentTotp(const QString& uuid)
 }
 
 QJsonArray
-BrowserService::findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* accepted)
+BrowserService::findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* entriesFound)
 {
-    if (accepted == nullptr) {
-        return {};
+    if (entriesFound) {
+       *entriesFound = false;
     }
 
-    *accepted = false;
     const bool alwaysAllowAccess = browserSettings()->alwaysAllowAccess();
     const bool ignoreHttpAuth = browserSettings()->httpAuthPermission();
     const QString siteHost = QUrl(entryParameters.siteUrl).host();
@@ -396,7 +395,10 @@ BrowserService::findEntries(const EntryParameters& entryParameters, const String
         entries.append(prepareEntry(entry));
     }
 
-    *accepted = true;
+    if (entriesFound != nullptr) {
+        *entriesFound = true;
+    }
+
     return entries;
 }
 

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -130,8 +130,8 @@ private:
 
     QList<Entry*> searchEntries(const QSharedPointer<Database>& db, const QString& siteUrl, const QString& formUrl);
     QList<Entry*> searchEntries(const QString& siteUrl, const QString& formUrl, const StringPairList& keyList);
-    QList<Entry*> sortEntries(QList<Entry*>& pwEntries, const QString& siteUrl, const QString& formUrl);
-    QList<Entry*> confirmEntries(QList<Entry*>& pwEntriesToConfirm,
+    QList<Entry*> sortEntries(QList<Entry*>& entries, const QString& siteUrl, const QString& formUrl);
+    QList<Entry*> confirmEntries(QList<Entry*>& entriesToConfirm,
                                  const EntryParameters& entryParameters,
                                  const QString& siteHost,
                                  const QString& formUrl,

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -89,7 +89,7 @@ public:
                   const QSharedPointer<Database>& selectedDb = {});
     bool updateEntry(const EntryParameters& entryParameters, const QString& uuid);
     bool deleteEntry(const QString& uuid);
-    QJsonArray findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* accepted);
+    QJsonArray findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* entriesFound);
     void requestGlobalAutoType(const QString& search);
 
     static const QString KEEPASSXCBROWSER_NAME;

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -88,7 +88,7 @@ public:
                   const QSharedPointer<Database>& selectedDb = {});
     bool updateEntry(const EntryParameters& entryParameters, const QString& uuid);
     bool deleteEntry(const QString& uuid);
-    QJsonArray
+    QPair<bool, QJsonArray>
     findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, const bool httpAuth = false);
     void requestGlobalAutoType(const QString& search);
 

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
  *  Copyright (C) 2013 Francois Ferrand
  *
@@ -51,6 +51,7 @@ struct EntryParameters
     QString hash;
     QString siteUrl;
     QString formUrl;
+    bool httpAuth;
 };
 
 class DatabaseWidget;
@@ -88,8 +89,7 @@ public:
                   const QSharedPointer<Database>& selectedDb = {});
     bool updateEntry(const EntryParameters& entryParameters, const QString& uuid);
     bool deleteEntry(const QString& uuid);
-    QPair<bool, QJsonArray>
-    findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, const bool httpAuth = false);
+    QJsonArray findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* accepted);
     void requestGlobalAutoType(const QString& search);
 
     static const QString KEEPASSXCBROWSER_NAME;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes two minor bugs with the Browser Integration:
- "No logins found" should be only returned when none are actually found. If Access Confirm Dialog is shown and all entries are denied, no error is returned, but zero users instead.
- If "Remember" checkbox is used with Deny, that setting is now working properly.

Fixes #5765.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)