### PR TITLE
Fix Proton Pass importer not importing email address when there is no username

### DIFF
--- a/src/format/ProtonPassReader.cpp
+++ b/src/format/ProtonPassReader.cpp
@@ -73,7 +73,13 @@ namespace
             }
 
             if (loginMap.contains("itemEmail")) {
-                entry->attributes()->set("login_email", loginMap.value("itemEmail").toString());
+                // Place the email value as the username if empty, otherwise set it as an attribute
+                const auto email = loginMap.value("itemEmail").toString();
+                if (entry->username().isEmpty()) {
+                    entry->setUsername(email);
+                } else if (!email.isEmpty()) {
+                    entry->attributes()->set("login_email", email);
+                }
             }
 
             // Set the entry url(s)


### PR DESCRIPTION
When exporting Proton Pass data in a JSON file, usernames and emails are treated as two distinct fields. However, the current implementation of the Proton Pass importer only imports the username field, which results in a blank username when the username is an email address. This PR fixes this issue.

## Testing strategy
Manually using json generated by Proton Pass.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
