### PR TITLE
Add yubikey param and DBus methods to unlock the database requiring yubikey

### DIFF
--- a/docs/man/keepassxc.1.adoc
+++ b/docs/man/keepassxc.1.adoc
@@ -55,6 +55,9 @@ Your database works offline and requires no internet connection.
 *--keyfile* <__keyfile__>::
   Key file of the database.
 
+*--yubikey* <__slot[:serial]__>::
+  YubiKey slot and optional serial used to access the database (e.g., 1:7370001).
+
 *--pw-stdin*::
   Reads password of the database from stdin.
 

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -43,7 +43,7 @@ public:
     void load(const QString& filename);
     QString filename();
     void clearForms();
-    void enterKey(const QString& pw, const QString& keyFile);
+    void enterKey(const QString& pw, const QString& keyFile, const QString& yubiKeySlot = {});
     QSharedPointer<Database> database();
     void resetQuickUnlock();
     bool unlockingDatabase();

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -153,7 +153,9 @@ void DatabaseTabWidget::openDatabase()
 void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
                                        bool inBackground,
                                        const QString& password,
-                                       const QString& keyfile)
+                                       const QString& keyfile,
+                                       const QString& yubiKeySlot,
+                                       bool dontUseLastYubiKey)
 {
     QString cleanFilePath = QDir::toNativeSeparators(filePath);
     QFileInfo fileInfo(cleanFilePath);
@@ -170,7 +172,7 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
         Q_ASSERT(dbWidget);
         if (dbWidget
             && dbWidget->database()->canonicalFilePath().compare(canonicalFilePath, FILE_CASE_SENSITIVE) == 0) {
-            dbWidget->performUnlockDatabase(password, keyfile);
+            dbWidget->performUnlockDatabase(password, keyfile, yubiKeySlot, dontUseLastYubiKey);
             if (!inBackground) {
                 // switch to existing tab if file is already open
                 setCurrentIndex(indexOf(dbWidget));
@@ -179,9 +181,9 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
         }
     }
 
-    auto* dbWidget = new DatabaseWidget(QSharedPointer<Database>::create(cleanFilePath), this);
+    auto* dbWidget = new DatabaseWidget(QSharedPointer<Database>::create(cleanFilePath), this, dontUseLastYubiKey);
     addDatabaseTab(dbWidget, inBackground);
-    dbWidget->performUnlockDatabase(password, keyfile);
+    dbWidget->performUnlockDatabase(password, keyfile, yubiKeySlot, dontUseLastYubiKey);
     updateLastDatabases(cleanFilePath);
 }
 
@@ -233,8 +235,8 @@ void DatabaseTabWidget::addDatabaseTab(DatabaseWidget* dbWidget, bool inBackgrou
     }
 
     connect(dbWidget,
-            SIGNAL(requestOpenDatabase(QString, bool, QString, QString)),
-            SLOT(addDatabaseTab(QString, bool, QString, QString)));
+            SIGNAL(requestOpenDatabase(QString, bool, QString, QString, QString)),
+            SLOT(addDatabaseTab(QString, bool, QString, QString, QString)));
     connect(dbWidget, SIGNAL(databaseFilePathChanged(QString, QString)), SLOT(updateTabName()));
     connect(dbWidget, SIGNAL(closeRequest()), SLOT(closeDatabaseTabFromSender()));
     connect(dbWidget,

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -51,7 +51,9 @@ public slots:
     void addDatabaseTab(const QString& filePath,
                         bool inBackground = false,
                         const QString& password = {},
-                        const QString& keyfile = {});
+                        const QString& keyfile = {},
+                        const QString& yubiKeySlot = {},
+                        bool dontUseLastYubiKey = false);
     void addDatabaseTab(DatabaseWidget* dbWidget, bool inBackground = false);
     bool closeDatabaseTab(int index);
     bool closeDatabaseTab(DatabaseWidget* dbWidget);

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -72,7 +72,7 @@ public:
         LockedMode
     };
 
-    explicit DatabaseWidget(QSharedPointer<Database> db, QWidget* parent = nullptr);
+    explicit DatabaseWidget(QSharedPointer<Database> db, QWidget* parent = nullptr, bool dontUseLastYubiKey = false);
     explicit DatabaseWidget(const QString& filePath, QWidget* parent = nullptr);
     ~DatabaseWidget() override;
 
@@ -139,8 +139,11 @@ signals:
     void currentModeChanged(DatabaseWidget::Mode mode);
     void groupChanged();
     void entrySelectionChanged();
-    void
-    requestOpenDatabase(const QString& filePath, bool inBackground, const QString& password, const QString& keyFile);
+    void requestOpenDatabase(const QString& filePath,
+                             bool inBackground,
+                             const QString& password,
+                             const QString& keyFile,
+                             const QString& yubiKeySlot = {});
     void databaseMerged(QSharedPointer<Database> mergedDb);
     void groupContextMenuRequested(const QPoint& globalPos);
     void entryContextMenuRequested(const QPoint& globalPos);
@@ -213,7 +216,10 @@ public slots:
     void switchToOpenDatabase(const QString& filePath);
     void switchToOpenDatabase(const QString& filePath, const QString& password, const QString& keyFile);
     void switchToCsvImport(const QString& filePath);
-    void performUnlockDatabase(const QString& password, const QString& keyfile = {});
+    void performUnlockDatabase(const QString& password,
+                               const QString& keyfile = {},
+                               const QString& yubiKeySlot = {},
+                               bool dontUseLastYubiKey = false);
     void csvImportFinished(bool accepted);
     void switchToImportKeepass1(const QString& filePath);
     void switchToImportOpVault(const QString& fileName);
@@ -233,6 +239,11 @@ public slots:
                      int autoHideTimeout = MessageWidget::DefaultAutoHideTimeout);
     void showErrorMessage(const QString& errorMessage);
     void hideMessage();
+
+#ifdef WITH_XC_YUBIKEY
+    void setDontUseLastYubiKey(bool dontUse);
+    bool getDontUseLastYubiKey();
+#endif
 
 protected:
     void closeEvent(QCloseEvent* event) override;
@@ -311,6 +322,8 @@ private:
 
     // Auto-Type related
     QString m_searchStringForAutoType;
+
+    bool m_dontUseLastYubiKey = false;
 };
 
 #endif // KEEPASSX_DATABASEWIDGET_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -693,8 +693,6 @@ MainWindow::MainWindow()
     m_statusBarLabel = new QLabel(statusBar());
     m_statusBarLabel->setObjectName("statusBarLabel");
     statusBar()->addPermanentWidget(m_statusBarLabel);
-
-    restoreConfigState();
 }
 
 MainWindow::~MainWindow()
@@ -707,7 +705,7 @@ MainWindow::~MainWindow()
 /**
  * Restore the main window's state after launch
  */
-void MainWindow::restoreConfigState()
+void MainWindow::restoreConfigState(bool dontUseLastYubiKey)
 {
     // start minimized if configured
     if (config()->get(Config::GUI_MinimizeOnStartup).toBool()) {
@@ -720,12 +718,12 @@ void MainWindow::restoreConfigState()
         const QStringList fileNames = config()->get(Config::LastOpenedDatabases).toStringList();
         for (const QString& filename : fileNames) {
             if (!filename.isEmpty() && QFile::exists(filename)) {
-                openDatabase(filename);
+                openDatabase(filename, {}, {}, {}, dontUseLastYubiKey);
             }
         }
         auto lastActiveFile = config()->get(Config::LastActiveDatabase).toString();
         if (!lastActiveFile.isEmpty()) {
-            openDatabase(lastActiveFile);
+            openDatabase(lastActiveFile, {}, {}, {}, dontUseLastYubiKey);
         }
     }
 }
@@ -872,9 +870,13 @@ void MainWindow::clearLastDatabases()
     }
 }
 
-void MainWindow::openDatabase(const QString& filePath, const QString& password, const QString& keyfile)
+void MainWindow::openDatabase(const QString& filePath,
+                              const QString& password,
+                              const QString& keyfile,
+                              const QString& yubiKeySlot,
+                              bool dontUseLastYubiKey)
 {
-    m_ui->tabWidget->addDatabaseTab(filePath, false, password, keyfile);
+    m_ui->tabWidget->addDatabaseTab(filePath, false, password, keyfile, yubiKeySlot, dontUseLastYubiKey);
 }
 
 void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -785,6 +785,17 @@ bool MainWindow::refreshHardwareKeys()
 #endif
 }
 
+QStringList MainWindow::listHardwareKeys()
+{
+    QStringList results = {};
+#ifdef WITH_XC_YUBIKEY
+    YubiKey::instance()->findValidKeys();
+    for (auto& slot : YubiKey::instance()->foundKeys())
+        results.append(QStringLiteral("%1:%2").arg(slot.second).arg(slot.first));
+#endif
+    return results;
+}
+
 void MainWindow::updateLastDatabasesMenu()
 {
     m_ui->menuRecentDatabases->clear();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -879,6 +879,11 @@ void MainWindow::openDatabase(const QString& filePath,
     m_ui->tabWidget->addDatabaseTab(filePath, false, password, keyfile, yubiKeySlot, dontUseLastYubiKey);
 }
 
+void MainWindow::openDatabaseYubiKey(const QString& filePath, const QString& password, const QString& yubiKeySlot)
+{
+    openDatabase(filePath, password, QString(""), yubiKeySlot, true);
+}
+
 void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
 {
     int currentIndex = m_ui->stackedWidget->currentIndex();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -77,6 +77,7 @@ public slots:
     void appExit();
     bool isHardwareKeySupported();
     bool refreshHardwareKeys();
+    QStringList listHardwareKeys();
     void displayGlobalMessage(const QString& text,
                               MessageWidget::MessageType type,
                               bool showClosebutton = true,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -73,6 +73,7 @@ public slots:
                       const QString& keyfile = {},
                       const QString& yubiKeySlot = {},
                       bool dontUseLastYubiKey = false);
+    void openDatabaseYubiKey(const QString& filePath, const QString& password, const QString& yubiKeySlot);
     void appExit();
     bool isHardwareKeySupported();
     bool refreshHardwareKeys();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -51,7 +51,7 @@ public:
     ~MainWindow() override;
 
     QList<DatabaseWidget*> getOpenDatabases();
-    void restoreConfigState();
+    void restoreConfigState(bool dontUseLastYubiKey = false);
     void setAllowScreenCapture(bool state);
 
     enum StackedWidgetIndex
@@ -68,7 +68,11 @@ signals:
     void activeDatabaseChanged(DatabaseWidget* dbWidget);
 
 public slots:
-    void openDatabase(const QString& filePath, const QString& password = {}, const QString& keyfile = {});
+    void openDatabase(const QString& filePath,
+                      const QString& password = {},
+                      const QString& keyfile = {},
+                      const QString& yubiKeySlot = {},
+                      bool dontUseLastYubiKey = false);
     void appExit();
     bool isHardwareKeySupported();
     bool refreshHardwareKeys();

--- a/src/gui/org.keepassxc.KeePassXC.MainWindow.xml
+++ b/src/gui/org.keepassxc.KeePassXC.MainWindow.xml
@@ -5,6 +5,12 @@
       <arg name="fileName" type="s" direction="in"/>
       <arg name="pw" type="s" direction="in"/>
       <arg name="keyFile" type="s" direction="in"/>
+      <arg name="yubiKeySlot" type="s" direction="in"/>
+    </method>
+    <method name="openDatabase">
+      <arg name="fileName" type="s" direction="in"/>
+      <arg name="pw" type="s" direction="in"/>
+      <arg name="keyFile" type="s" direction="in"/>
     </method>
     <method name="openDatabase">
       <arg name="fileName" type="s" direction="in"/>
@@ -12,6 +18,11 @@
     </method>
     <method name="openDatabase">
       <arg name="fileName" type="s" direction="in"/>
+    </method>
+    <method name="openDatabaseYubiKey">
+      <arg name="fileName" type="s" direction="in"/>
+      <arg name="pw" type="s" direction="in"/>
+      <arg name="yubiKeySlot" type="s" direction="in"/>
     </method>
     <method name="appExit">
     </method>

--- a/src/gui/org.keepassxc.KeePassXC.MainWindow.xml
+++ b/src/gui/org.keepassxc.KeePassXC.MainWindow.xml
@@ -32,6 +32,9 @@
     <method name="refreshHardwareKeys">
       <arg name="found" type="b" direction="out"/>
     </method>
+    <method name="listHardwareKeys">
+      <arg name="found" type="as" direction="out"/>
+    </method>
     <method name="lockAllDatabases">
     </method>
     <method name="closeAllDatabases">


### PR DESCRIPTION

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

At the moment, we do not have the option to unlock the database in the GUI in case we use hmac-secret from YubiKey.
Let's add a yubikey parameter that will allow us to unlock the database using the Yubikey slot we specified, and add DBus methods that will allow us to do the same from other processes.

The code that I am adding maintains backward compatibility for all program parameters and DBus,and additional parameters in functions inside the code are optional, so I do not expect regression in existing use cases.

One of the main changes I had to add (because I didn't know how to solve it sensibly) is to disable the functionality of remembering the last key used to open a given database when using the --yubikey parameter. This is because in the case of a larger number of keys, asynchronous searches by Keepass for available keys created a conflict with my method of using yubikey from the --yubikey parameter. However, it does not affect the behavior of the program without this parameter.

I added two new DBus methods (openDatabaseYubiKey and listHardwareKeys) and extended the openDatabase method with an optional parameter to indicate the YubiKey slot 

The listHardwareKeys parameter is used return a list of YubiKey slots available in the program.

I added the parameter openDatabaseYubiKey to maintain backward compatibility of the previous methods, and to give the possibility to unlock the database with just a password and yubikey (I don't like this way much, but I didn't have a better idea) 
## Screenshots

[TIP]:  # ( Do not include screenshots of your actual database! )
N/A

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual tests on existing databases:
- testing combinations of new and old parameters:
```
echo "test" | ./keepassxc /home/piorkov/Passwords/Passwords-test-onlypass.kdbx --pw-stdin
echo "test" | ./keepassxc /home/piorkov/Passwords/Passwords-test-filekey.kdbx --pw-stdin --keyfile /home/piorkov/Passwords/test-key
echo "test" | ./keepassxc /home/piorkov/Passwords/Passwords-test-yk-filekey.kdbx --pw-stdin --keyfile /home/piorkov/Passwords/test-key --yubikey 1
echo "test" | ./keepassxc /home/piorkov/Passwords/Passwords-test-yk.kdbx --pw-stdin --yubikey 1
```
- testing the new parameter itself (with two different YubiKey inserted to PC):
```
echo "test" | ./keepassxc /home/piorkov/Passwords/Passwords-test-yk.kdbx --pw-stdin --yubikey "1:<first YubiKey serial>"
echo "test" | ./keepassxc /home/piorkov/Passwords/Passwords-test-yk.kdbx --pw-stdin --yubikey "1:<second YubiKey serial>" #the same hmac-secret as in first YubiKey
echo "test" | ./keepassxc /home/piorkov/Passwords/Passwords-test-yk2.kdbx --pw-stdin --yubikey "2:<first YubiKey serial>"
```
- testing negative scenarios:
```
./keepassxc /home/piorkov/Passwords/Passwords-test-yk.kdbx --yubikey 1 #ignore yubikey param wihout password
echo "test" | ./keepassxc /home/piorkov/Passwords/Passwords-test-yk.kdbx --pw-stdin --yubikey 3 #wrong slot
```
- DBus test:
```
qdbus org.keepassxc.KeePassXC.MainWindow /keepassxc org.keepassxc.KeePassXC.MainWindow.listHardwareKeys #return Array of strings: ['2:<first YubiKey serial>', '1:<first YubiKey serial>', '1:<second YubiKey serial>']
qdbus org.keepassxc.KeePassXC.MainWindow /keepassxc org.keepassxc.KeePassXC.MainWindow.openDatabase /home/piorkov/Passwords/Passwords-test-onlypass.kdbx test
qdbus org.keepassxc.KeePassXC.MainWindow /keepassxc org.keepassxc.KeePassXC.MainWindow.openDatabase /home/piorkov/Passwords/Passwords-test-filekey.kdbx test /home/piorkov/Passwords/test-key
qdbus org.keepassxc.KeePassXC.MainWindow /keepassxc org.keepassxc.KeePassXC.MainWindow.openDatabase /home/piorkov/Passwords/Passwords-test-yk-filekey.kdbx test /home/piorkov/Passwords/test-key 1
qdbus org.keepassxc.KeePassXC.MainWindow /keepassxc org.keepassxc.KeePassXC.MainWindow.openDatabase /home/piorkov/Passwords/Passwords-test-yk-filekey.kdbx test /home/piorkov/Passwords/test-key "1:<first YubiKey serial>"
qdbus org.keepassxc.KeePassXC.MainWindow /keepassxc org.keepassxc.KeePassXC.MainWindow.openDatabaseYubiKey /home/piorkov/Passwords/Passwords-test-yk.kdbx test "1:<first YubiKey serial>"
```

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
