### PR TITLE
Add warning for duplicate URLs with Additional URLs list

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3919,6 +3919,10 @@ Error: %1</source>
         <source>Invalid URL</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Duplicate URL</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EntryView</name>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -326,17 +326,18 @@ void EditEntryWidget::insertURL()
 {
     Q_ASSERT(!m_history);
 
-    QString name("KP2A_URL");
+    QString name(BrowserService::ADDITIONAL_URL);
     int i = 1;
 
     while (m_entryAttributes->keys().contains(name)) {
-        name = QString("KP2A_URL_%1").arg(i);
+        name = QString("%1_%2").arg(BrowserService::ADDITIONAL_URL, QString::number(i));
         i++;
     }
 
     m_entryAttributes->set(name, tr("<empty URL>"));
     QModelIndex index = m_additionalURLsDataModel->indexByKey(name);
 
+    m_additionalURLsDataModel->setEntryUrl(m_entry->url());
     m_browserUi->additionalURLsView->setCurrentIndex(index);
     m_browserUi->additionalURLsView->edit(index);
 

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 #include "EntryURLModel.h"
 
+#include "browser/BrowserService.h"
 #include "core/EntryAttributes.h"
 #include "core/Tools.h"
 #include "gui/Icons.h"
@@ -68,18 +69,31 @@ QVariant EntryURLModel::data(const QModelIndex& index, int role) const
     const auto value = m_entryAttributes->value(key);
     const auto urlValid = Tools::checkUrlValid(value);
 
-    if (role == Qt::BackgroundRole && !urlValid) {
+    // Check for duplicate URLs in the attribute list
+    auto customKeys = m_entryAttributes->customKeys();
+    customKeys.removeOne(key);
+    const auto values = m_entryAttributes->values(customKeys);
+    const auto duplicateUrl = values.contains(value) || value == m_entryUrl;
+
+    if (role == Qt::BackgroundRole && (!urlValid || duplicateUrl)) {
         StateColorPalette statePalette;
         return statePalette.color(StateColorPalette::ColorRole::Error);
-    } else if (role == Qt::DecorationRole && !urlValid) {
+    } else if (role == Qt::DecorationRole && (!urlValid || duplicateUrl)) {
         return m_errorIcon;
     } else if (role == Qt::DisplayRole || role == Qt::EditRole) {
         return value;
+    } else if (role == Qt::ToolTipRole && duplicateUrl) {
+        return tr("Duplicate URL");
     } else if (role == Qt::ToolTipRole && !urlValid) {
         return tr("Invalid URL");
     }
 
     return {};
+}
+
+void EntryURLModel::setEntryUrl(const QString& entryUrl)
+{
+    m_entryUrl = entryUrl;
 }
 
 bool EntryURLModel::setData(const QModelIndex& index, const QVariant& value, int role)
@@ -88,11 +102,10 @@ bool EntryURLModel::setData(const QModelIndex& index, const QVariant& value, int
         return false;
     }
 
-    const int row = index.row();
-    const QString key = m_urls.at(row).first;
-    const QString oldValue = m_urls.at(row).second;
+    const auto row = index.row();
+    const auto key = m_urls.at(row).first;
 
-    if (EntryAttributes::isDefaultAttribute(key) || m_entryAttributes->containsValue(value.toString())) {
+    if (EntryAttributes::isDefaultAttribute(key)) {
         return false;
     }
 
@@ -113,7 +126,7 @@ QModelIndex EntryURLModel::indexByKey(const QString& key) const
     }
 
     if (row == -1) {
-        return QModelIndex();
+        return {};
     } else {
         return index(row, 0);
     }
@@ -122,7 +135,7 @@ QModelIndex EntryURLModel::indexByKey(const QString& key) const
 QString EntryURLModel::keyByIndex(const QModelIndex& index) const
 {
     if (!index.isValid()) {
-        return QString();
+        return {};
     } else {
         return m_urls.at(index.row()).first;
     }
@@ -133,9 +146,9 @@ void EntryURLModel::updateAttributes()
     clear();
     m_urls.clear();
 
-    const QList<QString> attributesKeyList = m_entryAttributes->keys();
-    for (const QString& key : attributesKeyList) {
-        if (!EntryAttributes::isDefaultAttribute(key) && key.contains("KP2A_URL")) {
+    const auto attributesKeyList = m_entryAttributes->keys();
+    for (const auto& key : attributesKeyList) {
+        if (!EntryAttributes::isDefaultAttribute(key) && key.contains(BrowserService::ADDITIONAL_URL)) {
             const auto value = m_entryAttributes->value(key);
             m_urls.append(qMakePair(key, value));
 

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -54,7 +54,7 @@ void EntryURLModel::setEntryAttributes(EntryAttributes* entryAttributes)
 
     endResetModel();
 }
-
+#include <QDebug>
 QVariant EntryURLModel::data(const QModelIndex& index, int role) const
 {
     if (!index.isValid()) {
@@ -69,11 +69,10 @@ QVariant EntryURLModel::data(const QModelIndex& index, int role) const
     const auto value = m_entryAttributes->value(key);
     const auto urlValid = Tools::checkUrlValid(value);
 
-    // Check for duplicate URLs in the attribute list
-    auto customKeys = m_entryAttributes->customKeys();
-    customKeys.removeOne(key);
-    const auto values = m_entryAttributes->values(customKeys);
-    const auto duplicateUrl = values.contains(value) || value == m_entryUrl;
+    // Check for duplicate URLs in the attribute list. Excludes the current key/value from the comparison.
+    auto customAttributeKeys = m_entryAttributes->customKeys();
+    customAttributeKeys.removeOne(key);
+    const auto duplicateUrl = m_entryAttributes->values(customAttributeKeys).contains(value) || value == m_entryUrl;
 
     if (role == Qt::BackgroundRole && (!urlValid || duplicateUrl)) {
         StateColorPalette statePalette;

--- a/src/gui/entry/EntryURLModel.h
+++ b/src/gui/entry/EntryURLModel.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 #ifndef KEEPASSXC_ENTRYURLMODEL_H
 #define KEEPASSXC_ENTRYURLMODEL_H
 
+#include "core/Entry.h"
 #include <QStandardItemModel>
 #include <QStyledItemDelegate>
 
@@ -43,8 +44,10 @@ class EntryURLModel : public QStandardItemModel
 
 public:
     explicit EntryURLModel(QObject* parent = nullptr);
+
     void setEntryAttributes(EntryAttributes* entryAttributes);
     void insertRow(const QString& key, const QString& value);
+    void setEntryUrl(const QString& entryUrl);
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
     QVariant data(const QModelIndex& index, int role) const override;
     QModelIndex indexByKey(const QString& key) const;
@@ -57,6 +60,7 @@ private:
     QList<QPair<QString, QString>> m_urls;
     EntryAttributes* m_entryAttributes;
     QIcon m_errorIcon;
+    QString m_entryUrl;
 };
 
 #endif // KEEPASSXC_ENTRYURLMODEL_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds a warning when a duplicate URL is inserted to Additional URLs list if the following criteria is met:
- Added URL is identical to the entry URL
- Added URL is already in the Additional URLs list

A new tooltip text is added for the warning. Previously a duplicate URL was changed back to `<empty URL>` without any warning or indication to the user that the entered URL already exists.

Fixes #7287.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
<img width="759" alt="Screenshot 2023-06-28 at 9 41 27" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/85b87227-73ed-49f9-bde0-477766e265d6">

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
