### PR TITLE
Skip a few Passkeys tests with Botan <= 2.14

### DIFF
--- a/tests/TestPasskeys.cpp
+++ b/tests/TestPasskeys.cpp
@@ -192,9 +192,11 @@ void TestPasskeys::testDecodeResponseData()
     QCOMPARE(publicKey["-3"], QString("4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M"));
 }
 
-#if defined BOTAN_VALID
 void TestPasskeys::testLoadingECPrivateKeyFromPem()
 {
+#if BOTAN_VERSION_CODE < BOTAN_VERSION_CODE_FOR(2, 14, 0)
+    QSKIP("ECDSA Signature is broken on Botan < 2.14.0");
+#endif
     const auto publicKeyCredentialRequestOptions =
         browserMessageBuilder()->getJsonObject(PublicKeyCredentialRequestOptions.toUtf8());
     const auto privateKeyPem = QString("-----BEGIN PRIVATE KEY-----"
@@ -215,7 +217,6 @@ void TestPasskeys::testLoadingECPrivateKeyFromPem()
         browserMessageBuilder()->getBase64FromArray(signature),
         QString("MEYCIQCpbDaYJ4b2ofqWBxfRNbH3XCpsyao7Iui5lVuJRU9HIQIhAPl5moNZgJu5zmurkKK_P900Ct6wd3ahVIqCEqTeeRdE"));
 }
-#endif
 
 void TestPasskeys::testLoadingRSAPrivateKeyFromPem()
 {
@@ -412,9 +413,11 @@ void TestPasskeys::testRegister()
     QCOMPARE(clientDataJsonObject["type"], QString("webauthn.create"));
 }
 
-#if defined BOTAN_VALID
 void TestPasskeys::testGet()
 {
+#if BOTAN_VERSION_CODE < BOTAN_VERSION_CODE_FOR(2, 14, 0)
+    QSKIP("ECDSA Signature is broken on Botan < 2.14.0");
+#endif
     const auto privateKeyPem = QString("-----BEGIN PRIVATE KEY-----"
                                        "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg5DX2R6I37nMSZqCp"
                                        "XfHlE3UeitkGGE03FqGsdfxIBoOhRANCAAQG7K80W2KRYW0ZWQOmUCrKMcSVqGnl"
@@ -449,7 +452,6 @@ void TestPasskeys::testGet()
     auto clientDataJsonObject = browserMessageBuilder()->getJsonObject(clientDataByteArray);
     QCOMPARE(clientDataJsonObject["challenge"].toString(), publicKeyCredentialRequestOptions["challenge"].toString());
 }
-#endif
 
 void TestPasskeys::testExtensions()
 {

--- a/tests/TestPasskeys.cpp
+++ b/tests/TestPasskeys.cpp
@@ -192,6 +192,7 @@ void TestPasskeys::testDecodeResponseData()
     QCOMPARE(publicKey["-3"], QString("4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M"));
 }
 
+#if defined BOTAN_VALID
 void TestPasskeys::testLoadingECPrivateKeyFromPem()
 {
     const auto publicKeyCredentialRequestOptions =
@@ -214,6 +215,7 @@ void TestPasskeys::testLoadingECPrivateKeyFromPem()
         browserMessageBuilder()->getBase64FromArray(signature),
         QString("MEYCIQCpbDaYJ4b2ofqWBxfRNbH3XCpsyao7Iui5lVuJRU9HIQIhAPl5moNZgJu5zmurkKK_P900Ct6wd3ahVIqCEqTeeRdE"));
 }
+#endif
 
 void TestPasskeys::testLoadingRSAPrivateKeyFromPem()
 {
@@ -410,6 +412,7 @@ void TestPasskeys::testRegister()
     QCOMPARE(clientDataJsonObject["type"], QString("webauthn.create"));
 }
 
+#if defined BOTAN_VALID
 void TestPasskeys::testGet()
 {
     const auto privateKeyPem = QString("-----BEGIN PRIVATE KEY-----"
@@ -446,6 +449,7 @@ void TestPasskeys::testGet()
     auto clientDataJsonObject = browserMessageBuilder()->getJsonObject(clientDataByteArray);
     QCOMPARE(clientDataJsonObject["challenge"].toString(), publicKeyCredentialRequestOptions["challenge"].toString());
 }
+#endif
 
 void TestPasskeys::testExtensions()
 {

--- a/tests/TestPasskeys.h
+++ b/tests/TestPasskeys.h
@@ -18,9 +18,13 @@
 #ifndef KEEPASSXC_TESTPASSKEYS_H
 #define KEEPASSXC_TESTPASSKEYS_H
 
-#include <QObject>
-
 #include "browser/BrowserPasskeys.h"
+#include <QObject>
+#include <botan/version.h>
+
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(2, 14, 0)
+#define BOTAN_VALID
+#endif
 
 class TestPasskeys : public QObject
 {
@@ -32,14 +36,16 @@ private slots:
 
     void testBase64WithHexStrings();
     void testDecodeResponseData();
-
+#if defined BOTAN_VALID
     void testLoadingECPrivateKeyFromPem();
+#endif
     void testLoadingRSAPrivateKeyFromPem();
     void testCreatingAttestationObjectWithEC();
     void testCreatingAttestationObjectWithRSA();
     void testRegister();
+#if defined BOTAN_VALID
     void testGet();
-
+#endif
     void testExtensions();
     void testParseFlags();
     void testSetFlags();

--- a/tests/TestPasskeys.h
+++ b/tests/TestPasskeys.h
@@ -22,10 +22,6 @@
 #include <QObject>
 #include <botan/version.h>
 
-#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(2, 14, 0)
-#define BOTAN_VALID
-#endif
-
 class TestPasskeys : public QObject
 {
     Q_OBJECT
@@ -36,16 +32,12 @@ private slots:
 
     void testBase64WithHexStrings();
     void testDecodeResponseData();
-#if defined BOTAN_VALID
     void testLoadingECPrivateKeyFromPem();
-#endif
     void testLoadingRSAPrivateKeyFromPem();
     void testCreatingAttestationObjectWithEC();
     void testCreatingAttestationObjectWithRSA();
     void testRegister();
-#if defined BOTAN_VALID
     void testGet();
-#endif
     void testExtensions();
     void testParseFlags();
     void testSetFlags();

--- a/tests/TestPasskeys.h
+++ b/tests/TestPasskeys.h
@@ -32,12 +32,14 @@ private slots:
 
     void testBase64WithHexStrings();
     void testDecodeResponseData();
+
     void testLoadingECPrivateKeyFromPem();
     void testLoadingRSAPrivateKeyFromPem();
     void testCreatingAttestationObjectWithEC();
     void testCreatingAttestationObjectWithRSA();
     void testRegister();
     void testGet();
+
     void testExtensions();
     void testParseFlags();
     void testSetFlags();


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Botan 2.12 is still included in some older distros, and creating a signature will fail because of: https://github.com/randombit/botan/pull/2293.
For now, disable a few tests if the Botan version is older than 2.14 that includes the fix.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
