### PR TITLE
Fix focus loss on save when the widget is not visible anymore

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -2185,7 +2185,7 @@ bool DatabaseWidget::performSave(QString& errorMessage, const QString& fileName)
     m_groupView->setDisabled(false);
     m_tagView->setDisabled(false);
 
-    if (focusWidget) {
+    if (focusWidget && focusWidget->isVisible()) {
         focusWidget->setFocus();
     }
 


### PR DESCRIPTION
During the save process, interactions with the UI are disabled. But the hotkeys still work and the user can swap to the
Edit Entry Widget with a new entry. When the save process is finished the focus is set to the widget that was shown initially.


Checking if the widget is still visible will prevent the loss of the focus on the new widget.

Fixes #7109 

## Testing strategy

1. Open a database with auto saving active
2. Add Entry, enter some data, OK 
3. Really quickly after the database index page opens, press Ctrl-N.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)