### PR TITLE
Allow for escape syntax to enable literal placeholders

### DIFF
--- a/docs/topics/Reference.adoc
+++ b/docs/topics/Reference.adoc
@@ -49,6 +49,8 @@ This section contains full details on advanced features available in KeePassXC.
 |{DB_DIR}	     |Absolute directory path of database file
 |===
 
+NOTE: You can insert literal placeholder strings by escaping the beginning and ending curly braces. For example, to insert the string `{USERNAME}`, you would type `++\{USERNAME\}++`.
+
 === Entry Cross-Reference
 A reference to another entry's field is possible using the shorthand syntax:
 `{REF:&lt;FIELD&gt;@&lt;SEARCH_IN&gt;:&lt;SEARCH_TEXT&gt;}`

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1059,6 +1059,15 @@ QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxD
         return str;
     }
 
+    // Short circuit if we have escaped the placeholder brackets
+    if (str.startsWith("\\{") && str.endsWith("\\}")) {
+        // Replace the escaped brackets with actuals and move on
+        auto ret = str;
+        ret.replace(0, 2, "{");
+        ret.replace(ret.size() - 2, 2, "}");
+        return ret;
+    }
+
     QString result;
     auto matches = placeholderRegEx.globalMatch(str);
     int capEnd = 0;

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -583,6 +583,17 @@ void TestEntry::testResolveReplacePlaceholders()
     // Test complicated and nested replacements
     QCOMPARE(entry2->resolveMultiplePlaceholders(entry2->url()),
              QString("cmd://sap.exe -system=server1 -client=12345 -user=Username2 -pw=Password1"));
+
+    auto* entry3 = new Entry();
+    entry3->setGroup(root);
+    entry3->setUuid(QUuid::createUuid());
+    entry3->setTitle("Entry 3");
+    entry3->setUsername("HMAC-SHA-256");
+    entry3->setUrl("{T-REPLACE-RX:!{USERNAME}!\\{USERNAME\\}!!}");
+
+    // Test escaped enclosures
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->url()), entry3->username());
+
     // Test invalid syntax
     QString error;
     entry1->resolveRegexPlaceholder("{T-REPLACE-RX:/{USERNAME}/.*+?/test/}", &error); // invalid regex


### PR DESCRIPTION
* Fixes #11890

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Added a test case, all existing ones pass, this is a minimal change that would not break existing placeholder syntax.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
