### PR TITLE
Enhance image attachment handling by caching loaded images and improv…

### DIFF
--- a/src/gui/entry/PreviewEntryAttachmentsDialog.h
+++ b/src/gui/entry/PreviewEntryAttachmentsDialog.h
@@ -50,10 +50,14 @@ private:
     void update();
     void updateTextAttachment(const QByteArray& data);
     void updateImageAttachment(const QByteArray& data);
+    void updateImageAttachment(const QImage& data);
+
+    QSize calculateImageSize();
 
     QScopedPointer<Ui::EntryAttachmentsDialog> m_ui;
 
     QString m_name;
     QByteArray m_data;
+    QImage m_imageCache;
     Tools::MimeType m_type{Tools::MimeType::Unknown};
 };


### PR DESCRIPTION
Enhance image attachment handling by caching loaded images and improving scaling logic.

Every image is cached to avoid the recreation of an image, improving performance and efficiency.

## Screenshots

Before the optimization(4Mb)
![before1](https://github.com/user-attachments/assets/1a20d4d9-4059-4b2b-8d4a-93d11e2a5d84)

After
![after1](https://github.com/user-attachments/assets/5bb868e1-7e69-48d1-9316-8060d17668dc)

## Testing strategy
Manual Testing: Verified the changes by manually testing various image attachment scenarios.

## Type of change
- ✅ Refactor (significant modification to existing code)
