### PR TITLE
Fix issue about removing entry from history and improve logic of history tab showing

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1190,6 +1190,7 @@ bool EditEntryWidget::commitEntry()
     }
 
     m_historyModel->setEntries(m_entry->historyItems(), m_entry);
+    setPageHidden(m_historyWidget, m_history || m_entry->historyItems().count() < 1);
     m_advancedUi->attachmentsWidget->linkAttachments(m_entry->attachments());
 
     showMessage(tr("Entry updated successfully."), MessageWidget::Positive);

--- a/src/gui/entry/EntryHistoryModel.cpp
+++ b/src/gui/entry/EntryHistoryModel.cpp
@@ -158,9 +158,10 @@ void EntryHistoryModel::deleteIndex(QModelIndex index)
 {
     auto entry = entryFromIndex(index);
     if (entry) {
-        beginRemoveRows(QModelIndex(), m_historyEntries.indexOf(entry), m_historyEntries.indexOf(entry));
+        beginRemoveRows(QModelIndex(), index.row(), index.row());
         m_historyEntries.removeAll(entry);
         m_deletedHistoryEntries << entry;
+        m_historyModifications.erase(m_historyModifications.begin() + index.row());
         endRemoveRows();
     }
 }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes #9936
Current deleteIndex() will not remove correspond entry in `m_historyModifications`, then this issue appears.


And the current showing logic of history tab is curious. when we perform a modification to an entry and commit it(i.e. click `OK` or `Apply`). The History Tab will not be showed automatically. we need to reopen the EditEntryWidget. I'm not sure about whether it's a bug, but it's a very small code midification, I bundle it to the related bug fix. Discussions are welcomed.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
1. edit an entry and apply serveral times
2. switch to `History` Tab
3. remove some rows of history item to check whether the UI update properly

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
