### PR TITLE
Alternative impl for copy-to-clipboard shortcut

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -39,14 +39,6 @@ class InactivityTimer;
 class SearchWidget;
 class MainWindowEventFilter;
 
-class ActionEventFilter : public QObject
-{
-    Q_OBJECT
-
-protected:
-    bool eventFilter(QObject* obj, QEvent* event) override;
-};
-
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -105,6 +97,7 @@ public slots:
     void restartApp(const QString& message);
 
 protected:
+    bool event(QEvent* event) override;
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
@@ -179,7 +172,6 @@ private:
 
     const QScopedPointer<Ui::MainWindow> m_ui;
     SignalMultiplexer m_actionMultiplexer;
-    ActionEventFilter m_actionEventFilter;
     QPointer<QAction> m_clearHistoryAction;
     QPointer<QAction> m_searchWidgetAction;
     QPointer<QMenu> m_entryContextMenu;
@@ -211,7 +203,6 @@ private:
     QTimer m_trayIconTriggerTimer;
     QSystemTrayIcon::ActivationReason m_trayIconTriggerReason;
 
-    friend class ActionEventFilter;
     friend class MainWindowEventFilter;
 };
 


### PR DESCRIPTION
It turns out that the previous implementation, based on installing an event filter in every `QAction` instance, does not work on macOS, likely due to a Qt bug: #10929.

Attempt to work around this by using a different implementation of the same idea, by reacting to `ShortcutOverride` events in the `MainWindow` object.

Fixes #10929 – hopefully.

## Testing strategy

Tested manually on Linux/Wayland. Also ran all tests, including GUI tests.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
