### PR TITLE
Fix crash when search clears while creating new entry

### DIFF
--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -565,6 +565,9 @@ void EntryPreviewWidget::setTabEnabled(QTabWidget* tabWidget, QWidget* widget, b
 
 QString EntryPreviewWidget::hierarchy(const Group* group, const QString& title)
 {
-    QString groupList = QString("%1").arg(group->hierarchy().join(" / "));
-    return title.isEmpty() ? groupList : QString("%1 / %2").arg(groupList, title);
+    if (group) {
+        QString groupList = QString("%1").arg(group->hierarchy().join(" / "));
+        return title.isEmpty() ? groupList : QString("%1 / %2").arg(groupList, title);
+    }
+    return {};
 }

--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -256,7 +256,6 @@ QPixmap Icons::entryIconPixmap(const Entry* entry, IconSize size)
     if (entry->iconUuid().isNull()) {
         icon = databaseIcons()->icon(entry->iconNumber(), size);
     } else {
-        Q_ASSERT(entry->database());
         if (entry->database()) {
             icon = Icons::customIconPixmap(entry->database(), entry->iconUuid(), size);
         }
@@ -275,7 +274,6 @@ QPixmap Icons::groupIconPixmap(const Group* group, IconSize size)
     if (group->iconUuid().isNull()) {
         icon = databaseIcons()->icon(group->iconNumber(), size);
     } else {
-        Q_ASSERT(group->database());
         if (group->database()) {
             icon = Icons::customIconPixmap(group->database(), group->iconUuid(), size);
         }
@@ -299,13 +297,16 @@ QString Icons::imageFormatsFilter()
     QStringList formatsStringList;
 
     for (const QByteArray& format : formats) {
+        bool codePointClean = true;
         for (char codePoint : format) {
             if (!QChar(codePoint).isLetterOrNumber()) {
-                continue;
+                codePointClean = false;
+                break;
             }
         }
-
-        formatsStringList.append("*." + QString::fromLatin1(format).toLower());
+        if (codePointClean) {
+            formatsStringList.append("*." + QString::fromLatin1(format).toLower());
+        }
     }
 
     return formatsStringList.join(" ");


### PR DESCRIPTION
* Fixes #7660
* Also fix code error in Icons::imageFormatsFilter. An inner loop looks for invalid characters in the code point, but erroneously calls `continue` within the inner loop when the intention was to continue in the outer loop. Fixed with a boolean test instead.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually before/after the changes. Crash consistently before, no crash after. Also tested while editing an entry, no crashes.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
