### PR TITLE
Reduce complexity of {CLEARFIELD} on Linux

### DIFF
--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -606,8 +606,8 @@ AutoTypeAction::Result AutoTypeExecutorX11::execType(const AutoTypeKey* action)
 AutoTypeAction::Result AutoTypeExecutorX11::execClearField(const AutoTypeClearField* action)
 {
     Q_UNUSED(action);
-    execType(new AutoTypeKey(Qt::Key_Home, Qt::ControlModifier));
-    execType(new AutoTypeKey(Qt::Key_End, Qt::ControlModifier | Qt::ShiftModifier));
+    execType(new AutoTypeKey(Qt::Key_Home));
+    execType(new AutoTypeKey(Qt::Key_End, Qt::ShiftModifier));
     execType(new AutoTypeKey(Qt::Key_Backspace));
     return AutoTypeAction::Result::Ok();
 }


### PR DESCRIPTION
Instead of `CTRL + HOME, CTRL + SHIFT + END, BACKSPACE` use `HOME, SHIFT + END, BACKSPACE`

Fixes #10006

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Linux (KDE)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
