### PR TITLE
Fix code formatting with new clang-format version

### DIFF
--- a/src/autotype/xcb/AutoTypeXCB.cpp
+++ b/src/autotype/xcb/AutoTypeXCB.cpp
@@ -50,14 +50,11 @@ AutoTypePlatformX11::AutoTypePlatformX11()
     m_atomTransientFor = XInternAtom(m_dpy, "WM_TRANSIENT_FOR", True);
     m_atomWindow = XInternAtom(m_dpy, "WINDOW", True);
 
-    m_classBlacklist << "desktop_window"
-                     << "gnome-panel"; // Gnome
-    m_classBlacklist << "kdesktop"
-                     << "kicker"; // KDE 3
+    m_classBlacklist << "desktop_window" << "gnome-panel"; // Gnome
+    m_classBlacklist << "kdesktop" << "kicker"; // KDE 3
     m_classBlacklist << "Plasma"; // KDE 4
     m_classBlacklist << "plasmashell"; // KDE 5
-    m_classBlacklist << "xfdesktop"
-                     << "xfce4-panel"; // Xfce 4
+    m_classBlacklist << "xfdesktop" << "xfce4-panel"; // Xfce 4
 
     m_xkb = nullptr;
 

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -25,8 +25,7 @@
 
 #include <QCommandLineParser>
 
-const QCommandLineOption Add::UsernameOption = QCommandLineOption(QStringList() << "u"
-                                                                                << "username",
+const QCommandLineOption Add::UsernameOption = QCommandLineOption(QStringList() << "u" << "username",
                                                                   QObject::tr("Username for the entry."),
                                                                   QObject::tr("username"));
 
@@ -37,13 +36,10 @@ const QCommandLineOption Add::NotesOption =
     QCommandLineOption(QStringList() << "notes", QObject::tr("Notes for the entry."), QObject::tr("Notes"));
 
 const QCommandLineOption Add::PasswordPromptOption =
-    QCommandLineOption(QStringList() << "p"
-                                     << "password-prompt",
-                       QObject::tr("Prompt for the entry's password."));
+    QCommandLineOption(QStringList() << "p" << "password-prompt", QObject::tr("Prompt for the entry's password."));
 
-const QCommandLineOption Add::GenerateOption = QCommandLineOption(QStringList() << "g"
-                                                                                << "generate",
-                                                                  QObject::tr("Generate a password for the entry."));
+const QCommandLineOption Add::GenerateOption =
+    QCommandLineOption(QStringList() << "g" << "generate", QObject::tr("Generate a password for the entry."));
 
 Add::Add()
 {

--- a/src/cli/AttachmentImport.cpp
+++ b/src/cli/AttachmentImport.cpp
@@ -25,9 +25,7 @@
 #include <QFile>
 
 const QCommandLineOption AttachmentImport::ForceOption =
-    QCommandLineOption(QStringList() << "f"
-                                     << "force",
-                       QObject::tr("Overwrite existing attachments."));
+    QCommandLineOption(QStringList() << "f" << "force", QObject::tr("Overwrite existing attachments."));
 
 AttachmentImport::AttachmentImport()
 {

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -27,21 +27,18 @@
 #define CLI_DEFAULT_CLIP_TIMEOUT 10
 
 const QCommandLineOption Clip::AttributeOption = QCommandLineOption(
-    QStringList() << "a"
-                  << "attribute",
+    QStringList() << "a" << "attribute",
     QObject::tr("Copy the given attribute to the clipboard. Defaults to \"password\" if not specified.",
                 "Don't translate \"password\", it refers to the attribute."),
     "attr",
     "password");
 
 const QCommandLineOption Clip::TotpOption =
-    QCommandLineOption(QStringList() << "t"
-                                     << "totp",
+    QCommandLineOption(QStringList() << "t" << "totp",
                        QObject::tr("Copy the current TOTP to the clipboard (equivalent to \"-a totp\")."));
 
 const QCommandLineOption Clip::BestMatchOption =
-    QCommandLineOption(QStringList() << "b"
-                                     << "best-match",
+    QCommandLineOption(QStringList() << "b" << "best-match",
                        QObject::tr("Must match only one entry, otherwise a list of possible matches is shown."));
 
 Clip::Clip()

--- a/src/cli/Command.cpp
+++ b/src/cli/Command.cpp
@@ -56,12 +56,10 @@ const QCommandLineOption Command::HelpOption = QCommandLineOption(QStringList()
                                                                   QObject::tr("Display this help."));
 
 const QCommandLineOption Command::QuietOption =
-    QCommandLineOption(QStringList() << "q"
-                                     << "quiet",
+    QCommandLineOption(QStringList() << "q" << "quiet",
                        QObject::tr("Silence password prompt and other secondary outputs."));
 
-const QCommandLineOption Command::KeyFileOption = QCommandLineOption(QStringList() << "k"
-                                                                                   << "key-file",
+const QCommandLineOption Command::KeyFileOption = QCommandLineOption(QStringList() << "k" << "key-file",
                                                                      QObject::tr("Key file of the database."),
                                                                      QObject::tr("path"));
 
@@ -69,8 +67,7 @@ const QCommandLineOption Command::NoPasswordOption =
     QCommandLineOption(QStringList() << "no-password", QObject::tr("Deactivate password key for the database."));
 
 const QCommandLineOption Command::YubiKeyOption =
-    QCommandLineOption(QStringList() << "y"
-                                     << "yubikey",
+    QCommandLineOption(QStringList() << "y" << "yubikey",
                        QObject::tr("Yubikey slot and optional serial used to access the database (e.g., 1:7370001)."),
                        QObject::tr("slot[:serial]"));
 

--- a/src/cli/DatabaseCreate.cpp
+++ b/src/cli/DatabaseCreate.cpp
@@ -25,8 +25,7 @@
 #include <QFileInfo>
 
 const QCommandLineOption DatabaseCreate::DecryptionTimeOption =
-    QCommandLineOption(QStringList() << "t"
-                                     << "decryption-time",
+    QCommandLineOption(QStringList() << "t" << "decryption-time",
                        QObject::tr("Target decryption time in MS for the database."),
                        QObject::tr("time"));
 
@@ -41,9 +40,7 @@ const QCommandLineOption DatabaseCreate::SetKeyFileOption =
                        QObject::tr("path"));
 
 const QCommandLineOption DatabaseCreate::SetPasswordOption =
-    QCommandLineOption(QStringList() << "p"
-                                     << "set-password",
-                       QObject::tr("Set a password for the database."));
+    QCommandLineOption(QStringList() << "p" << "set-password", QObject::tr("Set a password for the database."));
 
 DatabaseCreate::DatabaseCreate()
 {

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -24,14 +24,12 @@
 #include <QCommandLineParser>
 
 const QCommandLineOption Diceware::WordCountOption =
-    QCommandLineOption(QStringList() << "W"
-                                     << "words",
+    QCommandLineOption(QStringList() << "W" << "words",
                        QObject::tr("Word count for the diceware passphrase."),
                        QObject::tr("count", "CLI parameter"));
 
 const QCommandLineOption Diceware::WordListOption =
-    QCommandLineOption(QStringList() << "w"
-                                     << "word-list",
+    QCommandLineOption(QStringList() << "w" << "word-list",
                        QObject::tr("Wordlist for the diceware generator.\n[Default: EFF English]"),
                        QObject::tr("path"));
 

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -26,10 +26,8 @@
 
 #include <QCommandLineParser>
 
-const QCommandLineOption Edit::TitleOption = QCommandLineOption(QStringList() << "t"
-                                                                              << "title",
-                                                                QObject::tr("Title for the entry."),
-                                                                QObject::tr("title"));
+const QCommandLineOption Edit::TitleOption =
+    QCommandLineOption(QStringList() << "t" << "title", QObject::tr("Title for the entry."), QObject::tr("title"));
 
 Edit::Edit()
 {

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -25,9 +25,7 @@
 #include <zxcvbn.h>
 
 const QCommandLineOption Estimate::AdvancedOption =
-    QCommandLineOption(QStringList() << "a"
-                                     << "advanced",
-                       QObject::tr("Perform advanced analysis on the password."));
+    QCommandLineOption(QStringList() << "a" << "advanced", QObject::tr("Perform advanced analysis on the password."));
 
 Estimate::Estimate()
 {

--- a/src/cli/Export.cpp
+++ b/src/cli/Export.cpp
@@ -25,8 +25,7 @@
 #include <QCommandLineParser>
 
 const QCommandLineOption Export::FormatOption = QCommandLineOption(
-    QStringList() << "f"
-                  << "format",
+    QStringList() << "f" << "format",
     QObject::tr("Format to use when exporting. Available choices are 'xml' or 'csv'. Defaults to 'xml'."),
     QStringLiteral("xml|csv"));
 

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -24,41 +24,30 @@
 #include <QCommandLineParser>
 
 const QCommandLineOption Generate::PasswordLengthOption =
-    QCommandLineOption(QStringList() << "L"
-                                     << "length",
+    QCommandLineOption(QStringList() << "L" << "length",
                        QObject::tr("Length of the generated password"),
                        QObject::tr("length"));
 
-const QCommandLineOption Generate::LowerCaseOption = QCommandLineOption(QStringList() << "l"
-                                                                                      << "lower",
-                                                                        QObject::tr("Use lowercase characters"));
+const QCommandLineOption Generate::LowerCaseOption =
+    QCommandLineOption(QStringList() << "l" << "lower", QObject::tr("Use lowercase characters"));
 
-const QCommandLineOption Generate::UpperCaseOption = QCommandLineOption(QStringList() << "U"
-                                                                                      << "upper",
-                                                                        QObject::tr("Use uppercase characters"));
+const QCommandLineOption Generate::UpperCaseOption =
+    QCommandLineOption(QStringList() << "U" << "upper", QObject::tr("Use uppercase characters"));
 
-const QCommandLineOption Generate::NumbersOption = QCommandLineOption(QStringList() << "n"
-                                                                                    << "numeric",
-                                                                      QObject::tr("Use numbers"));
+const QCommandLineOption Generate::NumbersOption =
+    QCommandLineOption(QStringList() << "n" << "numeric", QObject::tr("Use numbers"));
 
-const QCommandLineOption Generate::SpecialCharsOption = QCommandLineOption(QStringList() << "s"
-                                                                                         << "special",
-                                                                           QObject::tr("Use special characters"));
+const QCommandLineOption Generate::SpecialCharsOption =
+    QCommandLineOption(QStringList() << "s" << "special", QObject::tr("Use special characters"));
 
-const QCommandLineOption Generate::ExtendedAsciiOption = QCommandLineOption(QStringList() << "e"
-                                                                                          << "extended",
-                                                                            QObject::tr("Use extended ASCII"));
+const QCommandLineOption Generate::ExtendedAsciiOption =
+    QCommandLineOption(QStringList() << "e" << "extended", QObject::tr("Use extended ASCII"));
 
-const QCommandLineOption Generate::ExcludeCharsOption = QCommandLineOption(QStringList() << "x"
-                                                                                         << "exclude",
-                                                                           QObject::tr("Exclude character set"),
-                                                                           QObject::tr("chars"));
+const QCommandLineOption Generate::ExcludeCharsOption =
+    QCommandLineOption(QStringList() << "x" << "exclude", QObject::tr("Exclude character set"), QObject::tr("chars"));
 
 const QCommandLineOption Generate::CustomCharacterSetOption =
-    QCommandLineOption(QStringList() << "c"
-                                     << "custom",
-                       QObject::tr("Use custom character set"),
-                       QObject::tr("chars"));
+    QCommandLineOption(QStringList() << "c" << "custom", QObject::tr("Use custom character set"), QObject::tr("chars"));
 
 const QCommandLineOption Generate::ExcludeSimilarCharsOption =
     QCommandLineOption(QStringList() << "exclude-similar", QObject::tr("Exclude similar looking characters"));

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -24,13 +24,10 @@
 #include <QCommandLineParser>
 
 const QCommandLineOption List::RecursiveOption =
-    QCommandLineOption(QStringList() << "R"
-                                     << "recursive",
-                       QObject::tr("Recursively list the elements of the group."));
+    QCommandLineOption(QStringList() << "R" << "recursive", QObject::tr("Recursively list the elements of the group."));
 
-const QCommandLineOption List::FlattenOption = QCommandLineOption(QStringList() << "f"
-                                                                                << "flatten",
-                                                                  QObject::tr("Flattens the output to single lines."));
+const QCommandLineOption List::FlattenOption =
+    QCommandLineOption(QStringList() << "f" << "flatten", QObject::tr("Flattens the output to single lines."));
 
 List::List()
 {

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -24,8 +24,7 @@
 #include <QCommandLineParser>
 
 const QCommandLineOption Merge::SameCredentialsOption =
-    QCommandLineOption(QStringList() << "s"
-                                     << "same-credentials",
+    QCommandLineOption(QStringList() << "s" << "same-credentials",
                        QObject::tr("Use the same credentials for both database files."));
 
 const QCommandLineOption Merge::KeyFileFromOption =

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -23,13 +23,11 @@
 
 #include <QCommandLineParser>
 
-const QCommandLineOption Show::TotpOption = QCommandLineOption(QStringList() << "t"
-                                                                             << "totp",
-                                                               QObject::tr("Show the entry's current TOTP."));
+const QCommandLineOption Show::TotpOption =
+    QCommandLineOption(QStringList() << "t" << "totp", QObject::tr("Show the entry's current TOTP."));
 
 const QCommandLineOption Show::ProtectedAttributesOption =
-    QCommandLineOption(QStringList() << "s"
-                                     << "show-protected",
+    QCommandLineOption(QStringList() << "s" << "show-protected",
                        QObject::tr("Show the protected attributes in clear text."));
 
 const QCommandLineOption Show::AllAttributesOption =
@@ -39,8 +37,7 @@ const QCommandLineOption Show::AttachmentsOption =
     QCommandLineOption(QStringList() << "show-attachments", QObject::tr("Show the attachments of the entry."));
 
 const QCommandLineOption Show::AttributesOption = QCommandLineOption(
-    QStringList() << "a"
-                  << "attributes",
+    QStringList() << "a" << "attributes",
     QObject::tr(
         "Names of the attributes to show. "
         "This option can be specified more than once, with each attribute shown one-per-line in the given order. "

--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -124,10 +124,7 @@ namespace Tools
         constexpr auto kibibyte = 1024;
         double size = bytes;
 
-        QStringList units = QStringList() << "B"
-                                          << "KiB"
-                                          << "MiB"
-                                          << "GiB";
+        QStringList units = QStringList() << "B" << "KiB" << "MiB" << "GiB";
         int i = 0;
         int maxI = units.size() - 1;
 

--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -77,12 +77,7 @@ CsvImportWidget::CsvImportWidget(QWidget* parent)
                    << QObject::tr("URL") << QObject::tr("Notes") << QObject::tr("TOTP") << QObject::tr("Icon")
                    << QObject::tr("Last Modified") << QObject::tr("Created");
 
-    m_fieldSeparatorList << ","
-                         << ";"
-                         << "-"
-                         << ":"
-                         << "."
-                         << "\t";
+    m_fieldSeparatorList << "," << ";" << "-" << ":" << "." << "\t";
 
     m_combos << m_ui->groupCombo << m_ui->titleCombo << m_ui->usernameCombo << m_ui->passwordCombo << m_ui->urlCombo
              << m_ui->notesCombo << m_ui->totpCombo << m_ui->iconCombo << m_ui->lastModifiedCombo << m_ui->createdCombo;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetMaintenance.h
@@ -39,7 +39,7 @@ public:
 
 public slots:
     void initialize() override;
-    void uninitialize() override{};
+    void uninitialize() override {};
     inline bool saveSettings() override
     {
         return true;

--- a/src/gui/passkeys/PasskeyImporter.cpp
+++ b/src/gui/passkeys/PasskeyImporter.cpp
@@ -68,13 +68,9 @@ void PasskeyImporter::importSelectedFile(QFile& file, QSharedPointer<Database>& 
     }
 
     const auto privateKey = passkeyObject["privateKey"].toString();
-    const auto missingKeys = Tools::getMissingValuesFromList<QString>(passkeyObject.keys(),
-                                                                      QStringList() << "relyingParty"
-                                                                                    << "url"
-                                                                                    << "username"
-                                                                                    << "credentialId"
-                                                                                    << "userHandle"
-                                                                                    << "privateKey");
+    const auto missingKeys = Tools::getMissingValuesFromList<QString>(
+        passkeyObject.keys(),
+        QStringList() << "relyingParty" << "url" << "username" << "credentialId" << "userHandle" << "privateKey");
     if (!missingKeys.isEmpty()) {
         MessageBox::information(m_parent,
                                 tr("Cannot import passkey"),

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -170,26 +170,22 @@ void TestBrowser::testSortPriority_data()
     QTest::newRow("Exact Match") << siteUrl << siteUrl << siteUrl << 100;
     QTest::newRow("Exact Match (site)") << siteUrl << siteUrl << formUrl << 100;
     QTest::newRow("Exact Match (form)") << siteUrl << "https://github.net" << siteUrl << 100;
-    QTest::newRow("Exact Match No Trailing Slash") << "https://github.com"
-                                                   << "https://github.com/" << formUrl << 100;
+    QTest::newRow("Exact Match No Trailing Slash") << "https://github.com" << "https://github.com/" << formUrl << 100;
     QTest::newRow("Exact Match No Scheme") << "github.com/login" << siteUrl << formUrl << 100;
-    QTest::newRow("Exact Match with Query") << "https://github.com/login?test=test#fragment"
-                                            << "https://github.com/login?test=test" << formUrl << 100;
+    QTest::newRow("Exact Match with Query")
+        << "https://github.com/login?test=test#fragment" << "https://github.com/login?test=test" << formUrl << 100;
 
     QTest::newRow("Site Query Mismatch") << siteUrl << siteUrl + "?test=test" << formUrl << 90;
 
     QTest::newRow("Path Mismatch (site)") << "https://github.com/" << siteUrl << formUrl << 85;
     QTest::newRow("Path Mismatch (site) No Scheme") << "github.com" << siteUrl << formUrl << 85;
-    QTest::newRow("Path Mismatch (form)") << "https://github.com/"
-                                          << "https://github.net" << formUrl << 85;
+    QTest::newRow("Path Mismatch (form)") << "https://github.com/" << "https://github.net" << formUrl << 85;
     QTest::newRow("Path Mismatch (diff parent)") << "https://github.com/keepassxreboot" << siteUrl << formUrl << 80;
-    QTest::newRow("Path Mismatch (diff parent, form)") << "https://github.com/keepassxreboot"
-                                                       << "https://github.net" << formUrl << 70;
+    QTest::newRow("Path Mismatch (diff parent, form)")
+        << "https://github.com/keepassxreboot" << "https://github.net" << formUrl << 70;
 
-    QTest::newRow("Subdomain Mismatch (site)") << siteUrl << "https://sub.github.com/"
-                                               << "https://github.net/" << 60;
-    QTest::newRow("Subdomain Mismatch (form)") << siteUrl << "https://github.net/"
-                                               << "https://sub.github.com/" << 50;
+    QTest::newRow("Subdomain Mismatch (site)") << siteUrl << "https://sub.github.com/" << "https://github.net/" << 60;
+    QTest::newRow("Subdomain Mismatch (form)") << siteUrl << "https://github.net/" << "https://sub.github.com/" << 50;
 
     QTest::newRow("Scheme Mismatch") << "http://github.com" << siteUrl << formUrl << 0;
     QTest::newRow("Scheme Mismatch w/path") << "http://github.com/login" << siteUrl << formUrl << 0;

--- a/tests/TestCsvParser.cpp
+++ b/tests/TestCsvParser.cpp
@@ -74,8 +74,7 @@ void TestCsvParser::testBackslashSyntax()
     QTextStream out(file.data());
     // attended result: one"\t\"wo
     out << "Xone\\\"\\\\t\\\\\\\"w\noX\n"
-        << "X13X,X2\\X,X,\"\"3\"X\r"
-        << "3,X\"4\"X,,\n"
+        << "X13X,X2\\X,X,\"\"3\"X\r" << "3,X\"4\"X,,\n"
         << "XX\n"
         << "\\";
     QVERIFY(parser->parse(file.data()));
@@ -195,8 +194,7 @@ void TestCsvParser::testComments()
     QTextStream out(file.data());
     out << "  #one\n"
         << " \t  # two, three \r\n"
-        << " #, sing\t with\r"
-        << " #\t  me!\n"
+        << " #, sing\t with\r" << " #\t  me!\n"
         << "useful,text #1!";
     QVERIFY(parser->parse(file.data()));
     t = parser->getCsvTable();
@@ -311,8 +309,7 @@ void TestCsvParser::testQualifier()
 {
     parser->setTextQualifier(QChar('X'));
     QTextStream out(file.data());
-    out << "X1X,X2XX,X,\"\"3\"\"\"X\r"
-        << "3,X\"4\"X,,\n";
+    out << "X1X,X2XX,X,\"\"3\"\"\"X\r" << "3,X\"4\"X,,\n";
     QVERIFY(parser->parse(file.data()));
     t = parser->getCsvTable();
     QVERIFY(t.size() == 2);

--- a/tests/TestSSHAgent.cpp
+++ b/tests/TestSSHAgent.cpp
@@ -42,8 +42,7 @@ void TestSSHAgent::initTestCase()
     QVERIFY(m_agentSocketFile.remove());
 
     QStringList arguments;
-    arguments << "-D"
-              << "-a" << m_agentSocketFileName;
+    arguments << "-D" << "-a" << m_agentSocketFileName;
 
     QElapsedTimer timer;
     timer.start();

--- a/tests/TestSharing.cpp
+++ b/tests/TestSharing.cpp
@@ -117,12 +117,9 @@ void TestSharing::testReferenceSerialization_data()
     QTest::addColumn<QString>("path");
     QTest::addColumn<QUuid>("uuid");
     QTest::addColumn<int>("type");
-    QTest::newRow("1") << "Password"
-                       << "/some/path" << QUuid::createUuid() << int(KeeShareSettings::Inactive);
-    QTest::newRow("2") << ""
-                       << "" << QUuid() << int(KeeShareSettings::SynchronizeWith);
-    QTest::newRow("3") << ""
-                       << "/some/path" << QUuid() << int(KeeShareSettings::ExportTo);
+    QTest::newRow("1") << "Password" << "/some/path" << QUuid::createUuid() << int(KeeShareSettings::Inactive);
+    QTest::newRow("2") << "" << "" << QUuid() << int(KeeShareSettings::SynchronizeWith);
+    QTest::newRow("3") << "" << "/some/path" << QUuid() << int(KeeShareSettings::ExportTo);
 }
 
 void TestSharing::testSettingsSerialization()

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -161,13 +161,11 @@ void TestTools::testBackupFilePatternSubstitution_data()
     QTest::newRow("{DB_FILENAME} substitution")
         << "some {DB_FILENAME} thing" << DEFAULT_DB_FILE_PATH
         << QStringLiteral("some ") + DEFAULT_DB_FILE_NAME + QStringLiteral(" thing");
-    QTest::newRow("{DB_FILENAME} substitution with multiple extensions") << "some {DB_FILENAME} thing"
-                                                                         << "/tmp/KeePassXC.kdbx.ext"
-                                                                         << "some KeePassXC.kdbx thing";
+    QTest::newRow("{DB_FILENAME} substitution with multiple extensions")
+        << "some {DB_FILENAME} thing" << "/tmp/KeePassXC.kdbx.ext" << "some KeePassXC.kdbx thing";
     // Not relevant right now, added test anyway
-    QTest::newRow("There should be no substitution loops") << "{DB_FILENAME}"
-                                                           << "{TIME:'{DB_FILENAME}'}.ext"
-                                                           << "{TIME:'{DB_FILENAME}'}";
+    QTest::newRow("There should be no substitution loops")
+        << "{DB_FILENAME}" << "{TIME:'{DB_FILENAME}'}.ext" << "{TIME:'{DB_FILENAME}'}";
 }
 
 void TestTools::testBackupFilePatternSubstitution()
@@ -193,8 +191,8 @@ void TestTools::testEscapeRegex_data()
     }
 
     QTest::newRow("Regular characters should not be escaped") << all_regular_characters << all_regular_characters;
-    QTest::newRow("Special characters should be escaped") << R"(.^$*+-?()[]{}|\)"
-                                                          << R"(\.\^\$\*\+\-\?\(\)\[\]\{\}\|\\)";
+    QTest::newRow("Special characters should be escaped")
+        << R"(.^$*+-?()[]{}|\)" << R"(\.\^\$\*\+\-\?\(\)\[\]\{\}\|\\)";
     QTest::newRow("Null character") << QString::fromLatin1("ab\0c", 4) << "ab\\0c";
 }
 
@@ -256,23 +254,17 @@ void TestTools::testConvertToRegex_data()
 
 void TestTools::testArrayContainsValues()
 {
-    const auto values = QStringList() << "first"
-                                      << "second"
-                                      << "third";
+    const auto values = QStringList() << "first" << "second" << "third";
 
     // One missing
-    const auto result1 = Tools::getMissingValuesFromList<QString>(values,
-                                                                  QStringList() << "first"
-                                                                                << "second"
-                                                                                << "none");
+    const auto result1 =
+        Tools::getMissingValuesFromList<QString>(values, QStringList() << "first" << "second" << "none");
     QCOMPARE(result1.length(), 1);
     QCOMPARE(result1.first(), QString("none"));
 
     // All found
-    const auto result2 = Tools::getMissingValuesFromList<QString>(values,
-                                                                  QStringList() << "first"
-                                                                                << "second"
-                                                                                << "third");
+    const auto result2 =
+        Tools::getMissingValuesFromList<QString>(values, QStringList() << "first" << "second" << "third");
     QCOMPARE(result2.length(), 0);
 
     // None are found

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -801,32 +801,23 @@ void TestGui::testPasswordEntryEntropy_data()
     QTest::addColumn<QString>("password");
     QTest::addColumn<QString>("expectedStrengthLabel");
 
-    QTest::newRow("Empty password") << ""
-                                    << "Password Quality: Poor";
+    QTest::newRow("Empty password") << "" << "Password Quality: Poor";
 
-    QTest::newRow("Well-known password") << "hello"
-                                         << "Password Quality: Poor";
+    QTest::newRow("Well-known password") << "hello" << "Password Quality: Poor";
 
-    QTest::newRow("Password composed of well-known words.") << "helloworld"
-                                                            << "Password Quality: Poor";
+    QTest::newRow("Password composed of well-known words.") << "helloworld" << "Password Quality: Poor";
 
-    QTest::newRow("Password composed of well-known words with number.") << "password1"
-                                                                        << "Password Quality: Poor";
+    QTest::newRow("Password composed of well-known words with number.") << "password1" << "Password Quality: Poor";
 
-    QTest::newRow("Password out of small character space.") << "D0g.................."
-                                                            << "Password Quality: Poor";
+    QTest::newRow("Password out of small character space.") << "D0g.................." << "Password Quality: Poor";
 
-    QTest::newRow("XKCD, easy substitutions.") << "Tr0ub4dour&3"
-                                               << "Password Quality: Poor";
+    QTest::newRow("XKCD, easy substitutions.") << "Tr0ub4dour&3" << "Password Quality: Poor";
 
-    QTest::newRow("XKCD, word generator.") << "correcthorsebatterystaple"
-                                           << "Password Quality: Weak";
+    QTest::newRow("XKCD, word generator.") << "correcthorsebatterystaple" << "Password Quality: Weak";
 
-    QTest::newRow("Random characters, medium length.") << "YQC3kbXbjC652dTDH"
-                                                       << "Password Quality: Good";
+    QTest::newRow("Random characters, medium length.") << "YQC3kbXbjC652dTDH" << "Password Quality: Good";
 
-    QTest::newRow("Random characters, long.") << "Bs5ZFfthWzR8DGFEjaCM6bGqhmCT4km"
-                                              << "Password Quality: Excellent";
+    QTest::newRow("Random characters, long.") << "Bs5ZFfthWzR8DGFEjaCM6bGqhmCT4km" << "Password Quality: Excellent";
 
     QTest::newRow("Long password using Zxcvbn chunk estimation")
         << "quintet-tamper-kinswoman-humility-vengeful-haven-tastiness-aspire-widget-ipad-cussed-reaffirm-ladylike-"
@@ -1544,18 +1535,14 @@ void TestGui::testSaveBackupPath_data()
 
     QTest::newRow("Absolute backup path") << tmpFile.fileName() << tmpFile.fileName();
     // relative paths should be resolved to database parent directory
-    QTest::newRow("Relative backup path (implicit)") << "other_dir/test.old.kdbx"
-                                                     << "other_dir/test.old.kdbx";
-    QTest::newRow("Relative backup path (explicit)") << "./other_dir2/test2.old.kdbx"
-                                                     << "other_dir2/test2.old.kdbx";
+    QTest::newRow("Relative backup path (implicit)") << "other_dir/test.old.kdbx" << "other_dir/test.old.kdbx";
+    QTest::newRow("Relative backup path (explicit)") << "./other_dir2/test2.old.kdbx" << "other_dir2/test2.old.kdbx";
 
-    QTest::newRow("Path with placeholders") << "{DB_FILENAME}.old.kdbx"
-                                            << "KeePassXC.old.kdbx";
+    QTest::newRow("Path with placeholders") << "{DB_FILENAME}.old.kdbx" << "KeePassXC.old.kdbx";
     // empty path should be replaced with default pattern
     QTest::newRow("Empty path") << QString("") << config()->getDefault(Config::BackupFilePathPattern).toString();
     // {DB_FILENAME} should be replaced with database filename
-    QTest::newRow("") << "{DB_FILENAME}_.old.kdbx"
-                      << "{DB_FILENAME}_.old.kdbx";
+    QTest::newRow("") << "{DB_FILENAME}_.old.kdbx" << "{DB_FILENAME}_.old.kdbx";
 }
 
 void TestGui::testSaveBackupPath()

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -119,8 +119,8 @@ class FakeClient : public DBusClient
 public:
     explicit FakeClient(DBusMgr* dbus)
         : DBusClient(
-            dbus,
-            {QStringLiteral("local"), 0, true, {ProcInfo{0, 0, QStringLiteral("fake-client"), QString{}, QString{}}}})
+              dbus,
+              {QStringLiteral("local"), 0, true, {ProcInfo{0, 0, QStringLiteral("fake-client"), QString{}, QString{}}}})
     {
     }
 };


### PR DESCRIPTION
Reran clang-format on Ubuntu 24.04 with Clang-18.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)