### PR TITLE
Fix wrong DACL memory size on Windows (createWindowsDACL) 

### DIFF
--- a/src/core/Bootstrap.cpp
+++ b/src/core/Bootstrap.cpp
@@ -180,7 +180,8 @@ namespace Bootstrap
 
         // Calculate the amount of memory that must be allocated for the DACL
         cbACL = sizeof(ACL) + sizeof(ACCESS_ALLOWED_ACE) + GetLengthSid(pTokenUser->User.Sid)
-                + sizeof(ACCESS_ALLOWED_ACE) + GetLengthSid(pLocalSystemSid) + GetLengthSid(pOwnerRightsSid);
+                + sizeof(ACCESS_ALLOWED_ACE) + GetLengthSid(pLocalSystemSid) + sizeof(ACCESS_ALLOWED_ACE)
+                + GetLengthSid(pOwnerRightsSid);
 
         // Create and initialize an ACL
         pACL = static_cast<PACL>(HeapAlloc(GetProcessHeap(), 0, cbACL));


### PR DESCRIPTION
The function `createWindowsDACL` incorrectly calculates the memory allocation size for the DACL.
Each `AddAccessAllowedAce` call should correspond to a `sizeof(ACCESS_ALLOWED_ACE)` plus the `GetLengthSid` of the SID being used, ensuring sufficient space in the ACL for each entry. However, the original code mistakenly includes only two instances of `sizeof(ACCESS_ALLOWED_ACE)` in the size calculation, although there are three instances of  `GetLengthSid` in the sum and there are up to three `AddAccessAllowedAce` calls when the `WITH_XC_SSHAGENT` compilation flag is defined.

This change corrects the DACL memory allocation calculation to accurately account for all potential `AddAccessAllowedAce` calls by conditionally including the third `sizeof(ACCESS_ALLOWED_ACE)`. This ensures correct memory allocation across all configurations.

Fixes https://github.com/keepassxreboot/keepassxc/issues/10713

## Testing strategy
manual test.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

