### PR TITLE
Fix cmake warning about compatibility min version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(KeePassXC)
 set(APP_ID "org.keepassxc.${PROJECT_NAME}")


### PR DESCRIPTION
#### What
  Upgraded the min version from 3.3.0 to 3.5.0. For now the latest version is [3.28.1](https://github.com/Kitware/CMake/releases/tag/v3.28.1).

#### Why
To fix this warning message:
```
CMake Deprecation Warning at CMakeLists.txt:17 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```
## Screenshots
N/A

## Testing strategy
- Run any make command, for example, `make format`

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
