### PR TITLE
Add safeguards to secure input on macOS

### DIFF
--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -231,7 +231,7 @@ bool PasswordWidget::eventFilter(QObject* watched, QEvent* event)
         if (isVisible() && (type == QEvent::KeyPress || type == QEvent::KeyRelease || type == QEvent::FocusIn)) {
             checkCapslockState();
         }
-        if (type == QEvent::FocusIn || type == QEvent::FocusOut) {
+        if (type == QEvent::FocusIn || type == QEvent::FocusOut || type == QEvent::Hide) {
             osUtils->setUserInputProtection(type == QEvent::FocusIn);
         }
     }

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -154,7 +154,11 @@ void MacUtils::setUserInputProtection(bool enable)
 {
     static bool secureInputEnabled = false;
     if (enable) {
-        // Always keep the internal counter set to 1
+        /*
+         * MacOS keeps a single counter over all apps that needs to be zero to disable secure input. By never going
+         * higher than 1 internally this makes sure secure input doesn't stay active after calling this function
+         * multiple times.
+         */
         if (secureInputEnabled) {
             DisableSecureEventInput();
         }

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -152,11 +152,18 @@ bool MacUtils::isCapslockEnabled()
 
 void MacUtils::setUserInputProtection(bool enable)
 {
+    static bool secureInputEnabled = false;
     if (enable) {
+        // Always keep the internal counter set to 1
+        if (secureInputEnabled) {
+            DisableSecureEventInput();
+        }
         EnableSecureEventInput();
     } else {
         DisableSecureEventInput();
     }
+    // Store our last known state
+    secureInputEnabled = enable;
 }
 
 /**


### PR DESCRIPTION
* Fixes #11906
* Disable secure input when password widget is hidden as well as focused out
* Add safeguard to ensure the internal counter that macOS keeps is always set to 1 preventing the ability to disable secure input by focus/unfocus a password field

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Replicated issue on macOS and cannot replicate it after these changes.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
