### PR TITLE
Add option to disable opening a browser window when double-clicking the "URL" column in EntryView.cpp

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -541,6 +541,10 @@
         <source>Export settings…</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Open browser on double clicking URL field in entry view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetSecurity</name>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -66,6 +66,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::UseDirectWriteSaves,{QS("UseDirectWriteSaves"), Local, false}},
     {Config::SearchLimitGroup,{QS("SearchLimitGroup"), Roaming, false}},
     {Config::MinimizeOnOpenUrl,{QS("MinimizeOnOpenUrl"), Roaming, false}},
+    {Config::OpenURLOnDoubleClick, {QS("OpenURLOnDoubleClick"), Roaming, true}},
     {Config::HideWindowOnCopy,{QS("HideWindowOnCopy"), Roaming, false}},
     {Config::MinimizeOnCopy,{QS("MinimizeOnCopy"), Roaming, true}},
     {Config::MinimizeAfterUnlock,{QS("MinimizeAfterUnlock"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -49,6 +49,7 @@ public:
         UseDirectWriteSaves,
         SearchLimitGroup,
         MinimizeOnOpenUrl,
+        OpenURLOnDoubleClick,
         HideWindowOnCopy,
         MinimizeOnCopy,
         MinimizeAfterUnlock,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -225,6 +225,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->autoReloadOnChangeCheckBox->setChecked(config()->get(Config::AutoReloadOnChange).toBool());
     m_generalUi->minimizeAfterUnlockCheckBox->setChecked(config()->get(Config::MinimizeAfterUnlock).toBool());
     m_generalUi->minimizeOnOpenUrlCheckBox->setChecked(config()->get(Config::MinimizeOnOpenUrl).toBool());
+    m_generalUi->openUrlOnDoubleClick->setChecked(config()->get(Config::OpenURLOnDoubleClick).toBool());
     m_generalUi->hideWindowOnCopyCheckBox->setChecked(config()->get(Config::HideWindowOnCopy).toBool());
     hideWindowOnCopyCheckBoxToggled(m_generalUi->hideWindowOnCopyCheckBox->isChecked());
     m_generalUi->minimizeOnCopyRadioButton->setChecked(config()->get(Config::MinimizeOnCopy).toBool());
@@ -382,6 +383,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::AutoReloadOnChange, m_generalUi->autoReloadOnChangeCheckBox->isChecked());
     config()->set(Config::MinimizeAfterUnlock, m_generalUi->minimizeAfterUnlockCheckBox->isChecked());
     config()->set(Config::MinimizeOnOpenUrl, m_generalUi->minimizeOnOpenUrlCheckBox->isChecked());
+    config()->set(Config::OpenURLOnDoubleClick, m_generalUi->openUrlOnDoubleClick->isChecked());
     config()->set(Config::HideWindowOnCopy, m_generalUi->hideWindowOnCopyCheckBox->isChecked());
     config()->set(Config::MinimizeOnCopy, m_generalUi->minimizeOnCopyRadioButton->isChecked());
     config()->set(Config::DropToBackgroundOnCopy, m_generalUi->dropToBackgroundOnCopyRadioButton->isChecked());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -57,9 +57,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>0</y>
-            <width>568</width>
-            <height>1153</height>
+            <y>-419</y>
+            <width>573</width>
+            <height>1397</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -557,6 +557,13 @@
                <widget class="QCheckBox" name="minimizeOnOpenUrlCheckBox">
                 <property name="text">
                  <string>Minimize when opening a URL</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="openUrlOnDoubleClick">
+                <property name="text">
+                 <string>Double clicking &quot;URL&quot; column opens a browser window</string>
                 </property>
                </widget>
               </item>

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -544,6 +544,16 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="openUrlOnDoubleClick">
+                <property name="text">
+                 <string>Open browser on double clicking URL field in entry view</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="useGroupIconOnEntryCreationCheckBox">
                 <property name="text">
                  <string>Use group icon on entry creation</string>
@@ -557,13 +567,6 @@
                <widget class="QCheckBox" name="minimizeOnOpenUrlCheckBox">
                 <property name="text">
                  <string>Minimize when opening a URL</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="openUrlOnDoubleClick">
-                <property name="text">
-                 <string>Double clicking &quot;URL&quot; column opens a browser window</string>
                 </property>
                </widget>
               </item>
@@ -1358,6 +1361,7 @@
   <tabstop>alternativeSaveComboBox</tabstop>
   <tabstop>ConfirmMoveEntryToRecycleBinCheckBox</tabstop>
   <tabstop>EnableCopyOnDoubleClickCheckBox</tabstop>
+  <tabstop>openUrlOnDoubleClick</tabstop>
   <tabstop>useGroupIconOnEntryCreationCheckBox</tabstop>
   <tabstop>minimizeOnOpenUrlCheckBox</tabstop>
   <tabstop>hideWindowOnCopyCheckBox</tabstop>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1495,11 +1495,6 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
             switchToEntryEdit(entry);
         }
         break;
-    case EntryModel::Url:
-        if (!entry->url().isEmpty()) {
-            openUrlForEntry(entry);
-        }
-        break;
     case EntryModel::Totp:
         if (entry->hasTotp()) {
             setClipboardTextAndMinimize(entry->totp());
@@ -1520,6 +1515,13 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
     // TODO: switch to 'Attachments' tab in details view/pane
     // case EntryModel::Attachments:
     //    break;
+    case EntryModel::Url:
+        if (!entry->url().isEmpty() && config()->get(Config::OpenURLOnDoubleClick).toBool()) {
+            openUrlForEntry(entry);
+            break;
+        }
+        // Note, order matters here. We want to fall into the default case.
+        [[fallthrough]];
     default:
         switchToEntryEdit(entry);
     }


### PR DESCRIPTION
This pull request introduces a new configuration option, `OpenURLOnDoubleClick`, which allows users to open URLs by double-clicking on the "URL" column. 
This changes the behavior as follows:
* Double-clicking the "URL" column of an entry will open a new browser window unless explicitly configured not to.
* In this case, double-clicking defaults to the "default" action (i.e., editing).
* Also changed the double-clicking behavior when no URL is configured. This previously did nothing, but now falls back to editing the entry - regardless of whether the new setting is enabled or not.

The setting can be configured in the "General" tab:
![image](https://github.com/user-attachments/assets/c3861fd0-e3e1-420f-aa15-de061083a568)

Fixes: #11327

## Testing strategy
Tested locally.


## Type of change
- ✅ New feature (change that adds functionality)
