### PR TITLE
Update .clang-format wtih C++17 standard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,7 +81,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        c++17
 TabWidth:        4
 UseTab:          Never
 ...


### PR DESCRIPTION
The standard name "Cpp11" [is no longer a valid option in clang-format](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#standard), it is now supposed to be "c++11", but we are on c++17 now, so change to that.
