### PR TITLE
Fix sorting of advanced attribute list

### DIFF
--- a/src/gui/entry/EntryAttributesModel.cpp
+++ b/src/gui/entry/EntryAttributesModel.cpp
@@ -24,6 +24,7 @@ EntryAttributesModel::EntryAttributesModel(QObject* parent)
     , m_entryAttributes(nullptr)
     , m_nextRenameDataChange(false)
 {
+    m_collator.setNumericMode(true);
 }
 
 void EntryAttributesModel::setEntryAttributes(EntryAttributes* entryAttributes)
@@ -150,7 +151,7 @@ void EntryAttributesModel::attributeAboutToAdd(const QString& key)
 {
     QList<QString> rows = m_attributes;
     rows.append(key);
-    std::sort(rows.begin(), rows.end());
+    std::sort(rows.begin(), rows.end(), m_collator);
     int row = rows.indexOf(key);
     beginInsertRows(QModelIndex(), row, row);
 }
@@ -180,7 +181,7 @@ void EntryAttributesModel::attributeAboutToRename(const QString& oldKey, const Q
     QList<QString> rows = m_attributes;
     rows.removeOne(oldKey);
     rows.append(newKey);
-    std::sort(rows.begin(), rows.end());
+    std::sort(rows.begin(), rows.end(), m_collator);
     int newRow = rows.indexOf(newKey);
     if (newRow > oldRow) {
         newRow++;
@@ -232,4 +233,5 @@ void EntryAttributesModel::updateAttributes()
             m_attributes.append(key);
         }
     }
+    std::sort(m_attributes.begin(), m_attributes.end(), m_collator);
 }

--- a/src/gui/entry/EntryAttributesModel.h
+++ b/src/gui/entry/EntryAttributesModel.h
@@ -19,6 +19,7 @@
 #define KEEPASSX_ENTRYATTRIBUTESMODEL_H
 
 #include <QAbstractListModel>
+#include <QCollator>
 
 class EntryAttributes;
 
@@ -55,6 +56,7 @@ private:
     EntryAttributes* m_entryAttributes;
     QList<QString> m_attributes;
     bool m_nextRenameDataChange;
+    QCollator m_collator;
 };
 
 #endif // KEEPASSX_ENTRYATTRIBUTESMODEL_H

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -201,6 +201,9 @@ void TestEntryModel::testAttributesModel()
 
     // make sure these don't generate messages
     entryAttributes->set("Title", "test");
+    entryAttributes->set("UserName", "test");
+    entryAttributes->set("Password", "test");
+    entryAttributes->set("URL", "test");
     entryAttributes->set("Notes", "test");
 
     QCOMPARE(spyDataChanged.count(), 1);
@@ -214,6 +217,16 @@ void TestEntryModel::testAttributesModel()
     entryAttributes->set("2nd", value, true);
     QVERIFY(entryAttributes->isProtected("2nd"));
     QCOMPARE(entryAttributes->value("2nd"), value);
+    entryAttributes->clear();
+
+    // test attribute sorting
+    entryAttributes->set("Test1", "1");
+    entryAttributes->set("Test11", "11");
+    entryAttributes->set("Test2", "2");
+    QCOMPARE(model->rowCount(), 3);
+    QCOMPARE(model->data(model->index(0, 0)).toString(), QString("Test1"));
+    QCOMPARE(model->data(model->index(1, 0)).toString(), QString("Test2"));
+    QCOMPARE(model->data(model->index(2, 0)).toString(), QString("Test11"));
 
     QSignalSpy spyReset(model, SIGNAL(modelReset()));
     entryAttributes->clear();


### PR DESCRIPTION
Sort advanced attribute list using locale aware sort.

Fixes #6175

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
1. Add an entry to a database
2. Go to "Edit entry" -> "Advanced"
3. Add some additional attributes via the "Add" button. E.g.: "Test1", "Test12", "Test2"
4. The additional attributes should be sorted now as "Test1", "Test2", "Test12"


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
