### PR TITLE
Fix terminating KeePassXC processes with MSI installer

### DIFF
--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -92,6 +92,9 @@
                     <RegistryValue Root="HKCU" Key="Software\KeePassXC" Name="DesktopShortcut" Type="integer" Value="1" KeyPath="yes"/>
                 </Component>
             </Directory>
+
+            <!-- Windows system folder -->
+            <Directory Id="SystemFolder" Name="SystemFolder" />
         </DirectoryRef>
 
         <!-- Custom properties to control installation options -->
@@ -116,12 +119,17 @@
         <Property Id="WixShellExecTarget" Value="[#CM_FP_KeePassXC.exe]" />
         <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
-        <!-- Action to kill running KeePassXC processes -->
-        <Property Id="WixSilentExecCmdLine" Value='taskkill /IM KeePassXC.exe; taskkill /IM keepassxc-proxy.exe /F' />
-        <CustomAction Id="KillKeePassXC" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="ignore" />
+        <!-- Action to kill running KeePassXC process -->
+        <Property Id="WixQuietExecCmdLine" Value='"[SystemFolder]taskkill.exe" /IM KeePassXC.exe' />
+        <CustomAction Id="KillKeePassXC" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="ignore" />
+
+        <!-- Action to kill running keepassxc-proxy processes -->
+        <Property Id="WixSilentExecCmdLine" Value='"[SystemFolder]taskkill.exe" /IM keepassxc-proxy.exe /F' />
+        <CustomAction Id="KillKeePassXCProxy" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="ignore" />
 
         <InstallExecuteSequence>
             <Custom Action="KillKeePassXC" Before="InstallValidate" />
+            <Custom Action="KillKeePassXCProxy" Before="InstallValidate" />
             <!-- Prevent pinned taskbar shortcut from being removed -->
             <RemoveShortcuts Suppress="yes" />
         </InstallExecuteSequence>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Shutdowns KeePassXC process and terminates `keepassxc-proxy.exe` processes during install.

Two `WixSilentExecCmdLine` properties are not accepted, and command line value cannot include two commands simultaneously. Using wildcards with a single `taskkill` command cannot be done either because KeePassXC cannot be terminated forcefully.
The first command line call is now using `WixQuietExecCmdLine` instead, and those two commands are divided to two different CustomActions.
User's system folder path is used in the front of `taskkill.exe`.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Updating from 2.7.0 and repairing installed 2.8.0-snapshot.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
