### PR TITLE
Added zsh completions

### DIFF
--- a/share/linux/completions/zsh/_keepassxc
+++ b/share/linux/completions/zsh/_keepassxc
@@ -1,0 +1,24 @@
+#compdef keepassxc
+
+_arguments -s \
+  '--help[Displays help on commandline options]' \
+  '--help-all[Displays help including Qt specific options]' \
+  '--version[Displays version information]' \
+  '--config[Specify path to a custom config file]:config:_files' \
+  '--localconfig[Specify path to a custom local config file]:localconfig:_files' \
+  '--lock[Lock all open databases]' \
+  '--keyfile[Specify the key file of the database]:keyfile:_files' \
+  '--pw-stdin[Read password of the database from stdin]' \
+  '--debug-info[Displays debugging information]' \
+  '--allow-screencapture[Allow screenshots and app recording (Windows/macOS)]' \
+  '--qmljsdebugger[Activate the QML/JS debugger with a specified port]:port:_values "port" "block"' \
+  '--platform[QPA plugin, see QGuiApplication documentation]:platformName:options' \
+  '--platformpluginpath[Path to the platform plugins]:path:_files' \
+  '--platformtheme[Specify the platform theme]:theme' \
+  '--plugin[Load additional plugin, can be specified multiple times]:plugin' \
+  '--qwindowgeometry[Specify window geometry for the main window]:geometry' \
+  '--qwindowicon[Default window icon]:icon:_files' \
+  '--qwindowtitle[Title of the first window]:title' \
+  '--reverse[Sets the application layout direction to Qt::RightToLeft (debugging helper)]' \
+  '--session[Restores the application from an earlier session]:session' \
+  '*:filename(s):_files -g "*.kdbx"'

--- a/share/linux/completions/zsh/_keepassxc
+++ b/share/linux/completions/zsh/_keepassxc
@@ -21,4 +21,4 @@ _arguments -s \
   '--qwindowtitle[Title of the first window]:title' \
   '--reverse[Sets the application layout direction to Qt::RightToLeft (debugging helper)]' \
   '--session[Restores the application from an earlier session]:session' \
-  '*:filename(s):_files -g "*.kdbx"'
+  '*:files:_files -g "*.kdbx"'

--- a/share/linux/completions/zsh/_keepassxc-cli
+++ b/share/linux/completions/zsh/_keepassxc-cli
@@ -1,0 +1,126 @@
+#compdef keepassxc-cli
+
+local curcontext="$curcontext" state line
+typeset -A opt_args
+
+_keepassxc-cli_commands() {
+  local -a commands
+  commands=(
+    'add:Add a new entry to the database.'
+    'analyze:Analyze passwords for weaknesses and problems.'
+    'attachment-export:Export an attachment of an entry.'
+    'attachment-import:Import an attachment to an entry.'
+    'attachment-rm:Remove an attachment from an entry.'
+    'clip:Copy an entry’s attribute to the clipboard.'
+    'close:Close the currently opened database.'
+    'db-create:Create a new database.'
+    'db-edit:Edit a database.'
+    'db-info:Show information about a database.'
+    'diceware:Generate a new random diceware passphrase.'
+    'edit:Edit an entry.'
+    'estimate:Estimate the entropy of a password.'
+    'export:Export the content of a database to standard output in a specified format.'
+    'generate:Generate a new random password.'
+    'help:Display help for a command.'
+    'import:Import the contents of an XML database.'
+    'ls:List entries in the database.'
+    'merge:Merge two databases.'
+    'mkdir:Add a new group to a database.'
+    'mv:Move an entry to a new group.'
+    'open:Open a database.'
+    'rm:Remove an entry from the database.'
+    'rmdir:Remove a group from the database.'
+    'search:Quickly find entries.'
+    'show:Show information about an entry.'
+  )
+  _describe -t commands 'keepassxc-cli command' commands
+}
+
+_arguments -C \
+  '1: :_keepassxc-cli_commands' \
+  '*:: :->args'
+
+case $state in
+  args)
+    case $line[1] in
+      add)
+        _keepassxc-cli_add
+        ;;
+      analyze)
+        _keepassxc-cli_analyze
+        ;;
+      attachment-export)
+        _keepassxc-cli_attachment-export
+        ;;
+      attachment-import)
+        _keepassxc-cli_attachment-import
+        ;;
+      attachment-rm)
+        _keepassxc-cli_attachment-rm
+        ;;
+      clip)
+        _keepassxc-cli_clip
+        ;;
+      close)
+        _message -r "Close the currently opened database."
+        ;;
+      db-create)
+        _keepassxc-cli_db-create
+        ;;
+      db-edit)
+        _keepassxc-cli_db-edit
+        ;;
+      db-info)
+        _keepassxc-cli_db-info
+        ;;
+      diceware)
+        _message -r "Generate a new random diceware passphrase."
+        ;;
+      edit)
+        _keepassxc-cli_edit
+        ;;
+      estimate)
+        _keepassxc-cli_estimate
+        ;;
+      export)
+        _keepassxc-cli_export
+        ;;
+      generate)
+        _keepassxc-cli_generate
+        ;;
+      help)
+        _message -r "Display command help."
+        ;;
+      import)
+        _keepassxc-cli_import
+        ;;
+      ls)
+        _keepassxc-cli_ls
+        ;;
+      merge)
+        _keepassxc-cli_merge
+        ;;
+      mkdir)
+        _keepassxc-cli_mkdir
+        ;;
+      mv)
+        _keepassxc-cli_mv
+        ;;
+      open)
+        _keepassxc-cli_open
+        ;;
+      rm)
+        _keepassxc-cli_rm
+        ;;
+      rmdir)
+        _keepassxc-cli_rmdir
+        ;;
+      search)
+        _keepassxc-cli_search
+        ;;
+      show)
+        _keepassxc-cli_show
+        ;;
+    esac
+    ;;
+esac

--- a/share/linux/completions/zsh/_keepassxc-cli_add
+++ b/share/linux/completions/zsh/_keepassxc-cli_add
@@ -1,0 +1,28 @@
+#compdef keepassxc-cli add
+
+_message -r "Usage: keepassxc-cli add [options] database entry"
+_message -r "Add a new entry to a database."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-u --username)'{-u,--username}'[Username for the entry.]:username' \
+  '--url[URL for the entry.]:URL' \
+  '--notes[Notes for the entry.]:Notes' \
+  '(-p --password-prompt)'{-p,--password-prompt}'[Prompt for the entry’s password.]' \
+  '(-g --generate)'{-g,--generate}'[Generate a password for the entry.]' \
+  '(-L --length)'{-L,--length}'[Length of the generated password.]:length' \
+  '(-l --lower)'{-l,--lower}'[Use lowercase characters in the generated password.]' \
+  '(-U --upper)'{-U,--upper}'[Use uppercase characters in the generated password.]' \
+  '(-n --numeric)'{-n,--numeric}'[Use numbers in the generated password.]' \
+  '(-s --special)'{-s,--special}'[Use special characters in the generated password.]' \
+  '(-e --extended)'{-e,--extended}'[Use extended ASCII characters in the generated password.]' \
+  '(-x --exclude)'{-x,--exclude}'[Exclude specific characters from the password.]:chars' \
+  '--exclude-similar[Exclude similar-looking characters from the password.]' \
+  '--every-group[Include characters from every selected group in the password.]' \
+  '(-c --custom)'{-c,--custom}'[Use a custom character set for the password.]:chars' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:entry'

--- a/share/linux/completions/zsh/_keepassxc-cli_analyze
+++ b/share/linux/completions/zsh/_keepassxc-cli_analyze
@@ -1,0 +1,14 @@
+#compdef keepassxc-cli analyze
+
+_message -r "Usage: keepassxc-cli analyze [options] database"
+_message -r "Analyze passwords for weaknesses and problems."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --keyfile)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-H --hibp)'{-H,--hibp}'[Check if any passwords have been publicly leaked using a file of SHA-1 hashes in HIBP format.]:FILENAME:_files' \
+  '--okon[Path to okon-cli to search a formatted HIBP file]:okon-cli:_files' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_attachment-export
+++ b/share/linux/completions/zsh/_keepassxc-cli_attachment-export
@@ -1,0 +1,16 @@
+#compdef keepassxc-cli attachment-export
+
+_message -r "Usage: keepassxc-cli attachment-export [options] database entry attachment-name export-file"
+_message -r "Export an attachment of an entry."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '--stdout[Output the attachment to stdout instead of a file.]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:entry' \
+  '3:attachment' \
+  '4:export:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_attachment-import
+++ b/share/linux/completions/zsh/_keepassxc-cli_attachment-import
@@ -1,0 +1,16 @@
+#compdef keepassxc-cli attachment-import
+
+_message -r "Usage: keepassxc-cli attachment-import [options] database entry attachment-name import-file"
+_message -r "Import an attachment to an entry."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-f --force)'{-f,--force}'[Overwrite existing attachments.]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:entry' \
+  '3:attachment' \
+  '4:import:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_attachment-rm
+++ b/share/linux/completions/zsh/_keepassxc-cli_attachment-rm
@@ -1,0 +1,14 @@
+#compdef keepassxc-cli attachment-rm
+
+_message -r "Usage: keepassxc-cli attachment-rm [options] database entry attachment-name"
+_message -r "Remove an attachment of an entry."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:entry' \
+  '3:attachment'

--- a/share/linux/completions/zsh/_keepassxc-cli_clip
+++ b/share/linux/completions/zsh/_keepassxc-cli_clip
@@ -1,0 +1,17 @@
+#compdef keepassxc-cli clip
+
+_message -r "Usage: keepassxc-cli clip [options] database entry [timeout]"
+_message -r "Copy an entry's attribute to the clipboard."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-a --attribute)'{-a,--attribute}'[Copy the given attribute to the clipboard. Defaults to "password" if not specified.]:attr' \
+  '(-t --totp)'{-t,--totp}'[Copy the current TOTP to the clipboard (equivalent to "-a totp").]' \
+  '(-b --best-match)'{-b,--best-match}'[Must match only one entry, otherwise a list of possible matches is shown.]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:entry' \
+  '3:timeout'

--- a/share/linux/completions/zsh/_keepassxc-cli_db-create
+++ b/share/linux/completions/zsh/_keepassxc-cli_db-create
@@ -1,0 +1,13 @@
+#compdef keepassxc-cli db-create
+
+_message -r "Usage: keepassxc-cli db-create [options] database"
+_message -r "Create a new database."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '--set-key-file[Set the key file for the database.]:path:_files' \
+  '-k[Set the key file for the database (deprecated, use --set-key-file instead).]:path:_files' \
+  '(-p --set-password)'{-p,--set-password}'[Set a password for the database.]' \
+  '(-t --decryption-time)'{-t,--decryption-time}'[Target decryption time in milliseconds for the database.]:time' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_db-edit
+++ b/share/linux/completions/zsh/_keepassxc-cli_db-edit
@@ -1,0 +1,16 @@
+#compdef keepassxc-cli db-edit
+
+_message -r "Usage: keepassxc-cli db-edit [options] database"
+_message -r "Edit a database."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '--set-key-file[Set the key file for the database.]:path:_files' \
+  '(-p --set-password)'{-p,--set-password}'[Set a password for the database.]' \
+  '--unset-key-file[Unset the key file for the database.]' \
+  '--unset-password[Unset the password for the database.]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_db-info
+++ b/share/linux/completions/zsh/_keepassxc-cli_db-info
@@ -1,0 +1,12 @@
+#compdef keepassxc-cli db-info
+
+_message -r "Usage: keepassxc-cli db-info [options] database"
+_message -r "Show a database's information."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_edit
+++ b/share/linux/completions/zsh/_keepassxc-cli_edit
@@ -1,0 +1,29 @@
+#compdef keepassxc-cli edit
+
+_message -r "Usage: keepassxc-cli edit [options] database entry"
+_message -r "Edit an entry."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-u --username)'{-u,--username}'[Username for the entry.]:username' \
+  '--url[URL for the entry.]:URL' \
+  '--notes[Notes for the entry.]:Notes' \
+  '(-p --password-prompt)'{-p,--password-prompt}'[Prompt for the entry’s password.]' \
+  '(-t --title)'{-t,--title}'[Title for the entry.]:title' \
+  '(-g --generate)'{-g,--generate}'[Generate a password for the entry.]' \
+  '(-L --length)'{-L,--length}'[Length of the generated password.]:length' \
+  '(-l --lower)'{-l,--lower}'[Use lowercase characters in the generated password.]' \
+  '(-U --upper)'{-U,--upper}'[Use uppercase characters in the generated password.]' \
+  '(-n --numeric)'{-n,--numeric}'[Use numbers in the generated password.]' \
+  '(-s --special)'{-s,--special}'[Use special characters in the generated password.]' \
+  '(-e --extended)'{-e,--extended}'[Use extended ASCII characters in the generated password.]' \
+  '(-x --exclude)'{-x,--exclude}'[Exclude specific characters from the password.]:chars' \
+  '--exclude-similar[Exclude similar-looking characters from the password.]' \
+  '--every-group[Include characters from every selected group in the password.]' \
+  '(-c --custom)'{-c,--custom}'[Use a custom character set for the password.]:chars' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:entry'

--- a/share/linux/completions/zsh/_keepassxc-cli_estimate
+++ b/share/linux/completions/zsh/_keepassxc-cli_estimate
@@ -1,0 +1,10 @@
+#compdef keepassxc-cli estimate
+
+_message -r "Usage: keepassxc-cli estimate [options] [password]"
+_message -r "Estimate the entropy of a password."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-a --advanced)'{-a,--advanced}'[Perform advanced analysis on the password.]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:password'

--- a/share/linux/completions/zsh/_keepassxc-cli_export
+++ b/share/linux/completions/zsh/_keepassxc-cli_export
@@ -1,0 +1,13 @@
+#compdef keepassxc-cli export
+
+_message -r "Usage: keepassxc-cli export [options] database"
+_message -r "Exports the content of a database to standard output in the specified format."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-f --format)'{-f,--format}'[Format to use when exporting. Choices are xml or csv (defaults to xml)]:format:(xml csv)' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_generate
+++ b/share/linux/completions/zsh/_keepassxc-cli_generate
@@ -1,0 +1,18 @@
+#compdef keepassxc-cli generate
+
+_message -r "Usage: keepassxc-cli generate [options]"
+_message -r "Generate a new random password."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-L --length)'{-L,--length}'[Length of the generated password.]:length' \
+  '(-l --lower)'{-l,--lower}'[Use lowercase characters in the generated password.]' \
+  '(-U --upper)'{-U,--upper}'[Use uppercase characters in the generated password.]' \
+  '(-n --numeric)'{-n,--numeric}'[Use numbers in the generated password.]' \
+  '(-s --special)'{-s,--special}'[Use special characters in the generated password.]' \
+  '(-e --extended)'{-e,--extended}'[Use extended ASCII characters in the generated password.]' \
+  '(-x --exclude)'{-x,--exclude}'[Exclude specific characters from the password.]:chars' \
+  '--exclude-similar[Exclude similar-looking characters from the password.]' \
+  '--every-group[Include characters from every selected group in the password.]' \
+  '(-c --custom)'{-c,--custom}'[Use a custom character set for the password.]:chars' \
+  '(-h --help)'{-h,--help}'[Display help information.]'

--- a/share/linux/completions/zsh/_keepassxc-cli_import
+++ b/share/linux/completions/zsh/_keepassxc-cli_import
@@ -1,0 +1,14 @@
+#compdef keepassxc-cli import
+
+_message -r "Usage: keepassxc-cli import [options] xml database"
+_message -r "Import the contents of an XML database."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '--set-key-file[Set the key file for the database.]:path:_files' \
+  '(-k)--k[Set the key file for the database (deprecated, use --set-key-file instead).]:path:_files' \
+  '(-p --set-password)'{-p,--set-password}'[Set a password for the database.]' \
+  '(-t --decryption-time)'{-t,--decryption-time}'[Target decryption time in milliseconds for the database.]:time' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:xml_db:_files' \
+  '2:db:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_ls
+++ b/share/linux/completions/zsh/_keepassxc-cli_ls
@@ -1,0 +1,15 @@
+#compdef keepassxc-cli ls
+
+_message -r "Usage: keepassxc-cli ls [options] database [group]"
+_message -r "List database entries."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-R --recursive)'{-R,--recursive}'[Recursively list the elements of the group.]' \
+  '(-f --flatten)'{-f,--flatten}'[Flatten the output to single lines.]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:group'

--- a/share/linux/completions/zsh/_keepassxc-cli_merge
+++ b/share/linux/completions/zsh/_keepassxc-cli_merge
@@ -1,0 +1,18 @@
+#compdef keepassxc-cli merge
+
+_message -r "Usage: keepassxc-cli merge [options] database database2"
+_message -r "Merge two databases."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-s --same-credentials)'{-s,--same-credentials}'[Use the same credentials for both database files.]' \
+  '--key-file-from[Key file of the database to merge from.]:path:_files' \
+  '--no-password-from[Deactivate password key for the database to merge from.]' \
+  '--dry-run[Only print the changes detected by the merge operation.]' \
+  '--yubikey-from[Yubikey slot for the second database.]:slot' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db1:_files' \
+  '2:db2:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_mkdir
+++ b/share/linux/completions/zsh/_keepassxc-cli_mkdir
@@ -1,0 +1,13 @@
+#compdef keepassxc-cli mkdir
+
+_message -r "Usage: keepassxc-cli mkdir [options] database group"
+_message -r "Add a new group to a database."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:group'

--- a/share/linux/completions/zsh/_keepassxc-cli_mv
+++ b/share/linux/completions/zsh/_keepassxc-cli_mv
@@ -1,0 +1,14 @@
+#compdef keepassxc-cli mv
+
+_message -r "Usage: keepassxc-cli mv [options] database entry group"
+_message -r "Move an entry to a new group."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:entry' \
+  '3:group'

--- a/share/linux/completions/zsh/_keepassxc-cli_open
+++ b/share/linux/completions/zsh/_keepassxc-cli_open
@@ -1,0 +1,12 @@
+#compdef keepassxc-cli open
+
+_message -r "Usage: keepassxc-cli open [options] database"
+_message -r "Open a database."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files'

--- a/share/linux/completions/zsh/_keepassxc-cli_rm
+++ b/share/linux/completions/zsh/_keepassxc-cli_rm
@@ -1,0 +1,13 @@
+#compdef keepassxc-cli rm
+
+_message -r "Usage: keepassxc-cli rm [options] database entry"
+_message -r "Remove an entry from the database."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:entry'

--- a/share/linux/completions/zsh/_keepassxc-cli_rmdir
+++ b/share/linux/completions/zsh/_keepassxc-cli_rmdir
@@ -1,0 +1,13 @@
+#compdef keepassxc-cli rmdir
+
+_message -r "Usage: keepassxc-cli rmdir [options] database group"
+_message -r "Remove a group from a database."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:group'

--- a/share/linux/completions/zsh/_keepassxc-cli_search
+++ b/share/linux/completions/zsh/_keepassxc-cli_search
@@ -1,0 +1,13 @@
+#compdef keepassxc-cli search
+
+_message -r "Usage: keepassxc-cli search [options] database term"
+_message -r "Find entries quickly."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:db:_files' \
+  '2:term'

--- a/share/linux/completions/zsh/_keepassxc-cli_show
+++ b/share/linux/completions/zsh/_keepassxc-cli_show
@@ -1,0 +1,18 @@
+#compdef keepassxc-cli show
+
+_message -r "Usage: keepassxc-cli show [options] database entry"
+_message -r "Show an entry's information."
+
+_arguments -s \
+  '(-q --quiet)'{-q,--quiet}'[Silence password prompt and other secondary outputs.]' \
+  '(-k --key-file)'{-k,--key-file}'[Key file of the database.]:path:_files' \
+  '--no-password[Deactivate password key for the database.]' \
+  '(-y --yubikey)'{-y,--yubikey}'[Yubikey slot and optional serial used to access the database (e.g., 1:7370001)]:slot[:serial]' \
+  '(-t --totp)'{-t,--totp}'[Show the entry’s current TOTP.]' \
+  '(-a --attributes)'{-a,--attributes}'[Specify an attribute to show. This option can be specified multiple times.]:attribute' \
+  '(-s --show-protected)'{-s,--show-protected}'[Show protected attributes in clear text.]' \
+  '--all[Show all attributes of the entry.]' \
+  '--show-attachments[Show attachments of the entry.]' \
+  '(-h --help)'{-h,--help}'[Display help information.]' \
+  '1:database path:_files' \
+  '2:entry name'

--- a/share/linux/completions/zsh/install.txt
+++ b/share/linux/completions/zsh/install.txt
@@ -1,0 +1,17 @@
+Quick Guide: Installing Zsh Completion Files
+
+1. Place completion files in one of these locations:
+- /usr/local/share/zsh/site-functions/
+- /usr/share/zsh/site-functions/
+- ~/.zsh/completion/
+
+2. To use a custom directory (e.g., ~/my_custom_completions) for completions:
+- Add to ~/.zshrc: fpath=(~/my_custom_completions $fpath)
+
+3. Ensure Zsh loads and uses your completions:
+- Add to ~/.zshrc: autoload -U compinit && compinit
+
+4. Apply changes:
+- Run: source ~/.zshrc or restart terminal
+
+Note: Check your completion files are chmod 644


### PR DESCRIPTION
Added zsh completion files. This feature allows zsh users to easily reference all options for keepassxc by typing into the zsh console:
keepassxc-cli command --\<tab key\>
--option1     --Description of option1
--option2     --Description of option2
...

I have included install.txt which contains instructions for end users and Linux distribution package maintaners on where it should be installed to.

## Screenshots
![image](https://github.com/user-attachments/assets/1d2fec36-adff-4017-a3bf-4c857fe829fd)
![image](https://github.com/user-attachments/assets/ad9082df-3191-4d1b-9e64-6cc8ab4a58d5)
![image](https://github.com/user-attachments/assets/44e11a39-0f87-45e9-8545-22dfe2f1fab4)
![image](https://github.com/user-attachments/assets/03dbc66a-ea39-40f8-aeee-8d0831358c72)
![image](https://github.com/user-attachments/assets/560f714b-e686-40c4-a371-68c8ced6528e)

## Testing strategy
Place all of the _keepassxc* files (exclude install.txt) in the following folder:
/usr/share/zsh/site-functions/

Set permissions:
chmod 644 /usr/share/zsh/site-functions/_keepassxc*

Add the following lines to the file "~/.zshrc":
autoload -Uz compinit
compinit

Restart the terminal
Type into console "keepassxc-cli\<space key\>" then hit \<tab key\> to see the commands for the program.
Type in "keepassxc-cli edit -" then hit \<tab key\> to see the option arguments for the command.
It is possible to string options together, for example you can continue completing after "keepassxc-cli edit --key-file \<file\> by typing "\<space key\>-" and hitting \<tab key\> again to see additional options. The first option (e.g. --key-file in this example) does not appear again in the new list that appears since it was already used.

## Type of change
- ✅ New feature (change that adds functionality)
- ✅ Documentation (non-code change)
