### PR TITLE
Fix database merge crash when fdosecrets is enabled

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1277,10 +1277,10 @@ void Entry::setGroup(Group* group, bool trackPrevious)
         }
     }
 
+    QObject::setParent(group);
+
     m_group = group;
     group->addEntry(this);
-
-    QObject::setParent(group);
 
     if (m_updateTimeinfo) {
         m_data.timeInfo.setLocationChanged(Clock::currentDateTimeUtc());

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -261,6 +261,7 @@ Merger::ChangeList Merger::resolveEntryConflict_MergeHistories(const MergeContex
     const int comparison = compare(targetEntry->timeInfo().lastModificationTime(),
                                    sourceEntry->timeInfo().lastModificationTime(),
                                    CompareItemIgnoreMilliseconds);
+    const int maxItems = targetEntry->database()->metadata()->historyMaxItems();
     if (comparison < 0) {
         Group* currentGroup = targetEntry->group();
         Entry* clonedEntry = sourceEntry->clone(Entry::CloneIncludeHistory);
@@ -269,15 +270,15 @@ Merger::ChangeList Merger::resolveEntryConflict_MergeHistories(const MergeContex
                qPrintable(sourceEntry->title()),
                qPrintable(currentGroup->name()));
         changes << tr("Synchronizing from newer source %1 [%2]").arg(targetEntry->title(), targetEntry->uuidToHex());
-        moveEntry(clonedEntry, currentGroup);
-        mergeHistory(targetEntry, clonedEntry, mergeMethod);
+        mergeHistory(targetEntry, clonedEntry, mergeMethod, maxItems);
         eraseEntry(targetEntry);
+        moveEntry(clonedEntry, currentGroup);
     } else {
         qDebug("Merge %s/%s with local on top/under %s",
                qPrintable(targetEntry->title()),
                qPrintable(sourceEntry->title()),
                qPrintable(targetEntry->group()->name()));
-        const bool changed = mergeHistory(sourceEntry, targetEntry, mergeMethod);
+        const bool changed = mergeHistory(sourceEntry, targetEntry, mergeMethod, maxItems);
         if (changed) {
             changes
                 << tr("Synchronizing from older source %1 [%2]").arg(targetEntry->title(), targetEntry->uuidToHex());
@@ -297,7 +298,10 @@ Merger::resolveEntryConflict(const MergeContext& context, const Entry* sourceEnt
     return resolveEntryConflict_MergeHistories(context, sourceEntry, targetEntry, mergeMode);
 }
 
-bool Merger::mergeHistory(const Entry* sourceEntry, Entry* targetEntry, Group::MergeMode mergeMethod)
+bool Merger::mergeHistory(const Entry* sourceEntry,
+                          Entry* targetEntry,
+                          Group::MergeMode mergeMethod,
+                          const int maxItems)
 {
     Q_UNUSED(mergeMethod);
     const auto targetHistoryItems = targetEntry->historyItems();
@@ -370,7 +374,6 @@ bool Merger::mergeHistory(const Entry* sourceEntry, Entry* targetEntry, Group::M
     }
 
     bool changed = false;
-    const int maxItems = targetEntry->database()->metadata()->historyMaxItems();
     const auto updatedHistoryItems = merged.values();
     for (int i = 0; i < maxItems; ++i) {
         const Entry* oldEntry = targetHistoryItems.value(targetHistoryItems.count() - i);

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -49,7 +49,7 @@ private:
     ChangeList mergeGroup(const MergeContext& context);
     ChangeList mergeDeletions(const MergeContext& context);
     ChangeList mergeMetadata(const MergeContext& context);
-    bool mergeHistory(const Entry* sourceEntry, Entry* targetEntry, Group::MergeMode mergeMethod);
+    bool mergeHistory(const Entry* sourceEntry, Entry* targetEntry, Group::MergeMode mergeMethod, const int maxItems);
     void moveEntry(Entry* entry, Group* targetGroup);
     void moveGroup(Group* group, Group* targetGroup);
     // remove an entry without a trace in the deletedObjects - needed for elemination cloned entries

--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -495,6 +495,10 @@ namespace FdoSecrets
         }
 
         auto item = Item::Create(this, entry);
+        if (!item) {
+            return;
+        }
+
         m_items << item;
         m_entryToItem[entry] = item;
 


### PR DESCRIPTION
I ran into a crash when merging two databases where the source/alien database had a newer entry:

```
(gdb) bt
#0  0x000055555564a5ae in QScopedPointer<QObjectData, QScopedPointerDeleter<QObjectData> >::operator-> (this=0x8)
    at /usr/include/x86_64-linux-gnu/qt5/QtCore/qscopedpointer.h:118
#1  0x000055555565ca82 in QObject::parent (this=0x0) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobject.h:425
#2  0x00005555558de6c2 in FdoSecrets::Item::collection (this=0x0) at /home/jkloetzke/src/keepassxc/src/fdosecrets/objects/Item.cpp:336
#3  0x00005555558b8818 in FdoSecrets::DBusMgr::emitItemCreated (this=0x555556866970, item=0x0)
    at /home/jkloetzke/src/keepassxc/src/fdosecrets/dbus/DBusMgr.cpp:540
#4  0x00005555558bdcf5 in QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<FdoSecrets::Item*>, void, void (FdoSecrets::DBusMgr::*)(FdoSecrets::Item*)>::call (
    f=(void (FdoSecrets::DBusMgr::*)(FdoSecrets::DBusMgr * const, FdoSecrets::Item *)) 0x5555558b87e0 <FdoSecrets::DBusMgr::emitItemCreated(FdoSecrets::Item*)>, o=0x555556866970, arg=0x7fffffffc190) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:152
#5  0x00005555558bd764 in QtPrivate::FunctionPointer<void (FdoSecrets::DBusMgr::*)(FdoSecrets::Item*)>::call<QtPrivate::List<FdoSecrets::Item*>, void> (
    f=(void (FdoSecrets::DBusMgr::*)(FdoSecrets::DBusMgr * const, FdoSecrets::Item *)) 0x5555558b87e0 <FdoSecrets::DBusMgr::emitItemCreated(FdoSecrets::Item*)>, o=0x555556866970, arg=0x7fffffffc190) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:185
#6  0x00005555558bcedd in QtPrivate::QSlotObject<void (FdoSecrets::DBusMgr::*)(FdoSecrets::Item*), QtPrivate::List<FdoSecrets::Item*>, void>::impl
    (which=1, this_=0x555557eebb40, r=0x555556866970, a=0x7fffffffc190, ret=0x0) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:418
#7  0x00007ffff62e8f4f in ?? () from /lib/x86_64-linux-gnu/libQt5Core.so.5
#8  0x0000555555893832 in FdoSecrets::Collection::itemCreated (this=0x555557bf3840, _t1=0x0)
    at /home/jkloetzke/tmp/keepassxc/src/fdosecrets/fdosecrets_autogen/64PJ3GCGVF/moc_Collection.cpp:378
#9  0x00005555558d7504 in FdoSecrets::Collection::onEntryAdded (this=0x555557bf3840, entry=0x55555619d1c0, emitSignal=true)
    at /home/jkloetzke/src/keepassxc/src/fdosecrets/objects/Collection.cpp:517
#10 0x00005555558d7555 in operator() (__closure=0x555557cbd390, entry=0x55555619d1c0)
    at /home/jkloetzke/src/keepassxc/src/fdosecrets/objects/Collection.cpp:528
#11 0x00005555558d9bf3 in QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<Entry*>, void, FdoSecrets::Collection::connectGroupSignalRecursive(Group*)::<lambda(Entry*)> >::call(struct {...} &, void **) (f=..., arg=0x7fffffffc410)
    at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:146
#12 0x00005555558d9909 in QtPrivate::Functor<FdoSecrets::Collection::connectGroupSignalRecursive(Group*)::<lambda(Entry*)>, 1>::call<QtPrivate::List<Entry*>, void>(struct {...} &, void *, void **) (f=..., arg=0x7fffffffc410) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:256
#13 0x00005555558d97b2 in QtPrivate::QFunctorSlotObject<FdoSecrets::Collection::connectGroupSignalRecursive(Group*)::<lambda(Entry*)>, 1, QtPrivate::List<Entry*>, void>::impl(int, QtPrivate::QSlotObjectBase *, QObject *, void **, bool *) (which=1, this_=0x555557cbd380, r=0x555557bf3840, 
    a=0x7fffffffc410, ret=0x0) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:443
#14 0x00007ffff62e8f4f in ?? () from /lib/x86_64-linux-gnu/libQt5Core.so.5
#15 0x0000555555671078 in Group::entryAdded (this=0x5555571b6a90, _t1=0x55555619d1c0)
    at /home/jkloetzke/tmp/keepassxc/src/keepassx_core_autogen/TAC5DWH4SE/moc_Group.cpp:458
#16 0x00005555556b740a in Group::addEntry (this=0x5555571b6a90, entry=0x55555619d1c0) at /home/jkloetzke/src/keepassxc/src/core/Group.cpp:961
#17 0x000055555569eb9b in Entry::setGroup (this=0x55555619d1c0, group=0x5555571b6a90, trackPrevious=true)
    at /home/jkloetzke/src/keepassxc/src/core/Entry.cpp:1270
#18 0x000055555582c26b in Merger::moveEntry (this=0x7fffffffc980, entry=0x55555619d1c0, targetGroup=0x5555571b6a90)
    at /home/jkloetzke/src/keepassxc/src/core/Merger.cpp:186
#19 0x000055555582d190 in Merger::resolveEntryConflict_MergeHistories (this=0x7fffffffc980, context=..., sourceEntry=0x555556e4c7e0, 
    targetEntry=0x555556afe710, mergeMethod=Group::KeepNewer) at /home/jkloetzke/src/keepassxc/src/core/Merger.cpp:349
#20 0x000055555582d7e3 in Merger::resolveEntryConflict (this=0x7fffffffc980, context=..., sourceEntry=0x555556e4c7e0, targetEntry=0x555556afe710)
    at /home/jkloetzke/src/keepassxc/src/core/Merger.cpp:393
#21 0x000055555582b187 in Merger::mergeGroup (this=0x7fffffffc980, context=...) at /home/jkloetzke/src/keepassxc/src/core/Merger.cpp:96
#22 0x000055555582b83e in Merger::mergeGroup (this=0x7fffffffc980, context=...) at /home/jkloetzke/src/keepassxc/src/core/Merger.cpp:129
#23 0x000055555582ac17 in Merger::merge (this=0x7fffffffc980) at /home/jkloetzke/src/keepassxc/src/core/Merger.cpp:65
#24 0x00005555557465c7 in DatabaseWidget::mergeDatabase (this=0x555556959480, accepted=true)
    at /home/jkloetzke/src/keepassxc/src/gui/DatabaseWidget.cpp:1179
```

It turns out the fdosecrets feature is not happy that a second entry is briefly added to a group/database with the same UUID. This will cause the DBus registration to fail. Subsequently, the `nullptr` is not handled and leads to the crash above. If desired, I can also open a PR for the `release/2.7.x` branch where I developed the fix in the first place.

## Screenshots
n/a

## Testing strategy
Merged the databases that previously caused the crash

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
