### PR TITLE
Passkeys: Fix duplicate database selection

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -666,7 +666,8 @@ QJsonObject BrowserService::showPasskeysRegisterPrompt(const QJsonObject& public
                               userId,
                               publicKeyCredentials.key);
         } else {
-            addPasskeyToGroup(nullptr,
+            addPasskeyToGroup(db,
+                              nullptr,
                               origin,
                               rpId,
                               rpName,
@@ -689,7 +690,7 @@ QJsonObject BrowserService::showPasskeysAuthenticationPrompt(const QJsonObject& 
                                                              const QString& origin,
                                                              const StringPairList& keyList)
 {
-    auto db = selectedDatabase();
+    auto db = getDatabase();
     if (!db) {
         return getPasskeyError(ERROR_KEEPASS_DATABASE_NOT_OPENED);
     }
@@ -738,7 +739,8 @@ QJsonObject BrowserService::showPasskeysAuthenticationPrompt(const QJsonObject& 
     return getPasskeyError(ERROR_PASSKEYS_REQUEST_CANCELED);
 }
 
-void BrowserService::addPasskeyToGroup(Group* group,
+void BrowserService::addPasskeyToGroup(const QSharedPointer<Database>& db,
+                                       Group* group,
                                        const QString& url,
                                        const QString& rpId,
                                        const QString& rpName,
@@ -749,7 +751,6 @@ void BrowserService::addPasskeyToGroup(Group* group,
 {
     // If no group provided, use the default browser group of the selected database
     if (!group) {
-        auto db = selectedDatabase();
         if (!db) {
             return;
         }

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -94,7 +94,8 @@ public:
     QJsonObject showPasskeysAuthenticationPrompt(const QJsonObject& publicKeyOptions,
                                                  const QString& origin,
                                                  const StringPairList& keyList);
-    void addPasskeyToGroup(Group* group,
+    void addPasskeyToGroup(const QSharedPointer<Database>& db,
+                           Group* group,
                            const QString& url,
                            const QString& rpId,
                            const QString& rpName,

--- a/src/gui/passkeys/PasskeyImporter.cpp
+++ b/src/gui/passkeys/PasskeyImporter.cpp
@@ -152,7 +152,7 @@ void PasskeyImporter::showImportDialog(QSharedPointer<Database>& database,
     }
 
     browserService()->addPasskeyToGroup(
-        group, url, relyingParty, relyingParty, username, credentialId, userHandle, privateKey);
+        db, group, url, relyingParty, relyingParty, username, credentialId, userHandle, privateKey);
 }
 
 Group* PasskeyImporter::getDefaultGroup(QSharedPointer<Database>& database) const


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Database selection is asked twice when registering new credentials when multiple databases are open, once in `showPasskeysRegisterPrompt()` and second time in `addPasskeyToGroup()`. Third time happens in `showPasskeysAuthenticationPrompt()` which is not necessary. Passkey entries are already returned from all connected databases.

Fixes #10602

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
- Open two databases, both connected.
- Register a new passkey -> two database selection dialogs are shown
- Authenticate it right away -> database selection dialog is shown again

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
