### PR TITLE
Fix TestGui::testDatabaseSettings open tab missing

### DIFF
--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1462,12 +1462,16 @@ void TestGui::testDatabaseSettings()
     m_db->metadata()->setName("testDatabaseSettings");
     triggerAction("actionDatabaseSettings");
     auto* dbSettingsDialog = m_dbWidget->findChild<QWidget*>("databaseSettingsDialog");
+    auto* dbSettingsCategoryList = dbSettingsDialog->findChild<CategoryListWidget*>("categoryList");
+    auto* dbSettingsStackedWidget = dbSettingsDialog->findChild<QStackedWidget*>("stackedWidget");
     auto* transformRoundsSpinBox = dbSettingsDialog->findChild<QSpinBox*>("transformRoundsSpinBox");
     auto advancedToggle = dbSettingsDialog->findChild<QCheckBox*>("advancedSettingsToggle");
 
     advancedToggle->setChecked(true);
     QApplication::processEvents();
 
+    dbSettingsCategoryList->setCurrentCategory(1); // go into security category
+    dbSettingsStackedWidget->findChild<QTabWidget*>()->setCurrentIndex(1); // go into encryption tab
     QVERIFY(transformRoundsSpinBox != nullptr);
     transformRoundsSpinBox->setValue(123456);
     QTest::keyClick(transformRoundsSpinBox, Qt::Key_Enter);


### PR DESCRIPTION
The test at TestGui::testDatabaseSettings for changing transform rounds at encryption settings tab inside the security category is done in memory as the opening the tab was missing.
This commit add instuctions for going into the encryption widget before making the changes.
This issue is mentioned [here](https://github.com/keepassxreboot/keepassxc/pull/9100#discussion_r1112630674) and was found as part of pull request #9100 .

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
You can duplicate the issue by running TestGui::testDatabaseSettings() line by line in debug and you will notice everything is done in memory as the gui does not go into the right area.
To test this fix you could just do the same with this branch, i also tested format and coverage after making this fix.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ❎ New feature (change that adds functionality)
- ❎ Breaking change (causes existing functionality to change)
- ❎ Refactor (significant modification to existing code)
- ❎ Documentation (non-code change)
