### PR TITLE
Maintain selected sort option when toggling filters

### DIFF
--- a/src/gui/reports/ReportsWidgetHealthcheck.cpp
+++ b/src/gui/reports/ReportsWidgetHealthcheck.cpp
@@ -238,6 +238,8 @@ void ReportsWidgetHealthcheck::loadSettings(QSharedPointer<Database> db)
     auto row = QList<QStandardItem*>();
     row << new QStandardItem(tr("Please wait, health data is being calculated…"));
     m_referencesModel->appendRow(row);
+    // Default sort by first column (health score)
+    m_ui->healthcheckTableView->sortByColumn(0, Qt::AscendingOrder);
 }
 
 void ReportsWidgetHealthcheck::showEvent(QShowEvent* event)
@@ -253,6 +255,11 @@ void ReportsWidgetHealthcheck::showEvent(QShowEvent* event)
 
 void ReportsWidgetHealthcheck::calculateHealth()
 {
+    // Save current sort order before clearing the model so we can restore it later
+    int sortColumn = m_ui->healthcheckTableView->horizontalHeader()->sortIndicatorSection();
+    Qt::SortOrder sortOrder = m_ui->healthcheckTableView->horizontalHeader()->sortIndicatorOrder();
+
+    // Safe to clear
     m_referencesModel->clear();
 
     // Perform the health check
@@ -277,8 +284,10 @@ void ReportsWidgetHealthcheck::calculateHealth()
     } else {
         m_referencesModel->setHorizontalHeaderLabels(QStringList() << tr("") << tr("Title") << tr("Path") << tr("Score")
                                                                    << tr("Reason"));
-        m_ui->healthcheckTableView->sortByColumn(0, Qt::AscendingOrder);
     }
+
+    // Restore sorting options that was stored before the model was cleared
+    m_ui->healthcheckTableView->sortByColumn(sortColumn, sortOrder);
 
     m_ui->healthcheckTableView->resizeColumnsToContents();
     m_ui->healthcheckTableView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);


### PR DESCRIPTION
In the database health report view:

If you sort by a column, then toggle one of the filters (show excluded, show expired) the user selected sort option is lost.

It *tries* to reset to sorting by the first column (quality) in ascending order. But that doesn't work either, you need to manually sort again. Or toggle filter again to get the "default sort" to actually take effect.

This PR stores the user sort option and restores it after filtering. Because it seems more like expected behavior from a user perspective.

Also valid is to fix the default sort, so it actually **does** reset the order when a filter has been toggled.

## Screenshots

### Old version

Step 1: Sort by **score/descending**

![image](https://github.com/user-attachments/assets/d0518bfd-ba14-4e16-a60b-15746845832b)

Step 2: Toggle *show  excluded entries*. UI indicates the table is sorted by **quality/ascending**. But it's not, it's still the previous sort: **score/descending**.

![image](https://github.com/user-attachments/assets/8899d320-d6ef-482b-bf2a-255496ae01d1)

Step 3: Toggle *show excluded entries* again. Now it's actually reset and displaying **quality/ascending**

![image](https://github.com/user-attachments/assets/e22f0bf3-4b59-4fe0-8dba-2d20e6182c36)

### New version

Step 1: Sort by **score/descending**

![image](https://github.com/user-attachments/assets/d0518bfd-ba14-4e16-a60b-15746845832b)

Step 2: Toggle *show excluded entries*. Sorting is kept to user choice **score/descending**.

![image](https://github.com/user-attachments/assets/3811d20b-5427-454f-9d58-f44d79d5cad7)

Step 3: Toggling *show excluded entries* again. Sorting is kept to user choice **score/descending**.

![image](https://github.com/user-attachments/assets/df1969fa-6fd2-4cab-a8ca-34a8d281a146)

## Testing strategy

Created multiple passwords with different qualities.

Created expired password.

Exclude a password.

Then toggle and sort in every direction

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
