### PR TITLE
use setWindowFlags() instead of setWindowFlag on Qt<5.9

### DIFF
--- a/src/gui/CloneDialog.cpp
+++ b/src/gui/CloneDialog.cpp
@@ -29,7 +29,11 @@ CloneDialog::CloneDialog(DatabaseWidget* parent, Database* db, Entry* entry)
     m_ui->setupUi(this);
 
     window()->layout()->setSizeConstraint(QLayout::SetFixedSize);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
     setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+#else
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+#endif
     setAttribute(Qt::WA_DeleteOnClose);
 
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(close()));

--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -36,7 +36,11 @@ DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
 {
     setWindowTitle(tr("Unlock Database - KeePassXC"));
     setWindowFlags(Qt::Dialog);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
     setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+#else
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+#endif
 #ifdef Q_OS_LINUX
     // Linux requires this to overcome some Desktop Environments (also no Quick Unlock)
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);

--- a/src/gui/TotpSetupDialog.cpp
+++ b/src/gui/TotpSetupDialog.cpp
@@ -29,7 +29,11 @@ TotpSetupDialog::TotpSetupDialog(QWidget* parent, Entry* entry)
 {
     m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
     setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+#else
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+#endif
     setFixedSize(sizeHint());
 
     connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(close()));


### PR DESCRIPTION
Fixes this error when building with Qt <5.9
This also applies to 2.7 branch

src/gui/CloneDialog.cpp:32:5: error: use of undeclared identifier 'setWindowFlag'
    setWindowFlag(Qt::WindowContextHelpButtonHint, false);
    ^

void QWidget::setWindowFlag(Qt::WindowType flag, bool on = true) --> This function was introduced in Qt 5.9.

---

Instead of `#if`, an alternative would be to use the statement for Qt<5.9 in all cases, which would permit to remove the `#if`...

That would be just replace:
```
setWindowFlag(Qt::WindowContextHelpButtonHint, false);
```
by
```
setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
```


[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
Builds fine on macports with qt < 5.9
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
