### PR TITLE
Do not hard-code colors in classic stylesheet for SearchBanner/KeeShareBanner

### DIFF
--- a/src/gui/styles/base/classicstyle.qss
+++ b/src/gui/styles/base/classicstyle.qss
@@ -9,8 +9,9 @@ QToolTip {
 
 DatabaseWidget #SearchBanner, DatabaseWidget #KeeShareBanner {
     font-weight: bold;
-    background-color: rgb(94, 161, 14);
-    border: 1px solid rgb(190, 190, 190);
+    background-color: palette(highlight);
+    color: palette(highlighted-text);
+    border: 1px solid palette(dark);
     padding: 2px;
 }
 


### PR DESCRIPTION
Having the green-ish hard-coded color makes the banner stand out too much when the platform native theming is used.


## Screenshots

### before
![before](https://github.com/keepassxreboot/keepassxc/assets/65779826/318a71d1-131d-482d-a39e-498370822c54)
![before-closeup](https://github.com/keepassxreboot/keepassxc/assets/65779826/cbf59058-1eef-4983-a8ef-0ae8e6b1f8ba)

### after (KvAdaptaDark)
![after](https://github.com/keepassxreboot/keepassxc/assets/65779826/a30084ca-9bc0-4498-b9a1-b1ac7115b081)
![after-closeup](https://github.com/keepassxreboot/keepassxc/assets/65779826/28c3af7b-e0fd-4c78-aab0-661fcfc46775)


## Testing strategy

I tested the built-in dark and light themes, and a couple themes from [Kvantum](https://github.com/tsujan/Kvantum) on linux. I was not able to test either mac or windows.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
