### PR TITLE
Add support for Thunderbird

### DIFF
--- a/src/browser/BrowserSettingsWidget.cpp
+++ b/src/browser/BrowserSettingsWidget.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -42,8 +42,9 @@ BrowserSettingsWidget::BrowserSettingsWidget(QWidget* parent)
 
     m_ui->extensionLabel->setOpenExternalLinks(true);
     m_ui->extensionLabel->setText(
-        tr("KeePassXC-Browser is needed for the browser integration to work. <br />Download it for %1 and %2 and %3. %4")
+        tr("KeePassXC-Browser is needed for the browser integration to work. <br />Download it for %1 and %2 and %3 and %4. %5")
             .arg("<a href=\"https://addons.mozilla.org/firefox/addon/keepassxc-browser/\">Firefox</a>",
+                 "<a href=\"https://addons.thunderbird.net/thunderbird/addon/keepassxc-mail/\">Thunderbird</a>",
                  "<a href=\"https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">"
                  "Google Chrome / Chromium / Vivaldi / Brave</a>",
                  "<a href=\"https://microsoftedge.microsoft.com/addons/detail/pdffhmdngciaglkoonimfcmckehcpafo\">Microsoft Edge</a>",
@@ -133,6 +134,7 @@ void BrowserSettingsWidget::loadSettings()
     m_ui->chromiumSupport->setChecked(settings->browserSupport(BrowserShared::CHROMIUM));
     m_ui->firefoxSupport->setChecked(settings->browserSupport(BrowserShared::FIREFOX));
     m_ui->edgeSupport->setChecked(settings->browserSupport(BrowserShared::EDGE));
+    m_ui->thunderBirdSupport->setChecked(settings->browserSupport(BrowserShared::THUNDERBIRD));
 #ifndef Q_OS_WIN
     m_ui->braveSupport->setChecked(settings->browserSupport(BrowserShared::BRAVE));
     m_ui->vivaldiSupport->setChecked(settings->browserSupport(BrowserShared::VIVALDI));
@@ -261,6 +263,7 @@ void BrowserSettingsWidget::saveSettings()
     settings->setBrowserSupport(BrowserShared::CHROMIUM, m_ui->chromiumSupport->isChecked());
     settings->setBrowserSupport(BrowserShared::FIREFOX, m_ui->firefoxSupport->isChecked());
     settings->setBrowserSupport(BrowserShared::EDGE, m_ui->edgeSupport->isChecked());
+    settings->setBrowserSupport(BrowserShared::THUNDERBIRD, m_ui->thunderBirdSupport->isChecked());
 #ifndef Q_OS_WIN
     settings->setBrowserSupport(BrowserShared::BRAVE, m_ui->braveSupport->isChecked());
     settings->setBrowserSupport(BrowserShared::VIVALDI, m_ui->vivaldiSupport->isChecked());

--- a/src/browser/BrowserSettingsWidget.ui
+++ b/src/browser/BrowserSettingsWidget.ui
@@ -134,6 +134,16 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="3">
+           <widget class="QCheckBox" name="thunderBirdSupport">
+            <property name="text">
+             <string>Thunderbird</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="chromeSupport">
             <property name="text">

--- a/src/browser/BrowserShared.h
+++ b/src/browser/BrowserShared.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -33,6 +33,7 @@ namespace BrowserShared
         TOR_BROWSER,
         BRAVE,
         EDGE,
+        THUNDERBIRD,
         CUSTOM,
         MAX_SUPPORTED
     };

--- a/src/browser/NativeMessageInstaller.h
+++ b/src/browser/NativeMessageInstaller.h
@@ -1,6 +1,5 @@
 /*
- *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -40,8 +39,10 @@ private:
     QString getTargetPath(BrowserShared::SupportedBrowsers browser) const;
     QString getBrowserName(BrowserShared::SupportedBrowsers browser) const;
     QString getNativeMessagePath(BrowserShared::SupportedBrowsers browser) const;
+    QString getHostName(BrowserShared::SupportedBrowsers browser) const;
     QJsonObject constructFile(BrowserShared::SupportedBrowsers browser);
     bool createNativeMessageFile(BrowserShared::SupportedBrowsers browser);
+    bool isFirefoxBrowser(BrowserShared::SupportedBrowsers browser) const;
 
     Q_DISABLE_COPY(NativeMessageInstaller);
 };


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds official support to keepassxc-mail with Mozilla Thunderbird. The implementation is using `org.keepassxc.keepassxc_mail` name with `keepassxc-mail@kkapsner.de` extension identifier.

TODO:
- [x] Test on macOS
- [ ] Test on Linux
- [ ] Test on Windows

Fixes #7838.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)