### PR TITLE
Pass parent to browser popups

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -270,7 +270,7 @@ QJsonObject BrowserService::createNewGroup(const QString& groupName)
         return result;
     }
 
-    auto dialogResult = MessageBox::warning(nullptr,
+    auto dialogResult = MessageBox::warning(m_currentDatabaseWidget,
                                             tr("KeePassXC: Create a new group"),
                                             tr("A request for creating a new group \"%1\" has been received.\n"
                                                "Do you want to create this group?\n")
@@ -443,7 +443,7 @@ QList<Entry*> BrowserService::confirmEntries(QList<Entry*>& entriesToConfirm,
 
     m_dialogActive = true;
     updateWindowState();
-    BrowserAccessControlDialog accessControlDialog;
+    BrowserAccessControlDialog accessControlDialog(m_currentDatabaseWidget);
 
     connect(m_currentDatabaseWidget, SIGNAL(databaseLockRequested()), &accessControlDialog, SLOT(reject()));
 
@@ -504,7 +504,7 @@ QList<Entry*> BrowserService::confirmEntries(QList<Entry*>& entriesToConfirm,
 void BrowserService::showPasswordGenerator(const KeyPairMessage& keyPairMessage)
 {
     if (!m_passwordGenerator) {
-        m_passwordGenerator.reset(PasswordGeneratorWidget::popupGenerator());
+        m_passwordGenerator.reset(PasswordGeneratorWidget::popupGenerator(m_currentDatabaseWidget));
 
         connect(m_passwordGenerator.data(), &PasswordGeneratorWidget::closed, m_passwordGenerator.data(), [=] {
             if (!m_passwordGenerator->isPasswordGenerated()) {
@@ -556,7 +556,7 @@ QString BrowserService::storeKey(const QString& key)
     QString id;
 
     do {
-        QInputDialog keyDialog;
+        QInputDialog keyDialog(m_currentDatabaseWidget);
         connect(m_currentDatabaseWidget, SIGNAL(databaseLockRequested()), &keyDialog, SLOT(reject()));
         keyDialog.setWindowTitle(tr("KeePassXC: New key association request"));
         keyDialog.setLabelText(tr("You have received an association request for the following database:\n%1\n\n"
@@ -579,7 +579,7 @@ QString BrowserService::storeKey(const QString& key)
 
         contains = db->metadata()->customData()->contains(CustomData::BrowserKeyPrefix + id);
         if (contains) {
-            dialogResult = MessageBox::warning(nullptr,
+            dialogResult = MessageBox::warning(m_currentDatabaseWidget,
                                                tr("KeePassXC: Overwrite existing key?"),
                                                tr("A shared encryption key with the name \"%1\" "
                                                   "already exists.\nDo you want to overwrite it?")
@@ -695,7 +695,7 @@ bool BrowserService::updateEntry(const EntryParameters& entryParameters, const Q
         MessageBox::Button dialogResult = MessageBox::No;
         if (!browserSettings()->alwaysAllowUpdate()) {
             raiseWindow();
-            dialogResult = MessageBox::question(nullptr,
+            dialogResult = MessageBox::question(m_currentDatabaseWidget,
                                                 tr("KeePassXC: Update Entry"),
                                                 tr("Do you want to update the information in %1 - %2?")
                                                     .arg(QUrl(entryParameters.siteUrl).host(), username),
@@ -732,7 +732,7 @@ bool BrowserService::deleteEntry(const QString& uuid)
         return false;
     }
 
-    auto dialogResult = MessageBox::warning(nullptr,
+    auto dialogResult = MessageBox::warning(m_currentDatabaseWidget,
                                             tr("KeePassXC: Delete entry"),
                                             tr("A request for deleting entry \"%1\" has been received.\n"
                                                "Do you want to delete the entry?\n")
@@ -1218,7 +1218,7 @@ QSharedPointer<Database> BrowserService::selectedDatabase()
         }
     }
 
-    BrowserEntrySaveDialog browserEntrySaveDialog;
+    BrowserEntrySaveDialog browserEntrySaveDialog(m_currentDatabaseWidget);
     int openDatabaseCount = browserEntrySaveDialog.setItems(databaseWidgets, m_currentDatabaseWidget);
     if (openDatabaseCount > 1) {
         int res = browserEntrySaveDialog.exec();


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Passes parent `QWidget` from the current `DatabaseWidget` to popups launched by the Browser Integration. This fixes a bug with Sway (and possibly other tiling Wayland window managers) where popups are creating a new tiled window instead of showing a normal sized popup. Cannot be reproduced with i3/X11.

Fixes #8033.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually with Fedora 38 & Sway / i3.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)