### PR TITLE
Allow deleting extension plugin data from Browser Statistics

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -8902,6 +8902,17 @@ This option is deprecated, use --set-key-file instead.</source>
         <source>Cannot generate valid passphrases because the wordlist is too short</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delete plugin data?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Delete plugin data from Entry(s)?</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
 </context>
 <context>
     <name>QtIOCompressor</name>
@@ -9052,6 +9063,13 @@ This option is deprecated, use --set-key-file instead.</source>
     <message>
         <source> (Expired)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Delete plugin data from Entry(s)…</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -977,6 +977,15 @@ bool BrowserService::deleteEntry(const QString& uuid)
     return true;
 }
 
+void BrowserService::removePluginData(Entry* entry) const
+{
+    if (entry) {
+        entry->beginUpdate();
+        entry->customData()->remove(BrowserService::KEEPASSXCBROWSER_NAME);
+        entry->endUpdate();
+    }
+}
+
 QList<Entry*> BrowserService::searchEntries(const QSharedPointer<Database>& db,
                                             const QString& siteUrl,
                                             const QString& formUrl,

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -118,6 +118,7 @@ public:
                   const QSharedPointer<Database>& selectedDb = {});
     bool updateEntry(const EntryParameters& entryParameters, const QString& uuid);
     bool deleteEntry(const QString& uuid);
+    void removePluginData(Entry* entry) const;
     QJsonArray findEntries(const EntryParameters& entryParameters, const StringPairList& keyList, bool* entriesFound);
     void requestGlobalAutoType(const QString& search);
 

--- a/src/gui/GuiTools.cpp
+++ b/src/gui/GuiTools.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -64,6 +64,21 @@ namespace GuiTools
 
             return answer == MessageBox::Move;
         }
+    }
+
+    bool confirmDeletePluginData(QWidget* parent, const QList<Entry*>& entries)
+    {
+        if (!parent || entries.isEmpty()) {
+            return false;
+        }
+
+        auto answer = MessageBox::question(parent,
+                                           QObject::tr("Delete plugin data?"),
+                                           QObject::tr("Delete plugin data from Entry(s)?", "", entries.size()),
+                                           MessageBox::Delete | MessageBox::Cancel,
+                                           MessageBox::Cancel);
+
+        return answer == MessageBox::Delete;
     }
 
     size_t deleteEntriesResolveReferences(QWidget* parent, const QList<Entry*>& entries, bool permanent)

--- a/src/gui/GuiTools.h
+++ b/src/gui/GuiTools.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@ class Entry;
 namespace GuiTools
 {
     bool confirmDeleteEntries(QWidget* parent, const QList<Entry*>& entries, bool permanent);
+    bool confirmDeletePluginData(QWidget* parent, const QList<Entry*>& entries);
     size_t deleteEntriesResolveReferences(QWidget* parent, const QList<Entry*>& entries, bool permanent);
 } // namespace GuiTools
 #endif // KEEPASSXC_GUITOOLS_H

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
@@ -214,9 +214,7 @@ void DatabaseSettingsWidgetBrowser::removeStoredPermissions()
         }
 
         if (entry->customData()->contains(BrowserService::KEEPASSXCBROWSER_NAME)) {
-            entry->beginUpdate();
-            entry->customData()->remove(BrowserService::KEEPASSXCBROWSER_NAME);
-            entry->endUpdate();
+            browserService()->removePluginData(entry);
             ++counter;
         }
         progress.setValue(progress.value() + 1);

--- a/src/gui/reports/ReportsWidgetBrowserStatistics.h
+++ b/src/gui/reports/ReportsWidgetBrowserStatistics.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -54,9 +54,11 @@ public slots:
     void emitEntryActivated(const QModelIndex& index);
     void customMenuRequested(QPoint);
     void deleteSelectedEntries();
+    void deletePluginDataFromSelectedEntries();
 
 private:
     void addStatisticsRow(bool hasUrls, bool hasSettings, Group*, Entry*, bool);
+    QList<Entry*> getSelectedEntries() const;
     QMap<QString, QStringList> getBrowserConfigFromEntry(Entry* entry) const;
 
     QScopedPointer<Ui::ReportsWidgetBrowserStatistics> m_ui;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds a new menu item to Browser Statistics in Database Reports that allows user to delete any extension plugin data from entry/entries.

Fixes #11185

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
<img width="339" alt="Screenshot 2024-09-01 at 9 44 28" src="https://github.com/user-attachments/assets/92a4b38a-c344-4061-8c52-c2e75fe80ce1">

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
