### PR TITLE
Various fixes to database settings

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1856,11 +1856,11 @@ Are you sure you want to continue without a password?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You must enter a stronger password to protect your database.</source>
+        <source>This is a weak password! For better protection of your secrets, you should choose a stronger password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is a weak password! For better protection of your secrets, you should choose a stronger password.</source>
+        <source>The provided password does not meet the minimum quality requirement.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -1041,6 +1041,13 @@ void Database::stopModifiedTimer()
 
 QUuid Database::publicUuid()
 {
+    // This feature requires KDBX4
+    if (m_data.formatVersion < KeePass2::FILE_VERSION_4) {
+        // Return the file path hash as a UUID for KDBX3
+        QCryptographicHash hasher(QCryptographicHash::Sha256);
+        hasher.addData(filePath().toUtf8());
+        return QUuid::fromRfc4122(hasher.result().left(16));
+    }
 
     if (!publicCustomData().contains("KPXC_PUBLIC_UUID")) {
         publicCustomData().insert("KPXC_PUBLIC_UUID", QUuid::createUuid().toRfc4122());

--- a/src/format/KeePass2.cpp
+++ b/src/format/KeePass2.cpp
@@ -49,10 +49,8 @@ const QString KeePass2::KDFPARAM_ARGON2_ASSOCDATA("A");
 
 const QList<QUuid> KeePass2::CIPHERS{KeePass2::CIPHER_AES256, KeePass2::CIPHER_TWOFISH, KeePass2::CIPHER_CHACHA20};
 
-const QList<QUuid> KeePass2::KDFS{KeePass2::KDF_ARGON2D,
-                                  KeePass2::KDF_ARGON2ID,
-                                  KeePass2::KDF_AES_KDBX4,
-                                  KeePass2::KDF_AES_KDBX3};
+const QList<QUuid> KeePass2::KDBX4_KDFS{KeePass2::KDF_ARGON2D, KeePass2::KDF_ARGON2ID, KeePass2::KDF_AES_KDBX4};
+const QList<QUuid> KeePass2::KDBX3_KDFS{KeePass2::KDF_AES_KDBX3};
 
 QByteArray KeePass2::hmacKey(const QByteArray& masterSeed, const QByteArray& transformedMasterKey)
 {

--- a/src/format/KeePass2.h
+++ b/src/format/KeePass2.h
@@ -67,7 +67,8 @@ namespace KeePass2
     extern const QString KDFPARAM_ARGON2_ASSOCDATA;
 
     extern const QList<QUuid> CIPHERS;
-    extern const QList<QUuid> KDFS;
+    extern const QList<QUuid> KDBX4_KDFS;
+    extern const QList<QUuid> KDBX3_KDFS;
 
     enum class HeaderFieldID
     {

--- a/src/gui/databasekey/KeyComponentWidget.cpp
+++ b/src/gui/databasekey/KeyComponentWidget.cpp
@@ -73,6 +73,10 @@ KeyComponentWidget::Page KeyComponentWidget::visiblePage() const
 
 void KeyComponentWidget::updateAddStatus(bool added)
 {
+    if (m_ui->stackedWidget->currentIndex() == Page::Edit) {
+        emit editCanceled();
+    }
+
     if (added) {
         m_ui->stackedWidget->setCurrentIndex(Page::LeaveOrRemove);
     } else {
@@ -99,12 +103,6 @@ void KeyComponentWidget::cancelEdit()
 {
     m_ui->stackedWidget->setCurrentIndex(m_previousPage);
     emit editCanceled();
-}
-
-void KeyComponentWidget::showEvent(QShowEvent* event)
-{
-    resetComponentEditWidget();
-    QWidget::showEvent(event);
 }
 
 void KeyComponentWidget::resetComponentEditWidget()

--- a/src/gui/databasekey/KeyComponentWidget.h
+++ b/src/gui/databasekey/KeyComponentWidget.h
@@ -104,9 +104,6 @@ signals:
     void editCanceled();
     void componentRemovalRequested();
 
-protected:
-    void showEvent(QShowEvent* event) override;
-
 private slots:
     void updateAddStatus(bool added);
     void doAdd();

--- a/src/gui/databasekey/PasswordEditWidget.cpp
+++ b/src/gui/databasekey/PasswordEditWidget.cpp
@@ -27,6 +27,9 @@ PasswordEditWidget::PasswordEditWidget(QWidget* parent)
     , m_compUi(new Ui::PasswordEditWidget())
 {
     initComponent();
+
+    // Explicitly clear password on cancel
+    connect(this, &PasswordEditWidget::editCanceled, this, [this] { setPassword({}); });
 }
 
 PasswordEditWidget::~PasswordEditWidget() = default;
@@ -59,7 +62,7 @@ bool PasswordEditWidget::isPasswordVisible() const
 
 bool PasswordEditWidget::isEmpty() const
 {
-    return (visiblePage() == Page::Edit) && m_compUi->enterPasswordEdit->text().isEmpty();
+    return visiblePage() != Page::Edit || m_compUi->enterPasswordEdit->text().isEmpty();
 }
 
 PasswordHealth::Quality PasswordEditWidget::getPasswordQuality() const
@@ -83,8 +86,7 @@ void PasswordEditWidget::initComponentEditWidget(QWidget* widget)
 {
     Q_UNUSED(widget);
     Q_ASSERT(m_compEditWidget);
-    m_compUi->enterPasswordEdit->setFocus();
-
+    setFocusProxy(m_compUi->enterPasswordEdit);
     m_compUi->enterPasswordEdit->setQualityVisible(true);
     m_compUi->repeatPasswordEdit->setQualityVisible(false);
 }
@@ -101,16 +103,6 @@ void PasswordEditWidget::initComponent()
     m_ui->componentDescription->setText(
         tr("<p>A password is the primary method for securing your database.</p>"
            "<p>Good passwords are long and unique. KeePassXC can generate one for you.</p>"));
-}
-
-void PasswordEditWidget::hideEvent(QHideEvent* event)
-{
-    if (!isVisible() && m_compUi->enterPasswordEdit) {
-        m_compUi->enterPasswordEdit->setText("");
-        m_compUi->repeatPasswordEdit->setText("");
-    }
-
-    QWidget::hideEvent(event);
 }
 
 bool PasswordEditWidget::validate(QString& errorMessage) const

--- a/src/gui/databasekey/PasswordEditWidget.h
+++ b/src/gui/databasekey/PasswordEditWidget.h
@@ -47,7 +47,6 @@ protected:
     QWidget* componentEditWidget() override;
     void initComponentEditWidget(QWidget* widget) override;
     void initComponent() override;
-    void hideEvent(QHideEvent* event) override;
 
 private slots:
     void setPassword(const QString& password);

--- a/src/gui/dbsettings/DatabaseSettingsDialog.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.cpp
@@ -92,36 +92,32 @@ DatabaseSettingsDialog::DatabaseSettingsDialog(QWidget* parent)
     scrollArea->setSizeAdjustPolicy(QScrollArea::AdjustToContents);
     scrollArea->setWidgetResizable(true);
     scrollArea->setWidget(m_databaseKeyWidget);
-    m_securityTabWidget->addTab(scrollArea, tr("Database Credentials"));
 
+    m_securityTabWidget->addTab(scrollArea, tr("Database Credentials"));
     m_securityTabWidget->addTab(m_encryptionWidget, tr("Encryption Settings"));
+    m_securityTabWidget->setCurrentIndex(0);
 
     m_ui->categoryList->addCategory(tr("Remote Sync"), icons()->icon("remote-sync"));
     m_ui->stackedWidget->addWidget(m_remoteWidget);
-
-#if defined(WITH_XC_KEESHARE)
-    addSettingsPage(new DatabaseSettingsPageKeeShare());
-#endif
-
-#if defined(WITH_XC_FDOSECRETS)
-    addSettingsPage(new DatabaseSettingsPageFdoSecrets());
-#endif
-
-    m_ui->stackedWidget->setCurrentIndex(0);
-    m_securityTabWidget->setCurrentIndex(0);
-
-    connect(m_securityTabWidget, SIGNAL(currentChanged(int)), SLOT(pageChanged()));
-    connect(m_ui->categoryList, SIGNAL(categoryChanged(int)), m_ui->stackedWidget, SLOT(setCurrentIndex(int)));
 
 #ifdef WITH_XC_BROWSER
     m_ui->categoryList->addCategory(tr("Browser Integration"), icons()->icon("internet-web-browser"));
     m_ui->stackedWidget->addWidget(m_browserWidget);
 #endif
 
+#ifdef WITH_XC_KEESHARE
+    addSettingsPage(new DatabaseSettingsPageKeeShare());
+#endif
+
+#ifdef WITH_XC_FDOSECRETS
+    addSettingsPage(new DatabaseSettingsPageFdoSecrets());
+#endif
+
     m_ui->categoryList->addCategory(tr("Maintenance"), icons()->icon("hammer-wrench"));
     m_ui->stackedWidget->addWidget(m_maintenanceWidget);
 
-    pageChanged();
+    m_ui->stackedWidget->setCurrentIndex(0);
+    connect(m_ui->categoryList, SIGNAL(categoryChanged(int)), m_ui->stackedWidget, SLOT(setCurrentIndex(int)));
 }
 
 DatabaseSettingsDialog::~DatabaseSettingsDialog() = default;
@@ -171,20 +167,28 @@ void DatabaseSettingsDialog::showRemoteSettings()
 void DatabaseSettingsDialog::save()
 {
     if (!m_generalWidget->save()) {
+        m_ui->categoryList->setCurrentCategory(0);
         return;
     }
 
     if (!m_databaseKeyWidget->save()) {
+        m_ui->categoryList->setCurrentCategory(1);
+        m_securityTabWidget->setCurrentIndex(0);
         return;
     }
 
     if (!m_encryptionWidget->save()) {
+        m_ui->categoryList->setCurrentCategory(1);
+        m_securityTabWidget->setCurrentIndex(1);
         return;
     }
 
     if (!m_remoteWidget->save()) {
+        m_ui->categoryList->setCurrentCategory(2);
         return;
     }
+
+    // Browser settings don't have anything to save
 
     for (const ExtraPage& extraPage : asConst(m_extraPages)) {
         extraPage.saveSettings();
@@ -195,10 +199,13 @@ void DatabaseSettingsDialog::save()
 
 void DatabaseSettingsDialog::reject()
 {
-    emit editFinished(false);
-}
+    m_generalWidget->discard();
+    m_databaseKeyWidget->discard();
+    m_encryptionWidget->discard();
+    m_remoteWidget->discard();
+#ifdef WITH_XC_BROWSER
+    m_browserWidget->discard();
+#endif
 
-void DatabaseSettingsDialog::pageChanged()
-{
-    m_ui->stackedWidget->currentIndex();
+    emit editFinished(false);
 }

--- a/src/gui/dbsettings/DatabaseSettingsDialog.h
+++ b/src/gui/dbsettings/DatabaseSettingsDialog.h
@@ -70,7 +70,6 @@ signals:
 private slots:
     void save();
     void reject();
-    void pageChanged();
 
 private:
     enum Page

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.h
@@ -47,13 +47,10 @@ protected:
 
 private slots:
     void benchmarkTransformRounds(int millisecs = Kdf::DEFAULT_ENCRYPTION_TIME);
-    void changeKdf(int index);
     void memoryChanged(int value);
     void parallelismChanged(int value);
     void updateDecryptionTime(int value);
-    void updateFormatCompatibility(int index, bool retransform = true);
-    void setupAlgorithmComboBox();
-    void setupKdfComboBox(bool enableKdbx3);
+    void loadKdfAlgorithms();
     void loadKdfParameters();
     void updateKdfFields();
     void markDirty();
@@ -71,7 +68,6 @@ private:
 
     bool m_isDirty = false;
     bool m_initWithAdvanced = false;
-    bool m_formatCompatibilityDirty = false;
     const QScopedPointer<Ui::DatabaseSettingsWidgetEncryption> m_ui;
 };
 

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1607,12 +1607,20 @@ void TestGui::testDatabaseSettings()
     passwordWidgets[0]->setText("b");
     passwordWidgets[1]->setText("b");
 
-    // Cancel password change
+    // Toggle between tabs to ensure the password remains
+    securityTabWidget->setCurrentIndex(1);
+    QApplication::processEvents();
+    securityTabWidget->setCurrentIndex(0);
+    QApplication::processEvents();
+    QCOMPARE(passwordWidgets[0]->text(), QString("b"));
+
+    // Cancel password change and confirm password is cleared
     auto cancelPasswordButton = passwordEditWidget->findChild<QPushButton*>("cancelButton");
     QVERIFY(cancelPasswordButton);
     QTest::mouseClick(cancelPasswordButton, Qt::LeftButton);
     QApplication::processEvents();
     QVERIFY(!passwordWidgets[0]->isVisible());
+    QCOMPARE(passwordWidgets[0]->text(), QString(""));
     QVERIFY(editPasswordButton->isVisible());
 
     // Switch to encryption tab and interact with various settings


### PR DESCRIPTION
Changes are split across 3 commits intentionally.

* Use SHA256 hash of the file path of the database to generate a UUID when using the KDBX3 format. This restores the original behavior of using the file path as the quick unlock lookup key.

* Fixes https://github.com/keepassxreboot/keepassxc/issues/10558
* Fixes https://github.com/keepassxreboot/keepassxc/issues/10723 - only display password strength warning when actively editing the password
* Also improve behavior of minimum quality warning
* Improve behavior and handling of password changes with the database settings dialog
* Prevents loss of newly entered password when toggling between elements in the settings page
* On error, switch to tab that prevents saving database settings for easier correction

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested extensively manually and added unit tests

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)