### PR TITLE
Allow horizontal scrolling with Shift+Scroll in EntryView.

### DIFF
--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -26,6 +26,7 @@
 #include <QMenu>
 #include <QPainter>
 #include <QScreen>
+#include <QScrollBar>
 #include <QShortcut>
 #include <QStyledItemDelegate>
 #include <QWindow>
@@ -593,4 +594,13 @@ void EntryView::startDrag(Qt::DropActions supportedActions)
 bool EntryView::isColumnHidden(int logicalIndex)
 {
     return header()->isSectionHidden(logicalIndex) || header()->sectionSize(logicalIndex) == 0;
+}
+
+void EntryView::wheelEvent(QWheelEvent* event)
+{
+    if (event->modifiers() & Qt::ShiftModifier) {
+        horizontalScrollBar()->event(event);
+    } else {
+        QAbstractScrollArea::wheelEvent(event);
+    }
 }

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -62,6 +62,7 @@ protected:
     void focusInEvent(QFocusEvent* event) override;
     void showEvent(QShowEvent* event) override;
     void startDrag(Qt::DropActions supportedActions) override;
+    void wheelEvent(QWheelEvent* event) override;
 
 private slots:
     void emitEntryActivated(const QModelIndex& index);


### PR DESCRIPTION
Allows horizontal scrolling when pressing Shift + Scroll. This is currently limited to the EntryView.

The code changes are minimal: We listen to `wheelEvent` and forward it to the parent or the horizontal scrollbar depending on whether Shift is pressed or not.

Implements feature: #11337 


## Testing strategy
Tested locally.


## Type of change
- ✅ New feature (change that adds functionality)
