### PR TITLE
Allow setting default file open directory with env var

### DIFF
--- a/docs/topics/UserInterface.adoc
+++ b/docs/topics/UserInterface.adoc
@@ -85,6 +85,7 @@ Additionally, the following environment variables may be useful when running the
 
 |KPXC_CONFIG                    | Override default path to roaming configuration file
 |KPXC_CONFIG_LOCAL              | Override default path to local configuration file
+|KPXC_INITIAL_DIR               | Override initial location picking for databases
 |SSH_AUTH_SOCKET                | Path of the unix file socket that the agent uses for communication with other processes (SSH Agent)
 |QT_SCALE_FACTOR [numeric]      | Defines a global scale factor for the whole application, including point-sized fonts.
 |QT_SCREEN_SCALE_FACTORS [list] | Specifies scale factors for each screen. See https://doc.qt.io/qt-5/highdpi.html#high-dpi-support-in-qt

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -2031,7 +2031,7 @@ bool DatabaseWidget::saveAs()
     if (!QFileInfo::exists(oldFilePath)) {
         QString defaultFileName = config()->get(Config::DefaultDatabaseFileName).toString();
         oldFilePath =
-            QDir::toNativeSeparators(config()->get(Config::LastDir).toString() + "/"
+            QDir::toNativeSeparators(FileDialog::getLastDir("db") + "/"
                                      + (defaultFileName.isEmpty() ? tr("Passwords").append(".kdbx") : defaultFileName));
     }
     const QString newFilePath = fileDialog()->getSaveFileName(
@@ -2121,13 +2121,13 @@ bool DatabaseWidget::saveBackup()
         if (!QFileInfo::exists(oldFilePath)) {
             QString defaultFileName = config()->get(Config::DefaultDatabaseFileName).toString();
             oldFilePath = QDir::toNativeSeparators(
-                config()->get(Config::LastDir).toString() + "/"
+                FileDialog::getLastDir("db") + "/"
                 + (defaultFileName.isEmpty() ? tr("Passwords").append(".kdbx") : defaultFileName));
         }
 
         const QString newFilePath = fileDialog()->getSaveFileName(this,
                                                                   tr("Save database backup"),
-                                                                  FileDialog::getLastDir("backup"),
+                                                                  FileDialog::getLastDir("backup", oldFilePath),
                                                                   tr("KeePass 2 Database").append(" (*.kdbx)"),
                                                                   nullptr,
                                                                   nullptr);

--- a/src/gui/FileDialog.cpp
+++ b/src/gui/FileDialog.cpp
@@ -19,6 +19,8 @@
 
 #include "core/Config.h"
 
+#include <QProcessEnvironment>
+
 FileDialog* FileDialog::m_instance(nullptr);
 
 FileDialog::FileDialog() = default;
@@ -35,7 +37,7 @@ QString FileDialog::getOpenFileName(QWidget* parent,
         m_nextFileName.clear();
         return result;
     } else {
-        const auto& workingDir = dir.isEmpty() ? config()->get(Config::LastDir).toString() : dir;
+        const auto& workingDir = dir.isEmpty() ? getLastDir("default") : dir;
         const auto result = QDir::toNativeSeparators(
             QFileDialog::getOpenFileName(parent, caption, workingDir, filter, selectedFilter, options));
 
@@ -61,7 +63,7 @@ QStringList FileDialog::getOpenFileNames(QWidget* parent,
         m_nextFileNames.clear();
         return results;
     } else {
-        const auto& workingDir = dir.isEmpty() ? config()->get(Config::LastDir).toString() : dir;
+        const auto& workingDir = dir.isEmpty() ? getLastDir("default") : dir;
         auto results = QFileDialog::getOpenFileNames(parent, caption, workingDir, filter, selectedFilter, options);
 
         for (auto& path : results) {
@@ -90,7 +92,7 @@ QString FileDialog::getSaveFileName(QWidget* parent,
         m_nextFileName.clear();
         return result;
     } else {
-        const auto& workingDir = dir.isEmpty() ? config()->get(Config::LastDir).toString() : dir;
+        const auto& workingDir = dir.isEmpty() ? getLastDir("default") : dir;
         const auto result = QDir::toNativeSeparators(
             QFileDialog::getSaveFileName(parent, caption, workingDir, filter, selectedFilter, options));
 
@@ -114,7 +116,7 @@ QString FileDialog::getExistingDirectory(QWidget* parent,
         m_nextDirName.clear();
         return result;
     } else {
-        const auto& workingDir = dir.isEmpty() ? config()->get(Config::LastDir).toString() : dir;
+        const auto& workingDir = dir.isEmpty() ? getLastDir("default") : dir;
         const auto result =
             QDir::toNativeSeparators(QFileDialog::getExistingDirectory(parent, caption, workingDir, options));
 
@@ -158,7 +160,15 @@ void FileDialog::saveLastDir(const QString& role, const QString& path, bool sens
 QString FileDialog::getLastDir(const QString& role, const QString& defaultDir)
 {
     auto lastDirs = config()->get(Config::LastDir).toHash();
-    return lastDirs.value(role, defaultDir).toString();
+    auto fallbackDir = defaultDir;
+
+    if (fallbackDir.isEmpty()) {
+        // Fallback to the environment variable, if it exists, otherwise use the home directory
+        const auto& env = QProcessEnvironment::systemEnvironment();
+        fallbackDir = env.value("KPXC_INITIAL_DIR", QDir::homePath());
+    }
+
+    return lastDirs.value(role, fallbackDir).toString();
 }
 
 FileDialog* FileDialog::instance()

--- a/src/gui/FileDialog.h
+++ b/src/gui/FileDialog.h
@@ -56,7 +56,7 @@ public:
     void setNextDirectory(const QString& path);
 
     static void saveLastDir(const QString& role, const QString& path, bool sensitive = false);
-    static QString getLastDir(const QString& role, const QString& defaultDir = QDir::homePath());
+    static QString getLastDir(const QString& role, const QString& defaultDir = QString());
 
     static FileDialog* instance();
 


### PR DESCRIPTION
## Testing strategy

Made sure the `KPXC_INITIAL_DIR` environment variable works as intended. This is a very minor change, I don't think adding a unit test for it would be worth it. Writing the test would actually require more core than the code itself. Plus, other environment variables are not tested either.

I did run the test suite though, everything's ok ! 

## Type of change

- ✅ Bug fix (one of the unit tests didn't pass, I fixed it in my second commit)
- ✅ New feature (change that adds functionality)
- ✅ Documentation (non-code change)

## Other

I replaced :

```
config()->get(Config::LastDir).toString()
```

with :

```
FileDialog::getLastDir("db")
```

Let me know if I shouldn't have done that, I don't know much about C++ but the `.toString()` felt wrong.

The `FileDialog::saveLastDir()` sets the `Config::LastDir` to a hashmap, how can a `toString()` work ? Plus I had to call the wrapper method `getLastDir()` in order to get the default directory to work, getting it from the config directly would bypass that.

https://github.com/keepassxreboot/keepassxc/blob/5b312889b87451d6e83a9f042b6cc68a98fa7d63/src/gui/FileDialog.cpp#L141-L156