### PR TITLE
Prevent checking file hash with an empty path

### DIFF
--- a/src/core/FileWatcher.cpp
+++ b/src/core/FileWatcher.cpp
@@ -131,7 +131,7 @@ void FileWatcher::checkFileChanged()
 QByteArray FileWatcher::calculateChecksum()
 {
     QFile file(m_filePath);
-    if (file.open(QFile::ReadOnly)) {
+    if (!m_filePath.isEmpty() && file.open(QFile::ReadOnly)) {
         QCryptographicHash hash(QCryptographicHash::Sha256);
         if (m_fileChecksumSizeBytes > 0) {
             hash.addData(file.read(m_fileChecksumSizeBytes));


### PR DESCRIPTION
A warning is issued from Qt when the path is empty. This happens most often during test runs, but can also occur when closing a database before everything gets cleaned up.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)