### PR TITLE
Greatly improve performance when rendering entry view

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -997,19 +997,19 @@ void Entry::updateModifiedSinceBegin()
 
 QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxDepth) const
 {
+    static QRegularExpression placeholderRegEx("(\\{[^\\}]+?\\})", QRegularExpression::CaseInsensitiveOption);
+
     if (maxDepth <= 0) {
         qWarning("Maximum depth of replacement has been reached. Entry uuid: %s", uuid().toString().toLatin1().data());
         return str;
     }
 
     QString result = str;
-    QRegExp placeholderRegEx("(\\{[^\\}]+\\})", Qt::CaseInsensitive, QRegExp::RegExp2);
-    placeholderRegEx.setMinimal(true);
-    int pos = 0;
-    while ((pos = placeholderRegEx.indexIn(str, pos)) != -1) {
-        const QString found = placeholderRegEx.cap(1);
+    auto matches = placeholderRegEx.globalMatch(str);
+    while (matches.hasNext()) {
+        auto match = matches.next();
+        const auto found = match.captured(1);
         result.replace(found, resolvePlaceholderRecursive(found, maxDepth - 1));
-        pos += placeholderRegEx.matchedLength();
     }
 
     if (result != str) {

--- a/src/gui/SortFilterHideProxyModel.cpp
+++ b/src/gui/SortFilterHideProxyModel.cpp
@@ -16,11 +16,11 @@
  */
 
 #include "SortFilterHideProxyModel.h"
-#include <QCollator>
 
 SortFilterHideProxyModel::SortFilterHideProxyModel(QObject* parent)
     : QSortFilterProxyModel(parent)
 {
+    m_collator.setNumericMode(true);
 }
 
 Qt::DropActions SortFilterHideProxyModel::supportedDragActions() const
@@ -38,7 +38,7 @@ void SortFilterHideProxyModel::hideColumn(int column, bool hide)
 
 bool SortFilterHideProxyModel::filterAcceptsColumn(int sourceColumn, const QModelIndex& sourceParent) const
 {
-    Q_UNUSED(sourceParent);
+    Q_UNUSED(sourceParent)
 
     return sourceColumn >= m_hiddenColumns.size() || !m_hiddenColumns.at(sourceColumn);
 }
@@ -48,9 +48,7 @@ bool SortFilterHideProxyModel::lessThan(const QModelIndex& left, const QModelInd
     auto leftData = sourceModel()->data(left, sortRole());
     auto rightData = sourceModel()->data(right, sortRole());
     if (leftData.type() == QVariant::String) {
-        QCollator sorter;
-        sorter.setNumericMode(true);
-        return sorter.compare(leftData.toString(), rightData.toString()) < 0;
+        return m_collator.compare(leftData.toString(), rightData.toString()) < 0;
     }
 
     return QSortFilterProxyModel::lessThan(left, right);

--- a/src/gui/SortFilterHideProxyModel.h
+++ b/src/gui/SortFilterHideProxyModel.h
@@ -19,6 +19,7 @@
 #define KEEPASSX_SORTFILTERHIDEPROXYMODEL_H
 
 #include <QBitArray>
+#include <QCollator>
 #include <QSortFilterProxyModel>
 
 class SortFilterHideProxyModel : public QSortFilterProxyModel
@@ -36,6 +37,7 @@ protected:
 
 private:
     QBitArray m_hiddenColumns;
+    QCollator m_collator;
 };
 
 #endif // KEEPASSX_SORTFILTERHIDEPROXYMODEL_H

--- a/src/sshagent/KeeAgentSettings.cpp
+++ b/src/sshagent/KeeAgentSettings.cpp
@@ -355,7 +355,11 @@ bool KeeAgentSettings::inEntryAttachments(const EntryAttachments* attachments)
  */
 bool KeeAgentSettings::fromEntry(const Entry* entry)
 {
-    return fromXml(entry->attachments()->value("KeeAgent.settings"));
+    const auto attachments = entry->attachments();
+    if (attachments->hasKey("KeeAgent.settings")) {
+        return fromXml(attachments->value("KeeAgent.settings"));
+    }
+    return false;
 }
 
 /**


### PR DESCRIPTION
* Fixes #9390
* Create one QCollator per entry view instead of creating one on every sort request. This greatly improves the speed of sorting and displaying entries.
* Rewrite recursive multiple placeholder replacement to use QRegularExpression

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested using a database that has 10,000 entries in the root group. Before these changes the database took 10 seconds to open or perform a search. After these changes the database takes 1 second to open (KDF time) and search is nearly instant.

Password is `a`:
[BigData_kdbx.zip](https://github.com/keepassxreboot/keepassxc/files/11412568/BigData_kdbx.zip)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
