### PR TITLE
Fix database password clearing when modifying key file / hardware key

### DIFF
--- a/src/gui/databasekey/PasswordEditWidget.cpp
+++ b/src/gui/databasekey/PasswordEditWidget.cpp
@@ -62,7 +62,7 @@ bool PasswordEditWidget::isPasswordVisible() const
 
 bool PasswordEditWidget::isEmpty() const
 {
-    return visiblePage() != Page::Edit || m_compUi->enterPasswordEdit->text().isEmpty();
+    return m_compUi->enterPasswordEdit->text().isEmpty();
 }
 
 PasswordHealth::Quality PasswordEditWidget::getPasswordQuality() const

--- a/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetDatabaseKey.cpp
@@ -160,7 +160,9 @@ bool DatabaseSettingsWidgetDatabaseKey::saveSettings()
     }
 
     // Show warning if database password has not been set
-    if (m_passwordEditWidget->visiblePage() == KeyComponentWidget::Page::AddNew || m_passwordEditWidget->isEmpty()) {
+    if (m_passwordEditWidget->visiblePage() == KeyComponentWidget::Page::AddNew
+        || (m_passwordEditWidget->visiblePage() == KeyComponentWidget::Page::Edit && m_passwordEditWidget->isEmpty())) {
+
         QScopedPointer<QMessageBox> msgBox(new QMessageBox(this));
         msgBox->setIcon(QMessageBox::Warning);
         msgBox->setWindowTitle(tr("No password set"));
@@ -179,7 +181,7 @@ bool DatabaseSettingsWidgetDatabaseKey::saveSettings()
         return false;
     }
 
-    if (!m_passwordEditWidget->isEmpty()) {
+    if (m_passwordEditWidget->visiblePage() == KeyComponentWidget::Page::Edit && !m_passwordEditWidget->isEmpty()) {
         // Prevent setting password with a quality less than the minimum required
         auto minQuality = qBound(0, config()->get(Config::Security_DatabasePasswordMinimumQuality).toInt(), 4);
         if (m_passwordEditWidget->getPasswordQuality() < static_cast<PasswordHealth::Quality>(minQuality)) {


### PR DESCRIPTION
Fix a bug in the database key settings dialog, where it was previously always incorrectly applying an empty password if the password was not changed but some other change was made (e.g. adding or removing a key file).

Fixes #10996.

I think this bug may have been introduced in #10821, specifically the change to `PasswordEditWidget::isEmpty()` [here](https://github.com/keepassxreboot/keepassxc/pull/10821/files#diff-eaf26af4c710405e13bf548bdcfad1f970daab35a2fb1944f12d0c99b82d9318).

## Testing strategy

Manual testing.

I can try to add an automated test if desired.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
