### PR TITLE
Fix issues with Entry Editing

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1755,9 +1755,17 @@ bool DatabaseWidget::lock()
 
     emit databaseLockRequested();
 
-    // ignore event if we are active and a modal dialog is still open (such as a message box or file dialog)
-    if (isVisible() && QApplication::activeModalWidget()) {
-        return false;
+    // Force close any modal widgets associated with this widget
+    auto modalWidget = QApplication::activeModalWidget();
+    if (modalWidget) {
+        auto parent = modalWidget->parentWidget();
+        while (parent) {
+            if (parent == this) {
+                modalWidget->close();
+                break;
+            }
+            parent = parent->parentWidget();
+        }
     }
 
     clipboard()->clearCopiedText();

--- a/src/gui/EditWidget.cpp
+++ b/src/gui/EditWidget.cpp
@@ -94,16 +94,19 @@ void EditWidget::setPageHidden(QWidget* widget, bool hidden)
         }
     }
 
-    if (index != -1) {
-        m_ui->categoryList->setCategoryHidden(index, hidden);
+    if (index == -1) {
+        return;
     }
 
-    if (index == m_ui->stackedWidget->currentIndex()) {
+    bool changed = m_ui->categoryList->isCategoryHidden(index) != hidden;
+    m_ui->categoryList->setCategoryHidden(index, hidden);
+
+    if (changed && index == m_ui->stackedWidget->currentIndex()) {
         int newIndex = m_ui->stackedWidget->currentIndex() - 1;
         if (newIndex < 0) {
             newIndex = m_ui->stackedWidget->count() - 1;
         }
-        m_ui->stackedWidget->setCurrentIndex(newIndex);
+        m_ui->categoryList->setCurrentCategory(newIndex);
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1821,7 +1821,9 @@ void MainWindow::closeModalWindow()
 
 void MainWindow::lockDatabasesAfterInactivity()
 {
-    m_ui->tabWidget->lockDatabases();
+    if (!m_ui->tabWidget->lockDatabases()) {
+        m_inactivityTimer->activate();
+    }
 }
 
 bool MainWindow::isTrayIconEnabled() const

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1173,21 +1173,23 @@ bool EditEntryWidget::commitEntry()
     toKeeAgentSettings(m_sshAgentSettings);
 #endif
 
+    // Begin entry update
+    if (!m_create) {
+        m_entry->beginUpdate();
+    }
+
 #ifdef WITH_XC_BROWSER
     if (config()->get(Config::Browser_Enabled).toBool()) {
         updateBrowser();
     }
 #endif
 
-    if (!m_create) {
-        m_entry->beginUpdate();
-    }
-
     updateEntryData(m_entry);
 
     if (!m_create) {
         m_entry->endUpdate();
     }
+    // End entry update
 
     m_historyModel->setEntries(m_entry->historyItems(), m_entry);
     setPageHidden(m_historyWidget, m_history || m_entry->historyItems().count() < 1);
@@ -1195,6 +1197,9 @@ bool EditEntryWidget::commitEntry()
 
     showMessage(tr("Entry updated successfully."), MessageWidget::Positive);
     setModified(false);
+    // Prevent a reload due to entry modified signals
+    m_entryModifiedTimer.stop();
+
     return true;
 }
 

--- a/src/gui/wizard/ImportWizardPageSelect.cpp
+++ b/src/gui/wizard/ImportWizardPageSelect.cpp
@@ -126,10 +126,16 @@ void ImportWizardPageSelect::updateDatabaseChoices() const
     auto mainWindow = getMainWindow();
     if (mainWindow) {
         for (auto dbWidget : mainWindow->getOpenDatabases()) {
+            // Remove all connections
+            disconnect(dbWidget, nullptr, nullptr, nullptr);
+
             // Skip over locked databases
             if (dbWidget->isLocked()) {
                 continue;
             }
+
+            connect(dbWidget, &DatabaseWidget::databaseLocked, this, &ImportWizardPageSelect::updateDatabaseChoices);
+            connect(dbWidget, &DatabaseWidget::databaseModified, this, &ImportWizardPageSelect::updateDatabaseChoices);
 
             // Enable the selection of an existing database
             m_ui->existingDatabaseRadio->setEnabled(true);
@@ -160,6 +166,11 @@ void ImportWizardPageSelect::updateDatabaseChoices() const
                 }
             }
         }
+    }
+
+    if (m_ui->existingDatabaseChoice->count() == 0) {
+        m_ui->existingDatabaseRadio->setEnabled(false);
+        m_ui->newDatabaseRadio->setChecked(true);
     }
 }
 


### PR DESCRIPTION
**Entry Editing Fixes:**

* Fix #10653 - prevent category switching if no category was actually hidden/visible. Also properly select a new category when a change is made instead of just changing the widget page.

* Fix apply button still being enabled after it is pressed and successfully committed

**Locking Fixes:**

* Fix https://github.com/keepassxreboot/keepassxc/issues/6593 - force close any modal dialogs associated with a database widget that is being locked.

* Partial fix for https://github.com/keepassxreboot/keepassxc/issues/721 but doesn't address the problem of needing to save a modified entry or database while locking.

* Also improves import dialog behavior if databases(s) lock while it is visible.

This also fixes the inactivity timer not being reactivated if database locking is not successful. This may fix incidents where the inactivity timer isn't working. 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually tested extensivel

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)