### PR TITLE
Remove password repeat application setting

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -561,10 +561,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Require password repeat when it is visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Hide passwords when editing them</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -134,7 +134,6 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_LockDatabaseMinimize, {QS("Security/LockDatabaseMinimize"), Roaming, false}},
     {Config::Security_LockDatabaseScreenLock, {QS("Security/LockDatabaseScreenLock"), Roaming, true}},
     {Config::Security_RelockAutoType, {QS("Security/RelockAutoType"), Roaming, false}},
-    {Config::Security_PasswordsRepeatVisible, {QS("Security/PasswordsRepeatVisible"), Roaming, true}},
     {Config::Security_PasswordsHidden, {QS("Security/PasswordsHidden"), Roaming, true}},
     {Config::Security_PasswordEmptyPlaceholder, {QS("Security/PasswordEmptyPlaceholder"), Roaming, false}},
     {Config::Security_HidePasswordPreviewPanel, {QS("Security/HidePasswordPreviewPanel"), Roaming, true}},
@@ -329,7 +328,7 @@ static const QHash<QString, Config::ConfigKey> deprecationMap = {
     {QS("security/passwordscleartext"), Config::Security_PasswordsHidden},
     {QS("security/passwordemptynodots"), Config::Security_PasswordEmptyPlaceholder},
     {QS("security/HidePasswordPreviewPanel"), Config::Security_HidePasswordPreviewPanel},
-    {QS("security/passwordsrepeat"), Config::Security_PasswordsRepeatVisible},
+    {QS("security/passwordsrepeat"), Config::Deleted},
     {QS("security/hidenotes"), Config::Security_HideNotes},
     {QS("KeeShare/Settings.own"), Config::KeeShare_Own},
     {QS("KeeShare/Settings.foreign"), Config::KeeShare_Foreign},
@@ -375,7 +374,8 @@ static const QHash<QString, Config::ConfigKey> deprecationMap = {
     {QS("Security/ResetTouchIdScreenlock"), Config::Deleted},
 
     // 2.8.0
-    {QS("GUI/AdvancedSettings"), Config::Deleted}};
+    {QS("GUI/AdvancedSettings"), Config::Deleted},
+    {QS("Security/PasswordsRepeatVisible"), Config::Deleted}};
 
 /**
  * Migrate settings from previous versions.

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -115,7 +115,6 @@ public:
         Security_LockDatabaseMinimize,
         Security_LockDatabaseScreenLock,
         Security_RelockAutoType,
-        Security_PasswordsRepeatVisible,
         Security_PasswordsHidden,
         Security_PasswordEmptyPlaceholder,
         Security_HidePasswordPreviewPanel,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -318,8 +318,6 @@ void ApplicationSettingsWidget::loadSettings()
     m_secUi->passwordPreviewCleartextCheckBox->setChecked(
         config()->get(Config::Security_HidePasswordPreviewPanel).toBool());
     m_secUi->hideTotpCheckBox->setChecked(config()->get(Config::Security_HideTotpPreviewPanel).toBool());
-    m_secUi->passwordsRepeatVisibleCheckBox->setChecked(
-        config()->get(Config::Security_PasswordsRepeatVisible).toBool());
     m_secUi->hideNotesCheckBox->setChecked(config()->get(Config::Security_HideNotes).toBool());
     m_secUi->NoConfirmMoveEntryToRecycleBinCheckBox->setChecked(
         config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool());
@@ -433,7 +431,6 @@ void ApplicationSettingsWidget::saveSettings()
 
     config()->set(Config::Security_HidePasswordPreviewPanel, m_secUi->passwordPreviewCleartextCheckBox->isChecked());
     config()->set(Config::Security_HideTotpPreviewPanel, m_secUi->hideTotpCheckBox->isChecked());
-    config()->set(Config::Security_PasswordsRepeatVisible, m_secUi->passwordsRepeatVisibleCheckBox->isChecked());
     config()->set(Config::Security_HideNotes, m_secUi->hideNotesCheckBox->isChecked());
     config()->set(Config::Security_NoConfirmMoveEntryToRecycleBin,
                   m_secUi->NoConfirmMoveEntryToRecycleBinCheckBox->isChecked());

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -187,13 +187,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="passwordsRepeatVisibleCheckBox">
-        <property name="text">
-         <string>Require password repeat when it is visible</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QCheckBox" name="passwordsHiddenCheckBox">
         <property name="text">
          <string>Hide passwords when editing them</string>
@@ -288,7 +281,6 @@
   <tabstop>clearSearchSpinBox</tabstop>
   <tabstop>lockDatabaseOnScreenLockCheckBox</tabstop>
   <tabstop>lockDatabaseMinimizeCheckBox</tabstop>
-  <tabstop>passwordsRepeatVisibleCheckBox</tabstop>
   <tabstop>passwordsHiddenCheckBox</tabstop>
   <tabstop>passwordShowDotsCheckBox</tabstop>
   <tabstop>passwordPreviewCleartextCheckBox</tabstop>

--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -148,8 +148,6 @@ void PasswordWidget::setRepeatPartner(PasswordWidget* repeatPartner)
     m_repeatPasswordWidget = repeatPartner;
     m_repeatPasswordWidget->setParentPasswordEdit(this);
 
-    connect(
-        m_ui->passwordEdit, SIGNAL(textChanged(QString)), m_repeatPasswordWidget, SLOT(autocompletePassword(QString)));
     connect(m_ui->passwordEdit, SIGNAL(textChanged(QString)), m_repeatPasswordWidget, SLOT(updateRepeatStatus()));
 }
 
@@ -178,12 +176,6 @@ void PasswordWidget::setShowPassword(bool show)
 
     if (m_repeatPasswordWidget) {
         m_repeatPasswordWidget->setEchoMode(show ? QLineEdit::Normal : QLineEdit::Password);
-        if (!config()->get(Config::Security_PasswordsRepeatVisible).toBool()) {
-            m_repeatPasswordWidget->setEnabled(!show);
-            m_repeatPasswordWidget->setText(text());
-        } else {
-            m_repeatPasswordWidget->setEnabled(true);
-        }
     }
 }
 
@@ -228,14 +220,6 @@ void PasswordWidget::updateRepeatStatus()
         m_correctAction->setVisible(false);
         m_errorAction->setVisible(false);
         setStyleSheet("");
-    }
-}
-
-void PasswordWidget::autocompletePassword(const QString& password)
-{
-    if (!config()->get(Config::Security_PasswordsRepeatVisible).toBool()
-        && m_ui->passwordEdit->echoMode() == QLineEdit::Normal) {
-        setText(password);
     }
 }
 

--- a/src/gui/PasswordWidget.h
+++ b/src/gui/PasswordWidget.h
@@ -61,7 +61,6 @@ protected:
     bool event(QEvent* event) override;
 
 private slots:
-    void autocompletePassword(const QString& password);
     void popupPasswordGenerator();
     void updateRepeatStatus();
     void updatePasswordStrength(const QString& password);

--- a/tests/TestConfig.cpp
+++ b/tests/TestConfig.cpp
@@ -35,7 +35,6 @@ void TestConfig::testUpgrade()
     Config::createConfigFromFile(tempFile.fileName());
 
     // value of new setting should be opposite the value of deprecated setting
-    QVERIFY(!config()->get(Config::Security_PasswordsRepeatVisible).toBool());
     QVERIFY(!config()->get(Config::Security_PasswordsHidden).toBool());
     QVERIFY(config()->get(Config::Security_PasswordEmptyPlaceholder).toBool());
 


### PR DESCRIPTION
* This removes the application setting to require typing the password in again even though it is visible.
* The behavior now is fixed such that when setting up your database password, if you make it visible you no longer need to type it into the repeat field.

Inspired by #9721 

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
