### PR TITLE
DarkTheme: Fix separator color for TagView

### DIFF
--- a/src/gui/tag/TagView.cpp
+++ b/src/gui/tag/TagView.cpp
@@ -20,6 +20,7 @@
 #include "TagModel.h"
 #include "core/Database.h"
 #include "core/Metadata.h"
+#include "gui/Application.h"
 #include "gui/Icons.h"
 #include "gui/MessageBox.h"
 
@@ -39,7 +40,11 @@ public:
         if (index.data(Qt::UserRole + 1).toBool()) {
             QRect bounds = option.rect;
             bounds.setY(bounds.bottom());
-            painter->fillRect(bounds, option.palette.mid());
+            if (kpxcApp->isDarkTheme()) {
+                painter->fillRect(bounds, option.palette.mid().color().lighter(185));
+            } else {
+                painter->fillRect(bounds, option.palette.mid());
+            }
         }
     }
 };


### PR DESCRIPTION
## Screenshots

![after](https://github.com/user-attachments/assets/25763387-69c8-43bf-9103-673ea1af9dd7) ![before](https://github.com/user-attachments/assets/ad205334-cc7c-4076-9917-3939c673f736)


## Testing strategy
Manually

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
