### PR TITLE
Remove registry detection of desktop shortcut setting

### DIFF
--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -101,13 +101,9 @@
             <RegistrySearch Id="AutoStartSearch" Root="HKCU" Key="Software\Microsoft\Windows\CurrentVersion\Run" Name="$(var.CPACK_PACKAGE_NAME)" Type="raw" />
         </Property>
         <Property Id="INSTALLDESKTOPSHORTCUT" Secure="yes" />
-        <Property Id="INSTALLDESKTOPSHORTCUT_REGISTRY">
-            <RegistrySearch Id="DesktopIconSearch" Root="HKCU" Key="Software\KeePassXC" Name="DesktopShortcut" Type="raw" />
-        </Property>
 
         <!-- Set properties based on existing conditions, prevents changing state on upgrade -->
         <SetProperty Id="AUTOSTARTPROGRAM" After="AppSearch" Value="">AUTOSTARTPROGRAM="0" OR (WIX_UPGRADE_DETECTED AND NOT AUTOSTARTPROGRAM_REGISTRY)</SetProperty>
-        <SetProperty Id="INSTALLDESKTOPSHORTCUT" After="AppSearch" Value="1">WIX_UPGRADE_DETECTED AND INSTALLDESKTOPSHORTCUT_REGISTRY</SetProperty>
         <SetProperty Id="LicenseAccepted" After="AppSearch" Value="1">WIX_UPGRADE_DETECTED</SetProperty>
 
         <FeatureRef Id="ProductFeature">


### PR DESCRIPTION
* Fixes #8711

This registry detection basically forces the creation of a desktop shortcut if the user ever decided to add one in the past. Instead, we now default to "No desktop shortcut" as usual and the user can decide to "re-add" it during installation if they choose.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested with upgrade installation

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
