### PR TITLE
Fix selected category icon color in Setting panel

### DIFF
--- a/src/gui/CategoryListWidget.cpp
+++ b/src/gui/CategoryListWidget.cpp
@@ -232,7 +232,7 @@ void CategoryListWidgetDelegate::paint(QPainter* painter,
     auto mode = QIcon::Normal;
     if ((opt.state & QStyle::State_Enabled) == 0) {
         mode = QIcon::Disabled;
-    } else if (opt.state & QStyle::State_HasFocus) {
+    } else if (opt.state & QStyle::State_Selected) {
         mode = QIcon::Selected;
     } else if (opt.state & QStyle::State_Active) {
         mode = QIcon::Active;

--- a/src/gui/CategoryListWidget.cpp
+++ b/src/gui/CategoryListWidget.cpp
@@ -232,9 +232,9 @@ void CategoryListWidgetDelegate::paint(QPainter* painter,
     auto mode = QIcon::Normal;
     if ((opt.state & QStyle::State_Enabled) == 0) {
         mode = QIcon::Disabled;
-    } else if (opt.state & QStyle::State_Selected) {
+    } else if (opt.state & QStyle::State_HasFocus) {
         mode = QIcon::Selected;
-    } else if (opt.state & QStyle::State_Active) {
+    } else if (opt.state & QStyle::State_Active || opt.state & QStyle::State_Selected) {
         mode = QIcon::Active;
     }
     painter->drawPixmap(left, opt.rect.top() + paddingTop, icon.pixmap(iconSize, mode));


### PR DESCRIPTION
Very trivial fix. 

The selected category icon in the Setting panel appears dark instead of light (as it should) unless it is focused. The icon only becomes correctly light when clicked, but it should remain light regardless of focus.

The issue appears to be a typo in the `CategoryListWidgetDelegate` code. This fix corrects the color logic to ensure the selected category icon is always displayed properly.

## Screenshots

![image](https://github.com/user-attachments/assets/40ba2db9-c8ee-4e36-9e93-554c81ea179c)


## Testing strategy

Open Settings panel and check that selected icon always has correct color.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
