### PR TITLE
Fix password generator close button for good

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -279,6 +279,8 @@ QJsonObject BrowserAction::handleGeneratePassword(QLocalSocket* socket, const QJ
             errorReply["requestID"] = requestId;
         }
 
+        // Show the existing password generator
+        browserService()->showPasswordGenerator({});
         return errorReply;
     }
 

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -205,12 +205,11 @@ private:
 
     bool m_dialogActive;
     bool m_bringToFrontRequested;
-    bool m_passwordGeneratorRequested;
     WindowState m_prevWindowState;
     QUuid m_keepassBrowserUUID;
 
     QPointer<DatabaseWidget> m_currentDatabaseWidget;
-    QScopedPointer<PasswordGeneratorWidget> m_passwordGenerator;
+    QPointer<PasswordGeneratorWidget> m_passwordGenerator;
 
     Q_DISABLE_COPY(BrowserService);
 

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -34,13 +34,12 @@
 #include "gui/styles/StateColorPalette.h"
 
 PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
-    : QDialog(parent)
+    : QWidget(parent)
     , m_passwordGenerator(new PasswordGenerator())
     , m_dicewareGenerator(new PassphraseGenerator())
     , m_ui(new Ui::PasswordGeneratorWidget())
 {
     m_ui->setupUi(this);
-    setWindowFlags(Qt::Widget);
 
     m_ui->buttonGenerate->setIcon(icons()->icon("refresh"));
     m_ui->buttonGenerate->setToolTip(
@@ -122,7 +121,7 @@ void PasswordGeneratorWidget::closeEvent(QCloseEvent* event)
 {
     // Emits closed signal when clicking X from title bar
     emit closed();
-    event->accept();
+    QWidget::closeEvent(event);
 }
 
 PasswordGeneratorWidget* PasswordGeneratorWidget::popupGenerator(QWidget* parent)

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 #define KEEPASSX_PASSWORDGENERATORWIDGET_H
 
 #include <QComboBox>
-#include <QDialog>
 #include <QTimer>
 
 #include "core/PassphraseGenerator.h"
@@ -35,7 +34,7 @@ class PasswordGenerator;
 class PasswordHealth;
 class PassphraseGenerator;
 
-class PasswordGeneratorWidget : public QDialog
+class PasswordGeneratorWidget : public QWidget
 {
     Q_OBJECT
 
@@ -71,6 +70,9 @@ public slots:
     void deleteWordList();
     void addWordList();
 
+protected:
+    void closeEvent(QCloseEvent* event) override;
+
 private slots:
     void updateButtonsEnabled(const QString& password);
     void updatePasswordStrength();
@@ -87,7 +89,6 @@ private:
     bool m_passwordGenerated = false;
     int m_firstCustomWordlistIndex;
 
-    void closeEvent(QCloseEvent* event) override;
     PasswordGenerator::CharClasses charClasses();
     PasswordGenerator::GeneratorFlags generatorFlags();
 


### PR DESCRIPTION
* Avoids using QDialog which breaks the standalone password generator

Revert "Fix password dialog close button"

This reverts commit 5b47190fcc4b2f51fb11849cef7f53346e8fe439.

Fixes #7952.

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows with latest browser extension

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
