### PR TITLE
Show Auto-Type select dialog even if window title is empty

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -153,6 +153,7 @@ AutoType::AutoType(QObject* parent, bool test)
 #endif
     }
 
+    connect(this, SIGNAL(autotypeFinished()), SLOT(resetAutoTypeState()));
     connect(qApp, SIGNAL(aboutToQuit()), SLOT(unloadPlugin()));
 }
 
@@ -353,7 +354,6 @@ void AutoType::executeAutoTypeActions(const Entry* entry,
         }
     }
 
-    resetAutoTypeState();
     m_inAutoType.unlock();
     emit autotypeFinished();
 }
@@ -488,11 +488,9 @@ void AutoType::performGlobalAutoType(const QList<QSharedPointer<Database>>& dbLi
                                            m_windowForGlobal,
                                            virtualMode ? AutoTypeExecutor::Mode::VIRTUAL
                                                        : AutoTypeExecutor::Mode::NORMAL);
-                    resetAutoTypeState();
                 });
         connect(selectDialog, &QDialog::rejected, this, [this] {
             restoreWindowState();
-            resetAutoTypeState();
             emit autotypeFinished();
         });
 
@@ -506,10 +504,8 @@ void AutoType::performGlobalAutoType(const QList<QSharedPointer<Database>>& dbLi
     } else if (!matchList.isEmpty()) {
         // Only one match and not asking, do it!
         executeAutoTypeActions(matchList.first().first, matchList.first().second, m_windowForGlobal);
-        resetAutoTypeState();
     } else {
         // We should never get here
-        resetAutoTypeState();
         emit autotypeFinished();
     }
 }

--- a/src/autotype/AutoType.h
+++ b/src/autotype/AutoType.h
@@ -66,6 +66,7 @@ signals:
 private slots:
     void startGlobalAutoType(const QString& search);
     void unloadPlugin();
+    void resetAutoTypeState();
 
 private:
     enum WindowState
@@ -83,7 +84,6 @@ private:
                                 WId window = 0,
                                 AutoTypeExecutor::Mode mode = AutoTypeExecutor::Mode::NORMAL);
     void restoreWindowState();
-    void resetAutoTypeState();
 
     static QList<QSharedPointer<AutoTypeAction>>
     parseSequence(const QString& entrySequence, const Entry* entry, QString& error, bool syntaxOnly = false);


### PR DESCRIPTION
* Fixes #11597

* Always reset Auto-Type state on finished signal

There were a couple code paths that did not reset the state appropriately and could cause undefined behavior in the auto-type processing.

I split the changes into two commits.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested on Windows with simulated window title being blank. The select dialog properly displays with the "Search all databases" checkbox checked as expected.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)