### PR TITLE
fix snap build. add libfreetype-dev and libfreetype6 as required pack…

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ apps:
     command: usr/bin/keepassxc-proxy
     extensions: [kde-neon]
     plugs: [home]
-    
+
 slots:
   session-dbus-interface:
     interface: dbus
@@ -53,6 +53,7 @@ parts:
       - libxi-dev
       - libxtst-dev
       - asciidoctor
+      - libfreetype-dev
     stage-packages:
       - dbus
       - libbotan-2-19
@@ -62,4 +63,10 @@ parts:
       - libpcsclite1
       - libminizip1
       - libxtst6
+      - libfreetype6
       - xclip
+lint:
+  ignore:
+    - library:
+      - lib/**/libhistory.so*
+


### PR DESCRIPTION
Adds libfreetype-dev and libfreetype6 to the required stage/build packages.
Adds an exception for the library linter to not to complain about unused /libhistory.so
Fixes the snap build process.
Fixes #9487

## Testing strategy
Built the snap with snapcraft

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

