### PR TITLE
Add uuid search

### DIFF
--- a/src/core/EntrySearcher.cpp
+++ b/src/core/EntrySearcher.cpp
@@ -218,6 +218,9 @@ bool EntrySearcher::searchEntryImpl(const Entry* entry)
             }
             found = false;
             break;
+        case Field::Uuid:
+            found = term.regex.match(entry->uuidToHex()).hasMatch();
+            break;
         default:
             // Terms without a specific field try to match title, username, url, and notes
             found = term.regex.match(entry->resolvePlaceholder(entry->title())).hasMatch()
@@ -253,7 +256,8 @@ void EntrySearcher::parseSearchTerms(const QString& searchString)
         {QStringLiteral("url"), Field::Url},
         {QStringLiteral("group"), Field::Group},
         {QStringLiteral("tag"), Field::Tag},
-        {QStringLiteral("is"), Field::Is}};
+        {QStringLiteral("is"), Field::Is},
+        {QStringLiteral("uuid"), Field::Uuid}};
 
     // Group 1 = modifiers, Group 2 = field, Group 3 = quoted string, Group 4 = unquoted string
     static QRegularExpression termParser(R"re(([-!*+]+)?(?:(\w*):)?(?:(?=")"((?:[^"\\]|\\.)*)"|([^ ]*))( |$))re");

--- a/src/core/EntrySearcher.h
+++ b/src/core/EntrySearcher.h
@@ -40,7 +40,8 @@ public:
         AttributeValue,
         Group,
         Tag,
-        Is
+        Is,
+        Uuid
     };
 
     struct SearchTerm

--- a/src/gui/SearchHelpWidget.ui
+++ b/src/gui/SearchHelpWidget.ui
@@ -214,6 +214,13 @@
           </property>
          </widget>
         </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_17">
+          <property name="text">
+           <string notr="true">uuid</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="1">
          <widget class="QLabel" name="label_5">
           <property name="text">

--- a/tests/TestEntrySearcher.cpp
+++ b/tests/TestEntrySearcher.cpp
@@ -17,6 +17,7 @@
 
 #include "TestEntrySearcher.h"
 #include "core/Group.h"
+#include "core/Tools.h"
 
 #include <QTest>
 
@@ -371,4 +372,25 @@ void TestEntrySearcher::testSkipProtected()
     m_searchResult =
         m_entrySearcher.search("_testAttribute:testE1 _testProtected:apple _testAttribute:testE2", m_rootGroup);
     QCOMPARE(m_searchResult, {});
+}
+
+void TestEntrySearcher::testUUIDSearch()
+{
+    auto entry1 = new Entry();
+    entry1->setGroup(m_rootGroup);
+    entry1->setTitle("testTitle");
+    auto uuid1 = QUuid::createUuid();
+    entry1->setUuid(uuid1);
+
+    auto entry2 = new Entry();
+    entry2->setGroup(m_rootGroup);
+    entry2->setTitle("testTitle2");
+    auto uuid2 = QUuid::createUuid();
+    entry2->setUuid(uuid2);
+
+    m_searchResult = m_entrySearcher.search("uuid:", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 2);
+
+    m_searchResult = m_entrySearcher.search("uuid:" + Tools::uuidToHex(uuid1), m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 1);
 }

--- a/tests/TestEntrySearcher.h
+++ b/tests/TestEntrySearcher.h
@@ -38,6 +38,7 @@ private slots:
     void testCustomAttributesAreSearched();
     void testGroup();
     void testSkipProtected();
+    void testUUIDSearch();
 
 private:
     Group* m_rootGroup;


### PR DESCRIPTION
* Allow searching by uuid using the `uuid:` field.

Helps with #1963


## Screenshots

before
![before](https://github.com/keepassxreboot/keepassxc/assets/33117017/c9a1eb88-d4f8-4032-ad3a-a7850c4b099b)

after
![after](https://github.com/keepassxreboot/keepassxc/assets/33117017/7f9bcdc0-cdf3-4617-8d03-353bd7dc9b6e)



## Testing strategy



## Type of change
- ✅ New feature (change that adds functionality)
