### PR TITLE
Passkeys: Return authenticatorData and publicKeyAlgorithm to extension

### DIFF
--- a/src/browser/BrowserPasskeys.h
+++ b/src/browser/BrowserPasskeys.h
@@ -119,7 +119,7 @@ private:
                                       const QString& credentialId,
                                       const QByteArray& cborEncodedPublicKey,
                                       const TestingVariables& predefinedVariables = {});
-    QByteArray buildAuthenticatorData(const QJsonObject& publicKey);
+    QByteArray buildAuthenticatorData(const QString& rpId, const QString& extensions);
     AttestationKeyPair buildCredentialPrivateKey(int alg,
                                                  const QString& predefinedFirst = QString(),
                                                  const QString& predefinedSecond = QString());


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds support for returning `authenticatorData` to the extension side on register. Currently it is only returned during the authentication. Related issue is mentioned here: https://github.com/keepassxreboot/keepassxc-browser/issues/2061

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Extension already supports `authenticatorData`, and support for public key functions is coming later.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
