### PR TITLE
Fix Flatpak config issues

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -98,9 +98,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_HidePreviewPanel, {QS("GUI/HidePreviewPanel"), Roaming, false}},
     {Config::GUI_AlwaysOnTop, {QS("GUI/GUI_AlwaysOnTop"), Local, false}},
     {Config::GUI_ToolButtonStyle, {QS("GUI/ToolButtonStyle"), Roaming, Qt::ToolButtonIconOnly}},
-#ifdef KEEPASSXC_DIST_FLATPAK
     {Config::GUI_LaunchAtStartup, {QS("GUI/LaunchAtStartup"), Roaming, false}},
-#endif
     {Config::GUI_ShowTrayIcon, {QS("GUI/ShowTrayIcon"), Roaming, false}},
     {Config::GUI_TrayIconAppearance, {QS("GUI/TrayIconAppearance"), Roaming, {}}},
     {Config::GUI_MinimizeToTray, {QS("GUI/MinimizeToTray"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -80,9 +80,7 @@ public:
         GUI_HidePreviewPanel,
         GUI_AlwaysOnTop,
         GUI_ToolButtonStyle,
-#ifdef KEEPASSXC_DIST_FLATPAK
         GUI_LaunchAtStartup,
-#endif
         GUI_ShowTrayIcon,
         GUI_TrayIconAppearance,
         GUI_MinimizeToTray,


### PR DESCRIPTION
Remove #ifdef guards from Config.h/cpp (no harm to non-Flatpak distros, this config variable is ignored)

Cleanup #ifdef usage in NixUtils.cpp

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
I am still trying to determine if this code actually works. It did not work with the test deploy of the flatpak via flathub. Waiting for prod deploy to test further.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
