### PR TITLE
Fix displaying escaped characters in message boxes

### DIFF
--- a/src/gui/MessageBox.cpp
+++ b/src/gui/MessageBox.cpp
@@ -88,6 +88,7 @@ MessageBox::Button MessageBox::messageBox(QWidget* parent,
 {
     if (m_nextAnswer == MessageBox::NoButton) {
         QMessageBox msgBox(parent);
+        msgBox.setTextFormat(Qt::RichText);
         msgBox.setIcon(icon);
         msgBox.setWindowTitle(title);
         msgBox.setText(text);


### PR DESCRIPTION
…val dialog

I changed the TextType in MessageBox class to plain text so as to display the & character correctly and prevent HTML injection.
Fixes #9356

## Screenshots
![image](https://github.com/keepassxreboot/keepassxc/assets/59435262/85f72f69-c74a-47d8-92a2-a825b812ecd1)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Breaking change (causes existing functionality to change)