### PR TITLE
Fix SSH Agent broken decrypt button

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2669,6 +2669,10 @@ Would you like to correct it?</source>
             <numerusform></numerusform>
         </translation>
     </message>
+    <message>
+        <source>(comment is encrypted)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EditEntryWidgetAdvanced</name>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2557,10 +2557,6 @@ Disable safe saves and try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(encrypted)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Select private key</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2668,10 +2664,6 @@ Would you like to correct it?</source>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
-    </message>
-    <message>
-        <source>(comment is encrypted)</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6206,6 +6198,10 @@ We recommend you use the AppImage available on our downloads page.</source>
     </message>
     <message>
         <source>Unexpected EOF when writing private key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(encrypted)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2665,6 +2665,10 @@ Would you like to correct it?</source>
             <numerusform></numerusform>
         </translation>
     </message>
+    <message>
+        <source>Failed to decrypt SSH key, ensure password is correct.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EditEntryWidgetAdvanced</name>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -661,23 +661,19 @@ void EditEntryWidget::updateSSHAgentKeyInfo()
     if (!key.fingerprint().isEmpty()) {
         m_sshAgentUi->fingerprintTextLabel->setText(key.fingerprint(QCryptographicHash::Md5) + "\n"
                                                     + key.fingerprint(QCryptographicHash::Sha256));
-    } else {
-        m_sshAgentUi->fingerprintTextLabel->setText(tr("(encrypted)"));
     }
 
     if (!key.comment().isEmpty()) {
         m_sshAgentUi->commentTextLabel->setText(key.comment());
-    } else if (key.encrypted()) {
-        m_sshAgentUi->commentTextLabel->setText(tr("(encrypted)"));
+    }
+
+    if (key.encrypted()) {
         m_sshAgentUi->decryptButton->setEnabled(true);
     }
 
-    if (!key.publicKey().isEmpty() && !key.encrypted()) {
+    if (!key.publicKey().isEmpty()) {
         m_sshAgentUi->publicKeyEdit->document()->setPlainText(key.publicKey());
         m_sshAgentUi->copyToClipboardButton->setEnabled(true);
-    } else {
-        m_sshAgentUi->publicKeyEdit->document()->setPlainText(key.publicKey() + tr("(comment is encrypted)"));
-        m_sshAgentUi->copyToClipboardButton->setDisabled(true);
     }
 
     // enable agent buttons only if we have an agent running

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -665,18 +665,18 @@ void EditEntryWidget::updateSSHAgentKeyInfo()
         m_sshAgentUi->fingerprintTextLabel->setText(tr("(encrypted)"));
     }
 
-    if (!key.comment().isEmpty() || !key.encrypted()) {
+    if (!key.comment().isEmpty()) {
         m_sshAgentUi->commentTextLabel->setText(key.comment());
-    } else {
+    } else if (key.encrypted()) {
         m_sshAgentUi->commentTextLabel->setText(tr("(encrypted)"));
         m_sshAgentUi->decryptButton->setEnabled(true);
     }
 
-    if (!key.publicKey().isEmpty()) {
+    if (!key.publicKey().isEmpty() && !key.encrypted()) {
         m_sshAgentUi->publicKeyEdit->document()->setPlainText(key.publicKey());
         m_sshAgentUi->copyToClipboardButton->setEnabled(true);
     } else {
-        m_sshAgentUi->publicKeyEdit->document()->setPlainText(tr("(encrypted)"));
+        m_sshAgentUi->publicKeyEdit->document()->setPlainText(key.publicKey() + tr("(comment is encrypted)"));
         m_sshAgentUi->copyToClipboardButton->setDisabled(true);
     }
 

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -667,9 +667,7 @@ void EditEntryWidget::updateSSHAgentKeyInfo()
         m_sshAgentUi->commentTextLabel->setText(key.comment());
     }
 
-    if (key.encrypted()) {
-        m_sshAgentUi->decryptButton->setEnabled(true);
-    }
+    m_sshAgentUi->decryptButton->setEnabled(key.encrypted());
 
     if (!key.publicKey().isEmpty()) {
         m_sshAgentUi->publicKeyEdit->document()->setPlainText(key.publicKey());
@@ -787,6 +785,7 @@ void EditEntryWidget::decryptPrivateKey()
     OpenSSHKey key;
 
     if (!getOpenSSHKey(key, true)) {
+        showMessage(tr("Failed to decrypt SSH key, ensure password is correct."), MessageWidget::Error);
         return;
     }
 
@@ -800,6 +799,7 @@ void EditEntryWidget::decryptPrivateKey()
                                                 + key.fingerprint(QCryptographicHash::Sha256));
     m_sshAgentUi->publicKeyEdit->document()->setPlainText(key.publicKey());
     m_sshAgentUi->copyToClipboardButton->setEnabled(true);
+    m_sshAgentUi->decryptButton->setEnabled(false);
 }
 
 void EditEntryWidget::copyPublicKey()

--- a/src/sshagent/KeeAgentSettings.cpp
+++ b/src/sshagent/KeeAgentSettings.cpp
@@ -489,11 +489,11 @@ bool KeeAgentSettings::toOpenSSHKey(const QString& username,
         }
     }
 
-    if (key.comment().isEmpty()) {
+    if (key.comment().isEmpty() && !key.encrypted()) {
         key.setComment(username);
     }
 
-    if (key.comment().isEmpty()) {
+    if (key.comment().isEmpty() && !key.encrypted()) {
         key.setComment(fileName);
     }
 

--- a/src/sshagent/KeeAgentSettings.cpp
+++ b/src/sshagent/KeeAgentSettings.cpp
@@ -489,11 +489,11 @@ bool KeeAgentSettings::toOpenSSHKey(const QString& username,
         }
     }
 
-    if (key.comment().isEmpty() && !key.encrypted()) {
+    if (key.comment().isEmpty()) {
         key.setComment(username);
     }
 
-    if (key.comment().isEmpty() && !key.encrypted()) {
+    if (key.comment().isEmpty()) {
         key.setComment(fileName);
     }
 

--- a/src/sshagent/KeeAgentSettings.cpp
+++ b/src/sshagent/KeeAgentSettings.cpp
@@ -490,11 +490,7 @@ bool KeeAgentSettings::toOpenSSHKey(const QString& username,
     }
 
     if (key.comment().isEmpty()) {
-        key.setComment(username);
-    }
-
-    if (key.comment().isEmpty()) {
-        key.setComment(fileName);
+        key.setComment(QString("%1@%2").arg(username, fileName));
     }
 
     return true;

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -84,7 +84,7 @@ const QString OpenSSHKey::type() const
 const QString OpenSSHKey::fingerprint(QCryptographicHash::Algorithm algo) const
 {
     if (m_rawPublicData.isEmpty()) {
-        return {};
+        return {tr("(encrypted)")};
     }
 
     QByteArray publicKey;
@@ -351,6 +351,8 @@ bool OpenSSHKey::parsePKCS1PEM(const QByteArray& in)
     // load private if no encryption
     if (!encrypted()) {
         return openKey();
+    } else {
+        m_comment = tr("(encrypted)");
     }
 
     return true;

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -84,7 +84,7 @@ const QString OpenSSHKey::type() const
 const QString OpenSSHKey::fingerprint(QCryptographicHash::Algorithm algo) const
 {
     if (m_rawPublicData.isEmpty()) {
-        return {tr("(encrypted)")};
+        return tr("(encrypted)");
     }
 
     QByteArray publicKey;


### PR DESCRIPTION
-  Fixes #10637

The reason is that the activation condition is: `if (!key.comment().isEmpty() || !key.encrypted())`.
But the comment is never empty because when opening the key we have:

```C++
if (key.comment().isEmpty() && !key.encrypted()) {
    key.setComment(username);
}

if (key.comment().isEmpty() && !key.encrypted()) {
    key.setComment(fileName);
}
```

I also took the opportunity to modify the text to be copied to the clipboard when the key is not decrypted.
Indeed, the undecrypted private key exposes the public key in clear text, but not its comment.

* `setPlainText(tr("(encrypted)"));`
to
* `setPlainText(key.publicKey() + tr("(comment is encrypted)"));`


## Testing strategy

Tested manually with ed25519 crypted key.

## Type of change

    ✅ Bug fix (non-breaking change that fixes an issue)
