### PR TITLE
Fix failing remote tests

### DIFF
--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -397,14 +397,10 @@ void TestGui::prepareAndTriggerRemoteSync(const QString& sourceToSync)
     QVERIFY(saveSettingsButton != nullptr);
     QTest::mouseClick(saveSettingsButton, Qt::LeftButton);
 
-    // find and click dialog OK button
-    auto buttons = dbSettingsDialog->findChild<QDialogButtonBox*>()->findChildren<QPushButton*>();
-    for (QPushButton* b : buttons) {
-        if (b->text() == "OK") {
-            QTest::mouseClick(b, Qt::LeftButton);
-            break;
-        }
-    }
+    auto okButton = dbSettingsDialog->findChild<QDialogButtonBox*>("buttonBox")->button(QDialogButtonBox::Ok);
+    QVERIFY(okButton);
+    QTest::mouseClick(okButton, Qt::LeftButton);
+
     QTRY_COMPARE(m_dbWidget->getRemoteParams().size(), 1);
 
     // trigger aboutToShow to create remote actions


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes failing remote tests:
```
QFATAL : TestGui::testRemoteSyncDatabaseRequiresPassword() Received signal 11
         Function time: 658ms Total time: 5010ms
FAIL!  : TestGui::testRemoteSyncDatabaseRequiresPassword() Received a fatal error.
   Loc: [Unknown file(0)]
```

Button text changed from `"OK"` to `"&OK"`. With this PR, it should not matter anymore what the button text is.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
