### PR TITLE
TestGui: testTotp: use QTRY_COMPARE

### DIFF
--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1030,7 +1030,7 @@ void TestGui::testTotp()
     auto* totpDialog = m_dbWidget->findChild<TotpDialog*>("TotpDialog");
     auto* totpLabel = totpDialog->findChild<QLabel*>("totpLabel");
 
-    QCOMPARE(totpLabel->text().replace(" ", ""), entry->totp());
+    QTRY_COMPARE(totpLabel->text().replace(" ", ""), entry->totp());
     QTest::keyClick(totpDialog, Qt::Key_Escape);
 
     // Test the QR code


### PR DESCRIPTION
A check in `TestGui::testTotp` [failed](https://ci.keepassxc.org/buildConfiguration/KeePassXC_MacOS/248424?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&showLog=248423_1081_942&logFilter=debug&logView=flowAware) in #10853, presumably because of inherent raciness:

```
20:28:37   FAIL!  : TestGui::testTotp() Compared values are not the same
20:28:37      Actual   (totpLabel->text().replace(" ", "")): "625751"
20:28:37      Expected (entry->totp())                     : "067152"
20:28:37      Loc: [/Users/KPXC/buildAgent/work/c401303cba1b4098/tests/gui/TestGui.cpp(1033)]
```

Paper over the raciness by using `QTRY_COMPARE` instead of `QCOMPARE`.