### PR TITLE
Fix menu location in alert

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3441,10 +3441,6 @@ Supported extensions are: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You can enable the DuckDuckGo website icon service under Tools -&gt; Settings -&gt; Security</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Existing icon selected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3484,6 +3480,10 @@ Supported extensions are: %1.</source>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <source>You can enable the DuckDuckGo website icon service under Application Settings -&gt; Security</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -220,7 +220,7 @@ void EditWidgetIcons::iconReceived(const QString& url, const QImage& icon)
         QString message(tr("Unable to fetch favicon."));
         if (!config()->get(Config::Security_IconDownloadFallback).toBool()) {
             message.append("\n").append(
-                tr("You can enable the DuckDuckGo website icon service under Tools -> Settings -> Security"));
+                tr("You can enable the DuckDuckGo website icon service under Application Settings -> Security"));
         }
         emit messageEditEntry(message, MessageWidget::Error);
         return;


### PR DESCRIPTION
Fixes: #9767

When unable to fetch a favicon and the DuckDuckGo website icon service is not enabled, returns a message with the wrong location to enable. Source changed to "You can enable the DuckDuckGo website icon service under Application Settings -> Security".

## Screenshots
![screenshot](https://github.com/keepassxreboot/keepassxc/assets/96984685/77917c83-e3e4-4951-b861-2a79c4d0715d)

## Testing strategy
Checked in Qt Linguist for the change in source text

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)