### PR TITLE
Passkeys: UI adjustments

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -848,10 +848,6 @@ Please select the correct database for saving credentials.</source>
 <context>
     <name>BrowserPasskeysConfirmationDialog</name>
     <message>
-        <source>KeePassXC: Passkey credentials</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -883,10 +879,6 @@ Please select the correct database for saving credentials.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 (%2)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Existing Passkey found.
 Do you want to register a new Passkey for:</source>
         <translation type="unfinished"></translation>
@@ -899,21 +891,25 @@ Do you want to register a new Passkey for:</source>
         <source>Authenticate Passkey credentials for:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Relying Party: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - Passkey credentials</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BrowserService</name>
     <message>
-        <source>KeePassXC: Create a new group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>A request for creating a new group &quot;%1&quot; has been received.
 Do you want to create this group?
 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>KeePassXC: New key association request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -929,24 +925,12 @@ chrome-laptop.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>KeePassXC: Overwrite existing key?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>A shared encryption key with the name &quot;%1&quot; already exists.
 Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>KeePassXC: Update Entry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Do you want to update the information in %1 - %2?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>KeePassXC: Delete entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -960,12 +944,32 @@ Do you want to delete the entry?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>KeePassXC: Update Passkey</source>
+        <source>Entry already has a Passkey.
+Do you want to overwrite the Passkey in %1 - %2?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Entry already has a Passkey.
-Do you want to overwrite the Passkey in %1 - %2?</source>
+        <source>KeePassXC - Create a new group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - New key association request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - Overwrite existing key?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - Update Passkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - Update Entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - Delete entry</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1743,15 +1747,7 @@ This may prevent connection to the browser plugin.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>KeePassXC: No keys found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No shared encryption keys found in KeePassXC settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>KeePassXC: Removed keys from database</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -1774,20 +1770,12 @@ Permissions to access entries will be revoked.</source>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>KeePassXC: Removed permissions</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message numerus="yes">
         <source>Successfully removed permissions from %n entry(s).</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
-    </message>
-    <message>
-        <source>KeePassXC: No entry with permissions found!</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The active database does not contain an entry with permissions.</source>
@@ -1800,6 +1788,22 @@ Permissions to access entries will be revoked.</source>
     <message>
         <source>Do you really want refresh the database ID?
 This is only necessary if your database is a copy of another and the browser extension cannot connect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No keys found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removed keys from database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removed permissions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No entry with permissions found!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5982,10 +5986,6 @@ Do you want to overwrite it?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Username: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6027,6 +6027,10 @@ Do you want to overwrite it?
     </message>
     <message>
         <source>Default Passkeys group (Imported Passkeys)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Relying Party: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/browser/BrowserPasskeysConfirmationDialog.cpp
+++ b/src/browser/BrowserPasskeysConfirmationDialog.cpp
@@ -33,6 +33,7 @@ BrowserPasskeysConfirmationDialog::BrowserPasskeysConfirmationDialog(QWidget* pa
 
     m_ui->setupUi(this);
     m_ui->updateButton->setVisible(false);
+    m_ui->verticalLayout->setAlignment(Qt::AlignTop);
 
     connect(m_ui->credentialsTable, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(accept()));
     connect(m_ui->confirmButton, SIGNAL(clicked()), SLOT(accept()));
@@ -48,12 +49,13 @@ BrowserPasskeysConfirmationDialog::~BrowserPasskeysConfirmationDialog()
 }
 
 void BrowserPasskeysConfirmationDialog::registerCredential(const QString& username,
-                                                           const QString& siteId,
+                                                           const QString& relyingParty,
                                                            const QList<Entry*>& existingEntries,
                                                            int timeout)
 {
     m_ui->firstLabel->setText(tr("Do you want to register Passkey for:"));
-    m_ui->dataLabel->setText(tr("%1 (%2)").arg(username, siteId));
+    m_ui->relyingPartyLabel->setText(tr("Relying Party: %1").arg(relyingParty));
+    m_ui->usernameLabel->setText(tr("Username: %1").arg(username));
     m_ui->secondLabel->setText("");
 
     if (!existingEntries.isEmpty()) {
@@ -64,6 +66,7 @@ void BrowserPasskeysConfirmationDialog::registerCredential(const QString& userna
         m_ui->confirmButton->setText(tr("Register new"));
         updateEntriesToTable(existingEntries);
     } else {
+        m_ui->verticalLayout->setSizeConstraint(QLayout::SetFixedSize);
         m_ui->confirmButton->setText(tr("Register"));
         m_ui->credentialsTable->setVisible(false);
     }
@@ -72,11 +75,12 @@ void BrowserPasskeysConfirmationDialog::registerCredential(const QString& userna
 }
 
 void BrowserPasskeysConfirmationDialog::authenticateCredential(const QList<Entry*>& entries,
-                                                               const QString& origin,
+                                                               const QString& relyingParty,
                                                                int timeout)
 {
     m_ui->firstLabel->setText(tr("Authenticate Passkey credentials for:"));
-    m_ui->dataLabel->setText(origin);
+    m_ui->relyingPartyLabel->setText(tr("Relying Party: %1").arg(relyingParty));
+    m_ui->usernameLabel->setVisible(false);
     m_ui->secondLabel->setText("");
     updateEntriesToTable(entries);
     startCounter(timeout);

--- a/src/browser/BrowserPasskeysConfirmationDialog.h
+++ b/src/browser/BrowserPasskeysConfirmationDialog.h
@@ -38,10 +38,10 @@ public:
     ~BrowserPasskeysConfirmationDialog() override;
 
     void registerCredential(const QString& username,
-                            const QString& siteId,
+                            const QString& relyingParty,
                             const QList<Entry*>& existingEntries,
                             int timeout);
-    void authenticateCredential(const QList<Entry*>& entries, const QString& origin, int timeout);
+    void authenticateCredential(const QList<Entry*>& entries, const QString& relyingParty, int timeout);
     Entry* getSelectedEntry() const;
     bool isPasskeyUpdated() const;
 

--- a/src/browser/BrowserPasskeysConfirmationDialog.ui
+++ b/src/browser/BrowserPasskeysConfirmationDialog.ui
@@ -6,69 +6,73 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>405</width>
-    <height>282</height>
+    <width>400</width>
+    <height>274</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>KeePassXC: Passkey credentials</string>
+   <string>KeePassXC - Passkey credentials</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="firstLabel">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="dataLabel">
-     <property name="textFormat">
-      <enum>Qt::PlainText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="secondLabel">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QLabel" name="firstLabel">
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="relyingPartyLabel">
+       <property name="text">
+        <string>Relying Party: %1</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="usernameLabel">
+       <property name="text">
+        <string>Username: %1</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="secondLabel">
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QTableWidget" name="credentialsTable">

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -276,7 +276,7 @@ QJsonObject BrowserService::createNewGroup(const QString& groupName)
     }
 
     auto dialogResult = MessageBox::warning(m_currentDatabaseWidget,
-                                            tr("KeePassXC: Create a new group"),
+                                            tr("KeePassXC - Create a new group"),
                                             tr("A request for creating a new group \"%1\" has been received.\n"
                                                "Do you want to create this group?\n")
                                                 .arg(groupName),
@@ -560,7 +560,7 @@ QString BrowserService::storeKey(const QString& key)
     do {
         QInputDialog keyDialog(m_currentDatabaseWidget);
         connect(m_currentDatabaseWidget, SIGNAL(databaseLockRequested()), &keyDialog, SLOT(reject()));
-        keyDialog.setWindowTitle(tr("KeePassXC: New key association request"));
+        keyDialog.setWindowTitle(tr("KeePassXC - New key association request"));
         keyDialog.setLabelText(tr("You have received an association request for the following database:\n%1\n\n"
                                   "Give the connection a unique name or ID, for example:\nchrome-laptop.")
                                    .arg(db->metadata()->name().toHtmlEscaped()));
@@ -582,7 +582,7 @@ QString BrowserService::storeKey(const QString& key)
         contains = db->metadata()->customData()->contains(CustomData::BrowserKeyPrefix + id);
         if (contains) {
             dialogResult = MessageBox::warning(m_currentDatabaseWidget,
-                                               tr("KeePassXC: Overwrite existing key?"),
+                                               tr("KeePassXC - Overwrite existing key?"),
                                                tr("A shared encryption key with the name \"%1\" "
                                                   "already exists.\nDo you want to overwrite it?")
                                                    .arg(id),
@@ -713,7 +713,7 @@ QJsonObject BrowserService::showPasskeysAuthenticationPrompt(const QJsonObject& 
 
     raiseWindow();
     BrowserPasskeysConfirmationDialog confirmDialog;
-    confirmDialog.authenticateCredential(entries, origin, timeout);
+    confirmDialog.authenticateCredential(entries, rpId, timeout);
     auto dialogResult = confirmDialog.exec();
     if (dialogResult == QDialog::Accepted) {
         hideWindow();
@@ -777,7 +777,7 @@ void BrowserService::addPasskeyToEntry(Entry* entry,
     if (entry->hasPasskey()) {
         if (MessageBox::question(
                 m_currentDatabaseWidget,
-                tr("KeePassXC: Update Passkey"),
+                tr("KeePassXC - Update Passkey"),
                 tr("Entry already has a Passkey.\nDo you want to overwrite the Passkey in %1 - %2?")
                     .arg(entry->title(), entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_USERNAME)),
                 MessageBox::Overwrite | MessageBox::Cancel,
@@ -889,7 +889,7 @@ bool BrowserService::updateEntry(const EntryParameters& entryParameters, const Q
         if (!browserSettings()->alwaysAllowUpdate()) {
             raiseWindow();
             dialogResult = MessageBox::question(m_currentDatabaseWidget,
-                                                tr("KeePassXC: Update Entry"),
+                                                tr("KeePassXC - Update Entry"),
                                                 tr("Do you want to update the information in %1 - %2?")
                                                     .arg(QUrl(entryParameters.siteUrl).host(), username),
                                                 MessageBox::Save | MessageBox::Cancel,
@@ -925,7 +925,7 @@ bool BrowserService::deleteEntry(const QString& uuid)
     }
 
     auto dialogResult = MessageBox::warning(m_currentDatabaseWidget,
-                                            tr("KeePassXC: Delete entry"),
+                                            tr("KeePassXC - Delete entry"),
                                             tr("A request for deleting entry \"%1\" has been received.\n"
                                                "Do you want to delete the entry?\n")
                                                 .arg(entry->title()),

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
@@ -174,10 +174,8 @@ void DatabaseSettingsWidgetBrowser::removeSharedEncryptionKeys()
     }
 
     if (keysToRemove.isEmpty()) {
-        MessageBox::information(this,
-                                tr("KeePassXC: No keys found"),
-                                tr("No shared encryption keys found in KeePassXC settings."),
-                                MessageBox::Ok);
+        MessageBox::information(
+            this, tr("No keys found"), tr("No shared encryption keys found in KeePassXC settings."), MessageBox::Ok);
         return;
     }
 
@@ -187,7 +185,7 @@ void DatabaseSettingsWidgetBrowser::removeSharedEncryptionKeys()
 
     const int count = keysToRemove.count();
     MessageBox::information(this,
-                            tr("KeePassXC: Removed keys from database"),
+                            tr("Removed keys from database"),
                             tr("Successfully removed %n encryption key(s) from KeePassXC settings.", "", count),
                             MessageBox::Ok);
 }
@@ -227,12 +225,12 @@ void DatabaseSettingsWidgetBrowser::removeStoredPermissions()
 
     if (counter > 0) {
         MessageBox::information(this,
-                                tr("KeePassXC: Removed permissions"),
+                                tr("Removed permissions"),
                                 tr("Successfully removed permissions from %n entry(s).", "", counter),
                                 MessageBox::Ok);
     } else {
         MessageBox::information(this,
-                                tr("KeePassXC: No entry with permissions found!"),
+                                tr("No entry with permissions found!"),
                                 tr("The active database does not contain an entry with permissions."),
                                 MessageBox::Ok);
     }

--- a/src/gui/passkeys/PasskeyExportDialog.ui
+++ b/src/gui/passkeys/PasskeyExportDialog.ui
@@ -87,6 +87,16 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="autoDefault">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="exportButton">
        <property name="accessibleName">
         <string>Export entries</string>
@@ -98,16 +108,6 @@
         <bool>true</bool>
        </property>
        <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-       <property name="autoDefault">
         <bool>true</bool>
        </property>
       </widget>

--- a/src/gui/passkeys/PasskeyImportDialog.cpp
+++ b/src/gui/passkeys/PasskeyImportDialog.cpp
@@ -45,12 +45,12 @@ PasskeyImportDialog::~PasskeyImportDialog()
 {
 }
 
-void PasskeyImportDialog::setInfo(const QString& url,
+void PasskeyImportDialog::setInfo(const QString& relyingParty,
                                   const QString& username,
                                   const QSharedPointer<Database>& database,
                                   bool isEntry)
 {
-    m_ui->urlLabel->setText(tr("URL: %1").arg(url));
+    m_ui->relyingPartyLabel->setText(tr("Relying Party: %1").arg(relyingParty));
     m_ui->usernameLabel->setText(tr("Username: %1").arg(username));
 
     if (isEntry) {

--- a/src/gui/passkeys/PasskeyImportDialog.h
+++ b/src/gui/passkeys/PasskeyImportDialog.h
@@ -36,7 +36,10 @@ public:
     explicit PasskeyImportDialog(QWidget* parent = nullptr);
     ~PasskeyImportDialog() override;
 
-    void setInfo(const QString& url, const QString& username, const QSharedPointer<Database>& database, bool isEntry);
+    void setInfo(const QString& relyingParty,
+                 const QString& username,
+                 const QSharedPointer<Database>& database,
+                 bool isEntry);
     QSharedPointer<Database> getSelectedDatabase() const;
     QUuid getSelectedEntryUuid() const;
     QUuid getSelectedGroupUuid() const;

--- a/src/gui/passkeys/PasskeyImportDialog.ui
+++ b/src/gui/passkeys/PasskeyImportDialog.ui
@@ -44,9 +44,12 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="urlLabel">
+      <widget class="QLabel" name="relyingPartyLabel">
        <property name="text">
-        <string>URL: %1</string>
+        <string>Relying Party: %1</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -58,23 +61,13 @@
        <property name="text">
         <string>Username: %1</string>
        </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>10</height>
-        </size>
-       </property>
-      </spacer>
      </item>
      <item>
       <widget class="QGroupBox" name="groupBox">
@@ -119,6 +112,19 @@
     </layout>
    </item>
    <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <spacer name="horizontalSpacer">
@@ -134,6 +140,16 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="autoDefault">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="importButton">
        <property name="accessibleName">
         <string>Import Passkey</string>
@@ -145,16 +161,6 @@
         <bool>true</bool>
        </property>
        <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-       <property name="autoDefault">
         <bool>true</bool>
        </property>
       </widget>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adjust the UI to be more consistent with each other, and fix some resizing issues.

Changes in this PR:
- Change dialog titles with `KeePassXC: ` to use `KeePassXC - ` like everywhere else.
- Show Relying Party instead of URL.
- Use `PlainText` for Username and Relying Party.
- Swap button positions in Import and Export dialogs to match these with other dialogs.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Old:
<img width="407" alt="old_import_1" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/b63061af-b4be-4d02-89ca-bd86dfae99e1">
<img width="612" alt="old_import_2" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/d354557d-4109-4f68-baa1-4dfa3b40caee">
<img width="517" alt="old_register" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/7fae96d0-8d7d-4877-b532-5660484fae27">
<img width="517" alt="old_auth" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/36aa5f32-d032-441a-a345-5dbac3a46201">
New:
<img width="407" alt="new_import_1" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/8f08c62e-6556-412e-a233-f1da0227e0c8">
<img width="612" alt="new_import_2" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/10b82bac-cfa7-411d-8de3-24b9b3407456">
<img width="367" alt="new_register" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/bb4657d7-4913-4cbf-9930-a7d7bfc60dc5">
<img width="512" alt="new_auth" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/e24935bf-7e80-41e2-850e-1ecb0c3535e3">

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
