### PR TITLE
Fix MacOS login items showing ambigious name

### DIFF
--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -130,6 +130,8 @@ void MacUtils::setLaunchAtStartup(bool enable)
     if (enable) {
         QSettings agent(getLaunchAgentFilename(), QSettings::NativeFormat);
         agent.setValue("Label", qApp->property("KPXC_QUALIFIED_APPNAME").toString());
+        agent.setValue("AssociatedBundleIdentifiers", qApp->property("KPXC_QUALIFIED_APPNAME").toString());
+        agent.setValue("Program", QApplication::applicationFilePath());
         agent.setValue("ProgramArguments", QStringList() << QApplication::applicationFilePath());
         agent.setValue("RunAtLoad", true);
         agent.setValue("StandardErrorPath", "/dev/null");


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
Fixes #8818.

Adding the `AssociatedBundleIdentifiers` plist property mentioned by user @nodeful fixes the issue of an ambigious (to most users) name appearing in their login items menu on MacOS.

Documentation relating to this property can be found here: https://developer.apple.com/documentation/servicemanagement/updating-helper-executables-from-earlier-versions-of-macos#Connect-services-to-app-names-in-System-Settings

Additionally we also add the `Program` property using the full path of the application bundle, this seems to further prevent the "organisation name" (from the certificate signing) from appearing in the login items screen. Without this extra change Janek Bevendorff's name would still appear after a delay 

## Screenshots
[TIP]:  # ( Do not include screenshots of your actual database! )
Before change:
<img width="464" alt="image" src="https://github.com/user-attachments/assets/6f9bd070-918f-403b-964b-1b25d026b44d">
After change:
<img width="464" alt="image" src="https://github.com/user-attachments/assets/ac7e7f93-3e2f-4776-aa50-9112b9fdf7d2">

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually editing the installed launchd.plist file `org.keepassxc.KeePassXC.plist` in `~/Library/LaunchAgents`. I couldn't get the latest KeePassXC develop commit to build on my local machine.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
