### PR TITLE
ssh-agent: keygen: Fix negative numbers in RSA key

### DIFF
--- a/src/sshagent/OpenSSHKeyGen.cpp
+++ b/src/sshagent/OpenSSHKeyGen.cpp
@@ -65,7 +65,7 @@ namespace OpenSSHKeyGen
             BinaryStream privateStream(&privateData);
             bigIntToStream(rsaKey.get_n(), privateStream, 1);
             bigIntToStream(rsaKey.get_e(), privateStream);
-            bigIntToStream(rsaKey.get_d(), privateStream);
+            bigIntToStream(rsaKey.get_d(), privateStream, 1);
             bigIntToStream(rsaKey.get_c(), privateStream, 1);
             bigIntToStream(rsaKey.get_p(), privateStream, 1);
             bigIntToStream(rsaKey.get_q(), privateStream, 1);


### PR DESCRIPTION
The private exponent d may be negative in which case an additional pad byte is needed. Otherwise ssh-agent fails to load the key.

Fixes https://github.com/keepassxreboot/keepassxc/issues/10320

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

```sh
❯ for i in $(seq 1 10000); do ./build/tests/testsshagent testKeyGenRSA; done | tee test.log
❯ grep FAIL test.log
```

(no output on grep, hence no test failing)



## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
