### PR TITLE
Prevent multiple lock requests on Linux

### DIFF
--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -320,6 +320,7 @@ private:
     QUuid m_entryBeforeLock;
 
     int m_saveAttempts;
+    bool m_attemptingLock = false;
 
     QScopedPointer<RemoteSettings> m_remoteSettings;
 


### PR DESCRIPTION
* Fixes #11000

When the screen locks on e.g. gnome we receive multiple independent signals of that, namely the Gnome session manager and the gnome / freedesktop screensaver.

When this happens, this causes multiple "lock database" requests to be issued. The first one correctly shows the question to discard/cancel, but the second one while the first is still asking goes and dismisses the question and then goes to ask it again. The result is it acts like you didn't answer correctly (ie, to cancel) and the database is locked.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Gnome

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)