### PR TITLE
Fix typos in tooltips from EditEntryWidgetBrowser.ui

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3010,15 +3010,7 @@ Would you like to correct it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Only send this setting to the browser for HTTP Auth dialogs. If enabled, normal login forms will not show this entry for selection.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Use this entry only with HTTP Basic Auth</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Do not send this setting to the browser for HTTP Auth dialogs. If enabled, HTTP Auth dialogs will not show this entry for selection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3043,6 +3035,14 @@ Would you like to correct it?</source>
     </message>
     <message>
         <source>Additional URLs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only send this entry to the browser for HTTP Auth dialogs. If enabled, normal login forms will not show this entry for selection.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do not send this entry to the browser for HTTP Auth dialogs. If enabled, HTTP Auth dialogs will not show this entry for selection.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gui/entry/EditEntryWidgetBrowser.ui
+++ b/src/gui/entry/EditEntryWidgetBrowser.ui
@@ -63,7 +63,7 @@
       <item>
        <widget class="QCheckBox" name="onlyHttpAuthCheckbox">
         <property name="toolTip">
-         <string>Only send this setting to the browser for HTTP Auth dialogs. If enabled, normal login forms will not show this entry for selection.</string>
+         <string>Only send this entry to the browser for HTTP Auth dialogs. If enabled, normal login forms will not show this entry for selection.</string>
         </property>
         <property name="text">
          <string>Use this entry only with HTTP Basic Auth</string>
@@ -73,7 +73,7 @@
       <item>
        <widget class="QCheckBox" name="notHttpAuthCheckbox">
         <property name="toolTip">
-         <string>Do not send this setting to the browser for HTTP Auth dialogs. If enabled, HTTP Auth dialogs will not show this entry for selection.</string>
+         <string>Do not send this entry to the browser for HTTP Auth dialogs. If enabled, HTTP Auth dialogs will not show this entry for selection.</string>
         </property>
         <property name="text">
          <string>Do not use this entry with HTTP Basic Auth</string>


### PR DESCRIPTION
A change that fix typos in HTTPS Basic Auth tooltips.

## Screenshots
Not compiled.


## Testing strategy
Not tested, non code change.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
