### PR TITLE
Search entry: respect shortcut config on Copy key

### DIFF
--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -57,7 +57,6 @@ signals:
     void caseSensitiveChanged(bool state);
     void limitGroupChanged(bool state);
     void escapePressed();
-    void copyPressed();
     void downPressed();
     void enterPressed();
     void lostFocus();

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1129,15 +1129,15 @@ void TestGui::testSearch()
     searchedEntry->setPassword("password");
     QClipboard* clipboard = QApplication::clipboard();
 
-    // Attempt password copy with selected test (should fail)
+    // Copy to clipboard: should copy search text (not password)
     QTest::keyClick(searchTextEdit, Qt::Key_C, Qt::ControlModifier);
-    QVERIFY(clipboard->text() != searchedEntry->password());
+    QCOMPARE(clipboard->text(), QString("someTHING"));
     // Deselect text and confirm password copies
     QTest::mouseClick(searchTextEdit, Qt::LeftButton);
     QTRY_VERIFY(searchTextEdit->selectedText().isEmpty());
     QTRY_VERIFY(searchTextEdit->hasFocus());
     QTest::keyClick(searchTextEdit, Qt::Key_C, Qt::ControlModifier);
-    QCOMPARE(searchedEntry->password(), clipboard->text());
+    QCOMPARE(clipboard->text(), searchedEntry->password());
     // Ensure Down focuses on entry view when search text is selected
     QTest::keyClick(searchTextEdit, Qt::Key_A, Qt::ControlModifier);
     QTest::keyClick(searchTextEdit, Qt::Key_Down);
@@ -1145,11 +1145,11 @@ void TestGui::testSearch()
     QCOMPARE(entryView->currentEntry(), searchedEntry);
     // Test that password copies with entry focused
     QTest::keyClick(entryView, Qt::Key_C, Qt::ControlModifier);
-    QCOMPARE(searchedEntry->password(), clipboard->text());
+    QCOMPARE(clipboard->text(), searchedEntry->password());
     // Refocus back to search edit
     QTest::mouseClick(searchTextEdit, Qt::LeftButton);
     QTRY_VERIFY(searchTextEdit->hasFocus());
-    // Test that password does not copy
+    // Select search text and test that password does not copy
     searchTextEdit->selectAll();
     QTest::keyClick(searchTextEdit, Qt::Key_C, Qt::ControlModifier);
     QTRY_COMPARE(clipboard->text(), QString("someTHING"));


### PR DESCRIPTION
If the system Copy key sequence (i.e. Ctrl+C or Cmd+C) is pressed while inside the search entry without any text being selected, previously we would copy the currently selected entry's password. This made sense when keyboard shortcuts were fixed. Now that they are configurable, change it to re-route the event to the main window, which can then take the appropriate action (i.e. Ctrl+C might be bound to some other action).

I originally had this as part of #10853, but decided it makes more sense as its own PR.

## Testing strategy

Confirmed that existing tests cover this case (and tweaked them a tiny bit).

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)