### PR TITLE
Fix logging for no clipping program worked

### DIFF
--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -329,6 +329,8 @@ namespace Utils
 
             if (clipProcess->exitCode() == EXIT_SUCCESS) {
                 return EXIT_SUCCESS;
+            } else {
+                failedProgramNames.append(prog.first);
             }
         }
 

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -648,6 +648,7 @@ void TestCli::testClip()
         || errorOutput.contains("No program defined for clipboard manipulation")) {
         QSKIP("Clip test skipped due to missing clipboard tool");
     }
+    QVERIFY(!errorOutput.contains("All clipping programs failed"));
 
     m_stderr->readLine(); // Skip password prompt
     QCOMPARE(m_stderr->readAll(), QByteArray());


### PR DESCRIPTION
If a clipping program exit with failure code, it should be added to `failedProgramNames`.

No clipping program worked should be checked in unit test.

## Testing strategy

In the past, if all clipping programs exited with failure code, CLI would say `All clipping programs failed. Tried `.
Now, it will say `All clipping programs failed. Tried xxx`.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)

