### PR TITLE
Remove unused merge methods

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -5616,22 +5616,6 @@ We recommend you use the AppImage available on our downloads page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Adding backup for older target %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Adding backup for older source %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reapplying older target entry on top of newer source %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reapplying older source entry on top of newer target %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Synchronizing from newer source %1 [%2]</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -39,9 +39,6 @@ public:
     enum MergeMode
     {
         Default, // Determine merge strategy from parent or fallback (Synchronize)
-        Duplicate, // lossy strategy regarding deletions, duplicate older changes in a new entry
-        KeepLocal, // merge history forcing local as top regardless of age
-        KeepRemote, // merge history forcing remote as top regardless of age
         KeepNewer, // merge history
         Synchronize, // merge history keeping most recent as top entry and applying deletions
     };

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -59,12 +59,6 @@ private:
     void eraseGroup(Group* group);
     ChangeList resolveEntryConflict(const MergeContext& context, const Entry* existingEntry, Entry* otherEntry);
     ChangeList resolveGroupConflict(const MergeContext& context, const Group* existingGroup, Group* otherGroup);
-    Merger::ChangeList
-    resolveEntryConflict_Duplicate(const MergeContext& context, const Entry* sourceEntry, Entry* targetEntry);
-    Merger::ChangeList
-    resolveEntryConflict_KeepLocal(const MergeContext& context, const Entry* sourceEntry, Entry* targetEntry);
-    Merger::ChangeList
-    resolveEntryConflict_KeepRemote(const MergeContext& context, const Entry* sourceEntry, Entry* targetEntry);
     Merger::ChangeList resolveEntryConflict_MergeHistories(const MergeContext& context,
                                                            const Entry* sourceEntry,
                                                            Entry* targetEntry,

--- a/tests/TestMerge.h
+++ b/tests/TestMerge.h
@@ -35,15 +35,9 @@ private slots:
     void testResolveGroupConflictOlder();
     void testMergeNotModified();
     void testMergeModified();
-    void testResolveConflictDuplicate();
     void testResolveConflictEntry_Synchronize();
-    void testResolveConflictEntry_KeepLocal();
-    void testResolveConflictEntry_KeepRemote();
     void testResolveConflictEntry_KeepNewer();
-    void testDeletionConflictEntry_Duplicate();
     void testDeletionConflictEntry_Synchronized();
-    void testDeletionConflictEntry_KeepLocal();
-    void testDeletionConflictEntry_KeepRemote();
     void testDeletionConflictEntry_KeepNewer();
     void testMoveEntry();
     void testMoveEntryPreserveChanges();


### PR DESCRIPTION
We only use two merge methods: `Synchronize` and `KeepNewer`. Removing the other unused merge methods simplifies the merge code a lot. In a future PR, I will also remove the field from the `Group` class, and only allow overwriting the default on the `Merger` object.

This is not a breaking change since the `Group` field was only changed from the unit tests.

## Testing strategy
unit tests are still passing

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)