### PR TITLE
Replace *locked* with *unlocked* in *Re-lock previously locked database*

### DIFF
--- a/share/translations/keepassxc_ar.ts
+++ b/share/translations/keepassxc_ar.ts
@@ -469,7 +469,7 @@
         <translation>إخفاء الإدخالات منتهية الصلاحية من الكتابة التلقائية</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>أعد قفل قاعدة البيانات التي تم تأمينها سابقًا بعد تنفيذ الطباعة التلقائية</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_bg.ts
+++ b/share/translations/keepassxc_bg.ts
@@ -469,7 +469,7 @@
         <translation>Пропускане на изтекли записи при автоматично въвеждане</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Повторно заключване на преди това заключено хранилище след извършване на автоматично въвеждане</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_ca.ts
+++ b/share/translations/keepassxc_ca.ts
@@ -453,7 +453,7 @@
         <translation>Amaga les entrades caducades del tecleig automàtic</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Torna a blocar la base de dades després d&apos;una compleció automàtica</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_cs.ts
+++ b/share/translations/keepassxc_cs.ts
@@ -469,7 +469,7 @@
         <translation>Skrýt položky, kterým skončila platnost, z automatického vyplňování</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Po provedení automatického vyplnění databázi opět zamknout, pokud předtím byla uzamčena.</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_da.ts
+++ b/share/translations/keepassxc_da.ts
@@ -469,7 +469,7 @@
         <translation>Skjul udløbne indlæg fra autoskriv</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Lås tidligere låste databaser igen efter udførsel af autoskriv</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_de.ts
+++ b/share/translations/keepassxc_de.ts
@@ -471,7 +471,7 @@
         <translation>Abgelaufene Einträge bei Auto-Type ausblenden</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Zuvor gesperrte Datenbank nach Auto-Type wieder sperren</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_el.ts
+++ b/share/translations/keepassxc_el.ts
@@ -469,7 +469,7 @@
         <translation>Απόκρυψη καταχωρήσεων που έχουν λήξει από την Αυτόματη Πληκτρολόγηση</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Να κλειδώνει εκ νέου η προηγούμενα κλειδωμένη βάση δεδομένων μετά την χρήση του Auto-Type</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -471,7 +471,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/keepassxc_en_GB.ts
+++ b/share/translations/keepassxc_en_GB.ts
@@ -469,8 +469,8 @@
         <translation>Hide expired entries from Auto-Type</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
-        <translation>Re-lock previously locked database after performing Auto-Type</translation>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
+        <translation>Re-lock previously unlocked database after performing Auto-Type</translation>
     </message>
     <message>
         <source>Auto-Type start delay:</source>

--- a/share/translations/keepassxc_en_US.ts
+++ b/share/translations/keepassxc_en_US.ts
@@ -469,8 +469,8 @@
         <translation>Hide expired entries from Auto-Type</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
-        <translation>Re-lock previously locked database after performing Auto-Type</translation>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
+        <translation>Re-lock previously unlocked database after performing Auto-Type</translation>
     </message>
     <message>
         <source>Auto-Type start delay:</source>

--- a/share/translations/keepassxc_es.ts
+++ b/share/translations/keepassxc_es.ts
@@ -469,7 +469,7 @@
         <translation>Ocultar apuntes expirados de la autoescritura</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Volver a bloquear la base de datos tras realizar un auto-tecleo</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_et.ts
+++ b/share/translations/keepassxc_et.ts
@@ -469,7 +469,7 @@
         <translation>Aegunud kirjeid automaatsisestuse jaoks ei pakuta</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Pärast automaatsisestuse sooritamist lukustatakse eelnevalt lukus olnud andmebaas uuesti</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_fi.ts
+++ b/share/translations/keepassxc_fi.ts
@@ -469,7 +469,7 @@
         <translation>Piilota vanhentuneet tietueet automaattisyötöltä</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Uudelleenlukitse aikaisemmin lukittu tietokanta automaattisyötön jälkeen</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_fil.ts
+++ b/share/translations/keepassxc_fil.ts
@@ -469,7 +469,7 @@
         <translation>Itago ang mga nag-expire na entry mula sa Auto-Type</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Muling i-lock ang dating naka-lock na database pagkatapos magsagawa ng Auto-Type</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_fr.ts
+++ b/share/translations/keepassxc_fr.ts
@@ -469,7 +469,7 @@
         <translation>Cacher à la saisie automatique les entrées expirées</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Après avoir effectué la saisie automatique, reverrouiller la base de données qui était verrouillée précédemment</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_fr_CA.ts
+++ b/share/translations/keepassxc_fr_CA.ts
@@ -469,7 +469,7 @@
         <translation>Exclure les entrées expirés de la saisie automatique</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Après avoir effectué la saisie automatique, reverrouiller la base de données qui était verrouillée précédemment</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_he.ts
+++ b/share/translations/keepassxc_he.ts
@@ -469,7 +469,7 @@
         <translation>הסתרת רשומות שפג תוקפם מהקלדה־אוטומטית</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>נעילת מסד־נתונים מחדש לאחר הקלדה־אוטומטית</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_hr.ts
+++ b/share/translations/keepassxc_hr.ts
@@ -453,7 +453,7 @@
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Ponovo zaključaj prethodno zaključanu bazu podataka nakon izvođenja Auto-Tipkanja</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_hu.ts
+++ b/share/translations/keepassxc_hu.ts
@@ -469,7 +469,7 @@
         <translation>Lejárt bejegyzések elrejtése automatikus beíráskor.</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Az előzőleg zárolt adatbázis újbóli zárolása automatikus beírást követően</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_id.ts
+++ b/share/translations/keepassxc_id.ts
@@ -469,7 +469,7 @@
         <translation>Sembunyikan entri kedaluwarsa dari Ketik-Otomatis</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Kunci ulang basis data yang sebelumnya terkunci setelah menjalankan Ketik-Otomatis</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_it.ts
+++ b/share/translations/keepassxc_it.ts
@@ -469,7 +469,7 @@
         <translation>Nascondi le voci scadute dalla digitazione automatica</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Blocca nuovamente un database precedentemente bloccato dopo il completamento automatico</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_ja.ts
+++ b/share/translations/keepassxc_ja.ts
@@ -469,7 +469,7 @@
         <translation>期限切れのエントリーは自動入力しない</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>自動入力実行後に以前ロックしていたデータベースを再ロックする</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_km.ts
+++ b/share/translations/keepassxc_km.ts
@@ -470,7 +470,7 @@
         <translation>លាក់ទិន្នន័យបញ្ចូលដែលផុតកំណត់ពីមុខងារវាយបញ្ចូលស្វ័យប្រវត្តិ</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>ចាក់សោមូលដ្ឋានទិន្នន័យដែលបានចាក់សោពីមុនឡើងវិញ បន្ទាប់ពីប្រើប្រាស់មុខងារវាយបញ្ចូលស្វ័យប្រវត្តិ</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_ko.ts
+++ b/share/translations/keepassxc_ko.ts
@@ -469,7 +469,7 @@
         <translation>자동 입력에서 만료된 항목 숨기기</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>자동 입력 이후 이전에 잠긴 데이터베이스 다시 잠그기</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_lt.ts
+++ b/share/translations/keepassxc_lt.ts
@@ -469,7 +469,7 @@
         <translation>Paslėpti nebegaliojančius įrašus nuo Auto-Įvedimo</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Iš naujo užrakinti anksčiau užrakintą duomenų bazę atlikus automatinį rinkimą</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_my.ts
+++ b/share/translations/keepassxc_my.ts
@@ -469,7 +469,7 @@
         <translation>သက်တမ်းကုန်ပြီးသော ဖြည့်သွင်းချက်များကို အလိုအလျောက် စာရိုက်ခြင်းမှ ဝှက်ရန်</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>အလိုအလျောက် စာရိုက်ခြင်းကို လုပ်ဆောင်ပြီးနောက် ယခင်က လော့ချထားသော ဒေတာဘေ့စ်ကို ပြန်လည်လော့ချပါ</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_nb.ts
+++ b/share/translations/keepassxc_nb.ts
@@ -469,7 +469,7 @@
         <translation>Skjul utløpte oppføringer fra autoskriv</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Lås tidligere låst database etter utført autoskriv</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_nl.ts
+++ b/share/translations/keepassxc_nl.ts
@@ -469,7 +469,7 @@
         <translation>Verlopen items verbergen van automatisch invullen</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Vergrendelde database na automatisch invullen opnieuw vergrendelen</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_pl.ts
+++ b/share/translations/keepassxc_pl.ts
@@ -469,7 +469,7 @@
         <translation>Ukryj wygasłe wpisy przed autowpisywaniem</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Ponownie zablokuj poprzednio zablokowaną bazę danych po wykonaniu autowpisywania</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_pt_BR.ts
+++ b/share/translations/keepassxc_pt_BR.ts
@@ -469,7 +469,7 @@
         <translation>Ocultar entradas expiradas de Auto-Digitar:</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Bloquear novamente o banco de dados anteriormente bloqueado depois de executar o Auto-Digitar</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_pt_PT.ts
+++ b/share/translations/keepassxc_pt_PT.ts
@@ -469,7 +469,7 @@
         <translation>Não usar entradas caducadas na escrita automática</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Bloquear novamente a base de dados depois de usar a escrita automática</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_ro.ts
+++ b/share/translations/keepassxc_ro.ts
@@ -469,7 +469,7 @@
         <translation>Ascunde din auto-tastare înregistrările expirate</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Încuie din nou baza de dată blocată anterior după efectuarea auto-tastării</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_ru.ts
+++ b/share/translations/keepassxc_ru.ts
@@ -469,7 +469,7 @@
         <translation>Скрыть истёкшие записи из автоввода</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Блокировать ранее заблокированную БД после автоввода</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_si.ts
+++ b/share/translations/keepassxc_si.ts
@@ -469,7 +469,7 @@
         <translation>ස්වයංක්‍රීය ටයිප් වෙතින් කල් ඉකුත් වූ ඇතුළත් කිරීම් සඟවන්න</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>ස්වයංක්‍රීය ටයිප් කිරීමෙන් පසු කලින් අගුලු දැමූ දත්ත සමුදාය නැවත අගුළු දමන්න</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_sk.ts
+++ b/share/translations/keepassxc_sk.ts
@@ -469,7 +469,7 @@
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Znova zamknúť predtým zamknutú databázu po vykonaní Automatického vypĺňania</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_sl.ts
+++ b/share/translations/keepassxc_sl.ts
@@ -453,7 +453,7 @@
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/share/translations/keepassxc_sq.ts
+++ b/share/translations/keepassxc_sq.ts
@@ -469,7 +469,7 @@
         <translation>Fshih nga Vetë-Shtypje zëra të skaduar</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Pas kryerjes së Vetë-Shtypjes, rikyç bazë të dhënash të kyçur më parë</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_sr.ts
+++ b/share/translations/keepassxc_sr.ts
@@ -469,7 +469,7 @@
         <translation>Сакрити уносе којима је истекао рок од Ауто-куцања</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Поново закључај претходно закључану базу након извођења ауто-уноса</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_sv.ts
+++ b/share/translations/keepassxc_sv.ts
@@ -469,7 +469,7 @@
         <translation>Dölj förfallna poster från autoskriv</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Lås tidigare låst databas efter att ha utfört autoskriv</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_th.ts
+++ b/share/translations/keepassxc_th.ts
@@ -469,7 +469,7 @@
         <translation>ซ่อนรายการที่หมดอายุจาก Auto-Type</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>ล็อคฐานข้อมูลก่อนหน้าอีกครั้งหลังทำการ Auto-Type</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_tr.ts
+++ b/share/translations/keepassxc_tr.ts
@@ -469,7 +469,7 @@
         <translation>Süresi geçmiş kayıtlar otomatik yazmada gizlensin</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Otomatik yazma sonrasında önceden kilitli veri tabanı yeniden kilitlensin</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_uk.ts
+++ b/share/translations/keepassxc_uk.ts
@@ -469,7 +469,7 @@
         <translation>Приховати протерміновані записи для автозаповнення</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>Блокувати попередньо заблоковану базу даних після виконання автозаповнення</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_zh_CN.ts
+++ b/share/translations/keepassxc_zh_CN.ts
@@ -469,7 +469,7 @@
         <translation>自动输入时隐藏已过期条目</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>执行自动输入后重新锁定之前锁定的数据库</translation>
     </message>
     <message>

--- a/share/translations/keepassxc_zh_TW.ts
+++ b/share/translations/keepassxc_zh_TW.ts
@@ -469,7 +469,7 @@
         <translation>從自動輸入隱藏過期的項目</translation>
     </message>
     <message>
-        <source>Re-lock previously locked database after performing Auto-Type</source>
+        <source>Re-lock previously unlocked database after performing Auto-Type</source>
         <translation>執行自動輸入後，將之前鎖定的資料庫重新鎖上</translation>
     </message>
     <message>

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -1063,7 +1063,7 @@
        <item>
         <widget class="QCheckBox" name="autoTypeRelockDatabaseCheckBox">
          <property name="text">
-          <string>Re-lock previously locked database after performing Auto-Type</string>
+          <string>Re-lock previously unlocked database after performing Auto-Type</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

String notably used in `Settings` > `Security` > `Convenience`.

Verified exhaustiveness thanks to:

```bash
grep -ri 're-lock' | grep 'locked' | grep -v 'Re-lock previously unlocked database after performing Auto-Type'
```

Corrected thanks to:

```bash
find -type f -exec sed -i 's/Re-lock previously locked database/Re-lock previously unlocked database/g' {} \;
```

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![image](https://github.com/keepassxreboot/keepassxc/assets/12752145/459da220-abfb-448a-a43c-3ec432342225)


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Documentation (non-code change)
