### PR TITLE
Add filter for showing all password in health report

### DIFF
--- a/src/core/PasswordHealth.cpp
+++ b/src/core/PasswordHealth.cpp
@@ -47,21 +47,28 @@ PasswordHealth::PasswordHealth(const QString& pwd)
 void PasswordHealth::init(double entropy)
 {
     m_score = m_entropy = entropy;
+    m_scoreDetails << QObject::tr("Password entropy is %1 bits").arg(QString::number(m_entropy, 'f', 2));
 
     switch (quality()) {
+    case Quality::Excellent:
+        m_scoreReasons << QObject::tr("Excellent password");
+        break;
+
+    case Quality::Good:
+        m_scoreReasons << QObject::tr("Good password");
+        break;
+
     case Quality::Bad:
     case Quality::Poor:
         m_scoreReasons << QObject::tr("Very weak password");
-        m_scoreDetails << QObject::tr("Password entropy is %1 bits").arg(QString::number(m_entropy, 'f', 2));
         break;
 
     case Quality::Weak:
         m_scoreReasons << QObject::tr("Weak password");
-        m_scoreDetails << QObject::tr("Password entropy is %1 bits").arg(QString::number(m_entropy, 'f', 2));
         break;
 
     default:
-        // No reason or details for good and excellent passwords
+        // should never happen
         break;
     }
 }

--- a/src/gui/reports/ReportsWidgetHealthcheck.cpp
+++ b/src/gui/reports/ReportsWidgetHealthcheck.cpp
@@ -124,10 +124,7 @@ Health::Health(QSharedPointer<Database> db)
                 m_anyExcludedEntries = true;
             }
 
-            // Add entry if its password isn't at least "good"
-            if (item->health->quality() < PasswordHealth::Quality::Good) {
-                m_items.append(item);
-            }
+            m_items.append(item);
         }
     }
 
@@ -154,6 +151,7 @@ ReportsWidgetHealthcheck::ReportsWidgetHealthcheck(QWidget* parent)
     connect(m_ui->healthcheckTableView, SIGNAL(doubleClicked(QModelIndex)), SLOT(emitEntryActivated(QModelIndex)));
     connect(m_ui->showExcluded, SIGNAL(stateChanged(int)), this, SLOT(calculateHealth()));
     connect(m_ui->showExpired, SIGNAL(stateChanged(int)), this, SLOT(calculateHealth()));
+    connect(m_ui->showWeakOnly, SIGNAL(stateChanged(int)), this, SLOT(calculateHealth()));
 
     new QShortcut(Qt::Key_Delete, this, SLOT(deleteSelectedEntries()));
 }
@@ -265,6 +263,16 @@ void ReportsWidgetHealthcheck::calculateHealth()
         if ((!m_ui->showExcluded->isChecked() && item->exclude)
             || (!m_ui->showExpired->isChecked() && item->entry->isExpired())) {
             continue;
+        }
+
+        if (m_ui->showWeakOnly->isChecked()) {
+            switch (item->entry->passwordHealth()->quality()) {
+            case PasswordHealth::Quality::Good:
+            case PasswordHealth::Quality::Excellent:
+                continue;
+            default:
+                break;
+            }
         }
 
         // Show the entry in the report

--- a/src/gui/reports/ReportsWidgetHealthcheck.ui
+++ b/src/gui/reports/ReportsWidgetHealthcheck.ui
@@ -55,6 +55,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="showWeakOnly">
+     <property name="text">
+      <string>Show weak passwords only</string>
+     </property>
+     <property name="checked">
+       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="showExpired">
      <property name="text">
       <string>Show expired entries</string>

--- a/tests/TestPasswordHealth.cpp
+++ b/tests/TestPasswordHealth.cpp
@@ -54,13 +54,13 @@ void TestPasswordHealth::testNoDb()
     QCOMPARE(good.score(), 78);
     QCOMPARE(int(good.entropy()), 78);
     QCOMPARE(good.quality(), PasswordHealth::Quality::Good);
-    QVERIFY(good.scoreReason().isEmpty());
-    QVERIFY(good.scoreDetails().isEmpty());
+    QVERIFY(!good.scoreReason().isEmpty());
+    QVERIFY(!good.scoreDetails().isEmpty());
 
     const auto excellent = PasswordHealth("prompter-ream-oversleep-step-extortion-quarrel-reflected-prefix");
     QCOMPARE(excellent.score(), 164);
     QCOMPARE(int(excellent.entropy()), 164);
     QCOMPARE(excellent.quality(), PasswordHealth::Quality::Excellent);
-    QVERIFY(excellent.scoreReason().isEmpty());
-    QVERIFY(excellent.scoreDetails().isEmpty());
+    QVERIFY(!excellent.scoreReason().isEmpty());
+    QVERIFY(!excellent.scoreDetails().isEmpty());
 }


### PR DESCRIPTION
edit: Build is failing on translations, I didn't add these yet because I saw some cli tools that are related to it but unsure how to use it. If this PR is going to be approved, please let me know what the process is to add translations.

---

Fixes: #5330

I'd like to see my password scores.

The health report only shows scores for weak passwords.

It's possible to add a *password strength* column to the passwords screen. It shows the strength as a color but unfortunately doesn't display the numeric score value which I'm interested in.

Password policies change over time because of hardware development. It helps to see the numeric scores to more accurately judge which passwords could be improved. And which ones are "degrading" over time.

There were 2 options, (1) to add it as a column to the password screen. (2) add it to the health report.

This PR adds it to the health report. I think it would be good to add it as a column to the password screen as well.

I implemented this feature by adding a new filter called **show weak passwords only** which defaults to true, which is the default behavior right now. Unchecking it shows all passwords.

## Screenshots

Default behavior:

![image](https://github.com/user-attachments/assets/863c702b-1aa9-4630-9603-661bd6072d9c)

After unchecking *show weak passwords only* filter:

![image](https://github.com/user-attachments/assets/128cabb1-5b4a-4149-a4b0-6ea298e03e7f)

## Testing strategy

Required 4 characters changed in 1 test module to account for `scoreReason` and `scoreDetails` being defined now for Good and Excellent passwords.

## Type of change

- ✅ New feature (change that adds functionality)
