### PR TITLE
Fix a couple more Qt 5.15 deprecation warnings

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -443,7 +443,7 @@ int Entry::size() const
     size += autoTypeAssociations()->associationsSize();
     size += attachments()->attachmentsSize();
     size += customData()->dataSize();
-    for (const QString& tag : tags().split(TagDelimiterRegex, QString::SkipEmptyParts)) {
+    for (const QString& tag : tags().split(TagDelimiterRegex, Qt::SkipEmptyParts)) {
         size += tag.toUtf8().size();
     }
 
@@ -672,7 +672,7 @@ void Entry::setOverrideUrl(const QString& url)
 
 void Entry::setTags(const QString& tags)
 {
-    auto taglist = tags.split(TagDelimiterRegex, QString::SkipEmptyParts);
+    auto taglist = tags.split(TagDelimiterRegex, Qt::SkipEmptyParts);
     // Trim whitespace before/after tag text
     for (auto& tag : taglist) {
         tag = tag.trimmed();

--- a/src/gui/remote/RemoteProcess.cpp
+++ b/src/gui/remote/RemoteProcess.cpp
@@ -36,7 +36,17 @@ void RemoteProcess::setTempFileLocation(const QString& tempFile)
 
 void RemoteProcess::start(const QString& command)
 {
-    m_process->start(resolveTemplateVariables(command));
+    const QString commandResolved = resolveTemplateVariables(command);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    QStringList cmdList = QProcess::splitCommand(commandResolved);
+    if (!cmdList.isEmpty()) {
+        const QString program = cmdList.takeFirst();
+        m_process->start(program, cmdList);
+    }
+#else
+    m_process->start(resolveTemplateVariables(commandResolved));
+#endif
+
     m_process->waitForStarted();
 }
 


### PR DESCRIPTION
Addendum to #7783. Needed due to commits made subsequently to the most recent update to that PR.

To prevent future regressions, I would suggest building with `-DWITH_DEV_BUILD=ON` (ideally against Qt 5.15) during CI.

## Testing strategy

Compiles successfully with `-DWITH_DEV_BUILD=ON`.

Unit tests pass successfully.

## Type of change
- ✅ Refactor (significant modification to existing code)
