### PR TITLE
Change drag/drop between databases to default to COPY

### DIFF
--- a/src/gui/group/GroupModel.h
+++ b/src/gui/group/GroupModel.h
@@ -29,6 +29,10 @@ class GroupModel : public QAbstractItemModel
 
 public:
     explicit GroupModel(Database* db, QObject* parent = nullptr);
+    const Database* database() const
+    {
+        return m_db;
+    }
     void changeDatabase(Database* newDb);
     QModelIndex index(Group* group) const;
     Group* groupFromIndex(const QModelIndex& index) const;

--- a/src/gui/group/GroupView.h
+++ b/src/gui/group/GroupView.h
@@ -51,10 +51,12 @@ private slots:
 
 protected:
     void dragMoveEvent(QDragMoveEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
     void focusInEvent(QFocusEvent* event) override;
 
 private:
     void recInitExpanded(Group* group);
+    void fixDropAction(QDropEvent* event);
 
     GroupModel* const m_model;
     bool m_updatingExpanded;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

Fixes #172 
This changes makes the drop action from one database to another as a copy  action, but inside the same database still a move action. As suggested by @NicoHood, this behavior is similar to file system managers with USB keys, and it is safer as it does not remove any data from a database.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )

- Create 2 testing databases
- Fill the first with a group, an inner group, and a password entry to each levels
- Drag an entry to the root of the second database
- Verify it's present in both databases
- Drag a group to the root of the second database
- Verify it's present in both databases
- Drag a password from a group to another
- Verify it has been moved
- Drag a group from a group to another
- Verify it has been moved
- Drag a password from a group to another with Control pushed
- Verify it has been copied
- Drag a password from a database to another with Shift pushed
- Verify it has been moved

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
