### PR TITLE
Add support for URL wildcards and exact URL

### DIFF
--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
  *  Copyright (C) 2013 Francois Ferrand
  *
@@ -132,6 +132,7 @@ public:
     static const QString OPTION_ONLY_HTTP_AUTH;
     static const QString OPTION_NOT_HTTP_AUTH;
     static const QString OPTION_OMIT_WWW;
+    static const QString ADDITIONAL_URL;
     static const QString OPTION_RESTRICT_KEY;
 
 signals:
@@ -199,7 +200,9 @@ private:
     bool handleURL(const QString& entryUrl,
                    const QString& siteUrl,
                    const QString& formUrl,
-                   const bool omitWwwSubdomain = false);
+                   const bool omitWwwSubdomain = false,
+                   const bool allowWildcards = false);
+    bool handleURLWithWildcards(const QUrl& entryQUrl, const QString& siteUrl);
     QString getDatabaseRootUuid();
     QString getDatabaseRecycleBinUuid();
     void hideWindow() const;

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -381,15 +381,31 @@ QString Entry::url() const
     return m_attributes->value(EntryAttributes::URLKey);
 }
 
+QString Entry::resolveUrl() const
+{
+    const auto entryUrl = url();
+    if (entryUrl.isEmpty()) {
+        return {};
+    }
+
+    return EntryAttributes::matchReference(entryUrl).hasMatch() ? resolveMultiplePlaceholders(entryUrl) : entryUrl;
+}
+
 QStringList Entry::getAllUrls() const
 {
     QStringList urlList;
-    auto entryUrl = url();
 
+    const auto entryUrl = resolveUrl();
     if (!entryUrl.isEmpty()) {
-        urlList << (EntryAttributes::matchReference(entryUrl).hasMatch() ? resolveMultiplePlaceholders(entryUrl)
-                                                                         : entryUrl);
+        urlList << entryUrl;
     }
+
+    return urlList << getAdditionalUrls();
+}
+
+QStringList Entry::getAdditionalUrls() const
+{
+    QStringList urlList;
 
     for (const auto& key : m_attributes->keys()) {
         if (key.startsWith(EntryAttributes::AdditionalUrlAttribute)

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -100,7 +100,9 @@ public:
     const AutoTypeAssociations* autoTypeAssociations() const;
     QString title() const;
     QString url() const;
+    QString resolveUrl() const;
     QStringList getAllUrls() const;
+    QStringList getAdditionalUrls() const;
     QString webUrl() const;
     QString displayUrl() const;
     QString username() const;

--- a/src/gui/UrlTools.cpp
+++ b/src/gui/UrlTools.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,6 +23,8 @@
 #endif
 #include <QRegularExpression>
 #include <QUrl>
+
+const QString UrlTools::URL_WILDCARD = "1kpxcwc1";
 
 Q_GLOBAL_STATIC(UrlTools, s_urlTools)
 
@@ -137,8 +139,9 @@ bool UrlTools::isUrlIdentical(const QString& first, const QString& second) const
         return false;
     }
 
-    const auto firstUrl = trimUrl(first);
-    const auto secondUrl = trimUrl(second);
+    // Replace URL wildcards for comparison if found
+    const auto firstUrl = trimUrl(QString(first).replace("*", UrlTools::URL_WILDCARD));
+    const auto secondUrl = trimUrl(QString(second).replace("*", UrlTools::URL_WILDCARD));
     if (firstUrl == secondUrl) {
         return true;
     }
@@ -146,27 +149,59 @@ bool UrlTools::isUrlIdentical(const QString& first, const QString& second) const
     return QUrl(firstUrl).matches(QUrl(secondUrl), QUrl::StripTrailingSlash);
 }
 
-bool UrlTools::isUrlValid(const QString& urlField) const
+bool UrlTools::isUrlValid(const QString& urlField, bool looseComparison) const
 {
     if (urlField.isEmpty() || urlField.startsWith("cmd://", Qt::CaseInsensitive)
         || urlField.startsWith("kdbx://", Qt::CaseInsensitive) || urlField.startsWith("{REF:A", Qt::CaseInsensitive)) {
         return true;
     }
 
-    QUrl url;
-    if (urlField.contains("://")) {
-        url = urlField;
-    } else {
-        url = QUrl::fromUserInput(urlField);
+    auto url = urlField;
+
+    // Loose comparison that allows wildcards and exact URL inside " characters
+    if (looseComparison) {
+        // Exact URL
+        if (url.startsWith("\"") && url.endsWith("\"")) {
+            // Do not allow exact URL with wildcards, or empty exact URL
+            if (url.contains("*") || url.length() == 2) {
+                return false;
+            }
+
+            // Get the URL inside ""
+            url.remove(0, 1);
+            url.remove(url.length() - 1, 1);
+        } else {
+            // Do not allow URL with just wildcards, or double wildcards, or no separator (.)
+            if (url.length() == url.count("*") || url.contains("**") || url.contains("*.*") || !url.contains(".")) {
+                return false;
+            }
+
+            url.replace("*", UrlTools::URL_WILDCARD);
+        }
     }
 
-    if (url.scheme() != "file" && url.host().isEmpty()) {
+    QUrl qUrl;
+    if (urlField.contains("://")) {
+        qUrl = url;
+    } else {
+        qUrl = QUrl::fromUserInput(url);
+    }
+
+    if (qUrl.scheme() != "file" && qUrl.host().isEmpty()) {
         return false;
+    }
+
+    // Prevent TLD wildcards
+    if (looseComparison) {
+        const auto tld = getTopLevelDomainFromUrl(url);
+        if (qUrl.host() == QString("%1.%2").arg(UrlTools::URL_WILDCARD, tld)) {
+            return false;
+        }
     }
 
     // Check for illegal characters. Adds also the wildcard * to the list
     QRegularExpression re("[<>\\^`{|}\\*]");
-    auto match = re.match(urlField);
+    auto match = re.match(url);
     if (match.hasMatch()) {
         return false;
     }

--- a/src/gui/UrlTools.cpp
+++ b/src/gui/UrlTools.cpp
@@ -191,6 +191,7 @@ bool UrlTools::isUrlValid(const QString& urlField, bool looseComparison) const
         return false;
     }
 
+#if defined(WITH_XC_NETWORKING) || defined(WITH_XC_BROWSER)
     // Prevent TLD wildcards
     if (looseComparison && url.contains(UrlTools::URL_WILDCARD)) {
         const auto tld = getTopLevelDomainFromUrl(url);
@@ -198,6 +199,7 @@ bool UrlTools::isUrlValid(const QString& urlField, bool looseComparison) const
             return false;
         }
     }
+#endif
 
     // Check for illegal characters. Adds also the wildcard * to the list
     QRegularExpression re("[<>\\^`{|}\\*]");

--- a/src/gui/UrlTools.cpp
+++ b/src/gui/UrlTools.cpp
@@ -192,7 +192,7 @@ bool UrlTools::isUrlValid(const QString& urlField, bool looseComparison) const
     }
 
     // Prevent TLD wildcards
-    if (looseComparison) {
+    if (looseComparison && url.contains(UrlTools::URL_WILDCARD)) {
         const auto tld = getTopLevelDomainFromUrl(url);
         if (qUrl.host() == QString("%1.%2").arg(UrlTools::URL_WILDCARD, tld)) {
             return false;

--- a/src/gui/UrlTools.h
+++ b/src/gui/UrlTools.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -41,8 +41,10 @@ public:
     bool isIpAddress(const QString& host) const;
 #endif
     bool isUrlIdentical(const QString& first, const QString& second) const;
-    bool isUrlValid(const QString& urlField) const;
+    bool isUrlValid(const QString& urlField, bool looseComparison = false) const;
     bool domainHasIllegalCharacters(const QString& domain) const;
+
+    static const QString URL_WILDCARD;
 
 private:
     QUrl convertVariantToUrl(const QVariant& var) const;

--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -67,7 +67,7 @@ QVariant EntryURLModel::data(const QModelIndex& index, int role) const
     }
 
     const auto value = m_entryAttributes->value(key);
-    const auto urlValid = urlTools()->isUrlValid(value);
+    const auto urlValid = urlTools()->isUrlValid(value, true);
 
     // Check for duplicate URLs in the attribute list. Excludes the current key/value from the comparison.
     auto customAttributeKeys = m_entryAttributes->customKeys().filter(EntryAttributes::AdditionalUrlAttribute);

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -45,6 +45,7 @@ private slots:
     void testSearchEntriesByReference();
     void testSearchEntriesWithPort();
     void testSearchEntriesWithAdditionalURLs();
+    void testSearchEntriesWithWildcardURLs();
     void testInvalidEntries();
     void testSubdomainsAndPaths();
     void testBestMatchingCredentials();
@@ -52,7 +53,7 @@ private slots:
     void testRestrictBrowserKey();
 
 private:
-    QList<Entry*> createEntries(QStringList& urls, Group* root) const;
+    QList<Entry*> createEntries(QStringList& urls, Group* root, bool additionalUrl = false) const;
     void compareEntriesByPath(QSharedPointer<Database> db, QList<Entry*> entries, QString path);
 
     QScopedPointer<BrowserAction> m_browserAction;

--- a/tests/TestUrlTools.cpp
+++ b/tests/TestUrlTools.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -133,6 +133,36 @@ void TestUrlTools::testIsUrlValid()
     while (i.hasNext()) {
         i.next();
         QCOMPARE(urlTools()->isUrlValid(i.key()), i.value());
+    }
+}
+
+void TestUrlTools::testIsUrlValidWithLooseComparison()
+{
+    QHash<QString, bool> urls;
+    urls[""] = true;
+    urls["\"https://github.com/login\""] = true;
+    urls["https://*.github.com/"] = true;
+    urls["*.github.com"] = true;
+    urls["https://*.com"] = false;
+    urls["https://*.computer.com"] = true; // TLD in domain (com) should not affect
+    urls["\"\""] = false;
+    urls["\"*.example.com\""] = false;
+    urls["http://*"] = false;
+    urls["*"] = false;
+    urls["****"] = false;
+    urls["*.co.jp"] = false;
+    urls["*.com"] = false;
+    urls["*.computer.com"] = true;
+    urls["*.computer.com/*com"] = true; // TLD in path should not affect this
+    urls["*com"] = false;
+    urls["*.com/"] = false;
+    urls["*.com/*"] = false;
+    urls["**.com/**"] = false;
+
+    QHashIterator<QString, bool> i(urls);
+    while (i.hasNext()) {
+        i.next();
+        QCOMPARE(urlTools()->isUrlValid(i.key(), true), i.value());
     }
 }
 

--- a/tests/TestUrlTools.h
+++ b/tests/TestUrlTools.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -34,6 +34,7 @@ private slots:
     void testIsIpAddress();
     void testIsUrlIdentical();
     void testIsUrlValid();
+    void testIsUrlValidWithLooseComparison();
     void testDomainHasIllegalCharacters();
 
 private:


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds support for URL wildcards and exact URL if the address is wrapped insinde `"` e.g. `"https://example.com/page.php"`. Without wildcards, URL's are handled normally with the old/current implementation.

This feature is restricted to Additional URLs only, because storing URLs in wildcard form is not recommended, and it breaks the possibility to open the URL to a browser.

The wildcards can be used freely, and some example addresses are:
- `https://*.example.com/page/*`
- `https://192.*.168.1/`
- `subdomain.of.*.example.com/page/*/login`

Fixes #3718.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually, and added automatic tests.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)