### PR TITLE
Passkeys: Fix incorrect username fill

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1148,13 +1148,7 @@ void BrowserService::denyEntry(Entry* entry, const QString& siteHost, const QStr
 QJsonObject BrowserService::prepareEntry(const Entry* entry)
 {
     QJsonObject res;
-#ifdef WITH_XC_BROWSER_PASSKEYS
-    // Use Passkey's username instead if found
-    res["login"] = entry->hasPasskey() ? passkeyUtils()->getUsernameFromEntry(entry)
-                                       : entry->resolveMultiplePlaceholders(entry->username());
-#else
     res["login"] = entry->resolveMultiplePlaceholders(entry->username());
-#endif
     res["password"] = entry->resolveMultiplePlaceholders(entry->password());
     res["name"] = entry->resolveMultiplePlaceholders(entry->title());
     res["uuid"] = entry->resolveMultiplePlaceholders(entry->uuidToHex());


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fix filling wrong username with a normal entry that has a passkey.
There are two possible situations with entries that has a passkey:
1) Entry only has a passkey. Username is set to `KPEX_PASSKEY_USERNAME`.
2) Entry has normal credentials and `KPEX_PASSKEY_USERNAME`.

In the second situation the normal username needs to be returned if entry has a passkey but `KPEX_PASSKEY_USERNAME` differs. The `KPEX_PASSKEY_USERNAME` attribute will be still used during authentication normally. The username only matters how the credential is displayed in the extension side, and during the Access Confirm Dialog.

Fixes #10840.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
