### PR TITLE
QMenubar option to show/hide itself

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3664,11 +3664,6 @@ This may cause the affected plugins to malfunction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Attachment &quot;%1&quot; already exists. 
-Would you like to overwrite the existing attachment?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Confirm Attachment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3695,6 +3690,11 @@ Do you want to save the changes to your database?</source>
     <message>
         <source>Saving updated attachment failed.
 Error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attachment &quot;%1&quot; already exists. 
+Would you like to overwrite the existing attachment?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5470,6 +5470,10 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show Menubar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5817,6 +5821,10 @@ We recommend you use the AppImage available on our downloads page.</source>
     </message>
     <message>
         <source>Set Theme: Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Show Menubar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -92,6 +92,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
 
     // GUI
     {Config::GUI_Language, {QS("GUI/Language"), Roaming, QS("system")}},
+    {Config::GUI_HideMenubar, {QS("GUI/HideMenubar"), Roaming, false}},
     {Config::GUI_HideToolbar, {QS("GUI/HideToolbar"), Roaming, false}},
     {Config::GUI_MovableToolbar, {QS("GUI/MovableToolbar"), Roaming, false}},
     {Config::GUI_HidePreviewPanel, {QS("GUI/HidePreviewPanel"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -74,6 +74,7 @@ public:
         LastDir,
 
         GUI_Language,
+        GUI_HideMenubar,
         GUI_HideToolbar,
         GUI_MovableToolbar,
         GUI_HidePreviewPanel,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -549,6 +549,7 @@ MainWindow::MainWindow()
     m_ui->menubar->installEventFilter(eventFilter);
     m_ui->toolBar->installEventFilter(eventFilter);
     m_ui->tabWidget->tabBar()->installEventFilter(eventFilter);
+    installEventFilter(eventFilter);
 #endif
 
 #ifdef Q_OS_MACOS
@@ -1632,6 +1633,7 @@ void MainWindow::applySettingsChanges()
         m_inactivityTimer->deactivate();
     }
 
+    m_ui->menubar->setHidden(config()->get(Config::GUI_HideMenubar).toBool());
     m_ui->toolBar->setHidden(config()->get(Config::GUI_HideToolbar).toBool());
     auto movable = config()->get(Config::GUI_MovableToolbar).toBool();
     m_ui->toolBar->setMovable(movable);
@@ -1994,6 +1996,16 @@ void MainWindow::initViewMenu()
         }
     });
 
+#ifdef Q_OS_MACOS
+    m_ui->actionShowMenubar->setVisible(false);
+#else
+    m_ui->actionShowMenubar->setChecked(!config()->get(Config::GUI_HideMenubar).toBool());
+    connect(m_ui->actionShowMenubar, &QAction::toggled, this, [this](bool checked) {
+        config()->set(Config::GUI_HideMenubar, !checked);
+        applySettingsChanges();
+    });
+#endif
+
     m_ui->actionShowToolbar->setChecked(!config()->get(Config::GUI_HideToolbar).toBool());
     connect(m_ui->actionShowToolbar, &QAction::toggled, this, [this](bool checked) {
         config()->set(Config::GUI_HideToolbar, !checked);
@@ -2099,6 +2111,9 @@ void MainWindow::initActionCollection()
                     m_ui->actionThemeDark,
                     m_ui->actionThemeClassic,
                     m_ui->actionCompactMode,
+#ifndef Q_OS_MACOS
+                    m_ui->actionShowMenubar,
+#endif
                     m_ui->actionShowToolbar,
                     m_ui->actionShowPreviewPanel,
                     m_ui->actionAllowScreenCapture,
@@ -2176,6 +2191,7 @@ MainWindowEventFilter::MainWindowEventFilter(QObject* parent)
 
 /**
  * MainWindow event filter to initiate empty-area drag on the toolbar, menubar, and tabbar.
+ * Also shows menubar with Alt when menubar itself is hidden.
  */
 bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
 {
@@ -2184,7 +2200,8 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
         return QObject::eventFilter(watched, event);
     }
 
-    if (event->type() == QEvent::MouseButtonPress) {
+    auto eventType = event->type();
+    if (eventType == QEvent::MouseButtonPress) {
         if (watched == mainWindow->m_ui->menubar) {
             auto* m = static_cast<QMouseEvent*>(event);
             if (!mainWindow->m_ui->menubar->actionAt(m->pos())) {
@@ -2201,6 +2218,15 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
             if (mainWindow->m_ui->tabWidget->tabBar()->tabAt(m->pos()) == -1) {
                 mainWindow->windowHandle()->startSystemMove();
                 return true;
+            }
+        }
+    } else if (eventType == QEvent::KeyRelease) {
+        if (watched == mainWindow) {
+            auto m = static_cast<QKeyEvent*>(event);
+            if (m->key() == Qt::Key_Alt && config()->get(Config::GUI_HideMenubar).toBool()) {
+                auto menubar = mainWindow->m_ui->menubar;
+                menubar->setVisible(!menubar->isVisible());
+                return false;
             }
         }
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2202,9 +2202,9 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
 
     auto eventType = event->type();
     if (eventType == QEvent::MouseButtonPress) {
+        auto mouseEvent = dynamic_cast<QMouseEvent*>(event);
         if (watched == mainWindow->m_ui->menubar) {
-            auto* m = static_cast<QMouseEvent*>(event);
-            if (!mainWindow->m_ui->menubar->actionAt(m->pos())) {
+            if (!mainWindow->m_ui->menubar->actionAt(mouseEvent->pos())) {
                 mainWindow->windowHandle()->startSystemMove();
                 return false;
             }
@@ -2214,18 +2214,21 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
                 return false;
             }
         } else if (watched == mainWindow->m_ui->tabWidget->tabBar()) {
-            auto* m = static_cast<QMouseEvent*>(event);
-            if (mainWindow->m_ui->tabWidget->tabBar()->tabAt(m->pos()) == -1) {
+            if (mainWindow->m_ui->tabWidget->tabBar()->tabAt(mouseEvent->pos()) == -1) {
                 mainWindow->windowHandle()->startSystemMove();
                 return true;
             }
         }
     } else if (eventType == QEvent::KeyRelease) {
         if (watched == mainWindow) {
-            auto m = static_cast<QKeyEvent*>(event);
-            if (m->key() == Qt::Key_Alt && config()->get(Config::GUI_HideMenubar).toBool()) {
+            auto keyEvent = dynamic_cast<QKeyEvent*>(event);
+            if (keyEvent->key() == Qt::Key_Alt && !keyEvent->modifiers()
+                && config()->get(Config::GUI_HideMenubar).toBool()) {
                 auto menubar = mainWindow->m_ui->menubar;
                 menubar->setVisible(!menubar->isVisible());
+                if (menubar->isVisible()) {
+                    menubar->setActiveAction(mainWindow->m_ui->menuFile->menuAction());
+                }
                 return false;
             }
         }

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -384,6 +384,7 @@
     <addaction name="actionAlwaysOnTop"/>
     <addaction name="actionAllowScreenCapture"/>
     <addaction name="actionShowPreviewPanel"/>
+    <addaction name="actionShowMenubar"/>
     <addaction name="actionShowToolbar"/>
     <addaction name="actionHideUsernames"/>
     <addaction name="actionHidePasswords"/>
@@ -1128,6 +1129,20 @@
    </property>
    <property name="toolTip">
     <string>Set Theme: Classic</string>
+   </property>
+  </action>
+  <action name="actionShowMenubar">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Menubar</string>
+   </property>
+   <property name="toolTip">
+    <string>Toggle Show Menubar</string>
    </property>
   </action>
   <action name="actionShowToolbar">


### PR DESCRIPTION
This pull request brings a minor new feature to the QMenubar View section. It implements the ability to show and hide menubar itself. This feature is basically 1:1 copy of the functionality that is quite common in modern menubars, but the best examples are probably Mozilla Firefox and Thunderbird.

When menubar is hidden, it can be toggled hidden/visible with Alt key press.

Also note that this feature does not apply to macOS.

Known Issues:
This is just a minor issue and I don't consider it a merge blocker. Qt eats the QMenubar automated focus that comes default when pressing Alt. It should select the first QMenubar element automatically, but when the menubar is changed from hidden to visible this does not happen. It works fine when menubar is already visible - which is the default so nothing broken there at least. I did all kinds of setFocus experiments around the eventFilter, but none worked this far. This issue is cross-platform and seems like a bug in Qt internal event propagation.

## Screenshots

The new menu action:
![image](https://github.com/keepassxreboot/keepassxc/assets/5409091/9022ba1e-dfe2-45e7-8601-71f97eb49776)

Here menu is hidden:
![image](https://github.com/keepassxreboot/keepassxc/assets/5409091/1024ae23-8606-4ed3-a30b-dcf3dbd1697e)

## Testing strategy
Manual tests with the UI itself. Regularly comparing functionality between this and Mozilla Firefox and Thunderbird.
Could not find places to unit test this as QtWidgets are not designed for that at all.

Tested on Ubuntu 22.04.4 and Windows 11.

## Type of change
- ✅ New feature (change that adds functionality)
