### PR TITLE
Add option to disable database lock when switching user on macOS

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -596,6 +596,10 @@
         <source>Hide TOTP in the entry preview panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Lock databases when switching user</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AutoType</name>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -135,6 +135,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_LockDatabaseIdleSeconds, {QS("Security/LockDatabaseIdleSeconds"), Roaming, 240}},
     {Config::Security_LockDatabaseMinimize, {QS("Security/LockDatabaseMinimize"), Roaming, false}},
     {Config::Security_LockDatabaseScreenLock, {QS("Security/LockDatabaseScreenLock"), Roaming, true}},
+    {Config::Security_LockDatabaseOnUserSwitch, {QS("Security/LockDatabaseOnUserSwitch"), Roaming, true}},
     {Config::Security_RelockAutoType, {QS("Security/RelockAutoType"), Roaming, false}},
     {Config::Security_PasswordsHidden, {QS("Security/PasswordsHidden"), Roaming, true}},
     {Config::Security_PasswordEmptyPlaceholder, {QS("Security/PasswordEmptyPlaceholder"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -116,6 +116,7 @@ public:
         Security_LockDatabaseIdleSeconds,
         Security_LockDatabaseMinimize,
         Security_LockDatabaseScreenLock,
+        Security_LockDatabaseOnUserSwitch,
         Security_RelockAutoType,
         Security_PasswordsHidden,
         Security_PasswordEmptyPlaceholder,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -317,6 +317,13 @@ void ApplicationSettingsWidget::loadSettings()
                                                       && config()->get(Config::Security_LockDatabaseMinimize).toBool());
     m_secUi->lockDatabaseOnScreenLockCheckBox->setChecked(
         config()->get(Config::Security_LockDatabaseScreenLock).toBool());
+#if defined(Q_OS_MACOS)
+    m_secUi->lockDatabasesOnUserSwitchCheckBox->setEnabled(true);
+#else
+    m_secUi->lockDatabasesOnUserSwitchCheckBox->setEnabled(false);
+#endif
+    m_secUi->lockDatabasesOnUserSwitchCheckBox->setChecked(
+        config()->get(Config::Security_LockDatabaseOnUserSwitch).toBool());
     m_secUi->fallbackToSearch->setChecked(config()->get(Config::Security_IconDownloadFallback).toBool());
 
     m_secUi->passwordsHiddenCheckBox->setChecked(config()->get(Config::Security_PasswordsHidden).toBool());
@@ -430,6 +437,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::Security_LockDatabaseIdleSeconds, m_secUi->lockDatabaseIdleSpinBox->value());
     config()->set(Config::Security_LockDatabaseMinimize, m_secUi->lockDatabaseMinimizeCheckBox->isChecked());
     config()->set(Config::Security_LockDatabaseScreenLock, m_secUi->lockDatabaseOnScreenLockCheckBox->isChecked());
+    config()->set(Config::Security_LockDatabaseOnUserSwitch, m_secUi->lockDatabasesOnUserSwitchCheckBox->isChecked());
     config()->set(Config::Security_IconDownloadFallback, m_secUi->fallbackToSearch->isChecked());
 
     config()->set(Config::Security_PasswordsHidden, m_secUi->passwordsHiddenCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -318,9 +318,9 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->lockDatabaseOnScreenLockCheckBox->setChecked(
         config()->get(Config::Security_LockDatabaseScreenLock).toBool());
 #if defined(Q_OS_MACOS)
-    m_secUi->lockDatabasesOnUserSwitchCheckBox->setEnabled(true);
+    m_secUi->lockDatabasesOnUserSwitchCheckBox->setVisible(true);
 #else
-    m_secUi->lockDatabasesOnUserSwitchCheckBox->setEnabled(false);
+    m_secUi->lockDatabasesOnUserSwitchCheckBox->setVisible(false);
 #endif
     m_secUi->lockDatabasesOnUserSwitchCheckBox->setChecked(
         config()->get(Config::Security_LockDatabaseOnUserSwitch).toBool());

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -187,6 +187,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="lockDatabasesOnUserSwitchCheckBox">
+        <property name="text">
+         <string>Lock databases when switching user</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="passwordsHiddenCheckBox">
         <property name="text">
          <string>Hide passwords when editing them</string>
@@ -277,6 +284,7 @@
   <tabstop>clearClipboardSpinBox</tabstop>
   <tabstop>lockDatabaseIdleCheckBox</tabstop>
   <tabstop>lockDatabaseIdleSpinBox</tabstop>
+  <tabstop>lockDatabasesOnUserSwitchCheckBox</tabstop>
   <tabstop>clearSearchCheckBox</tabstop>
   <tabstop>clearSearchSpinBox</tabstop>
   <tabstop>quickUnlockCheckBox</tabstop>

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -63,7 +63,7 @@ DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
     // clang-format on
 
 #ifdef Q_OS_MACOS
-    connect(macUtils(), SIGNAL(lockDatabases()), SLOT(lockDatabases()));
+    connect(macUtils(), SIGNAL(lockDatabasesOnUserSwitch()), SLOT(lockDatabasesOnUserSwitch()));
 #endif
 
     m_lockDelayTimer.setSingleShot(true);
@@ -697,6 +697,13 @@ void DatabaseTabWidget::lockDatabasesDelayed()
     m_lockDelayTimer.setInterval(lockDelay * 1000);
     if (!m_lockDelayTimer.isActive()) {
         m_lockDelayTimer.start();
+    }
+}
+
+void DatabaseTabWidget::lockDatabasesOnUserSwitch()
+{
+    if (config()->get(Config::Security_LockDatabaseOnUserSwitch).toBool()) {
+        lockDatabases();
     }
 }
 

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -63,7 +63,7 @@ DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
     // clang-format on
 
 #ifdef Q_OS_MACOS
-    connect(macUtils(), SIGNAL(lockDatabasesOnUserSwitch()), SLOT(lockDatabasesOnUserSwitch()));
+    connect(macUtils(), SIGNAL(userSwitched()), SLOT(lockDatabasesOnUserSwitch()));
 #endif
 
     m_lockDelayTimer.setSingleShot(true);

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -74,6 +74,7 @@ public slots:
 
     bool lockDatabases();
     void lockDatabasesDelayed();
+    void lockDatabasesOnUserSwitch();
     void closeDatabaseFromSender();
     void unlockDatabaseInDialog(DatabaseWidget* dbWidget, DatabaseOpenDialog::Intent intent);
     void unlockDatabaseInDialog(DatabaseWidget* dbWidget, DatabaseOpenDialog::Intent intent, const QString& filePath);

--- a/src/gui/osutils/macutils/AppKit.h
+++ b/src/gui/osutils/macutils/AppKit.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2016 Lennart Glauer <mail@lennart-glauer.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,8 +19,8 @@
 #ifndef KEEPASSX_APPKIT_H
 #define KEEPASSX_APPKIT_H
 
-#include <QObject>
 #include <QColor>
+#include <QObject>
 #include <unistd.h>
 
 class QWindow;
@@ -47,7 +47,7 @@ public:
     void setWindowSecurity(QWindow* window, bool state);
 
 signals:
-    void lockDatabases();
+    void lockDatabasesOnUserSwitch();
     void interfaceThemeChanged();
 
 private:

--- a/src/gui/osutils/macutils/AppKit.h
+++ b/src/gui/osutils/macutils/AppKit.h
@@ -47,7 +47,7 @@ public:
     void setWindowSecurity(QWindow* window, bool state);
 
 signals:
-    void lockDatabasesOnUserSwitch();
+    void userSwitched();
     void interfaceThemeChanged();
 
 private:

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -160,7 +160,7 @@
 {
     if ([[notification name] isEqualToString:NSWorkspaceSessionDidResignActiveNotification] && m_appkit)
     {
-        emit m_appkit->lockDatabasesOnUserSwitch();
+        emit m_appkit->userSwitched();
     }
 }
 

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -32,7 +32,7 @@
                                                            selector:@selector(didDeactivateApplicationObserver:)
                                                                name:NSWorkspaceDidDeactivateApplicationNotification
                                                              object:nil];
-    
+
         [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
                                                             selector:@selector(userSwitchHandler:)
                                                                 name:NSWorkspaceSessionDidResignActiveNotification
@@ -160,7 +160,7 @@
 {
     if ([[notification name] isEqualToString:NSWorkspaceSessionDidResignActiveNotification] && m_appkit)
     {
-        emit m_appkit->lockDatabases();
+        emit m_appkit->lockDatabasesOnUserSwitch();
     }
 }
 
@@ -188,7 +188,7 @@
         // Request screen recording permission on macOS 10.15+
         // This is necessary to get the current window title
         CGDisplayStreamRef stream = CGDisplayStreamCreate(CGMainDisplayID(), 1, 1, kCVPixelFormatType_32BGRA, nil,
-                                                          ^(CGDisplayStreamFrameStatus status, uint64_t displayTime, 
+                                                          ^(CGDisplayStreamFrameStatus status, uint64_t displayTime,
                                                                   IOSurfaceRef frameSurface, CGDisplayStreamUpdateRef updateRef) {
                                                               Q_UNUSED(status);
                                                               Q_UNUSED(displayTime);

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -39,7 +39,7 @@ MacUtils::MacUtils(QObject* parent)
     : OSUtilsBase(parent)
     , m_appkit(new AppKit())
 {
-    connect(m_appkit.data(), SIGNAL(lockDatabases()), SIGNAL(lockDatabases()));
+    connect(m_appkit.data(), SIGNAL(lockDatabasesOnUserSwitch()), SIGNAL(lockDatabasesOnUserSwitch()));
     connect(m_appkit.data(), SIGNAL(interfaceThemeChanged()), SIGNAL(interfaceThemeChanged()));
     connect(m_appkit.data(), &AppKit::interfaceThemeChanged, this, [this]() {
         // Emit with delay, since isStatusBarDark() still returns the old value

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -39,7 +39,7 @@ MacUtils::MacUtils(QObject* parent)
     : OSUtilsBase(parent)
     , m_appkit(new AppKit())
 {
-    connect(m_appkit.data(), SIGNAL(lockDatabasesOnUserSwitch()), SIGNAL(lockDatabasesOnUserSwitch()));
+    connect(m_appkit.data(), SIGNAL(userSwitched()), SIGNAL(userSwitched()));
     connect(m_appkit.data(), SIGNAL(interfaceThemeChanged()), SIGNAL(interfaceThemeChanged()));
     connect(m_appkit.data(), &AppKit::interfaceThemeChanged, this, [this]() {
         // Emit with delay, since isStatusBarDark() still returns the old value

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -66,7 +66,7 @@ public:
     bool setPreventScreenCapture(QWindow* window, bool prevent) const override;
 
 signals:
-    void lockDatabasesOnUserSwitch();
+    void userSwitched();
 
 protected:
     explicit MacUtils(QObject* parent = nullptr);

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -66,7 +66,7 @@ public:
     bool setPreventScreenCapture(QWindow* window, bool prevent) const override;
 
 signals:
-    void lockDatabases();
+    void lockDatabasesOnUserSwitch();
 
 protected:
     explicit MacUtils(QObject* parent = nullptr);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds a new configuration option for macOS to disable database lock when switching user. Enabled by default. Renamed the MacUtils' `lockDatabases()` signal to `lockDatabasesOnUserSwitch()` because it's the only one that is used currently, but the name is too generic. There might be some other scenarios where databases could be locked, so this one is now distinguished.

Fixes #6726.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)