### PR TITLE
Improve duplicate URL warning

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -544,6 +544,33 @@ bool BrowserService::isPasswordGeneratorRequested() const
     return m_passwordGeneratorRequested;
 }
 
+// Returns true if URLs are identical. Paths with "/" are removed during comparison.
+// URLs without scheme reverts to https.
+// Special handling is needed because QUrl::matches() with QUrl::StripTrailingSlash does not strip "/" paths.
+bool BrowserService::isUrlIdentical(const QString& first, const QString& second) const
+{
+    auto trimUrl = [](QString url) {
+        url = url.trimmed();
+        if (url.endsWith("/")) {
+            url.remove(url.length() - 1, 1);
+        }
+
+        return url;
+    };
+
+    if (first.isEmpty() || second.isEmpty()) {
+        return false;
+    }
+
+    const auto firstUrl = trimUrl(first);
+    const auto secondUrl = trimUrl(second);
+    if (firstUrl == secondUrl) {
+        return true;
+    }
+
+    return QUrl(firstUrl).matches(QUrl(secondUrl), QUrl::StripTrailingSlash);
+}
+
 QString BrowserService::storeKey(const QString& key)
 {
     auto db = getDatabase();

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -82,6 +82,7 @@ public:
     QString getCurrentTotp(const QString& uuid);
     void showPasswordGenerator(const KeyPairMessage& keyPairMessage);
     bool isPasswordGeneratorRequested() const;
+    bool isUrlIdentical(const QString& first, const QString& second) const;
 
     void addEntry(const EntryParameters& entryParameters,
                   const QString& group,

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -161,6 +161,9 @@ void EditEntryWidget::setupMain()
     connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), m_iconsWidget, SLOT(setUrl(QString)));
     m_mainUi->urlEdit->enableVerifyMode();
 #endif
+#ifdef WITH_XC_BROWSER
+    connect(m_mainUi->urlEdit, SIGNAL(textChanged(QString)), this, SLOT(entryURLEdited(const QString&)));
+#endif
     connect(m_mainUi->expireCheck, &QCheckBox::toggled, [&](bool enabled) {
         m_mainUi->expireDatePicker->setEnabled(enabled);
         if (enabled) {
@@ -397,6 +400,11 @@ void EditEntryWidget::updateCurrentURL()
         m_browserUi->editURLButton->setEnabled(false);
         m_browserUi->removeURLButton->setEnabled(false);
     }
+}
+
+void EditEntryWidget::entryURLEdited(const QString& url)
+{
+    m_additionalURLsDataModel->setEntryUrl(url);
 }
 #endif
 

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -132,6 +132,7 @@ private slots:
     void removeCurrentURL();
     void editCurrentURL();
     void updateCurrentURL();
+    void entryURLEdited(const QString& url);
 #endif
 
 private:

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -73,7 +73,8 @@ QVariant EntryURLModel::data(const QModelIndex& index, int role) const
     auto customAttributeKeys = m_entryAttributes->customKeys().filter(BrowserService::ADDITIONAL_URL);
     customAttributeKeys.removeOne(key);
 
-    const auto duplicateUrl = m_entryAttributes->values(customAttributeKeys).contains(value) || value == m_entryUrl;
+    const auto duplicateUrl = m_entryAttributes->values(customAttributeKeys).contains(value)
+                              || browserService()->isUrlIdentical(value, m_entryUrl);
 
     if (role == Qt::BackgroundRole && (!urlValid || duplicateUrl)) {
         StateColorPalette statePalette;

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -75,7 +75,6 @@ QVariant EntryURLModel::data(const QModelIndex& index, int role) const
 
     const auto duplicateUrl = m_entryAttributes->values(customAttributeKeys).contains(value)
                               || browserService()->isUrlIdentical(value, m_entryUrl);
-
     if (role == Qt::BackgroundRole && (!urlValid || duplicateUrl)) {
         StateColorPalette statePalette;
         return statePalette.color(StateColorPalette::ColorRole::Error);

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -54,7 +54,7 @@ void EntryURLModel::setEntryAttributes(EntryAttributes* entryAttributes)
 
     endResetModel();
 }
-#include <QDebug>
+
 QVariant EntryURLModel::data(const QModelIndex& index, int role) const
 {
     if (!index.isValid()) {

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -70,8 +70,9 @@ QVariant EntryURLModel::data(const QModelIndex& index, int role) const
     const auto urlValid = Tools::checkUrlValid(value);
 
     // Check for duplicate URLs in the attribute list. Excludes the current key/value from the comparison.
-    auto customAttributeKeys = m_entryAttributes->customKeys();
+    auto customAttributeKeys = m_entryAttributes->customKeys().filter(BrowserService::ADDITIONAL_URL);
     customAttributeKeys.removeOne(key);
+
     const auto duplicateUrl = m_entryAttributes->values(customAttributeKeys).contains(value) || value == m_entryUrl;
 
     if (role == Qt::BackgroundRole && (!urlValid || duplicateUrl)) {

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -753,7 +753,7 @@ void TestBrowser::testIsUrlIdentical()
     QVERIFY(browserService()->isUrlIdentical("https://example.com/  ", "  https://example.com"));
     QVERIFY(!browserService()->isUrlIdentical("https://example.com/", "  example.com"));
     QVERIFY(browserService()->isUrlIdentical("https://example.com/path/to/nowhere",
-                                              "https://example.com/path/to/nowhere/"));
+                                             "https://example.com/path/to/nowhere/"));
     QVERIFY(!browserService()->isUrlIdentical("https://example.com/", "://example.com/"));
     QVERIFY(browserService()->isUrlIdentical("ftp://127.0.0.1/", "ftp://127.0.0.1"));
 }

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -741,3 +741,19 @@ void TestBrowser::testBestMatchingWithAdditionalURLs()
     QCOMPARE(sorted.length(), 1);
     QCOMPARE(sorted[0]->url(), urls[0]);
 }
+
+void TestBrowser::testIsUrlIdentical()
+{
+    QVERIFY(browserService()->isUrlIdentical("https://example.com", "https://example.com"));
+    QVERIFY(browserService()->isUrlIdentical("https://example.com", "  https://example.com  "));
+    QVERIFY(!browserService()->isUrlIdentical("https://example.com", "https://example2.com"));
+    QVERIFY(!browserService()->isUrlIdentical("https://example.com/", "https://example.com/#login"));
+    QVERIFY(browserService()->isUrlIdentical("https://example.com", "https://example.com/"));
+    QVERIFY(browserService()->isUrlIdentical("https://example.com/", "https://example.com"));
+    QVERIFY(browserService()->isUrlIdentical("https://example.com/  ", "  https://example.com"));
+    QVERIFY(!browserService()->isUrlIdentical("https://example.com/", "  example.com"));
+    QVERIFY(browserService()->isUrlIdentical("https://example.com/path/to/nowhere",
+                                              "https://example.com/path/to/nowhere/"));
+    QVERIFY(!browserService()->isUrlIdentical("https://example.com/", "://example.com/"));
+    QVERIFY(browserService()->isUrlIdentical("ftp://127.0.0.1/", "ftp://127.0.0.1"));
+}

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -52,6 +52,7 @@ private slots:
     void testValidURLs();
     void testBestMatchingCredentials();
     void testBestMatchingWithAdditionalURLs();
+    void testIsUrlIdentical();
 
 private:
     QList<Entry*> createEntries(QStringList& urls, Group* root) const;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Improves #9588 by deleting a obsolete include and enabling Additional URL list comparison when entry URL is edited but not saved. Previously editing an entry URL on-the-fly didn't update the Additional URL list's duplicate URL warnings.

Fixes #9670.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
