### PR TITLE
Add challenge-response support for Nitrokey 3

### DIFF
--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -19,6 +19,7 @@
 
 #include "core/Tools.h"
 #include "crypto/Random.h"
+#include <algorithm>
 
 // MSYS2 does not define these macros
 // So set them to the value used by pcsc-lite
@@ -245,43 +246,43 @@ namespace
             const SCUINT dwRecvBufferSize = dwRecvLength;
             rv = SCardTransmit(handle, pioSendPci, pbSendBuffer, dwSendLength, nullptr, pbRecvBuffer, &dwRecvLength);
 
+            if (dwRecvLength < 2) {
+                // Any valid response should be at least 2 bytes (response status)
+                // However the protocol itself could fail
+                return SCARD_E_UNEXPECTED;
+            }
+
             uint8_t SW1 = pbRecvBuffer[dwRecvLength - 2];
-            // Check for the MoreDataAvailable SW1 code. If present, send GetResponse command repeatedly, until success SW,
-            // or filling the receiving buffer.
+            // Check for the MoreDataAvailable SW1 code. If present, send GetResponse command repeatedly, until success
+            // SW, or filling the receiving buffer.
             if (SW1 == SW_MORE_DATA_HIGH) {
                 while (true) {
+                    if (dwRecvBufferSize < dwRecvLength) {
+                        // No free buffer space remaining
+                        return SCARD_E_UNEXPECTED;
+                    }
                     // Overwrite Status Word in the receiving buffer
                     dwRecvLength -= 2;
-                    // Use different buffer for sending GET_RESPONSE, and getting the remaining reply
-                    uint8_t pbRecvBuffer_sr[255] = {};
-                    SCUINT dwRecvLength_sr = sizeof pbRecvBuffer_sr;
-                    const uint8_t bRecvBufferSize = sizeof pbRecvBuffer_sr - 2;
-                    uint8_t pbSendBuffer_sr[] = {CLA_ISO, INS_GET_RESPONSE, 0, 0, bRecvBufferSize};
+                    SCUINT dwRecvLength_sr = dwRecvBufferSize - dwRecvLength; // at least 2 bytes for SW are available
+                    const uint8_t bRecvDataSize =
+                        std::clamp(dwRecvLength_sr - 2, static_cast<SCUINT>(0), static_cast<SCUINT>(255));
+                    uint8_t pbSendBuffer_sr[] = {CLA_ISO, INS_GET_RESPONSE, 0, 0, bRecvDataSize};
                     rv = SCardTransmit(handle,
                                        pioSendPci,
                                        pbSendBuffer_sr,
                                        sizeof pbSendBuffer_sr,
                                        nullptr,
-                                       pbRecvBuffer_sr,
+                                       pbRecvBuffer + dwRecvLength,
                                        &dwRecvLength_sr);
 
-                    // Check if any new data are received. Break if the smartcard's status is other than success,
+                    // Check if any new data are received. Break if the smart card's status is other than success,
                     // or no new bytes were received.
                     if (!(rv == SCARD_S_SUCCESS && dwRecvLength_sr >= 2)) {
                         break;
                     }
 
-                    // Abort if receiving buffer is too small
-                    if (dwRecvLength + dwRecvLength_sr > dwRecvBufferSize ){
-                        return SCARD_E_UNEXPECTED;
-                    }
-
-                    // Copy it all to the main receiving buffer
-                    memmove(pbRecvBuffer + dwRecvLength, pbRecvBuffer_sr, dwRecvLength_sr);
                     dwRecvLength += dwRecvLength_sr;
-                    SW1 = pbRecvBuffer_sr[dwRecvLength_sr - 2];
-                    // Clear the helper buffer before potential exit (TODO call the right clearing function)
-                    memset(pbRecvBuffer_sr, 0, sizeof pbRecvBuffer_sr);
+                    SW1 = pbRecvBuffer[dwRecvLength - 2];
                     // Break the loop if there is no continuation status
                     if (SW1 != SW_MORE_DATA_HIGH) {
                         break;
@@ -295,6 +296,8 @@ namespace
                     // However the protocol itself could fail
                     rv = SCARD_E_UNEXPECTED;
                 } else {
+                    const uint8_t SW_HIGH = pbRecvBuffer[dwRecvLength - 2];
+                    const uint8_t SW_LOW = pbRecvBuffer[dwRecvLength - 1];
                     if (pbRecvBuffer[dwRecvLength - 2] == SW_OK_HIGH && pbRecvBuffer[dwRecvLength - 1] == SW_OK_LOW) {
                         rv = SCARD_S_SUCCESS;
                     } else if (pbRecvBuffer[dwRecvLength - 2] == SW_PRECOND_HIGH

--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -298,16 +298,13 @@ namespace
                 } else {
                     const uint8_t SW_HIGH = pbRecvBuffer[dwRecvLength - 2];
                     const uint8_t SW_LOW = pbRecvBuffer[dwRecvLength - 1];
-                    if (pbRecvBuffer[dwRecvLength - 2] == SW_OK_HIGH && pbRecvBuffer[dwRecvLength - 1] == SW_OK_LOW) {
+                    if (SW_HIGH == SW_OK_HIGH && SW_LOW == SW_OK_LOW) {
                         rv = SCARD_S_SUCCESS;
-                    } else if (pbRecvBuffer[dwRecvLength - 2] == SW_PRECOND_HIGH
-                               && pbRecvBuffer[dwRecvLength - 1] == SW_PRECOND_LOW) {
+                    } else if (SW_HIGH == SW_PRECOND_HIGH && SW_LOW == SW_PRECOND_LOW) {
                         // This happens if the key requires eg. a button press or if the applet times out
                         // Solution: Re-present the card to the reader
                         rv = SCARD_W_CARD_NOT_AUTHENTICATED;
-                    } else if ((pbRecvBuffer[dwRecvLength - 2] == SW_NOTFOUND_HIGH
-                                && pbRecvBuffer[dwRecvLength - 1] == SW_NOTFOUND_LOW)
-                               || pbRecvBuffer[dwRecvLength - 2] == SW_UNSUP_HIGH) {
+                    } else if ((SW_HIGH == SW_NOTFOUND_HIGH && SW_LOW == SW_NOTFOUND_LOW) || SW_HIGH == SW_UNSUP_HIGH) {
                         // This happens eg. during a select command when the AID is not found
                         rv = SCARD_E_FILE_NOT_FOUND;
                     } else {

--- a/src/keys/drivers/YubiKeyInterfacePCSC.h
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.h
@@ -24,6 +24,7 @@
 
 #define CLA_ISO 0x00
 #define INS_SELECT 0xA4
+#define INS_GET_RESPONSE 0xC0
 #define SEL_APP_AID 0x04
 #define INS_API_REQ 0x01
 #define INS_STATUS 0x03
@@ -37,6 +38,7 @@
 #define SW_NOTFOUND_HIGH 0x6A
 #define SW_NOTFOUND_LOW 0x82
 #define SW_UNSUP_HIGH 0x6D
+#define SW_MORE_DATA_HIGH 0x61
 
 typedef QPair<SCARDHANDLE, QByteArray> SCardAID;
 
@@ -75,6 +77,7 @@ private:
     //  and also for compatible third-party ones. They will be tried one by one.
     const QList<QByteArray> m_aid_codes = {
         QByteArrayLiteral("\xA0\x00\x00\x05\x27\x20\x01"), // Yubico Yubikey
+        QByteArrayLiteral("\xA0\x00\x00\x05\x27\x21\x01"), // Yubico Yubikey OATH AID / Nitrokey 3 Secrets App
         QByteArrayLiteral("\xA0\x00\x00\x06\x17\x00\x07\x53\x4E\xAF\x01") // Fidesmo development
     };
 
@@ -109,7 +112,10 @@ private:
         {QByteArrayLiteral("\x3B\x80\x80\x01\x01"), "Fidesmo Card 2.0"},
         {QByteArrayLiteral("\x3B\x8A\x80\x01\x00\x31\xC1\x73\xC8\x40\x00\x00\x90\x00\x90"), "VivoKey Apex"},
         {QByteArrayLiteral("\x3B\x8D\x80\x01\x00\x31\xC1\x73\xC8\x40\x00\x52\xA5\x10\x00\x90\x00\x70"),
-         "Dangerous Things FlexSecure"}};
+         "Dangerous Things FlexSecure"},
+        {QByteArrayLiteral("\x3b\x8f\x01\x80\x5d\x4e\x69\x74\x72\x6f\x6b\x65\x79\x00\x00\x00\x00\x00\x6a"),
+         "Nitrokey 3"},
+    };
 };
 
 #endif // KEEPASSX_YUBIKEY_INTERFACE_PCSC_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Add challenge-response support for Nitrokey 3. 

In detail:
- Add Get Response call when `More Available / 0x61 SW1` is received
- Increase buffer for answer to select call (required for Nitrokey 3)
- Small refactorization for reading the SW

Example log for selecting app with `More Available / Get Response` used below:
```
00009450 APDU: 00 A4 04 00 07 A0 00 00 05 27 20 01
00001675 SW: 6A 82
00000071 APDU: 00 A4 04 00 07 A0 00 00 05 27 21 01
00057807 SW: 61 0F
00000037 APDU: 00 C0 00 00 FF
00000893 SW: 79 03 04 0B 00 71 08 3C 73 5F 60 F2 03 EB 0D 90 00
```


To test:
- [x] Yubikey behavior for that change.  The Nitrokey 3's application responsible for challenge-response is   `QByteArrayLiteral("\xA0\x00\x00\x05\x27\x21\x01")`, which is Yubikey's OATH AID. Check if that could make any conflict.
    - Yubikey behaves normally - tests are passing.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![image](https://user-images.githubusercontent.com/17005426/236506823-7b08a136-43d0-44f6-ae5b-1f884c7e2207.png)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
1. Test creating database (manual)
2. Test opening database (manual)`

Automatic tests: `testykchallengeresponsekey` (built with ASAN)
```
~/w/3/k/c/tests (support-challenge-response-in-nitrokey3|✚2) $ ./testykchallengeresponsekey
********* Start testing of TestYubiKeyChallengeResponse *********
Config: Using QtTest library 5.15.9, Qt 5.15.9 (x86_64-little_endian-lp64 shared (dynamic) release build;
by GCC 13.0.1 20230401 (Red Hat 13.0.1-0)), fedora 38
PASS   : TestYubiKeyChallengeResponse::initTestCase()
PASS   : TestYubiKeyChallengeResponse::testDetectDevices()
PASS   : TestYubiKeyChallengeResponse::testKeyChallenge()
PASS   : TestYubiKeyChallengeResponse::cleanupTestCase()
Totals: 4 passed, 0 failed, 0 skipped, 0 blacklisted, 1336ms
********* Finished testing of TestYubiKeyChallengeResponse *********
```
This PR was tested against:
- Nitrokey 3 (unreleased firmware, based on v1.4), and
-  YubiKey 4 (4.3.5) [OTP+FIDO+CCID] Serial: 5668784

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
