### PR TITLE
Add drag & drop untracked cross-db move

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1267,7 +1267,9 @@ void Entry::setGroup(Group* group, bool trackPrevious)
             m_group->database()->addDeletedObject(m_uuid);
 
             // copy custom icon to the new database
-            group->database()->metadata()->copyCustomIcon(iconUuid(), m_group->database()->metadata());
+            if (group->database()) {
+                group->database()->metadata()->copyCustomIcon(iconUuid(), m_group->database()->metadata());
+            }
         } else if (trackPrevious && m_group->database() && group != m_group) {
             setPreviousParentGroup(m_group);
         }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1487,7 +1487,11 @@ QUuid Entry::previousParentGroupUuid() const
 
 void Entry::setPreviousParentGroupUuid(const QUuid& uuid)
 {
+    // prevent set from changing the LastModificationTime
+    bool prevUpdateTimeinfo = m_updateTimeinfo;
+    m_updateTimeinfo = false;
     set(m_data.previousParentGroupUuid, uuid);
+    m_updateTimeinfo = prevUpdateTimeinfo;
 }
 
 void Entry::setPreviousParentGroup(const Group* group)

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1483,9 +1483,8 @@ QUuid Entry::previousParentGroupUuid() const
 
 void Entry::setPreviousParentGroupUuid(const QUuid& uuid)
 {
-    // prevent set from changing the LastModificationTime
     bool prevUpdateTimeinfo = m_updateTimeinfo;
-    m_updateTimeinfo = false;
+    m_updateTimeinfo = false; // prevent update of LastModificationTime
     set(m_data.previousParentGroupUuid, uuid);
     m_updateTimeinfo = prevUpdateTimeinfo;
 }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -947,9 +947,9 @@ Entry* Entry::clone(CloneFlags flags) const
     if (flags & CloneResetTimeInfo) {
         QDateTime now = Clock::currentDateTimeUtc();
         entry->m_data.timeInfo.setCreationTime(now);
-        entry->m_data.timeInfo.setLastModificationTime(now);
         entry->m_data.timeInfo.setLastAccessTime(now);
         entry->m_data.timeInfo.setLocationChanged(now);
+        // preserve LastModificationTime
     }
 
     if (flags & CloneRenameTitle) {
@@ -1267,11 +1267,7 @@ void Entry::setGroup(Group* group, bool trackPrevious)
             m_group->database()->addDeletedObject(m_uuid);
 
             // copy custom icon to the new database
-            if (!iconUuid().isNull() && group->database() && m_group->database()->metadata()->hasCustomIcon(iconUuid())
-                && !group->database()->metadata()->hasCustomIcon(iconUuid())) {
-                group->database()->metadata()->addCustomIcon(iconUuid(),
-                                                             m_group->database()->metadata()->customIcon(iconUuid()));
-            }
+            group->database()->metadata()->copyCustomIcon(iconUuid(), m_group->database()->metadata());
         } else if (trackPrevious && m_group->database() && group != m_group) {
             setPreviousParentGroup(m_group);
         }

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -946,10 +946,15 @@ Entry* Entry::clone(CloneFlags flags) const
 
     if (flags & CloneResetTimeInfo) {
         QDateTime now = Clock::currentDateTimeUtc();
-        entry->m_data.timeInfo.setCreationTime(now);
-        entry->m_data.timeInfo.setLastAccessTime(now);
-        entry->m_data.timeInfo.setLocationChanged(now);
-        // preserve LastModificationTime
+        if (flags & CloneResetCreationTime) {
+            entry->m_data.timeInfo.setCreationTime(now);
+        }
+        if (flags & CloneResetLastAccessTime) {
+            entry->m_data.timeInfo.setLastAccessTime(now);
+        }
+        if (flags & CloneResetLocationChangedTime) {
+            entry->m_data.timeInfo.setLocationChanged(now);
+        }
     }
 
     if (flags & CloneRenameTitle) {

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -175,13 +175,18 @@ public:
     {
         CloneNoFlags = 0,
         CloneNewUuid = 1, // generate a random uuid for the clone
-        CloneResetTimeInfo = 2, // set all TimeInfo attributes except LastModificationTime to the current time
-        CloneIncludeHistory = 4, // clone the history items
+        CloneResetCreationTime = 2, // set timeInfo.CreationTime to the current time
+        CloneResetLastAccessTime = 4, // set timeInfo.LastAccessTime to the current time
+        CloneResetLocationChangedTime = 8, // set timeInfo.LocationChangedTime to the current time
+        CloneIncludeHistory = 16, // clone the history items
+        CloneRenameTitle = 32, // add "-Clone" after the original title
+        CloneUserAsRef = 64, // Add the user as a reference to the original entry
+        ClonePassAsRef = 128, // Add the password as a reference to the original entry
+
+        CloneResetTimeInfo = CloneResetCreationTime | CloneResetLastAccessTime | CloneResetLocationChangedTime,
+        CloneExactCopy = CloneIncludeHistory,
+        CloneCopy = CloneExactCopy | CloneNewUuid | CloneResetTimeInfo,
         CloneDefault = CloneNewUuid | CloneResetTimeInfo,
-        CloneCopy = CloneNewUuid | CloneResetTimeInfo | CloneIncludeHistory,
-        CloneRenameTitle = 8, // add "-Clone" after the original title
-        CloneUserAsRef = 16, // Add the user as a reference to the original entry
-        ClonePassAsRef = 32, // Add the password as a reference to the original entry
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -177,13 +177,11 @@ public:
         CloneNewUuid = 1, // generate a random uuid for the clone
         CloneResetTimeInfo = 2, // set all TimeInfo attributes except LastModificationTime to the current time
         CloneIncludeHistory = 4, // clone the history items
+        CloneDefault = CloneNewUuid | CloneResetTimeInfo,
+        CloneCopy = CloneNewUuid | CloneResetTimeInfo | CloneIncludeHistory,
         CloneRenameTitle = 8, // add "-Clone" after the original title
         CloneUserAsRef = 16, // Add the user as a reference to the original entry
         ClonePassAsRef = 32, // Add the password as a reference to the original entry
-
-        CloneCopy = CloneNewUuid | CloneResetTimeInfo | CloneIncludeHistory,
-        CloneExactCopy = CloneIncludeHistory,
-        CloneDefault = CloneNewUuid | CloneResetTimeInfo,
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -175,13 +175,15 @@ public:
     {
         CloneNoFlags = 0,
         CloneNewUuid = 1, // generate a random uuid for the clone
-        CloneResetTimeInfo = 2, // set all TimeInfo attributes to the current time
+        CloneResetTimeInfo = 2, // set all TimeInfo attributes except LastModificationTime to the current time
         CloneIncludeHistory = 4, // clone the history items
-        CloneDefault = CloneNewUuid | CloneResetTimeInfo,
-        CloneCopy = CloneNewUuid | CloneResetTimeInfo | CloneIncludeHistory,
         CloneRenameTitle = 8, // add "-Clone" after the original title
         CloneUserAsRef = 16, // Add the user as a reference to the original entry
         ClonePassAsRef = 32, // Add the password as a reference to the original entry
+
+        CloneCopy = CloneNewUuid | CloneResetTimeInfo | CloneIncludeHistory,
+        CloneExactCopy = CloneIncludeHistory,
+        CloneDefault = CloneNewUuid | CloneResetTimeInfo,
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -949,12 +949,16 @@ Group* Group::clone(Entry::CloneFlags entryFlags, Group::CloneFlags groupFlags) 
 
     clonedGroup->setUpdateTimeinfo(true);
     if (groupFlags & Group::CloneResetTimeInfo) {
-
         QDateTime now = Clock::currentDateTimeUtc();
-        clonedGroup->m_data.timeInfo.setCreationTime(now);
-        clonedGroup->m_data.timeInfo.setLastAccessTime(now);
-        clonedGroup->m_data.timeInfo.setLocationChanged(now);
-        // preserve LastModificationTime
+        if (groupFlags & Group::CloneResetCreationTime) {
+            clonedGroup->m_data.timeInfo.setCreationTime(now);
+        }
+        if (groupFlags & Group::CloneResetLastAccessTime) {
+            clonedGroup->m_data.timeInfo.setLastAccessTime(now);
+        }
+        if (groupFlags & Group::CloneResetLocationChangedTime) {
+            clonedGroup->m_data.timeInfo.setLocationChanged(now);
+        }
     }
 
     if (groupFlags & Group::CloneRenameTitle) {

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -469,10 +469,7 @@ void Group::setParent(Group* parent, int index, bool trackPrevious)
             recCreateDelObjects();
 
             // copy custom icon to the new database
-            if (!iconUuid().isNull() && parent->m_db && m_db->metadata()->hasCustomIcon(iconUuid())
-                && !parent->m_db->metadata()->hasCustomIcon(iconUuid())) {
-                parent->m_db->metadata()->addCustomIcon(iconUuid(), m_db->metadata()->customIcon(iconUuid()));
-            }
+            parent->m_db->metadata()->copyCustomIcon(iconUuid(), m_db->metadata());
         }
         if (m_db != parent->m_db) {
             connectDatabaseSignalsRecursive(parent->m_db);
@@ -949,9 +946,9 @@ Group* Group::clone(Entry::CloneFlags entryFlags, Group::CloneFlags groupFlags) 
 
         QDateTime now = Clock::currentDateTimeUtc();
         clonedGroup->m_data.timeInfo.setCreationTime(now);
-        clonedGroup->m_data.timeInfo.setLastModificationTime(now);
         clonedGroup->m_data.timeInfo.setLastAccessTime(now);
         clonedGroup->m_data.timeInfo.setLocationChanged(now);
+        // preserve LastModificationTime
     }
 
     if (groupFlags & Group::CloneRenameTitle) {

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -558,6 +558,16 @@ bool Group::hasChildren() const
     return !children().isEmpty();
 }
 
+bool Group::isDescendantOf(const Group* group) const
+{
+    for(const Group* parent = m_parent; parent; parent = parent->m_parent) {
+        if (parent == group) {
+            return true;
+        }
+    }
+    return false;
+}
+
 Database* Group::database()
 {
     return m_db;

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -469,7 +469,9 @@ void Group::setParent(Group* parent, int index, bool trackPrevious)
             recCreateDelObjects();
 
             // copy custom icon to the new database
-            parent->m_db->metadata()->copyCustomIcon(iconUuid(), m_db->metadata());
+            if (parent->m_db) {
+                parent->m_db->metadata()->copyCustomIcon(iconUuid(), m_db->metadata());
+            }
         }
         if (m_db != parent->m_db) {
             connectDatabaseSignalsRecursive(parent->m_db);

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -1240,7 +1240,11 @@ QUuid Group::previousParentGroupUuid() const
 
 void Group::setPreviousParentGroupUuid(const QUuid& uuid)
 {
+    // prevent set from changing the LastModificationTime
+    bool prevUpdateTimeinfo = m_updateTimeinfo;
+    m_updateTimeinfo = false;
     set(m_data.previousParentGroupUuid, uuid);
+    m_updateTimeinfo = prevUpdateTimeinfo;
 }
 
 void Group::setPreviousParentGroup(const Group* group)

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -1074,7 +1074,12 @@ void Group::cleanupParent()
     if (m_parent) {
         emit groupAboutToRemove(this);
         m_parent->m_children.removeAll(this);
+
+        bool prevUpdateTimeinfo = m_updateTimeinfo;
+        m_updateTimeinfo = false; // prevent update of LastModificationTime
         emitModified();
+        m_updateTimeinfo = prevUpdateTimeinfo;
+        
         emit groupRemoved();
     }
 }

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -494,7 +494,11 @@ void Group::setParent(Group* parent, int index, bool trackPrevious)
         m_data.timeInfo.setLocationChanged(Clock::currentDateTimeUtc());
     }
 
+    bool prevUpdateTimeInfo = m_updateTimeinfo;
+    m_updateTimeinfo = false; // prevent update of LastModificationTime
     emitModified();
+    m_updateTimeinfo = prevUpdateTimeInfo;
+    
 
     if (!moveWithinDatabase) {
         emit groupAdded();
@@ -1237,9 +1241,8 @@ QUuid Group::previousParentGroupUuid() const
 
 void Group::setPreviousParentGroupUuid(const QUuid& uuid)
 {
-    // prevent set from changing the LastModificationTime
     bool prevUpdateTimeinfo = m_updateTimeinfo;
-    m_updateTimeinfo = false;
+    m_updateTimeinfo = false; // prevent update of LastModificationTime
     set(m_data.previousParentGroupUuid, uuid);
     m_updateTimeinfo = prevUpdateTimeinfo;
 }

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -20,10 +20,23 @@
 #define KEEPASSX_GROUP_H
 
 #include <QPointer>
+#include <QList>
+#include <utility>
 
 #include "core/CustomData.h"
 #include "core/Database.h"
 #include "core/Entry.h"
+
+
+class Entry;
+class Group;
+
+
+template <typename TCallable> concept CGroupVisitor = std::is_invocable_v<TCallable, Group*>;
+template <typename TCallable> concept CGroupConstVisitor = std::is_invocable_v<TCallable, const Group*>;
+template <typename TCallable> concept CEntryVisitor = std::is_invocable_v<TCallable, Entry*>;
+template <typename TCallable> concept CEntryConstVisitor = std::is_invocable_v<TCallable, const Entry*>;
+
 
 class Group : public ModifiableObject
 {
@@ -153,6 +166,7 @@ public:
     void setParent(Group* parent, int index = -1, bool trackPrevious = true);
     QStringList hierarchy(int height = -1) const;
     bool hasChildren() const;
+    bool isDescendantOf(const Group* group) const;
 
     Database* database();
     const Database* database() const;
@@ -165,6 +179,41 @@ public:
     QList<Entry*> entriesRecursive(bool includeHistoryItems = false) const;
     QList<const Group*> groupsRecursive(bool includeSelf) const;
     QList<Group*> groupsRecursive(bool includeSelf);
+
+    // walk methods for traversing the tree efficiently (depth-first search)
+    template <CGroupVisitor TGroupCallable, CEntryVisitor TEntryCallable>
+    bool walk(bool includeSelf, TGroupCallable&& groupVisitor, TEntryCallable&& entryVisitor)
+    {
+        return walk<TGroupCallable, TEntryCallable, false, true, true>(
+            includeSelf, std::forward<TGroupCallable>(groupVisitor), std::forward<TEntryCallable>(entryVisitor));
+    }
+    template <CGroupConstVisitor TGroupCallable, CEntryConstVisitor TEntryCallable>
+    bool walk(bool includeSelf, TGroupCallable&& groupVisitor, TEntryCallable&& entryVisitor) const
+    {
+        return walk<TGroupCallable, TEntryCallable, true, true, true>(
+            includeSelf, std::forward<TGroupCallable>(groupVisitor), std::forward<TEntryCallable>(entryVisitor));
+    }
+    template <CGroupConstVisitor TGroupCallable> bool walkGroups(bool includeSelf, TGroupCallable&& groupVisitor) const
+    {
+        return walk<TGroupCallable, void*, true, true, false>(
+            includeSelf, std::forward<TGroupCallable>(groupVisitor), nullptr);
+    }
+    template <CGroupVisitor TGroupCallable> bool walkGroups(bool includeSelf, TGroupCallable&& groupVisitor)
+    {
+        return walk<TGroupCallable, void*, false, true, false>(
+            includeSelf, std::forward<TGroupCallable>(groupVisitor), nullptr);
+    }
+    template <CEntryConstVisitor TEntryCallable> bool walkEntries(TEntryCallable&& entryVisitor) const
+    {
+        return walk<void*, TEntryCallable, true, false, true>(
+            true, nullptr, std::forward<TEntryCallable>(entryVisitor));
+    }
+    template <CEntryVisitor TEntryCallable> bool walkEntries(TEntryCallable&& entryVisitor)
+    {
+        return walk<void*, TEntryCallable, false, false, true>(
+            true, nullptr, std::forward<TEntryCallable>(entryVisitor));
+    }
+
     QSet<QUuid> customIconsRecursive() const;
     QList<QString> usernamesRecursive(int topN = -1) const;
 
@@ -210,6 +259,8 @@ private slots:
     void updateTimeinfo();
 
 private:
+    template <typename TGroupCallable, typename TEntryCallable, bool kIsConst, bool kVisitGroups, bool kVisitEntries>
+    bool walk(bool includeSelf, TGroupCallable&& groupVisitor, TEntryCallable&& entryVisitor) const;
     template <class P, class V> bool set(P& property, const V& value, bool preserveTimeinfo = false);
 
     void emitModifiedEx(bool preserveTimeinfo);
@@ -239,5 +290,56 @@ private:
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Group::CloneFlags)
+
+// helpers to support non-bool returning callables
+template <bool kDefaultRetVal, typename TCallable, typename... Args>
+bool visitorPredicateImpl(std::true_type, TCallable&& callable, Args&&... args)
+{
+    return callable(std::forward<Args>(args)...);
+}
+
+template <bool kDefaultRetVal, typename TCallable, typename... Args>
+bool visitorPredicateImpl(std::false_type, TCallable&& callable, Args&&... args)
+{
+    callable(std::forward<Args>(args)...);
+    return kDefaultRetVal;
+}
+
+template <bool kDefaultRetVal, typename TCallable, typename... Args>
+bool visitorPredicate(TCallable&& callable, Args&&... args)
+{
+    using RetType = decltype(callable(args...));
+    return visitorPredicateImpl<kDefaultRetVal>(
+        std::is_same<RetType, bool>{}, std::forward<TCallable>(callable), std::forward<Args>(args)...);
+}
+
+template<typename TGroupCallable, typename TEntryCallable, bool kIsConst, bool kVisitGroups, bool kVisitEntries>
+bool Group::walk(bool includeSelf, TGroupCallable&& groupVisitor, TEntryCallable&& entryVisitor) const
+{
+    using GroupType = typename std::conditional<kIsConst,const Group, Group>::type;
+    QList<Group*> groupsToVisit;
+    if (includeSelf) {
+        groupsToVisit.append(const_cast<Group*>(this));
+    } else {
+        groupsToVisit.append(m_children);
+    }
+    while (!groupsToVisit.isEmpty()) {
+        GroupType* group = groupsToVisit.takeLast(); // right-to-left
+        if constexpr (kVisitGroups) {
+            if (visitorPredicate<false>(groupVisitor, group)) {
+                return true;
+            }
+        }
+        if constexpr (kVisitEntries) {
+            for (auto* entry : group->m_entries) {
+                if (visitorPredicate<false>(entryVisitor, entry)) {
+                    return true;
+                }
+            }
+        }
+        groupsToVisit.append(group->m_children);
+    }
+    return false;
+}
 
 #endif // KEEPASSX_GROUP_H

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -49,11 +49,8 @@ public:
         CloneNewUuid = 1, // generate a random uuid for the clone
         CloneResetTimeInfo = 2, // set all TimeInfo attributes except LastModificationTime to the current time
         CloneIncludeEntries = 4, // clone the group entries
+        CloneDefault = CloneNewUuid | CloneResetTimeInfo | CloneIncludeEntries,
         CloneRenameTitle = 8, // add "- Clone" after the original title
-
-        CloneCopy = CloneNewUuid | CloneResetTimeInfo | CloneIncludeEntries,
-        CloneExactCopy = CloneIncludeEntries,
-        CloneDefault = CloneCopy,
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -210,8 +210,9 @@ private slots:
     void updateTimeinfo();
 
 private:
-    template <class P, class V> bool set(P& property, const V& value);
+    template <class P, class V> bool set(P& property, const V& value, bool preserveTimeinfo = false);
 
+    void emitModifiedEx(bool preserveTimeinfo);
     void setParent(Database* db);
 
     void connectDatabaseSignalsRecursive(Database* db);

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -47,10 +47,16 @@ public:
     {
         CloneNoFlags = 0,
         CloneNewUuid = 1, // generate a random uuid for the clone
-        CloneResetTimeInfo = 2, // set all TimeInfo attributes except LastModificationTime to the current time
-        CloneIncludeEntries = 4, // clone the group entries
-        CloneDefault = CloneNewUuid | CloneResetTimeInfo | CloneIncludeEntries,
-        CloneRenameTitle = 8, // add "- Clone" after the original title
+        CloneResetCreationTime = 2, // set timeInfo.CreationTime to the current time
+        CloneResetLastAccessTime = 4, // set timeInfo.LastAccessTime to the current time
+        CloneResetLocationChangedTime = 8, // set timeInfo.LocationChangedTime to the current time
+        CloneIncludeEntries = 16, // clone the group entries
+        CloneRenameTitle = 32, // add "- Clone" after the original title
+
+        CloneResetTimeInfo = CloneResetCreationTime | CloneResetLastAccessTime | CloneResetLocationChangedTime,
+        CloneExactCopy = CloneIncludeEntries,
+        CloneCopy = CloneExactCopy | CloneNewUuid | CloneResetTimeInfo,
+        CloneDefault = CloneCopy,
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -47,10 +47,13 @@ public:
     {
         CloneNoFlags = 0,
         CloneNewUuid = 1, // generate a random uuid for the clone
-        CloneResetTimeInfo = 2, // set all TimeInfo attributes to the current time
+        CloneResetTimeInfo = 2, // set all TimeInfo attributes except LastModificationTime to the current time
         CloneIncludeEntries = 4, // clone the group entries
-        CloneDefault = CloneNewUuid | CloneResetTimeInfo | CloneIncludeEntries,
         CloneRenameTitle = 8, // add "- Clone" after the original title
+
+        CloneCopy = CloneNewUuid | CloneResetTimeInfo | CloneIncludeEntries,
+        CloneExactCopy = CloneIncludeEntries,
+        CloneDefault = CloneCopy,
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -180,7 +180,19 @@ public:
     QList<const Group*> groupsRecursive(bool includeSelf) const;
     QList<Group*> groupsRecursive(bool includeSelf);
 
-    // walk methods for traversing the tree efficiently (depth-first search)
+    /**
+    * Walk methods for traversing the tree (depth-first search)
+    *
+    * @param[in] includeSelf is the current group to be included or excluded
+    *     if `false` the current group's entries will not be included either
+    * @param[in] groupVisitor functor that takes a single argument: ([const] Group*)
+    *     the functor may return a bool to indicate whether to stop=`true` or continue=`false` traversing
+    *     for a non-`bool` return-type the value is ignored and the traversing will continue as if `false` had been returned
+    * @param[in] entryVisitor functor that takes a single argument: ([const] Entry*)
+    *     the functor may return a bool to indicate whether to stop=`true` or continue=`false` traversing
+    *     for a non-`bool` return-type the value is ignored and the traversing will continue as if `false` had been returned
+    * @return `false` if the traversing completed without stop, or `true` otherwise
+    */
     template <CGroupVisitor TGroupCallable, CEntryVisitor TEntryCallable>
     bool walk(bool includeSelf, TGroupCallable&& groupVisitor, TEntryCallable&& entryVisitor)
     {

--- a/src/core/Metadata.cpp
+++ b/src/core/Metadata.cpp
@@ -419,14 +419,21 @@ QUuid Metadata::findCustomIcon(const QByteArray& candidate)
     return m_customIconsHashes.value(hash, QUuid());
 }
 
+void Metadata::copyCustomIcon(const QUuid& iconUuid, const Metadata* otherMetadata)
+{
+    if (iconUuid.isNull()) { 
+        return;
+    }
+    Q_ASSERT(otherMetadata->hasCustomIcon(iconUuid));
+    if (!hasCustomIcon(iconUuid) && otherMetadata->hasCustomIcon(iconUuid)) {
+        addCustomIcon(iconUuid, otherMetadata->customIcon(iconUuid));
+    }
+}
+
 void Metadata::copyCustomIcons(const QSet<QUuid>& iconList, const Metadata* otherMetadata)
 {
     for (const QUuid& uuid : iconList) {
-        Q_ASSERT(otherMetadata->hasCustomIcon(uuid));
-
-        if (!hasCustomIcon(uuid) && otherMetadata->hasCustomIcon(uuid)) {
-            addCustomIcon(uuid, otherMetadata->customIcon(uuid));
-        }
+        copyCustomIcon(uuid, otherMetadata);
     }
 }
 

--- a/src/core/Metadata.h
+++ b/src/core/Metadata.h
@@ -138,6 +138,7 @@ public:
                        const QString& name = {},
                        const QDateTime& lastModified = {});
     void removeCustomIcon(const QUuid& uuid);
+    void copyCustomIcon(const QUuid& iconUuid, const Metadata* otherMetadata);
     void copyCustomIcons(const QSet<QUuid>& iconList, const Metadata* otherMetadata);
     QUuid findCustomIcon(const QByteArray& candidate);
     void setRecycleBinEnabled(bool value);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -708,10 +708,6 @@ QList<DatabaseWidget*> MainWindow::getOpenDatabases()
     return dbWidgets;
 }
 
-DatabaseWidget* MainWindow::currentDatabaseWidget() {
-    return m_ui->tabWidget->currentDatabaseWidget();
-}
-
 void MainWindow::showErrorMessage(const QString& message)
 {
     m_ui->globalMessageWidget->showMessage(message, MessageWidget::Error);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -708,6 +708,10 @@ QList<DatabaseWidget*> MainWindow::getOpenDatabases()
     return dbWidgets;
 }
 
+DatabaseWidget* MainWindow::currentDatabaseWidget() {
+    return m_ui->tabWidget->currentDatabaseWidget();
+}
+
 void MainWindow::showErrorMessage(const QString& message)
 {
     m_ui->globalMessageWidget->showMessage(message, MessageWidget::Error);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -52,6 +52,7 @@ public:
     ~MainWindow() override;
 
     QList<DatabaseWidget*> getOpenDatabases();
+    DatabaseWidget* currentDatabaseWidget();
     void restoreConfigState();
     void setAllowScreenCapture(bool state);
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -52,7 +52,6 @@ public:
     ~MainWindow() override;
 
     QList<DatabaseWidget*> getOpenDatabases();
-    DatabaseWidget* currentDatabaseWidget();
     void restoreConfigState();
     void setAllowScreenCapture(bool state);
 

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -447,7 +447,7 @@ Qt::DropActions EntryModel::supportedDropActions() const
 
 Qt::DropActions EntryModel::supportedDragActions() const
 {
-    return (Qt::MoveAction | Qt::CopyAction);
+    return Qt::MoveAction | Qt::CopyAction | Qt::LinkAction;
 }
 
 Qt::ItemFlags EntryModel::flags(const QModelIndex& modelIndex) const

--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -300,11 +300,11 @@ bool GroupModel::dropMimeData(const QMimeData* data,
         }
 
         if (action == Qt::MoveAction) {
-            // remove the original group if it moved a clone
+            // delete the original group when moving a clone
             if (group != dragGroup) {
                 QList<DeletedObject> delObjects(sourceDb->deletedObjects());
                 delete dragGroup;
-                // prevent group, sub-group(s) & entry(s) from ending up on the deleted object list
+                // prevent group(s)/entry(s) from ending up on the deleted object list by restoring the previous list.
                 sourceDb->setDeletedObjects(delObjects);
             }
         } else { // Action == Qt::CopyAction
@@ -356,11 +356,11 @@ bool GroupModel::dropMimeData(const QMimeData* data,
             }
 
             if (action == Qt::MoveAction) {
-                // remove the original entry if it moved a clone
+                // delete the original entry when moving a clone
                 if (entry != dragEntry) {
                     QList<DeletedObject> delObjects(sourceDb->deletedObjects());
                     delete dragEntry;
-                    // prevent entry from ending up on the deleted object list
+                    // prevent entry from ending up on the deleted object list by restoring the previous list.
                     sourceDb->setDeletedObjects(delObjects);
                 }
             } else { // Action == Qt::CopyAction

--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -289,7 +289,7 @@ bool GroupModel::dropMimeData(const QMimeData* data,
                 }
                 // TODO: unable to handle complex moves until the Merger interface supports single group/entry merging.
                 if (complexMove) {
-                    showErrorMessage(tr("Move Error: (sub-)group(s) and/or entry(s) already present in the other database"));
+                    showErrorMessage(tr("Move Error: (sub-)group(s) and/or entry(s) already present in this database"));
                     return true;
                 }
 
@@ -371,7 +371,7 @@ bool GroupModel::dropMimeData(const QMimeData* data,
         }
 
         if (numEntriesNotMoved) {            
-            showErrorMessage(tr("Move Error: %1 of %2 entry(s) already present in the other database").arg(numEntriesNotMoved).arg(numEntries));
+            showErrorMessage(tr("Move Error: %1 of %2 entry(s) already present in this database").arg(numEntriesNotMoved).arg(numEntries));
         }
     }
 

--- a/src/gui/group/GroupModel.cpp
+++ b/src/gui/group/GroupModel.cpp
@@ -25,6 +25,7 @@
 #include "core/Tools.h"
 #include "gui/DatabaseIcons.h"
 #include "gui/Icons.h"
+#include "gui/MainWindow.h"
 #include "keeshare/KeeShare.h"
 
 GroupModel::GroupModel(Database* db, QObject* parent)
@@ -204,9 +205,11 @@ bool GroupModel::dropMimeData(const QMimeData* data,
 
     if (action == Qt::IgnoreAction) {
         return true;
+    } else if (action != Qt::MoveAction && action != Qt::CopyAction && action != ::Qt::LinkAction) {
+        return false;
     }
 
-    if (!data || !(action & (Qt::MoveAction | Qt::CopyAction | Qt::LinkAction)) || !parent.isValid()) {
+    if (!data || !parent.isValid()) {
         return false;
     }
 
@@ -223,6 +226,12 @@ bool GroupModel::dropMimeData(const QMimeData* data,
         row = rowCount(parent);
     }
 
+    auto showErrorMessage = [](const QString& errorMessage){
+        if(auto dbWidget = getMainWindow()->currentDatabaseWidget()) {
+            dbWidget->showErrorMessage(errorMessage);
+        }
+    };
+
     // decode and insert
     QByteArray encoded = data->data(isGroup ? types.at(0) : types.at(1));
     QDataStream stream(&encoded, QIODevice::ReadOnly);
@@ -234,17 +243,17 @@ bool GroupModel::dropMimeData(const QMimeData* data,
         QUuid groupUuid;
         stream >> dbUuid >> groupUuid;
 
-        Database* db = Database::databaseByUuid(dbUuid);
-        if (!db) {
+        Database* sourceDb = Database::databaseByUuid(dbUuid);
+        if (!sourceDb) {
             return false;
         }
 
-        Group* dragGroup = db->rootGroup()->findGroupByUuid(groupUuid);
-        if (!dragGroup || !db->rootGroup()->findGroupByUuid(dragGroup->uuid()) || dragGroup == db->rootGroup()) {
+        Group* dragGroup = sourceDb->rootGroup()->findGroupByUuid(groupUuid);
+        if (!dragGroup || dragGroup == sourceDb->rootGroup()) {
             return false;
         }
 
-        if (dragGroup == parentGroup || dragGroup->findGroupByUuid(parentGroup->uuid())) {
+        if (dragGroup == parentGroup || parentGroup->isDescendantOf(dragGroup)) {
             return false;
         }
 
@@ -252,25 +261,55 @@ bool GroupModel::dropMimeData(const QMimeData* data,
             row--;
         }
 
-        Database* sourceDb = dragGroup->database();
         Database* targetDb = parentGroup->database();
-
         Group* group = dragGroup;
 
         if (sourceDb != targetDb) {
-            targetDb->metadata()->copyCustomIcons(group->customIconsRecursive(), sourceDb->metadata());
+            if (action == Qt::MoveAction || action == Qt::LinkAction) { // clang-format off
 
-            if (action == Qt::MoveAction) {
-                // -- Tracked move
+                Group* binGroup = sourceDb->metadata()->recycleBin();
+                if(binGroup && binGroup->uuid() == dragGroup->uuid()) {
+                    showErrorMessage(tr("Move error: \"%1\" group cannot be moved").arg(binGroup->name()));
+                    return true;
+                }
+                
+                // Collect all UUID(s) or short-circuit when UUID is deleted in targetDb
+                QSet<QUuid> uuidSet;
+                bool complexMove = group->walk(true,
+                    [&](const Group* group) {
+                        uuidSet.insert(group->uuid());
+                        return targetDb->containsDeletedObject(group->uuid());
+                    },
+                    [&](const Entry* entry) { 
+                        uuidSet.insert(entry->uuid()); 
+                        return targetDb->containsDeletedObject(entry->uuid());
+                    }
+                );
+
+                // Unable to handle complex moves until the Merger interface supports single group/entry merging
+                if (complexMove || targetDb->rootGroup()->walk(true,
+                    [&](const Group* group)-> bool {
+                        return uuidSet.contains(group->uuid());
+                    },
+                    [&](const Entry* entry) -> bool {
+                        return uuidSet.contains(entry->uuid());
+                    }
+                )) {
+                    showErrorMessage(tr("Move error: the group or one of it's descendants is already present in this database"));
+                    return true;
+                }
+            } // clang-format on
+
+            if (action == Qt::MoveAction) { // -- Tracked move
+
                 // A clone with new UUID but original CreationTime
                 group = dragGroup->clone(Entry::CloneFlags(Entry::CloneCopy & ~Entry::CloneResetCreationTime),
                                          Group::CloneFlags(Group::CloneCopy & ~Group::CloneResetCreationTime));
-                // Original UUID is marked as deleted to remove it from dbs that merge with this one
+                // Original UUID is marked as deleted to propagate the move to dbs that merge with this one
                 delete dragGroup;
-            } else if (action == Qt::LinkAction) {
-                // -- Untracked move
+            } else if (action == Qt::LinkAction) { // -- Untracked move
+
                 QList<DeletedObject> deletedObjects(sourceDb->deletedObjects());
-                // Exact copy of original
                 group = dragGroup->clone(Entry::CloneExactCopy, Group::CloneExactCopy);
                 delete dragGroup;
                 // Unmark UUID(s) as deleted by restoring the previous list
@@ -278,6 +317,8 @@ bool GroupModel::dropMimeData(const QMimeData* data,
             } else {
                 group = dragGroup->clone(Entry::CloneCopy);
             }
+
+            targetDb->metadata()->copyCustomIcons(group->customIconsRecursive(), sourceDb->metadata());
         } else if (action == Qt::CopyAction) {
             group = dragGroup->clone(Entry::CloneCopy);
         }
@@ -288,39 +329,49 @@ bool GroupModel::dropMimeData(const QMimeData* data,
             return false;
         }
 
+        int entries{0}, entriesNotMoved{0};
         while (!stream.atEnd()) {
             QUuid dbUuid;
             QUuid entryUuid;
             stream >> dbUuid >> entryUuid;
+            ++entries;
 
-            Database* db = Database::databaseByUuid(dbUuid);
-            if (!db) {
+            Database* sourceDb = Database::databaseByUuid(dbUuid);
+            if (!sourceDb) {
                 continue;
             }
 
-            Entry* dragEntry = db->rootGroup()->findEntryByUuid(entryUuid);
-            if (!dragEntry || !db->rootGroup()->findEntryByUuid(dragEntry->uuid())) {
+            Entry* dragEntry = sourceDb->rootGroup()->findEntryByUuid(entryUuid);
+            if (!dragEntry) {
                 continue;
             }
 
-            Database* sourceDb = dragEntry->group()->database();
             Database* targetDb = parentGroup->database();
-
             Entry* entry = dragEntry;
 
             if (sourceDb != targetDb) {
-                targetDb->metadata()->copyCustomIcon(entry->iconUuid(), sourceDb->metadata());
+                if (action == Qt::MoveAction || action == Qt::LinkAction) { // clang-format off
 
-                if (action == Qt::MoveAction) {
-                    // -- Tracked move
+                    // Unable to handle complex moves until the Merger interface supports single group/entry merging
+                    if (targetDb->containsDeletedObject(dragEntry->uuid()) || 
+                        targetDb->rootGroup()->walkEntries([=](const Entry* entry) { 
+                            return dragEntry->uuid() == entry->uuid(); 
+                        }
+                    )) {
+                        ++entriesNotMoved;
+                        continue;
+                    }
+                } // clang-format on
+
+                if (action == Qt::MoveAction) { // -- Tracked move
+
                     // A clone with new UUID but original CreationTime
                     entry = dragEntry->clone(Entry::CloneFlags(Entry::CloneCopy & ~Entry::CloneResetCreationTime));
-                    // Original UUID is marked as deleted to remove it from dbs that merge with this one
+                    // Original UUID is marked as deleted to propagate the move to dbs that merge with this one
                     delete dragEntry;
-                } else if (action == Qt::LinkAction) {
-                    // -- Untracked move
+                } else if (action == Qt::LinkAction) { // -- Untracked move
+
                     QList<DeletedObject> deletedObjects(sourceDb->deletedObjects());
-                    // Exact copy of original
                     entry = dragEntry->clone(Entry::CloneExactCopy);
                     delete dragEntry;
                     // Unmark UUID as deleted by restoring the previous list
@@ -328,11 +379,18 @@ bool GroupModel::dropMimeData(const QMimeData* data,
                 } else {
                     entry = dragEntry->clone(Entry::CloneCopy);
                 }
+
+                targetDb->metadata()->copyCustomIcon(entry->iconUuid(), sourceDb->metadata());
             } else if (action == Qt::CopyAction) {
                 entry = dragEntry->clone(Entry::CloneCopy);
             }
 
             entry->setGroup(parentGroup);
+        }
+
+        if (entriesNotMoved) {
+            showErrorMessage(
+                tr("Move error: %1 of %2 entry(s) are already present in this database").arg(entriesNotMoved).arg(entries));
         }
     }
 

--- a/src/gui/group/GroupView.cpp
+++ b/src/gui/group/GroupView.cpp
@@ -24,11 +24,15 @@
 #include "core/Config.h"
 #include "core/Group.h"
 #include "gui/group/GroupModel.h"
+#include "gui/entry/EntryView.h"
+#include "gui/DatabaseWidget.h"
 
 GroupView::GroupView(Database* db, QWidget* parent)
     : QTreeView(parent)
     , m_model(new GroupModel(db, this))
     , m_updatingExpanded(false)
+    , m_isDragEventSrcFromOtherDb(false)
+    , m_lastAcceptedDropAction(Qt::IgnoreAction)
 {
     QTreeView::setModel(m_model);
     setHeaderHidden(true);
@@ -73,19 +77,82 @@ void GroupView::changeDatabase(const QSharedPointer<Database>& newDb)
     m_model->changeDatabase(newDb.data());
 }
 
-void GroupView::dragMoveEvent(QDragMoveEvent* event)
+void GroupView::dragEnterEvent(QDragEnterEvent *event)
 {
-    if (event->keyboardModifiers() & Qt::ControlModifier) {
-        event->setDropAction(Qt::CopyAction);
-    } else {
-        event->setDropAction(Qt::MoveAction);
+    event->ignore(); // default to ignore
+
+    auto const eventSource = event->source();
+    // ignore events from other processes
+    if (!eventSource) { 
+        return;
     }
 
+    // ignore events with unsupported mime-types
+    auto supportedFormats = m_model->mimeTypes().toSet();
+    if (!supportedFormats.intersects(event->mimeData()->formats().toSet())) {
+        return;
+    }
+
+    auto firstAncestorOfTypeDatabaseWidget = [](QObject* object) -> DatabaseWidget* {
+        if (object) {
+            for (auto parent = object->parent(); parent; parent = parent->parent()) {
+                if (auto dbWidget = qobject_cast<DatabaseWidget*>(parent)) {
+                    return dbWidget;
+                }
+            }
+        }
+        return nullptr;
+    };
+
+    m_isDragEventSrcFromOtherDb = false;
+    if (GroupView* view = qobject_cast<GroupView*>(eventSource)) {
+        m_isDragEventSrcFromOtherDb = view != this;
+    } else if (EntryView* view = qobject_cast<EntryView*>(eventSource)) {
+        auto targetDbWidget = firstAncestorOfTypeDatabaseWidget(this);
+        auto sourceDbWidget = firstAncestorOfTypeDatabaseWidget(view);
+        m_isDragEventSrcFromOtherDb = sourceDbWidget != targetDbWidget;
+    }
+
+    QTreeView::dragEnterEvent(event);
+}
+
+void GroupView::dragMoveEvent(QDragMoveEvent* event)
+{
     QTreeView::dragMoveEvent(event);
 
+    if (!event->isAccepted()) {
+        return;
+    }
+
     // entries may only be dropped on groups
-    if (event->isAccepted() && event->mimeData()->hasFormat("application/x-keepassx-entry")
+    if (event->mimeData()->hasFormat("application/x-keepassx-entry")
         && (dropIndicatorPosition() == AboveItem || dropIndicatorPosition() == BelowItem)) {
+        event->ignore();
+        return;
+    }
+
+    // figure out which dropaction should be used
+    Qt::DropAction dropAction = Qt::MoveAction;
+    if (event->keyboardModifiers() & Qt::ControlModifier) {
+        dropAction = Qt::CopyAction;
+    } else if (event->keyboardModifiers() & Qt::AltModifier) {
+        dropAction = m_isDragEventSrcFromOtherDb ? Qt::LinkAction : Qt::IgnoreAction;
+    }
+
+    if (dropAction != Qt::IgnoreAction && event->possibleActions() & dropAction) {
+        event->setDropAction(dropAction);
+        m_lastAcceptedDropAction = event->dropAction();
+    } else {
+        event->ignore();
+    }
+}
+
+void GroupView::dropEvent(QDropEvent* event)
+{
+    if (m_lastAcceptedDropAction != Qt::IgnoreAction) {
+        event->setDropAction(m_lastAcceptedDropAction);
+        QTreeView::dropEvent(event);
+    } else {
         event->ignore();
     }
 }

--- a/src/gui/group/GroupView.h
+++ b/src/gui/group/GroupView.h
@@ -48,7 +48,9 @@ private slots:
     void contextMenuShortcutPressed();
 
 protected:
+    void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
     void focusInEvent(QFocusEvent* event) override;
 
 private:
@@ -56,6 +58,8 @@ private:
 
     GroupModel* const m_model;
     bool m_updatingExpanded;
+    bool m_isDragEventSrcFromOtherDb;
+    Qt::DropAction m_lastAcceptedDropAction;
 };
 
 #endif // KEEPASSX_GROUPVIEW_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -168,7 +168,7 @@ if(WITH_XC_SSHAGENT)
 endif()
 
 add_unit_test(NAME testentry SOURCES TestEntry.cpp
-        LIBS ${TEST_LIBRARIES})
+        LIBS testsupport ${TEST_LIBRARIES})
 
 add_unit_test(NAME testmerge SOURCES TestMerge.cpp
         LIBS testsupport ${TEST_LIBRARIES})

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -123,6 +123,8 @@ void TestEntry::testClone()
     QCOMPARE(entryCloneResetTime->title(), QString("New Title"));
     QCOMPARE(entryCloneResetTime->historyItems().size(), 0);
     QVERIFY(entryCloneResetTime->timeInfo().creationTime() != entryOrg->timeInfo().creationTime());
+    // Cloning with CloneResetTimeInfo should not affect the LastModificationTime
+    QCOMPARE(entryCloneResetTime->timeInfo().lastModificationTime(), entryOrg->timeInfo().lastModificationTime());
 
     // Date back history of original entry
     Entry* firstHistoryItem = entryOrg->historyItems()[0];

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -28,6 +28,8 @@ class TestEntry : public QObject
 
 private slots:
     void initTestCase();
+    void init();
+    void cleanup();
     void testHistoryItemDeletion();
     void testCopyDataFrom();
     void testClone();
@@ -40,6 +42,7 @@ private slots:
     void testIsRecycled();
     void testMoveUpDown();
     void testPreviousParentGroup();
+    void testTimeinfoChanges();
 };
 
 #endif // KEEPASSX_TESTENTRY_H

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -1367,4 +1367,17 @@ void TestGroup::testTimeinfoChanges()
     QCOMPARE(subgroup2->timeInfo().lastModificationTime(), startTime);
     QCOMPARE(subgroup2->timeInfo().locationChanged(), Clock::currentDateTimeUtc());
     QCOMPARE(db2.rootGroup()->timeInfo(), startTimeinfo);
+
+    QScopedPointer<Entry> entry1(new Entry());
+    entry1->setGroup(subgroup1);
+    // adding/removing an entry should not affect the LastModificationTime
+    QCOMPARE(subgroup1->timeInfo().lastModificationTime(), startTime);
+    entry1.reset(); // delete
+    QCOMPARE(subgroup1->timeInfo().lastModificationTime(), startTime);
+
+    // sorting should not affect the LastModificationTime
+    root->sortChildrenRecursively(true);
+    root->sortChildrenRecursively(false);
+    QCOMPARE(root->timeInfo().lastModificationTime(), startTime);
+    QCOMPARE(subgroup1->timeInfo().lastModificationTime(), startTime);
 }

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -382,18 +382,21 @@ void TestGroup::testClone()
     QCOMPARE(clonedGroup->iconNumber(), 42);
     QCOMPARE(clonedGroup->children().size(), 1);
     QCOMPARE(clonedGroup->entries().size(), 1);
+    QCOMPARE(clonedGroup->timeInfo(), originalGroup->timeInfo());
 
     Entry* clonedGroupEntry = clonedGroup->entries().at(0);
     QVERIFY(clonedGroupEntry->uuid() != originalGroupEntry->uuid());
     QCOMPARE(clonedGroupEntry->title(), QString("GroupEntry"));
     QCOMPARE(clonedGroupEntry->iconNumber(), 43);
     QCOMPARE(clonedGroupEntry->historyItems().size(), 0);
+    QCOMPARE(clonedGroupEntry->timeInfo(), originalGroupEntry->timeInfo());
 
     Group* clonedSubGroup = clonedGroup->children().at(0);
     QVERIFY(clonedSubGroup->uuid() != subGroup->uuid());
     QCOMPARE(clonedSubGroup->name(), QString("SubGroup"));
     QCOMPARE(clonedSubGroup->children().size(), 0);
     QCOMPARE(clonedSubGroup->entries().size(), 1);
+    QCOMPARE(clonedSubGroup->timeInfo(), subGroup->timeInfo());
 
     Entry* clonedSubGroupEntry = clonedSubGroup->entries().at(0);
     QVERIFY(clonedSubGroupEntry->uuid() != subGroupEntry->uuid());
@@ -411,15 +414,17 @@ void TestGroup::testClone()
     QCOMPARE(clonedGroupNewUuid->entries().size(), 0);
     QVERIFY(clonedGroupNewUuid->uuid() != originalGroup->uuid());
 
-    // Making sure the new modification date is not the same.
+    // Verify Timeinfo modifications for CloneResetTimeInfo
     m_clock->advanceSecond(1);
 
     QScopedPointer<Group> clonedGroupResetTimeInfo(
         originalGroup->clone(Entry::CloneNoFlags, Group::CloneNewUuid | Group::CloneResetTimeInfo));
     QCOMPARE(clonedGroupResetTimeInfo->entries().size(), 0);
     QVERIFY(clonedGroupResetTimeInfo->uuid() != originalGroup->uuid());
-    QVERIFY(clonedGroupResetTimeInfo->timeInfo().lastModificationTime()
-            != originalGroup->timeInfo().lastModificationTime());
+    QVERIFY(clonedGroupResetTimeInfo->timeInfo().creationTime() != originalGroup->timeInfo().creationTime());
+    QVERIFY(clonedGroupResetTimeInfo->timeInfo().lastAccessTime() != originalGroup->timeInfo().lastAccessTime());
+    QVERIFY(clonedGroupResetTimeInfo->timeInfo().locationChanged() != originalGroup->timeInfo().locationChanged());
+    QCOMPARE(clonedGroupResetTimeInfo->timeInfo().lastModificationTime(), originalGroup->timeInfo().lastModificationTime());
 }
 
 void TestGroup::testCopyCustomIcons()
@@ -1318,4 +1323,48 @@ void TestGroup::testAutoTypeState()
     QVERIFY(subGroup->autoTypeEnabled() == Group::TriState::Enable);
     QVERIFY(!entry1->groupAutoTypeEnabled());
     QVERIFY(entry2->groupAutoTypeEnabled());
+}
+
+void TestGroup::testTimeinfoChanges()
+{
+    Database db, db2;
+    auto* root = db.rootGroup();
+    auto* subgroup1 = new Group();
+    auto* subgroup2 = new Group();
+    subgroup1->setUuid(QUuid::createUuid());
+    subgroup1->setParent(root);
+    subgroup2->setUuid(QUuid::createUuid());
+    subgroup2->setParent(root);
+    QDateTime startTime = Clock::currentDateTimeUtc();
+    TimeInfo startTimeinfo;
+    startTimeinfo.setCreationTime(startTime);
+    startTimeinfo.setLastModificationTime(startTime);
+    startTimeinfo.setLocationChanged(startTime);
+    startTimeinfo.setLastAccessTime(startTime);
+    m_clock->advanceMinute(1);
+    root->setTimeInfo(startTimeinfo);
+    subgroup1->setTimeInfo(startTimeinfo);
+    subgroup2->setTimeInfo(startTimeinfo);
+
+    subgroup2->setPreviousParentGroup(subgroup1);
+    // setting previous parent group should not affect the LastModificationTime
+    QCOMPARE(subgroup2->timeInfo().lastModificationTime(), startTime);
+    subgroup2->setPreviousParentGroup(nullptr);
+    subgroup2->setParent(subgroup1);
+    QCOMPARE(root->timeInfo(), startTimeinfo);
+    QCOMPARE(subgroup1->timeInfo(), startTimeinfo);
+    // changing group should not affect LastModificationTime, CreationTime
+    QCOMPARE(subgroup2->timeInfo().creationTime(), startTime);
+    QCOMPARE(subgroup2->timeInfo().lastModificationTime(), startTime);
+    // changing group should affect the LocationChanged time
+    QCOMPARE(subgroup2->timeInfo().locationChanged(), Clock::currentDateTimeUtc());
+
+    // cross-db move
+    db2.rootGroup()->setTimeInfo(startTimeinfo);
+    m_clock->advanceMinute(1);
+    subgroup2->setParent(db2.rootGroup());
+    QCOMPARE(subgroup2->timeInfo().creationTime(), startTime);
+    QCOMPARE(subgroup2->timeInfo().lastModificationTime(), startTime);
+    QCOMPARE(subgroup2->timeInfo().locationChanged(), Clock::currentDateTimeUtc());
+    QCOMPARE(db2.rootGroup()->timeInfo(), startTimeinfo);
 }

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -50,6 +50,7 @@ private slots:
     void testMoveUpDown();
     void testPreviousParentGroup();
     void testAutoTypeState();
+    void testTimeinfoChanges();
 };
 
 #endif // KEEPASSX_TESTGROUP_H

--- a/tests/TestGroup.h
+++ b/tests/TestGroup.h
@@ -51,6 +51,7 @@ private slots:
     void testPreviousParentGroup();
     void testAutoTypeState();
     void testTimeinfoChanges();
+    void testWalk();
 };
 
 #endif // KEEPASSX_TESTGROUP_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

The current drag & drop cross-database move implementation is designed for the use-case where 2 or more systems have the same databases in continuous (direct) sync with each other. 
A serious disadvantage of the implementation is that the item directly loses the ability to merge with other versions of the item.

This PR adds an alternative "untracked" move implementation.
The exact item is moved to the target database as if it had always been created there and never existed in the source database.
Ideal for use-cases that do not use the database in direct-sync or for users that needs to retain the item's ability to merge with other versions.
If the database is used in a direct-sync setup, the user would have to temporary disable the sync, maintain the database, manually distribute the new database to the other systems, and resume the sync. Otherwise the item would reappear shortly after being moved.

An "untracked" cross-db move is done by holding a keyboard's Alt key while dragging & dropping an item in an other database.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

Manual testing by dragging different entries & groups between different databases.

## Type of change
- ✅ New feature (change that adds functionality)

## Remarks
This PR is based of changes made in PR: #10481
[Actual changes](https://github.com/vuurvli3g/keepassxc/compare/dragdrop-improvements...vuurvli3g:keepassxc:feature/dragdrop-untracked-move) of this PR (Relative to the other) start at 86c6f684b23457ce66e9afeb50ff30f38dec9cbf

