### PR TITLE
Add support for group selection when creating a passkey

### DIFF
--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -579,8 +579,9 @@ QJsonObject BrowserAction::handlePasskeysRegister(const QJsonObject& json, const
         return getErrorReply(action, ERROR_PASSKEYS_INVALID_URL_PROVIDED);
     }
 
+    const auto groupName = browserRequest.getString("groupName");
     const auto keyList = getConnectionKeys(browserRequest);
-    const auto response = browserService()->showPasskeysRegisterPrompt(publicKey, origin, keyList);
+    const auto response = browserService()->showPasskeysRegisterPrompt(publicKey, origin, groupName, keyList);
 
     const Parameters params{{"response", response}};
     return buildResponse(action, browserRequest.incrementedNonce, params);

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -80,7 +80,7 @@ public:
 
     QJsonObject getDatabaseGroups();
     QJsonArray getDatabaseEntries();
-    QJsonObject createNewGroup(const QString& groupName);
+    QJsonObject createNewGroup(const QString& groupName, bool isPasskeysGroup = false);
     QString getCurrentTotp(const QString& uuid);
     void showPasswordGenerator(const KeyPairMessage& keyPairMessage);
     bool isPasswordGeneratorRequested() const;
@@ -90,6 +90,7 @@ public:
 #ifdef WITH_XC_BROWSER_PASSKEYS
     QJsonObject showPasskeysRegisterPrompt(const QJsonObject& publicKeyOptions,
                                            const QString& origin,
+                                           const QString& groupName,
                                            const StringPairList& keyList);
     QJsonObject showPasskeysAuthenticationPrompt(const QJsonObject& publicKeyOptions,
                                                  const QString& origin,


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Adds support for group selection when creating a passkey. The group must be provided as a plain name or path. If no group has been provided, a default group "KeePassXC-Browser Passkeys" will be used.
A passkeys Icon will be set to the last group created.

Related to #2153. Extension side implementation will be done after KeePassXC version for this feature has been confirmed.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Current development branch on extension side is [here](https://github.com/keepassxreboot/keepassxc-browser/tree/feature/passkeys_modify_default_group).

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
