### PR TITLE
Prevent long-running threads from deadlocking the program with only 1 CPU

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include <QCommandLineParser>
 #include <QDir>
 #include <QFile>
+#include <QThreadPool>
 #include <QWindow>
 
 #include "cli/Utils.h"
@@ -63,6 +64,12 @@ int main(int argc, char** argv)
     Application::setApplicationName("KeePassXC");
     Application::setApplicationVersion(KEEPASSXC_VERSION);
     app.setProperty("KPXC_QUALIFIED_APPNAME", "org.keepassxc.KeePassXC");
+
+    // HACK: Prevent long-running threads from deadlocking the program with only 1 CPU
+    // See https://github.com/keepassxreboot/keepassxc/issues/10391
+    if (QThreadPool::globalInstance()->maxThreadCount() < 2) {
+        QThreadPool::globalInstance()->setMaxThreadCount(2);
+    }
 
     QCommandLineParser parser;
     parser.setApplicationDescription(QObject::tr("KeePassXC - cross-platform password manager"));


### PR DESCRIPTION
* Fixes #10391

NOTE: This fix is temporary until we can figure out with the code located here doesn't exit/complete properly

https://github.com/keepassxreboot/keepassxc/blob/b3bec8b2b495ebc2c1b4808cea615de093d0f1ba/src/gui/osutils/nixutils/DeviceListenerLibUsb.cpp#L44-L50

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested in virtual linux box with 1 CPU.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
