### PR TITLE
Add alternative path finding for PCSC headers/libraries

### DIFF
--- a/cmake/FindPCSC.cmake
+++ b/cmake/FindPCSC.cmake
@@ -21,16 +21,38 @@ endif()
 
 if(NOT PCSC_FOUND)
    # Search for PC/SC headers on Mac and Windows
+
+   # Additional search paths for Windows if not running in Visual Studio environment
+   if (WIN32) 
+      # Resolve the ambiguity of using two names for one architechture
+      if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x64")
+         set(ARCH_DIR "x64")
+      else()
+         set(ARCH_DIR "${CMAKE_SYSTEM_PROCESSOR}")
+      endif()
+
+      # Locate Windows SDK Paths
+      if (CMAKE_WINDOWS_KITS_10_DIR)
+         set(WINSDKROOTC_INCLUDE "${CMAKE_WINDOWS_KITS_10_DIR}/Include/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um")
+         set(WINSDKROOTC_LIB     "${CMAKE_WINDOWS_KITS_10_DIR}/LIB/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um/${ARCH_DIR}")
+      else()
+         set(WINSDKROOTC_INCLUDE "$ENV{ProgramFiles\(x86\)}/Windows Kits/10/Include/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um")
+         set(WINSDKROOTC_LIB     "$ENV{ProgramFiles\(x86\)}/Windows Kits/10/LIB/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um/${ARCH_DIR}")
+      endif()
+   endif()
+
    find_path(PCSC_INCLUDE_DIRS winscard.h
       HINTS
-      ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}
-      /usr/include/PCSC
+         ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}
+         /usr/include/PCSC
+         ${WINSDKROOTC_INCLUDE}
       PATH_SUFFIXES PCSC)
 
    # MAC library is PCSC, Windows library is WinSCard
    find_library(PCSC_LIBRARIES NAMES pcsclite libpcsclite WinSCard PCSC
       HINTS   
-      ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+         ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}
+         ${WINSDKROOTC_LIB})
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
* When running the build outside of a visual studio environment, PCSC libraries may not be discoverable. This change explicitly adds Windows SDK's to the search path.

From #11317 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
