### PR TITLE
Fix first entry is not selected when a search is performed

### DIFF
--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -219,11 +219,12 @@ void EntryView::displaySearch(const QList<Entry*>& entries)
     m_model->setEntries(entries);
     header()->showSection(EntryModel::ParentGroup);
 
+    setFirstEntryActive();
+
     // Reset sort column to 'Group', overrides DatabaseWidgetStateSync
     m_sortModel->sort(EntryModel::ParentGroup, Qt::AscendingOrder);
     sortByColumn(EntryModel::ParentGroup, Qt::AscendingOrder);
 
-    setFirstEntryActive();
     m_inSearchMode = true;
 }
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1082,6 +1082,13 @@ void TestGui::testSearch()
     QCOMPARE(groupView->currentGroup(), m_db->rootGroup());
     QVERIFY(!m_dbWidget->isSearchActive());
 
+    // check if first entry is selected after search
+    QTest::keyClicks(searchTextEdit, "some");
+    QTRY_VERIFY(m_dbWidget->isSearchActive());
+    QTRY_COMPARE(entryView->selectedEntries().length(), 1);
+    QModelIndex index_current = entryView->indexFromEntry(entryView->currentEntry());
+    QTRY_COMPARE(index_current.row(), 0);
+
     // Try to edit the first entry from the search view
     // Refocus back to search edit
     QTest::mouseClick(searchTextEdit, Qt::LeftButton);


### PR DESCRIPTION
Attempt to fix #9865

first fetching the first row entry, setting it active and then sorting the entries by parent group

## Testing strategy
1. open a populated .kdbx database with entries associated to root and child groups
2. search for a desired entry where multiple entries are returned as a list
3. observe which entry is set active visible to the user by a light green entry coloration in the GUI


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
