### PR TITLE
Fix unexpected additional resolved urls in testIconDownloader

### DIFF
--- a/tests/TestIconDownloader.cpp
+++ b/tests/TestIconDownloader.cpp
@@ -1,6 +1,9 @@
 #include "TestIconDownloader.h"
+
 #include <QTest>
-#include <gui/IconDownloader.h>
+
+#include "core/Config.h"
+#include "gui/IconDownloader.h"
 
 QTEST_GUILESS_MAIN(TestIconDownloader)
 
@@ -8,6 +11,7 @@ void TestIconDownloader::testIconDownloader()
 {
     QFETCH(QString, url);
     QFETCH(QStringList, expectation);
+    config()->set(Config::Security_IconDownloadFallback, false);
 
     IconDownloader downloader;
     downloader.setUrl(url);


### PR DESCRIPTION
I got unexpected additional resolved urls in testIconDownloader. Actual numbers were greater than expected for some test cases.
Set `Config::Security_IconDownloadFallback` to `false` before the test.


## Testing strategy
It gave me:
```
> ./build/tests/testicondownloader
...
Totals: 23 passed, 0 failed, 0 skipped, 0 blacklisted
```


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)