### PR TITLE
Allow groups to restrict by browser integration key (#6437)

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -953,7 +953,7 @@ Do you want to overwrite the Passkey in %1 - %2?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>KeePassXC - New key association request</source>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -970,6 +970,10 @@ Do you want to overwrite the Passkey in %1 - %2?</source>
     </message>
     <message>
         <source>KeePassXC - Delete entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - New key association request</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3207,6 +3211,14 @@ Would you like to correct it?</source>
     </message>
     <message>
         <source>Omit WWW subdomain from matching toggle for this and sub groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restrict matching to given browser key:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restrict matching to given browser key toggle for this and sub groups</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -119,6 +119,8 @@ public:
     QJsonArray findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* entriesFound);
     void requestGlobalAutoType(const QString& search);
 
+    static QString decodeCustomDataRestrictKey(const QString& key);
+
     static const QString KEEPASSXCBROWSER_NAME;
     static const QString KEEPASSXCBROWSER_OLD_NAME;
     static const QString OPTION_SKIP_AUTO_SUBMIT;
@@ -126,6 +128,7 @@ public:
     static const QString OPTION_ONLY_HTTP_AUTH;
     static const QString OPTION_NOT_HTTP_AUTH;
     static const QString OPTION_OMIT_WWW;
+    static const QString OPTION_RESTRICT_KEY;
 
 signals:
     void requestUnlock();
@@ -157,6 +160,7 @@ private:
     QList<Entry*> searchEntries(const QSharedPointer<Database>& db,
                                 const QString& siteUrl,
                                 const QString& formUrl,
+                                const QStringList& keys = {},
                                 bool passkey = false);
     QList<Entry*>
     searchEntries(const QString& siteUrl, const QString& formUrl, const StringPairList& keyList, bool passkey = false);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -288,6 +288,21 @@ void Group::setCustomDataTriState(const QString& key, const Group::TriState& val
     }
 }
 
+// Note that this returns an empty string both if the key is missing *or* if the key is present but value is empty.
+QString Group::resolveCustomDataString(const QString& key, bool checkParent) const
+{
+    // If not defined, check our parent up to the root group
+    if (!m_customData->contains(key)) {
+        if (!m_parent || !checkParent) {
+            return QString();
+        } else {
+            return m_parent->resolveCustomDataString(key);
+        }
+    }
+
+    return m_customData->value(key);
+}
+
 bool Group::equals(const Group* other, CompareItemOptions options) const
 {
     if (!other) {

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -102,6 +102,7 @@ public:
     const CustomData* customData() const;
     Group::TriState resolveCustomDataTriState(const QString& key, bool checkParent = true) const;
     void setCustomDataTriState(const QString& key, const Group::TriState& value);
+    QString resolveCustomDataString(const QString& key, bool checkParent = true) const;
     const Group* previousParentGroup() const;
     QUuid previousParentGroupUuid() const;
 

--- a/src/gui/group/EditGroupWidget.h
+++ b/src/gui/group/EditGroupWidget.h
@@ -81,6 +81,10 @@ private:
     Group::TriState triStateFromIndex(int index);
     void setupModifiedTracking();
 
+    void addRestrictKeyComboBoxItems(QStringList const& keyList, QString inheritValue);
+    void setRestrictKeyComboBoxIndex(const Group* group);
+    void setRestrictKeyCustomData(CustomData* customData);
+
     const QScopedPointer<Ui::EditGroupWidgetMain> m_mainUi;
 
     QPointer<QScrollArea> m_editGroupWidgetMain;

--- a/src/gui/group/EditGroupWidgetBrowser.ui
+++ b/src/gui/group/EditGroupWidgetBrowser.ui
@@ -136,6 +136,23 @@
        </widget>
       </item>
       <item row="5" column="0">
+       <widget class="QLabel" name="browserIntegrationRestrictKey">
+        <property name="text">
+         <string>Restrict matching to given browser key:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QComboBox" name="browserIntegrationRestrictKeyCombobox">
+        <property name="accessibleName">
+         <string>Restrict matching to given browser key toggle for this and sub groups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
        <spacer name="verticalSpacer_1">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -158,6 +175,7 @@
   <tabstop>browserIntegrationOnlyHttpAuthComboBox</tabstop>
   <tabstop>browserIntegrationNotHttpAuthComboBox</tabstop>
   <tabstop>browserIntegrationOmitWwwCombobox</tabstop>
+  <tabstop>browserIntegrationRestrictKeyCombobox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -49,6 +49,7 @@ private slots:
     void testSubdomainsAndPaths();
     void testBestMatchingCredentials();
     void testBestMatchingWithAdditionalURLs();
+    void testRestrictBrowserKey();
 
 private:
     QList<Entry*> createEntries(QStringList& urls, Group* root) const;


### PR DESCRIPTION
Relates to issue #6437

This branch adds the ability to set a browser restriction on groups.  This allows a given group tree to be visible only to a specific browser.  Previously, the workaround was to have separate databases for each browser.  However, this can become cumbersome under situations where someone may have a dozen or more browsers that each have to be unlocked whenever the screensaver activates.

## Screenshots
![image](https://github.com/keepassxreboot/keepassxc/assets/8960738/43d6c797-97ef-4185-a5c9-478b6bfe0f34)

## Testing strategy
- Added a new test function to test the new behavior

## Type of change
- ✅ New feature (change that adds functionality)
