### PR TITLE
Implement Secure Input Mode on macOS

### DIFF
--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -38,6 +38,7 @@ PasswordWidget::PasswordWidget(QWidget* parent)
 {
     m_ui->setupUi(this);
     setFocusProxy(m_ui->passwordEdit);
+    m_ui->passwordEdit->installEventFilter(this);
 
     const QIcon errorIcon = icons()->icon("dialog-error");
     m_errorAction = m_ui->passwordEdit->addAction(errorIcon, QLineEdit::TrailingPosition);
@@ -223,14 +224,19 @@ void PasswordWidget::updateRepeatStatus()
     }
 }
 
-bool PasswordWidget::event(QEvent* event)
+bool PasswordWidget::eventFilter(QObject* watched, QEvent* event)
 {
-    if (isVisible()
-        && (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease
-            || event->type() == QEvent::FocusIn)) {
-        checkCapslockState();
+    if (watched == m_ui->passwordEdit) {
+        auto type = event->type();
+        if (isVisible() && (type == QEvent::KeyPress || type == QEvent::KeyRelease || type == QEvent::FocusIn)) {
+            checkCapslockState();
+        }
+        if (type == QEvent::FocusIn || type == QEvent::FocusOut) {
+            osUtils->setUserInputProtection(type == QEvent::FocusIn);
+        }
     }
-    return QWidget::event(event);
+    // Continue with normal operations
+    return false;
 }
 
 void PasswordWidget::checkCapslockState()

--- a/src/gui/PasswordWidget.h
+++ b/src/gui/PasswordWidget.h
@@ -44,6 +44,8 @@ public:
     bool isPasswordVisible() const;
     QString text();
 
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
 signals:
     void textChanged(QString text);
 
@@ -56,9 +58,6 @@ public slots:
     void setReadOnly(bool state);
     void setEchoMode(QLineEdit::EchoMode mode);
     void setClearButtonEnabled(bool enabled);
-
-protected:
-    bool event(QEvent* event) override;
 
 private slots:
     void popupPasswordGenerator();

--- a/src/gui/osutils/OSUtilsBase.h
+++ b/src/gui/osutils/OSUtilsBase.h
@@ -56,6 +56,11 @@ public:
      */
     virtual bool isCapslockEnabled() = 0;
 
+    /**
+     * @param enable Toggle protection on user input (if available).
+     */
+    virtual void setUserInputProtection(bool enable) = 0;
+
     virtual void registerNativeEventFilter() = 0;
 
     virtual bool registerGlobalShortcut(const QString& name,

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -150,6 +150,15 @@ bool MacUtils::isCapslockEnabled()
 #endif
 }
 
+void MacUtils::setUserInputProtection(bool enable)
+{
+    if (enable) {
+        EnableSecureEventInput();
+    } else {
+        DisableSecureEventInput();
+    }
+}
+
 /**
  * Toggle application state between foreground app and UIElement app.
  * Foreground apps have dock icons, UIElement apps do not.

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -40,6 +40,7 @@ public:
     bool isLaunchAtStartupEnabled() const override;
     void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
+    void setUserInputProtection(bool enable) override;
 
     WId activeWindow();
     bool raiseWindow(WId pid);

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -235,6 +235,12 @@ bool NixUtils::isCapslockEnabled()
     return false;
 }
 
+void NixUtils::setUserInputProtection(bool enable)
+{
+    // Linux does not support this feature
+    Q_UNUSED(enable)
+}
+
 void NixUtils::registerNativeEventFilter()
 {
     qApp->installNativeEventFilter(this);

--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -35,6 +35,7 @@ public:
     bool isLaunchAtStartupEnabled() const override;
     void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
+    void setUserInputProtection(bool enable) override;
 
     void registerNativeEventFilter() override;
 

--- a/src/gui/osutils/winutils/WinUtils.cpp
+++ b/src/gui/osutils/winutils/WinUtils.cpp
@@ -136,6 +136,12 @@ bool WinUtils::isCapslockEnabled()
     return GetKeyState(VK_CAPITAL) == 1;
 }
 
+void WinUtils::setUserInputProtection(bool enable)
+{
+    // Windows does not support this feature
+    Q_UNUSED(enable)
+}
+
 bool WinUtils::isHighContrastMode() const
 {
     QSettings settings(R"(HKEY_CURRENT_USER\Control Panel\Accessibility\HighContrast)", QSettings::NativeFormat);

--- a/src/gui/osutils/winutils/WinUtils.h
+++ b/src/gui/osutils/winutils/WinUtils.h
@@ -44,6 +44,7 @@ public:
     bool isLaunchAtStartupEnabled() const override;
     void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
+    void setUserInputProtection(bool enable) override;
     bool isHighContrastMode() const;
 
     void registerNativeEventFilter() override;


### PR DESCRIPTION
* Fixes #4738
* Also fixes flaky handling of caps lock detection events

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
BEFORE / AFTER screen recording using Typinator as the canary:

https://github.com/user-attachments/assets/09012577-7b48-4551-868e-42c60807be5d

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested on macOS 15.1.1 using Typinator as a canary to see if keystrokes are visible to external apps granted the accessibility permission. Also tested non-password fields to demonstrate that secure input mode was properly disabled when focus on a password field is lost.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
