### PR TITLE
Create Support Auto-Type on Wayland

### DIFF
--- a/Support Auto-Type on Wayland
+++ b/Support Auto-Type on Wayland
@@ -1,0 +1,2 @@
+Support Auto-Type on Wayland
+


### PR DESCRIPTION
This document articulates the solutions put forth to tackle the GitHub issue about absence of Auto-Type feature in KeePassXC on Wayland. The objective is to have Auto-Type work on Wayland the same way it does on X. 

Proposed Solutions:

Study Wayland Protocols: 

Study Wayland protocols and see how they differ from X11 in the context of input types and windowing systems. This will help understand if there are any deficiencies or needs that must be formulated to have Auto-Type functionality integrated. 

Implement wlroots or Other Proprietary Libraries: 

Use libraries like wlroots that serve as compositing engines for Wayland. These libraries also aid in the handling of input events and may ease the implementation of Auto-Type parts. 

Add Input Method Support: 

Build support for input types that work with the compositor of Wayland. This includes creating a new input method module or modifying existing ones to ensure compatibility between KeePassXC and Wayland. 

Change the Existing Code: 

Investigate and reboot the code dealing with the Auto-Type feature first under X11 and then under Wayland in the environment. Identify code sections that utilize X11 and guarantee that the code sections will function with no errors in the Wayland setup. 

Testing In Different Environments: 

Design other test cases on other distributions of Linux based on Wayland, as described in the issue report and other Debian SID amd64.

Make sure that every possible scenario is considered, especially

