### PR TITLE
Fix passphrase word lists not rendering with UTF-8

### DIFF
--- a/src/core/PassphraseGenerator.cpp
+++ b/src/core/PassphraseGenerator.cpp
@@ -72,6 +72,7 @@ void PassphraseGenerator::setWordList(const QString& path)
     }
 
     QTextStream in(&file);
+    in.setCodec("UTF-8");
     QString line = in.readLine();
     bool isSigned = line.startsWith("-----BEGIN PGP SIGNED MESSAGE-----");
     if (isSigned) {


### PR DESCRIPTION
* Fixes #11599

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
BEFORE:
![image](https://github.com/user-attachments/assets/db95f814-a5d7-4998-ab49-31f20d957b01)

AFTER:
![image](https://github.com/user-attachments/assets/e78be018-2ba2-425d-9d40-5b4cd34d41ff)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested manually

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
