### PR TITLE
Accept both upper and lowercase 'S' for custom attribute for more compatibility

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1372,7 +1372,7 @@ Entry::PlaceholderType Entry::placeholderType(const QString& placeholder) const
     if (!placeholder.startsWith(QLatin1Char('{')) || !placeholder.endsWith(QLatin1Char('}'))) {
         return PlaceholderType::NotPlaceholder;
     }
-    if (placeholder.startsWith(QLatin1Literal("{S:"))) {
+    if (placeholder.startsWith(QLatin1Literal("{S:")) || placeholder.startsWith(QLatin1Literal("{s:"))) {
         return PlaceholderType::CustomAttribute;
     }
     if (placeholder.startsWith(QLatin1Literal("{REF:"))) {


### PR DESCRIPTION
I had an issue that auto type didn't work when using a kdbx from Keepass2.

Other KeePass forks both accept {S:Attr1} and {s:Attr1} as a placeholder for custom attributes. Keepassxc only accepts an uppercase S.

I don't see any risk by accepting both {S: and {s: as placeholder, which will further improve cross compatibility.