### PR TITLE
updates the Install.md documentation from qt5 to qt@5

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,9 +67,9 @@ Note: These steps place the compiled KeePassXC binary inside the `./build/src/` 
 
 ## MacOS Build Notes
 
-If you installed Qt5 via Homebrew and CMake fails to find your Qt installation, you can specify it manually by adding the following parameter:
+If you installed Qt@5 via Homebrew and CMake fails to find your Qt installation, you can specify it manually by adding the following parameter:
 
-`-DCMAKE_PREFIX_PATH=$(brew --prefix qt5)/lib/cmake`
+`-DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake`
 
 When building with ASAN support on macOS, you need to use `export ASAN_OPTIONS=detect_leaks=0` before running the tests (LSAN is no supported on macOS).
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )

issue #10422
Updated Install.md documentation to avoid warnings and possibly errors in the future:

homebrew warning: "Warning: Formula qt5 was renamed to qt@5."
changed qt5 to qt@5

also to avoid compilation warnings and potentially errors in the future I updated cmake setting in docs: 
"-DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake"





[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )

- ✅ Documentation (non-code change)
