### PR TITLE
Add configurable password strength check on database password

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1848,9 +1848,7 @@ Are you sure you want to continue without a password?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>WARNING! You have set a weak password. If you do not choose a stronger and more complex password, your database may be compromised more easily.
-
-Are you sure you want to continue using a weak password?</source>
+        <source>WARNING! Using a weak password may expose your accounts to security risks. Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1839,6 +1839,14 @@ Are you sure you want to continue without a password?</source>
         <source>Failed to change database credentials</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Weak password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You must enter a stronger password to protect your database.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetEncryption</name>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1848,13 +1848,13 @@ Are you sure you want to continue without a password?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>WARNING! You have set a weak password. If you do not choose a stronger and more complex password, your database may be compromised more easily.
-
-Are you sure you want to continue usign a weak password?</source>
+        <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Continue</source>
+        <source>WARNING! You have set a weak password. If you do not choose a stronger and more complex password, your database may be compromised more easily.
+
+Are you sure you want to continue using a weak password?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1848,7 +1848,7 @@ Are you sure you want to continue without a password?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>WARNING! Using a weak password may expose your accounts to security risks. Do you wish to continue?</source>
+        <source>This is a weak password! For better protection of your secrets, you should choose a stronger password.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6517,6 +6517,10 @@ Do you want to overwrite it?</source>
     </message>
     <message>
         <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue with weak password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1848,10 +1848,6 @@ Are you sure you want to continue without a password?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Continue</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>WARNING! You have set a weak password. If you do not choose a stronger and more complex password, your database may be compromised more easily.
 
 Are you sure you want to continue using a weak password?</source>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1847,6 +1847,16 @@ Are you sure you want to continue without a password?</source>
         <source>You must enter a stronger password to protect your database.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>WARNING! You have set a weak password. If you do not choose a stronger and more complex password, your database may be compromised more easily.
+
+Are you sure you want to continue usign a weak password?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetEncryption</name>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -144,6 +144,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},
     {Config::Security_EnableCopyOnDoubleClick,{QS("Security/EnableCopyOnDoubleClick"), Roaming, false}},
     {Config::Security_QuickUnlock, {QS("Security/QuickUnlock"), Local, true}},
+    {Config::Security_DatabasePasswordMinimumQuality, {QS("Security/DatabasePasswordMinimumQuality"), Local, 0}},
 
     // Browser
     {Config::Browser_Enabled, {QS("Browser/Enabled"), Roaming, false}},

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -144,7 +144,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},
     {Config::Security_EnableCopyOnDoubleClick,{QS("Security/EnableCopyOnDoubleClick"), Roaming, false}},
     {Config::Security_QuickUnlock, {QS("Security/QuickUnlock"), Local, true}},
-    {Config::Security_DatabasePasswordMinimumQuality, {QS("Security/DatabasePasswordMinimumQuality"), Local, 3}},
+    {Config::Security_DatabasePasswordMinimumQuality, {QS("Security/DatabasePasswordMinimumQuality"), Local, 0}},
 
     // Browser
     {Config::Browser_Enabled, {QS("Browser/Enabled"), Roaming, false}},

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -144,7 +144,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},
     {Config::Security_EnableCopyOnDoubleClick,{QS("Security/EnableCopyOnDoubleClick"), Roaming, false}},
     {Config::Security_QuickUnlock, {QS("Security/QuickUnlock"), Local, true}},
-    {Config::Security_DatabasePasswordMinimumQuality, {QS("Security/DatabasePasswordMinimumQuality"), Local, 0}},
+    {Config::Security_DatabasePasswordMinimumQuality, {QS("Security/DatabasePasswordMinimumQuality"), Local, 3}},
 
     // Browser
     {Config::Browser_Enabled, {QS("Browser/Enabled"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -124,6 +124,7 @@ public:
         Security_NoConfirmMoveEntryToRecycleBin,
         Security_EnableCopyOnDoubleClick,
         Security_QuickUnlock,
+        Security_DatabasePasswordMinimumQuality,
 
         Browser_Enabled,
         Browser_ShowNotification,

--- a/src/gui/MessageBox.cpp
+++ b/src/gui/MessageBox.cpp
@@ -66,6 +66,7 @@ void MessageBox::initializeButtonDefs()
         {Disable, {QMessageBox::tr("Disable"), QMessageBox::ButtonRole::AcceptRole}},
         {Merge, {QMessageBox::tr("Merge"), QMessageBox::ButtonRole::AcceptRole}},
         {Continue, {QMessageBox::tr("Continue"), QMessageBox::ButtonRole::AcceptRole}},
+        {ContinueWithWeakPass, {QMessageBox::tr("Continue with weak password"), QMessageBox::ButtonRole::AcceptRole}},
     };
 }
 

--- a/src/gui/MessageBox.h
+++ b/src/gui/MessageBox.h
@@ -58,10 +58,11 @@ public:
         Disable = 1 << 25,
         Merge = 1 << 26,
         Continue = 1 << 27,
+        ContinueWithWeakPass = 1 << 28,
 
         // Internal loop markers. Update Last when new KeePassXC button is added
         First = Ok,
-        Last = Continue,
+        Last = ContinueWithWeakPass,
     };
 
     enum Action

--- a/src/gui/databasekey/PasswordEditWidget.cpp
+++ b/src/gui/databasekey/PasswordEditWidget.cpp
@@ -62,6 +62,14 @@ bool PasswordEditWidget::isEmpty() const
     return (visiblePage() == Page::Edit) && m_compUi->enterPasswordEdit->text().isEmpty();
 }
 
+PasswordHealth::Quality PasswordEditWidget::getPasswordQuality() const
+{
+    QString pwd = m_compUi->enterPasswordEdit->text();
+    PasswordHealth passwordHealth(pwd);
+
+    return passwordHealth.quality();
+}
+
 QWidget* PasswordEditWidget::componentEditWidget()
 {
     m_compEditWidget = new QWidget();

--- a/src/gui/databasekey/PasswordEditWidget.h
+++ b/src/gui/databasekey/PasswordEditWidget.h
@@ -20,6 +20,8 @@
 
 #include "KeyComponentWidget.h"
 
+#include "core/PasswordHealth.h"
+
 namespace Ui
 {
     class PasswordEditWidget;
@@ -38,6 +40,7 @@ public:
     void setPasswordVisible(bool visible);
     bool isPasswordVisible() const;
     bool isEmpty() const;
+    PasswordHealth::Quality getPasswordQuality() const;
     bool validate(QString& errorMessage) const override;
 
 protected:

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
@@ -180,9 +180,8 @@ bool DatabaseSettingsWidgetDatabaseKey::save()
         auto dialogResult =
             MessageBox::warning(this,
                                 tr("Weak password"),
-                                tr("WARNING! You have set a weak password. If you do not choose a stronger and "
-                                   "more complex password, your database may be compromised more easily.\n\n"
-                                   "Are you sure you want to continue using a weak password?"),
+                                tr("WARNING! Using a weak password may expose your accounts to security risks. "
+                                   "Do you wish to continue?"),
                                 MessageBox::Continue | MessageBox::Cancel,
                                 MessageBox::Cancel);
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
@@ -177,13 +177,12 @@ bool DatabaseSettingsWidgetDatabaseKey::save()
     // Show warning if database password is weak
     if (!m_passwordEditWidget->isEmpty()
         && m_passwordEditWidget->getPasswordQuality() < PasswordHealth::Quality::Good) {
-        auto dialogResult =
-            MessageBox::warning(this,
-                                tr("Weak password"),
-                                tr("WARNING! Using a weak password may expose your accounts to security risks. "
-                                   "Do you wish to continue?"),
-                                MessageBox::Continue | MessageBox::Cancel,
-                                MessageBox::Cancel);
+        auto dialogResult = MessageBox::warning(this,
+                                                tr("Weak password"),
+                                                tr("This is a weak password! For better protection of your secrets, "
+                                                   "you should choose a stronger password."),
+                                                MessageBox::ContinueWithWeakPass | MessageBox::Cancel,
+                                                MessageBox::Cancel);
 
         if (dialogResult == MessageBox::Cancel) {
             return false;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
@@ -17,7 +17,9 @@
 
 #include "DatabaseSettingsWidgetDatabaseKey.h"
 
+#include "core/Config.h"
 #include "core/Database.h"
+#include "core/PasswordHealth.h"
 #include "gui/MessageBox.h"
 #include "gui/databasekey/KeyFileEditWidget.h"
 #include "gui/databasekey/PasswordEditWidget.h"
@@ -168,6 +170,16 @@ bool DatabaseSettingsWidgetDatabaseKey::save()
             return false;
         }
     } else if (!addToCompositeKey(m_passwordEditWidget, newKey, oldPasswordKey)) {
+        return false;
+    }
+
+    auto minQuality = static_cast<PasswordHealth::Quality>(config()->get(Config::Security_DatabasePasswordMinimumQuality).toInt());
+    if (m_passwordEditWidget->getPasswordQuality() < minQuality) {
+        MessageBox::critical(this,
+                                tr("Weak password"),
+                                tr("You must enter a stronger password to protect your database."),
+                                MessageBox::Ok,
+                                MessageBox::Ok);
         return false;
     }
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
@@ -182,7 +182,7 @@ bool DatabaseSettingsWidgetDatabaseKey::save()
         msgBox->setWindowTitle(tr("Weak password"));
         msgBox->setText(tr("WARNING! You have set a weak password. If you do not choose a stronger and "
                            "more complex password, your database may be compromised more easily.\n\n"
-                           "Are you sure you want to continue usign a weak password?"));
+                           "Are you sure you want to continue using a weak password?"));
         auto btn = msgBox->addButton(tr("Continue"), QMessageBox::ButtonRole::AcceptRole);
         msgBox->addButton(QMessageBox::Cancel);
         msgBox->setDefaultButton(QMessageBox::Cancel);

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
@@ -173,13 +173,14 @@ bool DatabaseSettingsWidgetDatabaseKey::save()
         return false;
     }
 
-    auto minQuality = static_cast<PasswordHealth::Quality>(config()->get(Config::Security_DatabasePasswordMinimumQuality).toInt());
+    auto minQuality =
+        static_cast<PasswordHealth::Quality>(config()->get(Config::Security_DatabasePasswordMinimumQuality).toInt());
     if (m_passwordEditWidget->getPasswordQuality() < minQuality) {
         MessageBox::critical(this,
-                                tr("Weak password"),
-                                tr("You must enter a stronger password to protect your database."),
-                                MessageBox::Ok,
-                                MessageBox::Ok);
+                             tr("Weak password"),
+                             tr("You must enter a stronger password to protect your database."),
+                             MessageBox::Ok,
+                             MessageBox::Ok);
         return false;
     }
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
@@ -177,18 +177,16 @@ bool DatabaseSettingsWidgetDatabaseKey::save()
     // Show warning if database password is weak
     if (!m_passwordEditWidget->isEmpty()
         && m_passwordEditWidget->getPasswordQuality() < PasswordHealth::Quality::Good) {
-        QScopedPointer<QMessageBox> msgBox(new QMessageBox(this));
-        msgBox->setIcon(QMessageBox::Warning);
-        msgBox->setWindowTitle(tr("Weak password"));
-        msgBox->setText(tr("WARNING! You have set a weak password. If you do not choose a stronger and "
-                           "more complex password, your database may be compromised more easily.\n\n"
-                           "Are you sure you want to continue using a weak password?"));
-        auto btn = msgBox->addButton(tr("Continue"), QMessageBox::ButtonRole::AcceptRole);
-        msgBox->addButton(QMessageBox::Cancel);
-        msgBox->setDefaultButton(QMessageBox::Cancel);
-        msgBox->exec();
+        auto dialogResult =
+            MessageBox::warning(this,
+                                tr("Weak password"),
+                                tr("WARNING! You have set a weak password. If you do not choose a stronger and "
+                                   "more complex password, your database may be compromised more easily.\n\n"
+                                   "Are you sure you want to continue using a weak password?"),
+                                MessageBox::Continue | MessageBox::Cancel,
+                                MessageBox::Cancel);
 
-        if (msgBox->clickedButton() != btn) {
+        if (dialogResult == MessageBox::Cancel) {
             return false;
         }
     }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -287,7 +287,7 @@ void TestGui::testCreateDatabase()
         fileDialog()->setNextFileName(tmpFile.fileName());
 
         // click Continue on the warning due to weak password
-        MessageBox::setNextAnswer(MessageBox::Continue);
+        MessageBox::setNextAnswer(MessageBox::ContinueWithWeakPass);
         QTest::keyClick(fileEdit, Qt::Key::Key_Enter);
 
         tmpFile.remove(););

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -257,9 +257,9 @@ void TestGui::testCreateDatabase()
             passwordWidget->findChild<PasswordWidget*>("repeatPasswordEdit")->findChild<QLineEdit*>("passwordEdit");
         QTRY_VERIFY(passwordEdit->isVisible());
         QTRY_VERIFY(passwordEdit->hasFocus());
-        QTest::keyClicks(passwordEdit, "Xi3R0nW9PWapNjj");
+        QTest::keyClicks(passwordEdit, "test");
         QTest::keyClick(passwordEdit, Qt::Key::Key_Tab);
-        QTest::keyClicks(passwordRepeatEdit, "Xi3R0nW9PWapNjj");
+        QTest::keyClicks(passwordRepeatEdit, "test");
 
         // add key file
         auto* additionalOptionsButton = wizard->currentPage()->findChild<QPushButton*>("additionalKeyOptionsToggle");
@@ -286,7 +286,10 @@ void TestGui::testCreateDatabase()
         tmpFile.close();
         fileDialog()->setNextFileName(tmpFile.fileName());
 
+        // click Continue on the warning due to weak password
+        MessageBox::setNextAnswer(MessageBox::Continue);
         QTest::keyClick(fileEdit, Qt::Key::Key_Enter);
+
         tmpFile.remove(););
 
     triggerAction("actionDatabaseNew");
@@ -309,7 +312,7 @@ void TestGui::testCreateDatabase()
     QCOMPARE(m_db->kdf()->uuid(), KeePass2::KDF_ARGON2D);
     QCOMPARE(m_db->cipher(), KeePass2::CIPHER_AES256);
     auto compositeKey = QSharedPointer<CompositeKey>::create();
-    compositeKey->addKey(QSharedPointer<PasswordKey>::create("Xi3R0nW9PWapNjj"));
+    compositeKey->addKey(QSharedPointer<PasswordKey>::create("test"));
     auto fileKey = QSharedPointer<FileKey>::create();
     fileKey->load(QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
     compositeKey->addKey(fileKey);

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -257,9 +257,9 @@ void TestGui::testCreateDatabase()
             passwordWidget->findChild<PasswordWidget*>("repeatPasswordEdit")->findChild<QLineEdit*>("passwordEdit");
         QTRY_VERIFY(passwordEdit->isVisible());
         QTRY_VERIFY(passwordEdit->hasFocus());
-        QTest::keyClicks(passwordEdit, "test");
+        QTest::keyClicks(passwordEdit, "Xi3R0nW9PWapNjj");
         QTest::keyClick(passwordEdit, Qt::Key::Key_Tab);
-        QTest::keyClicks(passwordRepeatEdit, "test");
+        QTest::keyClicks(passwordRepeatEdit, "Xi3R0nW9PWapNjj");
 
         // add key file
         auto* additionalOptionsButton = wizard->currentPage()->findChild<QPushButton*>("additionalKeyOptionsToggle");
@@ -309,7 +309,7 @@ void TestGui::testCreateDatabase()
     QCOMPARE(m_db->kdf()->uuid(), KeePass2::KDF_ARGON2D);
     QCOMPARE(m_db->cipher(), KeePass2::CIPHER_AES256);
     auto compositeKey = QSharedPointer<CompositeKey>::create();
-    compositeKey->addKey(QSharedPointer<PasswordKey>::create("test"));
+    compositeKey->addKey(QSharedPointer<PasswordKey>::create("Xi3R0nW9PWapNjj"));
     auto fileKey = QSharedPointer<FileKey>::create();
     fileKey->load(QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
     compositeKey->addKey(fileKey);

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -1880,7 +1880,7 @@ bool TestGuiFdoSecrets::driveNewDatabaseWizard()
             fileDialog()->setNextFileName(tmpFile.fileName());
 
             // click Continue on the warning due to weak password
-            MessageBox::setNextAnswer(MessageBox::Continue);
+            MessageBox::setNextAnswer(MessageBox::ContinueWithWeakPass);
             wizard->accept();
 
             tmpFile.remove();

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -1879,6 +1879,8 @@ bool TestGuiFdoSecrets::driveNewDatabaseWizard()
             tmpFile.close();
             fileDialog()->setNextFileName(tmpFile.fileName());
 
+            // click Continue on the warning due to weak password
+            MessageBox::setNextAnswer(MessageBox::Continue);
             wizard->accept();
 
             tmpFile.remove();


### PR DESCRIPTION
Fixes: https://github.com/keepassxreboot/keepassxc/issues/8190

KeepassXC does not provide a way to enforce the minimum strength of the database password, allowing users to pick easy to crack passwords. 

Although I see the point of @droidmonkey (https://github.com/keepassxreboot/keepassxc/issues/8190), I also believe that quality checks on the master password may be useful, especially when one wants to advocate the usage of this tool to non-security aware users.

For this reason, I added a new setting in the configuration file to enforce the minimum quality that a database password must have in order to be accepted, as follows:
```ini
[Security]
DatabasePasswordMinimumQuality=3
```
The values of `DatabasePasswordMinimumQuality` map to the values of `PasswordHealth::Quality`:

- 0: Bad
- 1: Poor
- 2: Weak
- 3: Good
- 4: Excellent

This setting is set to 0 by default, meaning that the behaviour of KeepassXC won't change when creating/changing the password database. However, it can be enabled with the appropriate value when needed.


## Screenshots
![keepassxc](https://github.com/keepassxreboot/keepassxc/assets/14147983/4acee28c-896a-4a24-aa6d-611a15b6c4e3)


## Testing strategy
Manual testing


## Type of change
- ✅ New feature (change that adds functionality)
