### PR TITLE
Detect outdated VC Redist with MSI Installer

### DIFF
--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -115,6 +115,14 @@
             <ComponentRef Id="DesktopShortcut" />
         </FeatureRef>
 
+        <!-- Detect VCRedist Version -->
+        <Property Id="VCREDISTINSTALLED">
+            <RegistrySearch Id="SearchVCRedist" Root="HKLM" Key="SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" Name="Version" Type="raw" Win64="yes"/>
+        </Property>
+        <Condition Message="The installed version of Visual Studio Redistributable is too old. Please install the latest version from: https://aka.ms/vs/17/release/vc_redist.x64.exe">
+            <![CDATA[VCREDISTINSTALLED AND VCREDISTINSTALLED > "14.32.31332.0"]]>
+        </Condition>
+
         <!-- Action to launch application after installer exits -->
         <Property Id="WixShellExecTarget" Value="[#CM_FP_KeePassXC.exe]" />
         <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />


### PR DESCRIPTION
* Fixes #10974

![image](https://github.com/user-attachments/assets/4db77c89-2f05-48e0-8133-34070b40d152)

This change will _prevent installation of KeePassXC_ until the VC Redist is updated. Unfortunately, we cannot launch the web browser since you are only allowed to define one launch command and we use that to start KeePassXC post-install.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested by reducing the version number in the registry.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
