### PR TITLE
Fix FindBotan.cmake: allow BOTAN_LIBRARY_DEBUG to be found in latest vcpkg

### DIFF
--- a/cmake/FindBotan.cmake
+++ b/cmake/FindBotan.cmake
@@ -13,7 +13,7 @@ include(FindPackageHandleStandardArgs)
 
 set(BOTAN_VERSIONS botan-3 botan-2)
 set(BOTAN_NAMES botan-3 botan-2 botan)
-set(BOTAN_NAMES_DEBUG botand-3 botand-2 botand botan)
+set(BOTAN_NAMES_DEBUG botand-3 botand-2 botand botan botan-3)
 
 find_path(
     BOTAN_INCLUDE_DIR


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )

When using the latest Botan library in vcpkg , and building with CMake, there will be an error that BOTAN_LIBRARY_DEBUG is unable to be found. 

This is because the debug library is now called "botan-3.lib", which is unable to be found by the statement `set(BOTAN_NAMES_DEBUG....` (line 16) since BOTAN_NAMES_DEBUG does not contain the keyword "botan-3". This commit adds that keyword.

[NOTE]: # ( Explain large or complex code modifications. )

I just added "botan-3" to the `set(BOTAN_NAMES_DEBUG....` on line 16

[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

I don't believe it pertains to any open issues.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

Before:
![image](https://github.com/keepassxreboot/keepassxc/assets/136134023/f7b3ecef-86d6-49e6-94bb-53cf994d8059)

After:
![image](https://github.com/keepassxreboot/keepassxc/assets/136134023/e6a0fbbe-20a4-467c-bf73-231039fe81e7)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )

I tested by running the cmake command again, in which it was able to detect the botan library.

[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)