### PR TITLE
Snap: Improve Web-browser Native Messaging host functionality

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1187,18 +1187,6 @@ Do you want to overwrite the passkey in %1 - %2?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Due to Snap sandboxing, you must run a script to enable browser integration.&lt;br /&gt;You can obtain this script from %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>KeePassXC-Browser is needed for the browser integration to work. &lt;br /&gt;Download it for %1 and %2 and %3. %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Please see special instructions for browser extension use below</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Executable Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1244,6 +1232,10 @@ Do you want to overwrite the passkey in %1 - %2?</source>
     </message>
     <message>
         <source>Allow using localhost with passkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC-Browser is needed for the browser integration to work. &lt;br /&gt;Download it for %1 and %2 and %3.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ plugs:
       - $HOME/.config/microsoft-edge/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
       - $HOME/.config/vivaldi/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
       - $HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
-      - $HOME/.local/share/torbrowser/tbb/x86_64/tor-browser_en-US/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts
+      - $HOME/.local/share/torbrowser/tbb/x86_64/tor-browser_en-US/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
 
 slots:
   session-dbus-interface:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ apps:
     command: usr/bin/keepassxc
     common-id: org.keepassxc.KeePassXC.desktop
     extensions: [kde-neon]
-    plugs: [home, unity7, network, network-bind, removable-media, raw-usb, password-manager-service]
+    plugs: [home, unity7, network, network-bind, removable-media, raw-usb, password-manager-service, browser-native-messaging]
     autostart: org.keepassxc.KeePassXC.desktop
   cli:
     command: usr/bin/keepassxc-cli
@@ -20,6 +20,18 @@ apps:
     command: usr/bin/keepassxc-proxy
     extensions: [kde-neon]
     plugs: [home]
+
+plugs:
+  browser-native-messaging:
+    interface: personal-files
+    write:
+      - $HOME/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
+      - $HOME/.config/chromium/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
+      - $HOME/.config/google-chrome/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
+      - $HOME/.config/microsoft-edge/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
+      - $HOME/.config/vivaldi/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
+      - $HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
+      - $HOME/.local/share/torbrowser/tbb/x86_64/tor-browser_en-US/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts
 
 slots:
   session-dbus-interface:

--- a/src/browser/BrowserSettingsWidget.cpp
+++ b/src/browser/BrowserSettingsWidget.cpp
@@ -31,23 +31,13 @@ BrowserSettingsWidget::BrowserSettingsWidget(QWidget* parent)
     m_ui->setupUi(this);
 
     // clang-format off
-    QString snapInstructions;
-#if defined(KEEPASSXC_DIST_SNAP)
-    snapInstructions = "<br /><br />" +
-            tr("Due to Snap sandboxing, you must run a script to enable browser integration."
-               "<br />"
-               "You can obtain this script from %1")
-               .arg("<a href=\"https://keepassxc.org/download#linux\">https://keepassxc.org</a>");
-#endif
-
     m_ui->extensionLabel->setOpenExternalLinks(true);
     m_ui->extensionLabel->setText(
-        tr("KeePassXC-Browser is needed for the browser integration to work. <br />Download it for %1 and %2 and %3. %4")
+        tr("KeePassXC-Browser is needed for the browser integration to work. <br />Download it for %1 and %2 and %3.")
             .arg("<a href=\"https://addons.mozilla.org/firefox/addon/keepassxc-browser/\">Firefox</a>",
                  "<a href=\"https://chrome.google.com/webstore/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">"
                  "Google Chrome / Chromium / Vivaldi / Brave</a>",
-                 "<a href=\"https://microsoftedge.microsoft.com/addons/detail/pdffhmdngciaglkoonimfcmckehcpafo\">Microsoft Edge</a>",
-                 snapInstructions));
+                 "<a href=\"https://microsoftedge.microsoft.com/addons/detail/pdffhmdngciaglkoonimfcmckehcpafo\">Microsoft Edge</a>"));
     // clang-format on
 
     m_ui->tabWidget->setEnabled(m_ui->enableBrowserSupport->isChecked());
@@ -149,16 +139,11 @@ void BrowserSettingsWidget::loadSettings()
     m_ui->useCustomProxy->setVisible(false);
     m_ui->customProxyLocation->setVisible(false);
     m_ui->customProxyLocationBrowseButton->setVisible(false);
-    m_ui->browsersGroupBox->setVisible(false);
-    m_ui->browsersGroupBox->setEnabled(false);
     m_ui->updateBinaryPath->setChecked(false);
     m_ui->updateBinaryPath->setVisible(false);
     // No custom browser for snaps
     m_ui->customBrowserSupport->setVisible(false);
     m_ui->customBrowserGroupBox->setVisible(false);
-    // Show notice to user
-    m_ui->messageWidget->showMessage(tr("Please see special instructions for browser extension use below"),
-                                     MessageWidget::Warning);
 #endif
 #ifdef KEEPASSXC_DIST_FLATPAK
     // The sandbox makes custom proxy locations very unintuitive

--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -226,6 +226,16 @@ QString NativeMessageInstaller::getNativeMessagePath(SupportedBrowsers browser) 
     } else {
         basePath = QDir::homePath() + "/.config";
     }
+#elif defined(KEEPASSXC_DIST_SNAP)
+    // Same as Flatpak above, with the exception that Snap also redefines $HOME
+    // Therefore we must explicitly reference $SNAP_REAL_HOME
+    if (browser == SupportedBrowsers::TOR_BROWSER) {
+	basePath = qEnvironmentVariable("SNAP_REAL_HOME") + "/.local/share";
+    } else if (browser == SupportedBrowsers::FIREFOX) {
+        basePath = qEnvironmentVariable("SNAP_REAL_HOME");
+    } else {
+        basePath = qEnvironmentVariable("SNAP_REAL_HOME") + "/.config";
+    }
 #elif defined(Q_OS_LINUX) || (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     if (browser == SupportedBrowsers::TOR_BROWSER) {
         basePath = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
@@ -296,6 +306,8 @@ QString NativeMessageInstaller::getInstalledProxyPath() const
     path = QProcessEnvironment::systemEnvironment().value("APPIMAGE");
 #elif defined(KEEPASSXC_DIST_FLATPAK)
     path = constructFlatpakPath();
+#elif defined(KEEPASSXC_DIST_SNAP)
+    path = "/snap/bin/keepassxc.proxy";
 #else
     path = QCoreApplication::applicationDirPath() + QStringLiteral("/keepassxc-proxy");
 #ifdef Q_OS_WIN

--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -230,7 +230,7 @@ QString NativeMessageInstaller::getNativeMessagePath(SupportedBrowsers browser) 
     // Same as Flatpak above, with the exception that Snap also redefines $HOME
     // Therefore we must explicitly reference $SNAP_REAL_HOME
     if (browser == SupportedBrowsers::TOR_BROWSER) {
-	basePath = qEnvironmentVariable("SNAP_REAL_HOME") + "/.local/share";
+        basePath = qEnvironmentVariable("SNAP_REAL_HOME") + "/.local/share";
     } else if (browser == SupportedBrowsers::FIREFOX) {
         basePath = qEnvironmentVariable("SNAP_REAL_HOME");
     } else {


### PR DESCRIPTION
This commit allows for the snap distribution of KeepassXC to self-manage native messaging manifests This is done by making the binary aware of the snapd environment changes that currently prevent this. Furthermore, the snap sandbox is expanded to the bare minimum needed to access these privileged files.

Please note if running a self-compiled / untrusted KeepassXC snap build (I.E, installed with --dangerous) that you must manually run `sudo snap connect keepassxc:browser-native-messaging` to grant permissions.

This will work on all distributions that expose `/snap/bin/` - such as Ubuntu, Debian, etc. For systems which don't provide `/snap/`, such as Fedora, follow instructions for enabling "Classic" snaps. e.g., `sudo ln -s /var/lib/snapd/snap /snap`

## Describe your changes in detail, why is this change required?
Currently, if users install KeepassXC as a snap, the "Browser Integration" interface will instruct them to use an external script to set up the Native Messaging hosts. This is a poor user experience as it's a snap specific requirement, and also because it prevents KeepassXC being able clean up the host files (the user cannot "untick" and press ok on any browser).

This helps remove user friction by making things "just work" without compromising in security in any manner, the sandbox is expanded purely to accommodate the exact files required,  and all existing certificate checks on the app & extensions themselves, the authentication process, etc, all remain as standard.

##  Explain large or complex code modifications. 
Ultimately, this mirrors the workarounds used for the Flatpak build, the app needs to actively consider that the $HOME path it is presented with is not the real value on the host. By doing so, the files are instead exposed where they need to be to enable other programs to use them.

Whilst this will reduce bug reports and user problems significantly, it's not a magic bullet. There's 2 elements that come into play with compatibility.

1) The browser itself may be sandboxed. If so, native-messaging support isn't guaranteed. It's available on Firefox and Chromium snaps in distributions newer than 22.04, in a "it just works experience". This is done via a downstream patch to the XDG Desktop Portals, and so, it wouldn't be compatible with e.g Fedora using the Firefox snap, until/unless https://github.com/flatpak/xdg-desktop-portal/pull/705 is merged and widely distributed.

Ultimately, most Snap users are Ubuntu users, so considering population demographics, this should still improve the majority of typical use cases.

2) The binary is hardcoded as `/bin/snap/keepassxc.proxy`, this isn't guaranteed to exist at that location. E.G., on Fedora, users would have to run `sudo ln -s /var/lib/snapd/snap /snap`, this follows the same semantics as enabling "Classic Snaps" support. This can be done before or after installation of KeepassXC, and KeepassXC itself is still operating under Strict confinement.

Again, considering user demographics, I'd imagine most other distributions use the AppImage, Flatpak, or distro repo versions before considering snap, meaning this shouldn't be a common occurrence relatively.

## Screenshots
N/A

## Testing strategy
1) Build the Snap
2) Ensure `sudo snap connect keepassxc:browser-native-messaging` is run, as will be required on any untrusted builds not published from the Snap Store.
3) Enable the browser integration functionality and test it on browsers.

Test Environment, Ubuntu 24.04

Firefox Snap + KeepassXC snap: ✅
Firefox native + KeepassXC snap: ✅
Chromium Snap + KeepassXC Snap: ✅
Google-Chrome native + KeepassXC snap: ✅
Brave Snap + KeepassXC Snap: Failure as Brave has not adopted the XDG Desktop Portal patches, no regression in this patch.
Brave native + KeepassXC Snap: ✅

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
