### PR TITLE
Browser: Fix cancel with database unlock dialog

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1686,10 +1686,8 @@ void BrowserService::handleDatabaseUnlockDialogFinished(bool accepted, DatabaseW
 {
     // User canceled the database open dialog
     if (dbWidget && !accepted && m_bringToFrontRequested) {
-        if (m_bringToFrontRequested) {
-            m_bringToFrontRequested = false;
-            hideWindow();
-        }
+        m_bringToFrontRequested = false;
+        hideWindow();
     }
 }
 

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -86,6 +86,10 @@ BrowserService::BrowserService()
     connect(getMainWindow(), &MainWindow::databaseUnlocked, this, &BrowserService::databaseUnlocked);
     connect(getMainWindow(), &MainWindow::databaseLocked, this, &BrowserService::databaseLocked);
     connect(getMainWindow(), &MainWindow::activeDatabaseChanged, this, &BrowserService::activeDatabaseChanged);
+    connect(getMainWindow(),
+            &MainWindow::databaseUnlockDialogFinished,
+            this,
+            &BrowserService::handleDatabaseUnlockDialogFinished);
 
     setEnabled(browserSettings()->isEnabled());
 }
@@ -1676,6 +1680,17 @@ void BrowserService::activeDatabaseChanged(DatabaseWidget* dbWidget)
     }
 
     m_currentDatabaseWidget = dbWidget;
+}
+
+void BrowserService::handleDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget)
+{
+    // User canceled the database open dialog
+    if (dbWidget && !accepted && m_bringToFrontRequested) {
+        if (m_bringToFrontRequested) {
+            m_bringToFrontRequested = false;
+            hideWindow();
+        }
+    }
 }
 
 void BrowserService::processClientMessage(QLocalSocket* socket, const QJsonObject& message)

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -145,6 +145,7 @@ public slots:
 
 private slots:
     void processClientMessage(QLocalSocket* socket, const QJsonObject& message);
+    void handleDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
 private:
     enum Access

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -821,6 +821,11 @@ void DatabaseTabWidget::handleDatabaseUnlockDialogFinished(bool accepted, Databa
         m_dbWidgetPendingLock = dbWidget;
     }
 
+    // If browser extension requested the unlock make sure cancel is handled
+    if (intent == DatabaseOpenDialog::Intent::Browser && !accepted && m_databaseOpenInProgress) {
+        m_databaseOpenInProgress = false;
+    }
+
     // signal other objects that the dialog finished
     emit databaseUnlockDialogFinished(accepted, dbWidget);
 }

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -822,9 +822,7 @@ void DatabaseTabWidget::handleDatabaseUnlockDialogFinished(bool accepted, Databa
     }
 
     // If browser extension requested the unlock make sure cancel is handled
-    if (intent == DatabaseOpenDialog::Intent::Browser && !accepted && m_databaseOpenInProgress) {
-        m_databaseOpenInProgress = false;
-    }
+    m_databaseOpenInProgress = false;
 
     // signal other objects that the dialog finished
     emit databaseUnlockDialogFinished(accepted, dbWidget);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -192,6 +192,10 @@ MainWindow::MainWindow()
     connect(m_ui->tabWidget, &DatabaseTabWidget::databaseLocked, this, &MainWindow::databaseLocked);
     connect(m_ui->tabWidget, &DatabaseTabWidget::databaseUnlocked, this, &MainWindow::databaseUnlocked);
     connect(m_ui->tabWidget, &DatabaseTabWidget::activeDatabaseChanged, this, &MainWindow::activeDatabaseChanged);
+    connect(m_ui->tabWidget,
+            &DatabaseTabWidget::databaseUnlockDialogFinished,
+            this,
+            &MainWindow::databaseUnlockDialogFinished);
 
     initViewMenu();
     initActionCollection();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -67,6 +67,7 @@ signals:
     void databaseUnlocked(DatabaseWidget* dbWidget);
     void databaseLocked(DatabaseWidget* dbWidget);
     void activeDatabaseChanged(DatabaseWidget* dbWidget);
+    void databaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
 public slots:
     void openDatabase(const QString& filePath, const QString& password = {}, const QString& keyfile = {});


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )
If database unlock dialog is canceled, the window state is not handled correctly. The following fixes needed to be done:
- Listen for `databaseUnlockDialogFinished` signal in `BrowserService`.
- If the dialog was canceled, set `m_bringToFrontRequested` to `false` and hide the window, similar to database unlock.
- If the dialog was canceled, set browser integration specific boolean `m_databaseOpenInProgress` in `DatabaseTabWidget` to `false` as well, so emitting a new dialog request will succeed.

Fixes #11430

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Manually. Steps to verify (and reproduce the error without the fix):
- Click "Reopen Database"
- Cancel the database unlock popup
- Try clicking "Reopen Database" again

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
