### PR TITLE
Also add "session" alias in secret service

### DIFF
--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -30,6 +30,7 @@
 namespace
 {
     constexpr auto DEFAULT_ALIAS = "default";
+    constexpr auto SESSION_ALIAS = "session";
 }
 
 namespace FdoSecrets
@@ -173,6 +174,7 @@ namespace FdoSecrets
         if (coll) {
             // adding alias will automatically remove the association with previous collection.
             coll->addAlias(DEFAULT_ALIAS).okOrDie();
+            coll->addAlias(SESSION_ALIAS).okOrDie();
         }
 
         m_insideEnsureDefaultAlias = false;


### PR DESCRIPTION
## Description

libsecret includes an alias named "session" in addition to "default" ([here](https://gnome.pages.gitlab.gnome.org/libsecret/const.COLLECTION_SESSION.html)), and it is used in Gnome Online Accounts to store OAuth2 secrets ([here](https://github.com/GNOME/gnome-online-accounts/blob/38fe0a8e9c452f241aec80ef35fe27586d6eac69/src/goabackend/goaoauth2provider.c#L1178)). Adding this alias to point to the current opened database by default avoids errors when configuring OAuth2 accounts.

## Testing strategy

Tested manually by recompiling with this PR applied and adding OAuth2 accounts in Gnome.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)