### PR TITLE
Fix raising Update Entry messagebox

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -727,8 +727,7 @@ bool BrowserService::updateEntry(const EntryParameters& entryParameters, const Q
                                                 tr("Do you want to update the information in %1 - %2?")
                                                     .arg(QUrl(entryParameters.siteUrl).host(), username),
                                                 MessageBox::Save | MessageBox::Cancel,
-                                                MessageBox::Cancel,
-                                                MessageBox::Raise);
+                                                MessageBox::Cancel);
         }
 
         if (browserSettings()->alwaysAllowUpdate() || dialogResult == MessageBox::Save) {


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Additional `MessageBox::Raise` causes this Message Box to not appear if the parent is something else than `nullptr`. On X11 and macOS the Message Box is not displayed at all. With Wayland it's displayed but the background is transparent.

Regression from https://github.com/keepassxreboot/keepassxc/pull/9652.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)