### PR TITLE
Fix various quirks with CSV import widget and parser

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -8683,18 +8683,6 @@ Kernel: %3 %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>malformed string</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>missing closing quote</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1: (row, col) %2,%3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>AES 256-bit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9230,6 +9218,18 @@ This option is deprecated, use --set-key-file instead.</source>
     </message>
     <message>
         <source>start minimized to the system tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>malformed string, possible unescaped delimiter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>missing closing delimiter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1, row: %2, column: %3</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1445,6 +1445,10 @@ Do you want to overwrite the passkey in %1 - %2?</source>
 Are you sure you want to import?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CsvParserModel</name>
@@ -9230,6 +9234,10 @@ This option is deprecated, use --set-key-file instead.</source>
     </message>
     <message>
         <source>%1, row: %2, column: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/format/CsvParser.h
+++ b/src/format/CsvParser.h
@@ -22,7 +22,7 @@
 #include <QBuffer>
 #include <QTextStream>
 
-class QFile;
+class QIODevice;
 
 typedef QStringList CsvRow;
 typedef QList<CsvRow> CsvTable;
@@ -34,7 +34,7 @@ public:
     CsvParser();
     ~CsvParser();
     // read data from device and parse it
-    bool parse(QFile* device);
+    bool parse(QIODevice* device);
     bool isFileLoaded();
     // reparse the same buffer (device is not opened again)
     bool reparse();
@@ -85,7 +85,7 @@ private:
     void parseQuoted(QString& s);
     void parseEscaped(QString& s);
     void parseEscapedText(QString& s);
-    bool readFile(QFile* device);
+    bool readFile(QIODevice* device);
     void reset();
     void clear();
     bool skipEndline();

--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -75,13 +75,14 @@ CsvImportWidget::CsvImportWidget(QWidget* parent)
     m_ui->tableViewFields->setFocusPolicy(Qt::NoFocus);
 
     m_columnHeader << QObject::tr("Group") << QObject::tr("Title") << QObject::tr("Username") << QObject::tr("Password")
-                   << QObject::tr("URL") << QObject::tr("Notes") << QObject::tr("TOTP") << QObject::tr("Icon")
-                   << QObject::tr("Last Modified") << QObject::tr("Created");
+                   << QObject::tr("URL") << QObject::tr("Tags") << QObject::tr("Notes") << QObject::tr("TOTP")
+                   << QObject::tr("Icon") << QObject::tr("Last Modified") << QObject::tr("Created");
 
     m_fieldSeparatorList << "," << ";" << "-" << ":" << "." << "\t";
 
     m_combos << m_ui->groupCombo << m_ui->titleCombo << m_ui->usernameCombo << m_ui->passwordCombo << m_ui->urlCombo
-             << m_ui->notesCombo << m_ui->totpCombo << m_ui->iconCombo << m_ui->lastModifiedCombo << m_ui->createdCombo;
+             << m_ui->tagsCombo << m_ui->notesCombo << m_ui->totpCombo << m_ui->iconCombo << m_ui->lastModifiedCombo
+             << m_ui->createdCombo;
 
     for (auto combo : m_combos) {
         combo->setModel(m_comboModel);
@@ -254,10 +255,11 @@ QSharedPointer<Database> CsvImportWidget::buildDatabase()
         entry->setUsername(m_parserModel->data(m_parserModel->index(r, 2)).toString());
         entry->setPassword(m_parserModel->data(m_parserModel->index(r, 3)).toString());
         entry->setUrl(m_parserModel->data(m_parserModel->index(r, 4)).toString());
-        entry->setNotes(m_parserModel->data(m_parserModel->index(r, 5)).toString());
+        entry->setTags(m_parserModel->data(m_parserModel->index(r, 5)).toString());
+        entry->setNotes(m_parserModel->data(m_parserModel->index(r, 6)).toString());
 
         // TOTP
-        auto otpString = m_parserModel->data(m_parserModel->index(r, 6));
+        auto otpString = m_parserModel->data(m_parserModel->index(r, 7));
         if (otpString.isValid() && !otpString.toString().isEmpty()) {
             auto totp = Totp::parseSettings(otpString.toString());
             if (!totp || totp->key.isEmpty()) {
@@ -269,14 +271,14 @@ QSharedPointer<Database> CsvImportWidget::buildDatabase()
 
         // Icon
         bool ok;
-        int icon = m_parserModel->data(m_parserModel->index(r, 7)).toInt(&ok);
+        int icon = m_parserModel->data(m_parserModel->index(r, 8)).toInt(&ok);
         if (ok) {
             entry->setIcon(icon);
         }
 
         // Modified Time
         TimeInfo timeInfo;
-        if (m_parserModel->data(m_parserModel->index(r, 8)).isValid()) {
+        if (m_parserModel->data(m_parserModel->index(r, 9)).isValid()) {
             auto datetime = m_parserModel->data(m_parserModel->index(r, 8)).toString();
             if (datetime.contains(QRegularExpression("^\\d+$"))) {
                 auto t = datetime.toLongLong();
@@ -295,7 +297,7 @@ QSharedPointer<Database> CsvImportWidget::buildDatabase()
             }
         }
         // Creation Time
-        if (m_parserModel->data(m_parserModel->index(r, 9)).isValid()) {
+        if (m_parserModel->data(m_parserModel->index(r, 10)).isValid()) {
             auto datetime = m_parserModel->data(m_parserModel->index(r, 9)).toString();
             if (datetime.contains(QRegularExpression("^\\d+$"))) {
                 auto t = datetime.toLongLong();

--- a/src/gui/csvImport/CsvImportWidget.ui
+++ b/src/gui/csvImport/CsvImportWidget.ui
@@ -79,7 +79,17 @@
          </widget>
         </item>
         <item row="0" column="4">
-         <widget class="QComboBox" name="notesCombo"/>
+         <widget class="QComboBox" name="notesCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="0" column="3">
          <widget class="QLabel" name="notesLabel">
@@ -120,16 +130,56 @@
          </widget>
         </item>
         <item row="4" column="1">
-         <widget class="QComboBox" name="urlCombo"/>
+         <widget class="QComboBox" name="urlCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="1" column="4">
-         <widget class="QComboBox" name="totpCombo"/>
+         <widget class="QComboBox" name="totpCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="4" column="4">
-         <widget class="QComboBox" name="createdCombo"/>
+         <widget class="QComboBox" name="createdCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QComboBox" name="titleCombo"/>
+         <widget class="QComboBox" name="titleCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="5" column="0" colspan="5">
          <widget class="QCheckBox" name="checkBoxFieldNames">
@@ -148,10 +198,30 @@
          </widget>
         </item>
         <item row="2" column="4">
-         <widget class="QComboBox" name="iconCombo"/>
+         <widget class="QComboBox" name="iconCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QComboBox" name="usernameCombo"/>
+         <widget class="QComboBox" name="usernameCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="3" column="0">
          <widget class="QLabel" name="passwordLabel">
@@ -192,7 +262,17 @@
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QComboBox" name="passwordCombo"/>
+         <widget class="QComboBox" name="passwordCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="usernameLabel">
@@ -233,7 +313,17 @@
          </widget>
         </item>
         <item row="3" column="4">
-         <widget class="QComboBox" name="lastModifiedCombo"/>
+         <widget class="QComboBox" name="lastModifiedCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="4" column="3">
          <widget class="QLabel" name="createdLabel">
@@ -255,7 +345,17 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QComboBox" name="groupCombo"/>
+         <widget class="QComboBox" name="groupCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
         <item row="3" column="3">
          <widget class="QLabel" name="lastModifiedLabel">

--- a/src/gui/csvImport/CsvImportWidget.ui
+++ b/src/gui/csvImport/CsvImportWidget.ui
@@ -40,165 +40,8 @@
         <string>Column Association</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="2" column="3">
-         <widget class="QLabel" name="iconLabel">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Icon</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="indent">
-           <number>2</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QLabel" name="totpLabel">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>TOTP</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="indent">
-           <number>2</number>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="4">
-         <widget class="QComboBox" name="notesCombo">
-          <property name="maximumSize">
-           <size>
-            <width>200</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="3">
-         <widget class="QLabel" name="notesLabel">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Notes</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="indent">
-           <number>2</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="titleLabel">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Title</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="indent">
-           <number>2</number>
-          </property>
-         </widget>
-        </item>
         <item row="4" column="1">
          <widget class="QComboBox" name="urlCombo">
-          <property name="maximumSize">
-           <size>
-            <width>200</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="4">
-         <widget class="QComboBox" name="totpCombo">
-          <property name="maximumSize">
-           <size>
-            <width>200</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="4">
-         <widget class="QComboBox" name="createdCombo">
-          <property name="maximumSize">
-           <size>
-            <width>200</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QComboBox" name="titleCombo">
-          <property name="maximumSize">
-           <size>
-            <width>200</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0" colspan="5">
-         <widget class="QCheckBox" name="checkBoxFieldNames">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>First line has field names</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="4">
-         <widget class="QComboBox" name="iconCombo">
           <property name="maximumSize">
            <size>
             <width>200</width>
@@ -223,25 +66,6 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="passwordLabel">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Password</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="indent">
-           <number>2</number>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="groupLabel">
           <property name="font">
@@ -261,16 +85,22 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="passwordCombo">
-          <property name="maximumSize">
-           <size>
-            <width>200</width>
-            <height>16777215</height>
-           </size>
+        <item row="0" column="3">
+         <widget class="QLabel" name="notesLabel">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
           </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
+          <property name="text">
+           <string>Notes</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="indent">
+           <number>2</number>
           </property>
          </widget>
         </item>
@@ -293,25 +123,6 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="urlLabel">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>URL</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="indent">
-           <number>2</number>
-          </property>
-         </widget>
-        </item>
         <item row="3" column="4">
          <widget class="QComboBox" name="lastModifiedCombo">
           <property name="maximumSize">
@@ -325,27 +136,21 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="3">
-         <widget class="QLabel" name="createdLabel">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
+        <item row="2" column="4">
+         <widget class="QComboBox" name="iconCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
           </property>
-          <property name="text">
-           <string>Created</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="indent">
-           <number>2</number>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="groupCombo">
+        <item row="1" column="4">
+         <widget class="QComboBox" name="totpCombo">
           <property name="maximumSize">
            <size>
             <width>200</width>
@@ -376,6 +181,51 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="titleCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="4">
+         <widget class="QComboBox" name="notesCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="passwordLabel">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Password</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="indent">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="2">
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
@@ -391,6 +241,169 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item row="4" column="3">
+         <widget class="QLabel" name="createdLabel">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Created</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="indent">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="4">
+         <widget class="QComboBox" name="createdCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="urlLabel">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>URL</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="indent">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QLabel" name="totpLabel">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>TOTP</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="indent">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QComboBox" name="passwordCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QLabel" name="iconLabel">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Icon</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="indent">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="titleLabel">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Title</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="indent">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="groupCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="tagsLabel">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Tags</string>
+          </property>
+          <property name="indent">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QComboBox" name="tagsCombo">
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -681,6 +694,22 @@
           </property>
           <property name="text">
            <string>Consider '\' an escape character</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0" colspan="2">
+         <widget class="QCheckBox" name="checkBoxFieldNames">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>First line has field names</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/src/gui/wizard/ImportWizardPageReview.cpp
+++ b/src/gui/wizard/ImportWizardPageReview.cpp
@@ -122,7 +122,11 @@ void ImportWizardPageReview::setupCsvImport(const QString& filename)
 
     m_csvWidget = new CsvImportWidget();
     connect(m_csvWidget, &CsvImportWidget::message, m_ui->messageWidget, [this](QString message) {
-        m_ui->messageWidget->showMessage(message, KMessageWidget::Error, -1);
+        if (message.isEmpty()) {
+            m_ui->messageWidget->hideMessage();
+        } else {
+            m_ui->messageWidget->showMessage(message, MessageWidget::Error, -1);
+        }
     });
 
     m_csvWidget->load(filename);

--- a/tests/TestCsvParser.h
+++ b/tests/TestCsvParser.h
@@ -37,7 +37,6 @@ private slots:
 
     void testUnicode();
     void testLF();
-    void testEmptyReparsing();
     void testSimple();
     void testEmptyQuoted();
     void testEmptyNewline();
@@ -58,6 +57,8 @@ private slots:
     void testColumns();
 
 private:
+    void writeToFile(const QString& contents);
+
     QScopedPointer<QTemporaryFile> file;
     QScopedPointer<CsvParser> parser;
     CsvTable t;


### PR DESCRIPTION
* Fixes #11502 - correct improper handling of text qualifiers
* Closes #7956 - support importing tags from csv
* Improve layout of csv import widget
* Hide error messages when trying to import again

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested extensively with various CSV files

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
