### PR TITLE
Passkeys: Do not ask update with a new user handle

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -633,12 +633,15 @@ QJsonObject BrowserService::showPasskeysRegisterPrompt(const QJsonObject& public
     const auto rpId = publicKeyOptions["rp"]["id"].toString();
     const auto timeout = publicKeyOptions["timeout"].toInt();
     const auto username = credentialCreationOptions["user"].toObject()["name"].toString();
+    const auto user = credentialCreationOptions["user"].toObject();
+    const auto userId = user["id"].toString();
 
     // Parse excludeCredentialDescriptorList
     if (!excludeCredentials.isEmpty() && isPasskeyCredentialExcluded(excludeCredentials, rpId, keyList)) {
         return getPasskeyError(ERROR_PASSKEYS_CREDENTIAL_IS_EXCLUDED);
     }
-    const auto existingEntries = getPasskeyEntries(rpId, keyList);
+
+    const auto existingEntries = getPasskeyEntriesWithUserHandle(rpId, userId, keyList);
 
     raiseWindow();
     BrowserPasskeysConfirmationDialog confirmDialog;
@@ -654,9 +657,6 @@ QJsonObject BrowserService::showPasskeysRegisterPrompt(const QJsonObject& public
         }
 
         const auto rpName = publicKeyOptions["rp"]["name"].toString();
-        const auto user = credentialCreationOptions["user"].toObject();
-        const auto userId = user["id"].toString();
-
         if (confirmDialog.isPasskeyUpdated()) {
             addPasskeyToEntry(confirmDialog.getSelectedEntry(),
                               rpId,
@@ -1341,6 +1341,22 @@ QList<Entry*> BrowserService::getPasskeyEntries(const QString& rpId, const Strin
     QList<Entry*> entries;
     for (const auto& entry : searchEntries(rpId, "", keyList, true)) {
         if (entry->hasPasskey() && entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_RELYING_PARTY) == rpId) {
+            entries << entry;
+        }
+    }
+
+    return entries;
+}
+
+// Returns all Passkey entries for the current Relying Party and identical user handle
+QList<Entry*> BrowserService::getPasskeyEntriesWithUserHandle(const QString& rpId,
+                                                              const QString& userId,
+                                                              const StringPairList& keyList)
+{
+    QList<Entry*> entries;
+    for (const auto& entry : searchEntries(rpId, "", keyList, true)) {
+        if (entry->hasPasskey() && entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_RELYING_PARTY) == rpId
+            && entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_USER_HANDLE) == userId) {
             entries << entry;
         }
     }

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -184,6 +184,8 @@ private:
 #ifdef WITH_XC_BROWSER_PASSKEYS
     QList<Entry*> getPasskeyEntries(const QString& rpId, const StringPairList& keyList);
     QList<Entry*>
+    getPasskeyEntriesWithUserHandle(const QString& rpId, const QString& userId, const StringPairList& keyList);
+    QList<Entry*>
     getPasskeyAllowedEntries(const QJsonObject& assertionOptions, const QString& rpId, const StringPairList& keyList);
     bool isPasskeyCredentialExcluded(const QJsonArray& excludeCredentials,
                                      const QString& rpId,


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
When user is creating a new passkey, the KeePassXC's dialog should not ask for update if the user handle is not found.

Fixes #10404

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
