### PR TITLE
Translation fix in keepassxc_cs.ts

### DIFF
--- a/share/translations/keepassxc_cs.ts
+++ b/share/translations/keepassxc_cs.ts
@@ -6124,7 +6124,7 @@ Do you want to overwrite it?</source>
     </message>
     <message>
         <source>Empty</source>
-        <translation>Prázdné</translation>
+        <translation>Vyprázdnit</translation>
     </message>
     <message>
         <source>Remove</source>


### PR DESCRIPTION
The word "empty" was translated as an adjective (as in "the folder is empty"), while it is actually supposed to be a verb (as in "empty the contents of the folder").