### PR TITLE
Allow adjusting application font size

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -243,6 +243,26 @@
         <source>Export KeePassXC Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetGeneral</name>
@@ -543,6 +563,14 @@
     </message>
     <message>
         <source>Open browser on double clicking URL field in entry view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size selection</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -117,6 +117,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::GUI_CheckForUpdatesIncludeBetas, {QS("GUI/CheckForUpdatesIncludeBetas"), Roaming, false}},
     {Config::GUI_ShowExpiredEntriesOnDatabaseUnlock, {QS("GUI/ShowExpiredEntriesOnDatabaseUnlock"), Roaming, true}},
     {Config::GUI_ShowExpiredEntriesOnDatabaseUnlockOffsetDays, {QS("GUI/ShowExpiredEntriesOnDatabaseUnlockOffsetDays"), Roaming, 3}},
+    {Config::GUI_FontSizeOffset, {QS("GUI/FontSizeOffset"), Local, 0}},
 
     {Config::GUI_MainWindowGeometry, {QS("GUI/MainWindowGeometry"), Local, {}}},
     {Config::GUI_MainWindowState, {QS("GUI/MainWindowState"), Local, {}}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -98,6 +98,7 @@ public:
         GUI_CheckForUpdatesIncludeBetas,
         GUI_ShowExpiredEntriesOnDatabaseUnlock,
         GUI_ShowExpiredEntriesOnDatabaseUnlockOffsetDays,
+        GUI_FontSizeOffset,
 
         GUI_MainWindowGeometry,
         GUI_MainWindowState,

--- a/src/gui/Application.h
+++ b/src/gui/Application.h
@@ -42,6 +42,7 @@ public:
     ~Application() override;
 
     static void bootstrap(const QString& uiLanguage = "system");
+    static void applyFontSize();
 
     void applyTheme();
 

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -170,6 +170,7 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
     m_generalUi->toolButtonStyleComboBox->installEventFilter(mouseWheelFilter);
     m_generalUi->languageComboBox->installEventFilter(mouseWheelFilter);
     m_generalUi->trayIconAppearance->installEventFilter(mouseWheelFilter);
+    m_generalUi->fontSizeComboBox->installEventFilter(mouseWheelFilter);
 
 #ifdef WITH_XC_UPDATECHECK
     connect(m_generalUi->checkForUpdatesOnStartupCheckBox, SIGNAL(toggled(bool)), SLOT(checkUpdatesToggled(bool)));
@@ -265,8 +266,23 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->toolButtonStyleComboBox->addItem(tr("Follow style"), Qt::ToolButtonFollowStyle);
     int toolButtonStyleIndex =
         m_generalUi->toolButtonStyleComboBox->findData(config()->get(Config::GUI_ToolButtonStyle));
-    if (toolButtonStyleIndex > 0) {
+    if (toolButtonStyleIndex >= 0) {
         m_generalUi->toolButtonStyleComboBox->setCurrentIndex(toolButtonStyleIndex);
+    }
+
+    m_generalUi->fontSizeComboBox->clear();
+    m_generalUi->fontSizeComboBox->addItem(tr("Small"), -1);
+    m_generalUi->fontSizeComboBox->addItem(tr("Normal"), 0);
+    m_generalUi->fontSizeComboBox->addItem(tr("Medium"), 1);
+    m_generalUi->fontSizeComboBox->addItem(tr("Large"), 2);
+
+    int fontSizeIndex = m_generalUi->fontSizeComboBox->findData(config()->get(Config::GUI_FontSizeOffset));
+    if (fontSizeIndex >= 0) {
+        m_generalUi->fontSizeComboBox->setCurrentIndex(fontSizeIndex);
+    } else {
+        // Custom value entered into config file, add it to the list and select it
+        m_generalUi->fontSizeComboBox->addItem(tr("Custom"), config()->get(Config::GUI_FontSizeOffset).toInt());
+        m_generalUi->fontSizeComboBox->setCurrentIndex(m_generalUi->fontSizeComboBox->count() - 1);
     }
 
     m_generalUi->systrayShowCheckBox->setChecked(config()->get(Config::GUI_ShowTrayIcon).toBool());
@@ -412,6 +428,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::GUI_ColorPasswords, m_generalUi->colorPasswordsCheckBox->isChecked());
 
     config()->set(Config::GUI_ToolButtonStyle, m_generalUi->toolButtonStyleComboBox->currentData().toString());
+    config()->set(Config::GUI_FontSizeOffset, m_generalUi->fontSizeComboBox->currentData().toInt());
 
     config()->set(Config::GUI_ShowTrayIcon, m_generalUi->systrayShowCheckBox->isChecked());
     config()->set(Config::GUI_TrayIconAppearance, m_generalUi->trayIconAppearance->currentData().toString());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -57,9 +57,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-419</y>
-            <width>573</width>
-            <height>1397</height>
+            <y>0</y>
+            <width>568</width>
+            <height>1202</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -493,6 +493,9 @@
                   <property name="enabled">
                    <bool>false</bool>
                   </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToContents</enum>
+                  </property>
                   <item>
                    <property name="text">
                     <string>Temporary file moved into place</string>
@@ -709,22 +712,6 @@
                 <property name="horizontalSpacing">
                  <number>10</number>
                 </property>
-                <item row="1" column="2">
-                 <widget class="QCheckBox" name="toolbarMovableCheckBox">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string>Movable toolbar</string>
-                  </property>
-                 </widget>
-                </item>
                 <item row="0" column="3">
                  <spacer name="horizontalSpacer_5">
                   <property name="orientation">
@@ -737,66 +724,6 @@
                    </size>
                   </property>
                  </spacer>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QComboBox" name="toolButtonStyleComboBox">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="focusPolicy">
-                   <enum>Qt::StrongFocus</enum>
-                  </property>
-                  <property name="accessibleName">
-                   <string>Toolbar button style</string>
-                  </property>
-                  <property name="sizeAdjustPolicy">
-                   <enum>QComboBox::AdjustToContents</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="toolButtonStyleLabel">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">margin-right: 5px</string>
-                  </property>
-                  <property name="text">
-                   <string>Toolbar button style:</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                  <property name="buddy">
-                   <cstring>toolButtonStyleComboBox</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QComboBox" name="languageComboBox">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="focusPolicy">
-                   <enum>Qt::StrongFocus</enum>
-                  </property>
-                  <property name="accessibleName">
-                   <string>Language selection</string>
-                  </property>
-                 </widget>
                 </item>
                 <item row="0" column="0">
                  <widget class="QLabel" name="languageLabel_2">
@@ -817,10 +744,112 @@
                   </property>
                  </widget>
                 </item>
+                <item row="1" column="2">
+                 <widget class="QCheckBox" name="toolbarMovableCheckBox">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Movable toolbar</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QComboBox" name="toolButtonStyleComboBox">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::StrongFocus</enum>
+                  </property>
+                  <property name="accessibleName">
+                   <string>Toolbar button style</string>
+                  </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToContents</enum>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QComboBox" name="languageComboBox">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::StrongFocus</enum>
+                  </property>
+                  <property name="accessibleName">
+                   <string>Language selection</string>
+                  </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToContents</enum>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="toolButtonStyleLabel">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Toolbar button style:</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                  <property name="buddy">
+                   <cstring>toolButtonStyleComboBox</cstring>
+                  </property>
+                 </widget>
+                </item>
                 <item row="0" column="2">
                  <widget class="QLabel" name="languageLabel_3">
                   <property name="text">
                    <string>(restart program to activate)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="fontSizeLabel">
+                  <property name="text">
+                   <string>Font size:</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                  <property name="buddy">
+                   <cstring>fontSizeComboBox</cstring>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QComboBox" name="fontSizeComboBox">
+                  <property name="focusPolicy">
+                   <enum>Qt::StrongFocus</enum>
+                  </property>
+                  <property name="accessibleName">
+                   <string>Font size selection</string>
+                  </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToContents</enum>
                   </property>
                  </widget>
                 </item>
@@ -911,6 +940,9 @@
                   </property>
                   <property name="accessibleName">
                    <string>Tray icon type</string>
+                  </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToContents</enum>
                   </property>
                  </widget>
                 </item>

--- a/src/gui/Font.cpp
+++ b/src/gui/Font.cpp
@@ -28,19 +28,21 @@ QFont Font::defaultFont()
 QFont Font::fixedFont()
 {
     auto fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    fixedFont.setPointSize(defaultFont().pointSize());
 
 #ifdef Q_OS_WIN
     // try to use Consolas on Windows, because the default Courier New has too many similar characters
-    auto consolasFont = QFontDatabase().font("Consolas", fixedFont.styleName(), fixedFont.pointSize());
+    auto consolasFont = QFontDatabase().font("Consolas", fixedFont.styleName(), defaultFont().pointSize());
     if (consolasFont.family().contains("consolas", Qt::CaseInsensitive)) {
         fixedFont = consolasFont;
-        // Bump up the font size by one point to match the default font
-        fixedFont.setPointSize(fixedFont.pointSize() + 1);
+        // Bump up the font size by one point to better match the default font on Windows
+        fixedFont.setPointSize(defaultFont().pointSize() + 1);
     }
 #endif
 #ifdef Q_OS_MACOS
     // Qt doesn't choose a monospace font correctly on macOS
-    fixedFont = QFontDatabase().font("Menlo", fixedFont.styleName(), qApp->font().pointSize());
+    fixedFont = QFontDatabase().font("Menlo", fixedFont.styleName(), defaultFont().pointSize());
+    fixedFont.setPointSize(defaultFont().pointSize());
 #endif
     return fixedFont;
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1640,6 +1640,8 @@ void MainWindow::applySettingsChanges()
     }
 
     updateTrayIcon();
+
+    kpxcApp->applyFontSize();
 }
 
 void MainWindow::setAllowScreenCapture(bool state)


### PR DESCRIPTION
* Closes #6822
* Fix fixed font not following default font's point size
* Allow for custom offset values manually set in the config file (bounded to -2 to 4)

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
![image](https://github.com/user-attachments/assets/056bd4d9-ae65-4b5a-b9ee-45d5885fe3ec)

Small Font:
![image](https://github.com/user-attachments/assets/913372aa-3d0b-4392-b480-40ea43d273ca)

Large Font:
![image](https://github.com/user-attachments/assets/4f02aac3-addf-4c19-8886-cda3bba49d60)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested on Windows, may need testing on other platforms

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
