### PR TITLE
Fix TOTP secret import from 1pux

### DIFF
--- a/src/format/OPUXReader.cpp
+++ b/src/format/OPUXReader.cpp
@@ -29,6 +29,7 @@
 #include <QJsonObject>
 #include <QScopedPointer>
 #include <QUrl>
+#include <QUrlQuery>
 
 #include <minizip/unzip.h>
 
@@ -127,8 +128,15 @@ namespace
                 const auto key = valueMap.firstKey();
                 if (key == "totp") {
                     // Build otpauth url
+                    QString secretValue = valueMap.value(key).toString();
+                    if (secretValue.contains("otpauth://totp/")) {
+                        QUrl url(secretValue);
+                        QUrlQuery query(url);
+                        secretValue = query.queryItemValue("secret");
+                    }
+
                     QUrl otpurl(QString("otpauth://totp/%1:%2?secret=%3")
-                                    .arg(entry->title(), entry->username(), valueMap.value(key).toString()));
+                                    .arg(entry->title(), entry->username(), secretValue));
 
                     if (entry->hasTotp()) {
                         // Store multiple TOTP definitions as additional otp attributes


### PR DESCRIPTION
I added an if statement that, if "otpauth://totp/" is present in the "totp" value, parses the value and sets only the totp secret as the value for "secretValue" instead of the entire record.

Fixes #10368 

## Testing strategy
I imported the same 1pux file that was in my issue and manually checked all the values of the otp field.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)