### PR TITLE
Fix Botan 2/3 include

### DIFF
--- a/src/keys/FileKey.h
+++ b/src/keys/FileKey.h
@@ -19,6 +19,7 @@
 #ifndef KEEPASSX_FILEKEY_H
 #define KEEPASSX_FILEKEY_H
 
+#include <botan/mem_ops.h>
 #include <botan/secmem.h>
 
 #include "keys/Key.h"


### PR DESCRIPTION
All this does is fix a missing include. It should still be compatible with all Botan versions down to 2.11.0 (the minimum the current KeepassXC codebase says it supports).

- `Botan::secure_scrub_memory` -> defined in `botan/mem_ops.h` (2.11.0 --> current)
- `Botan::secure_vector` -> defined in `botan/secmem.h`  (2.11.0 --> current)

The reason only including secmem.h worked in previous (<3.0) versions of Botan was because secmem.h included mem_ops.h. This is no longer the case since commit
randombit/botan@49dbbcb2bfda05ef9d3f09848c9ba22fcbcd5066 (2023-10-11; "Split out allocator helpers to allocator.h")

Fixes #10038