### PR TITLE
test: add test for maximum history in database settings

### DIFF
--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1470,6 +1470,7 @@ void TestGui::testDatabaseSettings()
     auto* dbSettingsStackedWidget = dbSettingsDialog->findChild<QStackedWidget*>("stackedWidget");
     auto* transformRoundsSpinBox = dbSettingsDialog->findChild<QSpinBox*>("transformRoundsSpinBox");
     auto advancedToggle = dbSettingsDialog->findChild<QCheckBox*>("advancedSettingsToggle");
+    auto* dbSettingsButtonBox = dbSettingsDialog->findChild<QDialogButtonBox*>("buttonBox");
 
     advancedToggle->setChecked(true);
     QApplication::processEvents();
@@ -1480,6 +1481,27 @@ void TestGui::testDatabaseSettings()
     transformRoundsSpinBox->setValue(123456);
     QTest::keyClick(transformRoundsSpinBox, Qt::Key_Enter);
     QTRY_COMPARE(m_db->kdf()->rounds(), 123456);
+
+    // test disable and default values for maximum history items and size
+    triggerAction("actionDatabaseSettings");
+    auto* historyMaxItemsCheckBox = dbSettingsDialog->findChild<QCheckBox*>("historyMaxItemsCheckBox");
+    auto* historyMaxItemsSpinBox = dbSettingsDialog->findChild<QSpinBox*>("historyMaxItemsSpinBox");
+    auto* historyMaxSizeCheckBox = dbSettingsDialog->findChild<QCheckBox*>("historyMaxSizeCheckBox");
+    auto* historyMaxSizeSpinBox = dbSettingsDialog->findChild<QSpinBox*>("historyMaxSizeSpinBox");
+    // test defaults
+    QCOMPARE(historyMaxItemsSpinBox->value(), Metadata::DefaultHistoryMaxItems);
+    QCOMPARE(historyMaxSizeSpinBox->value(), qRound(Metadata::DefaultHistoryMaxSize / qreal(1024 * 1024)));
+    // disable and test setting as well
+    historyMaxItemsCheckBox->setChecked(false);
+    historyMaxSizeCheckBox->setChecked(false);
+    QTest::mouseClick(dbSettingsButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    QTRY_COMPARE(m_db->metadata()->historyMaxItems(), -1);
+    QTRY_COMPARE(m_db->metadata()->historyMaxSize(), -1);
+    // then open to check the saved disabled state in gui
+    triggerAction("actionDatabaseSettings");
+    QCOMPARE(historyMaxItemsCheckBox->isChecked(), false);
+    QCOMPARE(historyMaxSizeCheckBox->isChecked(), false);
+    QTest::mouseClick(dbSettingsButtonBox->button(QDialogButtonBox::Cancel), Qt::LeftButton);
 
     checkSaveDatabase();
 }


### PR DESCRIPTION
Add a test to the TestGui::testDatabaseSettings function for the history maximum items and maximum size settings.
The test opens the database settings dialog, disables the history items and size settings, saves the changes, reopens the dialog, and then cancels without making any changes to load the default values.
The test ensures that the default values are loaded correctly.

This tests:
1. That the two settings show and present defaults as expected.
2. Disable in gui saves the right values
3. Changing values (while the setting is disabled)
4. Gui behavior when those settings are disabled

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Example for affecting coverage in one of the files
gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
Before:
![image](https://user-images.githubusercontent.com/15849761/221710307-c06db557-be6b-4a76-9fb6-19621c7e7e0a.png)
After:
![image](https://user-images.githubusercontent.com/15849761/221710378-e3aaf9d8-e721-4e37-9f04-a1b862217506.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
running all tests, i also added delays and run the script line by line in debug.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ❎ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ❎ Breaking change (causes existing functionality to change)
- ❎ Refactor (significant modification to existing code)
- ❎ Documentation (non-code change)
