### PR TITLE
Passkeys: Register to an existing entry

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -871,23 +871,6 @@ Please select the correct database for saving credentials.</source>
         </translation>
     </message>
     <message>
-        <source>Do you want to register Passkey for:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Existing Passkey found.
-Do you want to register a new Passkey for:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Select the existing Passkey and press Update to replace it.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Authenticate Passkey credentials for:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Relying Party: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -897,6 +880,27 @@ Do you want to register a new Passkey for:</source>
     </message>
     <message>
         <source>KeePassXC - Passkey credentials</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to existing entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Existing passkey found.
+Do you want to register a new passkey for:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select the existing passkey and press Update to replace it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticate passkey credentials for:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to register a passkey for:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -940,11 +944,6 @@ Do you want to delete the entry?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Entry already has a Passkey.
-Do you want to overwrite the Passkey in %1 - %2?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>KeePassXC - Create a new group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -954,10 +953,6 @@ Do you want to overwrite the Passkey in %1 - %2?</source>
     </message>
     <message>
         <source>KeePassXC - Overwrite existing key?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>KeePassXC - Update Passkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -974,6 +969,27 @@ Do you want to overwrite the Passkey in %1 - %2?</source>
     </message>
     <message>
         <source>Passkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - Passkey credentials</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register a new passkey to this entry:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - Update passkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Entry already has a passkey.
+Do you want to overwrite the passkey in %1 - %2?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1223,11 +1239,11 @@ Do you want to overwrite the Passkey in %1 - %2?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allows using insecure http://localhost with Passkeys for testing purposes.</source>
+        <source>Allows using insecure http://localhost with passkeys for testing purposes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow using localhost with Passkeys</source>
+        <source>Allow using localhost with passkeys</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6215,10 +6231,6 @@ We recommend you use the AppImage available on our downloads page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Export the following Passkey entries.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Filenames will be generated with title and .passkey file extension.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6236,6 +6248,10 @@ We recommend you use the AppImage available on our downloads page.</source>
     </message>
     <message>
         <source>Export to folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export the following passkey entries.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6295,15 +6311,7 @@ Do you want to overwrite it?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import the following Passkey:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Entry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Import the following Passkey to this entry:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6311,11 +6319,19 @@ Do you want to overwrite it?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Default Passkeys group (Imported Passkeys)</source>
+        <source>Relying Party: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Relying Party: %1</source>
+        <source>Import the following passkey:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import the following passkey to this entry:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default passkeys group (Imported Passkeys)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6330,10 +6346,6 @@ Do you want to overwrite it?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Passkey file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cannot open file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6342,21 +6354,25 @@ Do you want to overwrite it?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cannot import Passkey</source>
+        <source>Open passkey file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cannot import Passkey file &quot;%1&quot;. Data is missing.</source>
+        <source>Cannot import passkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cannot import Passkey file &quot;%1&quot;. Private key is missing or malformed.</source>
+        <source>Cannot import passkey file &quot;%1&quot;. Data is missing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cannot import Passkey file &quot;%1&quot;.
+        <source>Cannot import passkey file &quot;%1&quot;.
 The following data is missing:
 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot import passkey file &quot;%1&quot;. Private key is missing or malformed.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8585,10 +8601,6 @@ This option is deprecated, use --set-key-file instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown Passkeys error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Challenge is shorter than required minimum length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8680,6 +8692,10 @@ This option is deprecated, use --set-key-file instead.</source>
     </message>
     <message>
         <source>Unsupported KDF type, cannot decrypt json file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown passkeys error</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9009,14 +9025,6 @@ This option is deprecated, use --set-key-file instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please wait, list of entries with Passkeys is being updated…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>No entries with Passkeys.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9061,6 +9069,14 @@ This option is deprecated, use --set-key-file instead.</source>
     </message>
     <message>
         <source>The passkey file will be vulnerable to theft and unauthorized use, if left unsecured. Are you sure you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please wait, list of entries with passkeys is being updated…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No entries with passkeys.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/browser/BrowserMessageBuilder.cpp
+++ b/src/browser/BrowserMessageBuilder.cpp
@@ -151,7 +151,7 @@ QString BrowserMessageBuilder::getErrorMessage(const int errorCode) const
     case ERROR_PASSKEYS_WAIT_FOR_LIFETIMER:
         return QObject::tr("Wait for timer to expire");
     case ERROR_PASSKEYS_UNKNOWN_ERROR:
-        return QObject::tr("Unknown Passkeys error");
+        return QObject::tr("Unknown passkeys error");
     case ERROR_PASSKEYS_INVALID_CHALLENGE:
         return QObject::tr("Challenge is shorter than required minimum length");
     case ERROR_PASSKEYS_INVALID_USER_ID:

--- a/src/browser/BrowserPasskeysConfirmationDialog.cpp
+++ b/src/browser/BrowserPasskeysConfirmationDialog.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,7 +32,6 @@ BrowserPasskeysConfirmationDialog::BrowserPasskeysConfirmationDialog(QWidget* pa
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
 
     m_ui->setupUi(this);
-    m_ui->updateButton->setVisible(false);
     m_ui->verticalLayout->setAlignment(Qt::AlignTop);
 
     connect(m_ui->credentialsTable, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(accept()));
@@ -53,21 +52,22 @@ void BrowserPasskeysConfirmationDialog::registerCredential(const QString& userna
                                                            const QList<Entry*>& existingEntries,
                                                            int timeout)
 {
-    m_ui->firstLabel->setText(tr("Do you want to register Passkey for:"));
+    m_ui->firstLabel->setText(tr("Do you want to register a passkey for:"));
     m_ui->relyingPartyLabel->setText(tr("Relying Party: %1").arg(relyingParty));
     m_ui->usernameLabel->setText(tr("Username: %1").arg(username));
+    m_ui->updateButton->setVisible(true);
     m_ui->secondLabel->setText("");
 
     if (!existingEntries.isEmpty()) {
-        m_ui->firstLabel->setText(tr("Existing Passkey found.\nDo you want to register a new Passkey for:"));
-        m_ui->secondLabel->setText(tr("Select the existing Passkey and press Update to replace it."));
-
-        m_ui->updateButton->setVisible(true);
+        m_ui->firstLabel->setText(tr("Existing passkey found.\nDo you want to register a new passkey for:"));
+        m_ui->secondLabel->setText(tr("Select the existing passkey and press Update to replace it."));
+        m_ui->updateButton->setText(tr("Update"));
         m_ui->confirmButton->setText(tr("Register new"));
         updateEntriesToTable(existingEntries);
     } else {
         m_ui->verticalLayout->setSizeConstraint(QLayout::SetFixedSize);
         m_ui->confirmButton->setText(tr("Register"));
+        m_ui->updateButton->setText(tr("Add to existing entry"));
         m_ui->credentialsTable->setVisible(false);
     }
 
@@ -78,9 +78,10 @@ void BrowserPasskeysConfirmationDialog::authenticateCredential(const QList<Entry
                                                                const QString& relyingParty,
                                                                int timeout)
 {
-    m_ui->firstLabel->setText(tr("Authenticate Passkey credentials for:"));
+    m_ui->firstLabel->setText(tr("Authenticate passkey credentials for:"));
     m_ui->relyingPartyLabel->setText(tr("Relying Party: %1").arg(relyingParty));
     m_ui->usernameLabel->setVisible(false);
+    m_ui->updateButton->setVisible(false);
     m_ui->secondLabel->setText("");
     updateEntriesToTable(entries);
     startCounter(timeout);

--- a/src/browser/BrowserSettingsWidget.ui
+++ b/src/browser/BrowserSettingsWidget.ui
@@ -313,10 +313,10 @@
        <item>
         <widget class="QCheckBox" name="allowLocalhostWithPasskeys">
          <property name="toolTip">
-          <string>Allows using insecure http://localhost with Passkeys for testing purposes.</string>
+          <string>Allows using insecure http://localhost with passkeys for testing purposes.</string>
          </property>
          <property name="text">
-          <string>Allow using localhost with Passkeys</string>
+          <string>Allow using localhost with passkeys</string>
          </property>
         </widget>
        </item>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ * Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  * Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -1415,7 +1415,7 @@ void DatabaseWidget::switchToPasskeys()
 
 void DatabaseWidget::showImportPasskeyDialog(bool isEntry)
 {
-    PasskeyImporter passkeyImporter;
+    PasskeyImporter passkeyImporter(this);
 
     if (isEntry) {
         auto currentEntry = currentSelectedEntry();

--- a/src/gui/passkeys/PasskeyExportDialog.ui
+++ b/src/gui/passkeys/PasskeyExportDialog.ui
@@ -23,7 +23,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Export the following Passkey entries.</string>
+      <string>Export the following passkey entries.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/gui/passkeys/PasskeyExporter.cpp
+++ b/src/gui/passkeys/PasskeyExporter.cpp
@@ -27,13 +27,18 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 
+PasskeyExporter::PasskeyExporter(QWidget* parent)
+    : m_parent(parent)
+{
+}
+
 void PasskeyExporter::showExportDialog(const QList<Entry*>& items)
 {
     if (items.isEmpty()) {
         return;
     }
 
-    PasskeyExportDialog passkeyExportDialog;
+    PasskeyExportDialog passkeyExportDialog(m_parent);
     passkeyExportDialog.setEntries(items);
     auto ret = passkeyExportDialog.exec();
 
@@ -69,7 +74,7 @@ void PasskeyExporter::exportSelectedEntry(const Entry* entry, const QString& fol
 {
     const auto fullPath = QString("%1/%2.passkey").arg(folder, Tools::cleanFilename(entry->title()));
     if (QFile::exists(fullPath)) {
-        auto dialogResult = MessageBox::warning(nullptr,
+        auto dialogResult = MessageBox::warning(m_parent,
                                                 tr("KeePassXC: Passkey Export"),
                                                 tr("File \"%1.passkey\" already exists.\n"
                                                    "Do you want to overwrite it?\n")
@@ -84,7 +89,7 @@ void PasskeyExporter::exportSelectedEntry(const Entry* entry, const QString& fol
     QFile passkeyFile(fullPath);
     if (!passkeyFile.open(QIODevice::WriteOnly)) {
         MessageBox::information(
-            nullptr, tr("Cannot open file"), tr("Cannot open file \"%1\" for writing.").arg(fullPath));
+            m_parent, tr("Cannot open file"), tr("Cannot open file \"%1\" for writing.").arg(fullPath));
         return;
     }
 

--- a/src/gui/passkeys/PasskeyExporter.h
+++ b/src/gui/passkeys/PasskeyExporter.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,6 +20,8 @@
 
 #include <QList>
 #include <QObject>
+#include <QPointer>
+#include <QWidget>
 
 class Entry;
 
@@ -28,12 +30,15 @@ class PasskeyExporter : public QObject
     Q_OBJECT
 
 public:
-    explicit PasskeyExporter() = default;
+    explicit PasskeyExporter(QWidget* parent = nullptr);
 
     void showExportDialog(const QList<Entry*>& items);
 
 private:
     void exportSelectedEntry(const Entry* entry, const QString& folder);
+
+private:
+    QPointer<QWidget> m_parent;
 };
 
 #endif // KEEPASSXC_PASSKEYEXPORTER_H

--- a/src/gui/passkeys/PasskeyImportDialog.cpp
+++ b/src/gui/passkeys/PasskeyImportDialog.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -48,14 +48,17 @@ PasskeyImportDialog::~PasskeyImportDialog()
 void PasskeyImportDialog::setInfo(const QString& relyingParty,
                                   const QString& username,
                                   const QSharedPointer<Database>& database,
-                                  bool isEntry)
+                                  bool isEntry,
+                                  const QString& titleText,
+                                  const QString& infoText,
+                                  const QString& importButtonText)
 {
     m_ui->relyingPartyLabel->setText(tr("Relying Party: %1").arg(relyingParty));
     m_ui->usernameLabel->setText(tr("Username: %1").arg(username));
 
     if (isEntry) {
         m_ui->verticalLayout->setSizeConstraint(QLayout::SetFixedSize);
-        m_ui->infoLabel->setText(tr("Import the following Passkey to this entry:"));
+        m_ui->infoLabel->setText(tr("Import the following passkey to this entry:"));
         m_ui->groupBox->setVisible(false);
     }
 
@@ -70,6 +73,18 @@ void PasskeyImportDialog::setInfo(const QString& relyingParty,
         }
     }
     m_ui->selectDatabaseCombobBox->setEnabled(openDatabaseCount > 1);
+
+    if (!titleText.isEmpty()) {
+        setWindowTitle(titleText);
+    }
+
+    if (!infoText.isEmpty()) {
+        m_ui->infoLabel->setText(infoText);
+    }
+
+    if (!importButtonText.isEmpty()) {
+        m_ui->importButton->setText(importButtonText);
+    }
 }
 
 QSharedPointer<Database> PasskeyImportDialog::getSelectedDatabase() const
@@ -155,7 +170,7 @@ void PasskeyImportDialog::addGroups()
     }
 
     m_ui->selectGroupComboBox->clear();
-    m_ui->selectGroupComboBox->addItem(tr("Default Passkeys group (Imported Passkeys)"), {});
+    m_ui->selectGroupComboBox->addItem(tr("Default passkeys group (Imported Passkeys)"), {});
 
     for (const auto& group : m_selectedDatabase->rootGroup()->groupsRecursive(true)) {
         if (!group || group->isRecycled() || group == m_selectedDatabase->metadata()->recycleBin()) {

--- a/src/gui/passkeys/PasskeyImportDialog.h
+++ b/src/gui/passkeys/PasskeyImportDialog.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -39,7 +39,10 @@ public:
     void setInfo(const QString& relyingParty,
                  const QString& username,
                  const QSharedPointer<Database>& database,
-                 bool isEntry);
+                 bool isEntry,
+                 const QString& titleText = {},
+                 const QString& infoText = {},
+                 const QString& importButtonText = {});
     QSharedPointer<Database> getSelectedDatabase() const;
     QUuid getSelectedEntryUuid() const;
     QUuid getSelectedGroupUuid() const;

--- a/src/gui/passkeys/PasskeyImportDialog.ui
+++ b/src/gui/passkeys/PasskeyImportDialog.ui
@@ -36,7 +36,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Import the following Passkey:</string>
+        <string>Import the following passkey:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/gui/passkeys/PasskeyImporter.h
+++ b/src/gui/passkeys/PasskeyImporter.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,7 +21,9 @@
 #include "core/Database.h"
 #include <QFile>
 #include <QObject>
+#include <QPointer>
 #include <QUuid>
+#include <QWidget>
 
 class Entry;
 
@@ -30,21 +32,27 @@ class PasskeyImporter : public QObject
     Q_OBJECT
 
 public:
-    explicit PasskeyImporter() = default;
+    explicit PasskeyImporter(QWidget* parent = nullptr);
 
     void importPasskey(QSharedPointer<Database>& database, Entry* entry = nullptr);
-
-private:
-    void importSelectedFile(QFile& file, QSharedPointer<Database>& database, Entry* entry);
-    void showImportDialog(QSharedPointer<Database>& database,
+    bool showImportDialog(QSharedPointer<Database>& database,
+                          Entry* entry,
                           const QString& url,
                           const QString& relyingParty,
                           const QString& username,
                           const QString& credentialId,
                           const QString& userHandle,
                           const QString& privateKey,
-                          Entry* entry);
+                          const QString& titleText = {},
+                          const QString& infoText = {},
+                          const QString& importButtonText = {});
+
+private:
+    void importSelectedFile(QFile& file, QSharedPointer<Database>& database, Entry* entry);
     Group* getDefaultGroup(QSharedPointer<Database>& database) const;
+
+private:
+    QPointer<QWidget> m_parent;
 };
 
 #endif // KEEPASSXC_PASSKEYIMPORTER_H

--- a/src/gui/reports/ReportsWidgetPasskeys.cpp
+++ b/src/gui/reports/ReportsWidgetPasskeys.cpp
@@ -152,7 +152,7 @@ void ReportsWidgetPasskeys::loadSettings(QSharedPointer<Database> db)
     m_rowToEntry.clear();
 
     auto row = QList<QStandardItem*>();
-    row << new QStandardItem(tr("Please wait, list of entries with Passkeys is being updated…"));
+    row << new QStandardItem(tr("Please wait, list of entries with passkeys is being updated…"));
     m_referencesModel->appendRow(row);
 }
 
@@ -188,7 +188,7 @@ void ReportsWidgetPasskeys::updateEntries()
 
     // Set the table header
     if (m_referencesModel->rowCount() == 0) {
-        m_referencesModel->setHorizontalHeaderLabels(QStringList() << tr("No entries with Passkeys."));
+        m_referencesModel->setHorizontalHeaderLabels(QStringList() << tr("No entries with passkeys."));
     } else {
         m_referencesModel->setHorizontalHeaderLabels(QStringList() << tr("Title") << tr("Path") << tr("Username")
                                                                    << tr("Relying Party") << tr("URLs"));
@@ -282,7 +282,7 @@ void ReportsWidgetPasskeys::selectionChanged()
 
 void ReportsWidgetPasskeys::importPasskey()
 {
-    PasskeyImporter passkeyImporter;
+    PasskeyImporter passkeyImporter(this);
     passkeyImporter.importPasskey(m_db);
 
     updateEntries();
@@ -300,6 +300,6 @@ void ReportsWidgetPasskeys::exportPasskey()
         return;
     }
 
-    PasskeyExporter passkeyExporter;
+    PasskeyExporter passkeyExporter(this);
     passkeyExporter.showExportDialog(getSelectedEntries());
 }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Shows an extra button for creating a passkey directly to an existing entry. It opens the normal import dialog, with some texts changed.

Fixes #10372.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
<img width="542" alt="Screenshot 2024-03-12 at 19 40 33" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/5625bfc9-9191-4822-ae31-596636bd04cf">
<img width="612" alt="Screenshot 2024-03-12 at 19 40 37" src="https://github.com/keepassxreboot/keepassxc/assets/24570482/53831fb7-9158-4305-b3e2-44d48509bedd">

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
