### PR TITLE
Improve error message when browser proxy cannot be found

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1107,14 +1107,6 @@ Do you want to delete the entry?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Error:&lt;/b&gt; The custom proxy location cannot be found!&lt;br/&gt;Browser integration WILL NOT WORK without the proxy application.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;Warning:&lt;/b&gt; The following options can be dangerous!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Executable Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1139,11 +1131,19 @@ Do you want to delete the entry?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Error: &lt;/b&gt;</source>
+        <source>&lt;b&gt;Warning:&lt;/b&gt; Only adjust these settings if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Info: &lt;/b&gt;</source>
+        <source>The custom proxy location does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;Error:&lt;/b&gt; The custom proxy location does not exist. Correct this in the advanced settings tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;Error:&lt;/b&gt; The installed proxy executable is missing from the expected location: %1&lt;br/&gt;Please set a custom proxy location in the advanced settings or reinstall the application.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7962,22 +7962,6 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>allow screenshots and app recording (Windows/macOS)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;br/&gt;Proxy will be set at: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;br/&gt;The proxy executable is missing. We recommend &lt;b&gt;one of&lt;/b&gt;:&lt;br/&gt;  - to copy it to path %1&lt;br/&gt;       &lt;b&gt;or&lt;/b&gt;&lt;br/&gt;  - set a custom proxy location in Settings-&gt;Browser Integration-&gt;Advanced to a correct proxy executable.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;br/&gt; The custom proxy executable (%1) not found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;br/&gt; The proxy executable (%1) not installed correctly</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1138,6 +1138,14 @@ Do you want to delete the entry?
         <source>Allow limited access to all entries in connected databases (ignores site access restrictions)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&lt;b&gt;Error: &lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;Info: &lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CloneDialog</name>
@@ -7954,6 +7962,22 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>allow screenshots and app recording (Windows/macOS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;br/&gt;Proxy will be set at: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;br/&gt;The proxy executable is missing. We recommend &lt;b&gt;one of&lt;/b&gt;:&lt;br/&gt;  - to copy it to path %1&lt;br/&gt;       &lt;b&gt;or&lt;/b&gt;&lt;br/&gt;  - set a custom proxy location in Settings-&gt;Browser Integration-&gt;Advanced to a correct proxy executable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;br/&gt; The custom proxy executable (%1) not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;br/&gt; The proxy executable (%1) not installed correctly</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/browser/BrowserSettings.cpp
+++ b/src/browser/BrowserSettings.cpp
@@ -200,6 +200,11 @@ QString BrowserSettings::proxyLocation()
     return m_nativeMessageInstaller.getProxyPath();
 }
 
+QString BrowserSettings::proxyLocationAsInstalled() const
+{
+    return m_nativeMessageInstaller.getInstalledProxyPath();
+}
+
 #ifdef QT_DEBUG
 QString BrowserSettings::customExtensionId()
 {

--- a/src/browser/BrowserSettings.h
+++ b/src/browser/BrowserSettings.h
@@ -57,6 +57,7 @@ public:
     QString customProxyLocation();
     void setCustomProxyLocation(const QString& location);
     QString proxyLocation();
+    QString proxyLocationAsInstalled() const;
 #ifdef QT_DEBUG
     QString customExtensionId();
     void setCustomExtensionId(const QString& id);

--- a/src/browser/BrowserSettingsWidget.cpp
+++ b/src/browser/BrowserSettingsWidget.cpp
@@ -125,14 +125,7 @@ void BrowserSettingsWidget::loadSettings()
     m_ui->supportKphFields->setChecked(settings->supportKphFields());
     m_ui->noMigrationPrompt->setChecked(settings->noMigrationPrompt());
     m_ui->useCustomProxy->setChecked(settings->useCustomProxy());
-    if (settings->customProxyLocation().isEmpty()) {
-        // if custom proxy path was never set (or reset to "non-custom")
-        //  - set it to the default install path
-        m_ui->customProxyLocation->setText(settings->replaceHomePath(settings->proxyLocationAsInstalled()));
-    } else {
-        // otherwise use the custom user setting
-        m_ui->customProxyLocation->setText(settings->replaceHomePath(settings->customProxyLocation()));
-    }
+    m_ui->customProxyLocation->setText(settings->replaceHomePath(settings->customProxyLocation()));
     m_ui->updateBinaryPath->setChecked(settings->updateBinaryPath());
     m_ui->allowGetDatabaseEntriesRequest->setChecked(settings->allowGetDatabaseEntriesRequest());
     m_ui->allowExpiredCredentials->setChecked(settings->allowExpiredCredentials());

--- a/src/browser/BrowserSettingsWidget.h
+++ b/src/browser/BrowserSettingsWidget.h
@@ -32,7 +32,7 @@ class BrowserSettingsWidget : public QWidget
 
 public:
     explicit BrowserSettingsWidget(QWidget* parent = nullptr);
-    ~BrowserSettingsWidget();
+    ~BrowserSettingsWidget() override;
 
 public slots:
     void loadSettings();
@@ -40,11 +40,12 @@ public slots:
 
 private slots:
     void showProxyLocationFileDialog();
-    void validateCustomProxyLocation();
     void validateProxyLocation();
     void showCustomBrowserLocationFileDialog();
 
 private:
+    QString resolveCustomProxyLocation();
+
     QScopedPointer<Ui::BrowserSettingsWidget> m_ui;
 };
 

--- a/src/browser/BrowserSettingsWidget.h
+++ b/src/browser/BrowserSettingsWidget.h
@@ -41,6 +41,7 @@ public slots:
 private slots:
     void showProxyLocationFileDialog();
     void validateCustomProxyLocation();
+    void validateProxyLocation();
     void showCustomBrowserLocationFileDialog();
 
 private:

--- a/src/browser/BrowserSettingsWidget.ui
+++ b/src/browser/BrowserSettingsWidget.ui
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="MessageWidget" name="browserGlobalWarningWidget" native="true"/>
+    <widget class="MessageWidget" name="messageWidget" native="true"/>
    </item>
    <item>
     <widget class="QCheckBox" name="enableBrowserSupport">
@@ -267,12 +267,15 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
-        <widget class="MessageWidget" name="warningWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+        <widget class="MessageWidget" name="advancedMessageWidget" native="true">
+         <property name="text" stdset="0">
+          <string>&lt;b&gt;Warning:&lt;/b&gt; Only adjust these settings if necessary.</string>
+         </property>
+         <property name="closeButtonVisible" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="messageType" stdset="0">
+          <number>2</number>
          </property>
         </widget>
        </item>

--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -272,17 +272,37 @@ QString constructFlatpakPath()
 #endif
 
 /**
- * Gets the path to keepassxc-proxy binary
+ * Gets the path to currently effective keepassxc-proxy binary
+ * This is the binary placement which will be "advertised" to
+ * external clients (for example to browsers)
  *
- * @param location Custom proxy path
  * @return path Path to keepassxc-proxy
  */
 QString NativeMessageInstaller::getProxyPath() const
 {
+    QString result;
     if (browserSettings()->useCustomProxy()) {
-        return browserSettings()->customProxyLocation();
+        result = browserSettings()->customProxyLocation();
+    } else {
+        result = getInstalledProxyPath();
     }
+    return result;
+}
 
+/**
+ * Gets the path to keepassxc-proxy binary
+ * at the time of the installation (as expected to be).
+ * This is different for different types of installations
+ * like Windows/Linux/snap/flatpak/appimage etc.
+ * External clients should not depend on this function.
+ * It is to be used only in places where the user configures
+ * the services (not in places that the service is used).
+ * That is, the function should be not completely public but "friend"
+ *
+ * @return Path to keepassxc-proxy at the time of the installation
+ */
+QString NativeMessageInstaller::getInstalledProxyPath() const
+{
     QString path;
 #if defined(KEEPASSXC_DIST_APPIMAGE)
     path = QProcessEnvironment::systemEnvironment().value("APPIMAGE");

--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -272,11 +272,7 @@ QString constructFlatpakPath()
 #endif
 
 /**
- * Gets the path to currently effective keepassxc-proxy binary
- * This is the binary placement which will be "advertised" to
- * external clients (for example to browsers)
- *
- * @return path Path to keepassxc-proxy
+ * Returns the effective proxy path used to build the native messaging JSON script
  */
 QString NativeMessageInstaller::getProxyPath() const
 {
@@ -290,16 +286,7 @@ QString NativeMessageInstaller::getProxyPath() const
 }
 
 /**
- * Gets the path to keepassxc-proxy binary
- * at the time of the installation (as expected to be).
- * This is different for different types of installations
- * like Windows/Linux/snap/flatpak/appimage etc.
- * External clients should not depend on this function.
- * It is to be used only in places where the user configures
- * the services (not in places that the service is used).
- * That is, the function should be not completely public but "friend"
- *
- * @return Path to keepassxc-proxy at the time of the installation
+ * Returns the original proxy path at the time of installation
  */
 QString NativeMessageInstaller::getInstalledProxyPath() const
 {

--- a/src/browser/NativeMessageInstaller.h
+++ b/src/browser/NativeMessageInstaller.h
@@ -33,6 +33,7 @@ public:
     bool isBrowserEnabled(BrowserShared::SupportedBrowsers browser);
 
     QString getProxyPath() const;
+    QString getInstalledProxyPath() const;
     void updateBinaryPaths();
 
 private:


### PR DESCRIPTION
A warning dialog-box pops up at startup stating that the proxy binary cannot be found. 

Practically, this is done when _updating native messaging manifests_ (that means checking happens not only on startup but also when advanced settings are changed). That is, if newly written settings results in no proxy found - then the warning dialog will popup also. 
If the _"updating of native messaging manifests"_ does not happen (Browser-Integration is off **or** a specific browser is not enabled etc.), then we assume that the user is advanced and intentionally sets up complex proxy strategy --> so checking is not done. 

## Screenshots
![image](https://user-images.githubusercontent.com/24902257/236056716-694ce962-3eb0-4bd7-b806-88a14f6f7600.png)


## Testing strategy
- Tested the application on KDE Neon and run all unit-tests on Linux.
- did not test on Windows


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ improvent of Browser Integration Feature (change that adds functionality)


