### PR TITLE
"Group Full Path" column available in the EntryView

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -4197,6 +4197,10 @@ Would you like to overwrite the existing attachment?</source>
         <source>Background Color</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group Path</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EntryPreviewWidget</name>

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -136,6 +136,11 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
                 return entry->group()->name();
             }
             break;
+        case ParentGroupPath:
+            if (entry->group()) {
+                return entry->group()->fullPath();
+            }
+            break;
         case Title:
             result = entry->resolveMultiplePlaceholders(entry->title());
             if (attr->isReference(EntryAttributes::TitleKey)) {
@@ -377,6 +382,8 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
         switch (section) {
         case ParentGroup:
             return tr("Group");
+        case ParentGroupPath:
+            return tr("Group full path");
         case Title:
             return tr("Title");
         case Username:
@@ -414,6 +421,8 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
         switch (section) {
         case ParentGroup:
             return tr("Group name");
+        case ParentGroupPath:
+            return tr("Group full path");
         case Title:
             return tr("Entry title");
         case Username:
@@ -444,8 +453,6 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Has TOTP");
         case Color:
             return tr("Background Color");
-        case ParentGroupPath:
-            return tr("Group full path");
         }
     }
 

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -383,7 +383,7 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
         case ParentGroup:
             return tr("Group");
         case ParentGroupPath:
-            return tr("Group full path");
+            return tr("Group Path");
         case Title:
             return tr("Title");
         case Username:
@@ -422,7 +422,7 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
         case ParentGroup:
             return tr("Group name");
         case ParentGroupPath:
-            return tr("Group full path");
+            return tr("Group Path");
         case Title:
             return tr("Entry title");
         case Username:

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -116,7 +116,7 @@ int EntryModel::columnCount(const QModelIndex& parent) const
         return 0;
     }
 
-    return 16;
+    return 17;
 }
 
 QVariant EntryModel::data(const QModelIndex& index, int role) const
@@ -444,6 +444,8 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Has TOTP");
         case Color:
             return tr("Background Color");
+        case ParentGroupPath:
+            return tr("Group full path");
         }
     }
 

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -49,7 +49,8 @@ public:
         Totp = 12,
         Size = 13,
         PasswordStrength = 14,
-        Color = 15
+        Color = 15,
+        ParentGroupPath = 16
     };
 
     explicit EntryModel(QObject* parent = nullptr);

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -482,6 +482,7 @@ void EntryView::resetViewToDefaults()
     header()->hideSection(EntryModel::Size);
     header()->hideSection(EntryModel::PasswordStrength);
     header()->hideSection(EntryModel::Color);
+    header()->hideSection(EntryModel::ParentGroupPath);
     onHeaderChanged();
 
     // Reset column order to logical indices


### PR DESCRIPTION
Fixes #9574
This feature allows to see the "group full path" for the entries (both in the searching view and in normal view). The entries can then be sorted by their group full path, as with any other column. 
By default, the "group full path" is unchecked.
This feature is especially useful for large keepass databases with a lot of groups and sub-groups, where some entries might have the same or very similar title or username.


## Screenshots
![2024-02-07 15_01_21-keepass_PR_groupfullpath](https://github.com/keepassxreboot/keepassxc/assets/154235477/b10e9b7d-5f41-49f5-95ed-e657ab9a6984)
![2024-02-07 15_04_04-keepass_PR_groupfullpath](https://github.com/keepassxreboot/keepassxc/assets/154235477/7a36bfc4-9012-4d99-8c3c-52c121339281)



## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
- Run automatic tests in Linux (-DWITH_TESTS=ON -DWITH_GUI_TESTS=ON)
- Manually tested that works as expected


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
