### PR TITLE
Fix passphrase generator test

### DIFF
--- a/tests/TestPassphraseGenerator.cpp
+++ b/tests/TestPassphraseGenerator.cpp
@@ -50,5 +50,5 @@ void TestPassphraseGenerator::testWordCase()
     generator.setWordCase(PassphraseGenerator::TITLECASE);
     passphrase = generator.generatePassphrase();
     QRegularExpression regex("^(?:[A-Z][a-z-]* )*[A-Z][a-z-]*$");
-    QVERIFY2(regex.match(passphrase).hasMatch(), passphrase.toStdString().c_str());
+    QVERIFY2(regex.match(passphrase).hasMatch(), qPrintable(passphrase));
 }

--- a/tests/TestPassphraseGenerator.cpp
+++ b/tests/TestPassphraseGenerator.cpp
@@ -49,6 +49,6 @@ void TestPassphraseGenerator::testWordCase()
 
     generator.setWordCase(PassphraseGenerator::TITLECASE);
     passphrase = generator.generatePassphrase();
-    QRegularExpression regex("^([A-Z][a-z]* ?)+$");
-    QVERIFY(regex.match(passphrase).hasMatch());
+    QRegularExpression regex("^(?:[A-Z][a-z-]* )*[A-Z][a-z-]*$");
+    QVERIFY2(regex.match(passphrase).hasMatch(), passphrase.toStdString().c_str());
 }


### PR DESCRIPTION
Previously, the test case was assuming the wrong regex. In particular, the default word list (`eff_large.wordlist`) contains several words that contain dashes ([example](https://github.com/keepassxreboot/keepassxc/blob/e72cc7dd7387b9400d0f3ab2c2970f3c5cd4c5dc/share/wordlists/eff_large.wordlist#L2009)). Adjust the regex used in the test to reflect this. This should fix rare test failures ([example](
https://ci.keepassxc.org/buildConfiguration/KeePassXC_UbuntuLinux/248145?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true&showLog=248140_1339_1263&logFilter=debug&logView=flowAware)).

Additionally, if this test case ever fails again, the error message will include the generated passphrase, to make debugging easier.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
