### PR TITLE
Implemented database file hidden attribute preservation on Windows

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -33,6 +33,10 @@
 #include <QTemporaryFile>
 #include <QTimer>
 
+#ifdef _WIN32
+    #include <Windows.h>
+#endif
+
 QHash<QUuid, QPointer<Database>> Database::s_uuidMap;
 
 Database::Database()
@@ -280,6 +284,11 @@ bool Database::saveAs(const QString& filePath, SaveAction action, const QString&
     QFileInfo fileInfo(filePath);
     auto realFilePath = fileInfo.exists() ? fileInfo.canonicalFilePath() : fileInfo.absoluteFilePath();
     bool isNewFile = !QFile::exists(realFilePath);
+
+#ifdef _WIN32
+    bool isHidden = fileInfo.isHidden();
+#endif
+
     bool ok = AsyncTask::runAndWaitForFuture([&] { return performSave(realFilePath, action, backupFilePath, error); });
     if (ok) {
         setFilePath(filePath);
@@ -287,6 +296,14 @@ bool Database::saveAs(const QString& filePath, SaveAction action, const QString&
         if (isNewFile) {
             QFile::setPermissions(realFilePath, QFile::ReadUser | QFile::WriteUser);
         }
+
+ #ifdef _WIN32
+        if (isHidden)
+        {
+            SetFileAttributes(realFilePath.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN);
+        }
+#endif
+
         m_fileWatcher->start(realFilePath, 30, 1);
     } else {
         // Saving failed, don't rewatch file since it does not represent our database

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -33,8 +33,8 @@
 #include <QTemporaryFile>
 #include <QTimer>
 
-#ifdef _WIN32
-    #include <Windows.h>
+#ifdef Q_OS_WIN
+#include <Windows.h>
 #endif
 
 QHash<QUuid, QPointer<Database>> Database::s_uuidMap;
@@ -285,7 +285,7 @@ bool Database::saveAs(const QString& filePath, SaveAction action, const QString&
     auto realFilePath = fileInfo.exists() ? fileInfo.canonicalFilePath() : fileInfo.absoluteFilePath();
     bool isNewFile = !QFile::exists(realFilePath);
 
-#ifdef _WIN32
+#ifdef Q_OS_WIN
     bool isHidden = fileInfo.isHidden();
 #endif
 
@@ -297,9 +297,8 @@ bool Database::saveAs(const QString& filePath, SaveAction action, const QString&
             QFile::setPermissions(realFilePath, QFile::ReadUser | QFile::WriteUser);
         }
 
- #ifdef _WIN32
-        if (isHidden)
-        {
+#ifdef Q_OS_WIN
+        if (isHidden) {
             SetFileAttributes(realFilePath.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN);
         }
 #endif

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -30,9 +30,9 @@
 #include "format/KeePass2Writer.h"
 #include "util/TemporaryFile.h"
 
-#ifdef _WIN32
-    #include <QFileInfo>
-    #include <Windows.h>
+#ifdef Q_OS_WIN
+#include <QFileInfo>
+#include <Windows.h>
 #endif
 
 QTEST_GUILESS_MAIN(TestDatabase)
@@ -123,7 +123,7 @@ void TestDatabase::testSaveAs()
     QVERIFY(!db->isModified());
     QCOMPARE(spyFilePathChanged.count(), 1);
     QVERIFY(QFile::exists(newDbFileName));
-#ifdef _WIN32
+#ifdef Q_OS_WIN
     QVERIFY(!QFileInfo::QFileInfo(newDbFileName).isHidden());
     SetFileAttributes(newDbFileName.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN);
     QVERIFY2(db->saveAs(newDbFileName, Database::Atomic, QString(), &error), error.toLatin1());

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -30,6 +30,11 @@
 #include "format/KeePass2Writer.h"
 #include "util/TemporaryFile.h"
 
+#ifdef _WIN32
+    #include <QFileInfo>
+    #include <Windows.h>
+#endif
+
 QTEST_GUILESS_MAIN(TestDatabase)
 
 static QString dbFileName = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.kdbx");
@@ -118,6 +123,12 @@ void TestDatabase::testSaveAs()
     QVERIFY(!db->isModified());
     QCOMPARE(spyFilePathChanged.count(), 1);
     QVERIFY(QFile::exists(newDbFileName));
+#ifdef _WIN32
+    QVERIFY(!QFileInfo::QFileInfo(newDbFileName).isHidden());
+    SetFileAttributes(newDbFileName.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN);
+    QVERIFY2(db->saveAs(newDbFileName, Database::Atomic, QString(), &error), error.toLatin1());
+    QVERIFY(QFileInfo::QFileInfo(newDbFileName).isHidden());
+#endif
     QFile::remove(newDbFileName);
     QVERIFY(!QFile::exists(newDbFileName));
 


### PR DESCRIPTION
Implemented database file hidden attribute preservation on Windows by modifying the save function to check the hidden attribute of the original database before saving and then reapply it post-saving if running on Windows so that users can easily store their database in a hidden file without having to re-hide it every time it's modified.

## Screenshots:
![KeePassXC Patch](https://github.com/keepassxreboot/keepassxc/assets/161755224/26fcda9d-2a71-4192-bc73-5419a796cfa8)

## Testing strategy:
I updated the unit test accordingly but also manually tested using the following steps:
```
1) Create a KeePassXC database on Windows
2) Right-click the database file and set its hidden attribute to true
3) Modify the database in any way
4) Save the database
5) Check that the database file is still hidden
```

## Type of change:
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
