### PR TITLE
Fix bugs with preview widget

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -596,6 +596,10 @@
         <source>Use DuckDuckGo service to download website icons</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hide TOTP in the entry preview panel</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoType</name>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -139,6 +139,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_PasswordsHidden, {QS("Security/PasswordsHidden"), Roaming, true}},
     {Config::Security_PasswordEmptyPlaceholder, {QS("Security/PasswordEmptyPlaceholder"), Roaming, false}},
     {Config::Security_HidePasswordPreviewPanel, {QS("Security/HidePasswordPreviewPanel"), Roaming, true}},
+    {Config::Security_HideTotpPreviewPanel, {QS("Security/HideTotpPreviewPanel"), Roaming, false}},
     {Config::Security_AutoTypeAsk, {QS("Security/AutotypeAsk"), Roaming, true}},
     {Config::Security_IconDownloadFallback, {QS("Security/IconDownloadFallback"), Roaming, false}},
     {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -119,6 +119,7 @@ public:
         Security_PasswordsHidden,
         Security_PasswordEmptyPlaceholder,
         Security_HidePasswordPreviewPanel,
+        Security_HideTotpPreviewPanel,
         Security_AutoTypeAsk,
         Security_IconDownloadFallback,
         Security_NoConfirmMoveEntryToRecycleBin,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -314,6 +314,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->passwordShowDotsCheckBox->setChecked(config()->get(Config::Security_PasswordEmptyPlaceholder).toBool());
     m_secUi->passwordPreviewCleartextCheckBox->setChecked(
         config()->get(Config::Security_HidePasswordPreviewPanel).toBool());
+    m_secUi->hideTotpCheckBox->setChecked(config()->get(Config::Security_HideTotpPreviewPanel).toBool());
     m_secUi->passwordsRepeatVisibleCheckBox->setChecked(
         config()->get(Config::Security_PasswordsRepeatVisible).toBool());
     m_secUi->hideNotesCheckBox->setChecked(config()->get(Config::Security_HideNotes).toBool());
@@ -427,6 +428,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::Security_PasswordEmptyPlaceholder, m_secUi->passwordShowDotsCheckBox->isChecked());
 
     config()->set(Config::Security_HidePasswordPreviewPanel, m_secUi->passwordPreviewCleartextCheckBox->isChecked());
+    config()->set(Config::Security_HideTotpPreviewPanel, m_secUi->hideTotpCheckBox->isChecked());
     config()->set(Config::Security_PasswordsRepeatVisible, m_secUi->passwordsRepeatVisibleCheckBox->isChecked());
     config()->set(Config::Security_HideNotes, m_secUi->hideNotesCheckBox->isChecked());
     config()->set(Config::Security_NoConfirmMoveEntryToRecycleBin,

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -212,6 +212,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="hideTotpCheckBox">
+        <property name="text">
+         <string>Hide TOTP in the entry preview panel</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="hideNotesCheckBox">
         <property name="text">
          <string>Hide entry notes by default</string>

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -119,38 +119,50 @@ void EntryPreviewWidget::clear()
 
 void EntryPreviewWidget::setEntry(Entry* selectedEntry)
 {
+    if (m_currentEntry == selectedEntry) {
+        return;
+    }
+
     if (m_currentEntry) {
-        disconnect(m_currentEntry);
+        disconnect(m_currentEntry, nullptr, this, nullptr);
     }
     if (m_currentGroup) {
-        disconnect(m_currentGroup);
+        disconnect(m_currentGroup, nullptr, this, nullptr);
     }
 
     m_currentEntry = selectedEntry;
     m_currentGroup = nullptr;
 
-    if (!selectedEntry) {
+    if (!m_currentEntry) {
         hide();
         return;
     }
 
-    connect(selectedEntry, &Entry::modified, this, &EntryPreviewWidget::refresh);
+    connect(m_currentEntry, &Entry::modified, this, &EntryPreviewWidget::refresh);
     refresh();
+
+    if (m_currentEntry->hasTotp()) {
+        m_ui->entryTotpButton->setChecked(!config()->get(Config::Security_HideTotpPreviewPanel).toBool());
+    }
 }
 
 void EntryPreviewWidget::setGroup(Group* selectedGroup)
 {
+    if (m_currentGroup == selectedGroup) {
+        return;
+    }
+
     if (m_currentEntry) {
-        disconnect(m_currentEntry);
+        disconnect(m_currentEntry, nullptr, this, nullptr);
     }
     if (m_currentGroup) {
-        disconnect(m_currentGroup);
+        disconnect(m_currentGroup, nullptr, this, nullptr);
     }
 
     m_currentEntry = nullptr;
     m_currentGroup = selectedGroup;
 
-    if (!selectedGroup) {
+    if (!m_currentGroup) {
         hide();
         return;
     }
@@ -226,15 +238,15 @@ void EntryPreviewWidget::updateEntryTotp()
     Q_ASSERT(m_currentEntry);
     const bool hasTotp = m_currentEntry->hasTotp();
     m_ui->entryTotpButton->setVisible(hasTotp);
-    m_ui->entryTotpLabel->hide();
-    m_ui->entryTotpProgress->hide();
-    m_ui->entryTotpButton->setChecked(false);
 
     if (hasTotp) {
         m_totpTimer.start(1000);
         m_ui->entryTotpProgress->setMaximum(m_currentEntry->totpSettings()->step);
         updateTotpLabel();
     } else {
+        m_ui->entryTotpLabel->hide();
+        m_ui->entryTotpProgress->hide();
+        m_ui->entryTotpButton->setChecked(false);
         m_ui->entryTotpLabel->clear();
         m_totpTimer.stop();
     }


### PR DESCRIPTION
* Add configuration to hide TOTP in preview widget (shown by default).

* Retain the visibility of TOTP and other fields when the same entry remains selected in the preview panel.

* Fix disconnecting signals when switch entries / groups. This likely is going to fix crashes because we were compounding signals when focusing in on the main window.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
