### PR TITLE
Fix typos in DatabaseSettingsWidgetRemote

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -2292,16 +2292,6 @@ removed from the database.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>e.g.:
-get DatabaseOnRemote.kdbx {TEMP_DATABASE}
-exit
----
-{TEMP_DATABASE} is used as placeholder to store the database in a temporary location
-The command has to exit. In case of `sftp` as last commend `exit` has to be sent
-            </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2315,16 +2305,6 @@ The command has to exit. In case of `sftp` as last commend `exit` has to be sent
     </message>
     <message>
         <source>Upload input field</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>e.g.:
-put {TEMP_DATABASE} DatabaseOnRemote.kdbx
-exit
----
-{TEMP_DATABASE} is used as placeholder to store the database in a temporary location
-The command has to exit. In case of `sftp` as last commend `exit` has to be sent
-            </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2357,6 +2337,26 @@ The command has to exit. In case of `sftp` as last commend `exit` has to be sent
     </message>
     <message>
         <source>You have unsaved changes. Do you want to save them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>e.g.:
+get DatabaseOnRemote.kdbx {TEMP_DATABASE}
+exit
+---
+{TEMP_DATABASE} is used as placeholder to store the database in a temporary location
+The command has to exit. In case of `sftp` as last command `exit` has to be sent
+            </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>e.g.:
+put {TEMP_DATABASE} DatabaseOnRemote.kdbx
+exit
+---
+{TEMP_DATABASE} is used as placeholder to store the database in a temporary location
+The command has to exit. In case of `sftp` as last command `exit` has to be sent
+            </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gui/remote/DatabaseSettingsWidgetRemote.ui
+++ b/src/gui/remote/DatabaseSettingsWidgetRemote.ui
@@ -181,7 +181,7 @@ get DatabaseOnRemote.kdbx {TEMP_DATABASE}
 exit
 ---
 {TEMP_DATABASE} is used as placeholder to store the database in a temporary location
-The command has to exit. In case of `sftp` as last commend `exit` has to be sent
+The command has to exit. In case of `sftp` as last command `exit` has to be sent
             </string>
               </property>
              </widget>
@@ -231,7 +231,7 @@ put {TEMP_DATABASE} DatabaseOnRemote.kdbx
 exit
 ---
 {TEMP_DATABASE} is used as placeholder to store the database in a temporary location
-The command has to exit. In case of `sftp` as last commend `exit` has to be sent
+The command has to exit. In case of `sftp` as last command `exit` has to be sent
             </string>
               </property>
              </widget>


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes a few typos introduced in https://github.com/keepassxreboot/keepassxc/pull/7222.
`commend` -> `command`.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
