### PR TITLE
Fix crash on database open from browser

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -115,7 +115,7 @@ bool BrowserService::openDatabase(bool triggerUnlock)
         return true;
     }
 
-    if (triggerUnlock) {
+    if (triggerUnlock && !m_bringToFrontRequested) {
         m_bringToFrontRequested = true;
         updateWindowState();
         emit requestUnlock();

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -41,6 +41,7 @@ DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
     , m_dbWidgetStateSync(new DatabaseWidgetStateSync(this))
     , m_dbWidgetPendingLock(nullptr)
     , m_databaseOpenDialog(new DatabaseOpenDialog(this))
+    , m_databaseOpenInProgress(false)
 {
     auto* tabBar = new QTabBar(this);
     tabBar->setAcceptDrops(true);
@@ -857,6 +858,7 @@ void DatabaseTabWidget::emitDatabaseLockChanged()
         emit databaseLocked(dbWidget);
     } else {
         emit databaseUnlocked(dbWidget);
+        m_databaseOpenInProgress = false;
     }
 }
 
@@ -889,6 +891,11 @@ void DatabaseTabWidget::performGlobalAutoType(const QString& search)
 
 void DatabaseTabWidget::performBrowserUnlock()
 {
+    if (m_databaseOpenInProgress) {
+        return;
+    }
+
+    m_databaseOpenInProgress = true;
     auto dbWidget = currentDatabaseWidget();
     if (dbWidget && dbWidget->isLocked()) {
         unlockAnyDatabaseInDialog(DatabaseOpenDialog::Intent::Browser);

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -117,6 +117,7 @@ private:
     QPointer<DatabaseWidget> m_dbWidgetPendingLock;
     QPointer<DatabaseOpenDialog> m_databaseOpenDialog;
     QTimer m_lockDelayTimer;
+    bool m_databaseOpenInProgress;
 };
 
 #endif // KEEPASSX_DATABASETABWIDGET_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Do not allow multiple unlock screens when requesting unlock from browser. Large number of transform rounds are needed, so the unlock takes longer than e.g. five seconds. 

Fixes #9938.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually:
- Unlock from KeePassXC, then request unlock from browser
- Unlock from browser, then request another unlock from browser

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
