### PR TITLE
Write to buffer before writing directly to database file

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -434,16 +434,23 @@ bool Database::performSave(const QString& filePath, SaveAction action, const QSt
         break;
     }
     case DirectWrite: {
+        QBuffer dbBuffer;
+        dbBuffer.open(QIODevice::WriteOnly);
+        HashingStream hashingStream(&dbBuffer, QCryptographicHash::Md5, kFileBlockToHashSizeBytes);
+        if (!hashingStream.open(QIODevice::WriteOnly)) {
+            if (error) {
+                *error = hashingStream.errorString();
+            }
+            return false;
+        }
+        if (!writeDatabase(&hashingStream, error)) {
+            return false;
+        }
+
         // Open the original database file for direct-write
         QFile dbFile(filePath);
         if (dbFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-            HashingStream hashingStream(&dbFile, QCryptographicHash::Md5, kFileBlockToHashSizeBytes);
-            if (!hashingStream.open(QIODevice::WriteOnly)) {
-                return false;
-            }
-            if (!writeDatabase(&hashingStream, error)) {
-                return false;
-            }
+            dbFile.write(dbBuffer.data());
             dbFile.close();
             // store the new hash
             m_fileBlockHash = hashingStream.hashingResult();


### PR DESCRIPTION
* Fixes #11819

When direct write save option is enabled and a hardware key is used with a press required, it is possible that the database file will be truncated to 0 bytes. This is avoided by writing the database to a memory buffer first allowing for key transform to occur, then dumping the buffer into the database file.

This change also improves the overall safety of the direct write save option as there is far less chance for an error to occur while writing to the database file.

Thanks to @ChrisLnrn for reporting this issue!

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested using Yubikey with slot configured for press required.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
