### PR TITLE
Restore macOS monospace font size prior to #10282

### DIFF
--- a/src/gui/Font.cpp
+++ b/src/gui/Font.cpp
@@ -40,7 +40,7 @@ QFont Font::fixedFont()
 #endif
 #ifdef Q_OS_MACOS
     // Qt doesn't choose a monospace font correctly on macOS
-    fixedFont = QFontDatabase().font("Menlo", fixedFont.styleName(), fixedFont.pointSize());
+    fixedFont = QFontDatabase().font("Menlo", fixedFont.styleName(), qApp->font().pointSize());
 #endif
     return fixedFont;
 }


### PR DESCRIPTION
As mentioned on https://github.com/keepassxreboot/keepassxc/pull/10282#issuecomment-2105173039, with KeePassXC 2.7.8, the monospace font size has decreased on macOS.  From my measurement, it's decreased by about 24%, which makes passwords and note text harder to read.

This PR re-applies the change that #10282 removed, but only on macOS.

Fixes #10740

## Screenshots
| 2.7.7 | 2.7.8 | This PR |
| - | - | - |
| ![2 7 7](https://github.com/keepassxreboot/keepassxc/assets/190164/eba4762a-f61e-4851-abbd-3d6a24a8b9e9) | ![2 7 8](https://github.com/keepassxreboot/keepassxc/assets/190164/82ed8cb4-adf9-42a2-8edd-8a697ae91c5a) | ![This PR](https://github.com/keepassxreboot/keepassxc/assets/190164/944c4efc-30fa-41ff-8c92-58042ad098e8) |

## Testing strategy
AFAICT KeePassXC doesn't have automated tests for font selection.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
