### PR TITLE
Database merge confirmation dialog

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2775,11 +2775,7 @@ Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remote sync &apos;%1&apos; failed: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Error while saving database %1: %2</source>
+        <source>Merge aborted - database was not modified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2791,7 +2787,15 @@ Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Remote sync &apos;%1&apos; failed: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Syncing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error while saving database %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2808,10 +2812,6 @@ Disable safe saves and try again?</source>
     </message>
     <message>
         <source>Do you want to load the changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2839,6 +2839,10 @@ Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Reload database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Database file overwritten.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2851,11 +2855,15 @@ Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save</source>
+        <source>Merged changes do not match displayed changes!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save Database Backup</source>
+        <source>Actual Merge Result</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Database was not modified by merge operation, no changes were not applied!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2868,6 +2876,14 @@ Disable safe saves and try again?</source>
     </message>
     <message>
         <source>Confirm Recycle Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Database Backup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3940,6 +3956,62 @@ This may cause the affected plugins to malfunction.</source>
 %2</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expiration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TOTP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attachments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EntryAttachments</name>
@@ -4142,62 +4214,6 @@ Would you like to overwrite the existing attachment?</source>
     </message>
     <message>
         <source>Size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Title</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Username</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>URL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Custom Attributes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Icon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Expiration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>TOTP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Custom Data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Attachments</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto-Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6430,41 +6446,40 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
     </message>
 </context>
 <context>
+    <name>MergeDialog</name>
+    <message>
+        <source>Database Merge Confirmation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UUID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Merger</name>
     <message>
-        <source>Creating missing %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Relocating %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Overwriting %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Synchronizing from newer source %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Synchronizing from older source %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Deleting child %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Deleting orphan %1 [%2]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Changed deleted objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Adding missing icon %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6473,6 +6488,74 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
     </message>
     <message>
         <source>Adding custom data %1 [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Modified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous location: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of entries in group: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon (UUID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon (Number)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expiry time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Modification time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Add local modifications to new entry)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 (Add new modifications to existing entry)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Explicit deletion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Implicit deletion (e.g. removal of parent group)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adding new icon %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2671,14 +2671,6 @@ This is definitely a bug, please report it to the developers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Successfully merged the database files.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Database was not modified by merge operation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Search Results (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2775,10 +2767,6 @@ Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Merge aborted - database was not modified.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Downloading...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2855,18 +2843,6 @@ Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Merged changes do not match displayed changes!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Actual Merge Result</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Database was not modified by merge operation, no changes were not applied!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Confirm Delete Group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2884,6 +2860,18 @@ Disable safe saves and try again?</source>
     </message>
     <message>
         <source>Save Database Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Successfully merged the selected database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No changes were made by the merge operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge canceled, no changes were made.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,7 @@ set(gui_SOURCES
         gui/IconModels.cpp
         gui/KMessageWidget.cpp
         gui/MainWindow.cpp
+        gui/MergeDialog.cpp
         gui/MessageBox.cpp
         gui/MessageWidget.cpp
         gui/PasswordWidget.cpp

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -87,10 +87,10 @@ int Merge::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer
     }
 
     Merger merger(db2.data(), database.data());
-    QStringList changeList = merger.merge();
+    auto changeList = merger.merge();
 
-    for (auto& mergeChange : changeList) {
-        out << "\t" << mergeChange << Qt::endl;
+    for (const auto& mergeChange : changeList) {
+        out << "\t" << mergeChange.toString() << Qt::endl;
     }
 
     if (!changeList.isEmpty() && !parser->isSet(Merge::DryRunOption)) {

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -1193,67 +1193,6 @@ void Database::setPublicIcon(int iconIndex)
     markAsModified();
 }
 
-QSharedPointer<Database> Database::clone()
-{
-    auto newDatabase = QSharedPointer<Database>::create();
-
-    // deep copy of root group with same uuid
-    auto* newRootGroup =
-        m_rootGroup->clone(Entry::CloneFlag::CloneIncludeHistory, Group::CloneFlag::CloneIncludeEntries);
-    auto oldRoot = QScopedPointer(newDatabase->setRootGroup(newRootGroup));
-
-    // copy DatabaseData (except filePath and secrets)
-    newDatabase->m_data.formatVersion = m_data.formatVersion;
-    newDatabase->m_data.cipher = m_data.cipher;
-    newDatabase->m_data.compressionAlgorithm = m_data.compressionAlgorithm;
-    newDatabase->m_data.publicCustomData = m_data.publicCustomData;
-    if (m_data.kdf) {
-        newDatabase->m_data.kdf = m_data.kdf->clone();
-    }
-
-    // copy other members
-    newDatabase->m_deletedObjects = m_deletedObjects;
-    newDatabase->m_isTemporaryDatabase = m_isTemporaryDatabase;
-    newDatabase->m_commonUsernames = m_commonUsernames;
-    newDatabase->m_tagList = m_tagList;
-
-    auto getCorrespondingNewGroup = [&](const Group* oldGroup) -> Group* {
-        if (oldGroup) {
-            // get pointer to new group via UUID which was not changed by clone
-            auto uuid = oldGroup->uuid();
-            return newRootGroup->findGroupByUuid(uuid);
-        }
-        return nullptr;
-    };
-
-    auto newMetadata = newDatabase->m_metadata;
-    // copy metadata: recycle bin
-    auto* newRecycleBin = getCorrespondingNewGroup(m_metadata->recycleBin());
-    newMetadata->setRecycleBin(newRecycleBin);
-    newMetadata->setRecycleBinChanged(m_metadata->recycleBinChanged());
-    // copy metadata: templates
-    auto* newEntryTemplates = getCorrespondingNewGroup(m_metadata->entryTemplatesGroup());
-    newMetadata->setEntryTemplatesGroup(newEntryTemplates);
-    newMetadata->setEntryTemplatesGroupChanged(m_metadata->entryTemplatesGroupChanged());
-    // copy metadata: last selected group
-    auto* newLastSelectedGroup = getCorrespondingNewGroup(m_metadata->lastSelectedGroup());
-    newMetadata->setLastSelectedGroup(newLastSelectedGroup);
-    // copy metadata: last top-visible group
-    auto* newLastTopVisibleGroup = getCorrespondingNewGroup(m_metadata->lastTopVisibleGroup());
-    newMetadata->setLastTopVisibleGroup(newLastTopVisibleGroup);
-    // copy metadata: master key/settings change datetime
-    newMetadata->setDatabaseKeyChanged(m_metadata->databaseKeyChanged());
-    newMetadata->setSettingsChanged(m_metadata->settingsChanged());
-    // copy metadata: custom data
-    newMetadata->customData()->copyDataFrom(m_metadata->customData());
-    // copy metadata: custom icons (does not retain order)
-    newMetadata->copyCustomIcons(m_metadata->customIconsOrder().toSet(), m_metadata);
-    // copy metadata: other attributes
-    newMetadata->copyAttributesFrom(m_metadata);
-
-    return newDatabase;
-}
-
 void Database::markAsTemporaryDatabase()
 {
     m_isTemporaryDatabase = true;

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -1193,6 +1193,67 @@ void Database::setPublicIcon(int iconIndex)
     markAsModified();
 }
 
+QSharedPointer<Database> Database::clone()
+{
+    auto newDatabase = QSharedPointer<Database>::create();
+
+    // deep copy of root group with same uuid
+    auto* newRootGroup =
+        m_rootGroup->clone(Entry::CloneFlag::CloneIncludeHistory, Group::CloneFlag::CloneIncludeEntries);
+    auto oldRoot = QScopedPointer(newDatabase->setRootGroup(newRootGroup));
+
+    // copy DatabaseData (except filePath and secrets)
+    newDatabase->m_data.formatVersion = m_data.formatVersion;
+    newDatabase->m_data.cipher = m_data.cipher;
+    newDatabase->m_data.compressionAlgorithm = m_data.compressionAlgorithm;
+    newDatabase->m_data.publicCustomData = m_data.publicCustomData;
+    if (m_data.kdf) {
+        newDatabase->m_data.kdf = m_data.kdf->clone();
+    }
+
+    // copy other members
+    newDatabase->m_deletedObjects = m_deletedObjects;
+    newDatabase->m_isTemporaryDatabase = m_isTemporaryDatabase;
+    newDatabase->m_commonUsernames = m_commonUsernames;
+    newDatabase->m_tagList = m_tagList;
+
+    auto getCorrespondingNewGroup = [&](const Group* oldGroup) -> Group* {
+        if (oldGroup) {
+            // get pointer to new group via UUID which was not changed by clone
+            auto uuid = oldGroup->uuid();
+            return newRootGroup->findGroupByUuid(uuid);
+        }
+        return nullptr;
+    };
+
+    auto newMetadata = newDatabase->m_metadata;
+    // copy metadata: recycle bin
+    auto* newRecycleBin = getCorrespondingNewGroup(m_metadata->recycleBin());
+    newMetadata->setRecycleBin(newRecycleBin);
+    newMetadata->setRecycleBinChanged(m_metadata->recycleBinChanged());
+    // copy metadata: templates
+    auto* newEntryTemplates = getCorrespondingNewGroup(m_metadata->entryTemplatesGroup());
+    newMetadata->setEntryTemplatesGroup(newEntryTemplates);
+    newMetadata->setEntryTemplatesGroupChanged(m_metadata->entryTemplatesGroupChanged());
+    // copy metadata: last selected group
+    auto* newLastSelectedGroup = getCorrespondingNewGroup(m_metadata->lastSelectedGroup());
+    newMetadata->setLastSelectedGroup(newLastSelectedGroup);
+    // copy metadata: last top-visible group
+    auto* newLastTopVisibleGroup = getCorrespondingNewGroup(m_metadata->lastTopVisibleGroup());
+    newMetadata->setLastTopVisibleGroup(newLastTopVisibleGroup);
+    // copy metadata: master key/settings change datetime
+    newMetadata->setDatabaseKeyChanged(m_metadata->databaseKeyChanged());
+    newMetadata->setSettingsChanged(m_metadata->settingsChanged());
+    // copy metadata: custom data
+    newMetadata->customData()->copyDataFrom(m_metadata->customData());
+    // copy metadata: custom icons (does not retain order)
+    newMetadata->copyCustomIcons(m_metadata->customIconsOrder().toSet(), m_metadata);
+    // copy metadata: other attributes
+    newMetadata->copyAttributesFrom(m_metadata);
+
+    return newDatabase;
+}
+
 void Database::markAsTemporaryDatabase()
 {
     m_isTemporaryDatabase = true;

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -164,6 +164,14 @@ public:
     bool changeKdf(const QSharedPointer<Kdf>& kdf);
     QByteArray transformedDatabaseKey() const;
 
+    /**
+     * Create a deep copy of this database which is completely independent
+     * of the existing instance.
+     *
+     * @note this instance does not have a file path or the secret keys set
+     */
+    QSharedPointer<Database> clone();
+
     void markAsTemporaryDatabase();
     bool isTemporaryDatabase();
 

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -164,14 +164,6 @@ public:
     bool changeKdf(const QSharedPointer<Kdf>& kdf);
     QByteArray transformedDatabaseKey() const;
 
-    /**
-     * Create a deep copy of this database which is completely independent
-     * of the existing instance.
-     *
-     * @note this instance does not have a file path or the secret keys set
-     */
-    QSharedPointer<Database> clone();
-
     void markAsTemporaryDatabase();
     bool isTemporaryDatabase();
 

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -959,6 +959,68 @@ bool Entry::equals(const Entry* other, CompareItemOptions options) const
     return true;
 }
 
+QStringList Entry::calculateDifference(const Entry* other)
+{
+    QStringList modifiedFields;
+
+    if (*attributes() != *other->attributes()) {
+        bool foundAttribute = false;
+
+        if (title() != other->title()) {
+            modifiedFields << tr("Title");
+            foundAttribute = true;
+        }
+        if (username() != other->username()) {
+            modifiedFields << tr("Username");
+            foundAttribute = true;
+        }
+        if (password() != other->password()) {
+            modifiedFields << tr("Password");
+            foundAttribute = true;
+        }
+        if (url() != other->url()) {
+            modifiedFields << tr("URL");
+            foundAttribute = true;
+        }
+        if (notes() != other->notes()) {
+            modifiedFields << tr("Notes");
+            foundAttribute = true;
+        }
+
+        if (!foundAttribute) {
+            modifiedFields << tr("Custom Attributes");
+        }
+    }
+    if (iconNumber() != other->iconNumber() || iconUuid() != other->iconUuid()) {
+        modifiedFields << tr("Icon");
+    }
+    if (foregroundColor() != other->foregroundColor() || backgroundColor() != other->backgroundColor()) {
+        modifiedFields << tr("Color");
+    }
+    if (timeInfo().expires() != other->timeInfo().expires()
+        || timeInfo().expiryTime() != other->timeInfo().expiryTime()) {
+        modifiedFields << tr("Expiration");
+    }
+    if (totp() != other->totp()) {
+        modifiedFields << tr("TOTP");
+    }
+    if (*customData() != *other->customData()) {
+        modifiedFields << tr("Custom Data");
+    }
+    if (*attachments() != *other->attachments()) {
+        modifiedFields << tr("Attachments");
+    }
+    if (*autoTypeAssociations() != *other->autoTypeAssociations() || autoTypeEnabled() != other->autoTypeEnabled()
+        || defaultAutoTypeSequence() != other->defaultAutoTypeSequence()) {
+        modifiedFields << tr("Auto-Type");
+    }
+    if (tags() != other->tags()) {
+        modifiedFields << tr("Tags");
+    }
+
+    return modifiedFields;
+}
+
 Entry* Entry::clone(CloneFlags flags) const
 {
     auto entry = new Entry();

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -179,6 +179,13 @@ public:
 
     bool equals(const Entry* other, CompareItemOptions options = CompareItemDefault) const;
 
+    /**
+     * Determine differences between attributes of this and another entry.
+     *
+     * @return The list of attribute names that are different between the two entries
+     */
+    QStringList calculateDifference(const Entry* other);
+
     enum CloneFlag
     {
         CloneNoFlags = 0,

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -457,6 +457,7 @@ const Group* Group::parentGroup() const
 void Group::setParent(Group* parent, int index, bool trackPrevious)
 {
     Q_ASSERT(parent);
+    Q_ASSERT(this != parent);
     Q_ASSERT(index >= -1 && index <= parent->children().size());
     // setting a new parent for root groups is not allowed
     Q_ASSERT(!m_db || (m_db->rootGroup() != this));

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -21,6 +21,102 @@
 #include "core/Metadata.h"
 #include "core/Tools.h"
 
+Merger::Change::Change(Type type, QString details)
+    : m_type{type}
+    , m_details{std::move(details)}
+{
+}
+
+Merger::Change::Change(Type type, const Group& group, QString details)
+    : m_type{type}
+    , m_group{group.fullPath()}
+    , m_uuid{group.uuid()}
+    , m_details{std::move(details)}
+{
+}
+Merger::Change::Change(Type type, const Entry& entry, QString details)
+    : m_type{type}
+    , m_title{entry.title()}
+    , m_uuid{entry.uuid()}
+    , m_details{std::move(details)}
+{
+    if (const auto* group = entry.group()) {
+        m_group = group->fullPath();
+    }
+}
+Merger::Change::Change(QString details)
+    : m_details{std::move(details)}
+{
+}
+
+Merger::Change::Type Merger::Change::type() const
+{
+    return m_type;
+}
+const QString& Merger::Change::title() const
+{
+    return m_title;
+}
+const QString& Merger::Change::group() const
+{
+    return m_group;
+}
+const QUuid& Merger::Change::uuid() const
+{
+    return m_uuid;
+}
+const QString& Merger::Change::details() const
+{
+    return m_details;
+}
+
+QString Merger::Change::typeString() const
+{
+    switch (m_type) {
+    case Type::Added:
+        return tr("Added");
+    case Type::Modified:
+        return tr("Modified");
+    case Type::Moved:
+        return tr("Moved");
+    case Type::Deleted:
+        return tr("Deleted");
+    case Type::Metadata:
+        return "Metadata";
+    case Type::Unspecified:
+        return "";
+    default:
+        return "?";
+    }
+}
+
+QString Merger::Change::toString() const
+{
+    QString result;
+    if (m_type != Type::Unspecified) {
+        result += QString("%1: ").arg(typeString());
+    }
+    if (!m_group.isEmpty()) {
+        result += QString("'%1'").arg(m_group);
+    }
+    if (!m_title.isEmpty()) {
+        result += QString("/'%1'").arg(m_title);
+    }
+    if (!m_uuid.isNull()) {
+        result += QString(" [%1]").arg(m_uuid.toString());
+    }
+    if (!m_details.isEmpty()) {
+        result += QString(" (%1)").arg(m_details);
+    }
+    return result;
+}
+
+bool operator==(const Merger::Change& lhs, const Merger::Change& rhs)
+{
+    return lhs.type() == rhs.type() && lhs.group() == rhs.group() && lhs.title() == rhs.title()
+           && lhs.uuid() == rhs.uuid() && lhs.details() == rhs.details();
+}
+
 Merger::Merger(const Database* sourceDb, Database* targetDb)
     : m_mode(Group::Default)
 {
@@ -64,7 +160,7 @@ void Merger::setSkipDatabaseCustomData(bool state)
     m_skipCustomData = state;
 }
 
-QStringList Merger::merge()
+Merger::ChangeList Merger::merge()
 {
     // Order of merge steps is important - it is possible that we
     // create some items before deleting them afterwards
@@ -88,7 +184,7 @@ Merger::ChangeList Merger::mergeGroup(const MergeContext& context)
     for (Entry* sourceEntry : sourceEntries) {
         Entry* targetEntry = context.m_targetRootGroup->findEntryByUuid(sourceEntry->uuid());
         if (!targetEntry) {
-            changes << tr("Creating missing %1 [%2]").arg(sourceEntry->title(), sourceEntry->uuidToHex());
+            changes << Change(Change::Type::Added, *sourceEntry);
             // This entry does not exist at all. Create it.
             targetEntry = sourceEntry->clone(Entry::CloneIncludeHistory);
             moveEntry(targetEntry, context.m_targetGroup);
@@ -97,7 +193,8 @@ Merger::ChangeList Merger::mergeGroup(const MergeContext& context)
             const bool locationChanged =
                 targetEntry->timeInfo().locationChanged() < sourceEntry->timeInfo().locationChanged();
             if (locationChanged && targetEntry->group() != context.m_targetGroup) {
-                changes << tr("Relocating %1 [%2]").arg(sourceEntry->title(), sourceEntry->uuidToHex());
+                changes << Change(
+                    Change::Type::Moved, *sourceEntry, tr("Previous location: %1").arg(targetEntry->group()->name()));
                 moveEntry(targetEntry, context.m_targetGroup);
             }
             changes << resolveEntryConflict(context, sourceEntry, targetEntry);
@@ -109,7 +206,10 @@ Merger::ChangeList Merger::mergeGroup(const MergeContext& context)
     for (Group* sourceChildGroup : sourceChildGroups) {
         Group* targetChildGroup = context.m_targetRootGroup->findGroupByUuid(sourceChildGroup->uuid());
         if (!targetChildGroup) {
-            changes << tr("Creating missing %1 [%2]").arg(sourceChildGroup->name(), sourceChildGroup->uuidToHex());
+            changes << Change(
+                Change::Type::Added,
+                *sourceChildGroup,
+                tr("Number of entries in group: %1").arg(QString::number(sourceChildGroup->entries().size())));
             targetChildGroup = sourceChildGroup->clone(Entry::CloneNoFlags, Group::CloneNoFlags);
             moveGroup(targetChildGroup, context.m_targetGroup);
             TimeInfo timeinfo = targetChildGroup->timeInfo();
@@ -119,7 +219,8 @@ Merger::ChangeList Merger::mergeGroup(const MergeContext& context)
             bool locationChanged =
                 targetChildGroup->timeInfo().locationChanged() < sourceChildGroup->timeInfo().locationChanged();
             if (locationChanged && targetChildGroup->parent() != context.m_targetGroup) {
-                changes << tr("Relocating %1 [%2]").arg(sourceChildGroup->name(), sourceChildGroup->uuidToHex());
+                changes << Change(
+                    Change::Type::Moved, *sourceChildGroup, tr("Previous location: %1").arg(targetChildGroup->name()));
                 moveGroup(targetChildGroup, context.m_targetGroup);
                 TimeInfo timeinfo = targetChildGroup->timeInfo();
                 timeinfo.setLocationChanged(sourceChildGroup->timeInfo().locationChanged());
@@ -149,18 +250,57 @@ Merger::resolveGroupConflict(const MergeContext& context, const Group* sourceChi
 
     // only if the other group is newer, update the existing one.
     if (timeExisting < timeOther) {
-        changes << tr("Overwriting %1 [%2]").arg(sourceChildGroup->name(), sourceChildGroup->uuidToHex());
-        targetChildGroup->setName(sourceChildGroup->name());
-        targetChildGroup->setNotes(sourceChildGroup->notes());
+        QStringList modifications;
+        auto updateIfNecessary = [&modifications](const auto& targetValue,
+                                                  const auto& sourceValue,
+                                                  auto&& updateFunction,
+                                                  const QString& modification) {
+            if (targetValue != sourceValue) {
+                updateFunction(sourceValue);
+
+                modifications << modification;
+                return true;
+            }
+            return false;
+        };
+        updateIfNecessary(
+            targetChildGroup->name(),
+            sourceChildGroup->name(),
+            [&](auto&& newValue) { targetChildGroup->setName(newValue); },
+            tr("Group name"));
+        updateIfNecessary(
+            targetChildGroup->notes(),
+            sourceChildGroup->notes(),
+            [&](auto&& newValue) { targetChildGroup->setNotes(newValue); },
+            tr("Notes"));
         if (sourceChildGroup->iconNumber() == 0) {
-            targetChildGroup->setIcon(sourceChildGroup->iconUuid());
+            updateIfNecessary(
+                targetChildGroup->iconUuid(),
+                sourceChildGroup->iconUuid(),
+                [&](auto&& newValue) { targetChildGroup->setIcon(newValue); },
+                tr("Icon (UUID)"));
         } else {
-            targetChildGroup->setIcon(sourceChildGroup->iconNumber());
+            updateIfNecessary(
+                targetChildGroup->iconNumber(),
+                sourceChildGroup->iconNumber(),
+                [&](auto&& newValue) { targetChildGroup->setIcon(newValue); },
+                tr("Icon (Number)"));
         }
-        targetChildGroup->setExpiryTime(sourceChildGroup->timeInfo().expiryTime());
-        TimeInfo timeInfo = targetChildGroup->timeInfo();
-        timeInfo.setLastModificationTime(timeOther);
-        targetChildGroup->setTimeInfo(timeInfo);
+        updateIfNecessary(
+            targetChildGroup->timeInfo().expiryTime(),
+            sourceChildGroup->timeInfo().expiryTime(),
+            [&](auto&& newValue) { targetChildGroup->setExpiryTime(newValue); },
+            tr("Expiry time"));
+        updateIfNecessary(
+            timeExisting,
+            timeOther,
+            [&](auto&& newValue) {
+                TimeInfo timeInfo = targetChildGroup->timeInfo();
+                timeInfo.setLastModificationTime(newValue);
+                targetChildGroup->setTimeInfo(timeInfo);
+            },
+            tr("Modification time"));
+        changes << Change(Change::Type::Modified, *sourceChildGroup, modifications.join(", "));
     }
     return changes;
 }
@@ -268,6 +408,8 @@ Merger::ChangeList Merger::resolveEntryConflict_MergeHistories(const MergeContex
     const int comparison = compare(targetEntry->timeInfo().lastModificationTime(),
                                    sourceEntry->timeInfo().lastModificationTime(),
                                    CompareItemIgnoreMilliseconds);
+    auto differences = targetEntry->calculateDifference(sourceEntry);
+    differences += "History";
     const int maxItems = targetEntry->database()->metadata()->historyMaxItems();
     if (comparison < 0) {
         Group* currentGroup = targetEntry->group();
@@ -276,8 +418,10 @@ Merger::ChangeList Merger::resolveEntryConflict_MergeHistories(const MergeContex
                qPrintable(targetEntry->title()),
                qPrintable(sourceEntry->title()),
                qPrintable(currentGroup->name()));
-        changes << tr("Synchronizing from newer source %1 [%2]").arg(targetEntry->title(), targetEntry->uuidToHex());
         mergeHistory(targetEntry, clonedEntry, mergeMethod, maxItems);
+        changes << Change(Change::Type::Modified,
+                          *targetEntry,
+                          tr("%1 (Add local modifications to new entry)").arg(differences.join(", ")));
         eraseEntry(targetEntry);
         moveEntry(clonedEntry, currentGroup);
     } else {
@@ -287,8 +431,9 @@ Merger::ChangeList Merger::resolveEntryConflict_MergeHistories(const MergeContex
                qPrintable(targetEntry->group()->name()));
         const bool changed = mergeHistory(sourceEntry, targetEntry, mergeMethod, maxItems);
         if (changed) {
-            changes
-                << tr("Synchronizing from older source %1 [%2]").arg(targetEntry->title(), targetEntry->uuidToHex());
+            changes << Change(Change::Type::Modified,
+                              *targetEntry,
+                              tr("%1 (Add new modifications to existing entry)").arg(differences.join(", ")));
         }
     }
     return changes;
@@ -465,9 +610,9 @@ Merger::ChangeList Merger::mergeDeletions(const MergeContext& context)
         }
         deletions << object;
         if (entry->group()) {
-            changes << tr("Deleting child %1 [%2]").arg(entry->title(), entry->uuidToHex());
+            changes << Change(Change::Type::Deleted, *entry, tr("Explicit deletion"));
         } else {
-            changes << tr("Deleting orphan %1 [%2]").arg(entry->title(), entry->uuidToHex());
+            changes << Change(Change::Type::Deleted, *entry, tr("Implicit deletion (e.g. removal of parent group)"));
         }
         // Entry is inserted into deletedObjects after deletions are processed
         eraseEntry(entry);
@@ -475,7 +620,7 @@ Merger::ChangeList Merger::mergeDeletions(const MergeContext& context)
 
     while (!groups.isEmpty()) {
         auto* group = groups.takeFirst();
-        if (Tools::asSet(group->children()).intersects(Tools::asSet(groups))) {
+        if (!(group->children().toSet() & groups.toSet()).isEmpty()) {
             // we need to finish all children before we are able to determine if the group can be removed
             groups << group;
             continue;
@@ -491,15 +636,15 @@ Merger::ChangeList Merger::mergeDeletions(const MergeContext& context)
         }
         deletions << object;
         if (group->parentGroup()) {
-            changes << tr("Deleting child %1 [%2]").arg(group->name(), group->uuidToHex());
+            changes << Change(Change::Type::Deleted, *group, tr("Explicit deletion"));
         } else {
-            changes << tr("Deleting orphan %1 [%2]").arg(group->name(), group->uuidToHex());
+            changes << Change(Change::Type::Deleted, *group, tr("Implicit deletion (e.g. removal of parent group)"));
         }
         eraseGroup(group);
     }
     // Put every deletion to the earliest date of deletion
     if (deletions != context.m_targetDb->deletedObjects()) {
-        changes << tr("Changed deleted objects");
+        changes << Change(Change::Type::Metadata, tr("Changed deleted objects"));
     }
     context.m_targetDb->setDeletedObjects(deletions);
     return changes;
@@ -517,7 +662,8 @@ Merger::ChangeList Merger::mergeMetadata(const MergeContext& context)
     for (const auto& iconUuid : sourceMetadata->customIconsOrder()) {
         if (!targetMetadata->hasCustomIcon(iconUuid)) {
             targetMetadata->addCustomIcon(iconUuid, sourceMetadata->customIcon(iconUuid));
-            changes << tr("Adding missing icon %1").arg(QString::fromLatin1(iconUuid.toRfc4122().toHex()));
+            changes << Change(Change::Type::Metadata,
+                              tr("Adding new icon %1").arg(QString::fromLatin1(iconUuid.toRfc4122().toHex())));
         }
     }
 
@@ -541,7 +687,7 @@ Merger::ChangeList Merger::mergeMetadata(const MergeContext& context)
             if (!sourceMetadata->customData()->contains(key) && !sourceMetadata->customData()->isProtected(key)) {
                 auto value = targetMetadata->customData()->value(key);
                 targetMetadata->customData()->remove(key);
-                changes << tr("Removed custom data %1 [%2]").arg(key, value);
+                changes << Change(Change::Type::Metadata, tr("Removed custom data %1 [%2]").arg(key, value));
             }
         }
 
@@ -557,7 +703,7 @@ Merger::ChangeList Merger::mergeMetadata(const MergeContext& context)
             // Merge only if the values are not the same.
             if (sourceValue != targetValue) {
                 targetMetadata->customData()->set(key, sourceValue);
-                changes << tr("Adding custom data %1 [%2]").arg(key, sourceValue);
+                changes << Change(Change::Type::Metadata, tr("Adding custom data %1 [%2]").arg(key, sourceValue));
             }
         }
     }

--- a/src/core/Merger.cpp
+++ b/src/core/Merger.cpp
@@ -49,6 +49,17 @@ Merger::Change::Change(QString details)
 {
 }
 
+bool Merger::Change::operator==(const Merger::Change& other) const
+{
+    return m_type == other.m_type && m_group == other.m_group && m_title == other.m_title && m_uuid == other.m_uuid
+           && m_details == other.m_details;
+}
+
+bool Merger::Change::operator!=(const Merger::Change& other) const
+{
+    return !(*this == other);
+}
+
 Merger::Change::Type Merger::Change::type() const
 {
     return m_type;
@@ -111,12 +122,6 @@ QString Merger::Change::toString() const
     return result;
 }
 
-bool operator==(const Merger::Change& lhs, const Merger::Change& rhs)
-{
-    return lhs.type() == rhs.type() && lhs.group() == rhs.group() && lhs.title() == rhs.title()
-           && lhs.uuid() == rhs.uuid() && lhs.details() == rhs.details();
-}
-
 Merger::Merger(const Database* sourceDb, Database* targetDb)
     : m_mode(Group::Default)
 {
@@ -160,8 +165,9 @@ void Merger::setSkipDatabaseCustomData(bool state)
     m_skipCustomData = state;
 }
 
-Merger::ChangeList Merger::merge()
+Merger::ChangeList Merger::merge(bool dryRun)
 {
+    m_dryRun = dryRun;
     // Order of merge steps is important - it is possible that we
     // create some items before deleting them afterwards
     ChangeList changes;
@@ -170,9 +176,10 @@ Merger::ChangeList Merger::merge()
     changes << mergeMetadata(m_context);
 
     // At this point we have a list of changes we may want to show the user
-    if (!changes.isEmpty()) {
+    if (!changes.isEmpty() && !dryRun) {
         m_context.m_targetDb->markAsModified();
     }
+    m_dryRun = false;
     return changes;
 }
 
@@ -184,10 +191,12 @@ Merger::ChangeList Merger::mergeGroup(const MergeContext& context)
     for (Entry* sourceEntry : sourceEntries) {
         Entry* targetEntry = context.m_targetRootGroup->findEntryByUuid(sourceEntry->uuid());
         if (!targetEntry) {
-            changes << Change(Change::Type::Added, *sourceEntry);
             // This entry does not exist at all. Create it.
-            targetEntry = sourceEntry->clone(Entry::CloneIncludeHistory);
-            moveEntry(targetEntry, context.m_targetGroup);
+            changes << Change(Change::Type::Added, *sourceEntry);
+            if (!m_dryRun) {
+                targetEntry = sourceEntry->clone(Entry::CloneIncludeHistory);
+                moveEntry(targetEntry, context.m_targetGroup);
+            }
         } else {
             // Entry is already present in the database. Update it.
             const bool locationChanged =
@@ -195,36 +204,45 @@ Merger::ChangeList Merger::mergeGroup(const MergeContext& context)
             if (locationChanged && targetEntry->group() != context.m_targetGroup) {
                 changes << Change(
                     Change::Type::Moved, *sourceEntry, tr("Previous location: %1").arg(targetEntry->group()->name()));
-                moveEntry(targetEntry, context.m_targetGroup);
+                if (!m_dryRun) {
+                    moveEntry(targetEntry, context.m_targetGroup);
+                }
             }
             changes << resolveEntryConflict(context, sourceEntry, targetEntry);
         }
     }
 
-    // merge groups recursively
+    // merge child groups recursively
     const QList<Group*> sourceChildGroups = context.m_sourceGroup->children();
     for (Group* sourceChildGroup : sourceChildGroups) {
+        bool groupCreated = false;
         Group* targetChildGroup = context.m_targetRootGroup->findGroupByUuid(sourceChildGroup->uuid());
         if (!targetChildGroup) {
             changes << Change(
                 Change::Type::Added,
                 *sourceChildGroup,
                 tr("Number of entries in group: %1").arg(QString::number(sourceChildGroup->entries().size())));
+            // Create the target group, it will be cleaned up later if in dry run mode
             targetChildGroup = sourceChildGroup->clone(Entry::CloneNoFlags, Group::CloneNoFlags);
-            moveGroup(targetChildGroup, context.m_targetGroup);
-            TimeInfo timeinfo = targetChildGroup->timeInfo();
-            timeinfo.setLocationChanged(sourceChildGroup->timeInfo().locationChanged());
-            targetChildGroup->setTimeInfo(timeinfo);
+            groupCreated = true;
+            if (!m_dryRun) {
+                moveGroup(targetChildGroup, context.m_targetGroup);
+                TimeInfo timeinfo = targetChildGroup->timeInfo();
+                timeinfo.setLocationChanged(sourceChildGroup->timeInfo().locationChanged());
+                targetChildGroup->setTimeInfo(timeinfo);
+            }
         } else {
             bool locationChanged =
                 targetChildGroup->timeInfo().locationChanged() < sourceChildGroup->timeInfo().locationChanged();
             if (locationChanged && targetChildGroup->parent() != context.m_targetGroup) {
                 changes << Change(
                     Change::Type::Moved, *sourceChildGroup, tr("Previous location: %1").arg(targetChildGroup->name()));
-                moveGroup(targetChildGroup, context.m_targetGroup);
-                TimeInfo timeinfo = targetChildGroup->timeInfo();
-                timeinfo.setLocationChanged(sourceChildGroup->timeInfo().locationChanged());
-                targetChildGroup->setTimeInfo(timeinfo);
+                if (!m_dryRun) {
+                    moveGroup(targetChildGroup, context.m_targetGroup);
+                    TimeInfo timeinfo = targetChildGroup->timeInfo();
+                    timeinfo.setLocationChanged(sourceChildGroup->timeInfo().locationChanged());
+                    targetChildGroup->setTimeInfo(timeinfo);
+                }
             }
             changes << resolveGroupConflict(context, sourceChildGroup, targetChildGroup);
         }
@@ -235,6 +253,10 @@ Merger::ChangeList Merger::mergeGroup(const MergeContext& context)
                                 sourceChildGroup,
                                 targetChildGroup};
         changes << mergeGroup(subcontext);
+        // Cleanup the temporary target group structure
+        if (m_dryRun && groupCreated) {
+            delete subcontext.m_targetGroup;
+        }
     }
     return changes;
 }
@@ -251,14 +273,15 @@ Merger::resolveGroupConflict(const MergeContext& context, const Group* sourceChi
     // only if the other group is newer, update the existing one.
     if (timeExisting < timeOther) {
         QStringList modifications;
-        auto updateIfNecessary = [&modifications](const auto& targetValue,
-                                                  const auto& sourceValue,
-                                                  auto&& updateFunction,
-                                                  const QString& modification) {
+        auto updateIfNecessary = [&modifications, this](const auto& targetValue,
+                                                        const auto& sourceValue,
+                                                        auto&& updateFunction,
+                                                        const QString& modification) {
             if (targetValue != sourceValue) {
-                updateFunction(sourceValue);
-
                 modifications << modification;
+                if (!m_dryRun) {
+                    updateFunction(sourceValue);
+                }
                 return true;
             }
             return false;
@@ -307,6 +330,10 @@ Merger::resolveGroupConflict(const MergeContext& context, const Group* sourceChi
 
 void Merger::moveEntry(Entry* entry, Group* targetGroup)
 {
+    if (m_dryRun) {
+        return;
+    }
+
     Q_ASSERT(entry);
     Group* sourceGroup = entry->group();
     if (sourceGroup == targetGroup) {
@@ -336,6 +363,10 @@ void Merger::moveEntry(Entry* entry, Group* targetGroup)
 
 void Merger::moveGroup(Group* group, Group* targetGroup)
 {
+    if (m_dryRun) {
+        return;
+    }
+
     Q_ASSERT(group);
     Group* sourceGroup = group->parentGroup();
     if (sourceGroup == targetGroup) {
@@ -365,6 +396,10 @@ void Merger::moveGroup(Group* group, Group* targetGroup)
 
 void Merger::eraseEntry(Entry* entry)
 {
+    if (m_dryRun) {
+        return;
+    }
+
     Database* database = entry->database();
     // most simple method to remove an item from DeletedObjects :(
     const QList<DeletedObject> deletions = database->deletedObjects();
@@ -382,6 +417,10 @@ void Merger::eraseEntry(Entry* entry)
 
 void Merger::eraseGroup(Group* group)
 {
+    if (m_dryRun) {
+        return;
+    }
+
     Database* database = group->database();
     // most simple method to remove an item from DeletedObjects :(
     const QList<DeletedObject> deletions = database->deletedObjects();
@@ -418,10 +457,10 @@ Merger::ChangeList Merger::resolveEntryConflict_MergeHistories(const MergeContex
                qPrintable(targetEntry->title()),
                qPrintable(sourceEntry->title()),
                qPrintable(currentGroup->name()));
-        mergeHistory(targetEntry, clonedEntry, mergeMethod, maxItems);
         changes << Change(Change::Type::Modified,
                           *targetEntry,
                           tr("%1 (Add local modifications to new entry)").arg(differences.join(", ")));
+        mergeHistory(targetEntry, clonedEntry, mergeMethod, maxItems);
         eraseEntry(targetEntry);
         moveEntry(clonedEntry, currentGroup);
     } else {
@@ -445,8 +484,10 @@ Merger::resolveEntryConflict(const MergeContext& context, const Entry* sourceEnt
     // We need to cut off the milliseconds since the persistent format only supports times down to seconds
     // so when we import data from a remote source, it may represent the (or even some msec newer) data
     // which may be discarded due to higher runtime precision
-
-    Group::MergeMode mergeMode = m_mode == Group::Default ? context.m_targetGroup->mergeMode() : m_mode;
+    Group::MergeMode mergeMode = m_mode;
+    if (mergeMode == Group::Default && context.m_targetGroup) {
+        mergeMode = context.m_targetGroup->mergeMode();
+    }
     return resolveEntryConflict_MergeHistories(context, sourceEntry, targetEntry, mergeMode);
 }
 
@@ -469,11 +510,11 @@ bool Merger::mergeHistory(const Entry* sourceEntry,
         const QDateTime modificationTime = Clock::serialized(historyItem->timeInfo().lastModificationTime());
         if (merged.contains(modificationTime)
             && !merged[modificationTime]->equals(historyItem, CompareItemIgnoreMilliseconds)) {
-            ::qWarning("Inconsistent history entry of %s[%s] at %s contains conflicting changes - conflict resolution "
-                       "may lose data!",
-                       qPrintable(sourceEntry->title()),
-                       qPrintable(sourceEntry->uuidToHex()),
-                       qPrintable(modificationTime.toString("yyyy-MM-dd HH-mm-ss-zzz")));
+            qWarning("Inconsistent history entry of %s[%s] at %s contains conflicting changes - conflict resolution "
+                     "may lose data!",
+                     qPrintable(sourceEntry->title()),
+                     qPrintable(sourceEntry->uuidToHex()),
+                     qPrintable(modificationTime.toString("yyyy-MM-dd HH-mm-ss-zzz")));
         }
         merged[modificationTime] = historyItem->clone(Entry::CloneNoFlags);
     }
@@ -482,11 +523,10 @@ bool Merger::mergeHistory(const Entry* sourceEntry,
         const QDateTime modificationTime = Clock::serialized(historyItem->timeInfo().lastModificationTime());
         if (merged.contains(modificationTime)
             && !merged[modificationTime]->equals(historyItem, CompareItemIgnoreMilliseconds)) {
-            ::qWarning(
-                "History entry of %s[%s] at %s contains conflicting changes - conflict resolution may lose data!",
-                qPrintable(sourceEntry->title()),
-                qPrintable(sourceEntry->uuidToHex()),
-                qPrintable(modificationTime.toString("yyyy-MM-dd HH-mm-ss-zzz")));
+            qWarning("History entry of %s[%s] at %s contains conflicting changes - conflict resolution may lose data!",
+                     qPrintable(sourceEntry->title()),
+                     qPrintable(sourceEntry->uuidToHex()),
+                     qPrintable(modificationTime.toString("yyyy-MM-dd HH-mm-ss-zzz")));
         }
         if (preferRemote && merged.contains(modificationTime)) {
             // forcefully apply the remote history item
@@ -502,9 +542,9 @@ bool Merger::mergeHistory(const Entry* sourceEntry,
     if (targetModificationTime == sourceModificationTime
         && !targetEntry->equals(sourceEntry,
                                 CompareItemIgnoreMilliseconds | CompareItemIgnoreHistory | CompareItemIgnoreLocation)) {
-        ::qWarning("Entry of %s[%s] contains conflicting changes - conflict resolution may lose data!",
-                   qPrintable(sourceEntry->title()),
-                   qPrintable(sourceEntry->uuidToHex()));
+        qWarning("Entry of %s[%s] contains conflicting changes - conflict resolution may lose data!",
+                 qPrintable(sourceEntry->title()),
+                 qPrintable(sourceEntry->uuidToHex()));
     }
 
     if (targetModificationTime < sourceModificationTime) {
@@ -543,22 +583,24 @@ bool Merger::mergeHistory(const Entry* sourceEntry,
         qDeleteAll(updatedHistoryItems);
         return false;
     }
-    // We need to prevent any modification to the database since every change should be tracked either
-    // in a clone history item or in the Entry itself
-    const TimeInfo timeInfo = targetEntry->timeInfo();
-    const bool blockedSignals = targetEntry->blockSignals(true);
-    bool updateTimeInfo = targetEntry->canUpdateTimeinfo();
-    targetEntry->setUpdateTimeinfo(false);
-    targetEntry->removeHistoryItems(targetHistoryItems);
-    for (Entry* historyItem : merged) {
-        Q_ASSERT(!historyItem->parent());
-        targetEntry->addHistoryItem(historyItem);
+    if (!m_dryRun) {
+        // We need to prevent any modification to the database since every change should be tracked either
+        // in a clone history item or in the Entry itself
+        const TimeInfo timeInfo = targetEntry->timeInfo();
+        const bool blockedSignals = targetEntry->blockSignals(true);
+        bool updateTimeInfo = targetEntry->canUpdateTimeinfo();
+        targetEntry->setUpdateTimeinfo(false);
+        targetEntry->removeHistoryItems(targetHistoryItems);
+        for (Entry* historyItem : merged) {
+            Q_ASSERT(!historyItem->parent());
+            targetEntry->addHistoryItem(historyItem);
+        }
+        targetEntry->truncateHistory();
+        targetEntry->blockSignals(blockedSignals);
+        targetEntry->setUpdateTimeinfo(updateTimeInfo);
+        Q_ASSERT(timeInfo == targetEntry->timeInfo());
+        Q_UNUSED(timeInfo);
     }
-    targetEntry->truncateHistory();
-    targetEntry->blockSignals(blockedSignals);
-    targetEntry->setUpdateTimeinfo(updateTimeInfo);
-    Q_ASSERT(timeInfo == targetEntry->timeInfo());
-    Q_UNUSED(timeInfo);
     return true;
 }
 
@@ -582,7 +624,6 @@ Merger::ChangeList Merger::mergeDeletions(const MergeContext& context)
     for (const auto& object : (targetDeletions + sourceDeletions)) {
         if (!mergedDeletions.contains(object.uuid)) {
             mergedDeletions[object.uuid] = object;
-
             auto* entry = context.m_targetRootGroup->findEntryByUuid(object.uuid);
             if (entry) {
                 entries << entry;
@@ -614,8 +655,9 @@ Merger::ChangeList Merger::mergeDeletions(const MergeContext& context)
         } else {
             changes << Change(Change::Type::Deleted, *entry, tr("Implicit deletion (e.g. removal of parent group)"));
         }
-        // Entry is inserted into deletedObjects after deletions are processed
-        eraseEntry(entry);
+        if (!m_dryRun) {
+            eraseEntry(entry);
+        }
     }
 
     while (!groups.isEmpty()) {
@@ -640,13 +682,18 @@ Merger::ChangeList Merger::mergeDeletions(const MergeContext& context)
         } else {
             changes << Change(Change::Type::Deleted, *group, tr("Implicit deletion (e.g. removal of parent group)"));
         }
-        eraseGroup(group);
+        if (!m_dryRun) {
+            eraseGroup(group);
+        }
     }
     // Put every deletion to the earliest date of deletion
     if (deletions != context.m_targetDb->deletedObjects()) {
         changes << Change(Change::Type::Metadata, tr("Changed deleted objects"));
+        if (!m_dryRun) {
+            context.m_targetDb->setDeletedObjects(deletions);
+        }
     }
-    context.m_targetDb->setDeletedObjects(deletions);
+
     return changes;
 }
 
@@ -661,9 +708,11 @@ Merger::ChangeList Merger::mergeMetadata(const MergeContext& context)
 
     for (const auto& iconUuid : sourceMetadata->customIconsOrder()) {
         if (!targetMetadata->hasCustomIcon(iconUuid)) {
-            targetMetadata->addCustomIcon(iconUuid, sourceMetadata->customIcon(iconUuid));
             changes << Change(Change::Type::Metadata,
                               tr("Adding new icon %1").arg(QString::fromLatin1(iconUuid.toRfc4122().toHex())));
+            if (!m_dryRun) {
+                targetMetadata->addCustomIcon(iconUuid, sourceMetadata->customIcon(iconUuid));
+            }
         }
     }
 
@@ -686,8 +735,10 @@ Merger::ChangeList Merger::mergeMetadata(const MergeContext& context)
             // Do not remove protected custom data
             if (!sourceMetadata->customData()->contains(key) && !sourceMetadata->customData()->isProtected(key)) {
                 auto value = targetMetadata->customData()->value(key);
-                targetMetadata->customData()->remove(key);
                 changes << Change(Change::Type::Metadata, tr("Removed custom data %1 [%2]").arg(key, value));
+                if (!m_dryRun) {
+                    targetMetadata->customData()->remove(key);
+                }
             }
         }
 
@@ -702,8 +753,10 @@ Merger::ChangeList Merger::mergeMetadata(const MergeContext& context)
             auto targetValue = targetMetadata->customData()->value(key);
             // Merge only if the values are not the same.
             if (sourceValue != targetValue) {
-                targetMetadata->customData()->set(key, sourceValue);
                 changes << Change(Change::Type::Metadata, tr("Adding custom data %1 [%2]").arg(key, sourceValue));
+                if (!m_dryRun) {
+                    targetMetadata->customData()->set(key, sourceValue);
+                }
             }
         }
     }

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -27,17 +27,53 @@ class Merger : public QObject
 {
     Q_OBJECT
 public:
+    class Change;
+    using ChangeList = QList<Change>;
+
     Merger(const Database* sourceDb, Database* targetDb);
     Merger(const Group* sourceGroup, Group* targetGroup);
     void setForcedMergeMode(Group::MergeMode mode);
     void resetForcedMergeMode();
     void setSkipDatabaseCustomData(bool state);
-    QStringList merge();
+    ChangeList merge();
+
+    class Change
+    {
+    public:
+        enum class Type
+        {
+            Unspecified,
+            Added,
+            Modified,
+            Moved,
+            Deleted,
+            Metadata,
+        };
+
+        Change(Type type, QString details);
+        Change(Type type, const Group& group, QString details = "");
+        Change(Type type, const Entry& entry, QString details = "");
+        explicit Change(QString details = "");
+
+        [[nodiscard]] Type type() const;
+        [[nodiscard]] QString typeString() const;
+        [[nodiscard]] const QString& title() const;
+        [[nodiscard]] const QString& group() const;
+        [[nodiscard]] const QUuid& uuid() const;
+        [[nodiscard]] const QString& details() const;
+
+        [[nodiscard]] QString toString() const;
+        void merge();
+
+    private:
+        Type m_type{Type::Unspecified};
+        QString m_title;
+        QString m_group;
+        QUuid m_uuid;
+        QString m_details;
+    };
 
 private:
-    typedef QString Change;
-    typedef QStringList ChangeList;
-
     struct MergeContext
     {
         QPointer<const Database> m_sourceDb;
@@ -69,5 +105,7 @@ private:
     Group::MergeMode m_mode;
     bool m_skipCustomData = false;
 };
+
+bool operator==(const Merger::Change& lhs, const Merger::Change& rhs);
 
 #endif // KEEPASSXC_MERGER_H

--- a/src/core/Merger.h
+++ b/src/core/Merger.h
@@ -27,15 +27,11 @@ class Merger : public QObject
 {
     Q_OBJECT
 public:
-    class Change;
-    using ChangeList = QList<Change>;
-
     Merger(const Database* sourceDb, Database* targetDb);
     Merger(const Group* sourceGroup, Group* targetGroup);
     void setForcedMergeMode(Group::MergeMode mode);
     void resetForcedMergeMode();
     void setSkipDatabaseCustomData(bool state);
-    ChangeList merge();
 
     class Change
     {
@@ -65,6 +61,9 @@ public:
         [[nodiscard]] QString toString() const;
         void merge();
 
+        bool operator==(const Change& other) const;
+        bool operator!=(const Change& other) const;
+
     private:
         Type m_type{Type::Unspecified};
         QString m_title;
@@ -72,6 +71,10 @@ public:
         QUuid m_uuid;
         QString m_details;
     };
+
+    using ChangeList = QList<Change>;
+
+    ChangeList merge(bool dryRun = false);
 
 private:
     struct MergeContext
@@ -83,6 +86,7 @@ private:
         QPointer<const Group> m_sourceGroup;
         QPointer<Group> m_targetGroup;
     };
+
     ChangeList mergeGroup(const MergeContext& context);
     ChangeList mergeDeletions(const MergeContext& context);
     ChangeList mergeMetadata(const MergeContext& context);
@@ -104,8 +108,7 @@ private:
     MergeContext m_context;
     Group::MergeMode m_mode;
     bool m_skipCustomData = false;
+    bool m_dryRun = false;
 };
-
-bool operator==(const Merger::Change& lhs, const Merger::Change& rhs);
 
 #endif // KEEPASSXC_MERGER_H

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -44,6 +44,7 @@
 #include "gui/FileDialog.h"
 #include "gui/GuiTools.h"
 #include "gui/MainWindow.h"
+#include "gui/MergeDialog.h"
 #include "gui/MessageBox.h"
 #include "gui/TotpDialog.h"
 #include "gui/TotpExportSettingsDialog.h"
@@ -1387,14 +1388,31 @@ void DatabaseWidget::mergeDatabase(bool accepted)
             return;
         }
 
-        Merger merger(srcDb.data(), m_db.data());
-        QStringList changeList = merger.merge();
-
-        if (!changeList.isEmpty()) {
-            showMessage(tr("Successfully merged the database files."), MessageWidget::Information);
-        } else {
-            showMessage(tr("Database was not modified by merge operation."), MessageWidget::Information);
-        }
+        auto* mergeDialog = new MergeDialog(srcDb, m_db, this);
+        connect(mergeDialog, &MergeDialog::databaseMerged, [this](bool changed) {
+            if (changed) {
+                showMessage(tr("Successfully merged the database files."), MessageWidget::Information);
+            } else {
+                showMessage(tr("Database was not modified by merge operation."), MessageWidget::Information);
+            }
+        });
+        connect(mergeDialog,
+                &MergeDialog::databaseModifiedMerge,
+                [this](const Merger::ChangeList& actualChanges, const Merger::ChangeList&) {
+                    if (!actualChanges.isEmpty()) {
+                        showMessage(tr("Merged changes do not match displayed changes!"), MessageWidget::Warning);
+                        auto* actualChangesDialog = new MergeDialog(actualChanges, this);
+                        actualChangesDialog->setWindowTitle(tr("Actual Merge Result"));
+                        actualChangesDialog->open();
+                    } else {
+                        showMessage(tr("Database was not modified by merge operation, no changes were not applied!"),
+                                    MessageWidget::Warning);
+                    }
+                });
+        connect(mergeDialog, &MergeDialog::rejected, [this]() {
+            showMessage(tr("Merge aborted - database was not modified."), MessageWidget::Information);
+        });
+        mergeDialog->open();
     }
 
     switchToMainView();
@@ -1438,7 +1456,7 @@ bool DatabaseWidget::syncWithDatabase(const QSharedPointer<Database>& otherDb, Q
     emit updateSyncProgress(50, tr("Syncing..."));
     Merger firstMerge(m_db.data(), otherDb.data());
     Merger secondMerge(otherDb.data(), m_db.data());
-    QStringList changeList = firstMerge.merge() + secondMerge.merge();
+    auto changeList = firstMerge.merge() + secondMerge.merge();
 
     if (!changeList.isEmpty()) {
         // Save synced databases

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1388,35 +1388,30 @@ void DatabaseWidget::mergeDatabase(bool accepted)
             return;
         }
 
+#ifdef WITH_XC_KEESHARE
+        // Disable KeeShare while merging to avoid conflicts with incoming changes
+        KeeShare::instance()->setSharingEnabled(m_db, false);
+#endif
+
         auto* mergeDialog = new MergeDialog(srcDb, m_db, this);
         connect(mergeDialog, &MergeDialog::databaseMerged, [this](bool changed) {
             if (changed) {
-                showMessage(tr("Successfully merged the database files."), MessageWidget::Information);
+                showMessage(tr("Successfully merged the selected database."), MessageWidget::Positive);
+                emit databaseMerged(m_db);
             } else {
-                showMessage(tr("Database was not modified by merge operation."), MessageWidget::Information);
+                showMessage(tr("No changes were made by the merge operation."), MessageWidget::Information);
             }
         });
-        connect(mergeDialog,
-                &MergeDialog::databaseModifiedMerge,
-                [this](const Merger::ChangeList& actualChanges, const Merger::ChangeList&) {
-                    if (!actualChanges.isEmpty()) {
-                        showMessage(tr("Merged changes do not match displayed changes!"), MessageWidget::Warning);
-                        auto* actualChangesDialog = new MergeDialog(actualChanges, this);
-                        actualChangesDialog->setWindowTitle(tr("Actual Merge Result"));
-                        actualChangesDialog->open();
-                    } else {
-                        showMessage(tr("Database was not modified by merge operation, no changes were not applied!"),
-                                    MessageWidget::Warning);
-                    }
-                });
-        connect(mergeDialog, &MergeDialog::rejected, [this]() {
-            showMessage(tr("Merge aborted - database was not modified."), MessageWidget::Information);
+        connect(mergeDialog, &MergeDialog::finished, [this](int result) {
+            if (result == QDialog::Rejected) {
+                showMessage(tr("Merge canceled, no changes were made."), MessageWidget::Information);
+            }
+#ifdef WITH_XC_KEESHARE
+            KeeShare::instance()->setSharingEnabled(m_db, true);
+#endif
         });
         mergeDialog->open();
     }
-
-    switchToMainView();
-    emit databaseMerged(m_db);
 }
 
 void DatabaseWidget::syncUnlockedDatabase(bool accepted)

--- a/src/gui/MergeDialog.cpp
+++ b/src/gui/MergeDialog.cpp
@@ -31,22 +31,19 @@ MergeDialog::MergeDialog(QSharedPointer<Database> source, QSharedPointer<Databas
     , m_targetDatabase(std::move(target))
 {
     setAttribute(Qt::WA_DeleteOnClose);
+    // block input to other windows since other interactions can lead to unexpected merge results
+    setWindowModality(Qt::WindowModality::ApplicationModal);
 
     m_ui->setupUi(this);
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Merge"));
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setFocus();
 
-    connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this, &MergeDialog::abortMerge);
+    connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this, &MergeDialog::cancelMerge);
     connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &MergeDialog::performMerge);
 
     setupChangeTable();
-    setupHeaderContextMenu();
-
-    refreshMergeChanges();
-
-    // block input to other windows since other interactions can lead to unexpected merge results
-    setWindowModality(Qt::WindowModality::ApplicationModal);
+    updateChangeTable();
 }
 
 MergeDialog::MergeDialog(const Merger::ChangeList& changes, QWidget* parent)
@@ -65,19 +62,9 @@ MergeDialog::MergeDialog(const Merger::ChangeList& changes, QWidget* parent)
     connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &MergeDialog::close);
 
     setupChangeTable();
-    setupHeaderContextMenu();
 }
 
 MergeDialog::~MergeDialog() = default;
-
-QSharedPointer<Database> MergeDialog::createTemporaryTargetDatabase()
-{
-    auto tmpDatabase = m_targetDatabase->clone();
-    // make sure temporary merge will not overwrite actual database
-    tmpDatabase->setFilePath("");
-    tmpDatabase->markAsTemporaryDatabase();
-    return tmpDatabase;
-}
 
 QVector<MergeDialog::MergeDialogColumns> MergeDialog::columns()
 {
@@ -132,41 +119,31 @@ QString MergeDialog::cellValue(const Merger::Change& change, MergeDialogColumns 
 
 bool MergeDialog::isColumnHiddenByDefault(MergeDialogColumns column)
 {
-    return column == MergeDialogColumns::Uuid || column == MergeDialogColumns::Details;
-}
-
-void MergeDialog::calculateChanges()
-{
-    auto tmpDatabase = createTemporaryTargetDatabase();
-    m_changes = Merger(m_sourceDatabase.data(), tmpDatabase.get()).merge();
+    return column == MergeDialogColumns::Uuid;
 }
 
 void MergeDialog::setupChangeTable()
 {
-    assert(m_ui);
-    auto* table = m_ui->changeTable;
-    assert(table);
+    Q_ASSERT(m_ui);
+    Q_ASSERT(m_ui->changeTable);
 
-    table->verticalHeader()->setVisible(false);
-    table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeMode::Interactive);
-    table->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
+    m_ui->changeTable->verticalHeader()->setVisible(false);
+    m_ui->changeTable->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeMode::Interactive);
+    m_ui->changeTable->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
 
-    table->setShowGrid(false);
-    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    table->setSelectionBehavior(QAbstractItemView::SelectRows);
-    table->setSelectionMode(QAbstractItemView::SingleSelection);
-}
+    m_ui->changeTable->setShowGrid(false);
+    m_ui->changeTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_ui->changeTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_ui->changeTable->setSelectionMode(QAbstractItemView::SingleSelection);
 
-void MergeDialog::setupHeaderContextMenu()
-{
+    // Create the header context menu
     for (auto column : columns()) {
         auto* action = new QAction(columnName(column), this);
         action->setCheckable(true);
         action->setChecked(!isColumnHiddenByDefault(column));
         connect(action, &QAction::toggled, [this, column](bool checked) {
-            auto* table = m_ui->changeTable;
-            table->setColumnHidden(columnIndex(column), !checked);
-            table->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
+            m_ui->changeTable->setColumnHidden(columnIndex(column), !checked);
+            m_ui->changeTable->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
         });
         m_ui->changeTable->horizontalHeader()->addAction(action);
     }
@@ -174,51 +151,49 @@ void MergeDialog::setupHeaderContextMenu()
 
 void MergeDialog::updateChangeTable()
 {
-    assert(m_ui);
-    auto* table = m_ui->changeTable;
-    assert(table);
+    Q_ASSERT(m_ui);
+    Q_ASSERT(m_ui->changeTable);
+    Q_ASSERT(m_sourceDatabase.get());
+    Q_ASSERT(m_targetDatabase.get());
 
-    table->clear();
+    m_changes = Merger(m_sourceDatabase.data(), m_targetDatabase.get()).merge(true);
+
+    m_ui->changeTable->clear();
 
     auto allColumns = columns();
-    table->setColumnCount(allColumns.size());
-    table->setRowCount(m_changes.size());
+    m_ui->changeTable->setColumnCount(allColumns.size());
+    m_ui->changeTable->setRowCount(m_changes.size());
     for (auto column : allColumns) {
         auto name = columnName(column);
         auto index = columnIndex(column);
 
-        table->setHorizontalHeaderItem(index, new QTableWidgetItem(name));
-        table->setColumnHidden(index, isColumnHiddenByDefault(column));
+        m_ui->changeTable->setHorizontalHeaderItem(index, new QTableWidgetItem(name));
+        m_ui->changeTable->setColumnHidden(index, isColumnHiddenByDefault(column));
     }
     for (int row = 0; row < m_changes.size(); ++row) {
         const auto& change = m_changes[row];
         for (auto column : allColumns) {
-            auto value = cellValue(change, column);
-            table->setItem(row, columnIndex(column), new QTableWidgetItem(value));
+            m_ui->changeTable->setItem(row, columnIndex(column), new QTableWidgetItem(cellValue(change, column)));
         }
     }
 
-    table->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
+    m_ui->changeTable->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
 }
 
 void MergeDialog::performMerge()
 {
     auto changes = Merger(m_sourceDatabase.data(), m_targetDatabase.data()).merge();
     if (changes != m_changes) {
-        emit databaseModifiedMerge(changes, m_changes);
-    } else {
-        emit databaseMerged(!changes.isEmpty());
+        qWarning("Merge results differed from the expected changes. Expected: %d, Actual: %d",
+                 m_changes.size(),
+                 changes.size());
     }
+
+    emit databaseMerged(!changes.isEmpty());
     done(QDialog::Accepted);
 }
 
-void MergeDialog::abortMerge()
+void MergeDialog::cancelMerge()
 {
     done(QDialog::Rejected);
-}
-
-void MergeDialog::refreshMergeChanges()
-{
-    calculateChanges();
-    updateChangeTable();
 }

--- a/src/gui/MergeDialog.cpp
+++ b/src/gui/MergeDialog.cpp
@@ -1,0 +1,224 @@
+/*
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MergeDialog.h"
+#include "ui_MergeDialog.h"
+
+#include "core/Database.h"
+
+#include <QPushButton>
+#include <QShortcut>
+
+MergeDialog::MergeDialog(QSharedPointer<Database> source, QSharedPointer<Database> target, QWidget* parent)
+    : QDialog(parent)
+    , m_ui(new Ui::MergeDialog())
+    , m_headerContextMenu(new QMenu())
+    , m_sourceDatabase(std::move(source))
+    , m_targetDatabase(std::move(target))
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    m_ui->setupUi(this);
+
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Merge"));
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setFocus();
+
+    connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this, &MergeDialog::abortMerge);
+    connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &MergeDialog::performMerge);
+
+    setupChangeTable();
+    setupHeaderContextMenu();
+
+    refreshMergeChanges();
+
+    // block input to other windows since other interactions can lead to unexpected merge results
+    setWindowModality(Qt::WindowModality::ApplicationModal);
+}
+
+MergeDialog::MergeDialog(const Merger::ChangeList& changes, QWidget* parent)
+    : QDialog(parent)
+    , m_ui(new Ui::MergeDialog())
+    , m_headerContextMenu(new QMenu())
+    , m_changes(changes)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    m_ui->setupUi(this);
+
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setFocus();
+    m_ui->buttonBox->button(QDialogButtonBox::Abort)->hide();
+
+    connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &MergeDialog::close);
+
+    setupChangeTable();
+    setupHeaderContextMenu();
+}
+
+MergeDialog::~MergeDialog() = default;
+
+QSharedPointer<Database> MergeDialog::createTemporaryTargetDatabase()
+{
+    auto tmpDatabase = m_targetDatabase->clone();
+    // make sure temporary merge will not overwrite actual database
+    tmpDatabase->setFilePath("");
+    tmpDatabase->markAsTemporaryDatabase();
+    return tmpDatabase;
+}
+
+QVector<MergeDialog::MergeDialogColumns> MergeDialog::columns()
+{
+    return {MergeDialogColumns::Group,
+            MergeDialogColumns::Title,
+            MergeDialogColumns::Uuid,
+            MergeDialogColumns::Type,
+            MergeDialogColumns::Details};
+}
+
+int MergeDialog::columnIndex(MergeDialogColumns column)
+{
+    return columns().indexOf(column);
+}
+
+QString MergeDialog::columnName(MergeDialogColumns column)
+{
+    switch (column) {
+    case MergeDialogColumns::Group:
+        return tr("Group");
+    case MergeDialogColumns::Title:
+        return tr("Title");
+    case MergeDialogColumns::Uuid:
+        return tr("UUID");
+    case MergeDialogColumns::Type:
+        return tr("Change");
+    case MergeDialogColumns::Details:
+        return tr("Details");
+    }
+    return {};
+}
+
+QString MergeDialog::cellValue(const Merger::Change& change, MergeDialogColumns column)
+{
+    switch (column) {
+    case MergeDialogColumns::Group:
+        return change.group();
+    case MergeDialogColumns::Title:
+        return change.title();
+    case MergeDialogColumns::Uuid:
+        if (!change.uuid().isNull()) {
+            return change.uuid().toString();
+        }
+        break;
+    case MergeDialogColumns::Type:
+        return change.typeString();
+    case MergeDialogColumns::Details:
+        return change.details();
+    }
+    return {};
+}
+
+bool MergeDialog::isColumnHiddenByDefault(MergeDialogColumns column)
+{
+    return column == MergeDialogColumns::Uuid || column == MergeDialogColumns::Details;
+}
+
+void MergeDialog::calculateChanges()
+{
+    auto tmpDatabase = createTemporaryTargetDatabase();
+    m_changes = Merger(m_sourceDatabase.data(), tmpDatabase.get()).merge();
+}
+
+void MergeDialog::setupChangeTable()
+{
+    assert(m_ui);
+    auto* table = m_ui->changeTable;
+    assert(table);
+
+    table->verticalHeader()->setVisible(false);
+    table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeMode::Interactive);
+    table->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
+
+    table->setShowGrid(false);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table->setSelectionMode(QAbstractItemView::SingleSelection);
+}
+
+void MergeDialog::setupHeaderContextMenu()
+{
+    for (auto column : columns()) {
+        auto* action = new QAction(columnName(column), this);
+        action->setCheckable(true);
+        action->setChecked(!isColumnHiddenByDefault(column));
+        connect(action, &QAction::toggled, [this, column](bool checked) {
+            auto* table = m_ui->changeTable;
+            table->setColumnHidden(columnIndex(column), !checked);
+            table->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
+        });
+        m_ui->changeTable->horizontalHeader()->addAction(action);
+    }
+}
+
+void MergeDialog::updateChangeTable()
+{
+    assert(m_ui);
+    auto* table = m_ui->changeTable;
+    assert(table);
+
+    table->clear();
+
+    auto allColumns = columns();
+    table->setColumnCount(allColumns.size());
+    table->setRowCount(m_changes.size());
+    for (auto column : allColumns) {
+        auto name = columnName(column);
+        auto index = columnIndex(column);
+
+        table->setHorizontalHeaderItem(index, new QTableWidgetItem(name));
+        table->setColumnHidden(index, isColumnHiddenByDefault(column));
+    }
+    for (int row = 0; row < m_changes.size(); ++row) {
+        const auto& change = m_changes[row];
+        for (auto column : allColumns) {
+            auto value = cellValue(change, column);
+            table->setItem(row, columnIndex(column), new QTableWidgetItem(value));
+        }
+    }
+
+    table->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
+}
+
+void MergeDialog::performMerge()
+{
+    auto changes = Merger(m_sourceDatabase.data(), m_targetDatabase.data()).merge();
+    if (changes != m_changes) {
+        emit databaseModifiedMerge(changes, m_changes);
+    } else {
+        emit databaseMerged(!changes.isEmpty());
+    }
+    done(QDialog::Accepted);
+}
+
+void MergeDialog::abortMerge()
+{
+    done(QDialog::Rejected);
+}
+
+void MergeDialog::refreshMergeChanges()
+{
+    calculateChanges();
+    updateChangeTable();
+}

--- a/src/gui/MergeDialog.h
+++ b/src/gui/MergeDialog.h
@@ -47,29 +47,14 @@ public:
     ~MergeDialog() override;
 
 signals:
-    /**
-     * Signal will be emitted when a normal merge operation has been performed.
-     *
-     * @param databaseChanged True if the target database was changed due to the merge
-     */
+    // Signal will be emitted when a normal merge operation has been performed.
     void databaseMerged(bool databaseChanged);
-    /**
-     * Signal will be emitted when a merge has been performed, but the previously displayed changes differ from
-     * the ones that were actually performed.
-     *
-     * @param actualChanges Actual changes that have been merged
-     * @param expectedChanges Changes which were displayed to the user
-     */
-    void databaseModifiedMerge(const Merger::ChangeList& actualChanges, const Merger::ChangeList& expectedChanges);
 
 private slots:
     void performMerge();
-    void abortMerge();
-    void refreshMergeChanges();
+    void cancelMerge();
 
 private:
-    QSharedPointer<Database> createTemporaryTargetDatabase();
-
     enum class MergeDialogColumns
     {
         Group,
@@ -84,9 +69,7 @@ private:
     static QString cellValue(const Merger::Change& change, MergeDialogColumns column);
     static bool isColumnHiddenByDefault(MergeDialogColumns column);
 
-    void calculateChanges();
     void setupChangeTable();
-    void setupHeaderContextMenu();
     void updateChangeTable();
 
     QScopedPointer<Ui::MergeDialog> m_ui;

--- a/src/gui/MergeDialog.h
+++ b/src/gui/MergeDialog.h
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_MERGEDIALOG_H
+#define KEEPASSX_MERGEDIALOG_H
+
+#include "core/Merger.h"
+
+#include <QDialog>
+#include <QMenu>
+
+namespace Ui
+{
+    class MergeDialog;
+}
+
+class Database;
+
+class MergeDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    /**
+     * Merge source into copy of target and display changes.
+     * On user confirmation, merge source into target.
+     */
+    explicit MergeDialog(QSharedPointer<Database> source, QSharedPointer<Database> target, QWidget* parent = nullptr);
+    /**
+     * Display given changes.
+     */
+    explicit MergeDialog(const Merger::ChangeList& changes, QWidget* parent = nullptr);
+    ~MergeDialog() override;
+
+signals:
+    /**
+     * Signal will be emitted when a normal merge operation has been performed.
+     *
+     * @param databaseChanged True if the target database was changed due to the merge
+     */
+    void databaseMerged(bool databaseChanged);
+    /**
+     * Signal will be emitted when a merge has been performed, but the previously displayed changes differ from
+     * the ones that were actually performed.
+     *
+     * @param actualChanges Actual changes that have been merged
+     * @param expectedChanges Changes which were displayed to the user
+     */
+    void databaseModifiedMerge(const Merger::ChangeList& actualChanges, const Merger::ChangeList& expectedChanges);
+
+private slots:
+    void performMerge();
+    void abortMerge();
+    void refreshMergeChanges();
+
+private:
+    QSharedPointer<Database> createTemporaryTargetDatabase();
+
+    enum class MergeDialogColumns
+    {
+        Group,
+        Title,
+        Uuid,
+        Type,
+        Details
+    };
+    static QVector<MergeDialogColumns> columns();
+    static int columnIndex(MergeDialogColumns column);
+    static QString columnName(MergeDialogColumns column);
+    static QString cellValue(const Merger::Change& change, MergeDialogColumns column);
+    static bool isColumnHiddenByDefault(MergeDialogColumns column);
+
+    void calculateChanges();
+    void setupChangeTable();
+    void setupHeaderContextMenu();
+    void updateChangeTable();
+
+    QScopedPointer<Ui::MergeDialog> m_ui;
+    QScopedPointer<QMenu> m_headerContextMenu;
+
+    Merger::ChangeList m_changes;
+    QSharedPointer<Database> m_sourceDatabase;
+    QSharedPointer<Database> m_targetDatabase;
+};
+
+#endif // KEEPASSX_MERGEDIALOG_H

--- a/src/gui/MergeDialog.ui
+++ b/src/gui/MergeDialog.ui
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MergeDialog</class>
+ <widget class="QWidget" name="MergeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>450</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Database Merge Confirmation</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="changeTable"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Abort|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/entry/EntryHistoryModel.cpp
+++ b/src/gui/entry/EntryHistoryModel.cpp
@@ -193,64 +193,7 @@ void EntryHistoryModel::calculateHistoryModifications()
             continue;
         }
 
-        QStringList modifiedFields;
-
-        if (*curr->attributes() != *compare->attributes()) {
-            bool foundAttribute = false;
-
-            if (curr->title() != compare->title()) {
-                modifiedFields << tr("Title");
-                foundAttribute = true;
-            }
-            if (curr->username() != compare->username()) {
-                modifiedFields << tr("Username");
-                foundAttribute = true;
-            }
-            if (curr->password() != compare->password()) {
-                modifiedFields << tr("Password");
-                foundAttribute = true;
-            }
-            if (curr->url() != compare->url()) {
-                modifiedFields << tr("URL");
-                foundAttribute = true;
-            }
-            if (curr->notes() != compare->notes()) {
-                modifiedFields << tr("Notes");
-                foundAttribute = true;
-            }
-
-            if (!foundAttribute) {
-                modifiedFields << tr("Custom Attributes");
-            }
-        }
-        if (curr->iconNumber() != compare->iconNumber() || curr->iconUuid() != compare->iconUuid()) {
-            modifiedFields << tr("Icon");
-        }
-        if (curr->foregroundColor() != compare->foregroundColor()
-            || curr->backgroundColor() != compare->backgroundColor()) {
-            modifiedFields << tr("Color");
-        }
-        if (curr->timeInfo().expires() != compare->timeInfo().expires()
-            || curr->timeInfo().expiryTime() != compare->timeInfo().expiryTime()) {
-            modifiedFields << tr("Expiration");
-        }
-        if (curr->totp() != compare->totp()) {
-            modifiedFields << tr("TOTP");
-        }
-        if (*curr->customData() != *compare->customData()) {
-            modifiedFields << tr("Custom Data");
-        }
-        if (*curr->attachments() != *compare->attachments()) {
-            modifiedFields << tr("Attachments");
-        }
-        if (*curr->autoTypeAssociations() != *compare->autoTypeAssociations()
-            || curr->autoTypeEnabled() != compare->autoTypeEnabled()
-            || curr->defaultAutoTypeSequence() != compare->defaultAutoTypeSequence()) {
-            modifiedFields << tr("Auto-Type");
-        }
-        if (curr->tags() != compare->tags()) {
-            modifiedFields << tr("Tags");
-        }
+        auto modifiedFields = curr->calculateDifference(compare);
 
         m_historyModifications << modifiedFields.join(", ");
 

--- a/src/keeshare/KeeShare.cpp
+++ b/src/keeshare/KeeShare.cpp
@@ -217,6 +217,17 @@ void KeeShare::connectDatabase(QSharedPointer<Database> newDb, QSharedPointer<Da
     }
 }
 
+bool KeeShare::setSharingEnabled(QSharedPointer<Database> db, bool enabled)
+{
+    if (!db || !m_observersByDatabase.contains(db->uuid())) {
+        return false;
+    }
+
+    auto observer = m_observersByDatabase.value(db->uuid());
+    observer->setEnabled(enabled);
+    return true;
+}
+
 const QString KeeShare::signedContainerFileType()
 {
     static const QString filetype("kdbx.share");

--- a/src/keeshare/KeeShare.h
+++ b/src/keeshare/KeeShare.h
@@ -65,6 +65,7 @@ public:
     static QString referenceTypeLabel(const KeeShareSettings::Reference& reference);
 
     void connectDatabase(QSharedPointer<Database> newDb, QSharedPointer<Database> oldDb);
+    bool setSharingEnabled(QSharedPointer<Database> db, bool enabled);
 
     static const QString signedContainerFileType();
     static const QString unsignedContainerFileType();

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -57,6 +57,11 @@ ShareObserver::~ShareObserver()
     m_db->disconnect(this);
 }
 
+void ShareObserver::setEnabled(bool enabled)
+{
+    m_enabled = enabled;
+}
+
 void ShareObserver::deinitialize()
 {
     m_groupToReference.clear();
@@ -177,7 +182,7 @@ void ShareObserver::handleDatabaseChanged()
         return;
     }
     const auto active = KeeShare::active();
-    if (!active.out && !active.in) {
+    if (!m_enabled || (!active.out && !active.in)) {
         deinitialize();
     } else {
         reinitialize();

--- a/src/keeshare/ShareObserver.h
+++ b/src/keeshare/ShareObserver.h
@@ -37,6 +37,7 @@ public:
     ~ShareObserver();
 
     QSharedPointer<Database> database();
+    void setEnabled(bool enabled);
 
     struct Result
     {
@@ -82,6 +83,7 @@ private:
     QMap<QString, QPointer<Group>> m_shareToGroup;
     QMap<QString, QSharedPointer<FileWatcher>> m_fileWatchers;
     bool m_inFileUpdate = false;
+    bool m_enabled = true;
 };
 
 #endif // KEEPASSXC_SHAREOBSERVER_H

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -1682,8 +1682,9 @@ void TestCli::testMerge()
     m_stderr->readLine(); // Skip password prompt
     QCOMPARE(m_stderr->readAll(), QByteArray());
     QList<QByteArray> outLines1 = m_stdout->readAll().split('\n');
-    QVERIFY(outLines1.at(0).contains("Overwriting Internet"));
-    QVERIFY(outLines1.at(1).contains("Creating missing Some Website"));
+    QVERIFY(outLines1.at(0).contains("Modified"));
+    QVERIFY(outLines1.at(0).contains("Modification time"));
+    QVERIFY(outLines1.at(1).contains("Added"));
     QCOMPARE(outLines1.at(2),
              QString("Successfully merged %1 into %2.").arg(sourceFile.fileName(), targetFile1.fileName()).toUtf8());
 
@@ -1699,8 +1700,9 @@ void TestCli::testMerge()
     setInput("a");
     execCmd(mergeCmd, {"merge", "--dry-run", "-s", targetFile2.fileName(), sourceFile.fileName()});
     QList<QByteArray> outLines2 = m_stdout->readAll().split('\n');
-    QVERIFY(outLines2.at(0).contains("Overwriting Internet"));
-    QVERIFY(outLines2.at(1).contains("Creating missing Some Website"));
+    QVERIFY(outLines1.at(0).contains("Modified"));
+    QVERIFY(outLines1.at(0).contains("Modification time"));
+    QVERIFY(outLines2.at(1).contains("Added"));
     QCOMPARE(outLines2.at(2), QByteArray("Database was not modified by merge operation."));
 
     mergedDb = QSharedPointer<Database>::create();

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -1146,7 +1146,7 @@ void TestMerge::testCustomData()
     m_clock->advanceSecond(1);
 
     Merger merger(dbSource.data(), dbDestination.data());
-    QStringList changes = merger.merge();
+    auto changes = merger.merge();
 
     QVERIFY(!changes.isEmpty());
 
@@ -1167,7 +1167,7 @@ void TestMerge::testCustomData()
     dbSource->metadata()->customData()->set("key3", "oldValue");
     dbSource->metadata()->customData()->set("key3", "newValue");
     Merger merger2(dbSource.data(), dbDestination.data());
-    QStringList changes2 = merger2.merge();
+    auto changes2 = merger2.merge();
     QVERIFY(changes2.isEmpty());
 
     Merger merger3(dbSource2.data(), dbDestination2.data());

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -365,6 +365,10 @@ void TestGui::testMergeDatabase()
     QTest::keyClicks(editPasswordMerge, "a");
     QTest::keyClick(editPasswordMerge, Qt::Key_Enter);
 
+    // confirm merge in confirmation dialog
+    QTRY_VERIFY(QApplication::focusWindow()->title().contains("Merge"));
+    QTest::keyClick(QApplication::focusWidget(), Qt::Key_Enter);
+
     QTRY_COMPARE(dbMergeSpy.count(), 1);
     QTRY_VERIFY(m_tabWidget->tabText(m_tabWidget->currentIndex()).contains("*"));
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

This PR adds a dialog allowing a user to review the changes of a merge operation.
This dialog displays the changes and allows the user to abort the merge without modifying the database.

Fixes #1152

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![merge dialog](https://github.com/keepassxreboot/keepassxc/assets/28907748/b0470a81-4f58-4a63-bbc0-748fc9ba1c60)

![merge aborted](https://github.com/keepassxreboot/keepassxc/assets/28907748/9645c067-1e21-47d8-bdf7-f1592d9afe3d)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Manual testing and the execution of the already existing test suite `testmerge`.

 I also added a some basic tests verifying that a database will remain unmodified when only calculating the changelist and if for a merge without re-calculation only that changelist will be applied to the database.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature
- ✅ Refactor (small refactoring)