### PR TITLE
Add a warning in case any of the slots are not configured

### DIFF
--- a/src/keys/drivers/YubiKeyInterfaceUSB.cpp
+++ b/src/keys/drivers/YubiKeyInterfaceUSB.cpp
@@ -151,7 +151,7 @@ YubiKey::KeyMap YubiKeyInterfaceUSB::findValidKeys()
                 auto config = (slot == 1 ? CONFIG1_VALID : CONFIG2_VALID);
                 if (!(ykds_touch_level(st) & config)) {
                     // Slot is not configured
-                    qWarning("YubiKey slot %d is not configured for %s", slot, serial);
+                    qWarning("YubiKey slot %d is not configured for YubiKey with S/N: %s", slot, serial);
                     continue;
                 }
                 // Don't actually challenge a YubiKey Neo or below, they always require button press

--- a/src/keys/drivers/YubiKeyInterfaceUSB.cpp
+++ b/src/keys/drivers/YubiKeyInterfaceUSB.cpp
@@ -151,6 +151,7 @@ YubiKey::KeyMap YubiKeyInterfaceUSB::findValidKeys()
                 auto config = (slot == 1 ? CONFIG1_VALID : CONFIG2_VALID);
                 if (!(ykds_touch_level(st) & config)) {
                     // Slot is not configured
+                    qWarning("YubiKey slot %d is not configured for %s", slot, serial);
                     continue;
                 }
                 // Don't actually challenge a YubiKey Neo or below, they always require button press


### PR DESCRIPTION
Fixes #11543  by adding a warning message in Qt when any of the slots aren't configured.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

