### PR TITLE
Verify USB listener callback handle

### DIFF
--- a/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp
+++ b/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp
@@ -97,11 +97,13 @@ DeviceListenerLibUsb::registerHotplugCallback(bool arrived, bool left, int vendo
         // Avoid race conditions
         m_usbEvents.waitForFinished();
     }
-    if (!m_usbEvents.isRunning()) {
-        m_completed = false;
-        m_usbEvents = QtConcurrent::run(handleUsbEvents, static_cast<libusb_context*>(m_ctx), &m_completed);
+    if (handle > 0) {
+        m_callbackHandles.insert(handle);
+        if (!m_usbEvents.isRunning()) {
+            m_completed = false;
+            m_usbEvents = QtConcurrent::run(handleUsbEvents, static_cast<libusb_context*>(m_ctx), &m_completed);
+        }
     }
-    m_callbackHandles.insert(handle);
     return handle;
 }
 


### PR DESCRIPTION
Do not use `handle` if `libusb_hotplug_register_callback` fails

On OpenBSD USB listener callback fails. When this happens, opening and closing a DB takes a very long time. Maybe through `handleUsbEvents()`


## Testing strategy
Test wit yubikey on OpenBSD -current


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
