### PR TITLE
Prevent SSH Agent from using entries in the recycle bin

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -223,16 +223,16 @@ Entry* Group::lastTopVisibleEntry() const
 bool Group::isRecycled() const
 {
     auto group = this;
-    if (!group->database() || !group->m_db->metadata()) {
-        return false;
+    auto db = group->database();
+    if (db) {
+        auto recycleBin = db->metadata()->recycleBin();
+        do {
+            if (group == recycleBin) {
+                return true;
+            }
+            group = group->m_parent;
+        } while (group);
     }
-
-    do {
-        if (group == group->m_db->metadata()->recycleBin()) {
-            return true;
-        }
-        group = group->m_parent;
-    } while (group);
 
     return false;
 }

--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -486,7 +486,7 @@ void SSHAgent::setAutoRemoveOnLock(const OpenSSHKey& key, bool autoRemove)
     }
 }
 
-void SSHAgent::databaseLocked(QSharedPointer<Database> db)
+void SSHAgent::databaseLocked(const QSharedPointer<Database>& db)
 {
     if (!db) {
         return;
@@ -508,20 +508,20 @@ void SSHAgent::databaseLocked(QSharedPointer<Database> db)
     }
 }
 
-void SSHAgent::databaseUnlocked(QSharedPointer<Database> db)
+void SSHAgent::databaseUnlocked(const QSharedPointer<Database>& db)
 {
     if (!db || !isEnabled()) {
         return;
     }
 
-    for (Entry* e : db->rootGroup()->entriesRecursive()) {
-        if (db->metadata()->recycleBinEnabled() && e->group() == db->metadata()->recycleBin()) {
+    for (auto entry : db->rootGroup()->entriesRecursive()) {
+        if (entry->isRecycled()) {
             continue;
         }
 
         KeeAgentSettings settings;
 
-        if (!settings.fromEntry(e)) {
+        if (!settings.fromEntry(entry)) {
             continue;
         }
 
@@ -531,7 +531,7 @@ void SSHAgent::databaseUnlocked(QSharedPointer<Database> db)
 
         OpenSSHKey key;
 
-        if (!settings.toOpenSSHKey(e, key, true)) {
+        if (!settings.toOpenSSHKey(entry, key, true)) {
             continue;
         }
 

--- a/src/sshagent/SSHAgent.h
+++ b/src/sshagent/SSHAgent.h
@@ -63,8 +63,8 @@ signals:
     void enabledChanged(bool enabled);
 
 public slots:
-    void databaseLocked(QSharedPointer<Database> db);
-    void databaseUnlocked(QSharedPointer<Database> db);
+    void databaseLocked(const QSharedPointer<Database>& db);
+    void databaseUnlocked(const QSharedPointer<Database>& db);
 
 private:
     const quint8 SSH_AGENT_FAILURE = 5;


### PR DESCRIPTION
* Fixes #10516
* Also cleanup Group::isRecycled() code a little

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
