### PR TITLE
Passkeys: Enable Import Passkey entry menu item only if a single entry is selected

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -957,7 +957,7 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
 #ifdef WITH_XC_BROWSER_PASSKEYS
             m_ui->actionPasskeys->setEnabled(true);
             m_ui->actionImportPasskey->setEnabled(true);
-            m_ui->actionEntryImportPasskey->setEnabled(true);
+            m_ui->actionEntryImportPasskey->setEnabled(singleEntrySelected);
 #endif
 #ifdef WITH_XC_SSHAGENT
             bool singleEntryHasSshKey =


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
When no entry is selected, the entry menu item "Import Passkey" should be disabled.
Easy to reproduce if there's a group without entries, or none of the entries selected in a group.

Mentioned in: https://github.com/keepassxreboot/keepassxc/pull/9987#issuecomment-1995344798

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
