### PR TITLE
Improve codecov configuration

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -2,7 +2,24 @@ coverage:
   range: 60..80
   round: nearest
   precision: 2
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+        paths:
+          - "src"
+    patch:
+      default:
+        target: 75%
+        threshold: 0%
+        paths:
+          - "src"
 fixes:
   - "*/src/::"
+ignore:
+  - "src/gui/styles/**"
+  - "src/thirdparty/**"
+  - "src/zxcvbn/**"
 comment:
   require_changes: true


### PR DESCRIPTION
Improve the codecov configuration to prevent failed tests for minor code updates that only impact the code test coverage by less than 0.5%. Also ignore third party files when calculating coverage.