### PR TITLE
tests: gui: Fix NULL dereference in GUI tests

### DIFF
--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -354,8 +354,9 @@ void TestGui::testMergeDatabase()
     fileDialog()->setNextFileName(QString(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx"));
     triggerAction("actionDatabaseMerge");
 
-    QTRY_COMPARE(QApplication::focusWidget()->objectName(), QString("passwordEdit"));
     auto* editPasswordMerge = QApplication::focusWidget();
+    QVERIFY(editPasswordMerge);
+    QTRY_COMPARE(editPasswordMerge->objectName(), QString("passwordEdit"));
     QVERIFY(editPasswordMerge->isVisible());
 
     QTest::keyClicks(editPasswordMerge, "a");
@@ -457,8 +458,9 @@ void TestGui::testRemoteSyncDatabaseRequiresPassword()
     // need to process more events as opening with the same key did not work and more events have been fired
     QApplication::processEvents(QEventLoop::WaitForMoreEvents);
 
-    QTRY_COMPARE(QApplication::focusWidget()->objectName(), QString("passwordEdit"));
     auto* editPasswordSync = QApplication::focusWidget();
+    QVERIFY(editPasswordSync);
+    QTRY_COMPARE(editPasswordSync->objectName(), QString("passwordEdit"));
     QVERIFY(editPasswordSync->isVisible());
 
     QTest::keyClicks(editPasswordSync, "b");


### PR DESCRIPTION
This fixes a crash when running a GUI test. Fixes #10992


## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
I ran the test suite to confirm it no longer crashes.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
