### PR TITLE
Fix issues with Hardware Key auto detection

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -169,51 +169,50 @@ void DatabaseOpenWidget::toggleHardwareKeyComponent(bool state)
 bool DatabaseOpenWidget::event(QEvent* event)
 {
     bool ret = DialogyWidget::event(event);
+    auto type = event->type();
 
-    switch (event->type()) {
-    case QEvent::Show:
-    case QEvent::WindowActivate: {
+    if (type == QEvent::Show || type == QEvent::WindowActivate) {
         if (isOnQuickUnlockScreen() && (m_db.isNull() || !canPerformQuickUnlock())) {
             resetQuickUnlock();
         }
         toggleQuickUnlockScreen();
-        m_hideTimer.stop();
 
+        if (type == QEvent::Show) {
 #ifdef WITH_XC_YUBIKEY
 #ifdef Q_OS_WIN
-        m_deviceListener->registerHotplugCallback(true,
-                                                  true,
-                                                  YubiKeyInterfaceUSB::YUBICO_USB_VID,
-                                                  DeviceListener::MATCH_ANY,
-                                                  &DeviceListenerWin::DEV_CLS_KEYBOARD);
-        m_deviceListener->registerHotplugCallback(true,
-                                                  true,
-                                                  YubiKeyInterfaceUSB::ONLYKEY_USB_VID,
-                                                  DeviceListener::MATCH_ANY,
-                                                  &DeviceListenerWin::DEV_CLS_KEYBOARD);
+            m_deviceListener->registerHotplugCallback(true,
+                                                      true,
+                                                      YubiKeyInterfaceUSB::YUBICO_USB_VID,
+                                                      DeviceListener::MATCH_ANY,
+                                                      &DeviceListenerWin::DEV_CLS_KEYBOARD);
+            m_deviceListener->registerHotplugCallback(true,
+                                                      true,
+                                                      YubiKeyInterfaceUSB::ONLYKEY_USB_VID,
+                                                      DeviceListener::MATCH_ANY,
+                                                      &DeviceListenerWin::DEV_CLS_KEYBOARD);
 #else
-        m_deviceListener->registerHotplugCallback(true, true, YubiKeyInterfaceUSB::YUBICO_USB_VID);
-        m_deviceListener->registerHotplugCallback(true, true, YubiKeyInterfaceUSB::ONLYKEY_USB_VID);
+            m_deviceListener->registerHotplugCallback(true, true, YubiKeyInterfaceUSB::YUBICO_USB_VID);
+            m_deviceListener->registerHotplugCallback(true, true, YubiKeyInterfaceUSB::ONLYKEY_USB_VID);
 #endif
 #endif
+            m_hideTimer.stop();
+            pollHardwareKey();
+        }
 
-        return true;
-    }
-
-    case QEvent::Hide: {
+        ret = true;
+    } else if (type == QEvent::Hide || type == QEvent::WindowDeactivate) {
         // Schedule form clearing if we are hidden
-        if (!isVisible()) {
+        if (!m_hideTimer.isActive()) {
             m_hideTimer.start();
         }
 
 #ifdef WITH_XC_YUBIKEY
-        m_deviceListener->deregisterAllHotplugCallbacks();
+        if (type == QEvent::Hide) {
+            m_deviceListener->deregisterAllHotplugCallbacks();
+        }
 #endif
 
-        return true;
-    }
-
-    default:;
+        ret = true;
     }
 
     return ret;
@@ -512,7 +511,10 @@ void DatabaseOpenWidget::pollHardwareKey(bool manualTrigger)
     m_pollingHardwareKey = true;
     m_manualHardwareKeyRefresh = manualTrigger;
 
-    YubiKey::instance()->findValidKeysAsync();
+    // Add a delay, if this is an automatic trigger, to allow the USB device to settle as
+    // the device may not report a valid serial number immediately after plugging in
+    int delay = manualTrigger ? 0 : 500;
+    QTimer::singleShot(delay, this, [] { YubiKey::instance()->findValidKeysAsync(); });
 }
 
 void DatabaseOpenWidget::hardwareKeyResponse(bool found)

--- a/src/gui/osutils/macutils/DeviceListenerMac.cpp
+++ b/src/gui/osutils/macutils/DeviceListenerMac.cpp
@@ -54,7 +54,7 @@ void DeviceListenerMac::registerHotplugCallback(bool arrived, bool left, int ven
             CFRelease(vid);
         }
         if (productId > 0) {
-            auto pid = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &vendorId);
+            auto pid = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &productId);
             CFDictionaryAddValue(matchingDict, CFSTR(kIOHIDProductIDKey), pid);
             CFRelease(pid);
         }

--- a/src/keys/drivers/YubiKeyInterfaceUSB.cpp
+++ b/src/keys/drivers/YubiKeyInterfaceUSB.cpp
@@ -50,10 +50,22 @@ namespace
         yk_close_key(key);
     }
 
+    void printError()
+    {
+        if (yk_errno == YK_EUSBERR) {
+            qWarning("Hardware key USB error: %s", yk_usb_strerror());
+        } else {
+            qWarning("Hardware key error: %s", yk_strerror(yk_errno));
+        }
+    }
+
     unsigned int getSerial(YK_KEY* key)
     {
         unsigned int serial;
-        yk_get_serial(key, 1, 0, &serial);
+        if (!yk_get_serial(key, 1, 0, &serial)) {
+            printError();
+            return 0;
+        }
         return serial;
     }
 
@@ -70,11 +82,8 @@ namespace
             } else if (yk_errno == YK_ENOKEY) {
                 // No more connected keys
                 break;
-            } else if (yk_errno == YK_EUSBERR) {
-                qWarning("Hardware key USB error: %s", yk_usb_strerror());
-            } else {
-                qWarning("Hardware key error: %s", yk_strerror(yk_errno));
             }
+            printError();
         }
         return nullptr;
     }


### PR DESCRIPTION
* Fix #10656 - Add a small delay when before auto-polling hardware keys to all them to settle immediately after plugging in. This resolves an issue where the key's serial number could not be resolved due to hardware timeout.
* Also fix use of uninitialized variable if polling serial number fails for whatever reason.

* Fix typo in macOS key registration code

* Prevent registering duplicate listeners on window focus. These were not de-registered because we didn't trigger on unfocus. Show/Hide are sufficient triggers to add and remove listeners.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows with multiple keys. The serial number issue was most prevalent with Yubikey NEO and was immediately and fully resolved with the proposed fixes. There is no degradation to user experience.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)