### PR TITLE
refactor: remove unused merge function

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -5612,10 +5612,6 @@ We recommend you use the AppImage available on our downloads page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>older entry merged from database &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Synchronizing from newer source %1 [%2]</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -158,13 +158,6 @@ Merger::resolveGroupConflict(const MergeContext& context, const Group* sourceChi
     return changes;
 }
 
-bool Merger::markOlderEntry(Entry* entry)
-{
-    entry->attributes()->set(
-        "merged", tr("older entry merged from database \"%1\"").arg(entry->group()->database()->metadata()->name()));
-    return true;
-}
-
 void Merger::moveEntry(Entry* entry, Group* targetGroup)
 {
     Q_ASSERT(entry);

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -49,7 +49,6 @@ private:
     ChangeList mergeGroup(const MergeContext& context);
     ChangeList mergeDeletions(const MergeContext& context);
     ChangeList mergeMetadata(const MergeContext& context);
-    bool markOlderEntry(Entry* entry);
     bool mergeHistory(const Entry* sourceEntry, Entry* targetEntry, Group::MergeMode mergeMethod);
     void moveEntry(Entry* entry, Group* targetGroup);
     void moveGroup(Group* group, Group* targetGroup);


### PR DESCRIPTION
This function in unused since we removed the all the unused merge modes in f7fd3881e3b1c8872068d600d56b76ae95abfe7e

## Testing strategy
unit tests

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
