### PR TITLE
Hide the menubar when menus lose focus (if toggled off)

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -206,7 +206,6 @@ private:
     friend class MainWindowEventFilter;
 };
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
 class MainWindowEventFilter : public QObject
 {
     Q_OBJECT
@@ -214,8 +213,11 @@ class MainWindowEventFilter : public QObject
 public:
     explicit MainWindowEventFilter(QObject* parent);
     bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    QTimer m_menubarTimer;
+    QTimer m_altCoolDown;
 };
-#endif
 
 /**
  * Return instance of MainWindow created on app load


### PR DESCRIPTION
* Fixes #10768
* Also fix menubar toggling not working if Qt version is less than 5.15

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested manually

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)