### PR TITLE
Fix showing password generator from the toolbar icon

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -40,6 +40,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     , m_ui(new Ui::PasswordGeneratorWidget())
 {
     m_ui->setupUi(this);
+    setWindowFlags(Qt::Widget);
 
     m_ui->buttonGenerate->setIcon(icons()->icon("refresh"));
     m_ui->buttonGenerate->setToolTip(


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Password generator is a `QDialog` but is used with `QStackedWidget` which can only display `QWidget`'s. Adding an extra window flag will allow the generator to be shown as both (a widget and a popup).

Fixes #9983.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
