### PR TITLE
Exclude Flatpak and Snap from proxy detection warning

### DIFF
--- a/src/browser/BrowserSettingsWidget.cpp
+++ b/src/browser/BrowserSettingsWidget.cpp
@@ -199,6 +199,7 @@ QString BrowserSettingsWidget::resolveCustomProxyLocation()
 
 void BrowserSettingsWidget::validateProxyLocation()
 {
+#if !defined(KEEPASSXC_DIST_SNAP) && !defined(KEEPASSXC_DIST_FLATPAK)
     // Reset the UI
     m_ui->messageWidget->setVisible(false);
     m_ui->customProxyLocation->setStyleSheet("");
@@ -229,6 +230,7 @@ void BrowserSettingsWidget::validateProxyLocation()
             }
         }
     }
+#endif
 }
 
 void BrowserSettingsWidget::saveSettings()


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Need to exclude this warning for flatpak and snap distros since their proxy executable is in a unique and non-accessible location from the sandbox.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Oops...

![image](https://github.com/keepassxreboot/keepassxc/assets/2809491/8bbc0d8f-9236-450e-947c-49d7ece707d4)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
