### PR TITLE
Fix ifdefs with UrlTools

### DIFF
--- a/src/core/UrlTools.cpp
+++ b/src/core/UrlTools.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "UrlTools.h"
-#ifdef WITH_XC_NETWORKING
+#if defined(WITH_XC_NETWORKING) || defined(WITH_XC_BROWSER)
 #include <QHostAddress>
 #include <QNetworkCookie>
 #include <QNetworkCookieJar>
@@ -40,7 +40,7 @@ QUrl UrlTools::convertVariantToUrl(const QVariant& var) const
     return url;
 }
 
-#ifdef WITH_XC_NETWORKING
+#if defined(WITH_XC_NETWORKING) || defined(WITH_XC_BROWSER)
 QUrl UrlTools::getRedirectTarget(QNetworkReply* reply) const
 {
     QVariant var = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);

--- a/src/core/UrlTools.h
+++ b/src/core/UrlTools.h
@@ -32,7 +32,7 @@ public:
     explicit UrlTools() = default;
     static UrlTools* instance();
 
-#ifdef WITH_XC_NETWORKING
+#if defined(WITH_XC_NETWORKING) || defined(WITH_XC_BROWSER)
     QUrl getRedirectTarget(QNetworkReply* reply) const;
     QString getBaseDomainFromUrl(const QString& url) const;
     QString getTopLevelDomainFromUrl(const QString& url) const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,8 +150,6 @@ if(WITH_XC_NETWORKING)
             LIBS ${TEST_LIBRARIES})
 
     add_unit_test(NAME testicondownloader SOURCES TestIconDownloader.cpp LIBS ${TEST_LIBRARIES})
-
-    add_unit_test(NAME testurltools SOURCES TestUrlTools.cpp LIBS ${TEST_LIBRARIES})
 endif()
 
 if(WITH_XC_AUTOTYPE)
@@ -244,6 +242,10 @@ if(WITH_XC_BROWSER)
                     LIBS keepassxcbrowser ${TEST_LIBRARIES})
         endif()
     endif()
+endif()
+
+if(WITH_XC_NETWORKING OR WITH_XC_BROWSER)
+    add_unit_test(NAME testurltools SOURCES TestUrlTools.cpp LIBS ${TEST_LIBRARIES})
 endif()
 
 add_unit_test(NAME testcli SOURCES TestCli.cpp


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
`WITH_XC_NETWORKING` should not be a requirement for `WITH_XC_BROWSER`. UrlTools class should be used with both.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
