### PR TITLE
Use QClipboard::clear() instead of setting blank text

### DIFF
--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -99,7 +99,8 @@ void Clipboard::clearCopiedText()
 
     if (m_lastCopied == clipboard->text(QClipboard::Clipboard)
         || m_lastCopied == clipboard->text(QClipboard::Selection)) {
-        setText("", false);
+        clipboard->clear(QClipboard::Clipboard);
+        clipboard->clear(QClipboard::Selection);
     }
 
     m_lastCopied.clear();


### PR DESCRIPTION
* Fixes #9121 and #4498 and #4105

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows, CI tests all platforms

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
