### PR TITLE
Prevent user from leaving unlock window by hitting ESC (#11199)

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -85,7 +85,7 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     okBtn->setText(tr("Unlock"));
     okBtn->setDefault(true);
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(openDatabase()));
-    connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(cancelDatabaseUnlock()));
+    connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(closeDatabase()));
 
     connect(m_ui->addKeyFileLinkLabel, &QLabel::linkActivated, this, &DatabaseOpenWidget::browseKeyFile);
     connect(m_ui->keyFileLineEdit, &PasswordWidget::textChanged, this, [&](const QString& text) {
@@ -448,15 +448,13 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::buildDatabaseKey()
     return databaseKey;
 }
 
-void DatabaseOpenWidget::cancelDatabaseUnlock()
+void DatabaseOpenWidget::closeDatabase()
 {
-    auto result = MessageBox::question(this,
-                                       tr("Cancel Database Unlock"),
-                                       tr("Would you like to cancel unlocking this database?"),
-                                       MessageBox::Cancel | MessageBox::Ok,
-                                       MessageBox::Cancel);
-    if (result == MessageBox::Ok) {
+    if (m_escPressedOnce) {
         reject();
+    } else {
+        m_escPressedOnce = true;
+        m_ui->messageWidget->showMessage(tr("Press ESC again to close this database."), MessageWidget::Information);
     }
 }
 

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -85,7 +85,7 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     okBtn->setText(tr("Unlock"));
     okBtn->setDefault(true);
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(openDatabase()));
-    connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(reject()));
+    connect(m_ui->buttonBox, SIGNAL(rejected()), SLOT(cancelDatabaseUnlock()));
 
     connect(m_ui->addKeyFileLinkLabel, &QLabel::linkActivated, this, &DatabaseOpenWidget::browseKeyFile);
     connect(m_ui->keyFileLineEdit, &PasswordWidget::textChanged, this, [&](const QString& text) {
@@ -446,6 +446,18 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::buildDatabaseKey()
 #endif
 
     return databaseKey;
+}
+
+void DatabaseOpenWidget::cancelDatabaseUnlock()
+{
+    auto result = MessageBox::question(this,
+                                       tr("Cancel Database Unlock"),
+                                       tr("Would you like to cancel unlocking this database?"),
+                                       MessageBox::Cancel | MessageBox::Ok,
+                                       MessageBox::Cancel);
+    if (result == MessageBox::Ok) {
+        reject();
+    }
 }
 
 void DatabaseOpenWidget::reject()

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -74,10 +74,11 @@ protected:
 
 protected slots:
     virtual void openDatabase();
-    void reject();
 
 private slots:
     bool browseKeyFile();
+    void cancelDatabaseUnlock();
+    void reject();
     void toggleHardwareKeyComponent(bool state);
     void pollHardwareKey(bool manualTrigger = false);
     void hardwareKeyResponse(bool found);

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -77,7 +77,7 @@ protected slots:
 
 private slots:
     bool browseKeyFile();
-    void cancelDatabaseUnlock();
+    void closeDatabase();
     void reject();
     void toggleHardwareKeyComponent(bool state);
     void pollHardwareKey(bool manualTrigger = false);
@@ -91,6 +91,7 @@ private:
     bool m_manualHardwareKeyRefresh = false;
     bool m_blockQuickUnlock = false;
     bool m_unlockingDatabase = false;
+    bool m_escPressedOnce = false;
     QTimer m_hideTimer;
     QTimer m_hideNoHardwareKeysFoundTimer;
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes #11199 
The issue is about to improve user experience. In case the user is about to unlock the database and hits the escape key while the password field is on focus, the unlock window would close.
From the user point of view the window should not be closed at that point. With current changes the unlock window will
not be closed anymore when hitting the escape key and instead a popup will open and asks if the user really wants to cancel the unlock process.

Open question:
I think these changes reflect the initial discussed solution for this issue.
The current process is the same when hitting the escape key or clicking on the "Close" button. In my opinion the workflow
might be fine when hitting ESC, but I don't think a further popup after clicking on "Close" would be necessary. Should this be changed?

Anything else that should be changed?

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
![screenshot_kp](https://github.com/user-attachments/assets/a200d405-57e2-43bb-9e55-4d3e962066cc)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Are tests for this kind of contribution expected?


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)