### PR TITLE
Implement group sync

### DIFF
--- a/src/keeshare/KeeShareSettings.h
+++ b/src/keeshare/KeeShareSettings.h
@@ -126,6 +126,7 @@ namespace KeeShareSettings
         QUuid uuid;
         QString path;
         QString password;
+        bool recurse;
 
         Reference();
         bool isNull() const;

--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -110,7 +110,9 @@ namespace
         targetRoot->setUpdateTimeinfo(updateTimeinfo);
         cloneIcon(targetMetadata, sourceRoot->database(), targetRoot->iconUuid());
         cloneEntries(targetMetadata, sourceRoot, targetRoot);
-        cloneChildren(targetMetadata, sourceRoot, targetRoot);
+        if(reference.recurse) {
+            cloneChildren(targetMetadata, sourceRoot, targetRoot);
+        }
 
         auto key = QSharedPointer<CompositeKey>::create();
         key->addKey(QSharedPointer<PasswordKey>::create(reference.password));

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -43,6 +43,7 @@ EditGroupWidgetKeeShare::EditGroupWidgetKeeShare(QWidget* parent)
     connect(m_ui->pathEdit, SIGNAL(editingFinished()), SLOT(selectPath()));
     connect(m_ui->pathSelectionButton, SIGNAL(pressed()), SLOT(launchPathSelectionDialog()));
     connect(m_ui->typeComboBox, SIGNAL(currentIndexChanged(int)), SLOT(selectType()));
+    connect(m_ui->recurseIntoGroupsCheckbox, SIGNAL(toggled(bool)), SLOT(recurseIntoGroupsToggled(bool)));
     connect(m_ui->clearButton, SIGNAL(clicked(bool)), SLOT(clearInputs()));
 
     connect(KeeShare::instance(), SIGNAL(activeChanged()), SLOT(updateSharingState()));
@@ -97,6 +98,7 @@ void EditGroupWidgetKeeShare::updateSharingState()
     m_ui->pathEdit->setEnabled(isEnabled);
     m_ui->pathSelectionButton->setEnabled(isEnabled);
     m_ui->passwordEdit->setEnabled(isEnabled);
+    m_ui->recurseIntoGroupsCheckbox->setEnabled(isEnabled);
 
     if (!m_temporaryGroup || !isEnabled) {
         m_ui->messageWidget->hideMessage();
@@ -290,4 +292,14 @@ void EditGroupWidgetKeeShare::selectType()
     KeeShare::setReferenceTo(m_temporaryGroup, reference);
 
     updateSharingState();
+}
+
+void EditGroupWidgetKeeShare::recurseIntoGroupsToggled(bool toggled)
+{
+    if (!m_temporaryGroup) {
+        return;
+    }
+    auto reference = KeeShare::referenceOf(m_temporaryGroup);
+    reference.recurse = toggled;
+    KeeShare::setReferenceTo(m_temporaryGroup, reference);
 }

--- a/src/keeshare/group/EditGroupWidgetKeeShare.h
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.h
@@ -48,6 +48,7 @@ private slots:
     void selectPassword();
     void launchPathSelectionDialog();
     void selectPath();
+    void recurseIntoGroupsToggled(bool);
 
 private:
     QScopedPointer<Ui::EditGroupWidgetKeeShare> m_ui;

--- a/src/keeshare/group/EditGroupWidgetKeeShare.ui
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.ui
@@ -138,7 +138,7 @@
        </item>
       </layout>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <spacer name="horizontalSpacer">
@@ -171,7 +171,7 @@
        </item>
       </layout>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <spacer name="verticalSpacer_2">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -183,6 +183,13 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="recurseIntoGroupsCheckbox">
+       <property name="text">
+        <string>Share recursively</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Some small modifications to sync groups.

This is a really important feature, which is long overdue and the expected behavior for many users.

Fixes #3045

## ToDo
- [ ] Add a setting to disable the feature
- [ ] Add unit tests
- [ ] Sync root group icon if possible (maybe this needs to be fixed in the merge function idk)

NOTE: I personally won't implement these todos, as I'm not experienced with the codebase and Qt. Feel free to implement them and add them to the PR.

## Testing strategy
Create a KeeShare between two databases, add groups and entries to it and set icons and custom icons.

## Type of change
- ✅ New feature (change that adds functionality)
