### PR TITLE
Change conf path XDG_CACHE_HOME to XDG_STATE_HOME

### DIFF
--- a/docs/topics/DownloadInstall.adoc
+++ b/docs/topics/DownloadInstall.adoc
@@ -59,7 +59,7 @@ image::linux_store.png[]
 
 The Snap and Flatpak options are sandboxed applications (more secure). The Native option is installed with the operating system files. Read more about the limitations of these options here: https://keepassxc.org/docs/#faq-appsnap-yubikey[KeePassXC Snap FAQ]
 
-NOTE: KeePassXC stores a configuration file in `~/.cache` to remember window position, recent files, and other local settings. If you mount this folder to a tmpdisk you will lose settings after reboot.
+NOTE: KeePassXC stores a configuration file in `~/.local/state` to remember window position, recent files, and other local settings. If you mount this folder to a tmpdisk you will lose settings after reboot.
 
 === macOS
 To install the KeePassXC app on macOS, double click on the downloaded DMG file and use the click and drag option as shown:

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -476,19 +476,21 @@ void Config::init(const QString& configFileName, const QString& localConfigFileN
     // Upgrade from previous KeePassXC version which stores its config
     // in ~/.cache on Linux instead of ~/.local/state.
     // Move file to correct location before continuing.
-    QString oldLocalConfigPath;
-    oldLocalConfigPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/keepassxc";
-    QString suffix;
+    if (!QFile::exists(localConfigFileName)) {
+        QString oldLocalConfigPath;
+        oldLocalConfigPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/keepassxc";
+        QString suffix;
 #ifdef QT_DEBUG
-    suffix = "_debug";
+        suffix = "_debug";
 #endif
-    oldLocalConfigPath += QString("/keepassxc%1.ini").arg(suffix);
-    oldLocalConfigPath = QDir::toNativeSeparators(oldLocalConfigPath);
-    if (!QFile::exists(localConfigFileName) && QFile::exists(oldLocalConfigPath)) {
-        QDir().mkpath(QFileInfo(localConfigFileName).absolutePath());
-        QFile::copy(oldLocalConfigPath, localConfigFileName);
-        QFile::remove(oldLocalConfigPath);
-        QDir().rmdir(QFileInfo(oldLocalConfigPath).absolutePath());
+        oldLocalConfigPath += QString("/keepassxc%1.ini").arg(suffix);
+        oldLocalConfigPath = QDir::toNativeSeparators(oldLocalConfigPath);
+        if (QFile::exists(oldLocalConfigPath)) {
+            QDir().mkpath(QFileInfo(localConfigFileName).absolutePath());
+            QFile::copy(oldLocalConfigPath, localConfigFileName);
+            QFile::remove(oldLocalConfigPath);
+            QDir().rmdir(QFileInfo(oldLocalConfigPath).absolutePath());
+        }
     }
 #endif
 

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -512,7 +512,17 @@ QPair<QString, QString> Config::defaultConfigFiles()
 #else
     // On case-sensitive Operating Systems, force use of lowercase app directories
     configPath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/keepassxc";
-    localConfigPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/keepassxc";
+    // Qt does not support XDG_STATE_HOME yet, change this once XDG_STATE_HOME is added
+    QString xdgStateHome;
+    xdgStateHome = QFile::decodeName(qgetenv("XDG_STATE_HOME"));
+    if (!xdgStateHome.startsWith(u'/')){ 
+        xdgStateHome.clear(); // spec says relative paths should be ignored
+    }
+    if (xdgStateHome.isEmpty()) {
+        xdgStateHome = QDir::homePath() + "/.local/state";
+    }
+
+    localConfigPath = xdgStateHome + "/keepassxc";
 #endif
 
     QString suffix;

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -477,8 +477,8 @@ void Config::init(const QString& configFileName, const QString& localConfigFileN
     // in ~/.cache on Linux instead of ~/.local/state.
     // Move file to correct location before continuing.
     if (!QFile::exists(localConfigFileName)) {
-        QString oldLocalConfigPath;
-        oldLocalConfigPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/keepassxc";
+        QString oldLocalConfigPath =
+            QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/keepassxc";
         QString suffix;
 #ifdef QT_DEBUG
         suffix = "_debug";

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -515,7 +515,7 @@ QPair<QString, QString> Config::defaultConfigFiles()
     // Qt does not support XDG_STATE_HOME yet, change this once XDG_STATE_HOME is added
     QString xdgStateHome;
     xdgStateHome = QFile::decodeName(qgetenv("XDG_STATE_HOME"));
-    if (!xdgStateHome.startsWith(u'/')){ 
+    if (!xdgStateHome.startsWith(u'/')) {
         xdgStateHome.clear(); // spec says relative paths should be ignored
     }
     if (xdgStateHome.isEmpty()) {

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -533,8 +533,7 @@ QPair<QString, QString> Config::defaultConfigFiles()
     // On case-sensitive Operating Systems, force use of lowercase app directories
     configPath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/keepassxc";
     // Qt does not support XDG_STATE_HOME yet, change this once XDG_STATE_HOME is added
-    QString xdgStateHome;
-    xdgStateHome = QFile::decodeName(qgetenv("XDG_STATE_HOME"));
+    QString xdgStateHome = QFile::decodeName(qgetenv("XDG_STATE_HOME"));
     if (!xdgStateHome.startsWith(u'/')) {
         xdgStateHome.clear(); // spec says relative paths should be ignored
     }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -484,7 +484,7 @@ void Config::init(const QString& configFileName, const QString& localConfigFileN
 #endif
     oldLocalConfigPath += QString("/keepassxc%1.ini").arg(suffix);
     oldLocalConfigPath = QDir::toNativeSeparators(oldLocalConfigPath);
-    if (!localConfigFileName.isEmpty() && !QFile::exists(localConfigFileName) && QFile::exists(oldLocalConfigPath)) {
+    if (!QFile::exists(localConfigFileName) && QFile::exists(oldLocalConfigPath)) {
         QDir().mkpath(QFileInfo(localConfigFileName).absolutePath());
         QFile::copy(oldLocalConfigPath, localConfigFileName);
         QFile::remove(oldLocalConfigPath);


### PR DESCRIPTION
Keepassxc saves application state at XDG_CACHE_HOME which can be cleared on some systems periodicly.
This is not desireable as app state like window size is not consistent when openning the app.
To avoid this, this PR commit is switching the path to XDG_STATE_HOME which is more fitting based on the [freedesktop basedir spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), this will allow to prevent state file deletion as well.

Changes made based on how qt implements QStandardPaths (very similar to internal qt code)

Also added code to migrate old config files to new location and cleanup files from old location.

Fixes #9738 

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
N/A

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Manually tested file changes in `~/.local/state` and that migration from `~/.cache` works.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Documentation (non-code change)
