### PR TITLE
Fix issues with reloading and handling of externally modified db file

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2833,6 +2833,18 @@ Disable safe saves and try again?</source>
         <source>Unlock to reload</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Cannot save because the</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>database file &quot;%1&quot; was modified externally</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EditEntryWidget</name>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2782,67 +2782,39 @@ Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reloading database...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload aborted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reload OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Reload database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>How to proceed with your unsaved changes?</source>
+        <source>Reloading database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Merge all changes together</source>
+        <source>Reload canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Discard your changes</source>
+        <source>Reload successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ignore the changes in the file on disk</source>
+        <source>Reload pending user action…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>merged</source>
+        <source>The database file &quot;%1&quot; was modified externally.&lt;br&gt;How would you like to proceed?&lt;br&gt;&lt;br&gt;Merge all changes&lt;br&gt;Ignore the changes on disk until save&lt;br&gt;Discard unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>discarded</source>
+        <source>The database file &quot;%1&quot; was modified externally.&lt;br&gt;How would you like to proceed?&lt;br&gt;&lt;br&gt;Merge all changes then save&lt;br&gt;Overwrite the changes on disk&lt;br&gt;Discard unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Changes are %1</source>
+        <source>Database file overwritten.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Error: failed to open the database file for reload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unlock to reload</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cannot save because the</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>database file &quot;%1&quot; was modified externally</source>
+        <source>Database file on disk cannot be unlocked with current credentials.&lt;br&gt;Enter new credentials and/or present hardware key to continue.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1513,6 +1513,10 @@ Backup database located at %2</source>
         <source>Recycle Bin</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Database file read error.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseOpenDialog</name>
@@ -2684,24 +2688,6 @@ Save changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The database file has changed. Do you want to load the changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Merge Request</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The database file has changed and you have unsaved changes.
-Do you want to merge your changes?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Could not open the new database file while attempting to autoreload.
-Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Disable safe saves?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2785,6 +2771,66 @@ Disable safe saves and try again?</source>
     </message>
     <message>
         <source>Do you want to remove the passkey from this entry?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The database file &quot;%1&quot; was modified externally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to load the changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reloading database...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload aborted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reload database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How to proceed with your unsaved changes?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge all changes together</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard your changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore the changes in the file on disk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>merged</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>discarded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Changes are %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error: failed to open the database file for reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unlock to reload</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ set(core_SOURCES
         keys/PasswordKey.cpp
         keys/ChallengeResponseKey.cpp
         streams/HashedBlockStream.cpp
+        streams/HashingStream.cpp
         streams/HmacBlockStream.cpp
         streams/LayeredStream.cpp
         streams/qtiocompressor.cpp

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -63,8 +63,8 @@ Database::Database()
         updateTagList();
     });
     connect(this, &Database::modified, this, [this] { updateTagList(); });
-    connect(this, &Database::databaseSaved, this, [this]() { updateCommonUsernames(); });
-    connect(m_fileWatcher, &FileWatcher::fileChanged, this, [this] { emit Database::databaseFileChanged(false); });
+    connect(this, &Database::databaseSaved, this, [this] { updateCommonUsernames(); });
+    connect(m_fileWatcher, &FileWatcher::fileChanged, this, [this] { emit databaseFileChanged(false); });
 
     // static uuid map
     s_uuidMap.insert(m_uuid, this);

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -25,6 +25,7 @@
 #include "format/KdbxXmlReader.h"
 #include "format/KeePass2Reader.h"
 #include "format/KeePass2Writer.h"
+#include "streams/HashingStream.h"
 
 #include <QFileInfo>
 #include <QJsonObject>
@@ -63,7 +64,7 @@ Database::Database()
     });
     connect(this, &Database::modified, this, [this] { updateTagList(); });
     connect(this, &Database::databaseSaved, this, [this]() { updateCommonUsernames(); });
-    connect(m_fileWatcher, &FileWatcher::fileChanged, this, &Database::databaseFileChanged);
+    connect(m_fileWatcher, &FileWatcher::fileChanged, this, [this] { emit Database::databaseFileChanged(false); });
 
     // static uuid map
     s_uuidMap.insert(m_uuid, this);
@@ -150,6 +151,20 @@ bool Database::open(const QString& filePath, QSharedPointer<const CompositeKey> 
     }
 
     setEmitModified(false);
+
+    // update the hash of the first block
+    m_fileBlockHash.clear();
+    auto fileBlockData = dbFile.peek(kFileBlockToHashSizeBytes);
+    if (fileBlockData.size() != kFileBlockToHashSizeBytes) {
+        if (dbFile.size() >= kFileBlockToHashSizeBytes) {
+            if (error) {
+                *error = tr("Database file read error.");
+            }
+            return false;
+        }
+    } else {
+        m_fileBlockHash = QCryptographicHash::hash(fileBlockData, QCryptographicHash::Md5);
+    }
 
     KeePass2Reader reader;
     if (!reader.readDatabase(&dbFile, std::move(key), this)) {
@@ -260,14 +275,33 @@ bool Database::saveAs(const QString& filePath, SaveAction action, const QString&
         return false;
     }
 
-    if (filePath == m_data.filePath) {
-        // Fail-safe check to make sure we don't overwrite underlying file changes
-        // that have not yet triggered a file reload/merge operation.
-        if (!m_fileWatcher->hasSameFileChecksum()) {
-            if (error) {
-                *error = tr("Database file has unmerged changes.");
+    // Make sure we don't overwrite external modifications unless explicitly allowed
+    if (!m_ignoreFileChangesUntilSaved && !m_fileBlockHash.isEmpty() && filePath == m_data.filePath) {
+        QFile dbFile(filePath);
+        if (dbFile.exists()) {
+            if (!dbFile.open(QIODevice::ReadOnly)) {
+                if (error) {
+                    *error = tr("Unable to open file %1.").arg(filePath);
+                }
+                return false;
             }
-            return false;
+            auto fileBlockData = dbFile.read(kFileBlockToHashSizeBytes);
+            if (fileBlockData.size() == kFileBlockToHashSizeBytes) {
+                auto hash = QCryptographicHash::hash(fileBlockData, QCryptographicHash::Md5);
+                if (m_fileBlockHash != hash) {
+                    if (error) {
+                        *error = tr("Database file has unmerged changes.");
+                    }
+                    // emit the databaseFileChanged(true) signal async
+                    QMetaObject::invokeMethod(this, "databaseFileChanged", Qt::QueuedConnection, Q_ARG(bool, true));
+                    return false;
+                }
+            } else if (dbFile.size() >= kFileBlockToHashSizeBytes) {
+                if (error) {
+                    *error = tr("Database file read error.");
+                }
+                return false;
+            }
         }
     }
 
@@ -302,7 +336,7 @@ bool Database::saveAs(const QString& filePath, SaveAction action, const QString&
             SetFileAttributes(realFilePath.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN);
         }
 #endif
-
+        m_ignoreFileChangesUntilSaved = false;
         m_fileWatcher->start(realFilePath, 30, 1);
     } else {
         // Saving failed, don't rewatch file since it does not represent our database
@@ -325,8 +359,12 @@ bool Database::performSave(const QString& filePath, SaveAction action, const QSt
     case Atomic: {
         QSaveFile saveFile(filePath);
         if (saveFile.open(QIODevice::WriteOnly)) {
+            HashingStream hashingStream(&saveFile, QCryptographicHash::Md5, kFileBlockToHashSizeBytes);
+            if (!hashingStream.open(QIODevice::WriteOnly)) {
+                return false;
+            }
             // write the database to the file
-            if (!writeDatabase(&saveFile, error)) {
+            if (!writeDatabase(&hashingStream, error)) {
                 return false;
             }
 
@@ -334,6 +372,9 @@ bool Database::performSave(const QString& filePath, SaveAction action, const QSt
             saveFile.setFileTime(createTime, QFile::FileBirthTime);
 
             if (saveFile.commit()) {
+                // store the new hash
+                m_fileBlockHash = hashingStream.hashingResult();
+
                 // successfully saved database file
                 return true;
             }
@@ -347,8 +388,12 @@ bool Database::performSave(const QString& filePath, SaveAction action, const QSt
     case TempFile: {
         QTemporaryFile tempFile;
         if (tempFile.open()) {
+            HashingStream hashingStream(&tempFile, QCryptographicHash::Md5, kFileBlockToHashSizeBytes);
+            if (!hashingStream.open(QIODevice::WriteOnly)) {
+                return false;
+            }
             // write the database to the file
-            if (!writeDatabase(&tempFile, error)) {
+            if (!writeDatabase(&hashingStream, error)) {
                 return false;
             }
             tempFile.close(); // flush to disk
@@ -366,6 +411,8 @@ bool Database::performSave(const QString& filePath, SaveAction action, const QSt
                 QFile::setPermissions(filePath, perms);
                 // Retain original creation time
                 tempFile.setFileTime(createTime, QFile::FileBirthTime);
+                // store the new hash
+                m_fileBlockHash = hashingStream.hashingResult();
                 return true;
             } else if (backupFilePath.isEmpty() || !restoreDatabase(filePath, backupFilePath)) {
                 // Failed to copy new database in place, and
@@ -387,10 +434,16 @@ bool Database::performSave(const QString& filePath, SaveAction action, const QSt
         // Open the original database file for direct-write
         QFile dbFile(filePath);
         if (dbFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-            if (!writeDatabase(&dbFile, error)) {
+            HashingStream hashingStream(&dbFile, QCryptographicHash::Md5, kFileBlockToHashSizeBytes);
+            if (!hashingStream.open(QIODevice::WriteOnly)) {
+                return false;
+            }
+            if (!writeDatabase(&hashingStream, error)) {
                 return false;
             }
             dbFile.close();
+            // store the new hash
+            m_fileBlockHash = hashingStream.hashingResult();
             return true;
         }
         if (error) {
@@ -508,6 +561,9 @@ void Database::releaseData()
     m_deletedObjects.clear();
     m_commonUsernames.clear();
     m_tagList.clear();
+
+    m_fileBlockHash.clear();
+    m_ignoreFileChangesUntilSaved = false;
 }
 
 /**
@@ -644,8 +700,31 @@ void Database::setFilePath(const QString& filePath)
         m_data.filePath = filePath;
         // Don't watch for changes until the next open or save operation
         m_fileWatcher->stop();
+        m_ignoreFileChangesUntilSaved = false;
         emit filePathChanged(oldPath, filePath);
     }
+}
+
+const QByteArray& Database::fileBlockHash() const
+{
+    return m_fileBlockHash;
+}
+
+void Database::setIgnoreFileChangesUntilSaved(bool ignore)
+{
+    if (m_ignoreFileChangesUntilSaved != ignore) {
+        m_ignoreFileChangesUntilSaved = ignore;
+        if (ignore) {
+            m_fileWatcher->pause();
+        } else {
+            m_fileWatcher->resume();
+        }
+    }
+}
+
+bool Database::ignoreFileChangesUntilSaved() const
+{
+    return m_ignoreFileChangesUntilSaved;
 }
 
 QList<DeletedObject> Database::deletedObjects()

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -75,6 +75,9 @@ public:
     ~Database() override;
 
 private:
+    // size of the block of file data to hash for detecting external changes
+    static const quint32 kFileBlockToHashSizeBytes = 1024; // 1 KiB
+
     bool writeDatabase(QIODevice* device, QString* error = nullptr);
     bool backupDatabase(const QString& filePath, const QString& destinationFilePath);
     bool restoreDatabase(const QString& filePath, const QString& fromBackupFilePath);
@@ -107,6 +110,10 @@ public:
     QString filePath() const;
     QString canonicalFilePath() const;
     void setFilePath(const QString& filePath);
+
+    const QByteArray& fileBlockHash() const;
+    void setIgnoreFileChangesUntilSaved(bool ignore);
+    bool ignoreFileChangesUntilSaved() const;
 
     QString publicName();
     void setPublicName(const QString& name);
@@ -181,7 +188,7 @@ signals:
     void databaseOpened();
     void databaseSaved();
     void databaseDiscarded();
-    void databaseFileChanged();
+    void databaseFileChanged(bool triggeredBySave);
     void databaseNonDataChanged();
     void tagListUpdated();
 
@@ -233,6 +240,8 @@ private:
     void startModifiedTimer();
     void stopModifiedTimer();
 
+    QByteArray m_fileBlockHash;
+    bool m_ignoreFileChangesUntilSaved;
     QPointer<Metadata> const m_metadata;
     DatabaseData m_data;
     QPointer<Group> m_rootGroup;

--- a/src/core/FileWatcher.cpp
+++ b/src/core/FileWatcher.cpp
@@ -119,7 +119,7 @@ void FileWatcher::checkFileChanged()
 
     AsyncTask::runThenCallback([this] { return calculateChecksum(); },
                                this,
-                               [this](QByteArray checksum) {
+                               [this](const QByteArray& checksum) {
                                    if (checksum != m_fileChecksum) {
                                        m_fileChecksum = checksum;
                                        m_fileChangeDelayTimer.start(0);

--- a/src/core/FileWatcher.cpp
+++ b/src/core/FileWatcher.cpp
@@ -79,17 +79,18 @@ void FileWatcher::stop()
     m_fileChecksum.clear();
     m_fileChecksumTimer.stop();
     m_fileChangeDelayTimer.stop();
+    m_paused = false;
 }
 
 void FileWatcher::pause()
 {
-    m_ignoreFileChange = true;
+    m_paused = true;
     m_fileChangeDelayTimer.stop();
 }
 
 void FileWatcher::resume()
 {
-    m_ignoreFileChange = false;
+    m_paused = false;
     // Add a short delay to start in the next event loop
     if (!m_fileIgnoreDelayTimer.isActive()) {
         m_fileIgnoreDelayTimer.start(0);
@@ -98,7 +99,7 @@ void FileWatcher::resume()
 
 bool FileWatcher::shouldIgnoreChanges()
 {
-    return m_filePath.isEmpty() || m_ignoreFileChange || m_fileIgnoreDelayTimer.isActive()
+    return m_filePath.isEmpty() || m_ignoreFileChange || m_paused || m_fileIgnoreDelayTimer.isActive()
            || m_fileChangeDelayTimer.isActive();
 }
 

--- a/src/core/FileWatcher.h
+++ b/src/core/FileWatcher.h
@@ -56,6 +56,7 @@ private:
     QTimer m_fileChecksumTimer;
     int m_fileChecksumSizeBytes = -1;
     bool m_ignoreFileChange = false;
+    bool m_paused = false;
 };
 
 #endif // KEEPASSXC_FILEWATCHER_H

--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -192,9 +192,32 @@ void DatabaseOpenDialog::clearForms()
     m_tabBar->blockSignals(false);
 }
 
+void DatabaseOpenDialog::showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout)
+{
+    m_view->showMessage(text, type, autoHideTimeout);
+}
+
 QSharedPointer<Database> DatabaseOpenDialog::database() const
 {
     return m_db;
+}
+
+void DatabaseOpenDialog::done(int result)
+{
+    hide();
+
+    emit dialogFinished(result == QDialog::Accepted, m_currentDbWidget);
+    clearForms();
+
+    QDialog::done(result);
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
+    // CDialogs are not really closed, just hidden, pre Qt 6.3?
+    if (testAttribute(Qt::WA_DeleteOnClose)) {
+        setAttribute(Qt::WA_DeleteOnClose, false);
+        deleteLater();
+    }
+#endif
 }
 
 void DatabaseOpenDialog::complete(bool accepted)
@@ -210,9 +233,6 @@ void DatabaseOpenDialog::complete(bool accepted)
     } else {
         reject();
     }
-
-    emit dialogFinished(accepted, m_currentDbWidget);
-    clearForms();
 }
 
 void DatabaseOpenDialog::closeEvent(QCloseEvent* e)

--- a/src/gui/DatabaseOpenDialog.h
+++ b/src/gui/DatabaseOpenDialog.h
@@ -19,6 +19,7 @@
 #define KEEPASSX_UNLOCKDATABASEDIALOG_H
 
 #include "core/Global.h"
+#include "gui/MessageWidget.h"
 
 #include <QDialog>
 #include <QList>
@@ -51,11 +52,13 @@ public:
     Intent intent() const;
     QSharedPointer<Database> database() const;
     void clearForms();
+    void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);
 
 signals:
     void dialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
 public slots:
+    void done(int result) override;
     void complete(bool accepted);
     void tabChanged(int index);
 

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -220,6 +220,11 @@ bool DatabaseOpenWidget::unlockingDatabase()
     return m_unlockingDatabase;
 }
 
+void DatabaseOpenWidget::showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout)
+{
+    m_ui->messageWidget->showMessage(text, type, autoHideTimeout);
+}
+
 void DatabaseOpenWidget::load(const QString& filename)
 {
     clearForms();

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -25,6 +25,7 @@
 
 #include "config-keepassx.h"
 #include "gui/DialogyWidget.h"
+#include "gui/MessageWidget.h"
 #ifdef WITH_XC_YUBIKEY
 #include "osutils/DeviceListener.h"
 #endif
@@ -51,6 +52,7 @@ public:
     void enterKey(const QString& pw, const QString& keyFile);
     QSharedPointer<Database> database();
     bool unlockingDatabase();
+    void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);
 
     // Quick Unlock helper functions
     bool canPerformQuickUnlock() const;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -2213,17 +2213,18 @@ void DatabaseWidget::reloadDatabaseFile(bool triggeredBySave)
     if (triggeredBySave || m_db->isModified() || m_db->hasNonDataChanges()) {
         // Ask how to proceed
         auto prefix = triggeredBySave ? tr("Cannot save because the") : tr("The");
-        auto result = MessageBox::question(
-            this,
-            tr("Reload database"),
-            QString("%1 %2.\n%3\n\n%4.\n%5.\n%6.").arg(
-                prefix, tr("database file \"%1\" was modified externally").arg(displayFileName()),
-                tr("How to proceed with your unsaved changes?"),
-                tr("Merge all changes together"),
-                tr("Discard your changes"),
-                tr("Ignore the changes in the file on disk")),
-            MessageBox::Merge | MessageBox::Discard | MessageBox::Ignore | MessageBox::Cancel,
-            MessageBox::Merge);
+        auto result =
+            MessageBox::question(this,
+                                 tr("Reload database"),
+                                 QString("%1 %2.\n%3\n\n%4.\n%5.\n%6.")
+                                     .arg(prefix,
+                                          tr("database file \"%1\" was modified externally").arg(displayFileName()),
+                                          tr("How to proceed with your unsaved changes?"),
+                                          tr("Merge all changes together"),
+                                          tr("Discard your changes"),
+                                          tr("Ignore the changes in the file on disk")),
+                                 MessageBox::Merge | MessageBox::Discard | MessageBox::Ignore | MessageBox::Cancel,
+                                 MessageBox::Merge);
 
         if (result == MessageBox::Cancel) {
             reloadAbort();
@@ -2249,15 +2250,14 @@ void DatabaseWidget::reloadDatabaseFile(bool triggeredBySave)
     // the user needs to provide credentials
     auto dbWidget = new DatabaseWidget(std::move(db));
     auto openDialog = new DatabaseOpenDialog(this);
-    QObject::connect(openDialog, &QObject::destroyed, [=](QObject*) { dbWidget->deleteLater(); });
-    QObject::connect(
-        openDialog, &DatabaseOpenDialog::dialogFinished, this, [=](bool accepted, DatabaseWidget* dbWidget) {
-            if (accepted) {
-                reloadContinue(openDialog->database(), merge);
-            } else {
-                reloadAbort();
-            }
-        });
+    connect(openDialog, &QObject::destroyed, [=](QObject*) { dbWidget->deleteLater(); });
+    connect(openDialog, &DatabaseOpenDialog::dialogFinished, this, [=](bool accepted, DatabaseWidget*) {
+        if (accepted) {
+            reloadContinue(openDialog->database(), merge);
+        } else {
+            reloadAbort();
+        }
+    });
     openDialog->setAttribute(Qt::WA_DeleteOnClose); // free the memory on close
     openDialog->addDatabaseTab(dbWidget);
     openDialog->setActiveDatabaseTab(dbWidget);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -225,6 +225,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     connectDatabaseSignals();
 
     m_blockAutoSave = false;
+    m_reloading = false;
 
     m_autosaveTimer = new QTimer(this);
     m_autosaveTimer->setSingleShot(true);
@@ -1984,6 +1985,11 @@ bool DatabaseWidget::lock()
         return isLocked();
     }
 
+    // ignore when reloading
+    if (m_reloading) {
+        return false;
+    }
+
     // Don't try to lock the database while saving, this will cause a deadlock
     if (m_db->isSaving()) {
         QTimer::singleShot(200, this, SLOT(lock()));
@@ -2027,6 +2033,18 @@ bool DatabaseWidget::lock()
         if (config()->get(Config::AutoSaveOnExit).toBool()
             || config()->get(Config::AutoSaveAfterEveryChange).toBool()) {
             saved = save();
+
+            if (!saved) {
+                // detect if a reload was triggered
+                bool reloadTriggered = false;
+                auto connection =
+                    connect(this, &DatabaseWidget::reloadBegin, [&reloadTriggered] { reloadTriggered = true; });
+                QApplication::processEvents();
+                disconnect(connection);
+                if (reloadTriggered) {
+                    return false;
+                }
+            }
         }
 
         if (!saved) {
@@ -2085,28 +2103,43 @@ bool DatabaseWidget::lock()
     return true;
 }
 
-void DatabaseWidget::reloadDatabaseFile()
+void DatabaseWidget::reloadDatabaseFile(bool triggeredBySave)
 {
-    // Ignore reload if we are locked, saving, or currently editing an entry or group
-    if (!m_db || isLocked() || isEntryEditActive() || isGroupEditActive() || isSaving()) {
+    if (triggeredBySave) {
+        // not a failed save attempt due to file locking
+        m_saveAttempts = 0;
+    }
+    // Ignore reload if we are locked, saving, reloading, or currently editing an entry or group
+    if (!m_db || isLocked() || isEntryEditActive() || isGroupEditActive() || isSaving() || m_reloading) {
         return;
     }
 
     m_blockAutoSave = true;
+    m_reloading = true;
 
-    if (!config()->get(Config::AutoReloadOnChange).toBool()) {
+    emit reloadBegin();
+
+    if (!triggeredBySave && !config()->get(Config::AutoReloadOnChange).toBool()) {
         // Ask if we want to reload the db
-        auto result = MessageBox::question(this,
-                                           tr("File has changed"),
-                                           tr("The database file has changed. Do you want to load the changes?"),
-                                           MessageBox::Yes | MessageBox::No);
+        auto result = MessageBox::question(
+            this,
+            tr("File has changed"),
+            QString("%1.\n%2").arg(tr("The database file \"%1\" was modified externally").arg(displayFileName()),
+                                   tr("Do you want to load the changes?")),
+            MessageBox::Yes | MessageBox::No);
 
         if (result == MessageBox::No) {
             // Notify everyone the database does not match the file
             m_db->markAsModified();
+            m_reloading = false;
+
+            emit reloadEnd();
             return;
         }
     }
+
+    // notify
+    showMessage(tr("Reloading database..."), MessageWidget::Information, false, MessageWidget::DisableAutoHide);
 
     // Lock out interactions
     m_entryView->setDisabled(true);
@@ -2114,23 +2147,32 @@ void DatabaseWidget::reloadDatabaseFile()
     m_tagView->setDisabled(true);
     QApplication::processEvents();
 
-    QString error;
-    auto db = QSharedPointer<Database>::create(m_db->filePath());
-    if (db->open(database()->key(), &error)) {
-        if (m_db->isModified() || db->hasNonDataChanges()) {
-            // Ask if we want to merge changes into new database
-            auto result = MessageBox::question(
-                this,
-                tr("Merge Request"),
-                tr("The database file has changed and you have unsaved changes.\nDo you want to merge your changes?"),
-                MessageBox::Merge | MessageBox::Discard,
-                MessageBox::Merge);
+    auto reloadFinish = [this](bool hideMsg = true) {
+        // Return control
+        m_entryView->setDisabled(false);
+        m_groupView->setDisabled(false);
+        m_tagView->setDisabled(false);
 
-            if (result == MessageBox::Merge) {
-                // Merge the old database into the new one
-                Merger merger(m_db.data(), db.data());
-                merger.merge();
-            }
+        m_reloading = false;
+
+        if (hideMsg) {
+            hideMessage();
+        }
+
+        emit reloadEnd();
+    };
+    auto reloadAbort = [this, reloadFinish] {
+        // Mark db as modified since existing data may differ from file or file was deleted
+        m_db->markAsModified();
+
+        showMessage(tr("Reload aborted"), MessageWidget::Warning);
+        reloadFinish(false);
+    };
+    auto reloadContinue = [this, reloadFinish](QSharedPointer<Database> db, bool merge) {
+        if (merge) {
+            // Merge the old database into the new one
+            Merger merger(m_db.data(), db.data());
+            merger.merge();
         }
 
         QUuid groupBeforeReload = m_db->rootGroup()->uuid();
@@ -2147,17 +2189,93 @@ void DatabaseWidget::reloadDatabaseFile()
         processAutoOpen();
         restoreGroupEntryFocus(groupBeforeReload, entryBeforeReload);
         m_blockAutoSave = false;
-    } else {
-        showMessage(tr("Could not open the new database file while attempting to autoreload.\nError: %1").arg(error),
-                    MessageWidget::Error);
-        // Mark db as modified since existing data may differ from file or file was deleted
-        m_db->markAsModified();
+
+        showMessage(tr("Reload OK"), MessageWidget::Positive);
+        reloadFinish(false);
+    };
+
+    auto db = QSharedPointer<Database>::create(m_db->filePath());
+    bool openResult = db->open(database()->key());
+
+    // skip if the db is unchanged, or the db file is gone or for sure not a kp-db
+    if (bool sameHash = db->fileBlockHash() == m_db->fileBlockHash() || db->fileBlockHash().isEmpty()) {
+        if (!sameHash) {
+            // db file gone or invalid so mark modified
+            m_db->markAsModified();
+        }
+        m_blockAutoSave = false;
+        reloadFinish();
+        return;
     }
 
-    // Return control
-    m_entryView->setDisabled(false);
-    m_groupView->setDisabled(false);
-    m_tagView->setDisabled(false);
+    bool merge = false;
+    QString changesActionStr;
+    if (triggeredBySave || m_db->isModified() || m_db->hasNonDataChanges()) {
+        // Ask how to proceed
+        auto prefix = triggeredBySave ? tr("Cannot save because the") : tr("The");
+        auto result = MessageBox::question(
+            this,
+            tr("Reload database"),
+            QString("%1 %2.\n%3\n\n%4.\n%5.\n%6.").arg(
+                prefix, tr("database file \"%1\" was modified externally").arg(displayFileName()),
+                tr("How to proceed with your unsaved changes?"),
+                tr("Merge all changes together"),
+                tr("Discard your changes"),
+                tr("Ignore the changes in the file on disk")),
+            MessageBox::Merge | MessageBox::Discard | MessageBox::Ignore | MessageBox::Cancel,
+            MessageBox::Merge);
+
+        if (result == MessageBox::Cancel) {
+            reloadAbort();
+            return;
+        } else if (result == MessageBox::Ignore) {
+            m_db->setIgnoreFileChangesUntilSaved(true);
+            m_blockAutoSave = false;
+            reloadFinish();
+            return;
+        } else if (result == MessageBox::Merge) {
+            changesActionStr = tr("merged");
+            merge = true;
+        } else {
+            changesActionStr = tr("discarded");
+        }
+    }
+
+    if (openResult) {
+        reloadContinue(std::move(db), merge);
+        return;
+    }
+
+    // the user needs to provide credentials
+    auto dbWidget = new DatabaseWidget(std::move(db));
+    auto openDialog = new DatabaseOpenDialog(this);
+    QObject::connect(openDialog, &QObject::destroyed, [=](QObject*) { dbWidget->deleteLater(); });
+    QObject::connect(
+        openDialog, &DatabaseOpenDialog::dialogFinished, this, [=](bool accepted, DatabaseWidget* dbWidget) {
+            if (accepted) {
+                reloadContinue(openDialog->database(), merge);
+            } else {
+                reloadAbort();
+            }
+        });
+    openDialog->setAttribute(Qt::WA_DeleteOnClose); // free the memory on close
+    openDialog->addDatabaseTab(dbWidget);
+    openDialog->setActiveDatabaseTab(dbWidget);
+    if (!changesActionStr.isEmpty()) {
+        changesActionStr = QString("   [%1]").arg(tr("Changes are %1").arg(changesActionStr));
+    }
+    openDialog->showMessage(
+        QString("%1.\n%2%3")
+            .arg(tr("Error: failed to open the database file for reload"), tr("Unlock to reload"), changesActionStr),
+        MessageWidget::Error,
+        MessageWidget::DisableAutoHide);
+
+    // ensure the main window is visible for this
+    getMainWindow()->bringToFront();
+    // show the unlock dialog
+    openDialog->show();
+    openDialog->raise();
+    openDialog->activateWindow();
 }
 
 int DatabaseWidget::numberOfSelectedEntries() const
@@ -2320,6 +2438,11 @@ bool DatabaseWidget::save()
         return true;
     }
 
+    // Do no try to save if the database is being reloaded
+    if (m_reloading) {
+        return false;
+    }
+
     // Read-only and new databases ask for filename
     if (m_db->filePath().isEmpty()) {
         return saveAs();
@@ -2373,6 +2496,11 @@ bool DatabaseWidget::saveAs()
     if (isLocked()) {
         // We return true since a save is not required
         return true;
+    }
+
+    // Do no try to save if the database is being reloaded
+    if (m_reloading) {
+        return false;
     }
 
     QString oldFilePath = m_db->filePath();

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -170,6 +170,8 @@ signals:
     void clearSearch();
     void requestGlobalAutoType(const QString& search);
     void requestSearch(const QString& search);
+    void reloadBegin();
+    void reloadEnd();
 
 public slots:
     bool lock();
@@ -287,7 +289,7 @@ private slots:
     void finishSync(const RemoteParams* params, RemoteHandler::RemoteResult result);
     void emitCurrentModeChanged();
     // Database autoreload slots
-    void reloadDatabaseFile();
+    void reloadDatabaseFile(bool triggeredBySave);
     void restoreGroupEntryFocus(const QUuid& groupUuid, const QUuid& EntryUuid);
     void onConfigChanged(Config::ConfigKey key);
 
@@ -338,6 +340,7 @@ private:
 
     // Autoreload
     bool m_blockAutoSave;
+    bool m_reloading;
 
     // Autosave delay
     QPointer<QTimer> m_autosaveTimer;

--- a/src/streams/HashingStream.cpp
+++ b/src/streams/HashingStream.cpp
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "HashingStream.h"
+
+HashingStream::HashingStream(QIODevice* baseDevice)
+    : LayeredStream(baseDevice)
+    , m_hash(QCryptographicHash::Md5)
+    , m_sizeToHash(0)
+{
+    init();
+}
+
+HashingStream::HashingStream(QIODevice* baseDevice, QCryptographicHash::Algorithm hashAlgo, qint64 sizeToHash)
+    : LayeredStream(baseDevice)
+    , m_hash(hashAlgo)
+    , m_sizeToHash(sizeToHash)
+{
+    init();
+}
+
+HashingStream::~HashingStream()
+{
+    close();
+}
+
+void HashingStream::init()
+{
+    m_sizeHashed = 0;
+    m_sizeStreamed = 0;
+    m_hashFinalized = false;
+}
+
+bool HashingStream::reset()
+{
+    init();
+    m_hash.reset();
+    return LayeredStream::reset();
+}
+
+QByteArray HashingStream::hashingResult()
+{
+    if (m_sizeHashed <= 0 || (m_sizeToHash > 0 && m_sizeHashed != m_sizeToHash)) {
+        setErrorString("Not enough data to compute hash");
+        return {};
+    }
+    m_hashFinalized = true;
+    return m_hash.result();
+}
+
+qint64 HashingStream::readData(char* data, qint64 maxSize)
+{
+    auto sizeRead = LayeredStream::readData(data, maxSize);
+    if (sizeRead > 0) {
+        if (!m_hashFinalized) {
+            qint64 sizeToHash = sizeRead;
+            if (m_sizeToHash > 0) {
+                sizeToHash = qMin(m_sizeToHash - m_sizeStreamed, sizeRead);
+            }
+            if (sizeToHash > 0) {
+                m_hash.addData(data, sizeToHash);
+                m_sizeHashed += sizeToHash;
+            }
+        }
+        m_sizeStreamed += sizeRead;
+    }
+    return sizeRead;
+}
+
+qint64 HashingStream::writeData(const char* data, qint64 maxSize)
+{
+    auto sizeWritten = LayeredStream::writeData(data, maxSize);
+    if (sizeWritten > 0) {
+        if (!m_hashFinalized) {
+            qint64 sizeToHash = sizeWritten;
+            if (m_sizeToHash > 0) {
+                sizeToHash = qMin(m_sizeToHash - m_sizeStreamed, sizeWritten);
+            }
+            if (sizeToHash > 0) {
+                m_hash.addData(data, sizeToHash);
+                m_sizeHashed += sizeToHash;
+            }
+        }
+        m_sizeStreamed += sizeWritten;
+    }
+    return sizeWritten;
+}

--- a/src/streams/HashingStream.h
+++ b/src/streams/HashingStream.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_HASHINGSTREAM_H
+#define KEEPASSX_HASHINGSTREAM_H
+
+#include <QCryptographicHash>
+
+#include "streams/LayeredStream.h"
+
+class HashingStream : public LayeredStream
+{
+    Q_OBJECT
+
+public:
+    explicit HashingStream(QIODevice* baseDevice);
+    HashingStream(QIODevice* baseDevice, QCryptographicHash::Algorithm hashAlgo, qint64 sizeToHash);
+    ~HashingStream() override;
+
+    bool reset() override;
+
+    QByteArray hashingResult();
+
+protected:
+    void init();
+
+    qint64 readData(char* data, qint64 maxSize) override;
+    qint64 writeData(const char* data, qint64 maxSize) override;
+
+protected:
+    QCryptographicHash m_hash;
+    bool m_hashFinalized;
+    qint64 m_sizeToHash;
+    qint64 m_sizeHashed;
+    qint64 m_sizeStreamed;
+};
+
+#endif // KEEPASSX_HASHINGSTREAM_H

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -164,7 +164,7 @@ void TestDatabase::testSignals()
     // Short delay to allow file system settling to reduce test failures
     Tools::wait(100);
 
-    QSignalSpy spyFileChanged(db.data(), SIGNAL(databaseFileChanged()));
+    QSignalSpy spyFileChanged(db.data(), &Database::databaseFileChanged);
     QVERIFY(tempFile.copyFromFile(dbFileName));
     QTRY_COMPARE(spyFileChanged.count(), 1);
     QTRY_VERIFY(!db->isModified());
@@ -267,4 +267,42 @@ void TestDatabase::testCustomIcons()
     QCOMPARE(iconData.data, icon2);
     QCOMPARE(iconData.name, QString("Test"));
     QCOMPARE(iconData.lastModified, date);
+}
+
+void TestDatabase::testExternallyModified()
+{
+    TemporaryFile tempFile;
+    QVERIFY(tempFile.copyFromFile(dbFileName));
+
+    auto db = QSharedPointer<Database>::create();
+    auto key = QSharedPointer<CompositeKey>::create();
+    key->addKey(QSharedPointer<PasswordKey>::create("a"));
+
+    QString error;
+    QVERIFY(db->open(tempFile.fileName(), key, &error) == true);
+    db->metadata()->setName("test2");
+    QVERIFY(db->save(Database::Atomic, {}, &error));
+
+    QSignalSpy spyFileChanged(db.data(), &Database::databaseFileChanged);
+    QVERIFY(tempFile.copyFromFile(dbFileName));
+    QTRY_COMPARE(spyFileChanged.count(), 1);
+    // the first argument of the databaseFileChanged signal (triggeredBySave) should be false
+    QVERIFY(spyFileChanged.at(0).length() == 1);
+    QVERIFY(spyFileChanged.at(0).at(0).type() == QVariant::Bool);
+    QVERIFY(spyFileChanged.at(0).at(0).toBool() == false);
+    spyFileChanged.clear();
+    // shouldn't be able to save due to external changes
+    QVERIFY(db->save(Database::Atomic, {}, &error) == false);
+    QApplication::processEvents();
+    // save should have triggered another databaseFileChanged signal
+    QVERIFY(spyFileChanged.count() >= 1);
+    // the first argument of the databaseFileChanged signal (triggeredBySave) should be true
+    QVERIFY(spyFileChanged.at(0).at(0).type() == QVariant::Bool);
+    QVERIFY(spyFileChanged.at(0).at(0).toBool() == true);
+
+    // should be able to overwrite externally modified changes when explicitly requested
+    db->setIgnoreFileChangesUntilSaved(true);
+    QVERIFY(db->save(Database::Atomic, {}, &error));
+    // ignoreFileChangesUntilSaved should reset after save
+    QVERIFY(db->ignoreFileChangesUntilSaved() == false);
 }

--- a/tests/TestDatabase.h
+++ b/tests/TestDatabase.h
@@ -36,6 +36,7 @@ private slots:
     void testEmptyRecycleBinOnEmpty();
     void testEmptyRecycleBinWithHierarchicalData();
     void testCustomIcons();
+    void testExternallyModified();
 };
 
 #endif // KEEPASSX_TESTDATABASE_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


Based on the discussion of issue #5290 and analyses, I've come to the following list of issues.
- **Reloading is one-shot. If it is not completed successfully there is no mechanism to retry**:
Some scenarios where a reload will not complete successfully.
  - If the user is busy editing a group/entry the reload is ignored.
  - The user has auto-reload disabled and chooses "No" upon being asked to load the external changes. 
  - The db file could not be opened with the same key used to open the db:
    - The YubiKey is not inserted 
    - A different YubiKey is inserted (programmed with the same secret)
    - The window for touching the YubiKey was missed
    - The keys of the db file have changed (password changed, YubiKey added/removed, ...)
- **Overwriting a db file that was modified externally should not be possible (unless explicitly requested)**:
There is code in place that is supposed to protect against this but it doesn't function as intended.
https://github.com/keepassxreboot/keepassxc/blob/6f114226040917e07dd552d82cc5118db2e1d284/src/core/Database.cpp#L266
https://github.com/keepassxreboot/keepassxc/blob/6f114226040917e07dd552d82cc5118db2e1d284/src/core/FileWatcher.cpp#L107
https://github.com/keepassxreboot/keepassxc/blob/6f114226040917e07dd552d82cc5118db2e1d284/src/core/FileWatcher.cpp#L119-L125
The current hash of the file is directly saved in `m_fileChecksum` upon detecting the change.
The fail-safe check therefore only works as intended in the short window that the file was modified on disk but was not picked up by FileWatcher yet.
- **There is no way to provide other keys for reloading a db file**:
When keys of the db file have changed (password changed, YubiKey added/removed, ...). there should be a way to enter them.

This PR aims to address these issues.

### Changes ###

- Cannot overwrite an externally modified db file unless requested.
- Trying to save (overwrite) an externally modified db file will trigger a reload, serving as retry mechanism.
   In the case where the user has auto-reload disabled they will not see the "File changed - Want to reload?" dialog but can make a choice at the "Reload database" dialog (see screenshot).
- An additional choice is added to the previously known "Merge Request" dialog, now "Reload database" dialog (see screenshot), to allow the user to ignore the changes in the file on disk (and overwrite the file).
- If during the reload the db could not be opened with the original key (due to missing YubiKey etc..) the user is presented with the "Unlock Database" dialog (see screenshot).

Fixes #5290 
Fixes #9062
Fixes #8545 

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![reload_db_unsaved_changes](https://github.com/keepassxreboot/keepassxc/assets/85685555/9a9437a1-c566-4c70-be7d-bff92fae93ef)

![reload_db_unlock_dlg](https://github.com/keepassxreboot/keepassxc/assets/85685555/cd07501b-1135-4dce-8f1f-1ad50675aeb8)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added test-case to TestDatabase.
Manual testing.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
