### PR TITLE
Remove zero-width space character from comments

### DIFF
--- a/src/core/Totp.cpp
+++ b/src/core/Totp.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
+ *  Copyright (C) 2017 Weslly Honorato <weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/src/core/Totp.h
+++ b/src/core/Totp.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
+ *  Copyright (C) 2017 Weslly Honorato <weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/src/gui/TotpDialog.h
+++ b/src/gui/TotpDialog.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
+ *  Copyright (C) 2017 Weslly Honorato <weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/src/gui/TotpSetupDialog.h
+++ b/src/gui/TotpSetupDialog.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
+ *  Copyright (C) 2017 Weslly Honorato <weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/tests/TestTotp.cpp
+++ b/tests/TestTotp.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
+ *  Copyright (C) 2017 Weslly Honorato <weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/tests/TestTotp.h
+++ b/tests/TestTotp.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 Weslly Honorato <﻿weslly@protonmail.com>
+ *  Copyright (C) 2017 Weslly Honorato <weslly@protonmail.com>
  *  Copyright (C) 2017 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Remove Unicode character U+FEFF ZERO WIDTH NO-BREAK SPACE from Weslly's email address in a few places.

Not sure if this was done on purpose (anti-spam measure?), but it's not consistently done anyway (e.g. wasn't the case in
src/gui/TotpDialog.cpp), so it seems cleanest to remove this.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Documentation (non-code change)
