### PR TITLE
Fix build failure with Qt5.6

### DIFF
--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -325,7 +325,7 @@ void AutoTypeSelectDialog::buildActionMenu()
     });
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-    auto typeVirtualAction = new QAction(icons()->icon("auto-type"), tr("Use Virtual Keyboard"));
+    auto typeVirtualAction = new QAction(icons()->icon("auto-type"), tr("Use Virtual Keyboard"), nullptr);
     m_actionMenu->insertAction(copyUsernameAction, typeVirtualAction);
     typeVirtualAction->setShortcut(Qt::CTRL + Qt::Key_4);
     connect(typeVirtualAction, &QAction::triggered, this, [&] {


### PR DESCRIPTION
This is similar to https://github.com/keepassxreboot/keepassxc/pull/8829
It also applies to 2.7 branch

With Qt 5.6, build fails with error below.

This is because in Qt 5.6, the 3rd argument is not optional. Starting from Qt 5.7 the default value for the 3rd argument is nullptr, so setting it to nullptr.

https://doc.qt.io/archives/qt-5.6/qaction.html#QAction-2 https://doc.qt.io/archives/qt-5.7/qaction.html#QAction-2

Error:
src/autotype/AutoTypeSelectDialog.cpp:330:34: error: no matching constructor for initialization of 'QAction'
    auto typeVirtualAction = new QAction(icons()->icon("auto-type"), tr("Use Virtual Keyboard"));
                                 ^       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Builds on macports with qt <= 5.6

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
