### PR TITLE
Only perform group sort when GroupView is focused

### DIFF
--- a/docs/topics/KeyboardShortcuts.adoc
+++ b/docs/topics/KeyboardShortcuts.adoc
@@ -33,6 +33,10 @@ NOTE: On macOS please substitute `Ctrl` with `Cmd` (aka `⌘`).
 |Trigger AutoType             | Ctrl + Shift + V
 |Add key to SSH Agent         | Ctrl + H
 |Remove key from SSH Agent    | Ctrl + Shift + H
+|Move entry up (if unsorted)   | Ctrl + Alt + Up
+|Move entry down (if unsorted) | Ctrl + Alt + Down
+|Sort Groups A-Z              | Ctrl + Down
+|Sort Groups Z-A              | Ctrl + Up
 |Minimize Window              | Ctrl + M
 |Hide Window                  | Ctrl + Shift + M
 |Select Next Database Tab     | Ctrl + Tab ; Ctrl + PageDn

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -46,10 +46,10 @@ GroupView::GroupView(Database* db, QWidget* parent)
     new QShortcut(Qt::CTRL + Qt::Key_F10, this, SLOT(contextMenuShortcutPressed()), nullptr, Qt::WidgetShortcut);
 
     // keyboard shortcuts to sort children of a group
-    auto shortcut = new QShortcut(Qt::CTRL + Qt::Key_Down, this);
+    auto shortcut = new QShortcut(Qt::CTRL + Qt::Key_Down, this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(shortcut, &QShortcut::activated, this, [this]() { sortGroups(false); });
 
-    shortcut = new QShortcut(Qt::CTRL + Qt::Key_Up, this);
+    shortcut = new QShortcut(Qt::CTRL + Qt::Key_Up, this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(shortcut, &QShortcut::activated, this, [this]() { sortGroups(true); });
 
     modelReset();


### PR DESCRIPTION
* Fixes #10195
* Documented this keyboard shortcut and the ones for moving entries up and down

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
