### PR TITLE
Split GuiTests: extract TOTP gui tests

### DIFF
--- a/src/gui/TotpExportSettingsDialog.cpp
+++ b/src/gui/TotpExportSettingsDialog.cpp
@@ -64,6 +64,7 @@ TotpExportSettingsDialog::TotpExportSettingsDialog(DatabaseWidget* parent, Entry
     m_buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Copy"));
     m_buttonBox->setFocus();
     m_countDown->setAlignment(Qt::AlignCenter);
+    m_buttonBox->setObjectName("buttonBox");
 
     m_secTillClose = 45;
     autoClose();

--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -1936,7 +1936,7 @@ void BaseStyle::drawPrimitive(PrimitiveElement elem,
         auto fropt = qstyleoption_cast<const QStyleOptionFocusRect*>(option);
         if (!fropt)
             break;
-        //### check for d->alt_down
+        // ### check for d->alt_down
         if (!(fropt->state & State_KeyboardFocusChange))
             return;
         if (fropt->state & State_Item) {

--- a/tests/gui/CMakeLists.txt
+++ b/tests/gui/CMakeLists.txt
@@ -15,9 +15,9 @@
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-add_unit_test(NAME testgui SOURCES TestGui.cpp ../util/TemporaryFile.cpp LIBS ${TEST_LIBRARIES})
+add_unit_test(NAME testgui SOURCES TestGui.cpp  GuiTestBase.cpp ../util/TemporaryFile.cpp LIBS ${TEST_LIBRARIES})
 add_unit_test(NAME testguipixmaps SOURCES TestGuiPixmaps.cpp LIBS ${TEST_LIBRARIES})
-add_unit_test(NAME testguitotp SOURCES TestGuiTotp.cpp ../util/TemporaryFile.cpp LIBS ${TEST_LIBRARIES})
+add_unit_test(NAME testguitotp SOURCES TestGuiTotp.cpp GuiTestBase.cpp ../util/TemporaryFile.cpp LIBS ${TEST_LIBRARIES})
 
 if(WITH_XC_BROWSER)
     add_unit_test(NAME testguibrowser SOURCES TestGuiBrowser.cpp ../util/TemporaryFile.cpp LIBS ${TEST_LIBRARIES})

--- a/tests/gui/CMakeLists.txt
+++ b/tests/gui/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 add_unit_test(NAME testgui SOURCES TestGui.cpp ../util/TemporaryFile.cpp LIBS ${TEST_LIBRARIES})
 add_unit_test(NAME testguipixmaps SOURCES TestGuiPixmaps.cpp LIBS ${TEST_LIBRARIES})
+add_unit_test(NAME testguitotp SOURCES TestGuiTotp.cpp ../util/TemporaryFile.cpp LIBS ${TEST_LIBRARIES})
 
 if(WITH_XC_BROWSER)
     add_unit_test(NAME testguibrowser SOURCES TestGuiBrowser.cpp ../util/TemporaryFile.cpp LIBS ${TEST_LIBRARIES})

--- a/tests/gui/GuiTestBase.cpp
+++ b/tests/gui/GuiTestBase.cpp
@@ -94,6 +94,9 @@ void GuiTestBase::init()
     m_db = m_dbWidget->database();
 
     QApplication::processEvents();
+
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
+    QCOMPARE(findEntryView()->model()->rowCount(), 1);
 }
 
 // Every test ends with closing the temp database without saving

--- a/tests/gui/GuiTestBase.cpp
+++ b/tests/gui/GuiTestBase.cpp
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "GuiTestBase.h"
+#include "gui/Application.h"
+
+#include <QTest>
+
+#include "config-keepassx-tests.h"
+#include "crypto/Crypto.h"
+#include "gui/DatabaseTabWidget.h"
+#include "gui/FileDialog.h"
+#include "gui/MessageBox.h"
+#include "gui/PasswordWidget.h"
+
+void GuiTestBase::initTestCase()
+{
+    QVERIFY(Crypto::init());
+    Config::createTempFileInstance();
+    Application::bootstrap();
+
+    m_mainWindow.reset(new MainWindow());
+    m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
+    m_statusBarLabel = m_mainWindow->findChild<QLabel*>("statusBarLabel");
+    m_mainWindow->show();
+    m_mainWindow->resize(1024, 768);
+}
+
+// Every test starts with resetting config settings and opening the temp database
+void GuiTestBase::init()
+{
+    // Reset config to defaults
+    config()->resetToDefaults();
+    // Disable autosave so we can test the modified file indicator
+    config()->set(Config::AutoSaveAfterEveryChange, false);
+    config()->set(Config::AutoSaveOnExit, false);
+    // Enable the tray icon so we can test hiding/restoring the windowQByteArray
+    config()->set(Config::GUI_ShowTrayIcon, true);
+    // Disable the update check first time alert
+    config()->set(Config::UpdateCheckMessageShown, true);
+    // Disable quick unlock
+    config()->set(Config::Security_QuickUnlock, false);
+    // Disable atomic saves to prevent transient errors on some platforms
+    config()->set(Config::UseAtomicSaves, false);
+    // Disable showing expired entries on unlock
+    config()->set(Config::GUI_ShowExpiredEntriesOnDatabaseUnlock, false);
+
+    // Copy the test database file to the temporary file
+    auto origFilePath = QDir(KEEPASSX_TEST_DATA_DIR).absoluteFilePath("NewDatabase.kdbx");
+    QVERIFY(m_dbFile.copyFromFile(origFilePath));
+
+    m_dbFileName = QFileInfo(m_dbFile.fileName()).fileName();
+    m_dbFilePath = m_dbFile.fileName();
+
+    // make sure window is activated or focus tests may fail
+    m_mainWindow->activateWindow();
+    QApplication::processEvents();
+
+    fileDialog()->setNextFileName(m_dbFilePath);
+    triggerAction("actionDatabaseOpen");
+
+    QApplication::processEvents();
+
+    m_dbWidget = m_tabWidget->currentDatabaseWidget();
+    auto* databaseOpenWidget = m_tabWidget->currentDatabaseWidget()->findChild<QWidget*>("databaseOpenWidget");
+    QVERIFY(databaseOpenWidget);
+    // editPassword is not QLineEdit anymore but PasswordWidget
+    auto* editPassword =
+        databaseOpenWidget->findChild<PasswordWidget*>("editPassword")->findChild<QLineEdit*>("passwordEdit");
+    QVERIFY(editPassword);
+    editPassword->setFocus();
+
+    QTest::keyClicks(editPassword, "a");
+    QTest::keyClick(editPassword, Qt::Key_Enter);
+
+    QTRY_VERIFY(!m_dbWidget->isLocked());
+    m_db = m_dbWidget->database();
+
+    QApplication::processEvents();
+}
+
+// Every test ends with closing the temp database without saving
+void GuiTestBase::cleanup()
+{
+    // DO NOT save the database
+    m_db->markAsClean();
+    MessageBox::setNextAnswer(MessageBox::No);
+    triggerAction("actionDatabaseClose");
+    QApplication::processEvents();
+    MessageBox::setNextAnswer(MessageBox::NoButton);
+
+    delete m_dbWidget;
+}
+
+void GuiTestBase::cleanupTestCase()
+{
+    m_dbFile.remove();
+}
+
+void GuiTestBase::triggerAction(const QString& name)
+{
+    auto* action = m_mainWindow->findChild<QAction*>(name);
+    QVERIFY(action);
+    QVERIFY(action->isEnabled());
+    action->trigger();
+    QApplication::processEvents();
+}
+
+void GuiTestBase::clickIndex(const QModelIndex& index,
+                             QAbstractItemView* view,
+                             Qt::MouseButton button,
+                             Qt::KeyboardModifiers stateKey)
+{
+    view->scrollTo(index);
+    QTest::mouseClick(view->viewport(), button, stateKey, view->visualRect(index).center());
+}

--- a/tests/gui/GuiTestBase.cpp
+++ b/tests/gui/GuiTestBase.cpp
@@ -19,6 +19,7 @@
 #include "GuiTestBase.h"
 #include "gui/Application.h"
 
+#include <QPushButton>
 #include <QTest>
 
 #include "config-keepassx-tests.h"
@@ -124,6 +125,13 @@ void GuiTestBase::triggerAction(const QString& name)
     QVERIFY(action->isEnabled());
     action->trigger();
     QApplication::processEvents();
+}
+
+void GuiTestBase::clickDialogButton(QWidget* dialog, QDialogButtonBox::StandardButton button)
+{
+    auto* buttonBox = dialog->findChild<QDialogButtonBox*>("buttonBox");
+    QVERIFY(buttonBox);
+    QTest::mouseClick(buttonBox->button(button), Qt::LeftButton);
 }
 
 void GuiTestBase::clickIndex(const QModelIndex& index,

--- a/tests/gui/GuiTestBase.cpp
+++ b/tests/gui/GuiTestBase.cpp
@@ -22,11 +22,13 @@
 #include <QTest>
 
 #include "config-keepassx-tests.h"
+#include "core/Entry.h"
 #include "crypto/Crypto.h"
 #include "gui/DatabaseTabWidget.h"
 #include "gui/FileDialog.h"
 #include "gui/MessageBox.h"
 #include "gui/PasswordWidget.h"
+#include "gui/entry/EntryView.h"
 
 void GuiTestBase::initTestCase()
 {
@@ -128,4 +130,20 @@ void GuiTestBase::clickIndex(const QModelIndex& index,
 {
     view->scrollTo(index);
     QTest::mouseClick(view->viewport(), button, stateKey, view->visualRect(index).center());
+}
+
+EntryView* GuiTestBase::findEntryView()
+{
+    return m_dbWidget->findChild<EntryView*>("entryView");
+}
+
+Entry* GuiTestBase::selectEntryViewRow(const int row)
+{
+    auto* entryView = findEntryView();
+
+    QModelIndex entryIndex = entryView->model()->index(row, 1);
+    auto* entry = entryView->entryFromIndex(entryIndex);
+    clickIndex(entryIndex, entryView, Qt::LeftButton);
+
+    return entry;
 }

--- a/tests/gui/GuiTestBase.h
+++ b/tests/gui/GuiTestBase.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_GUI_TEST_BASE_H
+#define KEEPASSXC_GUI_TEST_BASE_H
+
+#include "gui/MainWindow.h"
+#include "util/TemporaryFile.h"
+
+class Database;
+class DatabaseTabWidget;
+class DatabaseWidget;
+class QAbstractItemView;
+
+class GuiTestBase : public QObject
+{
+    Q_OBJECT
+
+protected slots:
+    virtual void initTestCase();
+    virtual void init();
+    virtual void cleanup();
+    virtual void cleanupTestCase();
+
+protected:
+    void triggerAction(const QString& name);
+
+    static void clickIndex(const QModelIndex& index,
+                           QAbstractItemView* view,
+                           Qt::MouseButton button,
+                           Qt::KeyboardModifiers stateKey = 0);
+
+    QScopedPointer<MainWindow> m_mainWindow;
+    QPointer<QLabel> m_statusBarLabel;
+    QPointer<DatabaseTabWidget> m_tabWidget;
+    QPointer<DatabaseWidget> m_dbWidget;
+    QSharedPointer<Database> m_db;
+    TemporaryFile m_dbFile;
+    QString m_dbFileName;
+    QString m_dbFilePath;
+};
+
+#endif // KEEPASSXC_GUI_TEST_BASE_H

--- a/tests/gui/GuiTestBase.h
+++ b/tests/gui/GuiTestBase.h
@@ -19,6 +19,7 @@
 #ifndef KEEPASSXC_GUI_TEST_BASE_H
 #define KEEPASSXC_GUI_TEST_BASE_H
 
+#include "core/Tools.h"
 #include "gui/MainWindow.h"
 #include "util/TemporaryFile.h"
 
@@ -44,6 +45,11 @@ protected:
                            QAbstractItemView* view,
                            Qt::MouseButton button,
                            Qt::KeyboardModifiers stateKey = 0);
+
+    static void wait(int ms = 2000)
+    {
+        Tools::wait(ms);
+    }
 
     QScopedPointer<MainWindow> m_mainWindow;
     QPointer<QLabel> m_statusBarLabel;

--- a/tests/gui/GuiTestBase.h
+++ b/tests/gui/GuiTestBase.h
@@ -47,6 +47,7 @@ protected:
 
     void triggerAction(const QString& name);
 
+    static void clickDialogButton(QWidget* dialog, QDialogButtonBox::StandardButton button);
     static void clickIndex(const QModelIndex& index,
                            QAbstractItemView* view,
                            Qt::MouseButton button,

--- a/tests/gui/GuiTestBase.h
+++ b/tests/gui/GuiTestBase.h
@@ -21,12 +21,15 @@
 
 #include "core/Tools.h"
 #include "gui/MainWindow.h"
+#include "gui/entry/EntryView.h"
 #include "util/TemporaryFile.h"
 
 class Database;
 class DatabaseTabWidget;
 class DatabaseWidget;
 class QAbstractItemView;
+class Entry;
+class EntryView;
 
 class GuiTestBase : public QObject
 {
@@ -39,6 +42,9 @@ protected slots:
     virtual void cleanupTestCase();
 
 protected:
+    Entry* selectEntryViewRow(int row);
+    EntryView* findEntryView();
+
     void triggerAction(const QString& name);
 
     static void clickIndex(const QModelIndex& index,

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -32,7 +32,6 @@
 
 #include "config-keepassx-tests.h"
 #include "core/Tools.h"
-#include "crypto/Crypto.h"
 #include "gui/ApplicationSettingsWidget.h"
 #include "gui/CategoryListWidget.h"
 #include "gui/CloneDialog.h"
@@ -79,92 +78,6 @@ int main(int argc, char* argv[])
     TestGui tc;
     QTEST_SET_MAIN_SOURCE_PATH
     return QTest::qExec(&tc, argc, argv);
-}
-
-void TestGui::initTestCase()
-{
-    QVERIFY(Crypto::init());
-    Config::createTempFileInstance();
-    Application::bootstrap();
-
-    m_mainWindow.reset(new MainWindow());
-    m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
-    m_statusBarLabel = m_mainWindow->findChild<QLabel*>("statusBarLabel");
-    m_mainWindow->show();
-    m_mainWindow->resize(1024, 768);
-}
-
-// Every test starts with resetting config settings and opening the temp database
-void TestGui::init()
-{
-    // Reset config to defaults
-    config()->resetToDefaults();
-    // Disable autosave so we can test the modified file indicator
-    config()->set(Config::AutoSaveAfterEveryChange, false);
-    config()->set(Config::AutoSaveOnExit, false);
-    // Enable the tray icon so we can test hiding/restoring the windowQByteArray
-    config()->set(Config::GUI_ShowTrayIcon, true);
-    // Disable the update check first time alert
-    config()->set(Config::UpdateCheckMessageShown, true);
-    // Disable quick unlock
-    config()->set(Config::Security_QuickUnlock, false);
-    // Disable atomic saves to prevent transient errors on some platforms
-    config()->set(Config::UseAtomicSaves, false);
-    // Disable showing expired entries on unlock
-    config()->set(Config::GUI_ShowExpiredEntriesOnDatabaseUnlock, false);
-
-    // Copy the test database file to the temporary file
-    auto origFilePath = QDir(KEEPASSX_TEST_DATA_DIR).absoluteFilePath("NewDatabase.kdbx");
-    QVERIFY(m_dbFile.copyFromFile(origFilePath));
-
-    m_dbFileName = QFileInfo(m_dbFile.fileName()).fileName();
-    m_dbFilePath = m_dbFile.fileName();
-
-    // make sure window is activated or focus tests may fail
-    m_mainWindow->activateWindow();
-    QApplication::processEvents();
-
-    fileDialog()->setNextFileName(m_dbFilePath);
-    triggerAction("actionDatabaseOpen");
-
-    QApplication::processEvents();
-
-    m_dbWidget = m_tabWidget->currentDatabaseWidget();
-    auto* databaseOpenWidget = m_tabWidget->currentDatabaseWidget()->findChild<QWidget*>("databaseOpenWidget");
-    QVERIFY(databaseOpenWidget);
-    // editPassword is not QLineEdit anymore but PasswordWidget
-    auto* editPassword =
-        databaseOpenWidget->findChild<PasswordWidget*>("editPassword")->findChild<QLineEdit*>("passwordEdit");
-    QVERIFY(editPassword);
-    editPassword->setFocus();
-
-    QTest::keyClicks(editPassword, "a");
-    QTest::keyClick(editPassword, Qt::Key_Enter);
-
-    QTRY_VERIFY(!m_dbWidget->isLocked());
-    m_db = m_dbWidget->database();
-
-    QApplication::processEvents();
-}
-
-// Every test ends with closing the temp database without saving
-void TestGui::cleanup()
-{
-    // DO NOT save the database
-    m_db->markAsClean();
-    MessageBox::setNextAnswer(MessageBox::No);
-    triggerAction("actionDatabaseClose");
-    QApplication::processEvents();
-    MessageBox::setNextAnswer(MessageBox::NoButton);
-
-    if (m_dbWidget) {
-        delete m_dbWidget;
-    }
-}
-
-void TestGui::cleanupTestCase()
-{
-    m_dbFile.remove();
 }
 
 void TestGui::testSettingsDefaultTabOrder()
@@ -1846,15 +1759,6 @@ void TestGui::checkStatusBarText(const QString& textFragment)
                  qPrintable(QString("'%1' doesn't start with '%2'").arg(m_statusBarLabel->text(), textFragment)));
 }
 
-void TestGui::triggerAction(const QString& name)
-{
-    auto* action = m_mainWindow->findChild<QAction*>(name);
-    QVERIFY(action);
-    QVERIFY(action->isEnabled());
-    action->trigger();
-    QApplication::processEvents();
-}
-
 void TestGui::dragAndDropGroup(const QModelIndex& sourceIndex,
                                const QModelIndex& targetIndex,
                                int row,
@@ -1877,13 +1781,4 @@ void TestGui::dragAndDropGroup(const QModelIndex& sourceIndex,
     QCOMPARE(groupModel->dropMimeData(&mimeData, Qt::MoveAction, row, 0, targetIndex), expectedResult);
     QCOMPARE(group->parentGroup()->name(), expectedParentName);
     QCOMPARE(group->parentGroup()->children().indexOf(group), expectedPos);
-}
-
-void TestGui::clickIndex(const QModelIndex& index,
-                         QAbstractItemView* view,
-                         Qt::MouseButton button,
-                         Qt::KeyboardModifiers stateKey)
-{
-    view->scrollTo(index);
-    QTest::mouseClick(view->viewport(), button, stateKey, view->visualRect(index).center());
 }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -31,7 +31,6 @@
 #include <QToolBar>
 
 #include "config-keepassx-tests.h"
-#include "core/Tools.h"
 #include "gui/ApplicationSettingsWidget.h"
 #include "gui/CategoryListWidget.h"
 #include "gui/CloneDialog.h"
@@ -1541,7 +1540,7 @@ void TestGui::testAutoType()
     for (Entry* entry : m_db->rootGroup()->entries()) {
         m_db->rootGroup()->removeEntry(entry);
     }
-    Tools::wait(150);
+    wait(150);
 
     // 1. Create an entry with Auto-Type disabled
 
@@ -1745,7 +1744,7 @@ void TestGui::checkSaveDatabase()
             return;
         }
         QWARN("Failed to save database, trying again...");
-        Tools::wait(250);
+        wait(250);
     } while (++i < 2);
 
     QFAIL("Could not save database.");

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -43,8 +43,6 @@
 #include "gui/PasswordGeneratorWidget.h"
 #include "gui/PasswordWidget.h"
 #include "gui/SearchWidget.h"
-#include "gui/TotpDialog.h"
-#include "gui/TotpSetupDialog.h"
 #include "gui/databasekey/KeyFileEditWidget.h"
 #include "gui/databasekey/PasswordEditWidget.h"
 #include "gui/dbsettings/DatabaseSettingsDialog.h"
@@ -865,77 +863,6 @@ void TestGui::testDicewareEntryEntropy()
 
         QTest::mouseClick(generatedPassword, Qt::LeftButton);
         QTest::keyClick(generatedPassword, Qt::Key_Escape););
-}
-
-void TestGui::testTotp()
-{
-    auto* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
-    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
-
-    QCOMPARE(entryView->model()->rowCount(), 1);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
-    QModelIndex item = entryView->model()->index(0, 1);
-    Entry* entry = entryView->entryFromIndex(item);
-    clickIndex(item, entryView, Qt::LeftButton);
-
-    triggerAction("actionEntrySetupTotp");
-
-    auto* setupTotpDialog = m_dbWidget->findChild<TotpSetupDialog*>("TotpSetupDialog");
-
-    QApplication::processEvents();
-
-    QString exampleSeed = "gezd gnbvgY 3tqojqGEZdgnb vgy3tqoJq===";
-    QString expectedFinalSeed = exampleSeed.toUpper().remove(" ").remove("=");
-    auto* seedEdit = setupTotpDialog->findChild<QLineEdit*>("seedEdit");
-    seedEdit->setText("");
-    QTest::keyClicks(seedEdit, exampleSeed);
-
-    auto* setupTotpButtonBox = setupTotpDialog->findChild<QDialogButtonBox*>("buttonBox");
-    QTest::mouseClick(setupTotpButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
-    QTRY_VERIFY(!setupTotpDialog->isVisible());
-
-    // Make sure the entryView is selected and active
-    entryView->activateWindow();
-    QApplication::processEvents();
-    QTRY_VERIFY(entryView->hasFocus());
-
-    auto* entryEditAction = m_mainWindow->findChild<QAction*>("actionEntryEdit");
-    QWidget* entryEditWidget = toolBar->widgetForAction(entryEditAction);
-    QVERIFY(entryEditWidget->isVisible());
-    QVERIFY(entryEditWidget->isEnabled());
-    QTest::mouseClick(entryEditWidget, Qt::LeftButton);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
-
-    auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
-    editEntryWidget->setCurrentPage(1);
-    auto* attrTextEdit = editEntryWidget->findChild<QPlainTextEdit*>("attributesEdit");
-    QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("revealAttributeButton"), Qt::LeftButton);
-    QCOMPARE(attrTextEdit->toPlainText(), expectedFinalSeed);
-
-    auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
-    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
-
-    // Test the TOTP value
-    triggerAction("actionEntryTotp");
-
-    auto* totpDialog = m_dbWidget->findChild<TotpDialog*>("TotpDialog");
-    auto* totpLabel = totpDialog->findChild<QLabel*>("totpLabel");
-
-    QCOMPARE(totpLabel->text().replace(" ", ""), entry->totp());
-    QTest::keyClick(totpDialog, Qt::Key_Escape);
-
-    // Test the QR code
-    triggerAction("actionEntryTotpQRCode");
-    auto* qrCodeDialog = m_mainWindow->findChild<QDialog*>("entryQrCodeWidget");
-    QVERIFY(qrCodeDialog);
-    QVERIFY(qrCodeDialog->isVisible());
-    auto* qrCodeWidget = qrCodeDialog->findChild<QWidget*>("squareSvgWidget");
-    QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Initial QR code is not square");
-
-    // Test the QR code window resizing, make the dialog bigger.
-    qrCodeDialog->setFixedSize(800, 600);
-    QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Resized QR code is not square");
-    QTest::keyClick(qrCodeDialog, Qt::Key_Escape);
 }
 
 void TestGui::testSearch()

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -19,6 +19,7 @@
 #ifndef KEEPASSX_TESTGUI_H
 #define KEEPASSX_TESTGUI_H
 
+#include "GuiTestBase.h"
 #include "gui/MainWindow.h"
 #include "util/TemporaryFile.h"
 
@@ -27,16 +28,11 @@ class DatabaseTabWidget;
 class DatabaseWidget;
 class QAbstractItemView;
 
-class TestGui : public QObject
+class TestGui : public GuiTestBase
 {
     Q_OBJECT
 
 private slots:
-    void initTestCase();
-    void init();
-    void cleanup();
-    void cleanupTestCase();
-
     void testSettingsDefaultTabOrder();
     void testCreateDatabase();
     void testMergeDatabase();
@@ -71,28 +67,15 @@ private:
     void addCannedEntries();
     void checkDatabase(const QString& filePath, const QString& expectedDbName);
     void checkDatabase(const QString& filePath = {});
-    void triggerAction(const QString& name);
     void dragAndDropGroup(const QModelIndex& sourceIndex,
                           const QModelIndex& targetIndex,
                           int row,
                           bool expectedResult,
                           const QString& expectedParentName,
                           int expectedPos);
-    void clickIndex(const QModelIndex& index,
-                    QAbstractItemView* view,
-                    Qt::MouseButton button,
-                    Qt::KeyboardModifiers stateKey = 0);
+
     void checkSaveDatabase();
     void checkStatusBarText(const QString& textFragment);
-
-    QScopedPointer<MainWindow> m_mainWindow;
-    QPointer<QLabel> m_statusBarLabel;
-    QPointer<DatabaseTabWidget> m_tabWidget;
-    QPointer<DatabaseWidget> m_dbWidget;
-    QSharedPointer<Database> m_db;
-    TemporaryFile m_dbFile;
-    QString m_dbFileName;
-    QString m_dbFilePath;
 };
 
 #endif // KEEPASSX_TESTGUI_H

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -65,8 +65,7 @@ void TestGuiTotp::testTotpSetup()
     seedEdit->setText("");
     QTest::keyClicks(seedEdit, exampleSeed);
 
-    auto* setupTotpButtonBox = setupTotpDialog->findChild<QDialogButtonBox*>("buttonBox");
-    QTest::mouseClick(setupTotpButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    clickDialogButton(setupTotpDialog, QDialogButtonBox::Ok);
     QTRY_VERIFY(!setupTotpDialog->isVisible());
 
     // Make sure the entryView is selected and active
@@ -89,8 +88,7 @@ void TestGuiTotp::testTotpSetup()
     QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("revealAttributeButton"), Qt::LeftButton);
     QCOMPARE(attrTextEdit->toPlainText(), expectedFinalSeed);
 
-    auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
-    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    clickDialogButton(editEntryWidget, QDialogButtonBox::Ok);
 }
 
 void TestGuiTotp::testTotpValue()

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -1,0 +1,227 @@
+/*
+ *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestGuiTotp.h"
+#include "gui/Application.h"
+
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QTest>
+#include <QToolBar>
+
+#include "config-keepassx-tests.h"
+#include "crypto/Crypto.h"
+#include "gui/DatabaseTabWidget.h"
+#include "gui/FileDialog.h"
+#include "gui/MessageBox.h"
+#include "gui/PasswordWidget.h"
+#include "gui/TotpDialog.h"
+#include "gui/TotpSetupDialog.h"
+#include "gui/entry/EditEntryWidget.h"
+#include "gui/entry/EntryView.h"
+
+int main(int argc, char* argv[])
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+    Application app(argc, argv);
+    app.setApplicationName("KeePassXC");
+    app.setApplicationVersion(KEEPASSXC_VERSION);
+    app.setQuitOnLastWindowClosed(false);
+    app.setAttribute(Qt::AA_Use96Dpi, true);
+    app.applyTheme();
+    QTEST_DISABLE_KEYPAD_NAVIGATION
+    TestGuiTotp tc;
+    QTEST_SET_MAIN_SOURCE_PATH
+    return QTest::qExec(&tc, argc, argv);
+}
+
+void TestGuiTotp::initTestCase()
+{
+    QVERIFY(Crypto::init());
+    Config::createTempFileInstance();
+    Application::bootstrap();
+
+    m_mainWindow.reset(new MainWindow());
+    m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
+    m_statusBarLabel = m_mainWindow->findChild<QLabel*>("statusBarLabel");
+    m_mainWindow->show();
+    m_mainWindow->resize(1024, 768);
+}
+
+// Every test starts with resetting config settings and opening the temp database
+void TestGuiTotp::init()
+{
+    // Reset config to defaults
+    config()->resetToDefaults();
+    // Disable autosave so we can test the modified file indicator
+    config()->set(Config::AutoSaveAfterEveryChange, false);
+    config()->set(Config::AutoSaveOnExit, false);
+    // Enable the tray icon so we can test hiding/restoring the windowQByteArray
+    config()->set(Config::GUI_ShowTrayIcon, true);
+    // Disable the update check first time alert
+    config()->set(Config::UpdateCheckMessageShown, true);
+    // Disable quick unlock
+    config()->set(Config::Security_QuickUnlock, false);
+    // Disable atomic saves to prevent transient errors on some platforms
+    config()->set(Config::UseAtomicSaves, false);
+    // Disable showing expired entries on unlock
+    config()->set(Config::GUI_ShowExpiredEntriesOnDatabaseUnlock, false);
+
+    // Copy the test database file to the temporary file
+    auto origFilePath = QDir(KEEPASSX_TEST_DATA_DIR).absoluteFilePath("NewDatabase.kdbx");
+    QVERIFY(m_dbFile.copyFromFile(origFilePath));
+
+    m_dbFileName = QFileInfo(m_dbFile.fileName()).fileName();
+    m_dbFilePath = m_dbFile.fileName();
+
+    // make sure window is activated or focus tests may fail
+    m_mainWindow->activateWindow();
+    QApplication::processEvents();
+
+    fileDialog()->setNextFileName(m_dbFilePath);
+    triggerAction("actionDatabaseOpen");
+
+    QApplication::processEvents();
+
+    m_dbWidget = m_tabWidget->currentDatabaseWidget();
+    auto* databaseOpenWidget = m_tabWidget->currentDatabaseWidget()->findChild<QWidget*>("databaseOpenWidget");
+    QVERIFY(databaseOpenWidget);
+    // editPassword is not QLineEdit anymore but PasswordWidget
+    auto* editPassword =
+        databaseOpenWidget->findChild<PasswordWidget*>("editPassword")->findChild<QLineEdit*>("passwordEdit");
+    QVERIFY(editPassword);
+    editPassword->setFocus();
+
+    QTest::keyClicks(editPassword, "a");
+    QTest::keyClick(editPassword, Qt::Key_Enter);
+
+    QTRY_VERIFY(!m_dbWidget->isLocked());
+    m_db = m_dbWidget->database();
+
+    QApplication::processEvents();
+}
+
+// Every test ends with closing the temp database without saving
+void TestGuiTotp::cleanup()
+{
+    // DO NOT save the database
+    m_db->markAsClean();
+    MessageBox::setNextAnswer(MessageBox::No);
+    triggerAction("actionDatabaseClose");
+    QApplication::processEvents();
+    MessageBox::setNextAnswer(MessageBox::NoButton);
+
+    delete m_dbWidget;
+}
+
+void TestGuiTotp::cleanupTestCase()
+{
+    m_dbFile.remove();
+}
+
+void TestGuiTotp::testTotp()
+{
+    auto* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
+    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
+
+    QCOMPARE(entryView->model()->rowCount(), 1);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
+    QModelIndex item = entryView->model()->index(0, 1);
+    Entry* entry = entryView->entryFromIndex(item);
+    clickIndex(item, entryView, Qt::LeftButton);
+
+    triggerAction("actionEntrySetupTotp");
+
+    auto* setupTotpDialog = m_dbWidget->findChild<TotpSetupDialog*>("TotpSetupDialog");
+
+    QApplication::processEvents();
+
+    QString exampleSeed = "gezd gnbvgY 3tqojqGEZdgnb vgy3tqoJq===";
+    QString expectedFinalSeed = exampleSeed.toUpper().remove(" ").remove("=");
+    auto* seedEdit = setupTotpDialog->findChild<QLineEdit*>("seedEdit");
+    seedEdit->setText("");
+    QTest::keyClicks(seedEdit, exampleSeed);
+
+    auto* setupTotpButtonBox = setupTotpDialog->findChild<QDialogButtonBox*>("buttonBox");
+    QTest::mouseClick(setupTotpButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    QTRY_VERIFY(!setupTotpDialog->isVisible());
+
+    // Make sure the entryView is selected and active
+    entryView->activateWindow();
+    QApplication::processEvents();
+    QTRY_VERIFY(entryView->hasFocus());
+
+    auto* entryEditAction = m_mainWindow->findChild<QAction*>("actionEntryEdit");
+    QWidget* entryEditWidget = toolBar->widgetForAction(entryEditAction);
+    QVERIFY(entryEditWidget->isVisible());
+    QVERIFY(entryEditWidget->isEnabled());
+    QTest::mouseClick(entryEditWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
+
+    auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
+    editEntryWidget->setCurrentPage(1);
+    auto* attrTextEdit = editEntryWidget->findChild<QPlainTextEdit*>("attributesEdit");
+    QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("revealAttributeButton"), Qt::LeftButton);
+    QCOMPARE(attrTextEdit->toPlainText(), expectedFinalSeed);
+
+    auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+
+    // Test the TOTP value
+    triggerAction("actionEntryTotp");
+
+    auto* totpDialog = m_dbWidget->findChild<TotpDialog*>("TotpDialog");
+    auto* totpLabel = totpDialog->findChild<QLabel*>("totpLabel");
+
+    QCOMPARE(totpLabel->text().replace(" ", ""), entry->totp());
+    QTest::keyClick(totpDialog, Qt::Key_Escape);
+
+    // Test the QR code
+    triggerAction("actionEntryTotpQRCode");
+    auto* qrCodeDialog = m_mainWindow->findChild<QDialog*>("entryQrCodeWidget");
+    QVERIFY(qrCodeDialog);
+    QVERIFY(qrCodeDialog->isVisible());
+    auto* qrCodeWidget = qrCodeDialog->findChild<QWidget*>("squareSvgWidget");
+    QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Initial QR code is not square");
+
+    // Test the QR code window resizing, make the dialog bigger.
+    qrCodeDialog->setFixedSize(800, 600);
+    QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Resized QR code is not square");
+    QTest::keyClick(qrCodeDialog, Qt::Key_Escape);
+}
+
+void TestGuiTotp::triggerAction(const QString& name)
+{
+    auto* action = m_mainWindow->findChild<QAction*>(name);
+    QVERIFY(action);
+    QVERIFY(action->isEnabled());
+    action->trigger();
+    QApplication::processEvents();
+}
+
+void TestGuiTotp::clickIndex(const QModelIndex& index,
+                             QAbstractItemView* view,
+                             Qt::MouseButton button,
+                             Qt::KeyboardModifiers stateKey)
+{
+    view->scrollTo(index);
+    QTest::mouseClick(view->viewport(), button, stateKey, view->visualRect(index).center());
+}

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -30,6 +30,8 @@
 #include "gui/entry/EditEntryWidget.h"
 #include "gui/entry/EntryView.h"
 
+#define VERIFY_SQUARE(rect, message) QVERIFY2(rect.width() == rect.height(), message);
+
 int main(int argc, char* argv[])
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
@@ -104,17 +106,31 @@ void TestGuiTotp::testTotp()
 
     QCOMPARE(totpLabel->text().replace(" ", ""), entry->totp());
     QTest::keyClick(totpDialog, Qt::Key_Escape);
+}
 
-    // Test the QR code
+void TestGuiTotp::testQrCode()
+{
+    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
+
+    QCOMPARE(entryView->model()->rowCount(), 1);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
+    QModelIndex item = entryView->model()->index(0, 1);
+    clickIndex(item, entryView, Qt::LeftButton);
+
+    // Given an open QR code dialog.
     triggerAction("actionEntryTotpQRCode");
     auto* qrCodeDialog = m_mainWindow->findChild<QDialog*>("entryQrCodeWidget");
     QVERIFY(qrCodeDialog);
     QVERIFY(qrCodeDialog->isVisible());
     auto* qrCodeWidget = qrCodeDialog->findChild<QWidget*>("squareSvgWidget");
-    QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Initial QR code is not square");
 
-    // Test the QR code window resizing, make the dialog bigger.
+    // Test the default QR code widget shape.
+    VERIFY_SQUARE(qrCodeWidget->geometry(), "Initial QR code is not square")
+
+    // Test the resized QR code widget, make the dialog bigger.
     qrCodeDialog->setFixedSize(800, 600);
-    QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Resized QR code is not square");
+    VERIFY_SQUARE(qrCodeWidget->geometry(), "Resized QR code is not square")
+
+    // Cleanup, close the QR code dialog.
     QTest::keyClick(qrCodeDialog, Qt::Key_Escape);
 }

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -58,7 +58,6 @@ void TestGuiTotp::testTotp()
     QCOMPARE(entryView->model()->rowCount(), 1);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     QModelIndex item = entryView->model()->index(0, 1);
-    Entry* entry = entryView->entryFromIndex(item);
     clickIndex(item, entryView, Qt::LeftButton);
 
     triggerAction("actionEntrySetupTotp");
@@ -97,8 +96,18 @@ void TestGuiTotp::testTotp()
 
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+}
 
-    // Test the TOTP value
+void TestGuiTotp::testTotpValue()
+{
+    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
+
+    QCOMPARE(entryView->model()->rowCount(), 1);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
+    QModelIndex item = entryView->model()->index(0, 1);
+    Entry* entry = entryView->entryFromIndex(item);
+    clickIndex(item, entryView, Qt::LeftButton);
+
     triggerAction("actionEntryTotp");
 
     auto* totpDialog = m_dbWidget->findChild<TotpDialog*>("TotpDialog");

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -19,6 +19,7 @@
 #include "TestGuiTotp.h"
 #include "gui/Application.h"
 
+#include <QClipboard>
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QTest>
@@ -100,6 +101,12 @@ void TestGuiTotp::testTotpValue()
     auto* totpLabel = totpDialog->findChild<QLabel*>("totpLabel");
 
     QCOMPARE(totpLabel->text().replace(" ", ""), entry->totp());
+
+    // Test the clipboard copy
+    clickDialogButton(totpDialog, QDialogButtonBox::Ok);
+    QCOMPARE(QApplication::clipboard()->text(), entry->totp());
+    QVERIFY2(totpDialog->isVisible(), "OK button should not close the TOTP dialog.");
+
     QTest::keyClick(totpDialog, Qt::Key_Escape);
 }
 
@@ -120,6 +127,14 @@ void TestGuiTotp::testQrCode()
     // Test the resized QR code widget, make the dialog bigger.
     qrCodeDialog->setFixedSize(800, 600);
     VERIFY_SQUARE(qrCodeWidget->geometry(), "Resized QR code is not square")
+
+    // Test the clipboard copy
+    clickDialogButton(qrCodeDialog, QDialogButtonBox::Ok);
+    QCOMPARE(
+        QApplication::clipboard()->text(),
+        "otpauth://totp/"
+        "Sample%20Entry:User%20Name?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&period=30&digits=6&issuer=Sample%20Entry");
+    QVERIFY2(qrCodeDialog->isVisible(), "OK button should not close the TOTP dialog.");
 
     // Cleanup, close the QR code dialog.
     QTest::keyClick(qrCodeDialog, Qt::Key_Escape);

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -24,11 +24,6 @@
 #include <QTest>
 #include <QToolBar>
 
-#include "config-keepassx-tests.h"
-#include "crypto/Crypto.h"
-#include "gui/DatabaseTabWidget.h"
-#include "gui/FileDialog.h"
-#include "gui/MessageBox.h"
 #include "gui/PasswordWidget.h"
 #include "gui/TotpDialog.h"
 #include "gui/TotpSetupDialog.h"
@@ -51,90 +46,6 @@ int main(int argc, char* argv[])
     TestGuiTotp tc;
     QTEST_SET_MAIN_SOURCE_PATH
     return QTest::qExec(&tc, argc, argv);
-}
-
-void TestGuiTotp::initTestCase()
-{
-    QVERIFY(Crypto::init());
-    Config::createTempFileInstance();
-    Application::bootstrap();
-
-    m_mainWindow.reset(new MainWindow());
-    m_tabWidget = m_mainWindow->findChild<DatabaseTabWidget*>("tabWidget");
-    m_statusBarLabel = m_mainWindow->findChild<QLabel*>("statusBarLabel");
-    m_mainWindow->show();
-    m_mainWindow->resize(1024, 768);
-}
-
-// Every test starts with resetting config settings and opening the temp database
-void TestGuiTotp::init()
-{
-    // Reset config to defaults
-    config()->resetToDefaults();
-    // Disable autosave so we can test the modified file indicator
-    config()->set(Config::AutoSaveAfterEveryChange, false);
-    config()->set(Config::AutoSaveOnExit, false);
-    // Enable the tray icon so we can test hiding/restoring the windowQByteArray
-    config()->set(Config::GUI_ShowTrayIcon, true);
-    // Disable the update check first time alert
-    config()->set(Config::UpdateCheckMessageShown, true);
-    // Disable quick unlock
-    config()->set(Config::Security_QuickUnlock, false);
-    // Disable atomic saves to prevent transient errors on some platforms
-    config()->set(Config::UseAtomicSaves, false);
-    // Disable showing expired entries on unlock
-    config()->set(Config::GUI_ShowExpiredEntriesOnDatabaseUnlock, false);
-
-    // Copy the test database file to the temporary file
-    auto origFilePath = QDir(KEEPASSX_TEST_DATA_DIR).absoluteFilePath("NewDatabase.kdbx");
-    QVERIFY(m_dbFile.copyFromFile(origFilePath));
-
-    m_dbFileName = QFileInfo(m_dbFile.fileName()).fileName();
-    m_dbFilePath = m_dbFile.fileName();
-
-    // make sure window is activated or focus tests may fail
-    m_mainWindow->activateWindow();
-    QApplication::processEvents();
-
-    fileDialog()->setNextFileName(m_dbFilePath);
-    triggerAction("actionDatabaseOpen");
-
-    QApplication::processEvents();
-
-    m_dbWidget = m_tabWidget->currentDatabaseWidget();
-    auto* databaseOpenWidget = m_tabWidget->currentDatabaseWidget()->findChild<QWidget*>("databaseOpenWidget");
-    QVERIFY(databaseOpenWidget);
-    // editPassword is not QLineEdit anymore but PasswordWidget
-    auto* editPassword =
-        databaseOpenWidget->findChild<PasswordWidget*>("editPassword")->findChild<QLineEdit*>("passwordEdit");
-    QVERIFY(editPassword);
-    editPassword->setFocus();
-
-    QTest::keyClicks(editPassword, "a");
-    QTest::keyClick(editPassword, Qt::Key_Enter);
-
-    QTRY_VERIFY(!m_dbWidget->isLocked());
-    m_db = m_dbWidget->database();
-
-    QApplication::processEvents();
-}
-
-// Every test ends with closing the temp database without saving
-void TestGuiTotp::cleanup()
-{
-    // DO NOT save the database
-    m_db->markAsClean();
-    MessageBox::setNextAnswer(MessageBox::No);
-    triggerAction("actionDatabaseClose");
-    QApplication::processEvents();
-    MessageBox::setNextAnswer(MessageBox::NoButton);
-
-    delete m_dbWidget;
-}
-
-void TestGuiTotp::cleanupTestCase()
-{
-    m_dbFile.remove();
 }
 
 void TestGuiTotp::testTotp()
@@ -206,22 +117,4 @@ void TestGuiTotp::testTotp()
     qrCodeDialog->setFixedSize(800, 600);
     QVERIFY2(qrCodeWidget->geometry().width() == qrCodeWidget->geometry().height(), "Resized QR code is not square");
     QTest::keyClick(qrCodeDialog, Qt::Key_Escape);
-}
-
-void TestGuiTotp::triggerAction(const QString& name)
-{
-    auto* action = m_mainWindow->findChild<QAction*>(name);
-    QVERIFY(action);
-    QVERIFY(action->isEnabled());
-    action->trigger();
-    QApplication::processEvents();
-}
-
-void TestGuiTotp::clickIndex(const QModelIndex& index,
-                             QAbstractItemView* view,
-                             Qt::MouseButton button,
-                             Qt::KeyboardModifiers stateKey)
-{
-    view->scrollTo(index);
-    QTest::mouseClick(view->viewport(), button, stateKey, view->visualRect(index).center());
 }

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -28,7 +28,6 @@
 #include "gui/TotpDialog.h"
 #include "gui/TotpSetupDialog.h"
 #include "gui/entry/EditEntryWidget.h"
-#include "gui/entry/EntryView.h"
 
 #define VERIFY_SQUARE(rect, message) QVERIFY2(rect.width() == rect.height(), message);
 
@@ -52,11 +51,12 @@ int main(int argc, char* argv[])
 
 void TestGuiTotp::testTotpSetup()
 {
-    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
+    auto* entryView = findEntryView();
+
     QCOMPARE(entryView->model()->rowCount(), 1);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
-    QModelIndex item = entryView->model()->index(0, 1);
-    clickIndex(item, entryView, Qt::LeftButton);
+
+    selectEntryViewRow(0);
 
     triggerAction("actionEntrySetupTotp");
 
@@ -99,14 +99,10 @@ void TestGuiTotp::testTotpSetup()
 
 void TestGuiTotp::testTotpValue()
 {
-    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
-
-    QCOMPARE(entryView->model()->rowCount(), 1);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
-    QModelIndex item = entryView->model()->index(0, 1);
-    Entry* entry = entryView->entryFromIndex(item);
-    clickIndex(item, entryView, Qt::LeftButton);
+    QCOMPARE(findEntryView()->model()->rowCount(), 1);
 
+    auto* entry = selectEntryViewRow(0);
     triggerAction("actionEntryTotp");
 
     auto* totpDialog = m_dbWidget->findChild<TotpDialog*>("TotpDialog");
@@ -118,12 +114,10 @@ void TestGuiTotp::testTotpValue()
 
 void TestGuiTotp::testQrCode()
 {
-    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
-
-    QCOMPARE(entryView->model()->rowCount(), 1);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
-    QModelIndex item = entryView->model()->index(0, 1);
-    clickIndex(item, entryView, Qt::LeftButton);
+    QCOMPARE(findEntryView()->model()->rowCount(), 1);
+
+    selectEntryViewRow(0);
 
     // Given an open QR code dialog.
     triggerAction("actionEntryTotpQRCode");

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -50,11 +50,9 @@ int main(int argc, char* argv[])
     return QTest::qExec(&tc, argc, argv);
 }
 
-void TestGuiTotp::testTotp()
+void TestGuiTotp::testTotpSetup()
 {
-    auto* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
     auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
-
     QCOMPARE(entryView->model()->rowCount(), 1);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     QModelIndex item = entryView->model()->index(0, 1);
@@ -82,6 +80,7 @@ void TestGuiTotp::testTotp()
     QTRY_VERIFY(entryView->hasFocus());
 
     auto* entryEditAction = m_mainWindow->findChild<QAction*>("actionEntryEdit");
+    auto* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
     QWidget* entryEditWidget = toolBar->widgetForAction(entryEditAction);
     QVERIFY(entryEditWidget->isVisible());
     QVERIFY(entryEditWidget->isEnabled());

--- a/tests/gui/TestGuiTotp.cpp
+++ b/tests/gui/TestGuiTotp.cpp
@@ -51,11 +51,6 @@ int main(int argc, char* argv[])
 
 void TestGuiTotp::testTotpSetup()
 {
-    auto* entryView = findEntryView();
-
-    QCOMPARE(entryView->model()->rowCount(), 1);
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
-
     selectEntryViewRow(0);
 
     triggerAction("actionEntrySetupTotp");
@@ -75,6 +70,7 @@ void TestGuiTotp::testTotpSetup()
     QTRY_VERIFY(!setupTotpDialog->isVisible());
 
     // Make sure the entryView is selected and active
+    auto* entryView = findEntryView();
     entryView->activateWindow();
     QApplication::processEvents();
     QTRY_VERIFY(entryView->hasFocus());
@@ -99,9 +95,6 @@ void TestGuiTotp::testTotpSetup()
 
 void TestGuiTotp::testTotpValue()
 {
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
-    QCOMPARE(findEntryView()->model()->rowCount(), 1);
-
     auto* entry = selectEntryViewRow(0);
     triggerAction("actionEntryTotp");
 
@@ -114,9 +107,6 @@ void TestGuiTotp::testTotpValue()
 
 void TestGuiTotp::testQrCode()
 {
-    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
-    QCOMPARE(findEntryView()->model()->rowCount(), 1);
-
     selectEntryViewRow(0);
 
     // Given an open QR code dialog.

--- a/tests/gui/TestGuiTotp.h
+++ b/tests/gui/TestGuiTotp.h
@@ -27,6 +27,7 @@ class TestGuiTotp : public GuiTestBase
 
 private slots:
     void testTotp();
+    void testQrCode();
 };
 
 #endif // KEEPASSXC_TESTGUI_TOTP_H

--- a/tests/gui/TestGuiTotp.h
+++ b/tests/gui/TestGuiTotp.h
@@ -26,7 +26,7 @@ class TestGuiTotp : public GuiTestBase
     Q_OBJECT
 
 private slots:
-    void testTotp();
+    void testTotpSetup();
     void testTotpValue();
     void testQrCode();
 };

--- a/tests/gui/TestGuiTotp.h
+++ b/tests/gui/TestGuiTotp.h
@@ -27,6 +27,7 @@ class TestGuiTotp : public GuiTestBase
 
 private slots:
     void testTotp();
+    void testTotpValue();
     void testQrCode();
 };
 

--- a/tests/gui/TestGuiTotp.h
+++ b/tests/gui/TestGuiTotp.h
@@ -19,41 +19,14 @@
 #ifndef KEEPASSXC_TESTGUI_TOTP_H
 #define KEEPASSXC_TESTGUI_TOTP_H
 
-#include "gui/MainWindow.h"
-#include "util/TemporaryFile.h"
+#include "GuiTestBase.h"
 
-class Database;
-class DatabaseTabWidget;
-class DatabaseWidget;
-class QAbstractItemView;
-
-class TestGuiTotp : public QObject
+class TestGuiTotp : public GuiTestBase
 {
     Q_OBJECT
 
 private slots:
-    void initTestCase();
-    void init();
-    void cleanup();
-    void cleanupTestCase();
-
     void testTotp();
-
-private:
-    void triggerAction(const QString& name);
-    void clickIndex(const QModelIndex& index,
-                    QAbstractItemView* view,
-                    Qt::MouseButton button,
-                    Qt::KeyboardModifiers stateKey = 0);
-
-    QScopedPointer<MainWindow> m_mainWindow;
-    QPointer<QLabel> m_statusBarLabel;
-    QPointer<DatabaseTabWidget> m_tabWidget;
-    QPointer<DatabaseWidget> m_dbWidget;
-    QSharedPointer<Database> m_db;
-    TemporaryFile m_dbFile;
-    QString m_dbFileName;
-    QString m_dbFilePath;
 };
 
 #endif // KEEPASSXC_TESTGUI_TOTP_H

--- a/tests/gui/TestGuiTotp.h
+++ b/tests/gui/TestGuiTotp.h
@@ -16,8 +16,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSX_TESTGUI_H
-#define KEEPASSX_TESTGUI_H
+#ifndef KEEPASSXC_TESTGUI_TOTP_H
+#define KEEPASSXC_TESTGUI_TOTP_H
 
 #include "gui/MainWindow.h"
 #include "util/TemporaryFile.h"
@@ -27,7 +27,7 @@ class DatabaseTabWidget;
 class DatabaseWidget;
 class QAbstractItemView;
 
-class TestGui : public QObject
+class TestGuiTotp : public QObject
 {
     Q_OBJECT
 
@@ -37,53 +37,14 @@ private slots:
     void cleanup();
     void cleanupTestCase();
 
-    void testSettingsDefaultTabOrder();
-    void testCreateDatabase();
-    void testMergeDatabase();
-    void testAutoreloadDatabase();
-    void testTabs();
-    void testEditEntry();
-    void testSearchEditEntry();
-    void testAddEntry();
-    void testPasswordEntryEntropy();
-    void testPasswordEntryEntropy_data();
-    void testDicewareEntryEntropy();
-    void testSearch();
-    void testDeleteEntry();
-    void testCloneEntry();
-    void testEntryPlaceholders();
-    void testDragAndDropEntry();
-    void testDragAndDropGroup();
-    void testSaveAs();
-    void testSaveBackup();
-    void testSave();
-    void testSaveBackupPath();
-    void testSaveBackupPath_data();
-    void testDatabaseSettings();
-    void testKeePass1Import();
-    void testDatabaseLocking();
-    void testDragAndDropKdbxFiles();
-    void testSortGroups();
-    void testAutoType();
-    void testTrayRestoreHide();
+    void testTotp();
 
 private:
-    void addCannedEntries();
-    void checkDatabase(const QString& filePath, const QString& expectedDbName);
-    void checkDatabase(const QString& filePath = {});
     void triggerAction(const QString& name);
-    void dragAndDropGroup(const QModelIndex& sourceIndex,
-                          const QModelIndex& targetIndex,
-                          int row,
-                          bool expectedResult,
-                          const QString& expectedParentName,
-                          int expectedPos);
     void clickIndex(const QModelIndex& index,
                     QAbstractItemView* view,
                     Qt::MouseButton button,
                     Qt::KeyboardModifiers stateKey = 0);
-    void checkSaveDatabase();
-    void checkStatusBarText(const QString& textFragment);
 
     QScopedPointer<MainWindow> m_mainWindow;
     QPointer<QLabel> m_statusBarLabel;
@@ -95,4 +56,4 @@ private:
     QString m_dbFilePath;
 };
 
-#endif // KEEPASSX_TESTGUI_H
+#endif // KEEPASSXC_TESTGUI_TOTP_H


### PR DESCRIPTION
This is a pilot variant to split the monolithic TestGUI class. Started with TOTP tests, the next tests will be refactored one by one later.

The idea was discussed here: #9100.
It is recommended to review by commits to follow my step-by-steps changes.

## Type of change
- ✅ Refactor (significant modification to existing code)