### PR TITLE
Show a clear error if the key is found but the slots are not configured

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -10230,6 +10230,10 @@ Example: JBSWY3DPEHPK3PXP</source>
         <source>&lt;p&gt;If you own a &lt;a href=&quot;https://www.yubico.com/&quot;&gt;YubiKey&lt;/a&gt; or &lt;a href=&quot;https://onlykey.io&quot;&gt;OnlyKey&lt;/a&gt;, you can use it for additional security.&lt;/p&gt;&lt;p&gt;The key requires one of its slots to be programmed with &lt;a href=&quot;https://keepassxc.org/docs/#faq-yubikey-howto&quot;&gt;Challenge-Response&lt;/a&gt;.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hardware keys found, but no slots are configured</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>YubiKeyInterfacePCSC</name>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1664,6 +1664,10 @@ Are you sure you want to continue with this file?.</source>
         <source>&lt;a href=&quot;#&quot; style=&quot;text-decoration: underline&quot;&gt;I have a key file&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Hardware keys found, but no slots are configured.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingWidgetMetaData</name>

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -140,6 +140,11 @@ void DatabaseOpenWidget::toggleHardwareKeyComponent(bool state)
     m_ui->hardwareKeyProgress->setVisible(false);
     m_ui->hardwareKeyComponent->setVisible(state);
     m_ui->hardwareKeyCombo->setVisible(state && m_ui->hardwareKeyCombo->count() != 1);
+
+    m_ui->noHardwareKeysFoundLabel->setText(YubiKey::instance()->findConnectedKeys()
+                                                ? tr("Hardware keys found, but no slots are configured.")
+                                                : tr("No hardware keys found."));
+
     m_ui->noHardwareKeysFoundLabel->setVisible(!state && m_manualHardwareKeyRefresh);
     if (!state) {
         m_ui->useHardwareKeyCheckBox->setChecked(false);

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -102,7 +102,7 @@ DatabaseOpenWidget::DatabaseOpenWidget(QWidget* parent)
     m_ui->hardwareKeyProgress->setSizePolicy(sp);
 
 #ifdef WITH_XC_YUBIKEY
-    connect(m_deviceListener, SIGNAL(devicePlugged(bool, void*, void*)), this, SLOT(pollHardwareKey()));
+    connect(m_deviceListener, &DeviceListener::devicePlugged, this, [this] { pollHardwareKey(false, 500); });
     connect(YubiKey::instance(), SIGNAL(detectComplete(bool)), SLOT(hardwareKeyResponse(bool)), Qt::QueuedConnection);
 
     connect(YubiKey::instance(), &YubiKey::userInteractionRequest, this, [this] {
@@ -141,11 +141,11 @@ void DatabaseOpenWidget::toggleHardwareKeyComponent(bool state)
     m_ui->hardwareKeyComponent->setVisible(state);
     m_ui->hardwareKeyCombo->setVisible(state && m_ui->hardwareKeyCombo->count() != 1);
 
-    m_ui->noHardwareKeysFoundLabel->setText(YubiKey::instance()->findConnectedKeys()
+    m_ui->noHardwareKeysFoundLabel->setVisible(!state && m_manualHardwareKeyRefresh);
+    m_ui->noHardwareKeysFoundLabel->setText(YubiKey::instance()->connectedKeys() > 0
                                                 ? tr("Hardware keys found, but no slots are configured.")
                                                 : tr("No hardware keys found."));
 
-    m_ui->noHardwareKeysFoundLabel->setVisible(!state && m_manualHardwareKeyRefresh);
     if (!state) {
         m_ui->useHardwareKeyCheckBox->setChecked(false);
     }
@@ -525,7 +525,7 @@ bool DatabaseOpenWidget::browseKeyFile()
     return true;
 }
 
-void DatabaseOpenWidget::pollHardwareKey(bool manualTrigger)
+void DatabaseOpenWidget::pollHardwareKey(bool manualTrigger, int delay)
 {
     if (m_pollingHardwareKey) {
         return;
@@ -539,9 +539,6 @@ void DatabaseOpenWidget::pollHardwareKey(bool manualTrigger)
     m_pollingHardwareKey = true;
     m_manualHardwareKeyRefresh = manualTrigger;
 
-    // Add a delay, if this is an automatic trigger, to allow the USB device to settle as
-    // the device may not report a valid serial number immediately after plugging in
-    int delay = manualTrigger ? 0 : 500;
     QTimer::singleShot(delay, this, [] { YubiKey::instance()->findValidKeysAsync(); });
 }
 

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -79,7 +79,7 @@ protected slots:
 private slots:
     bool browseKeyFile();
     void toggleHardwareKeyComponent(bool state);
-    void pollHardwareKey(bool manualTrigger = false);
+    void pollHardwareKey(bool manualTrigger = false, int delay = 0);
     void hardwareKeyResponse(bool found);
 
 private:

--- a/src/gui/databasekey/YubiKeyEditWidget.cpp
+++ b/src/gui/databasekey/YubiKeyEditWidget.cpp
@@ -173,7 +173,9 @@ void YubiKeyEditWidget::hardwareKeyResponse(bool found)
 
     if (!found) {
         m_compUi->yubikeyProgress->setVisible(false);
-        m_compUi->comboChallengeResponse->addItem(tr("No hardware keys detected"));
+        m_compUi->comboChallengeResponse->addItem(YubiKey::instance()->findConnectedKeys()
+                                                      ? tr("Hardware keys found, but no slots are configured")
+                                                      : tr("No hardware keys detected"));
         m_isDetected = false;
         return;
     }

--- a/src/gui/databasekey/YubiKeyEditWidget.cpp
+++ b/src/gui/databasekey/YubiKeyEditWidget.cpp
@@ -173,7 +173,7 @@ void YubiKeyEditWidget::hardwareKeyResponse(bool found)
 
     if (!found) {
         m_compUi->yubikeyProgress->setVisible(false);
-        m_compUi->comboChallengeResponse->addItem(YubiKey::instance()->findConnectedKeys()
+        m_compUi->comboChallengeResponse->addItem(YubiKey::instance()->connectedKeys() > 0
                                                       ? tr("Hardware keys found, but no slots are configured")
                                                       : tr("No hardware keys detected"));
         m_isDetected = false;

--- a/src/keys/drivers/YubiKey.cpp
+++ b/src/keys/drivers/YubiKey.cpp
@@ -99,10 +99,8 @@ void YubiKey::findValidKeysAsync()
 YubiKey::KeyMap YubiKey::foundKeys()
 {
     QMutexLocker lock(&s_interfaceMutex);
-    KeyMap foundKeys;
-
-    foundKeys.insert(m_usbKeys);
-    foundKeys.insert(m_pcscKeys);
+    KeyMap foundKeys = m_usbKeys;
+    foundKeys.unite(m_pcscKeys);
 
     return foundKeys;
 }

--- a/src/keys/drivers/YubiKey.cpp
+++ b/src/keys/drivers/YubiKey.cpp
@@ -75,20 +75,11 @@ bool YubiKey::findValidKeys()
 {
     QMutexLocker lock(&s_interfaceMutex);
 
-    m_usbKeys = YubiKeyInterfaceUSB::instance()->findValidKeys();
-    m_pcscKeys = YubiKeyInterfacePCSC::instance()->findValidKeys();
+    m_connectedKeys = 0;
+    m_usbKeys = YubiKeyInterfaceUSB::instance()->findValidKeys(m_connectedKeys);
+    m_pcscKeys = YubiKeyInterfacePCSC::instance()->findValidKeys(m_connectedKeys);
 
     return !m_usbKeys.isEmpty() || !m_pcscKeys.isEmpty();
-}
-
-bool YubiKey::findConnectedKeys()
-{
-    QMutexLocker lock(&s_interfaceMutex);
-
-    m_usbConnectedKeys = YubiKeyInterfaceUSB::instance()->findKeys();
-    m_pcscConnectedKeys = YubiKeyInterfacePCSC::instance()->findKeys();
-
-    return !m_usbConnectedKeys.isEmpty() || !m_pcscConnectedKeys.isEmpty();
 }
 
 void YubiKey::findValidKeysAsync()
@@ -105,17 +96,9 @@ YubiKey::KeyMap YubiKey::foundKeys()
     return foundKeys;
 }
 
-YubiKey::KeyList YubiKey::foundConnectedKeys()
+int YubiKey::connectedKeys()
 {
-    QMutexLocker lock(&s_interfaceMutex);
-
-    KeyList foundKeys;
-    foundKeys.reserve(m_usbConnectedKeys.size() + m_pcscConnectedKeys.size());
-
-    foundKeys.append(m_usbConnectedKeys);
-    foundKeys.append(m_pcscConnectedKeys);
-
-    return foundKeys;
+    return m_connectedKeys;
 }
 
 QString YubiKey::errorMessage()

--- a/src/keys/drivers/YubiKey.h
+++ b/src/keys/drivers/YubiKey.h
@@ -38,7 +38,9 @@ class YubiKey : public QObject
     Q_OBJECT
 
 public:
-    typedef QMap<YubiKeySlot, QString> KeyMap;
+    using KeyMap = QMap<YubiKeySlot, QString>;
+    using KeyList = QList<unsigned int>;
+
     enum class ChallengeResult : int
     {
         YCR_ERROR = 0,
@@ -49,10 +51,12 @@ public:
     static YubiKey* instance();
     bool isInitialized();
 
+    bool findConnectedKeys();
     bool findValidKeys();
     void findValidKeysAsync();
 
     KeyMap foundKeys();
+    KeyList foundConnectedKeys();
 
     ChallengeResult challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response);
     bool testChallenge(YubiKeySlot slot, bool* wouldBlock = nullptr);
@@ -92,6 +96,9 @@ private:
 
     KeyMap m_usbKeys;
     KeyMap m_pcscKeys;
+
+    KeyList m_usbConnectedKeys;
+    KeyList m_pcscConnectedKeys;
 
     Q_DISABLE_COPY(YubiKey)
 };

--- a/src/keys/drivers/YubiKey.h
+++ b/src/keys/drivers/YubiKey.h
@@ -39,7 +39,6 @@ class YubiKey : public QObject
 
 public:
     using KeyMap = QMap<YubiKeySlot, QString>;
-    using KeyList = QList<unsigned int>;
 
     enum class ChallengeResult : int
     {
@@ -51,12 +50,11 @@ public:
     static YubiKey* instance();
     bool isInitialized();
 
-    bool findConnectedKeys();
     bool findValidKeys();
     void findValidKeysAsync();
 
     KeyMap foundKeys();
-    KeyList foundConnectedKeys();
+    int connectedKeys();
 
     ChallengeResult challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response);
     bool testChallenge(YubiKeySlot slot, bool* wouldBlock = nullptr);
@@ -97,8 +95,7 @@ private:
     KeyMap m_usbKeys;
     KeyMap m_pcscKeys;
 
-    KeyList m_usbConnectedKeys;
-    KeyList m_pcscConnectedKeys;
+    int m_connectedKeys = 0;
 
     Q_DISABLE_COPY(YubiKey)
 };

--- a/src/keys/drivers/YubiKeyInterface.h
+++ b/src/keys/drivers/YubiKeyInterface.h
@@ -32,8 +32,7 @@ class YubiKeyInterface : public QObject
 public:
     bool isInitialized() const;
 
-    virtual YubiKey::KeyMap findValidKeys() = 0;
-    virtual YubiKey::KeyList findKeys() = 0;
+    virtual YubiKey::KeyMap findValidKeys(int& connectedKeys) = 0;
     virtual YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) = 0;
     virtual bool testChallenge(YubiKeySlot slot, bool* wouldBlock) = 0;

--- a/src/keys/drivers/YubiKeyInterface.h
+++ b/src/keys/drivers/YubiKeyInterface.h
@@ -33,6 +33,7 @@ public:
     bool isInitialized() const;
 
     virtual YubiKey::KeyMap findValidKeys() = 0;
+    virtual YubiKey::KeyList findKeys() = 0;
     virtual YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) = 0;
     virtual bool testChallenge(YubiKeySlot slot, bool* wouldBlock) = 0;

--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -20,8 +20,6 @@
 #include "core/Tools.h"
 #include "crypto/Random.h"
 
-#include <QScopeGuard>
-
 // MSYS2 does not define these macros
 // So set them to the value used by pcsc-lite
 #ifndef MAX_ATR_SIZE
@@ -514,6 +512,29 @@ namespace
         });
     }
 
+    class ScopeGuard
+    {
+    public:
+        template <typename F>
+        explicit ScopeGuard(F&& fn)
+            : m_function(std::forward<F>(fn))
+        {
+            static_assert(std::is_convertible_v<F, std::function<void()>>,
+                          "the functor F isn't convertible to std::function<void()>");
+            static_assert(std::is_invocable_v<F>, "The functor F isn't invocable");
+        }
+
+        ~ScopeGuard()
+        {
+            if (m_function) {
+                m_function();
+            }
+        }
+
+    private:
+        std::function<void()> m_function{};
+    };
+
 } // namespace
 
 YubiKeyInterfacePCSC::YubiKeyInterfacePCSC()
@@ -580,7 +601,7 @@ YubiKey::KeyMap YubiKeyInterfacePCSC::findValidKeys()
             continue;
         }
 
-        QScopeGuard disconnect([hCard]() { SCardDisconnect(hCard, SCARD_LEAVE_CARD); });
+        ScopeGuard disconnect{[hCard]() { SCardDisconnect(hCard, SCARD_LEAVE_CARD); }};
 
         // Read the protocol and the ATR record
         char pbReader[MAX_READERNAME] = {0};
@@ -679,7 +700,7 @@ YubiKey::KeyList YubiKeyInterfacePCSC::findKeys()
             continue;
         }
 
-        QScopeGuard disconnect([hCard]() { SCardDisconnect(hCard, SCARD_LEAVE_CARD); });
+        ScopeGuard disconnect([hCard]() { SCardDisconnect(hCard, SCARD_LEAVE_CARD); });
 
         // Read the protocol and the ATR record
         char pbReader[MAX_READERNAME] = {0};

--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -20,6 +20,8 @@
 #include "core/Tools.h"
 #include "crypto/Random.h"
 
+#include <QScopeGuard>
+
 // MSYS2 does not define these macros
 // So set them to the value used by pcsc-lite
 #ifndef MAX_ATR_SIZE
@@ -578,6 +580,8 @@ YubiKey::KeyMap YubiKeyInterfacePCSC::findValidKeys()
             continue;
         }
 
+        QScopeGuard disconnect([hCard]() { SCardDisconnect(hCard, SCARD_LEAVE_CARD); });
+
         // Read the protocol and the ATR record
         char pbReader[MAX_READERNAME] = {0};
         SCUINT dwReaderLen = sizeof(pbReader);
@@ -632,6 +636,76 @@ YubiKey::KeyMap YubiKeyInterfacePCSC::findValidKeys()
                                             : tr("Passive", "USB Challenge-Response Key no interaction required"));
                     foundKeys.insert({serial, slot}, display);
                 }
+            }
+        }
+    }
+
+    return foundKeys;
+}
+
+YubiKey::KeyList YubiKeyInterfacePCSC::findKeys()
+{
+    m_error.clear();
+    if (!isInitialized()) {
+        return {};
+    }
+
+    YubiKey::KeyList foundKeys;
+
+    // Connect to each reader and look for cards
+    for (const auto& reader_name : getReaders(m_sc_context)) {
+        /* Some Yubikeys present their PCSC interface via USB as well
+           Although this would not be a problem in itself,
+           we filter these connections because in USB mode,
+           the PCSC challenge-response interface is usually locked
+           Instead, the other USB (HID) interface should pick up and
+           interface the key.
+           For more info see the comment block further below. */
+        if (reader_name.contains("yubikey", Qt::CaseInsensitive)) {
+            continue;
+        }
+
+        SCARDHANDLE hCard;
+        SCUINT dwActiveProtocol = SCARD_PROTOCOL_UNDEFINED;
+        auto rv = SCardConnect(m_sc_context,
+                               reader_name.toStdString().c_str(),
+                               SCARD_SHARE_SHARED,
+                               SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1,
+                               &hCard,
+                               &dwActiveProtocol);
+
+        if (rv != SCARD_S_SUCCESS) {
+            // Cannot connect to the reader
+            continue;
+        }
+
+        QScopeGuard disconnect([hCard]() { SCardDisconnect(hCard, SCARD_LEAVE_CARD); });
+
+        // Read the protocol and the ATR record
+        char pbReader[MAX_READERNAME] = {0};
+        SCUINT dwReaderLen = sizeof(pbReader);
+        SCUINT dwState = 0;
+        SCUINT dwProt = SCARD_PROTOCOL_UNDEFINED;
+        uint8_t pbAtr[MAX_ATR_SIZE] = {0};
+        SCUINT dwAtrLen = sizeof(pbAtr);
+
+        rv = SCardStatus(hCard, pbReader, &dwReaderLen, &dwState, &dwProt, pbAtr, &dwAtrLen);
+        if (rv != SCARD_S_SUCCESS || (dwProt != SCARD_PROTOCOL_T0 && dwProt != SCARD_PROTOCOL_T1)) {
+            // Could not read the ATR record or the protocol is not supported
+            continue;
+        }
+
+        // Find which AID to use
+        SCardAID satr;
+        if (findAID(hCard, m_aid_codes, satr)) {
+            // Build the UI name using the display name found in the ATR map
+            QByteArray atr(reinterpret_cast<char*>(pbAtr), dwAtrLen);
+
+            unsigned int serial = 0;
+            getSerial(satr, serial);
+
+            if (serial != 0) {
+                foundKeys.append(serial);
             }
         }
     }

--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -520,8 +520,8 @@ namespace
             : m_function(std::forward<F>(fn))
         {
             static_assert(std::is_convertible_v<F, std::function<void()>>,
-                          "the functor F isn't convertible to std::function<void()>");
-            static_assert(std::is_invocable_v<F>, "The functor F isn't invocable");
+                          "F-typed objects are not convertible to std::function<void()>");
+            static_assert(std::is_invocable_v<F>, "F-typed objects are not invocable");
         }
 
         ~ScopeGuard()

--- a/src/keys/drivers/YubiKeyInterfacePCSC.h
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.h
@@ -52,8 +52,7 @@ class YubiKeyInterfacePCSC : public YubiKeyInterface
 public:
     static YubiKeyInterfacePCSC* instance();
 
-    YubiKey::KeyMap findValidKeys() override;
-    YubiKey::KeyList findKeys() override;
+    YubiKey::KeyMap findValidKeys(int& connectedKeys) override;
 
     YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) override;

--- a/src/keys/drivers/YubiKeyInterfacePCSC.h
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.h
@@ -53,6 +53,7 @@ public:
     static YubiKeyInterfacePCSC* instance();
 
     YubiKey::KeyMap findValidKeys() override;
+    YubiKey::KeyList findKeys() override;
 
     YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) override;

--- a/src/keys/drivers/YubiKeyInterfaceUSB.cpp
+++ b/src/keys/drivers/YubiKeyInterfaceUSB.cpp
@@ -18,16 +18,25 @@
 
 #include "YubiKeyInterfaceUSB.h"
 
-#include "core/Tools.h"
 #include "crypto/Random.h"
 #include "thirdparty/ykcore/ykcore.h"
 #include "thirdparty/ykcore/ykstatus.h"
+
+#include <memory>
 
 namespace
 {
     constexpr int MAX_KEYS = 4;
 
-    YK_KEY* openKey(int index)
+    void closeKey(YK_KEY* key)
+    {
+        yk_close_key(key);
+    }
+
+    using Yubikey = std::unique_ptr<YK_KEY, decltype(&closeKey)>;
+    using YubikeyStatus = std::unique_ptr<YK_STATUS, decltype(&ykds_free)>;
+
+    Yubikey openKey(int index)
     {
         static const int vids[] = {YUBICO_VID, ONLYKEY_VID};
         static const int pids[] = {YUBIKEY_PID,
@@ -42,12 +51,9 @@ namespace
                                    PLUS_U2F_OTP_PID,
                                    ONLYKEY_PID};
 
-        return yk_open_key_vid_pid(vids, sizeof(vids) / sizeof(vids[0]), pids, sizeof(pids) / sizeof(pids[0]), index);
-    }
-
-    void closeKey(YK_KEY* key)
-    {
-        yk_close_key(key);
+        return Yubikey{
+            yk_open_key_vid_pid(vids, sizeof(vids) / sizeof(vids[0]), pids, sizeof(pids) / sizeof(pids[0]), index),
+            &closeKey};
     }
 
     void printError()
@@ -69,24 +75,25 @@ namespace
         return serial;
     }
 
-    YK_KEY* openKeySerial(unsigned int serial)
+    Yubikey openKeySerial(unsigned int serial)
     {
         for (int i = 0; i < MAX_KEYS; ++i) {
-            auto* yk_key = openKey(i);
-            if (yk_key) {
+            auto key = openKey(i);
+            if (key) {
                 // If the provided serial number is 0, or the key matches the serial, return it
-                if (serial == 0 || getSerial(yk_key) == serial) {
-                    return yk_key;
+                if (serial == 0 || getSerial(key.get()) == serial) {
+                    return key;
                 }
-                closeKey(yk_key);
             } else if (yk_errno == YK_ENOKEY) {
                 // No more connected keys
                 break;
             }
             printError();
         }
-        return nullptr;
+
+        return Yubikey{nullptr, &closeKey};
     }
+
 } // namespace
 
 YubiKeyInterfaceUSB::YubiKeyInterfaceUSB()
@@ -127,29 +134,28 @@ YubiKey::KeyMap YubiKeyInterfaceUSB::findValidKeys()
     for (int i = 0; i < MAX_KEYS; ++i) {
         auto yk_key = openKey(i);
         if (yk_key) {
-            auto serial = getSerial(yk_key);
+            auto serial = getSerial(yk_key.get());
             if (serial == 0) {
-                closeKey(yk_key);
                 continue;
             }
 
-            auto st = ykds_alloc();
-            yk_get_status(yk_key, st);
+            YubikeyStatus st{ykds_alloc(), &ykds_free};
+            yk_get_status(yk_key.get(), st.get());
             int vid, pid;
-            yk_get_key_vid_pid(yk_key, &vid, &pid);
+            yk_get_key_vid_pid(yk_key.get(), &vid, &pid);
 
             QString name = m_pid_names.value(pid, tr("Unknown"));
             if (vid == ONLYKEY_VID) {
                 name = QStringLiteral("OnlyKey %ver");
             }
             if (name.contains("%ver")) {
-                name = name.replace("%ver", QString::number(ykds_version_major(st)));
+                name = name.replace("%ver", QString::number(ykds_version_major(st.get())));
             }
 
             bool wouldBlock;
             for (int slot = 1; slot <= 2; ++slot) {
                 auto config = (slot == 1 ? CONFIG1_VALID : CONFIG2_VALID);
-                if (!(ykds_touch_level(st) & config)) {
+                if (!(ykds_touch_level(st.get()) & config)) {
                     // Slot is not configured
                     continue;
                 }
@@ -159,7 +165,7 @@ YubiKey::KeyMap YubiKeyInterfaceUSB::findValidKeys()
                     auto display = tr("%1 [%2] - Slot %3", "YubiKey NEO display fields")
                                        .arg(name, QString::number(serial), QString::number(slot));
                     keyMap.insert({serial, slot}, display);
-                } else if (performTestChallenge(yk_key, slot, &wouldBlock)) {
+                } else if (performTestChallenge(yk_key.get(), slot, &wouldBlock)) {
                     auto display =
                         tr("%1 [%2] - Slot %3, %4", "YubiKey display fields")
                             .arg(name,
@@ -170,9 +176,6 @@ YubiKey::KeyMap YubiKeyInterfaceUSB::findValidKeys()
                     keyMap.insert({serial, slot}, display);
                 }
             }
-
-            ykds_free(st);
-            closeKey(yk_key);
         } else if (yk_errno == YK_ENOKEY) {
             // No more keys are connected
             break;
@@ -186,6 +189,37 @@ YubiKey::KeyMap YubiKeyInterfaceUSB::findValidKeys()
     return keyMap;
 }
 
+YubiKey::KeyList YubiKeyInterfaceUSB::findKeys()
+{
+    m_error.clear();
+    if (!isInitialized()) {
+        return {};
+    }
+
+    YubiKey::KeyList keyList{};
+
+    // Try to detect up to 4 connected hardware keys
+    for (int i = 0; i < MAX_KEYS; ++i) {
+        if (auto yk_key = openKey(i); yk_key) {
+            auto serial = getSerial(yk_key.get());
+            if (serial == 0) {
+                continue;
+            }
+
+            keyList.append(serial);
+        } else if (yk_errno == YK_ENOKEY) {
+            // No more keys are connected
+            break;
+        } else if (yk_errno == YK_EUSBERR) {
+            qWarning("Hardware key USB error: %s", yk_usb_strerror());
+        } else {
+            qWarning("Hardware key error: %s", yk_strerror(yk_errno));
+        }
+    }
+
+    return keyList;
+}
+
 /**
  * Issue a test challenge to the specified slot to determine if challenge
  * response is properly configured.
@@ -197,11 +231,11 @@ YubiKey::KeyMap YubiKeyInterfaceUSB::findValidKeys()
 bool YubiKeyInterfaceUSB::testChallenge(YubiKeySlot slot, bool* wouldBlock)
 {
     bool ret = false;
-    auto* yk_key = openKeySerial(slot.first);
+    auto yk_key = openKeySerial(slot.first);
     if (yk_key) {
-        ret = performTestChallenge(yk_key, slot.second, wouldBlock);
+        ret = performTestChallenge(yk_key.get(), slot.second, wouldBlock);
     }
-    closeKey(yk_key);
+
     return ret;
 }
 
@@ -237,7 +271,7 @@ YubiKeyInterfaceUSB::challenge(YubiKeySlot slot, const QByteArray& challenge, Bo
         return YubiKey::ChallengeResult::YCR_ERROR;
     }
 
-    auto* yk_key = openKeySerial(slot.first);
+    auto yk_key = openKeySerial(slot.first);
     if (!yk_key) {
         // Key with specified serial number is not connected
         m_error =
@@ -246,9 +280,8 @@ YubiKeyInterfaceUSB::challenge(YubiKeySlot slot, const QByteArray& challenge, Bo
     }
 
     emit challengeStarted();
-    auto ret = performChallenge(yk_key, slot.second, true, challenge, response);
+    auto ret = performChallenge(yk_key.get(), slot.second, true, challenge, response);
 
-    closeKey(yk_key);
     emit challengeCompleted();
 
     return ret;

--- a/src/keys/drivers/YubiKeyInterfaceUSB.h
+++ b/src/keys/drivers/YubiKeyInterfaceUSB.h
@@ -35,8 +35,7 @@ public:
     static constexpr int YUBICO_USB_VID = YUBICO_VID;
     static constexpr int ONLYKEY_USB_VID = ONLYKEY_VID;
 
-    YubiKey::KeyMap findValidKeys() override;
-    YubiKey::KeyList findKeys() override;
+    YubiKey::KeyMap findValidKeys(int& connectedKeys) override;
 
     YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) override;

--- a/src/keys/drivers/YubiKeyInterfaceUSB.h
+++ b/src/keys/drivers/YubiKeyInterfaceUSB.h
@@ -36,6 +36,7 @@ public:
     static constexpr int ONLYKEY_USB_VID = ONLYKEY_VID;
 
     YubiKey::KeyMap findValidKeys() override;
+    YubiKey::KeyList findKeys() override;
 
     YubiKey::ChallengeResult
     challenge(YubiKeySlot slot, const QByteArray& challenge, Botan::secure_vector<char>& response) override;

--- a/src/keys/drivers/YubiKeyStub.cpp
+++ b/src/keys/drivers/YubiKeyStub.cpp
@@ -45,7 +45,17 @@ void YubiKey::findValidKeysAsync()
 {
 }
 
+bool YubiKey::findConnectedKeys()
+{
+    return false;
+}
+
 YubiKey::KeyMap YubiKey::foundKeys()
+{
+    return {};
+}
+
+YubiKey::KeyList YubiKey::foundConnectedKeys()
 {
     return {};
 }

--- a/src/keys/drivers/YubiKeyStub.cpp
+++ b/src/keys/drivers/YubiKeyStub.cpp
@@ -45,19 +45,14 @@ void YubiKey::findValidKeysAsync()
 {
 }
 
-bool YubiKey::findConnectedKeys()
-{
-    return false;
-}
-
 YubiKey::KeyMap YubiKey::foundKeys()
 {
     return {};
 }
 
-YubiKey::KeyList YubiKey::foundConnectedKeys()
+int YubiKey::connectedKeys()
 {
-    return {};
+    return 0;
 }
 
 QString YubiKey::errorMessage()

--- a/tests/TestYkChallengeResponseKey.cpp
+++ b/tests/TestYkChallengeResponseKey.cpp
@@ -57,17 +57,6 @@ void TestYubiKeyChallengeResponse::testDetectDevices()
     }
 }
 
-void TestYubiKeyChallengeResponse::testDetectConnectedDevices()
-{
-    YubiKey::instance()->findConnectedKeys();
-
-    const auto foundKeys = YubiKey::instance()->foundConnectedKeys();
-
-    for (const auto& serial : foundKeys) {
-        QVERIFY(serial != 0);
-    }
-}
-
 /**
  * Secret key for the YubiKey slot used by the unit test is
  * 1c e3 0f d7 8d 20 dc fa 40 b5 0c 18 77 9a fb 0f 02 28 8d b7

--- a/tests/TestYkChallengeResponseKey.cpp
+++ b/tests/TestYkChallengeResponseKey.cpp
@@ -24,6 +24,7 @@
 #include "keys/ChallengeResponseKey.h"
 
 #include <QCryptographicHash>
+#include <QRegularExpression>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -45,11 +46,25 @@ void TestYubiKeyChallengeResponse::testDetectDevices()
 
     // Look at the information retrieved from the key(s)
     const auto foundKeys = YubiKey::instance()->foundKeys();
+    QRegularExpression exp{"\\w+\\s+\\[\\d+\\]\\s+-\\s+Slot\\s+\\d"};
+
     for (auto i = foundKeys.cbegin(); i != foundKeys.cend(); ++i) {
         const auto& displayName = i.value();
-        QVERIFY(displayName.contains("Challenge-Response - Slot") || displayName.contains("Configured Slot -"));
+        auto match = exp.match(displayName);
+        QVERIFY(match.hasMatch());
         QVERIFY(displayName.contains(QString::number(i.key().first)));
         QVERIFY(displayName.contains(QString::number(i.key().second)));
+    }
+}
+
+void TestYubiKeyChallengeResponse::testDetectConnectedDevices()
+{
+    YubiKey::instance()->findConnectedKeys();
+
+    const auto foundKeys = YubiKey::instance()->foundConnectedKeys();
+
+    for (const auto& serial : foundKeys) {
+        QVERIFY(serial != 0);
     }
 }
 

--- a/tests/TestYkChallengeResponseKey.h
+++ b/tests/TestYkChallengeResponseKey.h
@@ -29,7 +29,6 @@ private slots:
     void initTestCase();
 
     void testDetectDevices();
-    void testDetectConnectedDevices();
     void testKeyChallenge();
 };
 

--- a/tests/TestYkChallengeResponseKey.h
+++ b/tests/TestYkChallengeResponseKey.h
@@ -29,6 +29,7 @@ private slots:
     void initTestCase();
 
     void testDetectDevices();
+    void testDetectConnectedDevices();
     void testKeyChallenge();
 };
 


### PR DESCRIPTION
- Fix the error message when a key is connected, but no slots are configured
- The solution is to check connected devices. If they exist, show the error: "Hardware keys found, but no slots are configured."
- Fix missing SCardDisconnect
- Fix outdated test cases

Fixes issue #11543


## Screenshots
![image](https://github.com/user-attachments/assets/ce3e1f08-db44-4979-88ea-78a14a42bd2a)

![image](https://github.com/user-attachments/assets/aa1354ca-a722-4800-88e6-08ce0a2c23ac)


## Testing strategy
- Check the fix on YubiKeys
- Add a unit test to verify the series numbers of connected devices


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)