### PR TITLE
Show database public icon on tab when visible

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1517,6 +1517,10 @@ Backup database located at %2</source>
         <source>Database file read error.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>No file path was provided.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseOpenDialog</name>

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -107,10 +107,6 @@ QUuid Database::uuid() const
  */
 bool Database::open(QSharedPointer<const CompositeKey> key, QString* error)
 {
-    Q_ASSERT(!m_data.filePath.isEmpty());
-    if (m_data.filePath.isEmpty()) {
-        return false;
-    }
     return open(m_data.filePath, std::move(key), error);
 }
 
@@ -128,6 +124,13 @@ bool Database::open(QSharedPointer<const CompositeKey> key, QString* error)
  */
 bool Database::open(const QString& filePath, QSharedPointer<const CompositeKey> key, QString* error)
 {
+    if (filePath.isEmpty()) {
+        if (error) {
+            *error = tr("No file path was provided.");
+        }
+        return false;
+    }
+
     QFile dbFile(filePath);
     if (!dbFile.exists()) {
         if (error) {

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -25,6 +25,7 @@
 #include "core/Tools.h"
 #include "format/CsvExporter.h"
 #include "gui/Clipboard.h"
+#include "gui/DatabaseIcons.h"
 #include "gui/DatabaseOpenDialog.h"
 #include "gui/DatabaseWidget.h"
 #include "gui/DatabaseWidgetStateSync.h"
@@ -675,6 +676,12 @@ void DatabaseTabWidget::updateTabName(int index)
     index = indexOf(dbWidget);
     setTabText(index, tabName(index));
     setTabToolTip(index, dbWidget->displayFilePath());
+    auto iconIndex = dbWidget->database()->publicIcon();
+    if (iconIndex >= 0 && iconIndex < databaseIcons()->count()) {
+        setTabIcon(index, databaseIcons()->icon(iconIndex));
+    } else {
+        setTabIcon(index, {});
+    }
     emit tabNameChanged();
 }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -96,6 +96,11 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
 {
     Q_ASSERT(m_db);
 
+    // Read public headers if the database hasn't been opened yet
+    if (!m_db->isInitialized()) {
+        m_db->open(nullptr);
+    }
+
     m_messageWidget->setHidden(true);
 
     auto mainLayout = new QVBoxLayout();
@@ -2095,6 +2100,7 @@ bool DatabaseWidget::lock()
     switchToOpenDatabase(m_db->filePath());
 
     auto newDb = QSharedPointer<Database>::create(m_db->filePath());
+    newDb->open(nullptr);
     replaceDatabase(newDb);
 
     m_attemptingLock = false;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
Adds the public icon (if set) to the database tab when it is visible.

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
Visible when locked
![image](https://github.com/user-attachments/assets/c9f835b7-440d-4e8d-92af-ccaa82e8049d)

and unlocked
![image](https://github.com/user-attachments/assets/e27a6ad7-b1ed-44bc-a51d-1937285121e8)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)