### PR TITLE
Passkeys: Fix showing correct username in the reports

### DIFF
--- a/src/gui/reports/ReportsWidgetPasskeys.cpp
+++ b/src/gui/reports/ReportsWidgetPasskeys.cpp
@@ -19,6 +19,7 @@
 #include "ui_ReportsWidgetPasskeys.h"
 
 #include "browser/BrowserPasskeys.h"
+#include "browser/PasskeyUtils.h"
 #include "core/AsyncTask.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
@@ -132,7 +133,7 @@ void ReportsWidgetPasskeys::addPasskeyRow(Group* group, Entry* entry)
     auto row = QList<QStandardItem*>();
     row << new QStandardItem(Icons::entryIconPixmap(entry), title);
     row << new QStandardItem(Icons::groupIconPixmap(group), group->hierarchy().join("/"));
-    row << new QStandardItem(entry->username());
+    row << new QStandardItem(passkeyUtils()->getUsernameFromEntry(entry));
     row << new QStandardItem(entry->attributes()->value(BrowserPasskeys::KPEX_PASSKEY_RELYING_PARTY));
     row << new QStandardItem(urlList.join('\n'));
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Reference usernames are not shown in the passkeys reports.

This field should refer to `KPEX_PASSKEY_USERNAME` attribute and ignore the entry's actual username setting. An entry can also contain a passkey, but has different usernames: e.g. `username@example.com` in the entry and just `username` in the attribute.

Fixes #10931.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
