### PR TITLE
Remove extra space in placeholder

### DIFF
--- a/share/translations/keepassxc_pt_BR.ts
+++ b/share/translations/keepassxc_pt_BR.ts
@@ -862,7 +862,7 @@ chrome-laptop</translation>
     <message>
         <source>A shared encryption key with the name &quot;%1&quot; already exists.
 Do you want to overwrite it?</source>
-        <translation>Uma chave de criptografia compartilhada com o nome &quot;% 1&quot; já existe.
+        <translation>Uma chave de criptografia compartilhada com o nome &quot;%1&quot; já existe.
 Você deseja sobrescreve-la?</translation>
     </message>
     <message>


### PR DESCRIPTION
Fix pt_BR translation showing "% 1" instead of the actual data.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
