### PR TITLE
Do not override fixed font size

### DIFF
--- a/src/gui/Font.cpp
+++ b/src/gui/Font.cpp
@@ -42,8 +42,5 @@ QFont Font::fixedFont()
     // Qt doesn't choose a monospace font correctly on macOS
     fixedFont = QFontDatabase().font("Menlo", fixedFont.styleName(), fixedFont.pointSize());
 #endif
-#ifndef Q_OS_WIN
-    fixedFont.setPointSize(qApp->font().pointSize());
-#endif
     return fixedFont;
 }


### PR DESCRIPTION
This allows properly configuring a readable/desired fixed font in system settings, `~/.config/keepassxcrc` etc.

As it was, KeePassXC would override the size of the system fixed font with the size of the system default font. At least on my system, that makes the monospace font come out significantly smaller than expected, and with bad scaling on top.

I do not believe this is a good or valid idea in any case, the way fonts work (traditionally), there simply is no algorithmic mechanism to truly match the size between two arbitrary font families.

As can be seen at https://github.com/jmbreuer/keepassxc/blob/85751e4ad2d918464b23ea88c8ac11390244194d/src/gui/Font.cpp#L38 there's already another workaround in place for Windows, where Consolas is chosen explicitly and its difference in size at typical desktop UI point size ranges is approximately compensated.

Without knowing both the system and the chosen monospace font in detail, such fudging attempts are futile IMO on other platforms (Linux especially).

I see no reason not to allow the user to choose a suitable font - including its size. Whether through the appropriate system-wide settings (which will be picked up by Qt), or in e.g. `~/.config/keepassxcrc`:

```ini
[General]
fixed=Droid Sans Mono Dotted,11,-1,5,50,0,0,0,0,0,Regular
```

Fixes #6822, #10277, and at least greatly improves a lot of the issues mentioned in #2741.

## Screenshots

Before:
![Selection_134](https://github.com/keepassxreboot/keepassxc/assets/1792037/125f438f-a853-45d5-8db4-d7d5227b10d7)

After:
![Selection_136](https://github.com/keepassxreboot/keepassxc/assets/1792037/eb3048ae-6aee-4555-b2c1-5d18da7622fa)


## Testing strategy

Visual confirmation.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
