### PR TITLE
Fix Indonesian language descriptor

### DIFF
--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -250,7 +250,7 @@ static const QString aboutContributors = R"(
     <li><strong>עברית (Hebrew)</strong>: avimar, ronyala, shemeshg, shmag18, ThunderB0lt, tryandtry, ztwersky</li>
     <li><strong>magyar (Hungarian)</strong>: andras_tim, bubu, entaevau, kempelen, meskobalazs, spammy, typingseashell, urbalazs</li>
     <li><strong>Íslenska (Icelandic)</strong>: MannVera</li>
-    <li><strong>Bahasa (Indonesian)</strong>: achmad, algustionesa, bora_ach, racrbmr, zk</li>
+    <li><strong>Bahasa Indonesia (Indonesian)</strong>: achmad, algustionesa, bora_ach, racrbmr, zk</li>
     <li><strong>Italiano (Italian)</strong>: aleb2000, amaxis, bovirus, duncanmid, FranzMari, Gringoarg, idetao, lucaim, NITAL, Peo,
         Pietrog, salvatorecordiano, seatedscribe, Stemby, the.sailor, tosky, VosaxAlo</li>
     <li><strong>日本語 (Japanese)</strong>: AlCooo, gojpdchx, helloguys, masoo, p2635, Shinichirou_Yamada, shortarrow, ssuhung, tadasu,

--- a/utils/transifex_translators.py
+++ b/utils/transifex_translators.py
@@ -25,7 +25,7 @@ LANGS = {
     "he" : "עברית (Hebrew)",
     "hr_HR" : "hrvatski jezik (Croatian)",
     "hu" : "magyar (Hungarian)",
-    "id" : "Bahasa (Indonesian)",
+    "id" : "Bahasa Indonesia (Indonesian)",
     "is_IS" : "Íslenska (Icelandic)",
     "it" : "Italiano (Italian)",
     "ja" : "日本語 (Japanese)",


### PR DESCRIPTION
Bahasa is simply means language in Indonesian.
Bahasa also being used in other Malay-derived language, e.g. Bahasa Melayu (Malay language).
Therefore, referring Indonesian language as merely "bahasa" is incorrect.

Source: Indonesian National Dictionary https://kbbi.kemdikbud.go.id/entri/bahasa

Example word usage:
![image](https://github.com/keepassxreboot/keepassxc/assets/8639337/ac00bd32-1f7f-4e69-8d90-88727dd9dea1)


## Testing strategy
Minor change that wouldn't need any additional testing.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
