### PR TITLE
Passkeys: Fix default timeout on authentication

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -709,7 +709,7 @@ QJsonObject BrowserService::showPasskeysAuthenticationPrompt(const QJsonObject& 
         return getPublicKeyCredentialFromEntry(entries.first(), publicKey, origin);
     }
 
-    const auto timeout = publicKey["timeout"].toInt();
+    const auto timeout = browserPasskeys()->getTimeout(userVerification, publicKey["timeout"].toInt());
 
     raiseWindow();
     BrowserPasskeysConfirmationDialog confirmDialog;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
If server has not set a timeout during Passkeys authentication, it should be set to a default value.

Fixes #10148.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually, by setting timeout to zero from the extension side.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
