### PR TITLE
Passkeys: Allow nfc and usb transports

### DIFF
--- a/src/browser/BrowserPasskeys.cpp
+++ b/src/browser/BrowserPasskeys.cpp
@@ -43,7 +43,9 @@ const QString BrowserPasskeys::AAGUID = QStringLiteral("fdb141b25d84443e8a354698
 // Authenticator capabilities
 const QString BrowserPasskeys::ATTACHMENT_CROSS_PLATFORM = QStringLiteral("cross-platform");
 const QString BrowserPasskeys::ATTACHMENT_PLATFORM = QStringLiteral("platform");
-const QString BrowserPasskeys::AUTHENTICATOR_TRANSPORT = QStringLiteral("internal");
+const QString BrowserPasskeys::AUTHENTICATOR_TRANSPORT_INTERNAL = QStringLiteral("internal");
+const QString BrowserPasskeys::AUTHENTICATOR_TRANSPORT_NFC = QStringLiteral("nfc");
+const QString BrowserPasskeys::AUTHENTICATOR_TRANSPORT_USB = QStringLiteral("usb");
 const bool BrowserPasskeys::SUPPORT_RESIDENT_KEYS = true;
 const bool BrowserPasskeys::SUPPORT_USER_VERIFICATION = true;
 

--- a/src/browser/BrowserPasskeys.h
+++ b/src/browser/BrowserPasskeys.h
@@ -91,7 +91,9 @@ public:
 
     static const QString ATTACHMENT_CROSS_PLATFORM;
     static const QString ATTACHMENT_PLATFORM;
-    static const QString AUTHENTICATOR_TRANSPORT;
+    static const QString AUTHENTICATOR_TRANSPORT_INTERNAL;
+    static const QString AUTHENTICATOR_TRANSPORT_NFC;
+    static const QString AUTHENTICATOR_TRANSPORT_USB;
     static const bool SUPPORT_RESIDENT_KEYS;
     static const bool SUPPORT_USER_VERIFICATION;
 

--- a/src/browser/PasskeyUtils.cpp
+++ b/src/browser/PasskeyUtils.cpp
@@ -340,8 +340,10 @@ QStringList PasskeyUtils::getAllowedCredentialsFromAssertionOptions(const QJsonO
         const auto cred = credential.toObject();
         const auto id = cred["id"].toString();
         const auto transports = cred["transports"].toArray();
-        const auto hasSupportedTransport =
-            transports.isEmpty() || transports.contains(BrowserPasskeys::AUTHENTICATOR_TRANSPORT);
+        const auto hasSupportedTransport = transports.isEmpty()
+                                           || (transports.contains(BrowserPasskeys::AUTHENTICATOR_TRANSPORT_INTERNAL)
+                                               || transports.contains(BrowserPasskeys::AUTHENTICATOR_TRANSPORT_NFC)
+                                               || transports.contains(BrowserPasskeys::AUTHENTICATOR_TRANSPORT_USB));
 
         if (cred["type"].toString() == BrowserPasskeys::PUBLIC_KEY && hasSupportedTransport && !id.isEmpty()) {
             allowedCredentials << id;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Allows `nfc` and `usb` transports when authenticating a Passkey.

https://github.com/keepassxreboot/keepassxc-browser/pull/2141 can be removed after this is included in an official release.

Fixes #10382.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
