### PR TITLE
Handle expired credentials normally

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -911,8 +911,8 @@ QJsonObject BrowserService::prepareEntry(const Entry* entry)
 BrowserService::Access
 BrowserService::checkAccess(const Entry* entry, const QString& siteHost, const QString& formHost, const QString& realm)
 {
-    if (entry->isExpired()) {
-        return browserSettings()->allowExpiredCredentials() ? Unknown : Denied;
+    if (entry->isExpired() && !browserSettings()->allowExpiredCredentials()) {
+        return Denied;
     }
 
     BrowserEntryConfig config;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Expired credentials always trigger the Access Confirm Dialog even if the entry has been allowed to the site. Expired credentials should respect the saved setting, or ask for confirmation when needed.
The browser extension will show `[Expired]` at the end of the entry in Autocomplete Menu and Login Popup, so the status already shown to the user.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)