### PR TITLE
Fix QT-based system theme detection

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -80,7 +80,7 @@ private:
         PreferLight
     };
     ColorschemePref m_systemColorschemePref = ColorschemePref::PreferNone;
-    bool m_systemColorschemePrefExists;
+    bool m_systemColorschemePrefExists = false;
 
     void setColorScheme(QDBusVariant value);
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
In the absence of xdg desktop portal, keepassxc falls back to use system's QT style for dark theme detection on Linux.
However, the `m_systemColorschemePrefExists` attribute was not initialized and therefore often had non-zero value after class construction, which prevents `NixUtils::isDarkMode()` from checking the QT style. 

May fix some issue related to dark mode detection.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manual testing.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

