### PR TITLE
Allow configuring shortcuts

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -111,13 +111,6 @@
     </message>
 </context>
 <context>
-    <name>ActionCollection</name>
-    <message>
-        <source>Shortcut %3 conflicts with action &apos;%1&apos; with title &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>AgentSettingsWidget</name>
     <message>
         <source>Enable SSH Agent integration</source>
@@ -5164,15 +5157,7 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Create a new database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Merge From Database…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Merge from another KDBX database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5180,15 +5165,7 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Add a new entry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Edit Entry…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>View or edit entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5197,10 +5174,6 @@ Are you sure you want to continue with this file?</source>
     </message>
     <message>
         <source>&amp;New Group…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add a new group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5236,15 +5209,7 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Statistics, health check, etc.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Database Settings…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Database settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5256,15 +5221,7 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Move entry one step up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Move do&amp;wn</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move entry one step down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5272,15 +5229,7 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Copy username to clipboard</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Copy &amp;Password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy password to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5316,23 +5265,11 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Copy title to clipboard</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Copy &amp;URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Copy URL to clipboard</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Copy notes to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5348,23 +5285,11 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import a KeePass 1 database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>1Password Vault…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import a 1Password Vault</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>CSV File…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Import a CSV file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5409,10 +5334,6 @@ Are you sure you want to continue with this file?</source>
     </message>
     <message>
         <source>&amp;Online Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go to online documentation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5485,10 +5406,6 @@ Are you sure you want to continue with this file?</source>
     </message>
     <message>
         <source>&amp;XML File…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>XML File…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5582,11 +5499,251 @@ We recommend you use the AppImage available on our downloads page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Passkeys</source>
+        <source>Import Passkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import Passkey</source>
+        <source>Quit Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open About Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge From Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Download All Favicons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sort Groups A-Z</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sort Groups Z-A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Database As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Database Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Database Reports</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Database Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Passkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clone Entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Entry Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Entry Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Application Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Password Generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Perform Auto-Type: {USERNAME}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Perform Auto-Type: {USERNAME}{ENTER}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Perform Auto-Type: {PASSWORD}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Perform Auto-Type: {PASSWORD}{ENTER}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Perform Auto-Type: {TOTP}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to HTML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import KeePass1 Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import 1Password Vault</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import CSV File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show TOTP QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set up TOTP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Donation Website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Bug Report</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Online Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Keyboard Shortcuts Guide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Database Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SSH Agent: Add Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SSH Agent: Remove Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Compact Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Theme: Automatic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Theme: Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Theme: Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Theme: Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Show Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Show Preview Panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Always on Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Hide Usernames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Hide Passwords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export to XML</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Allow Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9173,15 +9330,19 @@ Kernel: %3 %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shortcut %3 conflicts with action &apos;%1&apos; with title &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Shortcut Conflict</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut %1 conflicts with &apos;%2&apos;. Overwrite shortcut?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -8227,63 +8227,15 @@ Kernel: %3 %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>AES initialization failed</source>
+        <source>Enter Shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>AES encrypt failed</source>
+        <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to store in Linux Keyring</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not locate key in keyring</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not read key in keyring</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>AES decrypt failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No Polkit authentication agent was available</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Polkit authorization failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No Quick Unlock provider is available</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Polkit returned an error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to init KeePassXC crypto.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to encrypt key data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to get Windows Hello credential.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to decrypt key data.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Passkeys</source>
+        <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8312,6 +8264,66 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Resident Keys are not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Passkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES initialization failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES encrypt failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to store in Linux Keyring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Polkit returned an error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not locate key in keyring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not read key in keyring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES decrypt failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Polkit authentication agent was available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Polkit authorization failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Quick Unlock provider is available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to init KeePassXC crypto.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to encrypt key data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get Windows Hello credential.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to decrypt key data.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9166,6 +9178,10 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Shortcut Conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -111,6 +111,13 @@
     </message>
 </context>
 <context>
+    <name>ActionCollection</name>
+    <message>
+        <source>Shortcut %3 conflicts with action &apos;%1&apos; with title &apos;%2&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AgentSettingsWidget</name>
     <message>
         <source>Enable SSH Agent integration</source>
@@ -9144,6 +9151,21 @@ Kernel: %3 %4</source>
     </message>
     <message>
         <source>Export to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutSettingsWidget</name>
+    <message>
+        <source>Double click an action to change its shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut %3 conflicts with action &apos;%1&apos; with title &apos;%2&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut Conflict</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,7 @@ set(keepassx_SOURCES
         gui/styles/dark/DarkStyle.cpp
         gui/styles/light/LightStyle.cpp
         gui/AboutDialog.cpp
+        gui/ActionCollection.cpp
         gui/Application.cpp
         gui/CategoryListWidget.cpp
         gui/Clipboard.cpp
@@ -130,6 +131,7 @@ set(keepassx_SOURCES
         gui/SearchWidget.cpp
         gui/SortFilterHideProxyModel.cpp
         gui/SquareSvgWidget.cpp
+        gui/ShortcutSettingsPage.cpp
         gui/TotpSetupDialog.cpp
         gui/TotpDialog.cpp
         gui/TotpExportSettingsDialog.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,6 +182,7 @@ set(keepassx_SOURCES
         gui/widgets/ElidedLabel.cpp
         gui/widgets/KPToolBar.cpp
         gui/widgets/PopupHelpWidget.cpp
+        gui/widgets/ShortcutWidget.cpp
         gui/wizard/NewDatabaseWizard.cpp
         gui/wizard/NewDatabaseWizardPage.cpp
         gui/wizard/NewDatabaseWizardPageMetaData.cpp
@@ -321,7 +322,6 @@ set(autotype_SOURCES
         autotype/AutoTypeMatchView.cpp
         autotype/AutoTypeSelectDialog.cpp
         autotype/PickcharsDialog.cpp
-        autotype/ShortcutWidget.cpp
         autotype/WindowSelectComboBox.cpp)
 
 if(WIN32)

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -597,11 +597,11 @@ void Config::createTempFileInstance()
     tmpFile->setParent(m_instance);
 }
 
-QVector<Config::ShortcutEntry> Config::getShortcuts() const
+QList<Config::ShortcutEntry> Config::getShortcuts() const
 {
     m_settings->beginGroup("Shortcuts");
     const auto keys = m_settings->childKeys();
-    QVector<Config::ShortcutEntry> ret;
+    QList<ShortcutEntry> ret;
     ret.reserve(keys.size());
     for (const auto& key : keys) {
         const auto shortcut = m_settings->value(key).toString();
@@ -611,7 +611,7 @@ QVector<Config::ShortcutEntry> Config::getShortcuts() const
     return ret;
 }
 
-void Config::setShortcuts(const QVector<ShortcutEntry>& shortcuts)
+void Config::setShortcuts(const QList<ShortcutEntry>& shortcuts)
 {
     m_settings->beginGroup("Shortcuts");
     m_settings->remove(""); // clear previous

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -597,4 +597,28 @@ void Config::createTempFileInstance()
     tmpFile->setParent(m_instance);
 }
 
+QVector<Config::ShortcutEntry> Config::getShortcuts() const
+{
+    m_settings->beginGroup("Shortcuts");
+    const auto keys = m_settings->childKeys();
+    QVector<Config::ShortcutEntry> ret;
+    ret.reserve(keys.size());
+    for (const auto& key : keys) {
+        const auto shortcut = m_settings->value(key).toString();
+        ret.push_back(ShortcutEntry{key, shortcut});
+    }
+    m_settings->endGroup();
+    return ret;
+}
+
+void Config::setShortcuts(const QVector<ShortcutEntry>& shortcuts)
+{
+    m_settings->beginGroup("Shortcuts");
+    m_settings->remove(""); // clear previous
+    for (const auto& shortcutEntry : shortcuts) {
+        m_settings->setValue(shortcutEntry.name, shortcutEntry.shortcut);
+    }
+    m_settings->endGroup();
+}
+
 #undef QS

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -21,6 +21,7 @@
 
 #include <QPointer>
 #include <QVariant>
+#include <QVector>
 
 class QSettings;
 
@@ -198,6 +199,12 @@ public:
         Deleted
     };
 
+    struct ShortcutEntry
+    {
+        QString name;
+        QString shortcut;
+    };
+
     ~Config() override;
     QVariant get(ConfigKey key);
     QVariant getDefault(ConfigKey key);
@@ -207,6 +214,8 @@ public:
     bool hasAccessError();
     void sync();
     void resetToDefaults();
+    QVector<ShortcutEntry> getShortcuts() const;
+    void setShortcuts(const QVector<ShortcutEntry>& shortcuts);
 
     static Config* instance();
     static void createConfigFromFile(const QString& configFileName, const QString& localConfigFileName = {});

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -214,8 +214,9 @@ public:
     bool hasAccessError();
     void sync();
     void resetToDefaults();
-    QVector<ShortcutEntry> getShortcuts() const;
-    void setShortcuts(const QVector<ShortcutEntry>& shortcuts);
+
+    QList<ShortcutEntry> getShortcuts() const;
+    void setShortcuts(const QList<ShortcutEntry>& shortcuts);
 
     static Config* instance();
     static void createConfigFromFile(const QString& configFileName, const QString& localConfigFileName = {});

--- a/src/gui/ActionCollection.cpp
+++ b/src/gui/ActionCollection.cpp
@@ -1,0 +1,135 @@
+#include "ActionCollection.h"
+#include "core/Config.h"
+
+#include <QDebug>
+
+static bool assert_not_exists(const QVector<QAction*>& actions, const QString& name)
+{
+    for (auto a : actions) {
+        if (a->objectName() == name) {
+            return false;
+        }
+    }
+    return true;
+}
+
+ActionCollection* ActionCollection::instance()
+{
+    static ActionCollection ac;
+    return &ac;
+}
+
+QAction* ActionCollection::action(const QString& name) const
+{
+    if (name.isEmpty()) {
+        qWarning() << Q_FUNC_INFO << "Unexpected empty action name";
+    }
+    for (auto* action : m_actions) {
+        if (action->objectName() == name) {
+            return action;
+        }
+    }
+    qWarning() << "Unexpected unable to find action " << name << "in ActionCollection. Should not happen";
+    return nullptr;
+}
+
+QAction* ActionCollection::addAction(const QString& name, QObject* parent)
+{
+    auto a = new QAction(parent);
+    a->setObjectName(name);
+    return addAction(a);
+}
+
+QAction* ActionCollection::addAction(QAction* action)
+{
+    if (action->objectName().isEmpty()) {
+        qWarning() << Q_FUNC_INFO << "'action name' should not be empty";
+        return nullptr;
+    }
+    Q_ASSERT(assert_not_exists(m_actions, action->objectName()));
+    m_actions << action;
+    return action;
+}
+
+void ActionCollection::addActions(const QVector<QAction*> actions)
+{
+    m_actions.reserve(m_actions.size() + actions.size());
+    for (auto a : actions) {
+        addAction(a);
+    }
+}
+
+QKeySequence ActionCollection::defaultShortcut(QAction* action) const
+{
+    const QList<QKeySequence> shortcuts = defaultShortcuts(action);
+    return shortcuts.isEmpty() ? QKeySequence() : shortcuts.first();
+}
+
+QList<QKeySequence> ActionCollection::defaultShortcuts(QAction* action) const
+{
+    Q_ASSERT(m_actions.contains(action));
+    return action->property("defaultShortcuts").value<QList<QKeySequence>>();
+}
+
+void ActionCollection::setDefaultShortcut(QAction* action, const QKeySequence& shortcut)
+{
+    setDefaultShortcuts(action, QList<QKeySequence>() << shortcut);
+}
+
+void ActionCollection::setDefaultShortcuts(QAction* action, const QList<QKeySequence>& shortcuts)
+{
+    Q_ASSERT(m_actions.contains(action));
+    action->setShortcuts(shortcuts);
+    action->setProperty("defaultShortcuts", QVariant::fromValue(shortcuts));
+}
+
+void ActionCollection::restoreShortcuts()
+{
+    const QVector<Config::ShortcutEntry> shortcuts = Config::instance()->getShortcuts();
+    QHash<QString, QAction*> actionsByName;
+    actionsByName.reserve(shortcuts.size());
+    for (auto action : m_actions) {
+        actionsByName[action->objectName()] = action;
+    }
+    for (const auto& shortcut : shortcuts) {
+        auto it = actionsByName.find(shortcut.name);
+        if (it == actionsByName.end()) {
+            qWarning() << "Unexpected " << shortcut.name << ", not found in actions";
+            continue;
+        }
+        const auto key = QKeySequence::fromString(shortcut.shortcut);
+        it.value()->setShortcut(key);
+    }
+}
+
+void ActionCollection::saveShortcuts()
+{
+    QVector<Config::ShortcutEntry> shortcuts;
+    shortcuts.reserve(m_actions.size());
+    for (auto a : m_actions) {
+        if (defaultShortcuts(a) == a->shortcuts()) {
+            continue;
+        }
+        shortcuts.push_back(Config::ShortcutEntry{a->objectName(), a->shortcut().toString()});
+    }
+    Config::instance()->setShortcuts(shortcuts);
+}
+
+QPair<bool, QAction*>
+ActionCollection::isConflictingShortcut(QAction* action, const QKeySequence& seq, QString& outMessage) const
+{
+    if (seq.isEmpty()) {
+        return {false, nullptr}; // Empty sequences don't conflict with anything
+    }
+    for (auto a : m_actions) {
+        if (a == action) {
+            continue;
+        }
+        if (a->shortcut() == seq) {
+            outMessage = tr("Shortcut %3 conflicts with action '%1' with title '%2'")
+                             .arg(a->objectName(), a->text(), seq.toString());
+            return {true, a};
+        }
+    }
+    return {false, nullptr};
+}

--- a/src/gui/ActionCollection.cpp
+++ b/src/gui/ActionCollection.cpp
@@ -1,17 +1,24 @@
+/*
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "ActionCollection.h"
 #include "core/Config.h"
 
 #include <QDebug>
-
-static bool assert_not_exists(const QVector<QAction*>& actions, const QString& name)
-{
-    for (auto a : actions) {
-        if (a->objectName() == name) {
-            return false;
-        }
-    }
-    return true;
-}
 
 ActionCollection* ActionCollection::instance()
 {
@@ -19,117 +26,98 @@ ActionCollection* ActionCollection::instance()
     return &ac;
 }
 
-QAction* ActionCollection::action(const QString& name) const
+QList<QAction*> ActionCollection::actions() const
 {
-    if (name.isEmpty()) {
-        qWarning() << Q_FUNC_INFO << "Unexpected empty action name";
-    }
-    for (auto* action : m_actions) {
-        if (action->objectName() == name) {
-            return action;
-        }
-    }
-    qWarning() << "Unexpected unable to find action " << name << "in ActionCollection. Should not happen";
-    return nullptr;
+    return m_actions;
 }
 
-QAction* ActionCollection::addAction(const QString& name, QObject* parent)
+void ActionCollection::addAction(QAction* action)
 {
-    auto a = new QAction(parent);
-    a->setObjectName(name);
-    return addAction(a);
-}
-
-QAction* ActionCollection::addAction(QAction* action)
-{
-    if (action->objectName().isEmpty()) {
-        qWarning() << Q_FUNC_INFO << "'action name' should not be empty";
-        return nullptr;
+    if (!m_actions.contains(action)) {
+        m_actions << action;
     }
-    Q_ASSERT(assert_not_exists(m_actions, action->objectName()));
-    m_actions << action;
-    return action;
 }
 
-void ActionCollection::addActions(const QVector<QAction*> actions)
+void ActionCollection::addActions(const QList<QAction*>& actions)
 {
-    m_actions.reserve(m_actions.size() + actions.size());
     for (auto a : actions) {
         addAction(a);
     }
 }
 
-QKeySequence ActionCollection::defaultShortcut(QAction* action) const
+QKeySequence ActionCollection::defaultShortcut(const QAction* action) const
 {
-    const QList<QKeySequence> shortcuts = defaultShortcuts(action);
+    auto shortcuts = defaultShortcuts(action);
     return shortcuts.isEmpty() ? QKeySequence() : shortcuts.first();
 }
 
-QList<QKeySequence> ActionCollection::defaultShortcuts(QAction* action) const
+QList<QKeySequence> ActionCollection::defaultShortcuts(const QAction* action) const
 {
-    Q_ASSERT(m_actions.contains(action));
     return action->property("defaultShortcuts").value<QList<QKeySequence>>();
 }
 
 void ActionCollection::setDefaultShortcut(QAction* action, const QKeySequence& shortcut)
 {
-    setDefaultShortcuts(action, QList<QKeySequence>() << shortcut);
+    setDefaultShortcuts(action, {shortcut});
+}
+
+void ActionCollection::setDefaultShortcut(QAction* action,
+                                          QKeySequence::StandardKey standard,
+                                          const QKeySequence& fallback)
+{
+    if (!QKeySequence::keyBindings(standard).isEmpty()) {
+        setDefaultShortcuts(action, QKeySequence::keyBindings(standard));
+    } else if (fallback != 0) {
+        setDefaultShortcut(action, QKeySequence(fallback));
+    }
 }
 
 void ActionCollection::setDefaultShortcuts(QAction* action, const QList<QKeySequence>& shortcuts)
 {
-    Q_ASSERT(m_actions.contains(action));
     action->setShortcuts(shortcuts);
     action->setProperty("defaultShortcuts", QVariant::fromValue(shortcuts));
 }
 
 void ActionCollection::restoreShortcuts()
 {
-    const QVector<Config::ShortcutEntry> shortcuts = Config::instance()->getShortcuts();
+    const auto shortcuts = Config::instance()->getShortcuts();
     QHash<QString, QAction*> actionsByName;
-    actionsByName.reserve(shortcuts.size());
     for (auto action : m_actions) {
-        actionsByName[action->objectName()] = action;
+        actionsByName.insert(action->objectName(), action);
     }
     for (const auto& shortcut : shortcuts) {
-        auto it = actionsByName.find(shortcut.name);
-        if (it == actionsByName.end()) {
-            qWarning() << "Unexpected " << shortcut.name << ", not found in actions";
-            continue;
+        if (actionsByName.contains(shortcut.name)) {
+            const auto key = QKeySequence::fromString(shortcut.shortcut);
+            actionsByName.value(shortcut.name)->setShortcut(key);
         }
-        const auto key = QKeySequence::fromString(shortcut.shortcut);
-        it.value()->setShortcut(key);
     }
 }
 
 void ActionCollection::saveShortcuts()
 {
-    QVector<Config::ShortcutEntry> shortcuts;
+    QList<Config::ShortcutEntry> shortcuts;
     shortcuts.reserve(m_actions.size());
     for (auto a : m_actions) {
-        if (defaultShortcuts(a) == a->shortcuts()) {
-            continue;
+        // Only store non-default shortcut assignments
+        if (a->shortcut() != defaultShortcut(a)) {
+            shortcuts << Config::ShortcutEntry{a->objectName(), a->shortcut().toString()};
         }
-        shortcuts.push_back(Config::ShortcutEntry{a->objectName(), a->shortcut().toString()});
     }
     Config::instance()->setShortcuts(shortcuts);
 }
 
-QPair<bool, QAction*>
-ActionCollection::isConflictingShortcut(QAction* action, const QKeySequence& seq, QString& outMessage) const
+QAction* ActionCollection::isConflictingShortcut(const QAction* action, const QKeySequence& seq) const
 {
+    // Empty sequences don't conflict with anything
     if (seq.isEmpty()) {
-        return {false, nullptr}; // Empty sequences don't conflict with anything
+        return nullptr;
     }
+
     for (auto a : m_actions) {
-        if (a == action) {
-            continue;
-        }
-        if (a->shortcut() == seq) {
-            outMessage = tr("Shortcut %3 conflicts with action '%1' with title '%2'")
-                             .arg(a->objectName(), a->text(), seq.toString());
-            return {true, a};
+        if (a != action && a->shortcut() == seq) {
+            return a;
         }
     }
-    return {false, nullptr};
+
+    return nullptr;
 }

--- a/src/gui/ActionCollection.h
+++ b/src/gui/ActionCollection.h
@@ -1,0 +1,60 @@
+#ifndef KEEPASSXC_ACTION_COLLECTION_H
+#define KEEPASSXC_ACTION_COLLECTION_H
+
+#include <QAction>
+#include <QKeySequence>
+#include <QObject>
+
+/**
+ * This class manages all actions that are shortcut configurable.
+ * It also allows you to access the actions inside it from anywhere
+ * in the gui code.
+ */
+class ActionCollection : public QObject
+{
+    Q_OBJECT
+    ActionCollection() = default;
+
+public:
+    static ActionCollection* instance();
+
+    const QVector<QAction*> actions() const
+    {
+        return m_actions;
+    }
+
+    /**
+     * Add an action to the collection
+     */
+    QAction* addAction(const QString& name, QObject* parent = nullptr);
+
+    /**
+     * Add an action to the collection
+     */
+    QAction* addAction(QAction* action);
+
+    void addActions(const QVector<QAction*> actions);
+
+    /**
+     * Retreive an action from the collection
+     */
+    QAction* action(const QString& name) const;
+
+    void setDefaultShortcut(QAction* a, const QKeySequence& shortcut);
+    QKeySequence defaultShortcut(QAction* a) const;
+
+    void setDefaultShortcuts(QAction* a, const QList<QKeySequence>& shortcut);
+    QList<QKeySequence> defaultShortcuts(QAction* a) const;
+
+    // Check if any action conflicts with @p seq and return the conflicting action
+    QPair<bool, QAction*> isConflictingShortcut(QAction* action, const QKeySequence& seq, QString& outMessage) const;
+
+public Q_SLOTS:
+    void restoreShortcuts();
+    void saveShortcuts();
+
+private:
+    QVector<QAction*> m_actions;
+};
+
+#endif

--- a/src/gui/ActionCollection.h
+++ b/src/gui/ActionCollection.h
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef KEEPASSXC_ACTION_COLLECTION_H
 #define KEEPASSXC_ACTION_COLLECTION_H
 
@@ -18,43 +35,27 @@ class ActionCollection : public QObject
 public:
     static ActionCollection* instance();
 
-    const QVector<QAction*> actions() const
-    {
-        return m_actions;
-    }
+    QList<QAction*> actions() const;
 
-    /**
-     * Add an action to the collection
-     */
-    QAction* addAction(const QString& name, QObject* parent = nullptr);
+    void addAction(QAction* action);
+    void addActions(const QList<QAction*>& actions);
 
-    /**
-     * Add an action to the collection
-     */
-    QAction* addAction(QAction* action);
-
-    void addActions(const QVector<QAction*> actions);
-
-    /**
-     * Retreive an action from the collection
-     */
-    QAction* action(const QString& name) const;
+    QKeySequence defaultShortcut(const QAction* a) const;
+    QList<QKeySequence> defaultShortcuts(const QAction* a) const;
 
     void setDefaultShortcut(QAction* a, const QKeySequence& shortcut);
-    QKeySequence defaultShortcut(QAction* a) const;
-
+    void setDefaultShortcut(QAction* a, QKeySequence::StandardKey standard, const QKeySequence& fallback);
     void setDefaultShortcuts(QAction* a, const QList<QKeySequence>& shortcut);
-    QList<QKeySequence> defaultShortcuts(QAction* a) const;
 
     // Check if any action conflicts with @p seq and return the conflicting action
-    QPair<bool, QAction*> isConflictingShortcut(QAction* action, const QKeySequence& seq, QString& outMessage) const;
+    QAction* isConflictingShortcut(const QAction* action, const QKeySequence& seq) const;
 
-public Q_SLOTS:
+public slots:
     void restoreShortcuts();
     void saveShortcuts();
 
 private:
-    QVector<QAction*> m_actions;
+    QList<QAction*> m_actions;
 };
 
 #endif

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -21,6 +21,7 @@
 #include "ui_ApplicationSettingsWidgetSecurity.h"
 #include <QDesktopServices>
 #include <QDir>
+#include <QToolTip>
 
 #include "config-keepassx.h"
 
@@ -136,6 +137,22 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
         m_secUi->lockDatabaseMinimizeCheckBox->setToolTip(
             state ? tr("This setting cannot be enabled when minimize on unlock is enabled.") : "");
         m_secUi->lockDatabaseMinimizeCheckBox->setEnabled(!state);
+    });
+
+    // Set Auto-Type shortcut when changed
+    connect(
+        m_generalUi->autoTypeShortcutWidget, &ShortcutWidget::shortcutChanged, this, [this](auto key, auto modifiers) {
+            QString error;
+            if (autoType()->registerGlobalShortcut(key, modifiers, &error)) {
+                m_generalUi->autoTypeShortcutWidget->setStyleSheet("");
+            } else {
+                QToolTip::showText(mapToGlobal(rect().bottomLeft()), error);
+                m_generalUi->autoTypeShortcutWidget->setStyleSheet("background-color: #FF9696;");
+            }
+        });
+    connect(m_generalUi->autoTypeShortcutWidget, &ShortcutWidget::shortcutReset, this, [this] {
+        autoType()->unregisterGlobalShortcut();
+        m_generalUi->autoTypeShortcutWidget->setStyleSheet("");
     });
 
     // Disable mouse wheel grab when scrolling

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -58,8 +58,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>564</width>
-            <height>930</height>
+            <width>566</width>
+            <height>975</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1260,7 +1260,7 @@
   <customwidget>
    <class>ShortcutWidget</class>
    <extends>QLineEdit</extends>
-   <header>autotype/ShortcutWidget.h</header>
+   <header>gui/widgets/ShortcutWidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -40,9 +40,11 @@
 #include "core/Resources.h"
 #include "core/Tools.h"
 #include "gui/AboutDialog.h"
+#include "gui/ActionCollection.h"
 #include "gui/Icons.h"
 #include "gui/MessageBox.h"
 #include "gui/SearchWidget.h"
+#include "gui/ShortcutSettingsPage.h"
 #include "gui/entry/EntryView.h"
 #include "gui/osutils/OSUtils.h"
 
@@ -202,6 +204,7 @@ MainWindow::MainWindow()
 #endif
 
     initViewMenu();
+    initActionCollection();
 
 #if defined(WITH_XC_KEESHARE)
     KeeShare::init(this);
@@ -210,6 +213,8 @@ MainWindow::MainWindow()
             SIGNAL(sharingMessage(QString, MessageWidget::MessageType)),
             SLOT(displayGlobalMessage(QString, MessageWidget::MessageType)));
 #endif
+
+    m_ui->settingsWidget->addSettingsPage(new ShortcutSettingsPage());
 
 #ifdef WITH_XC_FDOSECRETS
     auto fdoSS = new FdoSecretsPlugin(m_ui->tabWidget);
@@ -261,45 +266,6 @@ MainWindow::MainWindow()
     m_inactivityTimer = new InactivityTimer(this);
     connect(m_inactivityTimer, SIGNAL(inactivityDetected()), this, SLOT(lockDatabasesAfterInactivity()));
     applySettingsChanges();
-
-    m_ui->actionDatabaseNew->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_N);
-    setShortcut(m_ui->actionDatabaseOpen, QKeySequence::Open, Qt::CTRL + Qt::Key_O);
-    setShortcut(m_ui->actionDatabaseSave, QKeySequence::Save, Qt::CTRL + Qt::Key_S);
-    setShortcut(m_ui->actionDatabaseSaveAs, QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S);
-    setShortcut(m_ui->actionDatabaseClose, QKeySequence::Close, Qt::CTRL + Qt::Key_W);
-    m_ui->actionDatabaseSettings->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Comma);
-    m_ui->actionReports->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_R);
-    setShortcut(m_ui->actionSettings, QKeySequence::Preferences, Qt::CTRL + Qt::Key_Comma);
-    m_ui->actionLockDatabase->setShortcut(Qt::CTRL + Qt::Key_L);
-    m_ui->actionLockAllDatabases->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_L);
-    setShortcut(m_ui->actionQuit, QKeySequence::Quit, Qt::CTRL + Qt::Key_Q);
-    setShortcut(m_ui->actionEntryNew, QKeySequence::New, Qt::CTRL + Qt::Key_N);
-    m_ui->actionEntryEdit->setShortcut(Qt::CTRL + Qt::Key_E);
-    m_ui->actionEntryDelete->setShortcut(Qt::CTRL + Qt::Key_D);
-    m_ui->actionEntryDelete->setShortcut(Qt::Key_Delete);
-    m_ui->actionEntryClone->setShortcut(Qt::CTRL + Qt::Key_K);
-    m_ui->actionEntryTotp->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_T);
-    m_ui->actionEntryDownloadIcon->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_D);
-    m_ui->actionEntryCopyTotp->setShortcut(Qt::CTRL + Qt::Key_T);
-    m_ui->actionEntryCopyPasswordTotp->setShortcut(Qt::CTRL + Qt::Key_Y);
-    m_ui->actionEntryMoveUp->setShortcut(Qt::CTRL + Qt::ALT + Qt::Key_Up);
-    m_ui->actionEntryMoveDown->setShortcut(Qt::CTRL + Qt::ALT + Qt::Key_Down);
-    m_ui->actionEntryCopyUsername->setShortcut(Qt::CTRL + Qt::Key_B);
-    m_ui->actionEntryCopyPassword->setShortcut(Qt::CTRL + Qt::Key_C);
-    m_ui->actionEntryCopyTitle->setShortcut(Qt::CTRL + Qt::Key_I);
-    m_ui->actionEntryAutoTypeSequence->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_V);
-    m_ui->actionEntryOpenUrl->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_U);
-    m_ui->actionEntryCopyURL->setShortcut(Qt::CTRL + Qt::Key_U);
-    m_ui->actionEntryRestore->setShortcut(Qt::CTRL + Qt::Key_R);
-
-    // Prevent conflicts with global Mac shortcuts (force Control on all platforms)
-#ifdef Q_OS_MAC
-    auto modifier = Qt::META;
-#else
-    auto modifier = Qt::CTRL;
-#endif
-    m_ui->actionEntryAddToAgent->setShortcut(modifier + Qt::Key_H);
-    m_ui->actionEntryRemoveFromAgent->setShortcut(modifier + Qt::SHIFT + Qt::Key_H);
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     // Qt 5.10 introduced a new "feature" to hide shortcuts in context menus
@@ -1678,9 +1644,11 @@ void MainWindow::showGroupContextMenu(const QPoint& globalPos)
 void MainWindow::setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback)
 {
     if (!QKeySequence::keyBindings(standard).isEmpty()) {
-        action->setShortcuts(standard);
+        ActionCollection::instance()->setDefaultShortcuts(action, QKeySequence::keyBindings(standard));
+        // action->setShortcuts(standard);
     } else if (fallback != 0) {
-        action->setShortcut(QKeySequence(fallback));
+        ActionCollection::instance()->setDefaultShortcut(action, QKeySequence(fallback));
+        // action->setShortcut(QKeySequence(fallback));
     }
 }
 
@@ -2092,6 +2060,141 @@ void MainWindow::initViewMenu()
     connect(m_ui->actionHidePasswords, &QAction::toggled, this, [](bool checked) {
         config()->set(Config::GUI_HidePasswords, checked);
     });
+}
+
+void MainWindow::initActionCollection()
+{
+    auto ac = ActionCollection::instance();
+    ac->addActions({
+        m_ui->actionQuit,
+        m_ui->actionAbout,
+        m_ui->actionCheckForUpdates,
+        m_ui->actionDatabaseOpen,
+        m_ui->actionDatabaseSave,
+        m_ui->actionDatabaseClose,
+        m_ui->actionDatabaseNew,
+        m_ui->actionDatabaseMerge,
+        m_ui->actionEntryNew,
+        m_ui->actionEntryEdit,
+        m_ui->actionEntryDelete,
+        m_ui->actionGroupNew,
+        m_ui->actionGroupEdit,
+        m_ui->actionGroupDelete,
+        m_ui->actionGroupDownloadFavicons,
+        m_ui->actionGroupSortAsc,
+        m_ui->actionGroupSortDesc,
+        m_ui->actionDatabaseSaveAs,
+        m_ui->actionDatabaseSecurity,
+        m_ui->actionReports,
+        m_ui->actionDatabaseSettings,
+        m_ui->actionEntryClone,
+        m_ui->actionEntryMoveUp,
+        m_ui->actionEntryMoveDown,
+        m_ui->actionEntryCopyUsername,
+        m_ui->actionEntryCopyPassword,
+        m_ui->actionSettings,
+        m_ui->actionPasswordGenerator,
+        m_ui->actionEntryAutoType,
+        m_ui->actionEntryAutoTypeUsername,
+        m_ui->actionEntryAutoTypeUsernameEnter,
+        m_ui->actionEntryAutoTypePassword,
+        m_ui->actionEntryAutoTypePasswordEnter,
+        m_ui->actionEntryAutoTypeTOTP,
+        m_ui->actionEntryDownloadIcon,
+        m_ui->actionEntryOpenUrl,
+        m_ui->actionLockDatabase,
+        m_ui->actionLockAllDatabases,
+        m_ui->actionEntryCopyTitle,
+        m_ui->actionEntryCopyURL,
+        m_ui->actionEntryCopyNotes,
+        m_ui->actionExportCsv,
+        m_ui->actionExportHtml,
+        m_ui->actionImportKeePass1,
+        m_ui->actionImportOpVault,
+        m_ui->actionImportCsv,
+        m_ui->actionEntryTotp,
+        m_ui->actionEntryTotpQRCode,
+        m_ui->actionEntrySetupTotp,
+        m_ui->actionEntryCopyTotp,
+        m_ui->actionEntryCopyPasswordTotp,
+        m_ui->actionGroupEmptyRecycleBin,
+        m_ui->actionDonate,
+        m_ui->actionBugReport,
+        m_ui->actionGettingStarted,
+        m_ui->actionOnlineHelp,
+        m_ui->actionUserGuide,
+        m_ui->actionKeyboardShortcuts,
+        m_ui->actionDatabaseSaveBackup,
+        m_ui->actionEntryAddToAgent,
+        m_ui->actionEntryRemoveFromAgent,
+        m_ui->actionCompactMode,
+        m_ui->actionThemeAuto,
+        m_ui->actionThemeLight,
+        m_ui->actionThemeDark,
+        m_ui->actionThemeClassic,
+        m_ui->actionShowToolbar,
+        m_ui->actionShowPreviewPanel,
+        m_ui->actionAlwaysOnTop,
+        m_ui->actionHideUsernames,
+        m_ui->actionHidePasswords,
+        m_ui->actionEntryAutoTypeSequence,
+        m_ui->actionGroupClone,
+        m_ui->actionEntryRestore,
+        m_ui->actionLockDatabaseToolbar,
+        m_ui->actionExportXML,
+        m_ui->actionAllowScreenCapture,
+    });
+
+    // Add actions whose shortcuts were set in the .ui file
+    const auto& acActions = ac->actions();
+    for (auto a : acActions) {
+        if (!a->shortcut().isEmpty()) {
+            ac->setDefaultShortcut(a, a->shortcut());
+        }
+    }
+
+    ac->setDefaultShortcut(m_ui->actionDatabaseNew, Qt::CTRL + Qt::SHIFT + Qt::Key_N);
+
+    setShortcut(m_ui->actionDatabaseOpen, QKeySequence::Open, Qt::CTRL + Qt::Key_O);
+    setShortcut(m_ui->actionDatabaseSave, QKeySequence::Save, Qt::CTRL + Qt::Key_S);
+    setShortcut(m_ui->actionDatabaseSaveAs, QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S);
+    setShortcut(m_ui->actionDatabaseClose, QKeySequence::Close, Qt::CTRL + Qt::Key_W);
+    ac->setDefaultShortcut(m_ui->actionDatabaseSettings, Qt::CTRL + Qt::SHIFT + Qt::Key_Comma);
+    ac->setDefaultShortcut(m_ui->actionReports, Qt::CTRL + Qt::SHIFT + Qt::Key_R);
+    setShortcut(m_ui->actionSettings, QKeySequence::Preferences, Qt::CTRL + Qt::Key_Comma);
+    ac->setDefaultShortcut(m_ui->actionLockDatabase, Qt::CTRL + Qt::Key_L);
+    ac->setDefaultShortcut(m_ui->actionLockAllDatabases, Qt::CTRL + Qt::SHIFT + Qt::Key_L);
+    setShortcut(m_ui->actionQuit, QKeySequence::Quit, Qt::CTRL + Qt::Key_Q);
+    setShortcut(m_ui->actionEntryNew, QKeySequence::New, Qt::CTRL + Qt::Key_N);
+
+    ac->setDefaultShortcut(m_ui->actionEntryEdit, Qt::CTRL + Qt::Key_E);
+    ac->setDefaultShortcut(m_ui->actionEntryDelete, Qt::CTRL + Qt::Key_D);
+    ac->setDefaultShortcut(m_ui->actionEntryDelete, Qt::Key_Delete);
+    ac->setDefaultShortcut(m_ui->actionEntryClone, Qt::CTRL + Qt::Key_K);
+    ac->setDefaultShortcut(m_ui->actionEntryTotp, Qt::CTRL + Qt::SHIFT + Qt::Key_T);
+    ac->setDefaultShortcut(m_ui->actionEntryDownloadIcon, Qt::CTRL + Qt::SHIFT + Qt::Key_D);
+    ac->setDefaultShortcut(m_ui->actionEntryCopyTotp, Qt::CTRL + Qt::Key_T);
+    ac->setDefaultShortcut(m_ui->actionEntryCopyPasswordTotp, Qt::CTRL + Qt::Key_Y);
+    ac->setDefaultShortcut(m_ui->actionEntryMoveUp, Qt::CTRL + Qt::ALT + Qt::Key_Up);
+    ac->setDefaultShortcut(m_ui->actionEntryMoveDown, Qt::CTRL + Qt::ALT + Qt::Key_Down);
+    ac->setDefaultShortcut(m_ui->actionEntryCopyUsername, Qt::CTRL + Qt::Key_B);
+    ac->setDefaultShortcut(m_ui->actionEntryCopyPassword, Qt::CTRL + Qt::Key_C);
+    ac->setDefaultShortcut(m_ui->actionEntryCopyTitle, Qt::CTRL + Qt::Key_I);
+    ac->setDefaultShortcut(m_ui->actionEntryAutoTypeSequence, Qt::CTRL + Qt::SHIFT + Qt::Key_V);
+    ac->setDefaultShortcut(m_ui->actionEntryOpenUrl, Qt::CTRL + Qt::SHIFT + Qt::Key_U);
+    ac->setDefaultShortcut(m_ui->actionEntryCopyURL, Qt::CTRL + Qt::Key_U);
+    ac->setDefaultShortcut(m_ui->actionEntryRestore, Qt::CTRL + Qt::Key_R);
+
+    // Prevent conflicts with global Mac shortcuts (force Control on all platforms)
+#ifdef Q_OS_MAC
+    auto modifier = Qt::META;
+#else
+    auto modifier = Qt::CTRL;
+#endif
+    ac->setDefaultShortcut(m_ui->actionEntryAddToAgent, modifier + Qt::Key_H);
+    ac->setDefaultShortcut(m_ui->actionEntryRemoveFromAgent, modifier + Qt::SHIFT + Qt::Key_H);
+
+    QTimer::singleShot(1, ac, &ActionCollection::restoreShortcuts);
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -191,6 +191,11 @@ MainWindow::MainWindow()
     connect(m_ui->tabWidget, &DatabaseTabWidget::databaseUnlocked, this, &MainWindow::databaseUnlocked);
     connect(m_ui->tabWidget, &DatabaseTabWidget::activeDatabaseChanged, this, &MainWindow::activeDatabaseChanged);
 
+    initViewMenu();
+    initActionCollection();
+
+    m_ui->settingsWidget->addSettingsPage(new ShortcutSettingsPage());
+
 #ifdef WITH_XC_BROWSER
     m_ui->settingsWidget->addSettingsPage(new BrowserSettingsPage());
     connect(
@@ -203,9 +208,6 @@ MainWindow::MainWindow()
     m_ui->settingsWidget->addSettingsPage(new AgentSettingsPage());
 #endif
 
-    initViewMenu();
-    initActionCollection();
-
 #if defined(WITH_XC_KEESHARE)
     KeeShare::init(this);
     m_ui->settingsWidget->addSettingsPage(new SettingsPageKeeShare(m_ui->tabWidget));
@@ -213,8 +215,6 @@ MainWindow::MainWindow()
             SIGNAL(sharingMessage(QString, MessageWidget::MessageType)),
             SLOT(displayGlobalMessage(QString, MessageWidget::MessageType)));
 #endif
-
-    m_ui->settingsWidget->addSettingsPage(new ShortcutSettingsPage());
 
 #ifdef WITH_XC_FDOSECRETS
     auto fdoSS = new FdoSecretsPlugin(m_ui->tabWidget);
@@ -1641,17 +1641,6 @@ void MainWindow::showGroupContextMenu(const QPoint& globalPos)
     m_ui->menuGroups->popup(globalPos);
 }
 
-void MainWindow::setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback)
-{
-    if (!QKeySequence::keyBindings(standard).isEmpty()) {
-        ActionCollection::instance()->setDefaultShortcuts(action, QKeySequence::keyBindings(standard));
-        // action->setShortcuts(standard);
-    } else if (fallback != 0) {
-        ActionCollection::instance()->setDefaultShortcut(action, QKeySequence(fallback));
-        // action->setShortcut(QKeySequence(fallback));
-    }
-}
-
 void MainWindow::applySettingsChanges()
 {
     int timeout = config()->get(Config::Security_LockDatabaseIdleSeconds).toInt() * 1000;
@@ -2065,108 +2054,119 @@ void MainWindow::initViewMenu()
 void MainWindow::initActionCollection()
 {
     auto ac = ActionCollection::instance();
-    ac->addActions({
-        m_ui->actionQuit,
-        m_ui->actionAbout,
-        m_ui->actionCheckForUpdates,
-        m_ui->actionDatabaseOpen,
-        m_ui->actionDatabaseSave,
-        m_ui->actionDatabaseClose,
-        m_ui->actionDatabaseNew,
-        m_ui->actionDatabaseMerge,
-        m_ui->actionEntryNew,
-        m_ui->actionEntryEdit,
-        m_ui->actionEntryDelete,
-        m_ui->actionGroupNew,
-        m_ui->actionGroupEdit,
-        m_ui->actionGroupDelete,
-        m_ui->actionGroupDownloadFavicons,
-        m_ui->actionGroupSortAsc,
-        m_ui->actionGroupSortDesc,
-        m_ui->actionDatabaseSaveAs,
-        m_ui->actionDatabaseSecurity,
-        m_ui->actionReports,
-        m_ui->actionDatabaseSettings,
-        m_ui->actionEntryClone,
-        m_ui->actionEntryMoveUp,
-        m_ui->actionEntryMoveDown,
-        m_ui->actionEntryCopyUsername,
-        m_ui->actionEntryCopyPassword,
-        m_ui->actionSettings,
-        m_ui->actionPasswordGenerator,
-        m_ui->actionEntryAutoType,
-        m_ui->actionEntryAutoTypeUsername,
-        m_ui->actionEntryAutoTypeUsernameEnter,
-        m_ui->actionEntryAutoTypePassword,
-        m_ui->actionEntryAutoTypePasswordEnter,
-        m_ui->actionEntryAutoTypeTOTP,
-        m_ui->actionEntryDownloadIcon,
-        m_ui->actionEntryOpenUrl,
-        m_ui->actionLockDatabase,
-        m_ui->actionLockAllDatabases,
-        m_ui->actionEntryCopyTitle,
-        m_ui->actionEntryCopyURL,
-        m_ui->actionEntryCopyNotes,
-        m_ui->actionExportCsv,
-        m_ui->actionExportHtml,
-        m_ui->actionImportKeePass1,
-        m_ui->actionImportOpVault,
-        m_ui->actionImportCsv,
-        m_ui->actionEntryTotp,
-        m_ui->actionEntryTotpQRCode,
-        m_ui->actionEntrySetupTotp,
-        m_ui->actionEntryCopyTotp,
-        m_ui->actionEntryCopyPasswordTotp,
-        m_ui->actionGroupEmptyRecycleBin,
-        m_ui->actionDonate,
-        m_ui->actionBugReport,
-        m_ui->actionGettingStarted,
-        m_ui->actionOnlineHelp,
-        m_ui->actionUserGuide,
-        m_ui->actionKeyboardShortcuts,
-        m_ui->actionDatabaseSaveBackup,
-        m_ui->actionEntryAddToAgent,
-        m_ui->actionEntryRemoveFromAgent,
-        m_ui->actionCompactMode,
-        m_ui->actionThemeAuto,
-        m_ui->actionThemeLight,
-        m_ui->actionThemeDark,
-        m_ui->actionThemeClassic,
-        m_ui->actionShowToolbar,
-        m_ui->actionShowPreviewPanel,
-        m_ui->actionAlwaysOnTop,
-        m_ui->actionHideUsernames,
-        m_ui->actionHidePasswords,
-        m_ui->actionEntryAutoTypeSequence,
-        m_ui->actionGroupClone,
-        m_ui->actionEntryRestore,
-        m_ui->actionLockDatabaseToolbar,
-        m_ui->actionExportXML,
-        m_ui->actionAllowScreenCapture,
-    });
+    ac->addActions({// Database Menu
+                    m_ui->actionDatabaseNew,
+                    m_ui->actionDatabaseOpen,
+                    m_ui->actionDatabaseSave,
+                    m_ui->actionDatabaseSaveAs,
+                    m_ui->actionDatabaseSaveBackup,
+                    m_ui->actionDatabaseClose,
+                    m_ui->actionLockDatabase,
+                    m_ui->actionLockAllDatabases,
+                    m_ui->actionDatabaseSettings,
+                    m_ui->actionDatabaseSecurity,
+                    m_ui->actionReports,
+                    m_ui->actionPasskeys,
+                    m_ui->actionDatabaseMerge,
+                    m_ui->actionImportPasskey,
+                    m_ui->actionImportCsv,
+                    m_ui->actionImportOpVault,
+                    m_ui->actionImportKeePass1,
+                    m_ui->actionExportCsv,
+                    m_ui->actionExportHtml,
+                    m_ui->actionExportXML,
+                    m_ui->actionQuit,
+                    // Entry Menu
+                    m_ui->actionEntryNew,
+                    m_ui->actionEntryEdit,
+                    m_ui->actionEntryClone,
+                    m_ui->actionEntryDelete,
+                    m_ui->actionEntryCopyUsername,
+                    m_ui->actionEntryCopyPassword,
+                    m_ui->actionEntryCopyURL,
+                    m_ui->actionEntryCopyTitle,
+                    m_ui->actionEntryCopyNotes,
+                    m_ui->actionEntryTotp,
+                    m_ui->actionEntryTotpQRCode,
+                    m_ui->actionEntrySetupTotp,
+                    m_ui->actionEntryCopyTotp,
+                    m_ui->actionEntryCopyPasswordTotp,
+                    m_ui->actionEntryAutoTypeSequence,
+                    m_ui->actionEntryAutoTypeUsername,
+                    m_ui->actionEntryAutoTypeUsernameEnter,
+                    m_ui->actionEntryAutoTypePassword,
+                    m_ui->actionEntryAutoTypePasswordEnter,
+                    m_ui->actionEntryAutoTypeTOTP,
+                    m_ui->actionEntryDownloadIcon,
+                    m_ui->actionEntryOpenUrl,
+                    m_ui->actionEntryMoveUp,
+                    m_ui->actionEntryMoveDown,
+                    m_ui->actionEntryAddToAgent,
+                    m_ui->actionEntryRemoveFromAgent,
+                    m_ui->actionEntryRestore,
+                    // Group Menu
+                    m_ui->actionGroupNew,
+                    m_ui->actionGroupEdit,
+                    m_ui->actionGroupClone,
+                    m_ui->actionGroupDelete,
+                    m_ui->actionGroupDownloadFavicons,
+                    m_ui->actionGroupSortAsc,
+                    m_ui->actionGroupSortDesc,
+                    m_ui->actionGroupEmptyRecycleBin,
+                    // Tools Menu
+                    m_ui->actionPasswordGenerator,
+                    m_ui->actionSettings,
+                    // View Menu
+                    m_ui->actionThemeAuto,
+                    m_ui->actionThemeLight,
+                    m_ui->actionThemeDark,
+                    m_ui->actionThemeClassic,
+                    m_ui->actionCompactMode,
+                    m_ui->actionShowToolbar,
+                    m_ui->actionShowPreviewPanel,
+                    m_ui->actionAllowScreenCapture,
+                    m_ui->actionAlwaysOnTop,
+                    m_ui->actionHideUsernames,
+                    m_ui->actionHidePasswords,
+                    // Help Menu
+                    m_ui->actionGettingStarted,
+                    m_ui->actionUserGuide,
+                    m_ui->actionKeyboardShortcuts,
+                    m_ui->actionOnlineHelp,
+                    m_ui->actionCheckForUpdates,
+                    m_ui->actionDonate,
+                    m_ui->actionBugReport,
+                    m_ui->actionAbout});
 
     // Add actions whose shortcuts were set in the .ui file
-    const auto& acActions = ac->actions();
-    for (auto a : acActions) {
-        if (!a->shortcut().isEmpty()) {
-            ac->setDefaultShortcut(a, a->shortcut());
+    for (const auto action : ac->actions()) {
+        if (!action->shortcut().isEmpty()) {
+            ac->setDefaultShortcut(action, action->shortcut());
         }
     }
 
-    ac->setDefaultShortcut(m_ui->actionDatabaseNew, Qt::CTRL + Qt::SHIFT + Qt::Key_N);
+    // Actions with standard shortcuts
+    ac->setDefaultShortcut(m_ui->actionDatabaseOpen, QKeySequence::Open, Qt::CTRL + Qt::Key_O);
+    ac->setDefaultShortcut(m_ui->actionDatabaseSave, QKeySequence::Save, Qt::CTRL + Qt::Key_S);
+    ac->setDefaultShortcut(m_ui->actionDatabaseSaveAs, QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S);
+    ac->setDefaultShortcut(m_ui->actionDatabaseClose, QKeySequence::Close, Qt::CTRL + Qt::Key_W);
+    ac->setDefaultShortcut(m_ui->actionSettings, QKeySequence::Preferences, Qt::CTRL + Qt::Key_Comma);
+    ac->setDefaultShortcut(m_ui->actionQuit, QKeySequence::Quit, Qt::CTRL + Qt::Key_Q);
+    ac->setDefaultShortcut(m_ui->actionEntryNew, QKeySequence::New, Qt::CTRL + Qt::Key_N);
 
-    setShortcut(m_ui->actionDatabaseOpen, QKeySequence::Open, Qt::CTRL + Qt::Key_O);
-    setShortcut(m_ui->actionDatabaseSave, QKeySequence::Save, Qt::CTRL + Qt::Key_S);
-    setShortcut(m_ui->actionDatabaseSaveAs, QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S);
-    setShortcut(m_ui->actionDatabaseClose, QKeySequence::Close, Qt::CTRL + Qt::Key_W);
+    // Prevent conflicts with global Mac shortcuts (force Control on all platforms)
+#ifdef Q_OS_MAC
+    auto modifier = Qt::META;
+#else
+    auto modifier = Qt::CTRL;
+#endif
+
+    // All other actions with default shortcuts
+    ac->setDefaultShortcut(m_ui->actionDatabaseNew, Qt::CTRL + Qt::SHIFT + Qt::Key_N);
     ac->setDefaultShortcut(m_ui->actionDatabaseSettings, Qt::CTRL + Qt::SHIFT + Qt::Key_Comma);
     ac->setDefaultShortcut(m_ui->actionReports, Qt::CTRL + Qt::SHIFT + Qt::Key_R);
-    setShortcut(m_ui->actionSettings, QKeySequence::Preferences, Qt::CTRL + Qt::Key_Comma);
     ac->setDefaultShortcut(m_ui->actionLockDatabase, Qt::CTRL + Qt::Key_L);
     ac->setDefaultShortcut(m_ui->actionLockAllDatabases, Qt::CTRL + Qt::SHIFT + Qt::Key_L);
-    setShortcut(m_ui->actionQuit, QKeySequence::Quit, Qt::CTRL + Qt::Key_Q);
-    setShortcut(m_ui->actionEntryNew, QKeySequence::New, Qt::CTRL + Qt::Key_N);
-
     ac->setDefaultShortcut(m_ui->actionEntryEdit, Qt::CTRL + Qt::Key_E);
     ac->setDefaultShortcut(m_ui->actionEntryDelete, Qt::CTRL + Qt::Key_D);
     ac->setDefaultShortcut(m_ui->actionEntryDelete, Qt::Key_Delete);
@@ -2184,13 +2184,6 @@ void MainWindow::initActionCollection()
     ac->setDefaultShortcut(m_ui->actionEntryOpenUrl, Qt::CTRL + Qt::SHIFT + Qt::Key_U);
     ac->setDefaultShortcut(m_ui->actionEntryCopyURL, Qt::CTRL + Qt::Key_U);
     ac->setDefaultShortcut(m_ui->actionEntryRestore, Qt::CTRL + Qt::Key_R);
-
-    // Prevent conflicts with global Mac shortcuts (force Control on all platforms)
-#ifdef Q_OS_MAC
-    auto modifier = Qt::META;
-#else
-    auto modifier = Qt::CTRL;
-#endif
     ac->setDefaultShortcut(m_ui->actionEntryAddToAgent, modifier + Qt::Key_H);
     ac->setDefaultShortcut(m_ui->actionEntryRemoveFromAgent, modifier + Qt::SHIFT + Qt::Key_H);
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -168,6 +168,7 @@ private:
     void dropEvent(QDropEvent* event) override;
 
     void initViewMenu();
+    void initActionCollection();
 
     const QScopedPointer<Ui::MainWindow> m_ui;
     SignalMultiplexer m_actionMultiplexer;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -154,8 +154,6 @@ private slots:
     void focusSearchWidget();
 
 private:
-    static void setShortcut(QAction* action, QKeySequence::StandardKey standard, int fallback = 0);
-
     static const QString BaseWindowTitle;
 
     void saveWindowInformation();

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -443,6 +443,9 @@
    <property name="text">
     <string>&amp;Quit</string>
    </property>
+   <property name="toolTip">
+    <string>Quit Application</string>
+   </property>
    <property name="menuRole">
     <enum>QAction::QuitRole</enum>
    </property>
@@ -450,6 +453,9 @@
   <action name="actionAbout">
    <property name="text">
     <string>&amp;About</string>
+   </property>
+   <property name="toolTip">
+    <string>Open About Dialog</string>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutRole</enum>
@@ -466,6 +472,9 @@
   <action name="actionDatabaseOpen">
    <property name="text">
     <string>&amp;Open Database…</string>
+   </property>
+   <property name="toolTip">
+    <string>Open Database</string>
    </property>
   </action>
   <action name="actionDatabaseSave">
@@ -489,7 +498,7 @@
     <string>&amp;New Database…</string>
    </property>
    <property name="toolTip">
-    <string>Create a new database</string>
+    <string>Create Database</string>
    </property>
   </action>
   <action name="actionDatabaseMerge">
@@ -497,7 +506,7 @@
     <string>&amp;Merge From Database…</string>
    </property>
    <property name="toolTip">
-    <string>Merge from another KDBX database</string>
+    <string>Merge From Database</string>
    </property>
   </action>
   <action name="actionEntryNew">
@@ -508,7 +517,7 @@
     <string>&amp;New Entry…</string>
    </property>
    <property name="toolTip">
-    <string>Add a new entry</string>
+    <string>Create Entry</string>
    </property>
   </action>
   <action name="actionEntryEdit">
@@ -519,7 +528,7 @@
     <string>&amp;Edit Entry…</string>
    </property>
    <property name="toolTip">
-    <string>View or edit entry</string>
+    <string>Edit Entry</string>
    </property>
   </action>
   <action name="actionEntryDelete">
@@ -528,6 +537,9 @@
    </property>
    <property name="text">
     <string>&amp;Delete Entry…</string>
+   </property>
+   <property name="toolTip">
+    <string>Delete Entry</string>
    </property>
   </action>
   <action name="actionGroupNew">
@@ -538,7 +550,7 @@
     <string>&amp;New Group…</string>
    </property>
    <property name="toolTip">
-    <string>Add a new group</string>
+    <string>Create Group</string>
    </property>
   </action>
   <action name="actionGroupEdit">
@@ -548,6 +560,9 @@
    <property name="text">
     <string>&amp;Edit Group…</string>
    </property>
+   <property name="toolTip">
+    <string>Edit Group</string>
+   </property>
   </action>
   <action name="actionGroupDelete">
    <property name="enabled">
@@ -555,6 +570,9 @@
    </property>
    <property name="text">
     <string>&amp;Delete Group…</string>
+   </property>
+   <property name="toolTip">
+    <string>Delete Group</string>
    </property>
   </action>
   <action name="actionGroupDownloadFavicons">
@@ -564,6 +582,9 @@
    <property name="text">
     <string>Download All &amp;Favicons…</string>
    </property>
+   <property name="toolTip">
+    <string>Download All Favicons</string>
+   </property>
   </action>
   <action name="actionGroupSortAsc">
    <property name="enabled">
@@ -571,6 +592,9 @@
    </property>
    <property name="text">
     <string>Sort &amp;A-Z</string>
+   </property>
+   <property name="toolTip">
+    <string>Sort Groups A-Z</string>
    </property>
   </action>
   <action name="actionGroupSortDesc">
@@ -580,6 +604,9 @@
    <property name="text">
     <string>Sort &amp;Z-A</string>
    </property>
+   <property name="toolTip">
+    <string>Sort Groups Z-A</string>
+   </property>
   </action>
   <action name="actionDatabaseSaveAs">
    <property name="enabled">
@@ -588,6 +615,9 @@
    <property name="text">
     <string>Sa&amp;ve Database As…</string>
    </property>
+   <property name="toolTip">
+    <string>Save Database As</string>
+   </property>
   </action>
   <action name="actionDatabaseSecurity">
    <property name="enabled">
@@ -595,6 +625,9 @@
    </property>
    <property name="text">
     <string>Database &amp;Security…</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Database Security</string>
    </property>
   </action>
   <action name="actionReports">
@@ -605,7 +638,7 @@
     <string>Database &amp;Reports…</string>
    </property>
    <property name="toolTip">
-    <string>Statistics, health check, etc.</string>
+    <string>Show Database Reports</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -619,7 +652,7 @@
     <string>&amp;Database Settings…</string>
    </property>
    <property name="toolTip">
-    <string>Database settings</string>
+    <string>Show Database Settings</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -633,7 +666,7 @@
     <string>Passkeys…</string>
    </property>
    <property name="toolTip">
-    <string>Passkeys</string>
+    <string>Show Passkeys</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -660,6 +693,9 @@
    <property name="text">
     <string>&amp;Clone Entry…</string>
    </property>
+   <property name="toolTip">
+    <string>Clone Entry</string>
+   </property>
   </action>
   <action name="actionEntryMoveUp">
    <property name="enabled">
@@ -669,7 +705,7 @@
     <string>Move u&amp;p</string>
    </property>
    <property name="toolTip">
-    <string>Move entry one step up</string>
+    <string>Move Entry Up</string>
    </property>
   </action>
   <action name="actionEntryMoveDown">
@@ -680,7 +716,7 @@
     <string>Move do&amp;wn</string>
    </property>
    <property name="toolTip">
-    <string>Move entry one step down</string>
+    <string>Move Entry Down</string>
    </property>
   </action>
   <action name="actionEntryCopyUsername">
@@ -691,7 +727,7 @@
     <string>Copy &amp;Username</string>
    </property>
    <property name="toolTip">
-    <string>Copy username to clipboard</string>
+    <string>Copy Username</string>
    </property>
   </action>
   <action name="actionEntryCopyPassword">
@@ -702,7 +738,7 @@
     <string>Copy &amp;Password</string>
    </property>
    <property name="toolTip">
-    <string>Copy password to clipboard</string>
+    <string>Copy Password</string>
    </property>
   </action>
   <action name="actionSettings">
@@ -711,6 +747,9 @@
    </property>
    <property name="text">
     <string>&amp;Settings</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Application Settings</string>
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>
@@ -722,6 +761,9 @@
    </property>
    <property name="text">
     <string>&amp;Password Generator</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Password Generator</string>
    </property>
   </action>
   <action name="actionEntryAutoType">
@@ -751,7 +793,7 @@
     <string notr="true">{USERNAME}</string>
    </property>
    <property name="toolTip">
-    <string notr="true">{USERNAME}</string>
+    <string>Perform Auto-Type: {USERNAME}</string>
    </property>
   </action>
   <action name="actionEntryAutoTypeUsernameEnter">
@@ -765,7 +807,7 @@
     <string notr="true">{USERNAME}{ENTER}</string>
    </property>
    <property name="toolTip">
-    <string notr="true">{USERNAME}{ENTER}</string>
+    <string>Perform Auto-Type: {USERNAME}{ENTER}</string>
    </property>
   </action>
   <action name="actionEntryAutoTypePassword">
@@ -779,7 +821,7 @@
     <string notr="true">{PASSWORD}</string>
    </property>
    <property name="toolTip">
-    <string notr="true">{PASSWORD}</string>
+    <string>Perform Auto-Type: {PASSWORD}</string>
    </property>
   </action>
   <action name="actionEntryAutoTypePasswordEnter">
@@ -793,7 +835,7 @@
     <string notr="true">{PASSWORD}{ENTER}</string>
    </property>
    <property name="toolTip">
-    <string notr="true">{PASSWORD}{ENTER}</string>
+    <string>Perform Auto-Type: {PASSWORD}{ENTER}</string>
    </property>
   </action>
   <action name="actionEntryAutoTypeTOTP">
@@ -807,7 +849,7 @@
     <string notr="true">{TOTP}</string>
    </property>
    <property name="toolTip">
-    <string notr="true">{TOTP}</string>
+    <string>Perform Auto-Type: {TOTP}</string>
    </property>
   </action>
   <action name="actionEntryDownloadIcon">
@@ -847,7 +889,7 @@
     <string>&amp;Title</string>
    </property>
    <property name="toolTip">
-    <string>Copy title to clipboard</string>
+    <string>Copy Title</string>
    </property>
   </action>
   <action name="actionEntryCopyURL">
@@ -858,7 +900,7 @@
     <string>Copy &amp;URL</string>
    </property>
    <property name="toolTip">
-    <string>Copy URL to clipboard</string>
+    <string>Copy URL</string>
    </property>
   </action>
   <action name="actionEntryCopyNotes">
@@ -869,7 +911,7 @@
     <string>&amp;Notes</string>
    </property>
    <property name="toolTip">
-    <string>Copy notes to clipboard</string>
+    <string>Copy Notes</string>
    </property>
   </action>
   <action name="actionExportCsv">
@@ -879,6 +921,9 @@
    <property name="text">
     <string>&amp;CSV File…</string>
    </property>
+   <property name="toolTip">
+    <string>Export to CSV</string>
+   </property>
   </action>
   <action name="actionExportHtml">
    <property name="enabled">
@@ -887,13 +932,16 @@
    <property name="text">
     <string>&amp;HTML File…</string>
    </property>
+   <property name="toolTip">
+    <string>Export to HTML</string>
+   </property>
   </action>
   <action name="actionImportKeePass1">
    <property name="text">
     <string>KeePass 1 Database…</string>
    </property>
    <property name="toolTip">
-    <string>Import a KeePass 1 database</string>
+    <string>Import KeePass1 Database</string>
    </property>
   </action>
   <action name="actionImportOpVault">
@@ -901,7 +949,7 @@
     <string>1Password Vault…</string>
    </property>
    <property name="toolTip">
-    <string>Import a 1Password Vault</string>
+    <string>Import 1Password Vault</string>
    </property>
   </action>
   <action name="actionImportCsv">
@@ -909,7 +957,7 @@
     <string>CSV File…</string>
    </property>
    <property name="toolTip">
-    <string>Import a CSV file</string>
+    <string>Import CSV File</string>
    </property>
   </action>
   <action name="actionEntryTotp">
@@ -921,10 +969,16 @@
    <property name="text">
     <string>Show QR Code</string>
    </property>
+   <property name="toolTip">
+    <string>Show TOTP QR Code</string>
+   </property>
   </action>
   <action name="actionEntrySetupTotp">
    <property name="text">
     <string>Set up TOTP…</string>
+   </property>
+   <property name="toolTip">
+    <string>Set up TOTP</string>
    </property>
   </action>
   <action name="actionEntryCopyTotp">
@@ -941,6 +995,9 @@
    <property name="text">
     <string>E&amp;mpty recycle bin</string>
    </property>
+   <property name="toolTip">
+    <string>Empty Recycle Bin</string>
+   </property>
    <property name="visible">
     <bool>false</bool>
    </property>
@@ -949,10 +1006,16 @@
    <property name="text">
     <string>&amp;Donate</string>
    </property>
+   <property name="toolTip">
+    <string>Open Donation Website</string>
+   </property>
   </action>
   <action name="actionBugReport">
    <property name="text">
     <string>Report a &amp;Bug</string>
+   </property>
+   <property name="toolTip">
+    <string>Open Bug Report</string>
    </property>
   </action>
   <action name="actionGettingStarted">
@@ -968,7 +1031,7 @@
     <string>&amp;Online Help</string>
    </property>
    <property name="toolTip">
-    <string>Go to online documentation</string>
+    <string>Open Online Documentation</string>
    </property>
   </action>
   <action name="actionUserGuide">
@@ -983,6 +1046,9 @@
    <property name="text">
     <string>&amp;Keyboard Shortcuts</string>
    </property>
+   <property name="toolTip">
+    <string>Open Keyboard Shortcuts Guide</string>
+   </property>
    <property name="shortcut">
     <string notr="true">Ctrl+/</string>
    </property>
@@ -994,15 +1060,24 @@
    <property name="text">
     <string>Save Database Backup…</string>
    </property>
+   <property name="toolTip">
+    <string>Save Database Backup</string>
+   </property>
   </action>
   <action name="actionEntryAddToAgent">
    <property name="text">
     <string>Add key to SSH Agent</string>
    </property>
+   <property name="toolTip">
+    <string>SSH Agent: Add Key</string>
+   </property>
   </action>
   <action name="actionEntryRemoveFromAgent">
    <property name="text">
     <string>Remove key from SSH Agent</string>
+   </property>
+   <property name="toolTip">
+    <string>SSH Agent: Remove Key</string>
    </property>
   </action>
   <action name="actionCompactMode">
@@ -1011,6 +1086,9 @@
    </property>
    <property name="text">
     <string>Compact Mode</string>
+   </property>
+   <property name="toolTip">
+    <string>Toggle Compact Mode</string>
    </property>
   </action>
   <action name="actionThemeAuto">
@@ -1023,6 +1101,9 @@
    <property name="text">
     <string>Automatic</string>
    </property>
+   <property name="toolTip">
+    <string>Set Theme: Automatic</string>
+   </property>
   </action>
   <action name="actionThemeLight">
    <property name="checkable">
@@ -1030,6 +1111,9 @@
    </property>
    <property name="text">
     <string>Light</string>
+   </property>
+   <property name="toolTip">
+    <string>Set Theme: Light</string>
    </property>
   </action>
   <action name="actionThemeDark">
@@ -1039,6 +1123,9 @@
    <property name="text">
     <string>Dark</string>
    </property>
+   <property name="toolTip">
+    <string>Set Theme: Dark</string>
+   </property>
   </action>
   <action name="actionThemeClassic">
    <property name="checkable">
@@ -1046,6 +1133,9 @@
    </property>
    <property name="text">
     <string>Classic (Platform-native)</string>
+   </property>
+   <property name="toolTip">
+    <string>Set Theme: Classic</string>
    </property>
   </action>
   <action name="actionShowToolbar">
@@ -1058,6 +1148,9 @@
    <property name="text">
     <string>Show Toolbar</string>
    </property>
+   <property name="toolTip">
+    <string>Toggle Show Toolbar</string>
+   </property>
   </action>
   <action name="actionShowPreviewPanel">
    <property name="checkable">
@@ -1069,6 +1162,9 @@
    <property name="text">
     <string>Show Preview Panel</string>
    </property>
+   <property name="toolTip">
+    <string>Toggle Show Preview Panel</string>
+   </property>
   </action>
   <action name="actionAlwaysOnTop">
    <property name="checkable">
@@ -1076,6 +1172,9 @@
    </property>
    <property name="text">
     <string>Always on Top</string>
+   </property>
+   <property name="toolTip">
+    <string>Toggle Always on Top</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Shift+A</string>
@@ -1087,6 +1186,9 @@
    </property>
    <property name="text">
     <string>Hide Usernames</string>
+   </property>
+   <property name="toolTip">
+    <string>Toggle Hide Usernames</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Shift+B</string>
@@ -1102,6 +1204,9 @@
    <property name="text">
     <string>Hide Passwords</string>
    </property>
+   <property name="toolTip">
+    <string>Toggle Hide Passwords</string>
+   </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Shift+C</string>
    </property>
@@ -1114,7 +1219,7 @@
     <string notr="true">{USERNAME}{TAB}{PASSWORD}{ENTER}</string>
    </property>
    <property name="toolTip">
-    <string notr="true">{USERNAME}{TAB}{PASSWORD}{ENTER}</string>
+    <string notr="true">Perform Auto-Type: Entry Default</string>
    </property>
   </action>
   <action name="actionGroupClone">
@@ -1130,7 +1235,7 @@
     <string notr="true" extracomment="Translatable string with plural form set in CPP file">Restore Entry(s)</string>
    </property>
    <property name="toolTip">
-    <string notr="true" extracomment="Translatable string with plural form set in CPP file">Restore Entry(s)</string>
+    <string notr="true" extracomment="Translatable string with plural form set in CPP file">Restore Entry</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+R</string>
@@ -1152,7 +1257,7 @@
     <string>&amp;XML File…</string>
    </property>
    <property name="toolTip">
-    <string>XML File…</string>
+    <string>Export to XML</string>
    </property>
   </action>
   <action name="actionAllowScreenCapture">
@@ -1161,6 +1266,9 @@
    </property>
    <property name="text">
     <string>Allow Screen Capture</string>
+   </property>
+   <property name="toolTip">
+    <string>Toggle Allow Screen Capture</string>
    </property>
   </action>
  </widget>

--- a/src/gui/ShortcutSettingsPage.cpp
+++ b/src/gui/ShortcutSettingsPage.cpp
@@ -1,0 +1,263 @@
+/*
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "ShortcutSettingsPage.h"
+#include "core/Config.h"
+#include "gui/ActionCollection.h"
+#include "gui/Icons.h"
+
+#include <QAbstractButton>
+#include <QDebug>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QHeaderView>
+#include <QKeySequenceEdit>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QSettings>
+#include <QSortFilterProxyModel>
+#include <QStandardItemModel>
+#include <QTreeView>
+#include <QVBoxLayout>
+
+class KeySequenceDialog : public QDialog
+{
+public:
+    KeySequenceDialog(QWidget* parent = nullptr)
+        : QDialog(parent)
+        , m_keySeqEdit(new QKeySequenceEdit(this))
+        , m_btnBox(new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel
+                                            | QDialogButtonBox::RestoreDefaults,
+                                        this))
+    {
+        QVBoxLayout* l = new QVBoxLayout(this);
+        connect(m_btnBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+        connect(m_btnBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+        connect(m_btnBox, &QDialogButtonBox::clicked, this, &KeySequenceDialog::restoreDefault);
+
+        auto hLayout = new QHBoxLayout();
+        l->addLayout(hLayout);
+        hLayout->addWidget(new QLabel(QObject::tr("Enter Shortcut")));
+        hLayout->addWidget(m_keySeqEdit);
+
+        l->addStretch();
+        l->addWidget(m_btnBox);
+
+        setFocusProxy(m_keySeqEdit);
+    }
+
+    QKeySequence keySequence() const
+    {
+        return m_keySeqEdit->keySequence();
+    }
+
+    bool shouldRestoreDefault() const
+    {
+        return m_restoreDefault;
+    }
+
+private:
+    void restoreDefault(QAbstractButton* btn)
+    {
+        if (m_btnBox->standardButton(btn) != QDialogButtonBox::RestoreDefaults) {
+            return;
+        }
+        m_restoreDefault = true;
+        reject();
+    }
+
+private:
+    bool m_restoreDefault = false;
+    QKeySequenceEdit* const m_keySeqEdit;
+    QDialogButtonBox* const m_btnBox;
+};
+
+class ShortcutSettingsWidget : public QWidget
+{
+    struct ShortcutChange
+    {
+        bool restoreDefault = false;
+        QKeySequence seq;
+    };
+
+public:
+    ShortcutSettingsWidget(QWidget* parent = nullptr)
+        : QWidget(parent)
+        , m_treeView(new QTreeView(this))
+        , m_filterLineEdit(new QLineEdit(this))
+    {
+        auto l = new QVBoxLayout(this);
+        l->addWidget(new QLabel(tr("Double click an action to change its shortcut")));
+        l->addWidget(m_filterLineEdit);
+        l->addWidget(m_treeView);
+
+        m_model.setColumnCount(2);
+        m_model.setHorizontalHeaderLabels({QObject::tr("Action"), QObject::tr("Shortcuts")});
+
+        m_proxy.setFilterKeyColumn(-1);
+        m_proxy.setFilterCaseSensitivity(Qt::CaseInsensitive);
+        m_proxy.setSourceModel(&m_model);
+        m_filterLineEdit->setPlaceholderText(tr("Filter..."));
+        connect(m_filterLineEdit, &QLineEdit::textChanged, &m_proxy, &QSortFilterProxyModel::setFilterFixedString);
+
+        m_treeView->setModel(&m_proxy);
+        m_treeView->setUniformRowHeights(true);
+        m_treeView->setAllColumnsShowFocus(true);
+        m_treeView->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+        m_treeView->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+        m_treeView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+        m_treeView->setSelectionMode(QAbstractItemView::SingleSelection);
+        m_treeView->setSelectionBehavior(QAbstractItemView::SelectRows);
+
+        connect(m_treeView, &QTreeView::doubleClicked, this, &ShortcutSettingsWidget::onDoubleClicked);
+    }
+
+    void loadSettings()
+    {
+        m_model.setRowCount(0);
+        const auto& actions = ActionCollection::instance()->actions();
+        for (auto a : actions) {
+            auto col1 = new QStandardItem(acceleratorsStrippedText(a->text()));
+            col1->setData(QVariant::fromValue(a), Qt::UserRole);
+            auto col2 = new QStandardItem(a->shortcut().toString());
+            m_model.appendRow({col1, col2});
+        }
+    }
+
+    void saveSettings()
+    {
+        if (!m_changed) {
+            return;
+        }
+        for (auto it = m_changedActions.begin(); it != m_changedActions.end(); ++it) {
+            auto action = it.key();
+            auto change = it.value();
+            if (change.restoreDefault) {
+                action->setShortcut(ActionCollection::instance()->defaultShortcut(action));
+            } else {
+                action->setShortcut(change.seq);
+            }
+        }
+        ActionCollection::instance()->saveShortcuts();
+    }
+
+private:
+    static QString acceleratorsStrippedText(QString text)
+    {
+        for (int i = 0; i < text.size(); ++i) {
+            if (text.at(i) == QLatin1Char('&') && i + 1 < text.size() && text.at(i + 1) != QLatin1Char('&')) {
+                text.remove(i, 1);
+            }
+        }
+        return text;
+    }
+
+    void onDoubleClicked(QModelIndex index)
+    {
+        if (index.column() != 0) {
+            index = index.sibling(index.row(), 0);
+        }
+        index = m_proxy.mapToSource(index);
+        auto action = index.data(Qt::UserRole).value<QAction*>();
+
+        KeySequenceDialog dlg(this);
+        int ret = dlg.exec();
+
+        ShortcutChange change;
+        if (ret == QDialog::Accepted) {
+            change.seq = dlg.keySequence();
+        } else if (dlg.shouldRestoreDefault()) {
+            change.restoreDefault = true;
+            change.seq = ActionCollection::instance()->defaultShortcut(action);
+        } else {
+            // Rejected
+            return;
+        }
+
+        QString errMsg;
+        QPair<bool, QAction*> res = ActionCollection::instance()->isConflictingShortcut(action, change.seq, errMsg);
+        bool showError = false;
+        if (res.first) {
+            // we conflicted with an action inside action collection
+            // check if the conflicted action is updated here
+            auto found = m_changedActions.constFind(res.second);
+            if (found == m_changedActions.cend()) {
+                showError = true;
+            } else {
+                auto changedSequence = found.value().seq;
+                if (!changedSequence.isEmpty() && changedSequence == change.seq) {
+                    showError = true;
+                }
+            }
+        } else {
+            // we did not confict with any shortcut inside action collection
+            // check if we conflict with any locally modified action
+            for (auto it = m_changedActions.cbegin(); it != m_changedActions.cend(); ++it) {
+                const auto& sc = it.value();
+                if (!change.seq.isEmpty() && change.seq == sc.seq) {
+                    showError = true;
+                    errMsg = tr("Shortcut %3 conflicts with action '%1' with title '%2'")
+                                 .arg(sc.seq.toString(), it.key()->objectName(), it.key()->text());
+                    break;
+                }
+            }
+        }
+
+        if (showError) {
+            QMessageBox::warning(this, tr("Shortcut Conflict"), errMsg);
+            return;
+        }
+
+        m_changed = true;
+        m_changedActions[action] = change;
+        auto item = m_model.itemFromIndex(index.sibling(index.row(), 1));
+        item->setText(change.seq.toString());
+    }
+
+private:
+    QTreeView* const m_treeView;
+    QLineEdit* const m_filterLineEdit;
+    QStandardItemModel m_model;
+    QSortFilterProxyModel m_proxy;
+    bool m_changed = false;
+    QHash<QAction*, ShortcutChange> m_changedActions;
+};
+
+QString ShortcutSettingsPage::name()
+{
+    return QObject::tr("Shortcuts");
+}
+
+QIcon ShortcutSettingsPage::icon()
+{
+    return icons()->icon("auto-type");
+}
+
+QWidget* ShortcutSettingsPage::createWidget()
+{
+    return new ShortcutSettingsWidget();
+}
+
+void ShortcutSettingsPage::loadSettings(QWidget* widget)
+{
+    static_cast<ShortcutSettingsWidget*>(widget)->loadSettings();
+}
+
+void ShortcutSettingsPage::saveSettings(QWidget* widget)
+{
+    static_cast<ShortcutSettingsWidget*>(widget)->saveSettings();
+}

--- a/src/gui/ShortcutSettingsPage.cpp
+++ b/src/gui/ShortcutSettingsPage.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,37 +14,39 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "ShortcutSettingsPage.h"
+
 #include "core/Config.h"
 #include "gui/ActionCollection.h"
 #include "gui/Icons.h"
+#include "gui/MessageBox.h"
+#include "gui/widgets/ShortcutWidget.h"
 
 #include <QAbstractButton>
 #include <QDebug>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QHeaderView>
-#include <QKeySequenceEdit>
 #include <QLabel>
 #include <QLineEdit>
-#include <QMessageBox>
-#include <QSettings>
+#include <QPushButton>
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
-#include <QTreeView>
+#include <QTableView>
 #include <QVBoxLayout>
 
-class KeySequenceDialog : public QDialog
+class KeySequenceDialog final : public QDialog
 {
 public:
-    KeySequenceDialog(QWidget* parent = nullptr)
+    explicit KeySequenceDialog(QWidget* parent = nullptr)
         : QDialog(parent)
-        , m_keySeqEdit(new QKeySequenceEdit(this))
+        , m_keySeqEdit(new ShortcutWidget(this))
         , m_btnBox(new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel
                                             | QDialogButtonBox::RestoreDefaults,
                                         this))
     {
-        QVBoxLayout* l = new QVBoxLayout(this);
+        auto* l = new QVBoxLayout(this);
         connect(m_btnBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
         connect(m_btnBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
         connect(m_btnBox, &QDialogButtonBox::clicked, this, &KeySequenceDialog::restoreDefault);
@@ -62,7 +64,7 @@ public:
 
     QKeySequence keySequence() const
     {
-        return m_keySeqEdit->keySequence();
+        return m_keySeqEdit->sequence();
     }
 
     bool shouldRestoreDefault() const
@@ -73,37 +75,36 @@ public:
 private:
     void restoreDefault(QAbstractButton* btn)
     {
-        if (m_btnBox->standardButton(btn) != QDialogButtonBox::RestoreDefaults) {
-            return;
+        if (m_btnBox->standardButton(btn) == QDialogButtonBox::RestoreDefaults) {
+            m_restoreDefault = true;
+            reject();
         }
-        m_restoreDefault = true;
-        reject();
     }
 
 private:
     bool m_restoreDefault = false;
-    QKeySequenceEdit* const m_keySeqEdit;
+    ShortcutWidget* const m_keySeqEdit;
     QDialogButtonBox* const m_btnBox;
 };
 
-class ShortcutSettingsWidget : public QWidget
+class ShortcutSettingsWidget final : public QWidget
 {
-    struct ShortcutChange
-    {
-        bool restoreDefault = false;
-        QKeySequence seq;
-    };
-
 public:
-    ShortcutSettingsWidget(QWidget* parent = nullptr)
+    explicit ShortcutSettingsWidget(QWidget* parent = nullptr)
         : QWidget(parent)
-        , m_treeView(new QTreeView(this))
+        , m_tableView(new QTableView(this))
         , m_filterLineEdit(new QLineEdit(this))
+        , m_resetShortcutsButton(new QPushButton(tr("Reset Shortcuts"), this))
     {
+        auto h = new QHBoxLayout();
+        h->addWidget(m_filterLineEdit);
+        h->addWidget(m_resetShortcutsButton);
+        h->setStretch(0, 1);
+
         auto l = new QVBoxLayout(this);
         l->addWidget(new QLabel(tr("Double click an action to change its shortcut")));
-        l->addWidget(m_filterLineEdit);
-        l->addWidget(m_treeView);
+        l->addLayout(h);
+        l->addWidget(m_tableView);
 
         m_model.setColumnCount(2);
         m_model.setHorizontalHeaderLabels({QObject::tr("Action"), QObject::tr("Shortcuts")});
@@ -111,27 +112,40 @@ public:
         m_proxy.setFilterKeyColumn(-1);
         m_proxy.setFilterCaseSensitivity(Qt::CaseInsensitive);
         m_proxy.setSourceModel(&m_model);
+
         m_filterLineEdit->setPlaceholderText(tr("Filter..."));
         connect(m_filterLineEdit, &QLineEdit::textChanged, &m_proxy, &QSortFilterProxyModel::setFilterFixedString);
 
-        m_treeView->setModel(&m_proxy);
-        m_treeView->setUniformRowHeights(true);
-        m_treeView->setAllColumnsShowFocus(true);
-        m_treeView->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-        m_treeView->header()->setSectionResizeMode(1, QHeaderView::Stretch);
-        m_treeView->setEditTriggers(QAbstractItemView::NoEditTriggers);
-        m_treeView->setSelectionMode(QAbstractItemView::SingleSelection);
-        m_treeView->setSelectionBehavior(QAbstractItemView::SelectRows);
+        connect(m_resetShortcutsButton, &QPushButton::clicked, this, [this]() {
+            auto ac = ActionCollection::instance();
+            for (auto action : ac->actions()) {
+                action->setShortcut(ac->defaultShortcut(action));
+            }
+            loadSettings();
+        });
 
-        connect(m_treeView, &QTreeView::doubleClicked, this, &ShortcutSettingsWidget::onDoubleClicked);
+        m_tableView->setModel(&m_proxy);
+        m_tableView->setSortingEnabled(true);
+        m_tableView->sortByColumn(0, Qt::AscendingOrder);
+        m_tableView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+        m_tableView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+        m_tableView->verticalHeader()->hide();
+        m_tableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+        m_tableView->setSelectionMode(QAbstractItemView::SingleSelection);
+        m_tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
+
+        connect(m_tableView, &QTableView::doubleClicked, this, &ShortcutSettingsWidget::onDoubleClicked);
     }
 
     void loadSettings()
     {
+        m_changedActions.clear();
+        m_filterLineEdit->clear();
         m_model.setRowCount(0);
         const auto& actions = ActionCollection::instance()->actions();
         for (auto a : actions) {
-            auto col1 = new QStandardItem(acceleratorsStrippedText(a->text()));
+            auto name = a->toolTip().isEmpty() ? acceleratorsStrippedText(a->text()) : a->toolTip();
+            auto col1 = new QStandardItem(name);
             col1->setData(QVariant::fromValue(a), Qt::UserRole);
             auto col2 = new QStandardItem(a->shortcut().toString());
             m_model.appendRow({col1, col2});
@@ -140,19 +154,14 @@ public:
 
     void saveSettings()
     {
-        if (!m_changed) {
-            return;
-        }
-        for (auto it = m_changedActions.begin(); it != m_changedActions.end(); ++it) {
-            auto action = it.key();
-            auto change = it.value();
-            if (change.restoreDefault) {
-                action->setShortcut(ActionCollection::instance()->defaultShortcut(action));
-            } else {
-                action->setShortcut(change.seq);
+        if (m_changedActions.count()) {
+            for (const auto& action : m_changedActions.keys()) {
+                action->setShortcut(m_changedActions.value(action));
             }
+            ActionCollection::instance()->saveShortcuts();
         }
-        ActionCollection::instance()->saveShortcuts();
+        m_changedActions.clear();
+        m_filterLineEdit->clear();
     }
 
 private:
@@ -174,67 +183,77 @@ private:
         index = m_proxy.mapToSource(index);
         auto action = index.data(Qt::UserRole).value<QAction*>();
 
-        KeySequenceDialog dlg(this);
-        int ret = dlg.exec();
+        KeySequenceDialog dialog(this);
+        int ret = dialog.exec();
 
-        ShortcutChange change;
+        QKeySequence change;
         if (ret == QDialog::Accepted) {
-            change.seq = dlg.keySequence();
-        } else if (dlg.shouldRestoreDefault()) {
-            change.restoreDefault = true;
-            change.seq = ActionCollection::instance()->defaultShortcut(action);
+            change = dialog.keySequence();
+        } else if (dialog.shouldRestoreDefault()) {
+            change = ActionCollection::instance()->defaultShortcut(action);
         } else {
             // Rejected
             return;
         }
 
-        QString errMsg;
-        QPair<bool, QAction*> res = ActionCollection::instance()->isConflictingShortcut(action, change.seq, errMsg);
-        bool showError = false;
-        if (res.first) {
+        auto conflict = ActionCollection::instance()->isConflictingShortcut(action, change);
+        bool hasConflict = false;
+        if (conflict) {
             // we conflicted with an action inside action collection
             // check if the conflicted action is updated here
-            auto found = m_changedActions.constFind(res.second);
-            if (found == m_changedActions.cend()) {
-                showError = true;
+            if (!m_changedActions.contains(conflict)) {
+                hasConflict = true;
             } else {
-                auto changedSequence = found.value().seq;
-                if (!changedSequence.isEmpty() && changedSequence == change.seq) {
-                    showError = true;
+                if (m_changedActions.value(conflict) == change) {
+                    hasConflict = true;
                 }
             }
-        } else {
-            // we did not confict with any shortcut inside action collection
+        } else if (!change.isEmpty()) {
+            // we did not conflict with any shortcut inside action collection
             // check if we conflict with any locally modified action
-            for (auto it = m_changedActions.cbegin(); it != m_changedActions.cend(); ++it) {
-                const auto& sc = it.value();
-                if (!change.seq.isEmpty() && change.seq == sc.seq) {
-                    showError = true;
-                    errMsg = tr("Shortcut %3 conflicts with action '%1' with title '%2'")
-                                 .arg(sc.seq.toString(), it.key()->objectName(), it.key()->text());
+            for (auto chAction : m_changedActions.keys()) {
+                if (m_changedActions.value(chAction) == change) {
+                    hasConflict = true;
+                    conflict = chAction;
                     break;
                 }
             }
         }
 
-        if (showError) {
-            QMessageBox::warning(this, tr("Shortcut Conflict"), errMsg);
-            return;
+        if (hasConflict) {
+            auto conflictName =
+                conflict->toolTip().isEmpty() ? acceleratorsStrippedText(conflict->text()) : conflict->toolTip();
+            auto conflictSeq = change.toString();
+
+            auto ans = MessageBox::question(
+                this,
+                tr("Shortcut Conflict"),
+                tr("Shortcut %1 conflicts with '%2'. Overwrite shortcut?").arg(conflictSeq, conflictName),
+                MessageBox::Overwrite | MessageBox::Discard,
+                MessageBox::Discard);
+            if (ans == MessageBox::Discard) {
+                // Bail out before making any changes
+                return;
+            }
+
+            // Reset the conflict shortcut
+            m_changedActions[conflict] = {};
+            for (auto item : m_model.findItems(conflictSeq, Qt::MatchExactly, 1)) {
+                item->setText("");
+            }
         }
 
-        m_changed = true;
         m_changedActions[action] = change;
         auto item = m_model.itemFromIndex(index.sibling(index.row(), 1));
-        item->setText(change.seq.toString());
+        item->setText(change.toString());
     }
 
-private:
-    QTreeView* const m_treeView;
-    QLineEdit* const m_filterLineEdit;
+    QTableView* m_tableView;
+    QLineEdit* m_filterLineEdit;
+    QPushButton* m_resetShortcutsButton;
     QStandardItemModel m_model;
     QSortFilterProxyModel m_proxy;
-    bool m_changed = false;
-    QHash<QAction*, ShortcutChange> m_changedActions;
+    QHash<QAction*, QKeySequence> m_changedActions;
 };
 
 QString ShortcutSettingsPage::name()

--- a/src/gui/ShortcutSettingsPage.h
+++ b/src/gui/ShortcutSettingsPage.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/ShortcutSettingsPage.h
+++ b/src/gui/ShortcutSettingsPage.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_SHORTCUT_SETTINGSPAGE_H
+#define KEEPASSXC_SHORTCUT_SETTINGSPAGE_H
+
+#include "gui/ApplicationSettingsWidget.h"
+
+class ShortcutSettingsPage : public ISettingsPage
+{
+public:
+    explicit ShortcutSettingsPage() = default;
+    ~ShortcutSettingsPage() override = default;
+
+    QString name() override;
+    QIcon icon() override;
+    QWidget* createWidget() override;
+    void loadSettings(QWidget* widget) override;
+    void saveSettings(QWidget* widget) override;
+};
+
+#endif // KEEPASSXC_BROWSERSETTINGSPAGE_H

--- a/src/gui/widgets/ShortcutWidget.h
+++ b/src/gui/widgets/ShortcutWidget.h
@@ -18,6 +18,7 @@
 #ifndef KEEPASSX_SHORTCUTWIDGET_H
 #define KEEPASSX_SHORTCUTWIDGET_H
 
+#include <QKeySequence>
 #include <QLineEdit>
 
 class ShortcutWidget : public QLineEdit
@@ -26,9 +27,16 @@ class ShortcutWidget : public QLineEdit
 
 public:
     explicit ShortcutWidget(QWidget* parent = nullptr);
+
     Qt::Key key() const;
     Qt::KeyboardModifiers modifiers() const;
+    QKeySequence sequence() const;
+
     void setShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers);
+
+signals:
+    void shortcutChanged(Qt::Key key, Qt::KeyboardModifiers modifiers);
+    void shortcutReset();
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
@@ -39,9 +47,9 @@ private:
     void displayShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers);
     void resetShortcut();
 
-    Qt::Key m_key;
-    Qt::KeyboardModifiers m_modifiers;
-    bool m_locked;
+    Qt::Key m_key = Qt::Key_unknown;
+    Qt::KeyboardModifiers m_modifiers = Qt::NoModifier;
+    bool m_locked = false;
 };
 
 #endif // KEEPASSX_SHORTCUTWIDGET_H

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -33,6 +33,7 @@
 #include "config-keepassx-tests.h"
 #include "core/Tools.h"
 #include "crypto/Crypto.h"
+#include "gui/ActionCollection.h"
 #include "gui/ApplicationSettingsWidget.h"
 #include "gui/CategoryListWidget.h"
 #include "gui/CloneDialog.h"
@@ -43,6 +44,7 @@
 #include "gui/PasswordGeneratorWidget.h"
 #include "gui/PasswordWidget.h"
 #include "gui/SearchWidget.h"
+#include "gui/ShortcutSettingsPage.h"
 #include "gui/TotpDialog.h"
 #include "gui/TotpSetupDialog.h"
 #include "gui/databasekey/KeyFileEditWidget.h"
@@ -1849,6 +1851,56 @@ void TestGui::testTrayRestoreHide()
     trayIcon->activated(QSystemTrayIcon::DoubleClick);
     QTRY_VERIFY(m_mainWindow->isVisible());
 #endif
+}
+
+void TestGui::testShortcutConfig()
+{
+    // Action collection should not be empty
+    QVERIFY(!ActionCollection::instance()->actions().isEmpty());
+
+    // Add an action, make sure it gets added
+    QAction* a = new QAction(ActionCollection::instance());
+    a->setObjectName("MyAction1");
+    ActionCollection::instance()->addAction(a);
+    QCOMPARE(ActionCollection::instance()->action("MyAction1"), a);
+
+    // Add an action, make sure it gets added
+    auto a2 = ActionCollection::instance()->addAction("MyAction2", ActionCollection::instance());
+    QCOMPARE(ActionCollection::instance()->action("MyAction2"), a2);
+
+    const QKeySequence seq(Qt::CTRL + Qt::SHIFT + Qt::ALT + Qt::Key_N);
+    ActionCollection::instance()->setDefaultShortcut(a, seq);
+    QCOMPARE(ActionCollection::instance()->defaultShortcut(a), seq);
+
+    bool v = false;
+    m_mainWindow->addAction(a);
+    connect(a, &QAction::triggered, ActionCollection::instance(), [&v] { v = !v; });
+    QTest::keyClick(m_mainWindow.data(), Qt::Key_N, Qt::ControlModifier | Qt::ShiftModifier | Qt::AltModifier);
+    QVERIFY(v);
+
+    // Change shortcut and save
+    const QKeySequence newSeq(Qt::CTRL + Qt::SHIFT + Qt::ALT + Qt::Key_M);
+    a->setShortcut(newSeq);
+    QVERIFY(a->shortcut() != ActionCollection::instance()->defaultShortcut(a));
+    ActionCollection::instance()->saveShortcuts();
+    QCOMPARE(a->shortcut(), newSeq);
+    const auto shortcuts = Config::instance()->getShortcuts();
+    Config::ShortcutEntry entryForA;
+    for (const auto& s : shortcuts) {
+        if (s.name == a->objectName()) {
+            entryForA = s;
+            break;
+        }
+    }
+    QCOMPARE(entryForA.name, a->objectName());
+    QCOMPARE(QKeySequence::fromString(entryForA.shortcut), a->shortcut());
+
+    // trigger the old shortcut
+    QTest::keyClick(m_mainWindow.data(), Qt::Key_N, Qt::ControlModifier | Qt::ShiftModifier | Qt::AltModifier);
+    QVERIFY(v); // value of v should not change
+    QTest::keyClick(m_mainWindow.data(), Qt::Key_M, Qt::ControlModifier | Qt::ShiftModifier | Qt::AltModifier);
+    QVERIFY(!v);
+    disconnect(a, nullptr, nullptr, nullptr);
 }
 
 void TestGui::testAutoType()

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1862,11 +1862,7 @@ void TestGui::testShortcutConfig()
     QAction* a = new QAction(ActionCollection::instance());
     a->setObjectName("MyAction1");
     ActionCollection::instance()->addAction(a);
-    QCOMPARE(ActionCollection::instance()->action("MyAction1"), a);
-
-    // Add an action, make sure it gets added
-    auto a2 = ActionCollection::instance()->addAction("MyAction2", ActionCollection::instance());
-    QCOMPARE(ActionCollection::instance()->action("MyAction2"), a2);
+    QVERIFY(ActionCollection::instance()->actions().contains(a));
 
     const QKeySequence seq(Qt::CTRL + Qt::SHIFT + Qt::ALT + Qt::Key_N);
     ActionCollection::instance()->setDefaultShortcut(a, seq);

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -67,6 +67,7 @@ private slots:
     void testSortGroups();
     void testAutoType();
     void testTrayRestoreHide();
+    void testShortcutConfig();
 
 private:
     void addCannedEntries();


### PR DESCRIPTION
Fixes #2689

This pull request aims to introduce shortcut configuration to keepassxc.

The design of the respective code is loosely based on KDE's KActionCollection. The ActionCollection manages all actions that can be shortcut configured. These actions are then exposed in the config and a user can assign a different shortcut.

For a first attempt, I have only added actions inside the MainWindow to the ActionCollection. This can be changed / improved upon iteratively

The GUI for configuring actions is pretty simple, it just consists of a `QTreeView` and `QKeySequenceEdit` to change the shortcut.

Note that I have tried to keep the implementation as minimal as possible to make it easy to understand. Things like
an improved gui and ux can always be added on top of an existing feature iteratively.

## Screenshots
![image](https://github.com/keepassxreboot/keepassxc/assets/7696024/eea1751e-1d28-44f8-b2c7-9fa6894dd305)


## Testing strategy
- Add a new shortcut -> trigger that shortcut. Close and reopen Keepassxc, the shortcut should still work with new shortcut
- Clear existing shortcut and restart keepassxc, shortcut should be cleared after restart

## Type of change
- ✅ New feature (change that adds functionality)
