### PR TITLE
Hardware keys: Fix PCSC daemon recovery on Linux

### DIFF
--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -70,7 +70,8 @@ namespace
         rv = SCardListReaders(context, nullptr, nullptr, &dwReaders);
         // On windows, USB hot-plugging causes the underlying API server to die
         // So on every USB unplug event, the API context has to be recreated
-        if (rv == SCARD_E_SERVICE_STOPPED) {
+        // On Linux, restarting the pcsc daemon causes the API server to die as well
+        if (rv == SCARD_E_SERVICE_STOPPED || rv == SCARD_E_NO_SERVICE) {
             // Dont care if the release works since the handle might be broken
             SCardReleaseContext(context);
             rv = SCardEstablishContext(SCARD_SCOPE_SYSTEM, nullptr, nullptr, &context);


### PR DESCRIPTION
This PR fixes a minor issue concerning the Linux PC/SC daemon. If the deamon is restarted while KeePassXC has an established Smartcard API context, said context becomes invalid and needs to be recreated.

This has become apparent as more recent versions of Linux's pcsc-lite tend to self-terminate after 60 seconds of no interactivity. The Linux implementation also differs slightly from the Windows one, it returns a different error code. So now we catch both errors and react appropriately. 

## Testing strategy
- Launch KeepassXC, scan for a NFC token and ensure it is recognized
- Restart the PCSC daemon: `sudo systemctl restart pcscd.service`
- Ensure the scan for the same token still works due to a new smartcard context having been established

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)