### PR TITLE
Passkeys: Fix RP ID validation

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -630,7 +630,7 @@ QJsonObject BrowserService::showPasskeysRegisterPrompt(const QJsonObject& public
     }
 
     const auto excludeCredentials = credentialCreationOptions["excludeCredentials"].toArray();
-    const auto rpId = publicKeyOptions["rp"]["id"].toString();
+    const auto rpId = credentialCreationOptions["rp"].toObject()["id"].toString();
     const auto timeout = publicKeyOptions["timeout"].toInt();
     const auto username = credentialCreationOptions["user"].toObject()["name"].toString();
 

--- a/src/browser/PasskeyUtils.cpp
+++ b/src/browser/PasskeyUtils.cpp
@@ -109,12 +109,15 @@ int PasskeyUtils::validateRpId(const QJsonValue& rpIdValue, const QString& effec
         return ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH;
     }
 
-    if (rpIdValue.isUndefined()) {
-        return ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH;
-    }
-
     if (effectiveDomain.isEmpty()) {
         return ERROR_PASSKEYS_ORIGIN_NOT_ALLOWED;
+    }
+
+    //  The RP ID defaults to being the caller's origin's effective domain unless the caller has explicitly set
+    //  options.rp.id
+    if (rpIdValue.isUndefined() || rpIdValue.isNull()) {
+        *result = effectiveDomain;
+        return PASSKEYS_SUCCESS;
     }
 
     const auto rpId = rpIdValue.toString();

--- a/tests/TestPasskeys.cpp
+++ b/tests/TestPasskeys.cpp
@@ -573,17 +573,18 @@ void TestPasskeys::testRpIdValidation()
     QString result;
     auto allowedIdentical = passkeyUtils()->validateRpId(QString("example.com"), QString("example.com"), &result);
     QCOMPARE(result, QString("example.com"));
-    QVERIFY(allowedIdentical == 0);
+    QVERIFY(allowedIdentical == PASSKEYS_SUCCESS);
 
     result.clear();
     auto allowedSubdomain = passkeyUtils()->validateRpId(QString("example.com"), QString("www.example.com"), &result);
     QCOMPARE(result, QString("example.com"));
-    QVERIFY(allowedSubdomain == 0);
+    QVERIFY(allowedSubdomain == PASSKEYS_SUCCESS);
 
     result.clear();
-    auto emptyRpId = passkeyUtils()->validateRpId({}, QString("example.com"), &result);
-    QCOMPARE(result, QString(""));
-    QVERIFY(emptyRpId == ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH);
+    QJsonValue emptyValue;
+    auto emptyRpId = passkeyUtils()->validateRpId(emptyValue, QString("example.com"), &result);
+    QCOMPARE(result, QString("example.com"));
+    QVERIFY(emptyRpId == PASSKEYS_SUCCESS);
 
     result.clear();
     auto ipRpId = passkeyUtils()->validateRpId(QString("127.0.0.1"), QString("example.com"), &result);


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
When RP ID is not set, it should be set to the effective domain, and not return an error.
https://www.w3.org/TR/2019/REC-webauthn-1-20190304/#GetAssn-DetermineRpId

Extension side will have a temporary fix until this has been merged and released.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Automatic test modified.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
