### PR TITLE
Improve attachment handling by using a file watcher after you change …

### DIFF
--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -25,6 +25,7 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QProcessEnvironment>
+#include <QScopeGuard>
 #include <QSet>
 #include <QTemporaryFile>
 #include <QUrl>
@@ -250,6 +251,25 @@ bool EntryAttachments::openAttachment(const QString& key, QString* errorMessage)
         watcher->start(tmpFile.fileName(), 5);
         connect(watcher.data(), &FileWatcher::fileChanged, this, &EntryAttachments::attachmentFileModified);
         m_attachmentFileWatchers.insert(tmpFile.fileName(), watcher);
+    } else if (auto path = m_openedAttachments.value(key); m_attachmentFileWatchers.contains(path)) {
+        auto watcher = m_attachmentFileWatchers.value(path);
+        watcher->stop();
+
+        QFile file(path);
+        auto finally = qScopeGuard([&file, &watcher, &path] {
+            file.close();
+            watcher->start(path, 5);
+        });
+
+        const auto attachmentData = value(key);
+
+        const bool saveOk = file.open(QIODevice::WriteOnly) && file.setPermissions(QFile::ReadOwner | QFile::WriteOwner)
+                            && file.write(attachmentData) == attachmentData.size() && file.flush();
+
+        if (!saveOk) {
+            *errorMessage = QString("%1 - %2").arg(key, file.errorString());
+            return false;
+        }
     }
 
     const bool openOk = QDesktopServices::openUrl(QUrl::fromLocalFile(m_openedAttachments.value(key)));

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -262,7 +262,6 @@ bool EntryAttachments::openAttachment(const QString& key, QString* errorMessage)
         });
 
         const auto attachmentData = value(key);
-
         const bool saveOk = file.open(QIODevice::WriteOnly) && file.setPermissions(QFile::ReadOwner | QFile::WriteOwner)
                             && file.write(attachmentData) == attachmentData.size() && file.flush();
 

--- a/src/gui/entry/NewEntryAttachmentsDialog.cpp
+++ b/src/gui/entry/NewEntryAttachmentsDialog.cpp
@@ -67,7 +67,7 @@ void NewEntryAttachmentsDialog::saveAttachment()
     auto text = m_ui->attachmentTextEdit->toPlainText().toUtf8();
 
     QString error;
-    if (validateFileName(fileName, error)) {
+    if (!validateFileName(fileName, error)) {
         QMessageBox::warning(this, tr("Save attachment"), error);
         return;
     }

--- a/src/gui/entry/NewEntryAttachmentsDialog.cpp
+++ b/src/gui/entry/NewEntryAttachmentsDialog.cpp
@@ -33,9 +33,7 @@ NewEntryAttachmentsDialog::NewEntryAttachmentsDialog(QPointer<EntryAttachments> 
 
     setWindowTitle(tr("New entry attachment"));
 
-    m_ui->dialogButtons->clear();
-    m_ui->dialogButtons->addButton(QDialogButtonBox::Ok);
-    m_ui->dialogButtons->addButton(QDialogButtonBox::Cancel);
+    m_ui->dialogButtons->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
     connect(m_ui->dialogButtons, SIGNAL(accepted()), this, SLOT(saveAttachment()));
     connect(m_ui->dialogButtons, SIGNAL(rejected()), this, SLOT(reject()));

--- a/src/gui/styles/dark/darkstyle.qss
+++ b/src/gui/styles/dark/darkstyle.qss
@@ -1,14 +1,12 @@
 DatabaseWidget:!active,
 DatabaseWidget #groupView:!active, DatabaseWidget #tagView:!active,
-EntryPreviewWidget QLineEdit:!active, EntryPreviewWidget QTextEdit:!active,
-EntryPreviewWidget TagsEdit:!active, QStatusBar:!active {
+EntryPreviewWidget *:!active[blendIn="true"], QStatusBar:!active {
     background-color: #404042;
 }
 
 DatabaseWidget:disabled,
 DatabaseWidget #groupView:disabled, DatabaseWidget #tagView:disabled,
-EntryPreviewWidget QLineEdit:disabled, EntryPreviewWidget QTextEdit:disabled,
-EntryPreviewWidget TagsEdit:disabled, QStatusBar:disabled {
+EntryPreviewWidget *:disabled[blendIn="true"], QStatusBar:disabled {
     background-color: #424242;
 }
 

--- a/src/gui/styles/light/lightstyle.qss
+++ b/src/gui/styles/light/lightstyle.qss
@@ -1,14 +1,12 @@
 DatabaseWidget:!active,
 DatabaseWidget #groupView:!active, DatabaseWidget #tagView:!active,
-EntryPreviewWidget QLineEdit:!active, EntryPreviewWidget QTextEdit:!active,
-EntryPreviewWidget TagsEdit:!active, QStatusBar:!active {
+EntryPreviewWidget *:!active[blendIn="true"], QStatusBar:!active {
     background-color: #FCFCFC;
 }
 
 DatabaseWidget:disabled,
 DatabaseWidget #groupView:disabled, DatabaseWidget #tagView:disabled,
-EntryPreviewWidget QLineEdit:disabled, EntryPreviewWidget QTextEdit:disabled,
-EntryPreviewWidget TagsEdit:disabled, QStatusBar:disabled {
+EntryPreviewWidget *:disabled[blendIn="true"], QStatusBar:disabled {
     background-color: #EDEDED;
 }
 


### PR DESCRIPTION
Improve attachment handling by using a file watcher after you change a file and undo that change in the KeePassXC app

This change avoids a situation where the open file has changed or an entry in the application has changed (possibly to be implemented in the future) and when you open that entry the editor shows you outdated data.


## Screenshots
No UI changes

## Testing strategy
I didn't find a corresponding test, so I checked manually


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
