### PR TITLE
Add database name, color, and icon options for unlock view

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2230,6 +2230,14 @@ removed from the database.</source>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Display icon:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select Database Icon</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetKeeShare</name>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2194,6 +2194,42 @@ removed from the database.</source>
         <source>Autosave delay since last change checkbox</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Public Database Metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning: the following settings are not encrypted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Display name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Publically visible display name used on the unlock dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Database public display name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Display color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Publically visible color used on the unlock dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Database public display color chooser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingsWidgetKeeShare</name>

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -1060,3 +1060,33 @@ bool Database::isTemporaryDatabase()
 {
     return m_isTemporaryDatabase;
 }
+
+QString Database::publicSummary()
+{
+    if (!publicCustomData().contains("KPXC_PUBLIC_SUMMARY")) {
+        return QString();
+    }
+
+    return publicCustomData()["KPXC_PUBLIC_SUMMARY"].toString();
+}
+
+void Database::setPublicSummary(const QString& newSummary)
+{
+    publicCustomData().insert("KPXC_PUBLIC_SUMMARY", newSummary);
+    markAsModified();
+}
+
+QString Database::publicColor()
+{
+    if (!publicCustomData().contains("KPXC_PUBLIC_COLOR")) {
+        return QString();
+    }
+
+    return publicCustomData()["KPXC_PUBLIC_COLOR"].toString();
+}
+
+void Database::setPublicColor(const QString& newSummary)
+{
+    publicCustomData().insert("KPXC_PUBLIC_COLOR", newSummary);
+    markAsModified();
+}

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -1081,6 +1081,24 @@ void Database::setPublicColor(const QString& color)
     markAsModified();
 }
 
+int Database::publicIcon()
+{
+    if (publicCustomData().contains("KPXC_PUBLIC_ICON")) {
+        return publicCustomData().value("KPXC_PUBLIC_ICON").toInt();
+    }
+    return -1;
+}
+
+void Database::setPublicIcon(int iconIndex)
+{
+    if (iconIndex < 0) {
+        publicCustomData().remove("KPXC_PUBLIC_ICON");
+    } else {
+        publicCustomData().insert("KPXC_PUBLIC_ICON", iconIndex);
+    }
+    markAsModified();
+}
+
 void Database::markAsTemporaryDatabase()
 {
     m_isTemporaryDatabase = true;

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -1051,6 +1051,36 @@ QUuid Database::publicUuid()
     return QUuid::fromRfc4122(publicCustomData()["KPXC_PUBLIC_UUID"].toByteArray());
 }
 
+QString Database::publicName()
+{
+    return publicCustomData().value("KPXC_PUBLIC_NAME").toString();
+}
+
+void Database::setPublicName(const QString& name)
+{
+    if (name.isEmpty()) {
+        publicCustomData().remove("KPXC_PUBLIC_NAME");
+    } else {
+        publicCustomData().insert("KPXC_PUBLIC_NAME", name);
+    }
+    markAsModified();
+}
+
+QString Database::publicColor()
+{
+    return publicCustomData().value("KPXC_PUBLIC_COLOR").toString();
+}
+
+void Database::setPublicColor(const QString& color)
+{
+    if (color.isEmpty()) {
+        publicCustomData().remove("KPXC_PUBLIC_COLOR");
+    } else {
+        publicCustomData().insert("KPXC_PUBLIC_COLOR", color);
+    }
+    markAsModified();
+}
+
 void Database::markAsTemporaryDatabase()
 {
     m_isTemporaryDatabase = true;
@@ -1059,34 +1089,4 @@ void Database::markAsTemporaryDatabase()
 bool Database::isTemporaryDatabase()
 {
     return m_isTemporaryDatabase;
-}
-
-QString Database::publicSummary()
-{
-    if (!publicCustomData().contains("KPXC_PUBLIC_SUMMARY")) {
-        return QString();
-    }
-
-    return publicCustomData()["KPXC_PUBLIC_SUMMARY"].toString();
-}
-
-void Database::setPublicSummary(const QString& newSummary)
-{
-    publicCustomData().insert("KPXC_PUBLIC_SUMMARY", newSummary);
-    markAsModified();
-}
-
-QString Database::publicColor()
-{
-    if (!publicCustomData().contains("KPXC_PUBLIC_COLOR")) {
-        return QString();
-    }
-
-    return publicCustomData()["KPXC_PUBLIC_COLOR"].toString();
-}
-
-void Database::setPublicColor(const QString& newSummary)
-{
-    publicCustomData().insert("KPXC_PUBLIC_COLOR", newSummary);
-    markAsModified();
 }

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -108,10 +108,10 @@ public:
     QString canonicalFilePath() const;
     void setFilePath(const QString& filePath);
 
-    QString publicSummary();
-    void setPublicSummary(const QString& newSummary);
+    QString publicName();
+    void setPublicName(const QString& name);
     QString publicColor();
-    void setPublicColor(const QString& newSummary);
+    void setPublicColor(const QString& color);
 
     Metadata* metadata();
     const Metadata* metadata() const;

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -112,6 +112,8 @@ public:
     void setPublicName(const QString& name);
     QString publicColor();
     void setPublicColor(const QString& color);
+    int publicIcon();
+    void setPublicIcon(int iconIndex);
 
     Metadata* metadata();
     const Metadata* metadata() const;

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -108,6 +108,11 @@ public:
     QString canonicalFilePath() const;
     void setFilePath(const QString& filePath);
 
+    QString publicSummary();
+    void setPublicSummary(const QString& newSummary);
+    QString publicColor();
+    void setPublicColor(const QString& newSummary);
+
     Metadata* metadata();
     const Metadata* metadata() const;
     Group* rootGroup();

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -72,9 +72,6 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     font.setPointSize(font.pointSize() + 4);
     font.setBold(true);
     m_ui->labelHeadline->setFont(font);
-    m_ui->labelHeadline->setText(tr("Unlock KeePassXC Database"));
-
-    m_ui->publicSummaryLabel->setVisible(false);
 
     m_ui->quickUnlockButton->setFont(font);
     m_ui->quickUnlockButton->setIcon(
@@ -231,27 +228,18 @@ void DatabaseOpenWidget::load(const QString& filename)
 
     m_ui->fileNameLabel->setRawText(m_filename);
 
-    if (!m_db->publicSummary().isEmpty()) {
-        m_ui->publicSummaryLabel->setVisible(true);
-        m_ui->publicSummaryLabel->setText(m_db->publicSummary());
+    auto label = tr("Unlock KeePassXC Database");
+    if (!m_db->publicName().isEmpty()) {
+        label.append(QString(": %1").arg(m_db->publicName()));
     }
+    m_ui->labelHeadline->setText(label);
 
-    m_ui->publicSummaryLabel->setStyleSheet("");
+    auto color = m_db->publicColor();
+    m_ui->displayColorLabel->setVisible(!color.isEmpty());
+    m_ui->displayColorLabel->setStyleSheet(
+        QString("background: %1; border: 1px solid palette(dark); border-radius: 4px").arg(color));
 
-    if (!m_db->publicColor().isEmpty()) {
-        QColor userColor = QColor(m_db->publicColor());
-
-        if (userColor.isValid()) {
-            float luminance = (0.299 * userColor.redF() + 0.587 * userColor.greenF() + 0.114 * userColor.blueF());
-
-            QColor textColor = Qt::white;
-            if (luminance > 0.5) {
-                textColor = Qt::black;
-            }
-
-            m_ui->publicSummaryLabel->setStyleSheet(QString("background-color:%1;color:%2;border-color:%1;").arg(userColor.name(), textColor.name()));
-        }
-    }
+    // m_ui->centralStack->setStyleSheet(QString("QStackedWidget {border: 4px solid %1}").arg(color));
 
     if (config()->get(Config::RememberLastKeyFiles).toBool()) {
         auto lastKeyFiles = config()->get(Config::LastKeyFiles).toHash();

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -74,6 +74,8 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     m_ui->labelHeadline->setFont(font);
     m_ui->labelHeadline->setText(tr("Unlock KeePassXC Database"));
 
+    m_ui->publicSummaryLabel->setVisible(false);
+
     m_ui->quickUnlockButton->setFont(font);
     m_ui->quickUnlockButton->setIcon(
         icons()->icon("fingerprint", true, palette().color(QPalette::Active, QPalette::HighlightedText)));
@@ -228,6 +230,28 @@ void DatabaseOpenWidget::load(const QString& filename)
     m_db->open(m_filename, nullptr, &error);
 
     m_ui->fileNameLabel->setRawText(m_filename);
+
+    if (!m_db->publicSummary().isEmpty()) {
+        m_ui->publicSummaryLabel->setVisible(true);
+        m_ui->publicSummaryLabel->setText(m_db->publicSummary());
+    }
+
+    m_ui->publicSummaryLabel->setStyleSheet("");
+
+    if (!m_db->publicColor().isEmpty()) {
+        QColor userColor = QColor(m_db->publicColor());
+
+        if (userColor.isValid()) {
+            float luminance = (0.299 * userColor.redF() + 0.587 * userColor.greenF() + 0.114 * userColor.blueF());
+
+            QColor textColor = Qt::white;
+            if (luminance > 0.5) {
+                textColor = Qt::black;
+            }
+
+            m_ui->publicSummaryLabel->setStyleSheet(QString("background-color:%1;color:%2;border-color:%1;").arg(userColor.name(), textColor.name()));
+        }
+    }
 
     if (config()->get(Config::RememberLastKeyFiles).toBool()) {
         auto lastKeyFiles = config()->get(Config::LastKeyFiles).toHash();

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -228,17 +228,29 @@ void DatabaseOpenWidget::load(const QString& filename)
 
     m_ui->fileNameLabel->setRawText(m_filename);
 
+    // Set the public name if defined
     auto label = tr("Unlock KeePassXC Database");
     if (!m_db->publicName().isEmpty()) {
         label.append(QString(": %1").arg(m_db->publicName()));
     }
     m_ui->labelHeadline->setText(label);
 
+    // Apply the public color to the central unlock stack if defined
     auto color = m_db->publicColor();
     if (!color.isEmpty()) {
         m_ui->centralStack->setStyleSheet(QString("QStackedWidget {border: 4px solid %1}").arg(color));
     } else {
         m_ui->centralStack->setStyleSheet("");
+    }
+
+    // Show the database icon if defined
+    auto iconIndex = m_db->publicIcon();
+    if (iconIndex >= 0 && iconIndex < databaseIcons()->count()) {
+        m_ui->dbIconLabel->setPixmap(databaseIcons()->icon(iconIndex, IconSize::Large));
+        m_ui->dbIconLabel->setVisible(true);
+    } else {
+        m_ui->dbIconLabel->setPixmap({});
+        m_ui->dbIconLabel->setVisible(false);
     }
 
     if (config()->get(Config::RememberLastKeyFiles).toBool()) {

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -235,11 +235,11 @@ void DatabaseOpenWidget::load(const QString& filename)
     m_ui->labelHeadline->setText(label);
 
     auto color = m_db->publicColor();
-    m_ui->displayColorLabel->setVisible(!color.isEmpty());
-    m_ui->displayColorLabel->setStyleSheet(
-        QString("background: %1; border: 1px solid palette(dark); border-radius: 4px").arg(color));
-
-    // m_ui->centralStack->setStyleSheet(QString("QStackedWidget {border: 4px solid %1}").arg(color));
+    if (!color.isEmpty()) {
+        m_ui->centralStack->setStyleSheet(QString("QStackedWidget {border: 4px solid %1}").arg(color));
+    } else {
+        m_ui->centralStack->setStyleSheet("");
+    }
 
     if (config()->get(Config::RememberLastKeyFiles).toBool()) {
         auto lastKeyFiles = config()->get(Config::LastKeyFiles).toHash();

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -40,7 +40,7 @@
      </item>
      <item>
       <widget class="QWidget" name="formContainer" native="true">
-       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,0,0,0,0,0,2">
+       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,0,0,0,0,2">
         <item>
          <spacer name="verticalSpacer_2">
           <property name="orientation">
@@ -87,22 +87,6 @@
            </spacer>
           </item>
          </layout>
-        </item>
-        <item>
-         <widget class="QLabel" name="displayColorLabel">
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>8</height>
-           </size>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background:cyan; border: 1px solid black; border-radius: 4px</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
         </item>
         <item>
          <widget class="ElidedLabel" name="fileNameLabel">

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -40,7 +40,7 @@
      </item>
      <item>
       <widget class="QWidget" name="formContainer" native="true">
-       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,0,0,0,0,2">
+       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,0,0,0,0,0,2">
         <item>
          <spacer name="verticalSpacer_2">
           <property name="orientation">
@@ -90,6 +90,22 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="publicSummaryLabel">
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="text">
+           <string>publicSummary</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="margin">
+           <number>10</number>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QStackedWidget" name="centralStack">

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -55,16 +55,52 @@
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="labelHeadline">
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
+           <number>9</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="labelHeadline">
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Unlock KeePassXC Database</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="displayColorLabel">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>8</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">background:cyan; border: 1px solid black; border-radius: 4px</string>
           </property>
           <property name="text">
-           <string>Unlock KeePassXC Database</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -90,22 +126,6 @@
            </size>
           </property>
          </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="publicSummaryLabel">
-          <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
-          </property>
-          <property name="text">
-           <string>publicSummary</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="margin">
-           <number>10</number>
-          </property>
-         </widget>
         </item>
         <item>
          <widget class="QStackedWidget" name="centralStack">

--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -60,6 +60,22 @@
            <number>9</number>
           </property>
           <item>
+           <widget class="QLabel" name="dbIconLabel">
+            <property name="minimumSize">
+             <size>
+              <width>32</width>
+              <height>32</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QLabel" name="labelHeadline">
             <property name="font">
              <font>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.cpp
@@ -18,6 +18,8 @@
 #include "DatabaseSettingsWidgetGeneral.h"
 #include "ui_DatabaseSettingsWidgetGeneral.h"
 
+#include <QColorDialog>
+
 #include "core/Clock.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
@@ -28,6 +30,8 @@ DatabaseSettingsWidgetGeneral::DatabaseSettingsWidgetGeneral(QWidget* parent)
     , m_ui(new Ui::DatabaseSettingsWidgetGeneral())
 {
     m_ui->setupUi(this);
+
+    connect(m_ui->dbPublicColorChooseButton, SIGNAL(clicked()), SLOT(pickColor()));
 
     connect(m_ui->historyMaxItemsCheckBox, SIGNAL(toggled(bool)), m_ui->historyMaxItemsSpinBox, SLOT(setEnabled(bool)));
     connect(m_ui->historyMaxSizeCheckBox, SIGNAL(toggled(bool)), m_ui->historyMaxSizeSpinBox, SLOT(setEnabled(bool)));
@@ -45,6 +49,9 @@ void DatabaseSettingsWidgetGeneral::initialize()
     m_ui->recycleBinEnabledCheckBox->setChecked(meta->recycleBinEnabled());
     m_ui->defaultUsernameEdit->setText(meta->defaultUserName());
     m_ui->compressionCheckbox->setChecked(m_db->compressionAlgorithm() != Database::CompressionNone);
+
+    m_ui->dbPublicSummary->setText(m_db->publicSummary());
+    m_ui->dbPublicColor->setText(m_db->publicColor());
 
     if (meta->historyMaxItems() > -1) {
         m_ui->historyMaxItemsSpinBox->setValue(meta->historyMaxItems());
@@ -116,6 +123,9 @@ bool DatabaseSettingsWidgetGeneral::saveSettings()
     meta->setRecycleBinEnabled(m_ui->recycleBinEnabledCheckBox->isChecked());
     meta->setSettingsChanged(Clock::currentDateTimeUtc());
 
+    m_db->setPublicSummary(m_ui->dbPublicSummary->text());
+    m_db->setPublicColor(m_ui->dbPublicColor->text());
+
     bool truncate = false;
 
     int historyMaxItems;
@@ -154,4 +164,11 @@ bool DatabaseSettingsWidgetGeneral::saveSettings()
     }
 
     return true;
+}
+
+void DatabaseSettingsWidgetGeneral::pickColor()
+{
+    QColor oldColor = QColor(m_ui->dbPublicColor->text());
+    QColor newColor = QColorDialog::getColor(oldColor);
+    m_ui->dbPublicColor->setText(newColor.name());
 }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
@@ -46,8 +46,10 @@ protected:
     void showEvent(QShowEvent* event) override;
 
 private slots:
-    void pickColor();
-    void setupColorButton(const QColor& color);
+    void pickPublicColor();
+    void setupPublicColorButton(const QColor& color);
+    void pickPublicIcon();
+    void setupPublicIconButton(int iconIndex);
 
 private:
     const QScopedPointer<Ui::DatabaseSettingsWidgetGeneral> m_ui;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
@@ -20,6 +20,8 @@
 
 #include "DatabaseSettingsWidget.h"
 
+#include <QColor>
+
 class Database;
 namespace Ui
 {
@@ -40,12 +42,14 @@ public slots:
     void uninitialize() override;
     bool saveSettings() override;
 
-private slots:
-    void pickColor();
-
 protected:
     void showEvent(QShowEvent* event) override;
 
+private slots:
+    void pickColor();
+    void setupColorButton(const QColor& color);
+
+private:
     const QScopedPointer<Ui::DatabaseSettingsWidgetGeneral> m_ui;
 };
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.h
@@ -40,6 +40,9 @@ public slots:
     void uninitialize() override;
     bool saveSettings() override;
 
+private slots:
+    void pickColor();
+
 protected:
     void showEvent(QShowEvent* event) override;
 

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
@@ -145,8 +145,8 @@
            <widget class="QPushButton" name="dbPublicColorButton">
             <property name="maximumSize">
              <size>
-              <width>25</width>
-              <height>25</height>
+              <width>30</width>
+              <height>30</height>
              </size>
             </property>
             <property name="toolTip">
@@ -169,6 +169,56 @@
           </item>
           <item>
            <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="dbPublicIconLabel">
+          <property name="text">
+           <string>Display icon:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QPushButton" name="dbPublicIconButton">
+            <property name="maximumSize">
+             <size>
+              <width>30</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>30</width>
+              <height>30</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="dbPublicIconClearButton">
+            <property name="text">
+             <string>Clear</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_4">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>453</width>
-    <height>394</height>
+    <height>647</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -88,6 +88,71 @@
          <string>Default username field</string>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Public Database Metadata</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QLabel" name="warningLabel">
+        <property name="text">
+         <string>Warning: the following settings are stored unencrypted.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QFormLayout" name="formLayout_2">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="dbPublicSummaryLabel">
+          <property name="text">
+           <string>Database summary:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="dbPublicSummary">
+          <property name="accessibleName">
+           <string>Database summary field</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="dbPublicColorLabel">
+          <property name="text">
+           <string>Database color:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLineEdit" name="dbPublicColor">
+            <property name="accessibleName">
+             <string>Database color field</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="dbPublicColorChooseButton">
+            <property name="text">
+             <string>Pick color...</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetGeneral.ui
@@ -100,8 +100,13 @@
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <widget class="QLabel" name="warningLabel">
+        <property name="font">
+         <font>
+          <italic>true</italic>
+         </font>
+        </property>
         <property name="text">
-         <string>Warning: the following settings are stored unencrypted.</string>
+         <string>Warning: the following settings are not encrypted.</string>
         </property>
        </widget>
       </item>
@@ -113,42 +118,67 @@
         <item row="0" column="0">
          <widget class="QLabel" name="dbPublicSummaryLabel">
           <property name="text">
-           <string>Database summary:</string>
+           <string>Display name:</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="dbPublicSummary">
+         <widget class="QLineEdit" name="dbPublicName">
+          <property name="toolTip">
+           <string>Publically visible display name used on the unlock dialog</string>
+          </property>
           <property name="accessibleName">
-           <string>Database summary field</string>
+           <string>Database public display name</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
          <widget class="QLabel" name="dbPublicColorLabel">
           <property name="text">
-           <string>Database color:</string>
+           <string>Display color:</string>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <property name="topMargin">
-           <number>0</number>
-          </property>
           <item>
-           <widget class="QLineEdit" name="dbPublicColor">
+           <widget class="QPushButton" name="dbPublicColorButton">
+            <property name="maximumSize">
+             <size>
+              <width>25</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Publically visible color used on the unlock dialog</string>
+            </property>
             <property name="accessibleName">
-             <string>Database color field</string>
+             <string>Database public display color chooser</string>
+            </property>
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="dbPublicColorChooseButton">
+           <widget class="QPushButton" name="dbPublicColorClearButton">
             <property name="text">
-             <string>Pick color...</string>
+             <string>Clear</string>
             </property>
            </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </item>
@@ -175,6 +205,19 @@ of entries remain at most.</string>
           </property>
           <property name="text">
            <string>Limit the amount of history items per entry to:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="recycleBinEnabledCheckBox">
+          <property name="toolTip">
+           <string>Move entries to a recycle bin group
+instead of deleting them from the database.
+Entries deleted from the recycle bin are
+removed from the database.</string>
+          </property>
+          <property name="text">
+           <string>Use recycle bin</string>
           </property>
          </widget>
         </item>
@@ -220,19 +263,6 @@ add up to the specified amount at most.</string>
           </property>
           <property name="maximum">
            <number>2000000000</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QCheckBox" name="recycleBinEnabledCheckBox">
-          <property name="toolTip">
-           <string>Move entries to a recycle bin group
-instead of deleting them from the database.
-Entries deleted from the recycle bin are
-removed from the database.</string>
-          </property>
-          <property name="text">
-           <string>Use recycle bin</string>
           </property>
          </widget>
         </item>

--- a/src/gui/styles/base/basestyle.qss
+++ b/src/gui/styles/base/basestyle.qss
@@ -38,7 +38,7 @@ EntryPreviewWidget TagsEdit
     padding-left: 0px;
 }
 
-DatabaseOpenWidget #centralStack {
+DatabaseOpenWidget #centralStack, DatabaseOpenWidget #publicSummaryLabel {
     border: 1px solid palette(mid);
     background: palette(light);
 }

--- a/src/gui/styles/base/classicstyle.qss
+++ b/src/gui/styles/base/classicstyle.qss
@@ -1,4 +1,4 @@
-DatabaseOpenWidget #centralStack {
+DatabaseOpenWidget #centralStack, DatabaseOpenWidget #publicSummaryLabel {
     border: 2px groove palette(mid);
     background: palette(light);
 }


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Closes #10783

Adds three database configuration options (stored as public custom data) that allow a database to have a public name/summary, color, and/or icon to be displayed on the unlock screen. This information is configured in the Database Settings and stored in the database public custom data (ie, unencrypted).

The name/summary is stored in KPXC_PUBLIC_NAME, the color is stored in KPXC_PUBLIC_COLOR, and the icon is stored in KPXC_PUBLIC_ICON.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )

![image](https://github.com/user-attachments/assets/de737298-5e13-49d7-b87f-f65f69b9d4fd)

![image](https://github.com/user-attachments/assets/583b65ce-64e3-4586-985f-49d9be4f2daa)

![image](https://github.com/user-attachments/assets/2a12758e-01ca-44df-806b-da748792bfef)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

I have extensively performed manual testing with different values of both the message (empty, short text, long text etc) and color (empty, varying colors, invalid colors etc). I've also tested opening/closing the database, starting keepassxc after it was the last DB opened etc to approach the unlock UI from different code paths.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
