### PR TITLE
Turn search reset off by default

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -127,7 +127,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     // Security
     {Config::Security_ClearClipboard, {QS("Security/ClearClipboard"), Roaming, true}},
     {Config::Security_ClearClipboardTimeout, {QS("Security/ClearClipboardTimeout"), Roaming, 10}},
-    {Config::Security_ClearSearch, {QS("Security/ClearSearch"), Roaming, true}},
+    {Config::Security_ClearSearch, {QS("Security/ClearSearch"), Roaming, false}},
     {Config::Security_ClearSearchTimeout, {QS("Security/ClearSearchTimeout"), Roaming, 5}},
     {Config::Security_HideNotes, {QS("Security/Security_HideNotes"), Roaming, false}},
     {Config::Security_LockDatabaseIdle, {QS("Security/LockDatabaseIdle"), Roaming, false}},


### PR DESCRIPTION
This is more user friendly, especially to newcomers.

Fixes: https://github.com/keepassxreboot/keepassxc/issues/9145

## Type of change

- ✅ Breaking change (causes existing functionality to change)
