### PR TITLE
Database Report: HIBP tab only if network enabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,8 +170,6 @@ set(keepassx_SOURCES
         gui/reports/ReportsDialog.cpp
         gui/reports/ReportsWidgetHealthcheck.cpp
         gui/reports/ReportsPageHealthcheck.cpp
-        gui/reports/ReportsWidgetHibp.cpp
-        gui/reports/ReportsPageHibp.cpp
         gui/reports/ReportsWidgetStatistics.cpp
         gui/reports/ReportsPageStatistics.cpp
         gui/osutils/OSUtilsBase.cpp
@@ -361,6 +359,8 @@ if(WITH_XC_NETWORKING)
             gui/UpdateCheckDialog.cpp
             gui/IconDownloader.cpp
             gui/IconDownloaderDialog.cpp
+            gui/reports/ReportsWidgetHibp.cpp
+            gui/reports/ReportsPageHibp.cpp
             updatecheck/UpdateChecker.cpp)
 endif()
 

--- a/src/gui/reports/ReportsDialog.cpp
+++ b/src/gui/reports/ReportsDialog.cpp
@@ -19,7 +19,10 @@
 #include "ui_ReportsDialog.h"
 
 #include "ReportsPageHealthcheck.h"
+#ifdef WITH_XC_NETWORKING
 #include "ReportsPageHibp.h"
+#include "ReportsWidgetHibp.h"
+#endif
 #include "ReportsPageStatistics.h"
 #ifdef WITH_XC_BROWSER
 #include "ReportsPageBrowserStatistics.h"
@@ -30,7 +33,6 @@
 #include "ReportsWidgetPasskeys.h"
 #endif
 #include "ReportsWidgetHealthcheck.h"
-#include "ReportsWidgetHibp.h"
 
 #include "core/Global.h"
 #include "core/Group.h"
@@ -61,7 +63,9 @@ ReportsDialog::ReportsDialog(QWidget* parent)
     : DialogyWidget(parent)
     , m_ui(new Ui::ReportsDialog())
     , m_healthPage(new ReportsPageHealthcheck())
+#ifdef WITH_XC_NETWORKING
     , m_hibpPage(new ReportsPageHibp())
+#endif
     , m_statPage(new ReportsPageStatistics())
 #ifdef WITH_XC_BROWSER
     , m_browserStatPage(new ReportsPageBrowserStatistics())
@@ -82,7 +86,9 @@ ReportsDialog::ReportsDialog(QWidget* parent)
 #ifdef WITH_XC_BROWSER
     addPage(m_browserStatPage);
 #endif
+#ifdef WITH_XC_NETWORKING
     addPage(m_hibpPage);
+#endif
 
     m_ui->stackedWidget->setCurrentIndex(0);
 
@@ -93,7 +99,9 @@ ReportsDialog::ReportsDialog(QWidget* parent)
 
     connect(m_ui->categoryList, SIGNAL(categoryChanged(int)), m_ui->stackedWidget, SLOT(setCurrentIndex(int)));
     connect(m_healthPage->m_healthWidget, SIGNAL(entryActivated(Entry*)), SLOT(entryActivationSignalReceived(Entry*)));
+#ifdef WITH_XC_NETWORKING
     connect(m_hibpPage->m_hibpWidget, SIGNAL(entryActivated(Entry*)), SLOT(entryActivationSignalReceived(Entry*)));
+#endif
 #ifdef WITH_XC_BROWSER
     connect(m_browserStatPage->m_browserWidget,
             SIGNAL(entryActivated(Entry*)),
@@ -164,9 +172,12 @@ void ReportsDialog::switchToMainView(bool previousDialogAccepted)
     if (previousDialogAccepted) {
         if (m_sender == m_healthPage->m_healthWidget) {
             m_healthPage->m_healthWidget->calculateHealth();
-        } else if (m_sender == m_hibpPage->m_hibpWidget) {
+        }
+#ifdef WITH_XC_NETWORKING
+        if (m_sender == m_hibpPage->m_hibpWidget) {
             m_hibpPage->m_hibpWidget->refreshAfterEdit();
         }
+#endif
 #ifdef WITH_XC_BROWSER
         if (m_sender == m_browserStatPage->m_browserWidget) {
             m_browserStatPage->m_browserWidget->calculateBrowserStatistics();

--- a/src/gui/reports/ReportsDialog.h
+++ b/src/gui/reports/ReportsDialog.h
@@ -79,7 +79,9 @@ private:
     QSharedPointer<Database> m_db;
     const QScopedPointer<Ui::ReportsDialog> m_ui;
     const QSharedPointer<ReportsPageHealthcheck> m_healthPage;
+#ifdef WITH_XC_NETWORKING
     const QSharedPointer<ReportsPageHibp> m_hibpPage;
+#endif
     const QSharedPointer<ReportsPageStatistics> m_statPage;
 #ifdef WITH_XC_BROWSER
     const QSharedPointer<ReportsPageBrowserStatistics> m_browserStatPage;

--- a/src/gui/reports/ReportsWidgetHibp.h
+++ b/src/gui/reports/ReportsWidgetHibp.h
@@ -18,14 +18,10 @@
 #ifndef KEEPASSXC_REPORTSWIDGETHIBP_H
 #define KEEPASSXC_REPORTSWIDGETHIBP_H
 
-#include "config-keepassx.h"
+#include "core/HibpDownloader.h"
 #include "gui/entry/EntryModel.h"
 
 #include <QWidget>
-
-#ifdef WITH_XC_NETWORKING
-#include "core/HibpDownloader.h"
-#endif
 
 class Database;
 class Entry;
@@ -75,10 +71,7 @@ private:
     QPointer<Entry> m_editedEntry; // The entry we're currently editing
     QString m_editedPassword; // The old password of the entry we're editing
     bool m_editedExcluded; // The old "known bad" flag of the entry we're editing
-
-#ifdef WITH_XC_NETWORKING
     HibpDownloader m_downloader; // This performs the actual HIBP online query
-#endif
 };
 
 #endif // KEEPASSXC_REPORTSWIDGETHIBP_H


### PR DESCRIPTION
In the Database Report widget, only include the HIBP section if KeePassXC was built with networking enabled. Previously, it would show the section but it would not be functional.

Fixes #10299.

## Screenshots

I can supply if interested.

## Testing strategy

I have manually confirmed that no HIBP section shows up in the Database Report when building with `-DWITH_XC_NETWORKING=OFF`. When built with networking enabled, it shows up as normal.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
