### PR TITLE
make tag-suggestions case insensitive

### DIFF
--- a/src/gui/tag/TagsEdit.cpp
+++ b/src/gui/tag/TagsEdit.cpp
@@ -408,6 +408,7 @@ struct TagsEdit::Impl
     void setupCompleter()
     {
         completer->setWidget(ifce);
+        completer->setCaseSensitivity(Qt::CaseInsensitive);
         connect(completer.get(),
                 static_cast<void (QCompleter::*)(QString const&)>(&QCompleter::activated),
                 [this](QString const& text) { currentText(text); });


### PR DESCRIPTION
Fixes #11675 


## Screenshots
not applicable

## Testing strategy
- Open entry
- Edit tag
- Enter existing tag but use opposite case from the existing tag

## Type of change
- ✅ New feature (change that adds functionality)
