### PR TITLE
Show character count in password generator dialog

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -6888,6 +6888,14 @@ Do you want to overwrite it?</source>
         <source>Special Characters</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>passwordLength</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Characters: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PasswordWidget</name>

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -57,6 +57,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
 
     connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updateButtonsEnabled(QString)));
     connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updatePasswordStrength()));
+    connect(m_ui->editNewPassword, SIGNAL(textChanged(QString)), SLOT(updatePasswordLengthLabel(QString)));
     connect(m_ui->buttonAdvancedMode, SIGNAL(toggled(bool)), SLOT(setAdvancedMode(bool)));
     connect(m_ui->buttonAddHex, SIGNAL(clicked()), SLOT(excludeHexChars()));
     connect(m_ui->editAdditionalChars, SIGNAL(textChanged(QString)), SLOT(updateGenerator()));
@@ -80,7 +81,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     connect(m_ui->tabWidget, SIGNAL(currentChanged(int)), SLOT(updateGenerator()));
     connect(m_ui->wordCaseComboBox, SIGNAL(currentIndexChanged(int)), SLOT(updateGenerator()));
 
-    // set font size of password quality and entropy labels dynamically to 80% of
+    // set font size of password quality, characters, and entropy labels dynamically to 80% of
     // the default font size, but make it no smaller than 8pt
     QFont defaultFont;
     auto smallerSize = static_cast<int>(defaultFont.pointSize() * 0.8f);
@@ -88,6 +89,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
         defaultFont.setPointSize(smallerSize);
         m_ui->entropyLabel->setFont(defaultFont);
         m_ui->strengthLabel->setFont(defaultFont);
+        m_ui->passwordLengthLabel->setFont(defaultFont);
     }
 
     // set default separator to Space
@@ -314,6 +316,11 @@ void PasswordGeneratorWidget::updatePasswordStrength()
         m_ui->strengthLabel->setText(tr("Password Quality: %1").arg(tr("Excellent", "Password quality")));
         break;
     }
+}
+
+void PasswordGeneratorWidget::updatePasswordLengthLabel(const QString& password)
+{
+    m_ui->passwordLengthLabel->setText(tr("Characters: %1").arg(QString::number(password.length())));
 }
 
 void PasswordGeneratorWidget::applyPassword()

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -76,6 +76,7 @@ protected:
 private slots:
     void updateButtonsEnabled(const QString& password);
     void updatePasswordStrength();
+    void updatePasswordLengthLabel(const QString& password);
     void setAdvancedMode(bool advanced);
     void excludeHexChars();
 

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>729</width>
-    <height>427</height>
+    <height>433</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -48,6 +48,50 @@
        </item>
        <item>
         <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="passwordLengthLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>70</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>passwordLength</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+         </property>
+         <property name="margin">
+          <number>3</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_6">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -895,6 +895,7 @@ void TestGui::testPasswordEntryEntropy()
             pwGeneratorWidget->findChild<PasswordWidget*>("editNewPassword")->findChild<QLineEdit*>("passwordEdit");
         auto* entropyLabel = pwGeneratorWidget->findChild<QLabel*>("entropyLabel");
         auto* strengthLabel = pwGeneratorWidget->findChild<QLabel*>("strengthLabel");
+        auto* passwordLengthLabel = pwGeneratorWidget->findChild<QLabel*>("passwordLengthLabel");
 
         QFETCH(QString, password);
         QFETCH(QString, expectedStrengthLabel);
@@ -902,10 +903,12 @@ void TestGui::testPasswordEntryEntropy()
         // Dynamically calculate entropy due to variances with zxcvbn wordlists
         PasswordHealth health(password);
         auto expectedEntropy = QString("Entropy: %1 bit").arg(QString::number(health.entropy(), 'f', 2));
+        auto expectedPasswordLength = QString("Characters: %1").arg(QString::number(password.length()));
 
         generatedPassword->setText(password);
         QCOMPARE(entropyLabel->text(), expectedEntropy);
         QCOMPARE(strengthLabel->text(), expectedStrengthLabel);
+        QCOMPARE(passwordLengthLabel->text(), expectedPasswordLength);
 
         QTest::mouseClick(generatedPassword, Qt::LeftButton);
         QTest::keyClick(generatedPassword, Qt::Key_Escape););


### PR DESCRIPTION
This adds a new label called "Characters" to the password generator dialog that displays the number of characters in the password text field. This makes it easy to figure out how many characters are in the password if the user enters or deletes characters from the generated password.

This fixes #10858.

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![keepassxc-password-dialog](https://github.com/keepassxreboot/keepassxc/assets/10790920/144071c8-9eae-41f7-bed2-dbe907725717)

## Testing strategy
I piggy-backed off the existing entropy tests and verified that the length in the new password label is the same as the expected length.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)