### PR TITLE
Fix renaming extension key name in Database Settings

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -611,7 +611,7 @@ QString BrowserService::storeKey(const QString& key)
 
     hideWindow();
     db->metadata()->customData()->set(CustomData::BrowserKeyPrefix + id, key);
-    db->metadata()->customData()->set(QString("%1_%2").arg(CustomData::Created, id),
+    db->metadata()->customData()->set(QString("%1%2").arg(CustomData::Created, id),
                                       QLocale::system().toString(Clock::currentDateTime(), QLocale::ShortFormat));
     return id;
 }

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -597,7 +597,8 @@ QString BrowserService::storeKey(const QString& key)
             return {};
         }
 
-        contains = db->metadata()->customData()->contains(CustomData::BrowserKeyPrefix + id);
+        contains =
+            db->metadata()->customData()->contains(CustomData::getKeyWithPrefix(CustomData::BrowserKeyPrefix, id));
         if (contains) {
             dialogResult = MessageBox::warning(m_currentDatabaseWidget,
                                                tr("KeePassXC - Overwrite existing key?"),
@@ -610,8 +611,8 @@ QString BrowserService::storeKey(const QString& key)
     } while (contains && dialogResult == MessageBox::Cancel);
 
     hideWindow();
-    db->metadata()->customData()->set(CustomData::BrowserKeyPrefix + id, key);
-    db->metadata()->customData()->set(QString("%1%2").arg(CustomData::Created, id),
+    db->metadata()->customData()->set(CustomData::getKeyWithPrefix(CustomData::BrowserKeyPrefix, id), key);
+    db->metadata()->customData()->set(CustomData::getKeyWithPrefix(CustomData::Created, id),
                                       QLocale::system().toString(Clock::currentDateTime(), QLocale::ShortFormat));
     return id;
 }
@@ -623,7 +624,7 @@ QString BrowserService::getKey(const QString& id)
         return {};
     }
 
-    return db->metadata()->customData()->value(CustomData::BrowserKeyPrefix + id);
+    return db->metadata()->customData()->value(CustomData::getKeyWithPrefix(CustomData::BrowserKeyPrefix, id));
 }
 
 #ifdef WITH_XC_BROWSER_PASSKEYS
@@ -1065,7 +1066,8 @@ QList<Entry*> BrowserService::searchEntries(const QString& siteUrl,
     // Check if database is connected with KeePassXC-Browser. If so, return browser key (otherwise empty)
     auto databaseConnected = [&](const QSharedPointer<Database>& db) {
         for (const StringPair& keyPair : keyList) {
-            QString key = db->metadata()->customData()->value(CustomData::BrowserKeyPrefix + keyPair.first);
+            const auto key = db->metadata()->customData()->value(
+                CustomData::getKeyWithPrefix(CustomData::BrowserKeyPrefix, keyPair.first));
             if (!key.isEmpty() && keyPair.second == key) {
                 return keyPair.first;
             }

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -23,7 +23,6 @@
 const QString CustomData::LastModified = QStringLiteral("_LAST_MODIFIED");
 const QString CustomData::Created = QStringLiteral("_CREATED_");
 const QString CustomData::BrowserKeyPrefix = QStringLiteral("KPXC_BROWSER_");
-const QString CustomData::BrowserLegacyKeyPrefix = QStringLiteral("Public Key: ");
 const QString CustomData::ExcludeFromReportsLegacy = QStringLiteral("KnownBad");
 const QString CustomData::FdoSecretsExposedGroup = QStringLiteral("FDO_SECRETS_EXPOSED_GROUP");
 const QString CustomData::RandomSlug = QStringLiteral("KPXC_RANDOM_SLUG");
@@ -50,6 +49,15 @@ bool CustomData::hasKey(const QString& key) const
 QString CustomData::value(const QString& key) const
 {
     return m_data.value(key).value;
+}
+
+QString CustomData::getKeyWithPrefix(const QString& prefix, const QString& key)
+{
+    QString keyWithPrefix;
+    keyWithPrefix.reserve(prefix.length() + key.length());
+    keyWithPrefix.append(prefix);
+    keyWithPrefix.append(key);
+    return keyWithPrefix;
 }
 
 const CustomData::CustomDataItem& CustomData::item(const QString& key) const

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 #include "core/Global.h"
 
 const QString CustomData::LastModified = QStringLiteral("_LAST_MODIFIED");
-const QString CustomData::Created = QStringLiteral("_CREATED");
+const QString CustomData::Created = QStringLiteral("_CREATED_");
 const QString CustomData::BrowserKeyPrefix = QStringLiteral("KPXC_BROWSER_");
 const QString CustomData::BrowserLegacyKeyPrefix = QStringLiteral("Public Key: ");
 const QString CustomData::ExcludeFromReportsLegacy = QStringLiteral("KnownBad");

--- a/src/core/CustomData.h
+++ b/src/core/CustomData.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -64,11 +64,12 @@ public:
     bool operator==(const CustomData& other) const;
     bool operator!=(const CustomData& other) const;
 
+    static QString getKeyWithPrefix(const QString& prefix, const QString& key);
+
     // Pre-defined keys
     static const QString LastModified;
     static const QString Created;
     static const QString BrowserKeyPrefix;
-    static const QString BrowserLegacyKeyPrefix;
     static const QString FdoSecretsExposedGroup;
     static const QString RandomSlug;
     static const QString RemoteProgramSettings;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2018 Sami Vänttinen <sami.vanttinen@protonmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -124,7 +124,7 @@ void DatabaseSettingsWidgetBrowser::updateModel()
         if (key.startsWith(CustomData::BrowserKeyPrefix)) {
             QString strippedKey = key;
             strippedKey.remove(CustomData::BrowserKeyPrefix);
-            auto created = customData()->value(QString("%1_%2").arg(CustomData::Created, strippedKey));
+            auto created = customData()->value(getKeyWithPrefix(CustomData::Created, strippedKey));
             auto createdItem = new QStandardItem(created);
             createdItem->setEditable(false);
             m_customDataModel->appendRow(QList<QStandardItem*>()
@@ -267,18 +267,16 @@ void DatabaseSettingsWidgetBrowser::editFinished(QStandardItem* item)
 
     if (itemSelectionModel) {
         auto indexList = itemSelectionModel->selectedRows(item->column());
-        if (indexList.length() > 0) {
-            QString newValue = item->index().data().toString();
+        if (!indexList.isEmpty()) {
+            auto newValue = item->index().data().toString();
 
             // The key is edited
             if (item->column() == 0) {
-                // Get the old key/value pair, remove it and replace it
-                m_valueInEdit.insert(0, CustomData::BrowserKeyPrefix);
-                auto tempValue = customData()->value(m_valueInEdit);
-                newValue.insert(0, CustomData::BrowserKeyPrefix);
+                // Update created timestamp with the new key
+                replaceKey(CustomData::Created, m_valueInEdit, newValue);
 
-                m_db->metadata()->customData()->remove(m_valueInEdit);
-                m_db->metadata()->customData()->set(newValue, tempValue);
+                // Get the old key/value pair, remove it and replace it
+                replaceKey(CustomData::BrowserKeyPrefix, m_valueInEdit, newValue);
             } else {
                 // Replace just the value
                 for (const QString& key : m_db->metadata()->customData()->keys()) {
@@ -300,4 +298,21 @@ void DatabaseSettingsWidgetBrowser::editFinished(QStandardItem* item)
 void DatabaseSettingsWidgetBrowser::updateSharedKeyList()
 {
     updateModel();
+}
+
+// Replaces a key and the created timestamp for it
+void DatabaseSettingsWidgetBrowser::replaceKey(const QString& prefix,
+                                               const QString& oldName,
+                                               const QString& newName) const
+{
+    const auto oldKey = getKeyWithPrefix(prefix, oldName);
+    const auto newKey = getKeyWithPrefix(prefix, newName);
+    const auto tempValue = customData()->value(oldKey);
+    m_db->metadata()->customData()->remove(oldKey);
+    m_db->metadata()->customData()->set(newKey, tempValue);
+}
+
+QString DatabaseSettingsWidgetBrowser::getKeyWithPrefix(const QString& prefix, const QString& key) const
+{
+    return QString("%1%2").arg(prefix, key);
 }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
@@ -102,9 +102,10 @@ void DatabaseSettingsWidgetBrowser::removeSelectedKey()
     const QItemSelectionModel* itemSelectionModel = m_ui->customDataTable->selectionModel();
     if (itemSelectionModel) {
         for (const QModelIndex& index : itemSelectionModel->selectedRows(0)) {
-            QString key = index.data().toString();
-            key.insert(0, CustomData::BrowserKeyPrefix);
+            const auto key = CustomData::getKeyWithPrefix(CustomData::BrowserKeyPrefix, index.data().toString());
+            const auto createdKey = CustomData::getKeyWithPrefix(CustomData::Created, index.data().toString());
             customData()->remove(key);
+            customData()->remove(createdKey);
         }
         updateModel();
     }
@@ -124,7 +125,7 @@ void DatabaseSettingsWidgetBrowser::updateModel()
         if (key.startsWith(CustomData::BrowserKeyPrefix)) {
             QString strippedKey = key;
             strippedKey.remove(CustomData::BrowserKeyPrefix);
-            auto created = customData()->value(getKeyWithPrefix(CustomData::Created, strippedKey));
+            auto created = customData()->value(CustomData::getKeyWithPrefix(CustomData::Created, strippedKey));
             auto createdItem = new QStandardItem(created);
             createdItem->setEditable(false);
             m_customDataModel->appendRow(QList<QStandardItem*>()
@@ -305,14 +306,9 @@ void DatabaseSettingsWidgetBrowser::replaceKey(const QString& prefix,
                                                const QString& oldName,
                                                const QString& newName) const
 {
-    const auto oldKey = getKeyWithPrefix(prefix, oldName);
-    const auto newKey = getKeyWithPrefix(prefix, newName);
+    const auto oldKey = CustomData::getKeyWithPrefix(prefix, oldName);
+    const auto newKey = CustomData::getKeyWithPrefix(prefix, newName);
     const auto tempValue = customData()->value(oldKey);
     m_db->metadata()->customData()->remove(oldKey);
     m_db->metadata()->customData()->set(newKey, tempValue);
-}
-
-QString DatabaseSettingsWidgetBrowser::getKeyWithPrefix(const QString& prefix, const QString& key) const
-{
-    return QString("%1%2").arg(prefix, key);
 }

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.h
@@ -63,7 +63,6 @@ private:
     void updateModel();
     void settingsWarning();
     void replaceKey(const QString& prefix, const QString& oldName, const QString& newName) const;
-    QString getKeyWithPrefix(const QString& prefix, const QString& key) const;
 
 protected:
     void showEvent(QShowEvent* event) override;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.h
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2018 Sami Vänttinen <sami.vanttinen@protonmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -62,6 +62,8 @@ private slots:
 private:
     void updateModel();
     void settingsWarning();
+    void replaceKey(const QString& prefix, const QString& oldName, const QString& newName) const;
+    QString getKeyWithPrefix(const QString& prefix, const QString& key) const;
 
 protected:
     void showEvent(QShowEvent* event) override;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
When renaming a stored connection key for Browser Integration in Database Settings the key for _Created_ timestamp is not renamed. This causes an empty value to be shown for the renamed key. Also removes the _Created_ key when deleting stored key.

Introduces a static method `CustomData::getKeyWithPrefix()` instead of different concatenations in various classes.

Fixes #11353

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
