### PR TITLE
Passkeys: Create AAGUID for KeePassXC

### DIFF
--- a/src/browser/BrowserPasskeys.cpp
+++ b/src/browser/BrowserPasskeys.cpp
@@ -37,6 +37,9 @@
 
 Q_GLOBAL_STATIC(BrowserPasskeys, s_browserPasskeys);
 
+// KeePassXC AAGUID: fdb141b2-5d84-443e-8a35-4698c205a502
+const QString BrowserPasskeys::AAGUID = QStringLiteral("fdb141b25d84443e8a354698c205a502");
+
 const QString BrowserPasskeys::PUBLIC_KEY = QStringLiteral("public-key");
 const QString BrowserPasskeys::REQUIREMENT_DISCOURAGED = QStringLiteral("discouraged");
 const QString BrowserPasskeys::REQUIREMENT_PREFERRED = QStringLiteral("preferred");
@@ -181,8 +184,8 @@ PrivateKey BrowserPasskeys::buildAttestationObject(const QJsonObject& publicKey,
     const char counter[4] = {0x00, 0x00, 0x00, 0x00};
     result.append(QByteArray::fromRawData(counter, 4));
 
-    // AAGUID (use the default/non-set)
-    result.append("\x01\x02\x03\x04\x05\x06\x07\b\x01\x02\x03\x04\x05\x06\x07\b");
+    // AAGUID
+    result.append(browserMessageBuilder()->getArrayFromHexString(AAGUID));
 
     // Credential length
     const char credentialLength[2] = {0x00, 0x20};

--- a/src/browser/BrowserPasskeys.h
+++ b/src/browser/BrowserPasskeys.h
@@ -94,6 +94,7 @@ public:
     int getTimeout(const QString& userVerification, int timeout) const;
     QStringList getAllowedCredentialsFromPublicKey(const QJsonObject& publicKey) const;
 
+    static const QString AAGUID;
     static const QString PUBLIC_KEY;
     static const QString REQUIREMENT_DISCOURAGED;
     static const QString REQUIREMENT_PREFERRED;

--- a/tests/TestPasskeys.cpp
+++ b/tests/TestPasskeys.cpp
@@ -75,7 +75,7 @@ const QString PublicKeyCredential = R"(
         "id": "yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8",
         "rawId": "cabcc52799707294f060c39d5d29b11796f9718425a813336db53f77ea052cef",
         "response": {
-            "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVikdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBFAAAAAAECAwQFBgcIAQIDBAUGBwgAIMq8xSeZcHKU8GDDnV0psReW-XGEJagTM221P3fqBSzvpQECAyYgASFYIAbsrzRbYpFhbRlZA6ZQKsoxxJWoaeXwh-XUuDLNCIXdIlgg4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M",
+            "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVikdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBFAAAAAP2xQbJdhEQ-ijVGmMIFpQIAIMq8xSeZcHKU8GDDnV0psReW-XGEJagTM221P3fqBSzvpQECAyYgASFYIAbsrzRbYpFhbRlZA6ZQKsoxxJWoaeXwh-XUuDLNCIXdIlgg4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M",
             "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoibFZlSHpWeFdzcjhNUXhNa1pGMHRpNkZYaGRnTWxqcUt6Z0EtcV96azJNbmlpM2VKNDdWRjk3c3FVb1lrdFZDODVXQVoxdUlBU20tYV9sREZad3NMZnciLCJvcmlnaW4iOiJodHRwczovL3dlYmF1dGhuLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
         },
         "type": "public-key"
@@ -167,7 +167,7 @@ void TestPasskeys::testDecodeResponseData()
 
     // The attestationObject should include the same ID after decoding with the response root
     QCOMPARE(credentialData["credentialId"].toString(), publicKeyCredential["id"].toString());
-    QCOMPARE(credentialData["aaguid"].toString(), QString("AQIDBAUGBwgBAgMEBQYHCA"));
+    QCOMPARE(credentialData["aaguid"].toString(), QString("_bFBsl2ERD6KNUaYwgWlAg"));
     QCOMPARE(authData["rpIdHash"].toString(), QString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
     QCOMPARE(flags["AT"], true);
     QCOMPARE(flags["UP"], true);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Creates an AAGUID for KeePassXC: `fdb141b2-5d84-443e-8a35-4698c205a502`.
After merged, it's possible to add the AAGUID to the unofficial database: https://github.com/passkeydeveloper/passkey-authenticator-aaguids

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
