### PR TITLE
Use XDG Desktop Portal to autostart the flatpak Fixes #8668

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -97,6 +97,9 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_HidePreviewPanel, {QS("GUI/HidePreviewPanel"), Roaming, false}},
     {Config::GUI_AlwaysOnTop, {QS("GUI/GUI_AlwaysOnTop"), Local, false}},
     {Config::GUI_ToolButtonStyle, {QS("GUI/ToolButtonStyle"), Roaming, Qt::ToolButtonIconOnly}},
+#ifdef KEEPASSXC_DIST_FLATPAK
+    {Config::GUI_LaunchAtStartup, {QS("GUI/LaunchAtStartup"), Roaming, false}},
+#endif
     {Config::GUI_ShowTrayIcon, {QS("GUI/ShowTrayIcon"), Roaming, false}},
     {Config::GUI_TrayIconAppearance, {QS("GUI/TrayIconAppearance"), Roaming, {}}},
     {Config::GUI_MinimizeToTray, {QS("GUI/MinimizeToTray"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -79,6 +79,9 @@ public:
         GUI_HidePreviewPanel,
         GUI_AlwaysOnTop,
         GUI_ToolButtonStyle,
+#ifdef KEEPASSXC_DIST_FLATPAK
+        GUI_LaunchAtStartup,
+#endif
         GUI_ShowTrayIcon,
         GUI_TrayIconAppearance,
         GUI_MinimizeToTray,

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -27,6 +27,10 @@
 #include <QStandardPaths>
 #include <QStyle>
 #include <QTextStream>
+#ifdef KEEPASSXC_DIST_FLATPAK
+#include "core/Config.h"
+#include <QRandomGenerator>
+#endif
 #ifdef WITH_XC_X11
 #include <QX11Info>
 
@@ -123,12 +127,17 @@ QString NixUtils::getAutostartDesktopFilename(bool createDirs) const
 
 bool NixUtils::isLaunchAtStartupEnabled() const
 {
+#if !defined(KEEPASSXC_DIST_FLATPAK)
     return QFile::exists(getAutostartDesktopFilename());
     ;
+#else
+    return config()->get(Config::GUI_LaunchAtStartup).toBool();
+#endif
 }
 
 void NixUtils::setLaunchAtStartup(bool enable)
 {
+#if !defined(KEEPASSXC_DIST_FLATPAK)
     if (enable) {
         QFile desktopFile(getAutostartDesktopFilename(true));
         if (!desktopFile.open(QIODevice::WriteOnly)) {
@@ -163,6 +172,49 @@ void NixUtils::setLaunchAtStartup(bool enable)
     } else if (isLaunchAtStartupEnabled()) {
         QFile::remove(getAutostartDesktopFilename());
     }
+#else
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    QDBusMessage msg = QDBusMessage::createMethodCall("org.freedesktop.portal.Desktop",
+                                                      "/org/freedesktop/portal/desktop",
+                                                      "org.freedesktop.portal.Background",
+                                                      "RequestBackground");
+
+    QMap<QString, QVariant> options;
+    options["autostart"] = QVariant(enable);
+    options["reason"] = QVariant("Launch KeePassXC at startup");
+    int token = QRandomGenerator::global()->bounded(1000, 9999);
+    options["handle_token"] = QVariant(QString("org/keepassxc/KeePassXC/%1").arg(token));
+
+    msg << "" << options;
+
+    QDBusMessage response = sessionBus.call(msg);
+
+    QDBusObjectPath handle = response.arguments().at(0).value<QDBusObjectPath>();
+
+    bool res = sessionBus.connect("org.freedesktop.portal.Desktop",
+                                  handle.path(),
+                                  "org.freedesktop.portal.Request",
+                                  "Response",
+                                  this,
+                                  SLOT(launchAtStartupRequested(uint, QVariantMap)));
+
+    if (!res) {
+        qDebug() << "Could not connect to org.freedesktop.portal.Request::Response signal";
+    }
+#endif
+}
+
+void NixUtils::launchAtStartupRequested(uint response, const QVariantMap& results)
+{
+    if (response > 0) {
+        qDebug() << "The interaction was cancelled";
+        return;
+    }
+    bool isLauchedAtStartup = results["autostart"].value<bool>();
+    qDebug() << "The autostart value is set to:" << isLauchedAtStartup;
+#if defined(KEEPASSXC_DIST_FLATPAK)
+    config()->set(Config::GUI_LaunchAtStartup, isLauchedAtStartup);
+#endif
 }
 
 bool NixUtils::isCapslockEnabled()

--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -54,6 +54,7 @@ public:
 private slots:
     void handleColorSchemeRead(QDBusVariant value);
     void handleColorSchemeChanged(QString ns, QString key, QDBusVariant value);
+    void launchAtStartupRequested(uint response, const QVariantMap& results);
 
 private:
     explicit NixUtils(QObject* parent = nullptr);


### PR DESCRIPTION
When using the KeePassXC flatpak, uses the Background XDG Desktop Portal to create a desktop file automatically in the right location instead of creating one directly in the wrong location. Fixes #8668

TODO:
- [x] Checking if autostart was enable does not work, and that results in the app thinking autostart is disabled. When the settings are opened the checkbox "Automatically launch KeePassXC at system startup" is unticked and if they are applied without re-ticking the checkbox, the autostart will be disabled. This check was previously done by checking if the desktop file existed, but it does not make sense to do that if we don't create this file ourselves. Should the autostart status be saved in a config file elsewhere instead ?

An empty string is passed instead of the window id of the application since I don't know how to get this id.

## Testing strategy
I built and tested the flatpak manually on Fedora 39 on Gnome and KDE, when the "Automatically launch KeePassXC at system startup" checkbox is ticked and the settings are applied, the portal creates the file `~/.config/autostart/org.keepassxc.KeePassXC.desktop`:

```
[Desktop Entry]
Exec=flatpak run org.keepassxc.KeePassXC
Name=org.keepassxc.KeePassXC
Type=Application
X-Flatpak=org.keepassxc.KeePassXC
```


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

