### PR TITLE
Passkey importer: fix file picker parent

### DIFF
--- a/src/gui/passkeys/PasskeyImporter.cpp
+++ b/src/gui/passkeys/PasskeyImporter.cpp
@@ -39,7 +39,7 @@ void PasskeyImporter::importPasskey(QSharedPointer<Database>& database, Entry* e
 {
     auto filter = QString("%1 (*.passkey);;%2 (*)").arg(tr("Passkey file"), tr("All files"));
     auto fileName =
-        fileDialog()->getOpenFileName(nullptr, tr("Open passkey file"), FileDialog::getLastDir("passkey"), filter);
+        fileDialog()->getOpenFileName(m_parent, tr("Open passkey file"), FileDialog::getLastDir("passkey"), filter);
     if (fileName.isEmpty()) {
         return;
     }


### PR DESCRIPTION
When selecting _Database → Import Passkey_, we show a file picker. Previously, we did not specify a parent widget for it. This could have undesirable effects on its presentation. (For example, with the Sway tiling Wayland compositor, it would show the file picker as a tiled window rather than a floating one.)

Fix the issue by passing in the parent widget. This is also in line with all other usages of `FileDialog::getOpenFileName()` in this project.

## Testing strategy

I have confirmed that this change fixes the issue for me, using Sway.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
