### PR TITLE
Replace legacy code on macOS builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -386,7 +386,7 @@ target_link_libraries(keepassxc_gui
         ${sshagent_LIB})
 
 if(APPLE)
-    target_link_libraries(keepassxc_gui "-framework Foundation -framework AppKit -framework Carbon -framework Security -framework LocalAuthentication")
+    target_link_libraries(keepassxc_gui "-framework Foundation -framework AppKit -framework Carbon -framework Security -framework LocalAuthentication -framework ScreenCaptureKit")
     if(Qt5MacExtras_FOUND)
         target_link_libraries(keepassxc_gui Qt5::MacExtras)
     endif()

--- a/src/autotype/mac/CMakeLists.txt
+++ b/src/autotype/mac/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(autotype_mac_SOURCES AutoTypeMac.cpp)
 
 add_library(keepassxc-autotype-cocoa MODULE ${autotype_mac_SOURCES})
-set_target_properties(keepassxc-autotype-cocoa PROPERTIES LINK_FLAGS "-framework Foundation -framework AppKit -framework Carbon")
+set_target_properties(keepassxc-autotype-cocoa PROPERTIES LINK_FLAGS "-framework Foundation -framework AppKit -framework Carbon -framework ScreenCaptureKit")
 target_link_libraries(keepassxc-autotype-cocoa ${PROGNAME} Qt5::Core Qt5::Widgets)
 
 install(TARGETS keepassxc-autotype-cocoa

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -19,7 +19,9 @@
 #import "AppKitImpl.h"
 #import <QWindow>
 #import <Cocoa/Cocoa.h>
-
+#if __clang_major__ >= 13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_3
+#import <ScreenCaptureKit/ScreenCaptureKit.h>
+#endif
 @implementation AppKitImpl
 
 - (id) initWithObject:(AppKit*)appkit
@@ -181,28 +183,33 @@
 //
 // Check if screen recording is enabled, may show an popup asking for permissions
 //
-- (bool) enableScreenRecording
+- (bool)enableScreenRecording 
 {
-#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
-    if (@available(macOS 10.15, *)) {
-        // Request screen recording permission on macOS 10.15+
-        // This is necessary to get the current window title
-        CGDisplayStreamRef stream = CGDisplayStreamCreate(CGMainDisplayID(), 1, 1, kCVPixelFormatType_32BGRA, nil,
-                                                          ^(CGDisplayStreamFrameStatus status, uint64_t displayTime,
-                                                                  IOSurfaceRef frameSurface, CGDisplayStreamUpdateRef updateRef) {
-                                                              Q_UNUSED(status);
-                                                              Q_UNUSED(displayTime);
-                                                              Q_UNUSED(frameSurface);
-                                                              Q_UNUSED(updateRef);
-                                                          });
-        if (stream) {
-            CFRelease(stream);
-        } else {
-            return NO;
-        }
-    }
+#if __clang_major__ >= 13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_3
+        __block BOOL hasPermission = NO;
+        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+        // Attempt to use SCShareableContent to check for screen recording permission
+        [SCShareableContent getShareableContentWithCompletionHandler:^(SCShareableContent * _Nullable content, 
+                                                                        NSError * _Nullable error) {
+            if (content) {
+                // Successfully obtained content, indicating permission is granted
+                hasPermission = YES;
+            } else {
+                // No permission or other error occurred
+                hasPermission = NO;
+            }
+            // Notify the semaphore that the asynchronous task is complete
+            dispatch_semaphore_signal(sema);
+        }];
+
+        // Wait for the asynchronous callback to complete
+        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+        // Return the final result
+        return hasPermission;
 #endif
-    return YES;
+    return YES; // Return YES for macOS versions that do not support ScreenCaptureKit
 }
 
 - (void) toggleForegroundApp:(bool) foreground

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -22,6 +22,7 @@
 #if __clang_major__ >= 13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_3
 #import <ScreenCaptureKit/ScreenCaptureKit.h>
 #endif
+
 @implementation AppKitImpl
 
 - (id) initWithObject:(AppKit*)appkit
@@ -183,7 +184,7 @@
 //
 // Check if screen recording is enabled, may show an popup asking for permissions
 //
-- (bool)enableScreenRecording 
+- (bool) enableScreenRecording 
 {
 #if __clang_major__ >= 13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_3
         __block BOOL hasPermission = NO;

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -187,6 +187,7 @@
 - (bool) enableScreenRecording 
 {
 #if __clang_major__ >= 13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_3
+    if (@available(macOS 12.3, *)) {
         __block BOOL hasPermission = NO;
         dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
@@ -210,6 +211,7 @@
 
         // Return the final result
         return hasPermission;
+    }
 #endif
     return YES; // Return YES for macOS versions that do not support ScreenCaptureKit
 }

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -194,6 +194,7 @@
         // Attempt to use SCShareableContent to check for screen recording permission
         [SCShareableContent getShareableContentWithCompletionHandler:^(SCShareableContent * _Nullable content, 
                                                                         NSError * _Nullable error) {
+            Q_UNUSED(error);
             if (content) {
                 // Successfully obtained content, indicating permission is granted
                 hasPermission = YES;

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -204,7 +204,8 @@
         }];
 
         // Wait for the asynchronous callback to complete
-        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC);
+        dispatch_semaphore_wait(sema, timeout);
 
         // Return the final result
         return hasPermission;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )

fix #11288, The CGDisplayStreamCreate function has been deprecated and the current code fails to compile on macOS 15 and above. Following Apple's official recommendations, this fix replaces CGDisplayStreamCreate with ScreenCaptureKit (MacOS 12.3+). Since ScreenCaptureKit is an asynchronous framework, necessary semaphore waiting has been added to the code. This change successfully triggers the screen recording permission request dialog and allows proper use of autotype when permission is granted. The code has been tested and confirmed working on macOS 15.0.1.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
