### PR TITLE
Botan: don't call deprecated functions

### DIFF
--- a/src/browser/BrowserPasskeys.cpp
+++ b/src/browser/BrowserPasskeys.cpp
@@ -19,6 +19,7 @@
 #include "BrowserMessageBuilder.h"
 #include "BrowserService.h"
 #include "PasskeyUtils.h"
+#include "config-keepassx.h"
 #include "crypto/Random.h"
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -276,7 +277,11 @@ BrowserPasskeys::buildCredentialPrivateKey(int alg, const QString& predefinedFir
             try {
                 Botan::Ed25519_PrivateKey key(*randomGen()->getRng());
                 auto publicKey = key.get_public_key();
+#ifdef WITH_XC_BOTAN3
+                auto privateKey = key.raw_private_key_bits();
+#else
                 auto privateKey = key.get_private_key();
+#endif
                 firstPart = browserMessageBuilder()->getQByteArray(publicKey.data(), publicKey.size());
                 secondPart = browserMessageBuilder()->getQByteArray(privateKey.data(), privateKey.size());
 

--- a/src/crypto/SymmetricCipher.cpp
+++ b/src/crypto/SymmetricCipher.cpp
@@ -34,7 +34,11 @@ bool SymmetricCipher::init(Mode mode, Direction direction, const QByteArray& key
     try {
         auto botanMode = modeToString(mode);
         auto botanDirection =
+#ifdef WITH_XC_BOTAN3
+            (direction == SymmetricCipher::Encrypt ? Botan::Cipher_Dir::Encryption : Botan::Cipher_Dir::Decryption);
+#else
             (direction == SymmetricCipher::Encrypt ? Botan::Cipher_Dir::ENCRYPTION : Botan::Cipher_Dir::DECRYPTION);
+#endif
 
         auto cipher = Botan::Cipher_Mode::create_or_throw(botanMode.toStdString(), botanDirection);
         m_cipher.reset(cipher.release());

--- a/src/sshagent/OpenSSHKeyGen.cpp
+++ b/src/sshagent/OpenSSHKeyGen.cpp
@@ -18,6 +18,7 @@
 #include "OpenSSHKeyGen.h"
 #include "BinaryStream.h"
 #include "OpenSSHKey.h"
+#include "config-keepassx.h"
 #include "crypto/Random.h"
 
 #include <botan/ecdsa.h>
@@ -126,7 +127,11 @@ namespace OpenSSHKeyGen
             QByteArray privateData;
             BinaryStream privateStream(&privateData);
             vectorToStream(ed25519Key.get_public_key(), privateStream);
+#ifdef WITH_XC_BOTAN3
+            vectorToStream(ed25519Key.raw_private_key_bits(), privateStream);
+#else
             vectorToStream(ed25519Key.get_private_key(), privateStream);
+#endif
 
             key.setType("ssh-ed25519");
             key.setCheck(randomGen()->randomUInt(std::numeric_limits<quint32>::max() - 1) + 1);


### PR DESCRIPTION
These commits were temporarily part of #7783, but they are unrelated to Qt and make more sense separately.

Fix a couple of cases where we were using deprecated Botan symbols. This is in service of making a `-DWITH_DEV_BUILD=ON` build compile successfully, which this achieves when combined with #7783.

This is behind a Botan version ifdef, because Botan 2 only has the old symbols, whereas Botan 3 deprecates the old symbols and introduces the new ones.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)