### PR TITLE
Keepassx fails to compile on FreeBSD due to libusb implementation differences

### DIFF
--- a/src/gui/osutils/DeviceListener.cpp
+++ b/src/gui/osutils/DeviceListener.cpp
@@ -57,7 +57,7 @@ DeviceListener::registerHotplugCallback(bool arrived, bool left, int vendorId, i
 void DeviceListener::deregisterHotplugCallback(Handle handle)
 {
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    m_listeners[0]->deregisterHotplugCallback(static_cast<int>(handle));
+    m_listeners[0]->deregisterHotplugCallback(handle);
 #else
     if (m_listeners.contains(handle)) {
         m_listeners[handle]->deregisterHotplugCallback();

--- a/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp
+++ b/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp
@@ -49,7 +49,7 @@ namespace
     }
 } // namespace
 
-qintptr DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int vendorId, int productId, const QUuid*)
+Handle DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int vendorId, int productId, const QUuid*)
 {
     if (!m_ctx) {
         if (libusb_init(reinterpret_cast<libusb_context**>(&m_ctx)) != LIBUSB_SUCCESS) {

--- a/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp
+++ b/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp
@@ -49,7 +49,7 @@ namespace
     }
 } // namespace
 
-int DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int vendorId, int productId, const QUuid*)
+qintptr DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int vendorId, int productId, const QUuid*)
 {
     if (!m_ctx) {
         if (libusb_init(reinterpret_cast<libusb_context**>(&m_ctx)) != LIBUSB_SUCCESS) {
@@ -66,7 +66,7 @@ int DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int v
         events |= LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT;
     }
 
-    int handle = 0;
+    Handle handle = 0;
     const QPointer that = this;
     const int ret = libusb_hotplug_register_callback(
         static_cast<libusb_context*>(m_ctx),
@@ -84,7 +84,7 @@ int DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int v
             return 0;
         },
         that,
-        &handle);
+        &static_cast<libusb_hotplug_callback_handle>(handle));
     if (ret != LIBUSB_SUCCESS) {
         qWarning("Failed to register USB listener callback.");
         handle = 0;
@@ -102,12 +102,12 @@ int DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int v
     return handle;
 }
 
-void DeviceListenerLibUsb::deregisterHotplugCallback(int handle)
+void DeviceListenerLibUsb::deregisterHotplugCallback(Handle handle)
 {
     if (!m_ctx || !m_callbackHandles.contains(handle)) {
         return;
     }
-    libusb_hotplug_deregister_callback(static_cast<libusb_context*>(m_ctx), handle);
+    libusb_hotplug_deregister_callback(static_cast<libusb_context*>(m_ctx), static_cast<libusb_hotplug_callback_handle>(handle));
     m_callbackHandles.remove(handle);
 
     if (m_callbackHandles.isEmpty() && m_usbEvents.isRunning()) {

--- a/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp
+++ b/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp
@@ -20,6 +20,7 @@
 
 #include <QPointer>
 #include <QtConcurrent>
+#include <QtGlobal>
 #include <libusb.h>
 
 DeviceListenerLibUsb::DeviceListenerLibUsb(QWidget* parent)
@@ -49,7 +50,8 @@ namespace
     }
 } // namespace
 
-Handle DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int vendorId, int productId, const QUuid*)
+DeviceListenerLibUsb::Handle
+DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int vendorId, int productId, const QUuid*)
 {
     if (!m_ctx) {
         if (libusb_init(reinterpret_cast<libusb_context**>(&m_ctx)) != LIBUSB_SUCCESS) {
@@ -67,6 +69,7 @@ Handle DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, in
     }
 
     Handle handle = 0;
+    auto* handleNative = reinterpret_cast<libusb_hotplug_callback_handle*>(&handle);
     const QPointer that = this;
     const int ret = libusb_hotplug_register_callback(
         static_cast<libusb_context*>(m_ctx),
@@ -77,14 +80,14 @@ Handle DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, in
         LIBUSB_HOTPLUG_MATCH_ANY,
         [](libusb_context* ctx, libusb_device* device, libusb_hotplug_event event, void* userData) -> int {
             if (!ctx) {
-                return 0;
+                return true;
             }
             emit static_cast<DeviceListenerLibUsb*>(userData)->devicePlugged(
                 event == LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, ctx, device);
-            return 0;
+            return false;
         },
         that,
-        &static_cast<libusb_hotplug_callback_handle>(handle));
+        handleNative);
     if (ret != LIBUSB_SUCCESS) {
         qWarning("Failed to register USB listener callback.");
         handle = 0;
@@ -107,7 +110,12 @@ void DeviceListenerLibUsb::deregisterHotplugCallback(Handle handle)
     if (!m_ctx || !m_callbackHandles.contains(handle)) {
         return;
     }
-    libusb_hotplug_deregister_callback(static_cast<libusb_context*>(m_ctx), static_cast<libusb_hotplug_callback_handle>(handle));
+#ifdef Q_OS_FREEBSD
+    auto* handleNative = reinterpret_cast<libusb_hotplug_callback_handle>(handle);
+#else
+    auto handleNative = static_cast<libusb_hotplug_callback_handle>(handle);
+#endif
+    libusb_hotplug_deregister_callback(static_cast<libusb_context*>(m_ctx), handleNative);
     m_callbackHandles.remove(handle);
 
     if (m_callbackHandles.isEmpty() && m_usbEvents.isRunning()) {

--- a/src/gui/osutils/nixutils/DeviceListenerLibUsb.h
+++ b/src/gui/osutils/nixutils/DeviceListenerLibUsb.h
@@ -32,12 +32,13 @@ class DeviceListenerLibUsb : public QObject
     Q_OBJECT
 
 public:
+    typedef qintptr Handle;
     explicit DeviceListenerLibUsb(QWidget* parent);
     DeviceListenerLibUsb(const DeviceListenerLibUsb&) = delete;
     ~DeviceListenerLibUsb() override;
 
-    int registerHotplugCallback(bool arrived, bool left, int vendorId = -1, int productId = -1, const QUuid* = nullptr);
-    void deregisterHotplugCallback(int handle);
+    Handle registerHotplugCallback(bool arrived, bool left, int vendorId = -1, int productId = -1, const QUuid* = nullptr);
+    void deregisterHotplugCallback(Handle handle);
     void deregisterAllHotplugCallbacks();
 
 signals:
@@ -45,7 +46,7 @@ signals:
 
 private:
     void* m_ctx;
-    QSet<int> m_callbackHandles;
+    QSet<Handle> m_callbackHandles;
     QFuture<void> m_usbEvents;
     QAtomicInt m_completed;
 };

--- a/src/gui/osutils/nixutils/DeviceListenerLibUsb.h
+++ b/src/gui/osutils/nixutils/DeviceListenerLibUsb.h
@@ -37,7 +37,8 @@ public:
     DeviceListenerLibUsb(const DeviceListenerLibUsb&) = delete;
     ~DeviceListenerLibUsb() override;
 
-    Handle registerHotplugCallback(bool arrived, bool left, int vendorId = -1, int productId = -1, const QUuid* = nullptr);
+    Handle
+    registerHotplugCallback(bool arrived, bool left, int vendorId = -1, int productId = -1, const QUuid* = nullptr);
     void deregisterHotplugCallback(Handle handle);
     void deregisterAllHotplugCallbacks();
 


### PR DESCRIPTION
On FreeBSD the libusb_hotplug_register_callback() function uses a pointer to a struct as an handle.

I'm changing the methods to use this as expected by the system library.

This now compiles fine but fails at runtime.

Not sure why this patch is not working and I must admit I do not understand what is being done using `qintptr` in https://github.com/keepassxreboot/keepassxc/blob/f0932914424543f29e81f6c8933bbe2e8553b68c/src/gui/osutils/DeviceListener.h#L41.

This has been noticed here: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=277652

The failures with my patch are described here: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=277652#c10

I do not have a yubikey so I cannot do testing myself.

Thanks in advance for any help!


## Testing strategy

As said, with this changes the source compiles on FreeBSD, and the resulting binary works, except when exercising the modified code.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
