### PR TITLE
Dark theme fix colors for qmenu

### DIFF
--- a/src/gui/styles/dark/darkstyle.qss
+++ b/src/gui/styles/dark/darkstyle.qss
@@ -10,6 +10,15 @@ EntryPreviewWidget TagsEdit:disabled {
     background-color: #424242;
 }
 
+QMenu {
+    border: 1px solid #56565A;
+}
+
+QMenu::separator {
+    height: 1px;
+    background-color: #56565A;
+}
+
 QPushButton:!default:hover {
     /* Using slightly darker shade from palette(button) */
     background: #252528;


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc/issues/11213

Fixed the colors for the dropdown menu so that it doesn't blend in with the background. 

## Screenshots
![4](https://github.com/user-attachments/assets/00b89fe2-0607-4993-b4d8-be32d382c084)![1](https://github.com/user-attachments/assets/9cc31a24-b1b8-4c76-834d-2de66addfbdc)


## Testing strategy
Manual.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

