### PR TITLE
Fixes #9255 Access Confirmation dialog should not be shown with option ConfirmAccessItem set to false

### DIFF
--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -23,6 +23,7 @@
 #include "fdosecrets/objects/Session.h"
 #include "fdosecrets/widgets/AccessControlDialog.h"
 
+#include "FdoSecretsSettings.h"
 #include "core/Entry.h"
 #include "gui/MessageBox.h"
 
@@ -298,7 +299,7 @@ namespace FdoSecrets
                 }
                 auto entry = item->backend();
                 auto uuid = entry->uuid();
-                if (client->itemKnown(uuid)) {
+                if (client->itemKnown(uuid) || !FdoSecrets::settings()->confirmAccessItem()) {
                     if (!client->itemAuthorized(uuid)) {
                         m_numRejected += 1;
                     }


### PR DESCRIPTION
This fixes #9255 

Access Confirmation dialog ignores ConfirmAccessItem set to false

The author of this patch is @mormegil-cz, [comment](https://github.com/keepassxreboot/keepassxc/issues/7571#issuecomment-1663497558)

>I believe the problem with the program ignoring the Confirm when passwords are retrieved by clients setting is in 
> UnlockPrompt::unlockItems where the code tests whether client->itemKnown(uuid) and then if !client->itemAuthorized(uuid). 
> However: while DBusClient::itemAuthorized takes into account the FdoSecrets::settings()->confirmAccessItem() setting, 
> DBusClient::itemKnown does not.
> Which means the code in unlockItems ignores the setting and always needs to ask for the confirmation.

> **I am not sure which of the two places is the correct one to add the check**: 
> - Either DBusClient::itemKnown should return true  always when FdoSecrets::settings()->confirmAccessItem() is unset, or
> - UnlockPrompt::unlockItems should check for the setting as well


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
