### PR TITLE
Disable entry level Auto-Type when disabled on the entry or group level

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -203,6 +203,11 @@ const TimeInfo& Entry::timeInfo() const
 bool Entry::autoTypeEnabled() const
 {
     return m_data.autoTypeEnabled;
+}
+
+bool Entry::groupAutoTypeEnabled() const
+{
+    return group() && group()->resolveAutoTypeEnabled();
 }
 
 int Entry::autoTypeObfuscation() const

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -91,6 +91,7 @@ public:
     QStringList tagList() const;
     const TimeInfo& timeInfo() const;
     bool autoTypeEnabled() const;
+    bool groupAutoTypeEnabled() const;
     int autoTypeObfuscation() const;
     QString defaultAutoTypeSequence() const;
     QString effectiveAutoTypeSequence() const;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1,6 +1,6 @@
 /*
+ * Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  * Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- * Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1975,6 +1975,16 @@ bool DatabaseWidget::currentEntryHasNotes()
         return false;
     }
     return !currentEntry->resolveMultiplePlaceholders(currentEntry->notes()).isEmpty();
+}
+
+bool DatabaseWidget::currentEntryHasAutoTypeEnabled()
+{
+    auto currentEntry = currentSelectedEntry();
+    if (!currentEntry) {
+        return false;
+    }
+
+    return currentEntry->autoTypeEnabled() && currentEntry->groupAutoTypeEnabled();
 }
 
 GroupView* DatabaseWidget::groupView()

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -116,6 +116,7 @@ public:
 #ifdef WITH_XC_SSHAGENT
     bool currentEntryHasSshKey();
 #endif
+    bool currentEntryHasAutoTypeEnabled();
 
     QByteArray entryViewState() const;
     bool setEntryViewState(const QByteArray& state) const;

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -468,7 +468,9 @@ void EntryPreviewWidget::updateEntryAutotypeTab()
     }
 
     m_ui->entryAutotypeTree->addTopLevelItems(items);
-    setTabEnabled(m_ui->entryTabWidget, m_ui->entryAutotypeTab, m_currentEntry->autoTypeEnabled());
+    setTabEnabled(m_ui->entryTabWidget,
+                  m_ui->entryAutotypeTab,
+                  m_currentEntry->autoTypeEnabled() && m_currentEntry->groupAutoTypeEnabled());
 }
 
 void EntryPreviewWidget::updateGroupHeaderLine()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -929,8 +929,9 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
             m_ui->menuEntryCopyAttribute->setEnabled(singleEntrySelected);
             m_ui->menuEntryTotp->setEnabled(singleEntrySelected);
             m_ui->menuTags->setEnabled(entriesSelected);
-            m_ui->actionEntryAutoType->setEnabled(singleEntrySelected);
-            m_ui->actionEntryAutoType->menu()->setEnabled(singleEntrySelected);
+            m_ui->actionEntryAutoType->setEnabled(singleEntrySelected && dbWidget->currentEntryHasAutoTypeEnabled());
+            m_ui->actionEntryAutoType->menu()->setEnabled(singleEntrySelected
+                                                          && dbWidget->currentEntryHasAutoTypeEnabled());
             m_ui->actionEntryAutoTypeSequence->setText(
                 singleEntrySelected ? dbWidget->currentSelectedEntry()->effectiveAutoTypeSequence()
                                     : Group::RootAutoTypeSequence);

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -1292,4 +1292,30 @@ void TestGroup::testPreviousParentGroup()
     group1->setParent(root);
     QVERIFY(group1->previousParentGroupUuid() == group2->uuid());
     QVERIFY(group1->previousParentGroup() == group2);
+}
+
+void TestGroup::testAutoTypeState()
+{
+    Database db;
+    auto* root = db.rootGroup();
+
+    auto* entry1 = new Entry();
+    entry1->setGroup(root);
+
+    auto subGroup = new Group();
+    subGroup->setParent(root);
+    auto* entry2 = new Entry();
+    entry2->setGroup(subGroup);
+
+    // Disable Auto-Type from root group
+    root->setAutoTypeEnabled(Group::TriState::Disable);
+    QVERIFY(!entry1->groupAutoTypeEnabled());
+    QVERIFY(!entry2->groupAutoTypeEnabled());
+
+    // Enable Auto-Type for sub group
+    subGroup->setAutoTypeEnabled(Group::TriState::Enable);
+    QVERIFY(root->autoTypeEnabled() == Group::TriState::Disable);
+    QVERIFY(subGroup->autoTypeEnabled() == Group::TriState::Enable);
+    QVERIFY(!entry1->groupAutoTypeEnabled());
+    QVERIFY(entry2->groupAutoTypeEnabled());
 }

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -49,6 +49,7 @@ private slots:
     void testUsernamesRecursive();
     void testMoveUpDown();
     void testPreviousParentGroup();
+    void testAutoTypeState();
 };
 
 #endif // KEEPASSX_TESTGROUP_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
If a group or an entry has disabled Auto-Type, the menu item for "Perform Auto-Type" should be disabled along with the default keyboard shortcut that performs it. Global Auto-Type is not affected.

A new `groupAutoTypeEnabled()` for `Entry` is needed. Returning the group state directly from `Entry::autoTypeEnabled()` would affect to the entry's Auto-Type setting.

Fixes #9660.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Automated tests also added.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
