### PR TITLE
Increase the time interval for window show workaround

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1818,7 +1818,7 @@ void MainWindow::hide()
 {
 #ifndef Q_OS_WIN
     qint64 current_time = Clock::currentMilliSecondsSinceEpoch();
-    if (current_time - m_lastShowTime < 50) {
+    if (current_time - m_lastShowTime < 250) {
         return;
     }
 #endif


### PR DESCRIPTION
The interval in the workaround for showing the window is too short, extend it.

Previously I was using an old system and running a patched version of keepassxc. However, now I am running a modern system and the existing value is not sufficient.

## Testing strategy
Tried showing the keepasxc window by clicking the tray icon several times.

Unlike with the previous interval which makes it possible to show the window once in several attempts with the new interval it works reliably

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
