### PR TITLE
Passkeys: Rename User ID to Credential ID

### DIFF
--- a/src/browser/BrowserPasskeys.h
+++ b/src/browser/BrowserPasskeys.h
@@ -54,7 +54,7 @@ enum AuthenticatorFlags
 
 struct PublicKeyCredential
 {
-    QString id;
+    QString credentialId;
     QJsonObject response;
     QByteArray key;
 };
@@ -87,7 +87,7 @@ public:
                                                          const TestingVariables& predefinedVariables = {});
     QJsonObject buildGetPublicKeyCredential(const QJsonObject& publicKeyCredentialRequestOptions,
                                             const QString& origin,
-                                            const QString& userId,
+                                            const QString& credentialId,
                                             const QString& userHandle,
                                             const QString& privateKeyPem);
     bool isUserVerificationValid(const QString& userVerification) const;
@@ -112,7 +112,7 @@ private:
     QJsonObject buildClientDataJson(const QJsonObject& publicKey, const QString& origin, bool get);
     PrivateKey buildAttestationObject(const QJsonObject& publicKey,
                                       const QString& extensions,
-                                      const QString& id,
+                                      const QString& credentialId,
                                       const TestingVariables& predefinedVariables = {});
     QByteArray buildGetAttestationObject(const QJsonObject& publicKey);
     PrivateKey buildCredentialPrivateKey(int alg,

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -666,12 +666,18 @@ QJsonObject BrowserService::showPasskeysRegisterPrompt(const QJsonObject& public
                               rpId,
                               rpName,
                               username,
-                              publicKeyCredentials.id,
+                              publicKeyCredentials.credentialId,
                               userHandle,
                               publicKeyCredentials.key);
         } else {
-            addPasskeyToGroup(
-                nullptr, origin, rpId, rpName, username, publicKeyCredentials.id, userHandle, publicKeyCredentials.key);
+            addPasskeyToGroup(nullptr,
+                              origin,
+                              rpId,
+                              rpName,
+                              username,
+                              publicKeyCredentials.credentialId,
+                              userHandle,
+                              publicKeyCredentials.key);
         }
 
         hideWindow();
@@ -730,7 +736,7 @@ void BrowserService::addPasskeyToGroup(Group* group,
                                        const QString& rpId,
                                        const QString& rpName,
                                        const QString& username,
-                                       const QString& userId,
+                                       const QString& credentialId,
                                        const QString& userHandle,
                                        const QString& privateKey)
 {
@@ -751,7 +757,7 @@ void BrowserService::addPasskeyToGroup(Group* group,
     entry->setUrl(url);
     entry->setIcon(KEEPASSXCBROWSER_PASSKEY_ICON);
 
-    addPasskeyToEntry(entry, rpId, rpName, username, userId, userHandle, privateKey);
+    addPasskeyToEntry(entry, rpId, rpName, username, credentialId, userHandle, privateKey);
 
     // Remove blank entry history
     entry->removeHistoryItems(entry->historyItems());
@@ -761,7 +767,7 @@ void BrowserService::addPasskeyToEntry(Entry* entry,
                                        const QString& rpId,
                                        const QString& rpName,
                                        const QString& username,
-                                       const QString& userId,
+                                       const QString& credentialId,
                                        const QString& userHandle,
                                        const QString& privateKey)
 {
@@ -776,7 +782,7 @@ void BrowserService::addPasskeyToEntry(Entry* entry,
     entry->beginUpdate();
 
     entry->attributes()->set(BrowserPasskeys::KPEX_PASSKEY_USERNAME, username);
-    entry->attributes()->set(BrowserPasskeys::KPEX_PASSKEY_GENERATED_USER_ID, userId, true);
+    entry->attributes()->set(BrowserPasskeys::KPEX_PASSKEY_GENERATED_USER_ID, credentialId, true);
     entry->attributes()->set(BrowserPasskeys::KPEX_PASSKEY_PRIVATE_KEY_PEM, privateKey, true);
     entry->attributes()->set(BrowserPasskeys::KPEX_PASSKEY_RELYING_PARTY, rpId);
     entry->attributes()->set(BrowserPasskeys::KPEX_PASSKEY_USER_HANDLE, userHandle, true);
@@ -1324,9 +1330,9 @@ QJsonObject
 BrowserService::getPublicKeyCredentialFromEntry(const Entry* entry, const QJsonObject& publicKey, const QString& origin)
 {
     const auto privateKeyPem = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_PRIVATE_KEY_PEM);
-    const auto userId = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_GENERATED_USER_ID);
+    const auto credentialId = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_GENERATED_USER_ID);
     const auto userHandle = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_USER_HANDLE);
-    return browserPasskeys()->buildGetPublicKeyCredential(publicKey, origin, userId, userHandle, privateKeyPem);
+    return browserPasskeys()->buildGetPublicKeyCredential(publicKey, origin, credentialId, userHandle, privateKeyPem);
 }
 
 // Checks if the same user ID already exists for the current site

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -84,7 +84,6 @@ public:
     QString getCurrentTotp(const QString& uuid);
     void showPasswordGenerator(const KeyPairMessage& keyPairMessage);
     bool isPasswordGeneratorRequested() const;
-    bool isUrlIdentical(const QString& first, const QString& second) const;
     QSharedPointer<Database> selectedDatabase();
 #ifdef WITH_XC_BROWSER_PASSKEYS
     QJsonObject
@@ -97,14 +96,14 @@ public:
                            const QString& rpId,
                            const QString& rpName,
                            const QString& username,
-                           const QString& userId,
+                           const QString& credentialId,
                            const QString& userHandle,
                            const QString& privateKey);
     void addPasskeyToEntry(Entry* entry,
                            const QString& rpId,
                            const QString& rpName,
                            const QString& username,
-                           const QString& userId,
+                           const QString& credentialId,
                            const QString& userHandle,
                            const QString& privateKey);
 #endif

--- a/src/gui/passkeys/PasskeyExporter.cpp
+++ b/src/gui/passkeys/PasskeyExporter.cpp
@@ -60,7 +60,7 @@ void PasskeyExporter::showExportDialog(const QList<Entry*>& items)
  *      "relyingParty: <relying party>,
  *      "url": <URL>,
  *      "userHandle": <user handle>,
- *      "userId": <generated user id>,
+ *      "credentialId": <generated credential id>,
  *      "username:" <username>
  * }
  */
@@ -91,7 +91,7 @@ void PasskeyExporter::exportSelectedEntry(const Entry* entry, const QString& fol
     passkeyObject["relyingParty"] = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_RELYING_PARTY);
     passkeyObject["url"] = entry->url();
     passkeyObject["username"] = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_USERNAME);
-    passkeyObject["userId"] = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_GENERATED_USER_ID);
+    passkeyObject["credentialId"] = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_GENERATED_USER_ID);
     passkeyObject["userHandle"] = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_USER_HANDLE);
     passkeyObject["privateKey"] = entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_PRIVATE_KEY_PEM);
 

--- a/src/gui/passkeys/PasskeyImporter.cpp
+++ b/src/gui/passkeys/PasskeyImporter.cpp
@@ -64,11 +64,11 @@ void PasskeyImporter::importSelectedFile(QFile& file, QSharedPointer<Database>& 
     const auto relyingParty = passkeyObject["relyingParty"].toString();
     const auto url = passkeyObject["url"].toString();
     const auto username = passkeyObject["username"].toString();
-    const auto password = passkeyObject["userId"].toString();
+    const auto credentialId = passkeyObject["credentialId"].toString();
     const auto userHandle = passkeyObject["userHandle"].toString();
     const auto privateKey = passkeyObject["privateKey"].toString();
 
-    if (relyingParty.isEmpty() || username.isEmpty() || password.isEmpty() || userHandle.isEmpty()
+    if (relyingParty.isEmpty() || username.isEmpty() || credentialId.isEmpty() || userHandle.isEmpty()
         || privateKey.isEmpty()) {
         MessageBox::information(nullptr,
                                 tr("Cannot import Passkey"),
@@ -80,7 +80,7 @@ void PasskeyImporter::importSelectedFile(QFile& file, QSharedPointer<Database>& 
             tr("Cannot import Passkey"),
             tr("Cannot import Passkey file \"%1\". Private key is missing or malformed.").arg(file.fileName()));
     } else {
-        showImportDialog(database, url, relyingParty, username, password, userHandle, privateKey);
+        showImportDialog(database, url, relyingParty, username, credentialId, userHandle, privateKey);
     }
 }
 
@@ -88,7 +88,7 @@ void PasskeyImporter::showImportDialog(QSharedPointer<Database>& database,
                                        const QString& url,
                                        const QString& relyingParty,
                                        const QString& username,
-                                       const QString& userId,
+                                       const QString& credentialId,
                                        const QString& userHandle,
                                        const QString& privateKey)
 {
@@ -120,7 +120,7 @@ void PasskeyImporter::showImportDialog(QSharedPointer<Database>& database,
     }
 
     browserService()->addPasskeyToGroup(
-        group, url, relyingParty, relyingParty, username, userId, userHandle, privateKey);
+        group, url, relyingParty, relyingParty, username, credentialId, userHandle, privateKey);
 }
 
 Group* PasskeyImporter::getDefaultGroup(QSharedPointer<Database>& database)

--- a/src/gui/passkeys/PasskeyImporter.h
+++ b/src/gui/passkeys/PasskeyImporter.h
@@ -39,7 +39,7 @@ private:
                           const QString& url,
                           const QString& relyingParty,
                           const QString& username,
-                          const QString& userId,
+                          const QString& credentialId,
                           const QString& userHandle,
                           const QString& privateKey);
     Group* getDefaultGroup(QSharedPointer<Database>& database);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
According to [specifications](https://w3c.github.io/webauthn/#ref-for-dom-credential-id), the value stored here is Credential ID, not User ID. User ID is stored as User Handle for later use, but the newly generated value is a Credential ID. These shouldn't be mixed, especially in the JSON file.

`KPEX_PASSKEY_GENERATED_USER_ID` is changed to `KPEX_PASSKEY_CREDENTIAL_ID`.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)