### PR TITLE
Show access key underline (mnemonics) of menu items on focus

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -5734,10 +5734,6 @@ Are you sure you want to continue with this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6395,7 +6391,7 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clear all identities in ssh-agent</source>
+        <source>&amp;View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6431,6 +6427,10 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Clear all identities in ssh-agent</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -377,7 +377,7 @@
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>View</string>
+     <string>&amp;View</string>
     </property>
     <widget class="QMenu" name="menuTheme">
      <property name="title">

--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -29,6 +29,7 @@
 #include <QFile>
 #include <QHeaderView>
 #include <QListView>
+#include <QMenuBar>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPoint>
@@ -4695,7 +4696,24 @@ int BaseStyle::styleHint(StyleHint hint,
     case SH_WindowFrame_Mask:
         return 0;
     case SH_UnderlineShortcut: {
-        return false;
+#if defined(Q_OS_WIN) or defined(Q_OS_LINUX)
+        // Only show underline shortcuts if the user focused with ALT (Win/Linux only)
+        auto menu = qobject_cast<const QMenu*>(widget);
+        if (menu) {
+            auto p = menu->parentWidget();
+            while (p) {
+                auto mb = qobject_cast<QMenuBar*>(p);
+                if (mb && mb->hasFocus()) {
+                    return 1;
+                }
+                p = p->parentWidget();
+            }
+        }
+        auto mb = qobject_cast<const QMenuBar*>(widget);
+        return (mb && mb->hasFocus()) ? 1 : 0;
+#else
+        return 0;
+#endif
     }
     case SH_Widget_Animate:
         return 1;


### PR DESCRIPTION
* Fixes #7325

Qt 5.x defaults to always show mnemonic underlines in menus. Qt 6.x fixes this, but we can't port the fix since it relies on private theme namespaces. Anyway, to get around this, simply check if the widget is a menubar and focused. If so, we draw the underlines. Only applies when the user actually presses ALT so this is desired behavior.

NOTE: Underlines in menus will disappear once you focus on the menu, still working on this... I don't know if there will be a fully acceptable solution without tapping into MainWindow directly and setting up some state bools.

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
![image](https://github.com/user-attachments/assets/2ddc30b1-e16c-4dad-98be-439511ffe71d)

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested on Windows and Linux. This fix doesn't apply to macOS since it doesn't show the mnemonic underlines.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)