### PR TITLE
Snap: Remove $HOME access from keepassxc-proxy

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,6 @@ apps:
   proxy:
     command: usr/bin/keepassxc-proxy
     extensions: [kde-neon]
-    plugs: [home]
 
 plugs:
   browser-native-messaging:


### PR DESCRIPTION
`keepassxc-proxy` only requires access to the local Unix socket that's already granted by the baseline sandbox profile. The main application is responsible for manipulating the database and has its own permissions, the proxy itself doesn't need to touch user files.

## Testing strategy
1) Build and install snap
2) Configure KeepassXC Browser integration and test that it functions as expected

This patch works fine with manual testing on Ubuntu 24.04.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
