### PR TITLE
Additional exclusion fields for Windows Clipboard

### DIFF
--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -60,6 +60,8 @@ void Clipboard::setText(const QString& text, bool clear)
     mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
 #elif defined(Q_OS_WIN)
     mime->setData("ExcludeClipboardContentFromMonitorProcessing", QByteArrayLiteral("1"));
+    mime->setData("CanIncludeInClipboardHistory", {4, '\0'});
+    mime->setData("CanUploadToCloudClipboard ", {4, '\0'});
 #endif
 
     if (clipboard->supportsSelection()) {


### PR DESCRIPTION
* Fixes #7127

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and documented with doc blocks! )
Tested on Windows using cloud clipboard and clipboard history, both did not show any trace of copied items from the database.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)