### PR TITLE
Add LibreWolf snap helper setup

### DIFF
--- a/utils/keepassxc-snap-helper.sh
+++ b/utils/keepassxc-snap-helper.sh
@@ -94,6 +94,11 @@ setupEdge() {
     INSTALL_DIR="${BASE_DIR}/.config/microsoft-edge/NativeMessagingHosts"
 }
 
+setupLibreWolf() {
+    JSON_OUT=${JSON_FIREFOX}
+    INSTALL_DIR="${BASE_DIR}/.librewolf/native-messaging-hosts"
+}
+
 # --------------------------------
 # Start of script
 # --------------------------------
@@ -109,6 +114,7 @@ BROWSER=$(whiptail \
             "5" "Brave" \
             "6" "Tor Browser" \
             "7" "Microsoft Edge" \
+            "8" "LibreWolf" \
             3>&1 1>&2 2>&3)
 
 exitstatus=$?
@@ -125,6 +131,7 @@ if [[ $exitstatus == 0 ]]; then
         5) setupBrave ;;
         6) setupTorBrowser ;;
         7) setupEdge ;;
+        8) setupLibreWolf ;;
     esac
 
     # Install the JSON file


### PR DESCRIPTION
This change makes it easy to configure LibreWolf to work with KeePassXC.

## Screenshots
![image](https://github.com/user-attachments/assets/07e28a3c-c0d6-4b4d-9756-2f20e71cf364)

## Testing strategy
1. Install LibreWolf
2. Run LibreWolf once
3. Run `utils/keepassxc-snap-helper.sh` and select LibreWolf
4. Restart LibreWolf
5. Install the KeePassXC addon
6. Connect it to your KeePassXC database

## Type of change
- ✅ New feature (change that adds functionality
