### PR TITLE
Make open folder icon exempt from "Apply group icon to entry"

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -33,6 +33,7 @@
 #include <QtConcurrentFilter>
 
 const int Group::DefaultIconNumber = 48;
+const int Group::OpenFolderIconNumber = 49;
 const int Group::RecycleBinIconNumber = 43;
 const QString Group::RootAutoTypeSequence = "{USERNAME}{TAB}{PASSWORD}{ENTER}";
 
@@ -1132,7 +1133,8 @@ void Group::applyGroupIconOnCreateTo(Entry* entry)
         return;
     }
 
-    if (iconNumber() == Group::DefaultIconNumber && iconUuid().isNull()) {
+    if ((iconNumber() == Group::DefaultIconNumber || iconNumber() == Group::OpenFolderIconNumber)
+        && iconUuid().isNull()) {
         return;
     }
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -110,6 +110,7 @@ public:
     bool equals(const Group* other, CompareItemOptions options) const;
 
     static const int DefaultIconNumber;
+    static const int OpenFolderIconNumber;
     static const int RecycleBinIconNumber;
     static const QString RootAutoTypeSequence;
 


### PR DESCRIPTION
* Fix #9201

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
