### PR TITLE
Correct Argon2 settings when creating new database

### DIFF
--- a/src/crypto/kdf/Argon2Kdf.cpp
+++ b/src/crypto/kdf/Argon2Kdf.cpp
@@ -33,11 +33,11 @@
  */
 Argon2Kdf::Argon2Kdf(Type type)
     : Kdf::Kdf(type == Type::Argon2d ? KeePass2::KDF_ARGON2D : KeePass2::KDF_ARGON2ID)
-    , m_version(0x13)
-    , m_memory(1 << 16)
-    , m_parallelism(static_cast<quint32>(QThread::idealThreadCount()))
+    , m_version(ARGON2_DEFAULT_VERSION)
+    , m_memory(ARGON2_DEFAULT_MEMORY)
+    , m_parallelism(qMin<quint32>(QThread::idealThreadCount(), ARGON2_DEFAULT_PARALLELISM))
 {
-    m_rounds = 10;
+    m_rounds = ARGON2_DEFAULT_ROUNDS;
 }
 
 quint32 Argon2Kdf::version() const
@@ -52,7 +52,7 @@ bool Argon2Kdf::setVersion(quint32 version)
         m_version = version;
         return true;
     }
-    m_version = 0x13;
+    m_version = ARGON2_DEFAULT_VERSION;
     return false;
 }
 
@@ -73,7 +73,7 @@ bool Argon2Kdf::setMemory(quint64 kibibytes)
         m_memory = kibibytes;
         return true;
     }
-    m_memory = 16;
+    m_memory = ARGON2_DEFAULT_MEMORY;
     return false;
 }
 
@@ -89,7 +89,7 @@ bool Argon2Kdf::setParallelism(quint32 threads)
         m_parallelism = threads;
         return true;
     }
-    m_parallelism = 1;
+    m_parallelism = ARGON2_DEFAULT_PARALLELISM;
     return false;
 }
 

--- a/src/crypto/kdf/Argon2Kdf.h
+++ b/src/crypto/kdf/Argon2Kdf.h
@@ -20,6 +20,11 @@
 
 #include "Kdf.h"
 
+constexpr auto ARGON2_DEFAULT_VERSION = 0x13;
+constexpr auto ARGON2_DEFAULT_ROUNDS = 10;
+constexpr auto ARGON2_DEFAULT_MEMORY = 1 << 16;
+constexpr auto ARGON2_DEFAULT_PARALLELISM = 4;
+
 class Argon2Kdf : public Kdf
 {
 public:
@@ -46,6 +51,15 @@ public:
     QString toString() const override;
 
     int benchmark(int msec) const override;
+
+    static quint64 toMebibytes(quint64 kibibytes)
+    {
+        return kibibytes >> 10;
+    }
+    static quint64 toKibibytes(quint64 mebibits)
+    {
+        return mebibits << 10;
+    }
 
     quint32 m_version;
     quint64 m_memory;

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
@@ -159,12 +159,7 @@ void DatabaseSettingsWidgetEncryption::initialize()
     // Set up KDF algorithms
     loadKdfAlgorithms();
 
-    // Perform Benchmark if requested
     if (isNewDatabase) {
-        if (IS_ARGON2(m_ui->kdfComboBox->currentData())) {
-            m_ui->memorySpinBox->setValue(16);
-            m_ui->parallelismSpinBox->setValue(2);
-        }
         benchmarkTransformRounds();
     }
 
@@ -225,7 +220,7 @@ void DatabaseSettingsWidgetEncryption::loadKdfParameters()
         // Set Argon2 parameters
         auto argon2Kdf = kdf.staticCast<Argon2Kdf>();
         m_ui->transformRoundsSpinBox->setValue(argon2Kdf->rounds());
-        m_ui->memorySpinBox->setValue(static_cast<int>(argon2Kdf->memory()) / (1 << 10));
+        m_ui->memorySpinBox->setValue(Argon2Kdf::toMebibytes(argon2Kdf->memory()));
         m_ui->parallelismSpinBox->setValue(argon2Kdf->parallelism());
     } else if (!dbIsArgon2 && !kdfIsArgon2) {
         // Set AES KDF parameters
@@ -233,8 +228,8 @@ void DatabaseSettingsWidgetEncryption::loadKdfParameters()
     } else {
         // Set reasonable defaults and then benchmark
         if (kdfIsArgon2) {
-            m_ui->memorySpinBox->setValue(16);
-            m_ui->parallelismSpinBox->setValue(2);
+            m_ui->memorySpinBox->setValue(Argon2Kdf::toMebibytes(ARGON2_DEFAULT_MEMORY));
+            m_ui->parallelismSpinBox->setValue(ARGON2_DEFAULT_PARALLELISM);
         }
         benchmarkTransformRounds();
     }
@@ -343,7 +338,7 @@ bool DatabaseSettingsWidgetEncryption::saveSettings()
     kdf->setRounds(m_ui->transformRoundsSpinBox->value());
     if (IS_ARGON2(kdf->uuid())) {
         auto argon2Kdf = kdf.staticCast<Argon2Kdf>();
-        argon2Kdf->setMemory(static_cast<quint64>(m_ui->memorySpinBox->value()) * (1 << 10));
+        argon2Kdf->setMemory(Argon2Kdf::toKibibytes(m_ui->memorySpinBox->value()));
         argon2Kdf->setParallelism(static_cast<quint32>(m_ui->parallelismSpinBox->value()));
     }
 
@@ -377,8 +372,8 @@ void DatabaseSettingsWidgetEncryption::benchmarkTransformRounds(int millisecs)
         auto argon2Kdf = kdf.staticCast<Argon2Kdf>();
         // Set a small static number of rounds for the benchmark
         argon2Kdf->setRounds(4);
-        if (!argon2Kdf->setMemory(static_cast<quint64>(m_ui->memorySpinBox->value()) * (1 << 10))) {
-            m_ui->memorySpinBox->setValue(static_cast<int>(argon2Kdf->memory() / (1 << 10)));
+        if (!argon2Kdf->setMemory(Argon2Kdf::toKibibytes(m_ui->memorySpinBox->value()))) {
+            m_ui->memorySpinBox->setValue(Argon2Kdf::toMebibytes(argon2Kdf->memory()));
         }
         if (!argon2Kdf->setParallelism(static_cast<quint32>(m_ui->parallelismSpinBox->value()))) {
             m_ui->parallelismSpinBox->setValue(argon2Kdf->parallelism());


### PR DESCRIPTION
* Argon2 default parallelism settings were set to the number of threads on the computer. That is excessive on high cpu count computers.

See https://github.com/keepassxreboot/keepassxc/issues/11852#issuecomment-2708232687

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested manually and unit tests

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
