### PR TITLE
Fix status bar on WelcomeScreen

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -679,6 +679,11 @@ MainWindow::MainWindow()
 
     restoreConfigState();
     updateMenuActionState();
+
+    // Check the current screen and hide the status bar if it is the WelcomeScreen
+    if (m_ui->stackedWidget->currentIndex() == WelcomeScreen) {
+        statusBar()->hide();
+    }
 }
 
 MainWindow::~MainWindow()
@@ -1159,8 +1164,10 @@ void MainWindow::switchToDatabases()
 {
     if (m_ui->tabWidget->currentIndex() == -1) {
         m_ui->stackedWidget->setCurrentIndex(WelcomeScreen);
+        statusBar()->hide();
     } else {
         m_ui->stackedWidget->setCurrentIndex(DatabaseTabScreen);
+        statusBar()->show();
     }
 }
 
@@ -1269,8 +1276,10 @@ void MainWindow::databaseTabChanged(int tabIndex)
 {
     if (tabIndex != -1 && m_ui->stackedWidget->currentIndex() == WelcomeScreen) {
         m_ui->stackedWidget->setCurrentIndex(DatabaseTabScreen);
+        statusBar()->show();
     } else if (tabIndex == -1 && m_ui->stackedWidget->currentIndex() == DatabaseTabScreen) {
         m_ui->stackedWidget->setCurrentIndex(WelcomeScreen);
+        statusBar()->hide();
     }
 
     m_actionMultiplexer.setCurrentObject(m_ui->tabWidget->currentDatabaseWidget());


### PR DESCRIPTION
The status bar on the welcome screen does not match the overall design style. I suggest to just hide it.

## Screenshots
![a](https://github.com/user-attachments/assets/a8fcb713-f567-4bba-8074-bb0384740192)
![b](https://github.com/user-attachments/assets/d207d0b4-cdc1-46e4-a707-c191eb0fd8fa)

## Testing strategy
Manually

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
