### PR TITLE
fix display of bytes without decimals (#10594)

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -138,7 +138,9 @@ namespace Tools
             i++;
         }
 
-        return QString("%1 %2").arg(QLocale().toString(size, 'f', precision), units.at(i));
+        // do not display decimals for smallest unit bytes identified by index i==0
+        const quint32 displayPrecision = (i == 0 ? 0 : precision);
+        return QString("%1 %2").arg(QLocale().toString(size, 'f', displayPrecision), units.at(i));
     }
 
     QString humanReadableTimeDifference(qint64 seconds)

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -2113,7 +2113,7 @@ void TestCli::testShow()
                         "Tags: \n"
                         "\n"
                         "Attachments:\n"
-                        "  Sample attachment.txt (15.0 B)\n"));
+                        "  Sample attachment.txt (15 B)\n"));
 
     setInput("a");
     execCmd(showCmd, {"show", m_dbFile->fileName(), "--show-attachments", "/Homebanking/Subgroup/Subgroup Entry"});

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -38,7 +38,7 @@ void TestTools::testHumanReadableFileSize()
     constexpr auto kibibyte = 1024u;
     using namespace Tools;
 
-    QCOMPARE(createDecimal("1", "00", "B"), humanReadableFileSize(1));
+    QCOMPARE(QString("1 B"), humanReadableFileSize(1));
     QCOMPARE(createDecimal("1", "00", "KiB"), humanReadableFileSize(kibibyte));
     QCOMPARE(createDecimal("1", "00", "MiB"), humanReadableFileSize(kibibyte * kibibyte));
     QCOMPARE(createDecimal("1", "00", "GiB"), humanReadableFileSize(kibibyte * kibibyte * kibibyte));


### PR DESCRIPTION
The method `Tools::humanReadableFileSize()` is fixed to choose the number of decimals depending on the final unit used for the output. For file size smaller than 1024 bytes, the unit will be bytes without decimals. For larger files, the appropriate unit will show the number of decimals given by the argument.
Fixes #10594 .

## Screenshots
![KeePassXC_attachment_decimal_bytes_fixed_10594](https://github.com/keepassxreboot/keepassxc/assets/94784984/fc20b83e-c6cf-406c-8bef-4864b8258f87)

## Testing strategy
Tested with files of size smaller than 1024 bytes to no longer display the decimals.
Tested with files with at least 1024 bytes of size to still display two decimals in the list of attachments.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
