### PR TITLE
Snap: Add u2f-devices plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,12 +10,12 @@ apps:
     command: usr/bin/keepassxc
     common-id: org.keepassxc.KeePassXC.desktop
     extensions: [kde-neon]
-    plugs: [home, unity7, network, network-bind, removable-media, raw-usb, password-manager-service, browser-native-messaging]
+    plugs: [home, unity7, network, network-bind, removable-media, raw-usb, password-manager-service, browser-native-messaging, u2f-devices]
     autostart: org.keepassxc.KeePassXC.desktop
   cli:
     command: usr/bin/keepassxc-cli
     extensions: [kde-neon]
-    plugs: [home, removable-media, raw-usb]
+    plugs: [home, removable-media, raw-usb, u2f-devices]
   proxy:
     command: usr/bin/keepassxc-proxy
     extensions: [kde-neon]


### PR DESCRIPTION
The KeepassXC snap currently can't access Yubikeys and other hardware authenticators. This plug grants access to common authenticators. This doesn't grant access to *all* authenticators, the device must be known to snapd and present itself in a way that guarantees it's secure to access (e.g., it must have a unique device ID that doesn't overlap with other generic components).

Effectively the list of devices can be seen here: https://github.com/snapcore/snapd/blob/master/interfaces/builtin/u2f_devices.go

It would be preferable, although not mandatory, if this could be made to autoconnect via the Snap Forums review process. I'd believe KeepassXC would be likely granted this access automatically, and doing so ultimately helps further reduce bug reports/issues with that build for minimum burden after the one time setup. Otherwise, manual connection is simply just `sudo snap connect keepassxc:u2f-devices`.

If a specific device doesn't work, users should log a bug with snapd, not KeepassXC.

- ✅ Bug fix (non-breaking change that fixes an issue)