### PR TITLE
Fix password generator floating issue

### DIFF
--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -131,6 +131,7 @@ PasswordGeneratorWidget* PasswordGeneratorWidget::popupGenerator(QWidget* parent
     auto pwGenerator = new PasswordGeneratorWidget(parent);
     pwGenerator->setWindowModality(Qt::ApplicationModal);
     pwGenerator->setWindowFlags(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
+    pwGenerator->setFixedSize(pwGenerator->size());
     pwGenerator->setStandaloneMode(false);
 
     connect(pwGenerator, SIGNAL(closed()), pwGenerator, SLOT(deleteLater()));

--- a/src/gui/PasswordGeneratorWidget.ui
+++ b/src/gui/PasswordGeneratorWidget.ui
@@ -10,6 +10,12 @@
     <height>433</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Generate Password</string>
   </property>


### PR DESCRIPTION
On Sway (and probably other Wayland compositors, at least `wlroots` ones), windows default to being tiled. For windows which are not resizable, they instead default to being in float mode. See
https://github.com/swaywm/sway/issues/3095 for reference.

I don't think there's a good reason for having the password generator popup be resizable (and even looks awful when stretched vertically).

- Added a size policy to marking the window with a fixed width. This requires having a minimum and maximum size on the widget.
- Copied the original geometry size with `fixedWidth` to automatically generate `minimumSize` and `maximumSize`, to avoid repeating the same property values reduntantly in the ui file.

First PR here, hope I didn't miss any Contribution notes :)

## Screenshots
![image](https://github.com/user-attachments/assets/d39f5ff6-7dc6-4f1d-bcde-949b4d25fc09)


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
