### PR TITLE
Fix crash on screen lock or computer sleep

### DIFF
--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -188,30 +188,33 @@ private:
         QScopedPointer<PasswordKey> challengeResponseKey;
 
         QSharedPointer<const CompositeKey> key;
-        QSharedPointer<Kdf> kdf = QSharedPointer<AesKdf>::create(true);
+        QSharedPointer<Kdf> kdf;
 
         QVariantMap publicCustomData;
 
         DatabaseData()
-            : masterSeed(new PasswordKey())
-            , transformedDatabaseKey(new PasswordKey())
-            , challengeResponseKey(new PasswordKey())
         {
-            kdf->randomizeSeed();
+            clear();
         }
 
         void clear()
         {
+            resetKeys();
             filePath.clear();
+            publicCustomData.clear();
+        }
 
-            masterSeed.reset();
-            transformedDatabaseKey.reset();
-            challengeResponseKey.reset();
+        void resetKeys()
+        {
+            masterSeed.reset(new PasswordKey());
+            transformedDatabaseKey.reset(new PasswordKey());
+            challengeResponseKey.reset(new PasswordKey());
 
             key.reset();
-            kdf.reset();
 
-            publicCustomData.clear();
+            // Default to AES KDF, KDBX4 databases overwrite this
+            kdf.reset(new AesKdf(true));
+            kdf->randomizeSeed();
         }
     };
 

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -264,9 +264,7 @@ void DatabaseOpenWidget::clearForms()
     m_ui->hardwareKeyCombo->clear();
     toggleQuickUnlockScreen();
 
-    QString error;
-    m_db.reset(new Database());
-    m_db->open(m_filename, nullptr, &error);
+    m_db.reset(new Database(m_filename));
 }
 
 QSharedPointer<Database> DatabaseOpenWidget::database()

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -582,7 +582,9 @@ void TestKeePass2Format::testKdbxKeyChange()
 
     db->setKey(key1);
     writeKdbx(&buffer, db.data(), hasError, errorString);
-    QVERIFY(!hasError);
+    if (hasError) {
+        QFAIL(qPrintable(QStringLiteral("Error while reading database: ").append(errorString)));
+    }
 
     // read database
     db = QSharedPointer<Database>::create();
@@ -599,7 +601,9 @@ void TestKeePass2Format::testKdbxKeyChange()
     // write database
     buffer.seek(0);
     writeKdbx(&buffer, db.data(), hasError, errorString);
-    QVERIFY(!hasError);
+    if (hasError) {
+        QFAIL(qPrintable(QStringLiteral("Error while reading database: ").append(errorString)));
+    }
 
     // read database
     db = QSharedPointer<Database>::create();


### PR DESCRIPTION
* Fixes #10455
* Fixes #10432
* Fixes #10415

Prevent setting critical key components to nullptr when database data is cleared. This can result in a crash due to race condition between threads.

Added a bunch of asserts to detect this problem and if guards to prevent actual crashes.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
