### PR TITLE
Add a password discard confirmation

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -6903,6 +6903,14 @@ Do you want to overwrite it?</source>
         <source>Characters: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Confirm Close Password Generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Discard this password forever?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PasswordWidget</name>

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -67,7 +67,7 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
     connect(m_ui->buttonGenerate, SIGNAL(clicked()), SLOT(regeneratePassword()));
     connect(m_ui->buttonDeleteWordList, SIGNAL(clicked()), SLOT(deleteWordList()));
     connect(m_ui->buttonAddWordList, SIGNAL(clicked()), SLOT(addWordList()));
-    connect(m_ui->buttonClose, SIGNAL(clicked()), SIGNAL(closed()));
+    connect(m_ui->buttonClose, SIGNAL(clicked()), SLOT(confirmClose()));
 
     connect(m_ui->sliderLength, SIGNAL(valueChanged(int)), SLOT(passwordLengthChanged(int)));
     connect(m_ui->spinBoxLength, SIGNAL(valueChanged(int)), SLOT(passwordLengthChanged(int)));
@@ -119,11 +119,32 @@ PasswordGeneratorWidget::PasswordGeneratorWidget(QWidget* parent)
 
 PasswordGeneratorWidget::~PasswordGeneratorWidget() = default;
 
+bool PasswordGeneratorWidget::confirmDiscard()
+{
+    auto result = MessageBox::warning(this,
+                                      tr("Confirm Close Password Generator"),
+                                      tr("Discard this password forever?"),
+                                      MessageBox::Discard | MessageBox::Cancel,
+                                      MessageBox::Cancel);
+    return (result == MessageBox::Discard);
+}
+
+void PasswordGeneratorWidget::confirmClose()
+{
+    if (confirmDiscard()) {
+        emit closed();
+    }
+}
+
 void PasswordGeneratorWidget::closeEvent(QCloseEvent* event)
 {
-    // Emits closed signal when clicking X from title bar
-    emit closed();
-    QWidget::closeEvent(event);
+    if (confirmDiscard()) {
+        // Emits closed signal when clicking X from title bar
+        emit closed();
+        QWidget::closeEvent(event);
+    } else {
+        event->ignore();
+    }
 }
 
 PasswordGeneratorWidget* PasswordGeneratorWidget::popupGenerator(QWidget* parent)

--- a/src/gui/PasswordGeneratorWidget.h
+++ b/src/gui/PasswordGeneratorWidget.h
@@ -48,6 +48,7 @@ public:
     explicit PasswordGeneratorWidget(QWidget* parent = nullptr);
     ~PasswordGeneratorWidget() override;
 
+    bool confirmDiscard();
     void loadSettings();
     void saveSettings();
     void setPasswordLength(int length);
@@ -63,6 +64,7 @@ signals:
     void closed();
 
 public slots:
+    void confirmClose();
     void regeneratePassword();
     void applyPassword();
     void copyPassword();

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -902,6 +902,7 @@ void TestGui::testPasswordEntryEntropy()
         QCOMPARE(strengthLabel->text(), expectedStrengthLabel);
         QCOMPARE(passwordLengthLabel->text(), expectedPasswordLength);
 
+        MessageBox::setNextAnswer(MessageBox::Discard);
         QTest::mouseClick(generatedPassword, Qt::LeftButton);
         QTest::keyClick(generatedPassword, Qt::Key_Escape););
 }
@@ -967,6 +968,7 @@ void TestGui::testDicewareEntryEntropy()
         QCOMPARE(strengthLabel->text(), QString("Password Quality: Good"));
         QCOMPARE(wordLengthLabel->text().toInt(), pwGeneratorWidget->getGeneratedPassword().size());
 
+        MessageBox::setNextAnswer(MessageBox::Discard);
         QTest::mouseClick(generatedPassword, Qt::LeftButton);
         QTest::keyClick(generatedPassword, Qt::Key_Escape););
 }


### PR DESCRIPTION
This PR adds a confirmation dialog on password generator close that confirms discarding the password. 

## Screenshots
![A dialog with a warning sign titled "Confirm Close Password Generator." It asks "Discard this password forever?" and lists two options: Discard and No](https://github.com/keepassxreboot/keepassxc/assets/185275/e1bdf879-643d-494c-94ad-aaff35f8c99e)


## Testing strategy
Tests are currently broken: Something about MessageBox::setNextAnswer is blocking the closing of the database in the test. Once this is fixed (I need help with this please) I will write tests that check:

- Closing can be aborted by clicking no
- Clicking yes always closes the dialog


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
