### PR TITLE
Return on first !disabled item in BrowserAccessControlDialog::areAllDisabled()

### DIFF
--- a/src/browser/BrowserAccessControlDialog.cpp
+++ b/src/browser/BrowserAccessControlDialog.cpp
@@ -150,14 +150,13 @@ void BrowserAccessControlDialog::selectionChanged()
 
 bool BrowserAccessControlDialog::areAllDisabled() const
 {
-    auto areAllDisabled = true;
     for (const auto& item : getAllItems()) {
         if (item->flags() != Qt::NoItemFlags) {
-            areAllDisabled = false;
+            return false;
         }
     }
 
-    return areAllDisabled;
+    return true;
 }
 
 QList<QTableWidgetItem*> BrowserAccessControlDialog::getAllItems() const


### PR DESCRIPTION
Iterate only over the elements needed.
No extra variable required.

## Screenshots
None.

## Testing strategy
I don't think it applies here. (Tested in my mind)

## Type of change
Minor code optimization.
