### PR TITLE
Remember sort order in Autotype popup dialog (WIP)

### DIFF
--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -85,6 +85,10 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     connect(m_ui->action, &QToolButton::clicked, this, &AutoTypeSelectDialog::activateCurrentMatch);
 
     connect(m_ui->cancelButton, SIGNAL(clicked()), SLOT(reject()));
+
+    auto sortColumn = config()->get(Config::AutoTypeDialogSortColumn).toInt();
+    auto sortOrder = config()->get(Config::AutoTypeDialogSortOrder).toInt();
+    m_ui->view->sortByColumn(sortColumn, sortOrder == 0 ? Qt::AscendingOrder : Qt::DescendingOrder);
 }
 
 // Required for QScopedPointer
@@ -397,6 +401,8 @@ void AutoTypeSelectDialog::showEvent(QShowEvent* event)
 void AutoTypeSelectDialog::hideEvent(QHideEvent* event)
 {
     config()->set(Config::GUI_AutoTypeSelectDialogSize, size());
+    config()->set(Config::AutoTypeDialogSortColumn, m_ui->view->horizontalHeader()->sortIndicatorSection());
+    config()->set(Config::AutoTypeDialogSortOrder, m_ui->view->horizontalHeader()->sortIndicatorOrder());
     if (!m_accepted) {
         emit rejected();
     }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -77,6 +77,8 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::AutoTypeDelay,{QS("AutoTypeDelay"), Roaming, 25}},
     {Config::AutoTypeStartDelay,{QS("AutoTypeStartDelay"), Roaming, 500}},
     {Config::AutoTypeHideExpiredEntry,{QS("AutoTypeHideExpiredEntry"), Roaming, false}},
+    {Config::AutoTypeDialogSortColumn,{QS("AutoTypeDialogSortColumn"), Roaming, 0}},
+    {Config::AutoTypeDialogSortOrder,{QS("AutoTypeDialogSortOrder"), Roaming, Qt::AscendingOrder}},
     {Config::GlobalAutoTypeKey,{QS("GlobalAutoTypeKey"), Roaming, 0}},
     {Config::GlobalAutoTypeModifiers,{QS("GlobalAutoTypeModifiers"), Roaming, 0}},
     {Config::GlobalAutoTypeRetypeTime,{QS("GlobalAutoTypeRetypeTime"), Roaming, 15}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -60,6 +60,8 @@ public:
         AutoTypeDelay,
         AutoTypeStartDelay,
         AutoTypeHideExpiredEntry,
+        AutoTypeDialogSortColumn,
+        AutoTypeDialogSortOrder,
         GlobalAutoTypeKey,
         GlobalAutoTypeModifiers,
         GlobalAutoTypeRetypeTime,


### PR DESCRIPTION
Fixes #1684.

I hope to add screenshots and unit tests later.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
I tested as follows:

1. Created a database with two entries
2. Used the global auto-type shortcut key
3. Clicked on a column header to set the sort order
4. Closed the auto-type popup
5. Used the global auto-type shortcut key again
6. Checked that the sort order and column were still the same

[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

