### PR TITLE
Fix open remote database

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -4748,6 +4748,14 @@ The command has to exit. In case of `sftp` as last commend `exit` has to be sent
         <source>Remote Database (.kdbx)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Timeout:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KMessageWidget</name>

--- a/src/gui/remote/RemoteProcess.cpp
+++ b/src/gui/remote/RemoteProcess.cpp
@@ -17,7 +17,6 @@
 
 #include "RemoteProcess.h"
 
-#include <QTemporaryDir>
 #include <QUuid>
 
 RemoteProcess::RemoteProcess(QObject* parent)

--- a/src/gui/wizard/ImportWizardPageReview.cpp
+++ b/src/gui/wizard/ImportWizardPageReview.cpp
@@ -92,6 +92,7 @@ void ImportWizardPageReview::initializePage()
     case ImportWizard::IMPORT_REMOTE:
         m_db = importRemote(field("DownloadCommand").toString(),
                             field("DownloadInput").toString(),
+                            field("DownloadTimeoutSec").toInt(),
                             field("ImportPassword").toString(),
                             field("ImportKeyFile").toString());
         break;
@@ -239,17 +240,20 @@ bool ImportWizardPageReview::isCsvImport() const
 
 QSharedPointer<Database> ImportWizardPageReview::importRemote(const QString& downloadCommand,
                                                               const QString& downloadInput,
+                                                              int downloadTimeoutSec,
                                                               const QString& password,
                                                               const QString& keyfile)
 {
     auto* params = new RemoteParams();
     params->downloadCommand = downloadCommand;
     params->downloadInput = downloadInput;
+    params->downloadTimeoutMsec = downloadTimeoutSec * 1000;
 
     auto result = m_remoteHandler->download(params);
 
     if (!result.success) {
         m_ui->messageWidget->showMessage(result.errorMessage, KMessageWidget::Error, -1);
+        return {};
     }
 
     auto key = QSharedPointer<CompositeKey>::create();

--- a/src/gui/wizard/ImportWizardPageReview.h
+++ b/src/gui/wizard/ImportWizardPageReview.h
@@ -58,6 +58,7 @@ private:
     QSharedPointer<Database> importProtonPass(const QString& filename);
     QSharedPointer<Database> importRemote(const QString& downloadCommand,
                                           const QString& downloadInput,
+                                          int downloadTimeSec,
                                           const QString& password,
                                           const QString& keyfile);
 

--- a/src/gui/wizard/ImportWizardPageSelect.cpp
+++ b/src/gui/wizard/ImportWizardPageSelect.cpp
@@ -76,6 +76,7 @@ ImportWizardPageSelect::ImportWizardPageSelect(QWidget* parent)
     registerField("ImportKeyFile", m_ui->keyFileEdit);
     registerField("DownloadCommand", m_ui->downloadCommand);
     registerField("DownloadInput", m_ui->downloadCommandInput, "plainText", "textChanged");
+    registerField("DownloadTimeoutSec", m_ui->downloadTimeoutSec);
 }
 
 ImportWizardPageSelect::~ImportWizardPageSelect()
@@ -274,6 +275,8 @@ void ImportWizardPageSelect::setDownloadCommand(bool downloadCommandEnabled)
     m_ui->downloadCommandInputLabel->setVisible(downloadCommandEnabled);
     m_ui->downloadCommandInput->setVisible(downloadCommandEnabled);
     m_ui->downloadCommandHelpButton->setVisible(downloadCommandEnabled);
+    m_ui->downloadTimeoutLabel->setVisible(downloadCommandEnabled);
+    m_ui->downloadTimeoutSec->setVisible(downloadCommandEnabled);
 
     m_ui->temporaryDatabaseRadio->setVisible(downloadCommandEnabled);
 

--- a/src/gui/wizard/ImportWizardPageSelect.ui
+++ b/src/gui/wizard/ImportWizardPageSelect.ui
@@ -94,14 +94,14 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetMinimumSize</enum>
       </property>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="importFileLabel">
         <property name="text">
          <string>Import File:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <layout class="QHBoxLayout" name="importFileLayout">
         <item>
          <widget class="QLineEdit" name="importFileEdit"/>
@@ -115,24 +115,24 @@
         </item>
        </layout>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="passwordLabel">
         <property name="text">
          <string>Password:</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="PasswordWidget" name="passwordEdit" native="true"/>
       </item>
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="keyFileLabel">
         <property name="text">
          <string>Key File:</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <layout class="QHBoxLayout" name="keyFileLayout">
         <item>
          <widget class="QLineEdit" name="keyFileEdit"/>
@@ -146,7 +146,7 @@
         </item>
        </layout>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <spacer name="verticalSpacer_3">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -162,7 +162,7 @@
         </property>
        </spacer>
       </item>
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="importIntoLabel">
         <property name="text">
          <string>Import Into:</string>
@@ -172,7 +172,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="8" column="1">
        <widget class="QGroupBox" name="importIntoGroupBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -294,6 +294,29 @@ exit
 {TEMP_DATABASE} is used as placeholder to store the database in a temporary location
 The command has to exit. In case of `sftp` as last commend `exit` has to be sent
          </string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="downloadTimeoutLabel">
+        <property name="text">
+         <string>Timeout:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="downloadTimeoutSec">
+        <property name="suffix">
+         <string> seconds</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>300</number>
+        </property>
+        <property name="value">
+         <number>10</number>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
- Display correct error message.
    Wrong error message was displayed as no early return statement was used.
- Use configurable timeout for opening remote database as it is done for syncing

See https://github.com/keepassxreboot/keepassxc/pull/10896#issuecomment-2598243038 for reference