### PR TITLE
Fix crash when pressing home key on empty tags field

### DIFF
--- a/src/gui/tag/TagsEdit.cpp
+++ b/src/gui/tag/TagsEdit.cpp
@@ -337,7 +337,7 @@ struct TagsEdit::Impl
         assert(i < tags.size());
         auto occurrencesOfCurrentText =
             std::count_if(tags.cbegin(), tags.cend(), [this](const auto& tag) { return tag.text == currentText(); });
-        if (currentText().isEmpty() || occurrencesOfCurrentText > 1) {
+        if (tags.size() > 1 && (currentText().isEmpty() || occurrencesOfCurrentText > 1)) {
             tags.erase(std::next(tags.begin(), std::ptrdiff_t(editing_index)));
             if (editing_index <= i) { // Do we shift positions after `i`?
                 --i;


### PR DESCRIPTION
* Fixes #11344 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Pressing Home no longer produces crashes and all other functionality remains in tact.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
