### PR TITLE
Clean up wordlist by removing hyphenated words and trailing newline

### DIFF
--- a/share/wordlists/eff_large.wordlist
+++ b/share/wordlists/eff_large.wordlist
@@ -2006,7 +2006,6 @@ drizzly
 drone
 drool
 droop
-drop-in
 dropforge
 dropkick
 droplet
@@ -2525,7 +2524,6 @@ feed
 feel
 feisty
 feline
-felt-tip
 feminine
 feminism
 feminist
@@ -6637,7 +6635,6 @@ synthesis
 synthetic
 syrup
 system
-t-shirt
 tabasco
 tabby
 tableful
@@ -7745,7 +7742,6 @@ yiddish
 yield
 yin
 yippee
-yo-yo
 yodel
 yoga
 yogurt

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1032,7 +1032,7 @@ void TestGui::testDicewareEntryEntropy()
         auto* strengthLabel = pwGeneratorWidget->findChild<QLabel*>("strengthLabel");
         auto* wordLengthLabel = pwGeneratorWidget->findChild<QLabel*>("passwordLengthLabel");
 
-        QTRY_COMPARE_WITH_TIMEOUT(entropyLabel->text(), QString("Entropy: 77.55 bit"), 200);
+        QTRY_COMPARE_WITH_TIMEOUT(entropyLabel->text(), QString("Entropy: 77.54 bit"), 200);
         QCOMPARE(strengthLabel->text(), QString("Password Quality: Good"));
         QCOMPARE(wordLengthLabel->text(),
                  QString("Characters: %1").arg(QString::number(pwGeneratorWidget->getGeneratedPassword().length())));


### PR DESCRIPTION
The newline at the end of the eff_large.wordlist file was removed, as well as the 4 words that contain a hyphen:

drop-in

felt-tip

t-shirt

yo-yo

This change is useful, because when generating a passphrase you generally will not be able to use (or want to use) hyphens. The newline at the end of the file is removed to prevent breakages for anyone trying to export and use this list for their own projects. Note that the newline may replace itself depending on how GitHub handles it.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
