### PR TITLE
MainWindow: move shortcuts from .cpp to .ui file + change Clone Entry shortcut

### DIFF
--- a/src/gui/ActionCollection.cpp
+++ b/src/gui/ActionCollection.cpp
@@ -61,14 +61,10 @@ void ActionCollection::setDefaultShortcut(QAction* action, const QKeySequence& s
     setDefaultShortcuts(action, {shortcut});
 }
 
-void ActionCollection::setDefaultShortcut(QAction* action,
-                                          QKeySequence::StandardKey standard,
-                                          const QKeySequence& fallback)
+void ActionCollection::setDefaultShortcut(QAction* action, QKeySequence::StandardKey standard)
 {
     if (!QKeySequence::keyBindings(standard).isEmpty()) {
         setDefaultShortcuts(action, QKeySequence::keyBindings(standard));
-    } else if (fallback != 0) {
-        setDefaultShortcut(action, QKeySequence(fallback));
     }
 }
 

--- a/src/gui/ActionCollection.h
+++ b/src/gui/ActionCollection.h
@@ -44,7 +44,7 @@ public:
     QList<QKeySequence> defaultShortcuts(const QAction* a) const;
 
     void setDefaultShortcut(QAction* a, const QKeySequence& shortcut);
-    void setDefaultShortcut(QAction* a, QKeySequence::StandardKey standard, const QKeySequence& fallback);
+    void setDefaultShortcut(QAction* a, QKeySequence::StandardKey standard);
     void setDefaultShortcuts(QAction* a, const QList<QKeySequence>& shortcut);
 
     // Check if any action conflicts with @p seq and return the conflicting action

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2190,54 +2190,29 @@ void MainWindow::initActionCollection()
                     m_ui->actionBugReport,
                     m_ui->actionAbout});
 
-    // Add actions whose shortcuts were set in the .ui file
+    // Register as default any shortcuts that were set in the .ui file
     for (const auto action : ac->actions()) {
         if (!action->shortcut().isEmpty()) {
             ac->setDefaultShortcut(action, action->shortcut());
         }
     }
 
-    // Actions with standard shortcuts
-    ac->setDefaultShortcut(m_ui->actionDatabaseOpen, QKeySequence::Open, Qt::CTRL + Qt::Key_O);
-    ac->setDefaultShortcut(m_ui->actionDatabaseSave, QKeySequence::Save, Qt::CTRL + Qt::Key_S);
-    ac->setDefaultShortcut(m_ui->actionDatabaseSaveAs, QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S);
-    ac->setDefaultShortcut(m_ui->actionDatabaseClose, QKeySequence::Close, Qt::CTRL + Qt::Key_W);
-    ac->setDefaultShortcut(m_ui->actionSettings, QKeySequence::Preferences, Qt::CTRL + Qt::Key_Comma);
-    ac->setDefaultShortcut(m_ui->actionQuit, QKeySequence::Quit, Qt::CTRL + Qt::Key_Q);
-    ac->setDefaultShortcut(m_ui->actionEntryNew, QKeySequence::New, Qt::CTRL + Qt::Key_N);
+    // Actions with standard shortcuts (if no standard shortcut exists, leave the existing
+    // shortcuts from the .ui file in place)
+    ac->setDefaultShortcut(m_ui->actionDatabaseOpen, QKeySequence::Open);
+    ac->setDefaultShortcut(m_ui->actionDatabaseSave, QKeySequence::Save);
+    ac->setDefaultShortcut(m_ui->actionDatabaseSaveAs, QKeySequence::SaveAs);
+    ac->setDefaultShortcut(m_ui->actionDatabaseClose, QKeySequence::Close);
+    ac->setDefaultShortcut(m_ui->actionSettings, QKeySequence::Preferences);
+    ac->setDefaultShortcut(m_ui->actionQuit, QKeySequence::Quit);
+    ac->setDefaultShortcut(m_ui->actionEntryNew, QKeySequence::New);
 
     // Prevent conflicts with global Mac shortcuts (force Control on all platforms)
+    // Note: Qt::META means Ctrl on Mac.
 #ifdef Q_OS_MAC
-    auto modifier = Qt::META;
-#else
-    auto modifier = Qt::CTRL;
+    ac->setDefaultShortcut(m_ui->actionEntryAddToAgent, Qt::META + Qt::Key_H);
+    ac->setDefaultShortcut(m_ui->actionEntryRemoveFromAgent, Qt::META + Qt::SHIFT + Qt::Key_H);
 #endif
-
-    // All other actions with default shortcuts
-    ac->setDefaultShortcut(m_ui->actionDatabaseNew, Qt::CTRL + Qt::SHIFT + Qt::Key_N);
-    ac->setDefaultShortcut(m_ui->actionDatabaseSettings, Qt::CTRL + Qt::SHIFT + Qt::Key_Comma);
-    ac->setDefaultShortcut(m_ui->actionReports, Qt::CTRL + Qt::SHIFT + Qt::Key_R);
-    ac->setDefaultShortcut(m_ui->actionLockDatabase, Qt::CTRL + Qt::Key_L);
-    ac->setDefaultShortcut(m_ui->actionLockAllDatabases, Qt::CTRL + Qt::SHIFT + Qt::Key_L);
-    ac->setDefaultShortcut(m_ui->actionEntryEdit, Qt::CTRL + Qt::Key_E);
-    ac->setDefaultShortcut(m_ui->actionEntryDelete, Qt::CTRL + Qt::Key_D);
-    ac->setDefaultShortcut(m_ui->actionEntryDelete, Qt::Key_Delete);
-    ac->setDefaultShortcut(m_ui->actionEntryClone, Qt::CTRL + Qt::Key_K);
-    ac->setDefaultShortcut(m_ui->actionEntryTotp, Qt::CTRL + Qt::SHIFT + Qt::Key_T);
-    ac->setDefaultShortcut(m_ui->actionEntryDownloadIcon, Qt::CTRL + Qt::SHIFT + Qt::Key_D);
-    ac->setDefaultShortcut(m_ui->actionEntryCopyTotp, Qt::CTRL + Qt::Key_T);
-    ac->setDefaultShortcut(m_ui->actionEntryCopyPasswordTotp, Qt::CTRL + Qt::Key_Y);
-    ac->setDefaultShortcut(m_ui->actionEntryMoveUp, Qt::CTRL + Qt::ALT + Qt::Key_Up);
-    ac->setDefaultShortcut(m_ui->actionEntryMoveDown, Qt::CTRL + Qt::ALT + Qt::Key_Down);
-    ac->setDefaultShortcut(m_ui->actionEntryCopyUsername, Qt::CTRL + Qt::Key_B);
-    ac->setDefaultShortcut(m_ui->actionEntryCopyPassword, Qt::CTRL + Qt::Key_C);
-    ac->setDefaultShortcut(m_ui->actionEntryCopyTitle, Qt::CTRL + Qt::Key_I);
-    ac->setDefaultShortcut(m_ui->actionEntryAutoTypeSequence, Qt::CTRL + Qt::SHIFT + Qt::Key_V);
-    ac->setDefaultShortcut(m_ui->actionEntryOpenUrl, Qt::CTRL + Qt::SHIFT + Qt::Key_U);
-    ac->setDefaultShortcut(m_ui->actionEntryCopyURL, Qt::CTRL + Qt::Key_U);
-    ac->setDefaultShortcut(m_ui->actionEntryRestore, Qt::CTRL + Qt::Key_R);
-    ac->setDefaultShortcut(m_ui->actionEntryAddToAgent, modifier + Qt::Key_H);
-    ac->setDefaultShortcut(m_ui->actionEntryRemoveFromAgent, modifier + Qt::SHIFT + Qt::Key_H);
 
     QTimer::singleShot(1, ac, &ActionCollection::restoreShortcuts);
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -992,17 +992,17 @@ void MainWindow::setMenuActionState(DatabaseWidget::Mode mode)
         case DatabaseWidget::Mode::LockedMode: {
             // Enable select actions when editing an entry
             bool editEntryActive = dbWidget->isEntryEditActive();
-            const auto editEntryActionsMask = QList<QAction*>({m_ui->actionEntryCopyUsername,
-                                                               m_ui->actionEntryCopyPassword,
-                                                               m_ui->actionEntryCopyURL,
-                                                               m_ui->actionEntryOpenUrl,
-                                                               m_ui->actionEntryAutoType,
-                                                               m_ui->actionEntryDownloadIcon,
-                                                               m_ui->actionEntryCopyNotes,
-                                                               m_ui->actionEntryCopyTitle,
-                                                               m_ui->menuEntryCopyAttribute->menuAction(),
-                                                               m_ui->menuEntryTotp->menuAction(),
-                                                               m_ui->actionEntrySetupTotp});
+            const QList<QAction*> editEntryActionsMask{m_ui->actionEntryCopyUsername,
+                                                       m_ui->actionEntryCopyPassword,
+                                                       m_ui->actionEntryCopyURL,
+                                                       m_ui->actionEntryOpenUrl,
+                                                       m_ui->actionEntryAutoType,
+                                                       m_ui->actionEntryDownloadIcon,
+                                                       m_ui->actionEntryCopyNotes,
+                                                       m_ui->actionEntryCopyTitle,
+                                                       m_ui->menuEntryCopyAttribute->menuAction(),
+                                                       m_ui->menuEntryTotp->menuAction(),
+                                                       m_ui->actionEntrySetupTotp};
 
             auto entryActions = m_ui->menuEntries->actions();
             entryActions << m_ui->menuEntryCopyAttribute->actions();

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -731,7 +731,7 @@
     <string>Clone Entry</string>
    </property>
    <property name="shortcut">
-    <string notr="true">Ctrl+K</string>
+    <string notr="true">Ctrl+D</string>
    </property>
   </action>
   <action name="actionEntryMoveUp">

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -447,6 +447,9 @@
    <property name="toolTip">
     <string>Quit Application</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Q</string>
+   </property>
    <property name="menuRole">
     <enum>QAction::QuitRole</enum>
    </property>
@@ -477,6 +480,9 @@
    <property name="toolTip">
     <string>Open Database</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+O</string>
+   </property>
   </action>
   <action name="actionDatabaseSave">
    <property name="enabled">
@@ -484,6 +490,9 @@
    </property>
    <property name="text">
     <string>&amp;Save Database</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+S</string>
    </property>
   </action>
   <action name="actionDatabaseClose">
@@ -493,6 +502,9 @@
    <property name="text">
     <string>&amp;Close Database</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+W</string>
+   </property>
   </action>
   <action name="actionDatabaseNew">
    <property name="text">
@@ -500,6 +512,9 @@
    </property>
    <property name="toolTip">
     <string>Create Database</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+N</string>
    </property>
   </action>
   <action name="actionDatabaseMerge">
@@ -520,6 +535,9 @@
    <property name="toolTip">
     <string>Create Entry</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+N</string>
+   </property>
   </action>
   <action name="actionEntryEdit">
    <property name="enabled">
@@ -531,6 +549,9 @@
    <property name="toolTip">
     <string>Edit Entry</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+E</string>
+   </property>
   </action>
   <action name="actionEntryDelete">
    <property name="enabled">
@@ -541,6 +562,9 @@
    </property>
    <property name="toolTip">
     <string>Delete Entry</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Del</string>
    </property>
   </action>
   <action name="actionGroupNew">
@@ -619,6 +643,9 @@
    <property name="toolTip">
     <string>Save Database As</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+S</string>
+   </property>
   </action>
   <action name="actionDatabaseSecurity">
    <property name="enabled">
@@ -641,6 +668,9 @@
    <property name="toolTip">
     <string>Show Database Reports</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+R</string>
+   </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
    </property>
@@ -654,6 +684,9 @@
    </property>
    <property name="toolTip">
     <string>Show Database Settings</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+,</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -697,6 +730,9 @@
    <property name="toolTip">
     <string>Clone Entry</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+K</string>
+   </property>
   </action>
   <action name="actionEntryMoveUp">
    <property name="enabled">
@@ -707,6 +743,9 @@
    </property>
    <property name="toolTip">
     <string>Move Entry Up</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Alt+Up</string>
    </property>
   </action>
   <action name="actionEntryMoveDown">
@@ -719,6 +758,9 @@
    <property name="toolTip">
     <string>Move Entry Down</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Alt+Down</string>
+   </property>
   </action>
   <action name="actionEntryCopyUsername">
    <property name="enabled">
@@ -729,6 +771,9 @@
    </property>
    <property name="toolTip">
     <string>Copy Username</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+B</string>
    </property>
   </action>
   <action name="actionEntryCopyPassword">
@@ -741,6 +786,9 @@
    <property name="toolTip">
     <string>Copy Password</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+C</string>
+   </property>
   </action>
   <action name="actionSettings">
    <property name="checkable">
@@ -751,6 +799,9 @@
    </property>
    <property name="toolTip">
     <string>Show Application Settings</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+,</string>
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>
@@ -865,6 +916,9 @@
    <property name="text">
     <string>Download &amp;Favicon</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+D</string>
+   </property>
   </action>
   <action name="actionEntryOpenUrl">
    <property name="enabled">
@@ -872,6 +926,9 @@
    </property>
    <property name="text">
     <string>Open &amp;URL</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+U</string>
    </property>
   </action>
   <action name="actionLockDatabase">
@@ -881,6 +938,9 @@
    <property name="text">
     <string>&amp;Lock Database</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+L</string>
+   </property>
   </action>
   <action name="actionLockAllDatabases">
    <property name="enabled">
@@ -888,6 +948,9 @@
    </property>
    <property name="text">
     <string>Lock &amp;All Databases</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+L</string>
    </property>
   </action>
   <action name="actionEntryCopyTitle">
@@ -900,6 +963,9 @@
    <property name="toolTip">
     <string>Copy Title</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+I</string>
+   </property>
   </action>
   <action name="actionEntryCopyURL">
    <property name="enabled">
@@ -910,6 +976,9 @@
    </property>
    <property name="toolTip">
     <string>Copy URL</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+U</string>
    </property>
   </action>
   <action name="actionEntryCopyNotes">
@@ -973,6 +1042,9 @@
    <property name="text">
     <string>Show TOTP</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+T</string>
+   </property>
   </action>
   <action name="actionEntryTotpQRCode">
    <property name="text">
@@ -994,10 +1066,16 @@
    <property name="text">
     <string>Copy &amp;TOTP</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+T</string>
+   </property>
   </action>
   <action name="actionEntryCopyPasswordTotp">
    <property name="text">
     <string>Copy Password and TOTP</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Y</string>
    </property>
   </action>
   <action name="actionGroupEmptyRecycleBin">
@@ -1080,6 +1158,9 @@
    <property name="toolTip">
     <string>SSH Agent: Add Key</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+H</string>
+   </property>
   </action>
   <action name="actionEntryRemoveFromAgent">
    <property name="text">
@@ -1087,6 +1168,9 @@
    </property>
    <property name="toolTip">
     <string>SSH Agent: Remove Key</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+H</string>
    </property>
   </action>
   <action name="actionCompactMode">
@@ -1243,6 +1327,9 @@
    </property>
    <property name="toolTip">
     <string notr="true">Perform Auto-Type: Entry Default</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+V</string>
    </property>
   </action>
   <action name="actionGroupClone">


### PR DESCRIPTION
Where possible, move shortcuts from being defined in `MainWindow.cpp` to being defined in `MainWindow.ui`. Previously, there was a seemingly random mix of both practices.

The only shortcuts defined in the `.cpp` file are now ones that can't be defined in the `.ui` file, because they are in some way conditional.

This also reduces the number of compiler warnings of the kind

    warning: arithmetic between different enumeration types ‘Qt::Modifier’ and ‘Qt::Key’ is deprecated [-Wdeprecated-enum-enum-conversion]

with recent GCC versions.

And some minor code cleanups in `MainWindow.cpp`.

Also, change the shortcut for the Clone Entry shortcut from Ctrl+K to Ctrl+D (see discussion below).

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)
