### PR TITLE
Fix sidebar resize behaviour

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -141,6 +141,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     m_mainSplitter->addWidget(rightHandSideWidget);
     m_mainSplitter->setStretchFactor(0, 0);
     m_mainSplitter->setStretchFactor(1, 100);
+    m_mainSplitter->setCollapsible(1, false);
     m_mainSplitter->setSizes({1, 1});
 
     m_previewSplitter->setOrientation(Qt::Vertical);
@@ -363,20 +364,27 @@ QHash<Config::ConfigKey, QList<int>> DatabaseWidget::splitterSizes() const
 
 void DatabaseWidget::setSplitterSizes(const QHash<Config::ConfigKey, QList<int>>& sizes)
 {
+    // Set the splitter sizes, if the size is invalid set a default ratio based on this widget size
     for (auto itr = sizes.constBegin(); itr != sizes.constEnd(); ++itr) {
-        // Less than two sizes indicates an invalid value
-        if (itr.value().size() < 2) {
-            continue;
-        }
+        auto value = itr.value();
         switch (itr.key()) {
         case Config::GUI_SplitterState:
-            m_mainSplitter->setSizes(itr.value());
+            if (value.size() < 2) {
+                value = QList({static_cast<int>(width() * 0.25), static_cast<int>(width() * 0.75)});
+            }
+            m_mainSplitter->setSizes(value);
             break;
         case Config::GUI_PreviewSplitterState:
-            m_previewSplitter->setSizes(itr.value());
+            if (value.size() < 2) {
+                value = QList({static_cast<int>(height() * 0.8), static_cast<int>(height() * 0.2)});
+            }
+            m_previewSplitter->setSizes(value);
             break;
         case Config::GUI_GroupSplitterState:
-            m_groupSplitter->setSizes(itr.value());
+            if (value.size() < 2) {
+                value = QList({static_cast<int>(height() * 0.6), static_cast<int>(height() * 0.4)});
+            }
+            m_groupSplitter->setSizes(value);
             break;
         default:
             break;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -123,7 +123,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     m_groupSplitter->addWidget(tagsWidget);
     m_groupSplitter->setStretchFactor(0, 100);
     m_groupSplitter->setStretchFactor(1, 0);
-    m_groupSplitter->setSizes({1,1});
+    m_groupSplitter->setSizes({1, 1});
 
     auto rightHandSideWidget = new QWidget(m_mainSplitter);
     auto rightHandSideVBox = new QVBoxLayout();

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -138,8 +138,9 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     m_mainSplitter->setChildrenCollapsible(true);
     m_mainSplitter->addWidget(m_groupSplitter);
     m_mainSplitter->addWidget(rightHandSideWidget);
-    m_mainSplitter->setStretchFactor(0, 30);
-    m_mainSplitter->setStretchFactor(1, 70);
+    m_mainSplitter->setStretchFactor(0, 0);
+    m_mainSplitter->setStretchFactor(1, 100);
+    m_mainSplitter->setSizes({1, 1});
 
     m_previewSplitter->setOrientation(Qt::Vertical);
     m_previewSplitter->setChildrenCollapsible(true);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -121,8 +121,9 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     m_groupSplitter->setChildrenCollapsible(true);
     m_groupSplitter->addWidget(m_groupView);
     m_groupSplitter->addWidget(tagsWidget);
-    m_groupSplitter->setStretchFactor(0, 70);
-    m_groupSplitter->setStretchFactor(1, 30);
+    m_groupSplitter->setStretchFactor(0, 100);
+    m_groupSplitter->setStretchFactor(1, 0);
+    m_groupSplitter->setSizes({1,1});
 
     auto rightHandSideWidget = new QWidget(m_mainSplitter);
     auto rightHandSideVBox = new QVBoxLayout();

--- a/src/gui/DatabaseWidgetStateSync.cpp
+++ b/src/gui/DatabaseWidgetStateSync.cpp
@@ -62,17 +62,24 @@ void DatabaseWidgetStateSync::setActive(DatabaseWidget* dbWidget)
     m_activeDbWidget = dbWidget;
 
     if (m_activeDbWidget) {
-        m_blockUpdates = true;
+        // Give the database widget a chance to render itself before restoring the state
+        QTimer::singleShot(0, this, [this] {
+            if (!m_activeDbWidget) {
+                return;
+            }
 
-        m_activeDbWidget->setSplitterSizes(m_splitterSizes);
+            m_blockUpdates = true;
 
-        if (m_activeDbWidget->isSearchActive()) {
-            restoreSearchView();
-        } else {
-            restoreListView();
-        }
+            m_activeDbWidget->setSplitterSizes(m_splitterSizes);
 
-        m_blockUpdates = false;
+            if (m_activeDbWidget->isSearchActive()) {
+                restoreSearchView();
+            } else {
+                restoreListView();
+            }
+
+            m_blockUpdates = false;
+        });
 
         connect(m_activeDbWidget, SIGNAL(splitterSizesChanged()), SLOT(updateSplitterSizes()));
         connect(m_activeDbWidget, SIGNAL(entryViewStateChanged()), SLOT(updateViewState()));


### PR DESCRIPTION
Change the stretching factor for children widgets of m_mainSplitter and m_groupSplitter to keep their size fixed during a window resize. 

Fixes: #10613

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)