### PR TITLE
App settings: fix widget tab order

### DIFF
--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -1280,6 +1280,7 @@
   <tabstop>languageComboBox</tabstop>
   <tabstop>toolButtonStyleComboBox</tabstop>
   <tabstop>toolbarMovableCheckBox</tabstop>
+  <tabstop>colorPasswordsCheckBox</tabstop>
   <tabstop>monospaceNotesCheckBox</tabstop>
   <tabstop>minimizeOnCloseCheckBox</tabstop>
   <tabstop>systrayShowCheckBox</tabstop>

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -279,12 +279,16 @@
   <tabstop>lockDatabaseIdleSpinBox</tabstop>
   <tabstop>clearSearchCheckBox</tabstop>
   <tabstop>clearSearchSpinBox</tabstop>
+  <tabstop>quickUnlockCheckBox</tabstop>
   <tabstop>lockDatabaseOnScreenLockCheckBox</tabstop>
   <tabstop>lockDatabaseMinimizeCheckBox</tabstop>
   <tabstop>passwordsHiddenCheckBox</tabstop>
   <tabstop>passwordShowDotsCheckBox</tabstop>
   <tabstop>passwordPreviewCleartextCheckBox</tabstop>
+  <tabstop>hideTotpCheckBox</tabstop>
   <tabstop>hideNotesCheckBox</tabstop>
+  <tabstop>NoConfirmMoveEntryToRecycleBinCheckBox</tabstop>
+  <tabstop>EnableCopyOnDoubleClickCheckBox</tabstop>
   <tabstop>fallbackToSearch</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
Fix tab order of checkboxes in Application Settings -> General.

Also fix another tab order issue in Application Settings -> Security.

Fixes #9765.

## Testing strategy

Tested manually.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
