### PR TITLE
Improve Portability Check

### DIFF
--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -19,6 +19,7 @@
 #include "NativeMessageInstaller.h"
 #include "BrowserSettings.h"
 #include "config-keepassx.h"
+#include "core/Config.h"
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -209,8 +210,8 @@ QString NativeMessageInstaller::getNativeMessagePath(SupportedBrowsers browser) 
     QString basePath;
 #if defined(Q_OS_WIN)
     // If portable settings file exists save the JSON scripts to the application folder
-    if (QFile::exists(QCoreApplication::applicationDirPath() + QStringLiteral("/keepassxc.ini"))) {
-        basePath = QCoreApplication::applicationDirPath();
+    if (Config::isPortable()) {
+        basePath = Config::portableConfigDir();
     } else {
         basePath = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
     }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -512,20 +512,8 @@ void Config::init(const QString& configFileName, const QString& localConfigFileN
 QPair<QString, QString> Config::defaultConfigFiles()
 {
     // Check if we are running in portable mode, if so store the config files local to the app
-#ifdef Q_OS_WIN
-    // Enable QFileInfo::isWritable check on Windows
-    extern Q_CORE_EXPORT int qt_ntfs_permission_lookup;
-    qt_ntfs_permission_lookup++;
-#endif
-    auto portablePath = QCoreApplication::applicationDirPath().append("/%1");
-    auto portableFile = portablePath.arg(".portable");
-    bool isPortable = QFile::exists(portableFile) && QFileInfo(portableFile).isWritable();
-#ifdef Q_OS_WIN
-    qt_ntfs_permission_lookup--;
-#endif
-
-    if (isPortable) {
-        return {portablePath.arg("config/keepassxc.ini"), portablePath.arg("config/keepassxc_local.ini")};
+    if (isPortable()) {
+        return {portableConfigDir().append("/keepassxc.ini"), portableConfigDir().append("/keepassxc_local.ini")};
     }
 
     QString configPath;
@@ -600,6 +588,27 @@ void Config::createTempFileInstance()
     Q_UNUSED(openResult);
     m_instance = new Config(tmpFile->fileName(), "", qApp);
     tmpFile->setParent(m_instance);
+}
+
+bool Config::isPortable()
+{
+#ifdef Q_OS_WIN
+    // Enable QFileInfo::isWritable check on Windows
+    extern Q_CORE_EXPORT int qt_ntfs_permission_lookup;
+    qt_ntfs_permission_lookup++;
+#endif
+    auto portablePath = QCoreApplication::applicationDirPath().append("/%1");
+    auto portableFile = portablePath.arg(".portable");
+    auto isPortable = QFile::exists(portableFile) && QFileInfo(portableFile).isWritable();
+#ifdef Q_OS_WIN
+    qt_ntfs_permission_lookup--;
+#endif
+    return isPortable;
+}
+
+QString Config::portableConfigDir()
+{
+    return QCoreApplication::applicationDirPath().append("/config");
 }
 
 QList<Config::ShortcutEntry> Config::getShortcuts() const

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -225,6 +225,8 @@ public:
     static Config* instance();
     static void createConfigFromFile(const QString& configFileName, const QString& localConfigFileName = {});
     static void createTempFileInstance();
+    static bool isPortable();
+    static QString portableConfigDir();
 
 signals:
     void changed(ConfigKey key);


### PR DESCRIPTION


## Screenshots
Fixes #10755 
The check checked against keepassxc.ini being in the application directory, while the .portable file was actually being responsible for determining if the application was installed in portable mode. 
In addition this fixes KeePassXCPortable on portableapps.com, as the check returned "not-portable" there, when it should have responsed "portable".
![image](https://github.com/keepassxreboot/keepassxc/assets/159909425/689ca5b4-1b35-40be-9b61-457824473aad)

## Testing strategy
No Test was conducted as it was only a filename change.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)