### PR TITLE
Change wordlist container from qvector to qset

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -7654,10 +7654,6 @@ Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The word list is too small (&lt; 1000 items)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Title for the entry.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8900,6 +8896,10 @@ This option is deprecated, use --set-key-file instead.</source>
     </message>
     <message>
         <source>Only PBKDF and Argon2 are supported, cannot decrypt json file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot generate valid passphrases because the wordlist is too short</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -71,7 +71,7 @@ int Diceware::execute(const QStringList& arguments)
     if (!dicewareGenerator.isValid()) {
         // We already validated the word count input so if the generator is invalid, it
         // must be because the word list is too small.
-        err << QObject::tr("The word list is too small (< 1000 items)") << Qt::endl;
+        err << QObject::tr("Cannot generate valid passphrases because the wordlist is too short") << Qt::endl;
         return EXIT_FAILURE;
     }
 

--- a/src/core/PassphraseGenerator.h
+++ b/src/core/PassphraseGenerator.h
@@ -18,7 +18,7 @@
 #ifndef KEEPASSX_PASSPHRASEGENERATOR_H
 #define KEEPASSX_PASSPHRASEGENERATOR_H
 
-#include <QVector>
+#include <QList>
 
 class PassphraseGenerator
 {
@@ -43,15 +43,18 @@ public:
 
     QString generatePassphrase() const;
 
-    static constexpr int DefaultWordCount = 7;
+    static const int DefaultWordCount;
     static const char* DefaultSeparator;
     static const char* DefaultWordList;
 
 private:
     int m_wordCount;
+    int m_minimum_wordlist_length = 4000;
     PassphraseWordCase m_wordCase;
     QString m_separator;
-    QVector<QString> m_wordlist;
+    QList<QString> m_wordlist;
+
+    friend class TestPassphraseGenerator;
 };
 
 #endif // KEEPASSX_PASSPHRASEGENERATOR_H

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -1088,7 +1088,7 @@ void TestCli::testDiceware()
     smallWordFile.close();
 
     execCmd(dicewareCmd, {"diceware", "-W", "11", "-w", smallWordFile.fileName()});
-    QCOMPARE(m_stderr->readLine(), QByteArray("The word list is too small (< 1000 items)\n"));
+    QCOMPARE(m_stderr->readLine(), QByteArray("Cannot generate valid passphrases because the wordlist is too short\n"));
 }
 
 void TestCli::testEdit()

--- a/tests/TestPassphraseGenerator.cpp
+++ b/tests/TestPassphraseGenerator.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "TestPassphraseGenerator.h"
+#include "config-keepassx-tests.h"
 #include "core/PassphraseGenerator.h"
 #include "crypto/Crypto.h"
 
@@ -51,4 +52,19 @@ void TestPassphraseGenerator::testWordCase()
     passphrase = generator.generatePassphrase();
     QRegularExpression regex("^(?:[A-Z][a-z-]* )*[A-Z][a-z-]*$");
     QVERIFY2(regex.match(passphrase).hasMatch(), qPrintable(passphrase));
+}
+
+void TestPassphraseGenerator::testUniqueEntriesInWordlist()
+{
+    PassphraseGenerator generator;
+    // set the limit down, so we don;t have to do a very large file
+    generator.m_minimum_wordlist_length = 4;
+
+    // link to bad wordlist
+    QString path = QString(KEEPASSX_TEST_DATA_DIR).append("/wordlists/bad_wordlist_with_duplicate_entries.wordlist");
+
+    // setting will work, it creates the warning however, and isValid will fail
+    generator.setWordList(path);
+    // so this fails
+    QVERIFY(!generator.isValid());
 }

--- a/tests/TestPassphraseGenerator.h
+++ b/tests/TestPassphraseGenerator.h
@@ -27,6 +27,7 @@ class TestPassphraseGenerator : public QObject
 private slots:
     void initTestCase();
     void testWordCase();
+    void testUniqueEntriesInWordlist();
 };
 
 #endif // KEEPASSXC_TESTPASSPHRASEGENERATOR_H

--- a/tests/data/wordlists/bad_wordlist_with_duplicate_entries.wordlist
+++ b/tests/data/wordlists/bad_wordlist_with_duplicate_entries.wordlist
@@ -1,0 +1,4 @@
+abacus
+abdomen
+abdominal
+abdominal


### PR DESCRIPTION
Currently it is possible to use wordlists with duplicate entries. This results in lower entropy for the generated passphrases, because less unique words exist. 

This solution is very simple:

Replace the `QVector` representing currently the wordlist with a `QSet`. This removes all duplicate entries in a given wordlist.

As a result, this avoids that a malicious wordlist that has the proper length (>4000 entries) but with repetitions (effectively << 4000 entries) can be used and potentially create weaker passphrases than estimated.

Example:
List with 4000 items but only 64 unique words would lead to only 48 bit of Entropy instead of ~95 bit!


## Testing strategy
There is a new test which loads a wordlist with duplicate entries and will detect improper use. Had to add a bad wordlist to the test data


## Type of change
- ✅ New feature (change that adds functionality)
