### PR TITLE
Implement T-CONV and T-REPLACE-RX entry placeholders

### DIFF
--- a/docs/topics/AutoType.adoc
+++ b/docs/topics/AutoType.adoc
@@ -37,7 +37,7 @@ TIP: You can use an asterisk (`\*`) to match any value (e.g., when a window titl
 .Auto-Type entry sequences
 image::autotype_entry_sequences.png[]
 
-2. _(Optional)_ Define a custom Auto-Type sequence for each window title match by selecting the _Use specific sequence for this association_ checkbox. Sequence action codes and field placeholders are detailed in the following table. Beyond the most important ones detailed below, there are additional action codes and placeholders available: xref:UserGuide.adoc#_auto_type_actions[Auto-Type Actions Reference] and xref:UserGuide.adoc#_entry_placeholders[Entry Placeholders Reference]. Action codes and placeholders are not case sensitive.
+2. _(Optional)_ Define a custom Auto-Type sequence for each window title match by selecting the _Use specific sequence for this association_ checkbox. Sequence action codes and field placeholders are detailed in the following table. Beyond the most important ones detailed below, there are additional action codes and placeholders available: <<Auto-Type Actions, Auto-Type Actions Reference>> and <<Entry Placeholders, Entry Placeholders Reference>>. Action codes and placeholders are not case sensitive.
 +
 [grid=rows, frame=none, width=90%]
 |===

--- a/docs/topics/DatabaseOperations.adoc
+++ b/docs/topics/DatabaseOperations.adoc
@@ -84,7 +84,7 @@ There are three ways that KeePassXC can handle database files. This behavior is 
 
 3. *Direct-write saves* write directly to the existing database file. This is an unsafe operation since any interruption can leave your entire database inaccessible. We only recommend using this option when interfacing with Linux GVFS services (e.g. Google Cloud on Gnome) and other types of storage services that host a virtual drive system.
 
-In addition to these save options, KeePassXC can create a backup of your existing database file just prior to saving. This backup will be saved at the path specified in the *Backup destination* field. This path can be absolute or relative. The latter will be resolved according to the databases path. It is possible to specify a custom naming scheme with placeholders. See xref:UserGuide.adoc#_backup_path_placeholders[Backup Path Placeholders] for available placeholders and examples.
+In addition to these save options, KeePassXC can create a backup of your existing database file just prior to saving. This backup will be saved at the path specified in the *Backup destination* field. This path can be absolute or relative. The latter will be resolved according to the databases path. It is possible to specify a custom naming scheme with placeholders. See <<Backup Path Placeholders, Backup Path Placeholders>> for available placeholders and examples.
 
 image::save_options.png[]
 // end::advanced[]
@@ -180,7 +180,7 @@ image::clone_entry_dialog.png[,50%]
 .References in a cloned entry
 image::clone_entry_references.png[]
 
-4. You can create your own references using the xref:UserGuide.adoc#_entry_cross_reference[Entry Reference Syntax]
+4. You can create your own references using the <<Entry Cross-Reference, Entry Reference Syntax>>
 
 == Searching the Database
 KeePassXC provides an enhanced and granular search features the enables you to search for specific entries in the databases using the different modifiers, wild card characters, and logical operators.
@@ -266,7 +266,7 @@ image::edit_entry_colors.png[]
 === Icons
 You can select an icon to be displayed with each entry for easy identification. KeePassXC comes with a set of default icons that you can use or you can use your own custom icons. If you defined a URL with an entry, you can also download the favorite icon for that particular website.
 
-NOTE: To delete a custom icon, go to xref:UserGuide.adoc#_database_maintenance[Database Maintenance] where you can purge unused icons and delete one or more icons at a time.
+NOTE: To delete a custom icon, go to <<Database Maintenance>> where you can purge unused icons and delete one or more icons at a time.
 
 .Entry icon selection
 image::edit_entry_icons.png[]

--- a/docs/topics/Reference.adoc
+++ b/docs/topics/Reference.adoc
@@ -18,6 +18,8 @@ This section contains full details on advanced features available in KeePassXC.
 |{NOTES}         |Notes
 |{TOTP}          |Current TOTP value (if configured)
 |{S:&lt;ATTRIBUTE_NAME&gt;}   |Value for the given attribute (case sensitive)
+|{T-CONV:/&lt;PLACEHOLDER&gt;/&lt;METHOD&gt;/} |Text conversion for resolved placeholder (eg, {USERNAME}) using the following methods: UPPER, LOWER, BASE64, HEX, URI, URI-DEC
+|{T-REPLACE-RX:/&lt;PLACEHOLDER&gt;/&lt;REGEX&gt;/&lt;REPLACE&gt;/} |Use a regular expression to find and replace data from a resolved placeholder (eg, {USERNAME}). Refer to match groups using $1, $2, etc.
 |{URL:RMVSCM}	        |URL without scheme (e.g., https)
 |{URL:WITHOUTSCHEME}	|URL without scheme
 |{URL:SCM}	     |URL Scheme

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -682,19 +682,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid conversion type: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid conversion syntax: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid regular expression syntax %1
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Invalid placeholder: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3812,6 +3799,19 @@ This may cause the affected plugins to malfunction.</source>
     </message>
     <message>
         <source>Passkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid conversion type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid conversion syntax: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid regular expression syntax %1
+%2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -225,7 +225,9 @@ public:
         DateTimeUtcHour,
         DateTimeUtcMinute,
         DateTimeUtcSecond,
-        DbDir
+        DbDir,
+        Conversion,
+        Regex
     };
 
     static const int DefaultIconNumber;
@@ -244,6 +246,8 @@ public:
     QString resolvePlaceholder(const QString& str) const;
     QString resolveUrlPlaceholder(const QString& str, PlaceholderType placeholderType) const;
     QString resolveDateTimePlaceholder(PlaceholderType placeholderType) const;
+    QString resolveConversionPlaceholder(const QString& str, QString* error = nullptr) const;
+    QString resolveRegexPlaceholder(const QString& str, QString* error = nullptr) const;
     PlaceholderType placeholderType(const QString& placeholder) const;
     QString resolveUrl(const QString& url) const;
 

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -36,6 +36,8 @@ private slots:
     void testResolveRecursivePlaceholders();
     void testResolveReferencePlaceholders();
     void testResolveNonIdPlaceholdersToUuid();
+    void testResolveConversionPlaceholders();
+    void testResolveReplacePlaceholders();
     void testResolveClonedEntry();
     void testIsRecycled();
     void testMoveUpDown();


### PR DESCRIPTION
* Closes #7293
* Move existing T-CONV and T-REPLACE-RX code from AutoType to Entry. Replumb AutoType to use the entry functions.
* Improve placeholder code in various place

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Added unit tests

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)