### PR TITLE
Fix signal/slot disconnect when opening import wizard

### DIFF
--- a/src/gui/wizard/ImportWizardPageSelect.cpp
+++ b/src/gui/wizard/ImportWizardPageSelect.cpp
@@ -127,7 +127,7 @@ void ImportWizardPageSelect::updateDatabaseChoices() const
     if (mainWindow) {
         for (auto dbWidget : mainWindow->getOpenDatabases()) {
             // Remove all connections
-            disconnect(dbWidget, nullptr, nullptr, nullptr);
+            disconnect(dbWidget, nullptr, this, nullptr);
 
             // Skip over locked databases
             if (dbWidget->isLocked()) {


### PR DESCRIPTION
* Fixes #11037

P.S. - I hate the QObject::disconnect function

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested locally

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)