### PR TITLE
Fix Keeshare Entries with Reference Attributes not updating

### DIFF
--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -57,9 +57,7 @@ namespace
             const auto* sourceReference = sourceDb->rootGroup()->findEntryByUuid(targetEntry->uuid());
             const auto resolvedValue = sourceReference->resolveMultiplePlaceholders(standardValue);
             targetEntry->beginUpdate();
-            targetEntry->setUpdateTimeinfo(false);
             targetEntry->attributes()->set(attribute, resolvedValue, targetEntry->attributes()->isProtected(attribute));
-            targetEntry->setUpdateTimeinfo(true);
             targetEntry->endUpdate();
         }
     }

--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -56,9 +56,11 @@ namespace
             // but those cases with high probability constructed examples and very rare in real usage
             const auto* sourceReference = sourceDb->rootGroup()->findEntryByUuid(targetEntry->uuid());
             const auto resolvedValue = sourceReference->resolveMultiplePlaceholders(standardValue);
+            targetEntry->beginUpdate();
             targetEntry->setUpdateTimeinfo(false);
             targetEntry->attributes()->set(attribute, resolvedValue, targetEntry->attributes()->isProtected(attribute));
             targetEntry->setUpdateTimeinfo(true);
+            targetEntry->endUpdate();
         }
     }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
 A Entry that gets shared containing a reference Attribute would not write a history entry upon resolving said Attribute resulting in the import into the target database not beeing triggered despite the changes beeing written to the keeshare db.
Fixes #10356 
Fixes #7282
I will put this as a nonbreaking change since this should not influence any keeshares made without a reference Attribute in an entry.

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
Original Entry
![image](https://github.com/user-attachments/assets/14ee1bea-ad94-4d81-a766-c9ffc159d17a)
Target Db Entry
![image](https://github.com/user-attachments/assets/164b1c56-4a6a-4656-9f90-36da99d3646b)


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Test Performed on both windows and linux
1. Created 2 DB 1 for exporting a keeshare and 1 for importing a keeshare
2. Created 1 entry at the root of the first db and clone it with references and put the clone into its own folder that then gets exported as a keeshare db.
3. import said keeshare into the second db
4. change the Password attribute of the first entry created in the root folder of Database 1
5. check in Database 2 if the changes get reflected

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
