### PR TITLE
Refactor YubiKey key to avoid deadlock

### DIFF
--- a/src/keys/drivers/YubiKey.h
+++ b/src/keys/drivers/YubiKey.h
@@ -84,6 +84,8 @@ signals:
 private:
     explicit YubiKey();
 
+    void findValidKeys(const QMutexLocker& locker);
+
     static YubiKey* m_instance;
 
     QTimer m_interactionTimer;


### PR DESCRIPTION
The application freezes if the Quick Unlock feature is activated, your database uses a composed password (password + YubiKey), and you try to Unlock Database while the YubiKey is unplugged.

This issue is related to a deadlock, which is fixed in this PR.

- Add mutex to get m_connectedKeys
- Fix deadlock when the app uses Quick Unlock and the YubiKey is unplugged

steps to reproduce:
- Create a database(password + yubikey)
- Activate the Quick Unlock feature
- Lock the database
- Unplug yubikey
- Try to unlock the database

Result: The application freezes.
Expected: The application is working

## Screenshots
![Screenshot_20250129_025354-1](https://github.com/user-attachments/assets/135c5265-dda6-46fe-bbd3-59d8f3b4579b)


## Testing strategy
Manual Testing

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
