### PR TITLE
Support tearing off tags menu

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -824,15 +824,15 @@ void MainWindow::updateSetTagsMenu()
     if (dbWidget) {
         // Enumerate tags applied to the selected entries
         QSet<QString> selectedTags;
-        for (auto entry : dbWidget->entryView()->selectedEntries()) {
-            for (auto tag : entry->tagList()) {
+        for (const auto entry : dbWidget->entryView()->selectedEntries()) {
+            for (const auto& tag : entry->tagList()) {
                 selectedTags.insert(tag);
             }
         }
 
         // Add known database tags as actions and set checked if
         // a selected entry has that tag
-        for (auto tag : dbWidget->database()->tagList()) {
+        for (const auto& tag : dbWidget->database()->tagList()) {
             auto action = m_ui->menuTags->addAction(icons()->icon("tag"), tag);
             action->setCheckable(true);
             action->setChecked(selectedTags.contains(tag));
@@ -942,6 +942,14 @@ void MainWindow::updateMenuActionState()
     m_ui->menuEntryCopyAttribute->setEnabled(singleEntryOrEditing);
     m_ui->menuEntryTotp->setEnabled(singleEntrySelected);
     m_ui->menuTags->setEnabled(multiEntrySelected);
+    // Handle tear-off tags menu
+    if (m_ui->menuTags->menuAction()->isVisible()) {
+        if (!databaseUnlocked) {
+            m_ui->menuTags->hideTearOffMenu();
+        } else {
+            updateSetTagsMenu();
+        }
+    }
     m_ui->actionEntryAutoType->setEnabled(singleEntrySelected && dbWidget->currentEntryHasAutoTypeEnabled());
     m_ui->actionEntryAutoType->menu()->setEnabled(singleEntrySelected && dbWidget->currentEntryHasAutoTypeEnabled());
     m_ui->actionEntryAutoTypeSequence->setText(singleEntrySelected

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -817,8 +817,14 @@ void MainWindow::updateCopyAttributesMenu()
 
 void MainWindow::updateSetTagsMenu()
 {
-    // Remove all existing actions
-    m_ui->menuTags->clear();
+    auto actionForTag = [](const QMenu* menu, const QString& tag) -> QAction* {
+        for (const auto action : menu->actions()) {
+            if (action->text() == tag) {
+                return action;
+            }
+        }
+        return nullptr;
+    };
 
     auto dbWidget = m_ui->tabWidget->currentDatabaseWidget();
     if (dbWidget) {
@@ -832,11 +838,24 @@ void MainWindow::updateSetTagsMenu()
 
         // Add known database tags as actions and set checked if
         // a selected entry has that tag
-        for (const auto& tag : dbWidget->database()->tagList()) {
-            auto action = m_ui->menuTags->addAction(icons()->icon("tag"), tag);
-            action->setCheckable(true);
-            action->setChecked(selectedTags.contains(tag));
-            m_setTagsMenuActions->addAction(action);
+        const auto tagList = dbWidget->database()->tagList();
+        for (const auto& tag : tagList) {
+            auto action = actionForTag(m_ui->menuTags, tag);
+            if (action) {
+                action->setChecked(selectedTags.contains(tag));
+            } else {
+                action = m_ui->menuTags->addAction(icons()->icon("tag"), tag);
+                action->setCheckable(true);
+                action->setChecked(selectedTags.contains(tag));
+                m_setTagsMenuActions->addAction(action);
+            }
+        }
+
+        // Remove missing tags
+        for (const auto action : m_ui->menuTags->actions()) {
+            if (!tagList.contains(action->text())) {
+                action->deleteLater();
+            }
         }
     }
 
@@ -943,7 +962,7 @@ void MainWindow::updateMenuActionState()
     m_ui->menuEntryTotp->setEnabled(singleEntrySelected);
     m_ui->menuTags->setEnabled(multiEntrySelected);
     // Handle tear-off tags menu
-    if (m_ui->menuTags->menuAction()->isVisible()) {
+    if (m_ui->menuTags->isTearOffMenuVisible()) {
         if (!databaseUnlocked) {
             m_ui->menuTags->hideTearOffMenu();
         } else {

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -314,6 +314,9 @@
      <addaction name="actionEntrySetupTotp"/>
     </widget>
     <widget class="QMenu" name="menuTags">
+     <property name="tearOffEnabled">
+      <bool>true</bool>
+     </property>
      <property name="title">
       <string>Tags</string>
      </property>

--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -2636,7 +2636,21 @@ void BaseStyle::drawControl(ControlElement element,
         }
         break;
     }
+    case CE_MenuTearoff: {
+        if (option->state & State_Selected) {
+            painter->fillRect(option->rect, option->palette.brush(QPalette::Highlight));
+            painter->setPen(QPen(option->palette.highlightedText().color(), 1, Qt::DashLine));
+        } else {
+            painter->fillRect(option->rect, option->palette.brush(QPalette::Button));
+            painter->setPen(QPen(option->palette.buttonText().color(), 1, Qt::DashLine));
+        }
 
+        painter->drawLine(option->rect.x() + 2,
+                          option->rect.y() + option->rect.height() / 2,
+                          option->rect.x() + option->rect.width() - 4,
+                          option->rect.y() + option->rect.height() / 2);
+        break;
+    }
     case CE_MenuItem: {
         auto menuItem = qstyleoption_cast<const QStyleOptionMenuItem*>(option);
         if (!menuItem)


### PR DESCRIPTION
* Closes #11649 - tags menu can be torn off to set and unset tags without having to dive into the context menu every time.

* Tags menu will hide when database is locked or view is switched away from the main database view (eg, settings)

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
See #11649 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested on windows manually

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)