### PR TITLE
Fix multiple crashes on Linux

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -295,6 +295,11 @@ QString DatabaseOpenWidget::filename()
 
 void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
 {
+    if (unlockingDatabase()) {
+        qWarning("Ignoring unlock request for %s because of running unlock action.", qPrintable(m_filename));
+        return;
+    }
+
     m_ui->editPassword->setText(pw);
     m_ui->keyFileLineEdit->setText(keyFile);
     m_blockQuickUnlock = true;

--- a/src/gui/osutils/DeviceListener.cpp
+++ b/src/gui/osutils/DeviceListener.cpp
@@ -35,7 +35,7 @@ void DeviceListener::connectSignals(DEVICELISTENER_IMPL* listener)
 {
     connect(listener, &DEVICELISTENER_IMPL::devicePlugged, this, [&](bool state, void* ctx, void* device) {
         // Wait a few ms to prevent USB device access conflicts
-        QTimer::singleShot(50, [&] { emit devicePlugged(state, ctx, device); });
+        QTimer::singleShot(50, this, [&] { emit devicePlugged(state, ctx, device); });
     });
 }
 


### PR DESCRIPTION
Fix crash when multiple dbus unlock calls are issued
* Fixes #11512

Fix crash on Linux when database is closed without hardware key present
* Fixes #11450

[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX" )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested before/after change, crash no longer occurs with guard in place

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)