### PR TITLE
Update URLs to Chrome Web Store page for `KeePassXC-Browser` extension

### DIFF
--- a/docs/topics/BrowserPlugin.adoc
+++ b/docs/topics/BrowserPlugin.adoc
@@ -17,7 +17,7 @@ The KeePassXC-Browser extension is available on the following web browsers:
 You can download the KeePassXC-Browser extension from your web browser. To download the KeePassXC-Browser extension, perform the following steps:
 
 1. Click the link corresponding to your browser:
-  * https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk[Chrome, Chromium, Vivaldi, and Brave]
+  * https://chromewebstore.google.com/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk[Chrome, Chromium, Vivaldi, and Brave]
   * https://addons.mozilla.org/en-US/firefox/addon/keepassxc-browser[Mozilla Firefox and Tor-Browser]
   * https://microsoftedge.microsoft.com/addons/detail/keepassxcbrowser/pdffhmdngciaglkoonimfcmckehcpafo[Microsoft Edge]
 

--- a/src/browser/BrowserSettingsWidget.cpp
+++ b/src/browser/BrowserSettingsWidget.cpp
@@ -44,7 +44,7 @@ BrowserSettingsWidget::BrowserSettingsWidget(QWidget* parent)
     m_ui->extensionLabel->setText(
         tr("KeePassXC-Browser is needed for the browser integration to work. <br />Download it for %1 and %2 and %3. %4")
             .arg("<a href=\"https://addons.mozilla.org/firefox/addon/keepassxc-browser/\">Firefox</a>",
-                 "<a href=\"https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">"
+                 "<a href=\"https://chromewebstore.google.com/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">"
                  "Google Chrome / Chromium / Vivaldi / Brave</a>",
                  "<a href=\"https://microsoftedge.microsoft.com/addons/detail/pdffhmdngciaglkoonimfcmckehcpafo\">Microsoft Edge</a>",
                  snapInstructions));


### PR DESCRIPTION
Noted the existing Chrome Webstore URL is now redirected:

- `https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk`
- now to...
- `https://chromewebstore.google.com/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk`

Simply updating this URL to avoid the `HTTP 301` redirection.

Thanks team - absolutely love KeePassXC 👍 

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ Documentation (non-code change)
