### PR TITLE
An additional button to facilitate typing passwords.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -131,6 +131,11 @@ Copyright: none
 License: CC0
 Comment: Taken from https://github.com/paomedia/small-n-flat
 
+Files: share/icons/application/scalable/actions/masked-password-on.svg
+       share/icons/application/scalable/actions/masked-password-off.svg
+Copyright: 2023 Przemyslaw Zygmunt <p.zygmunt@acsoftware.pl>
+License: MIT
+
 Files: share/icons/badges/2_Expired.svg
        share/icons/database/C37_KPercentage.svg
        share/icons/database/C45_Cancel.svg

--- a/share/icons/application/scalable/actions/masked-password-off.svg
+++ b/share/icons/application/scalable/actions/masked-password-off.svg
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="mdi-eye-outline"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   sodipodi:docname="masked-password-off.svg"
+   inkscape:version="1.2.1 (9c6d41e4, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs89">
+    <linearGradient
+       id="linearGradient7649"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.90277779;"
+         offset="0"
+         id="stop7647" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2667"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.53725493;"
+         offset="0"
+         id="stop2665" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="namedview87"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="33.875"
+     inkscape:cx="13.225092"
+     inkscape:cy="10.553506"
+     inkscape:window-width="1920"
+     inkscape:window-height="959"
+     inkscape:window-x="1920"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="mdi-eye-outline" />
+  <rect
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663"
+     width="3.0996313"
+     height="12.95941"
+     x="0.85608858"
+     y="5.1070108"
+     ry="0.44280443" />
+  <rect
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663-4"
+     width="3.0996313"
+     height="12.95941"
+     x="5.7712178"
+     y="5.0922508"
+     ry="0.44280443" />
+  <rect
+     style="fill:none;fill-opacity:0.53725493;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663-4-6"
+     width="3.0996313"
+     height="12.95941"
+     x="10.464945"
+     y="5.0922508"
+     ry="0.44280443" />
+  <path
+     style="fill:#000000;fill-opacity:0.974026;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path8046-5-7"
+     sodipodi:type="arc"
+     sodipodi:cx="12.014759"
+     sodipodi:cy="11.321443"
+     sodipodi:rx="0.26568264"
+     sodipodi:ry="0.28044274"
+     sodipodi:start="0"
+     sodipodi:end="6.270046"
+     sodipodi:arc-type="slice"
+     d="m 12.280442,11.321443 a 0.26568264,0.28044274 0 0 1 -0.26481,0.280441 0.26568264,0.28044274 0 0 1 -0.26655,-0.278599 0.26568264,0.28044274 0 0 1 0.263059,-0.282272 0.26568264,0.28044274 0 0 1 0.268278,0.276745 l -0.26566,0.0037 z" />
+  <rect
+     style="fill:none;fill-opacity:0.53725493;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663-4-6-0"
+     width="3.0996313"
+     height="12.95941"
+     x="15.247232"
+     y="5.1217713"
+     ry="0.44280443" />
+  <rect
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663-4-6-0-3"
+     width="3.0996313"
+     height="12.95941"
+     x="19.999998"
+     y="5.1512914"
+     ry="0.44280443" />
+  <path
+     style="opacity:1;fill:#000000;fill-opacity:0.974026;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path8046"
+     sodipodi:type="arc"
+     sodipodi:cx="7.321033"
+     sodipodi:cy="11.321033"
+     sodipodi:rx="0.26568264"
+     sodipodi:ry="0.28044274"
+     sodipodi:start="0"
+     sodipodi:end="6.270046"
+     sodipodi:arc-type="slice"
+     d="m 7.5867156,11.321033 a 0.26568264,0.28044274 0 0 1 -0.2648099,0.280441 0.26568264,0.28044274 0 0 1 -0.2665496,-0.278599 0.26568264,0.28044274 0 0 1 0.2630588,-0.282272 0.26568264,0.28044274 0 0 1 0.2682778,0.276745 l -0.2656597,0.0037 z" />
+  <path
+     style="fill:#000000;fill-opacity:0.974026;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path8046-5"
+     sodipodi:type="arc"
+     sodipodi:cx="2.4206638"
+     sodipodi:cy="11.321443"
+     sodipodi:rx="0.26568264"
+     sodipodi:ry="0.28044274"
+     sodipodi:start="0"
+     sodipodi:end="6.270046"
+     sodipodi:arc-type="slice"
+     d="m 2.6863465,11.321443 a 0.26568264,0.28044274 0 0 1 -0.2648099,0.280441 0.26568264,0.28044274 0 0 1 -0.2665497,-0.278599 0.26568264,0.28044274 0 0 1 0.2630588,-0.282272 0.26568264,0.28044274 0 0 1 0.2682778,0.276745 l -0.2656597,0.0037 z" />
+  <path
+     style="fill:#000000;fill-opacity:0.974026;stroke:#000000;stroke-width:0.99988;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path8046-8"
+     sodipodi:type="arc"
+     sodipodi:cx="21.549629"
+     sodipodi:cy="11.321445"
+     sodipodi:rx="0.26556012"
+     sodipodi:ry="0.28050381"
+     sodipodi:start="0"
+     sodipodi:end="6.270046"
+     sodipodi:arc-type="slice"
+     d="m 21.815189,11.321445 a 0.26556012,0.28050381 0 0 1 -0.264687,0.280503 0.26556012,0.28050381 0 0 1 -0.266427,-0.27866 0.26556012,0.28050381 0 0 1 0.262937,-0.282333 0.26556012,0.28050381 0 0 1 0.268154,0.276805 l -0.265537,0.0037 z" />
+  <path
+     style="fill:#000000;fill-opacity:0.974026;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path8046-5-8"
+     sodipodi:type="arc"
+     sodipodi:cx="16.797049"
+     sodipodi:cy="11.321443"
+     sodipodi:rx="0.26568264"
+     sodipodi:ry="0.28044274"
+     sodipodi:start="0"
+     sodipodi:end="6.270046"
+     sodipodi:arc-type="slice"
+     d="m 17.062731,11.321443 a 0.26568264,0.28044274 0 0 1 -0.26481,0.280441 0.26568264,0.28044274 0 0 1 -0.266549,-0.278599 0.26568264,0.28044274 0 0 1 0.263058,-0.282272 0.26568264,0.28044274 0 0 1 0.268278,0.276745 l -0.265659,0.0037 z" />
+</svg>

--- a/share/icons/application/scalable/actions/masked-password-on.svg
+++ b/share/icons/application/scalable/actions/masked-password-on.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="mdi-eye-outline"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   sodipodi:docname="masked-password-on.svg"
+   inkscape:version="1.2.1 (9c6d41e4, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs89">
+    <linearGradient
+       id="linearGradient7649"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.90277779;"
+         offset="0"
+         id="stop7647" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2667"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.53725493;"
+         offset="0"
+         id="stop2665" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2667"
+       id="linearGradient2669"
+       x1="1.50738"
+       y1="11.660517"
+       x2="7.6734319"
+       y2="11.660517"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.91512915,0.11808114)" />
+  </defs>
+  <sodipodi:namedview
+     id="namedview87"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="33.875"
+     inkscape:cx="13.225092"
+     inkscape:cy="10.553506"
+     inkscape:window-width="1920"
+     inkscape:window-height="963"
+     inkscape:window-x="1920"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="mdi-eye-outline" />
+  <rect
+     style="fill:url(#linearGradient2669);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663"
+     width="3.0996313"
+     height="12.95941"
+     x="0.85608858"
+     y="5.1070108"
+     ry="0.44280443" />
+  <rect
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663-4"
+     width="3.0996313"
+     height="12.95941"
+     x="5.7712178"
+     y="5.0922508"
+     ry="0.44280443" />
+  <rect
+     style="fill:#000000;fill-opacity:0.53725493;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663-4-6"
+     width="3.0996313"
+     height="12.95941"
+     x="10.464945"
+     y="5.0922508"
+     ry="0.44280443" />
+  <rect
+     style="fill:#000000;fill-opacity:0.53725493;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663-4-6-0"
+     width="3.0996313"
+     height="12.95941"
+     x="15.247232"
+     y="5.1217713"
+     ry="0.44280443" />
+  <rect
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2663-4-6-0-3"
+     width="3.0996313"
+     height="12.95941"
+     x="19.999998"
+     y="5.1512914"
+     ry="0.44280443" />
+  <path
+     style="opacity:1;fill:#000000;fill-opacity:0.974026;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path8046"
+     sodipodi:type="arc"
+     sodipodi:cx="7.321033"
+     sodipodi:cy="11.321033"
+     sodipodi:rx="0.26568264"
+     sodipodi:ry="0.28044274"
+     sodipodi:start="0"
+     sodipodi:end="6.270046"
+     sodipodi:arc-type="slice"
+     d="m 7.5867156,11.321033 a 0.26568264,0.28044274 0 0 1 -0.2648099,0.280441 0.26568264,0.28044274 0 0 1 -0.2665496,-0.278599 0.26568264,0.28044274 0 0 1 0.2630588,-0.282272 0.26568264,0.28044274 0 0 1 0.2682778,0.276745 l -0.2656597,0.0037 z" />
+  <path
+     style="fill:#000000;fill-opacity:0.974026;stroke:#000000;stroke-width:0.99988;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path8046-8"
+     sodipodi:type="arc"
+     sodipodi:cx="21.549629"
+     sodipodi:cy="11.321445"
+     sodipodi:rx="0.26556012"
+     sodipodi:ry="0.28050381"
+     sodipodi:start="0"
+     sodipodi:end="6.270046"
+     sodipodi:arc-type="slice"
+     d="m 21.815189,11.321445 a 0.26556012,0.28050381 0 0 1 -0.264687,0.280503 0.26556012,0.28050381 0 0 1 -0.266427,-0.27866 0.26556012,0.28050381 0 0 1 0.262937,-0.282333 0.26556012,0.28050381 0 0 1 0.268154,0.276805 l -0.265537,0.0037 z" />
+</svg>

--- a/share/icons/icons.qrc
+++ b/share/icons/icons.qrc
@@ -63,6 +63,8 @@
         <file>application/scalable/actions/password-generator.svg</file>
         <file>application/scalable/actions/password-show-off.svg</file>
         <file>application/scalable/actions/password-show-on.svg</file>
+        <file>application/scalable/actions/masked-password-on.svg</file>
+        <file>application/scalable/actions/masked-password-off.svg</file>
         <file>application/scalable/actions/qrcode.svg</file>
         <file>application/scalable/actions/refresh.svg</file>
         <file>application/scalable/actions/reports.svg</file>

--- a/src/gui/EntryPreviewWidget.h
+++ b/src/gui/EntryPreviewWidget.h
@@ -57,6 +57,7 @@ private slots:
     void updateEntryAutotypeTab();
     void setUsernameVisible(bool state);
     void setPasswordVisible(bool state);
+    void setIndexVisible(bool state);
     void setEntryNotesVisible(bool state);
     void setGroupNotesVisible(bool state);
     void setNotesVisible(QTextEdit* notesWidget, const QString& notes, bool state);

--- a/src/gui/EntryPreviewWidget.ui
+++ b/src/gui/EntryPreviewWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>530</width>
-    <height>257</height>
+    <width>554</width>
+    <height>313</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -236,6 +236,38 @@
                  </widget>
                 </item>
                 <item>
+                 <spacer name="horizontalSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>5</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QToolButton" name="toggleIndexButton">
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="iconSize">
+                   <size>
+                    <width>14</width>
+                    <height>14</height>
+                   </size>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QScrollArea" name="passwordScrollArea">
                   <property name="frameShape">
                    <enum>QFrame::NoFrame</enum>
@@ -257,8 +289,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>157</width>
-                     <height>63</height>
+                     <width>99</width>
+                     <height>72</height>
                     </rect>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_8">


### PR DESCRIPTION
Forms with so-called masked passwords are becoming more and more common. Such solutions are especially used in banking systems. This means that the password entry form expects the user to input random characters from the password. In such a case, automatic completion does not work and rewriting passwords is very inconvenient. I added a button that, when pressed, shows the index for each character in the password. This makes it easier to enter the password expected by the form. By default, the button is unchecked.

Below are two examples from banking systems in which the form is based on masked passwords.

<img width="1086" alt="Zrzut ekranu 2023-10-11 o 21 00 55" src="https://github.com/keepassxreboot/keepassxc/assets/6603397/df00297f-5e68-4d35-9a17-af0c9b6f1571">

<img width="487" alt="Zrzut ekranu 2023-10-11 o 20 26 09" src="https://github.com/keepassxreboot/keepassxc/assets/6603397/d26c8880-ee9d-4334-892f-74dbfb560999">

Below are screenshots showing the changes I made.
The colors depend on the selected theme and whether password coloring is enabled in the settings.

Light theme without colors:
<img width="586" alt="KeePassXC_Light_NoColors" src="https://github.com/keepassxreboot/keepassxc/assets/6603397/121dbb10-a8d9-43a3-ac75-88fb27112438">

Light theme with colors:
<img width="586" alt="KeePassXC_Light_Colors" src="https://github.com/keepassxreboot/keepassxc/assets/6603397/a50e9f57-a1e4-40e3-ac02-c9facf780393">

Dark theme without colors:
<img width="586" alt="KeePassXC_Dark_NoColors" src="https://github.com/keepassxreboot/keepassxc/assets/6603397/26096a80-60bf-4cd2-9c57-5a33e1a2acfd">

Dark theme with colors:
<img width="586" alt="KeePassXC_Dark_Colors" src="https://github.com/keepassxreboot/keepassxc/assets/6603397/846408a9-0956-4ab8-acaa-67bf19469117">

Clasic theme without colors:
<img width="976" alt="KeePassXC_Clasic_NoColors" src="https://github.com/keepassxreboot/keepassxc/assets/6603397/23a29966-c1e6-416e-a19c-faa80f583712">

Clasic theme with colors:
<img width="976" alt="KeePassXC_Clasic_Colors" src="https://github.com/keepassxreboot/keepassxc/assets/6603397/8e9d56fa-391e-4290-88b4-bf2dab9ec990">

I also designed icons for the button.
This symbolizes a form with masked passwords:
![masked](https://github.com/keepassxreboot/keepassxc/assets/6603397/6a27440f-36aa-42ab-b306-ef0cb9a6e059)

This symbolizes a form with an unmasked (traditional) password:
![notmasked](https://github.com/keepassxreboot/keepassxc/assets/6603397/df161f0a-ccf2-41a0-b940-23da6457407e)

## Type of change
- ✅ New feature (change that adds functionality)