### PR TITLE
implement database closing question on esc press

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1708,6 +1708,10 @@ Are you sure you want to continue with this file?.</source>
         <source>Hardware keys found, but no slots are configured.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Press ESC again to close this database</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DatabaseSettingWidgetMetaData</name>

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -159,6 +159,29 @@ void DatabaseOpenWidget::toggleHardwareKeyComponent(bool state)
         m_ui->useHardwareKeyCheckBox->setText(tr("Use hardware key"));
     }
 }
+void DatabaseOpenWidget::closeDatabase()
+{
+    int closeWarningInterval = 3000;
+
+    if (!m_triedToQuit && window() == getMainWindow()) {
+        m_triedToQuit = true;
+        m_ui->messageWidget->showMessage(
+            tr("Press ESC again to close this database"), MessageWidget::Warning, closeWarningInterval);
+
+        QTimer::singleShot(closeWarningInterval, this, [this]() { m_triedToQuit = false; });
+        return;
+    }
+    reject();
+}
+
+void DatabaseOpenWidget::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Escape) {
+        closeDatabase();
+    } else {
+        DialogyWidget::keyPressEvent(event);
+    }
+}
 
 bool DatabaseOpenWidget::event(QEvent* event)
 {

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -66,6 +66,7 @@ signals:
 
 protected:
     bool event(QEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
     QSharedPointer<CompositeKey> buildDatabaseKey();
     void setUserInteractionLock(bool state);
 
@@ -81,6 +82,7 @@ protected slots:
 private slots:
     bool browseKeyFile();
     void toggleHardwareKeyComponent(bool state);
+    void closeDatabase();
     void pollHardwareKey(bool manualTrigger = false, int delay = 0);
     void hardwareKeyResponse(bool found);
 
@@ -92,6 +94,7 @@ private:
     bool m_manualHardwareKeyRefresh = false;
     bool m_blockQuickUnlock = false;
     bool m_unlockingDatabase = false;
+    bool m_triedToQuit = false;
     QTimer m_hideTimer;
     QTimer m_hideNoHardwareKeysFoundTimer;
 


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc/issues/11199
Based on the comments of https://github.com/keepassxreboot/keepassxc/pull/11221

### Issue

Pressing the ESC key while a password (or key file) entry widget is focused causes the database to close unexpectedly. The original fix seems abandoned, so I implemented a fix myself. 

### Solution

A confirmation message now appears when ESC is pressed. The user must press ESC again within 3 seconds to confirm closing the database; otherwise, the action is canceled.

Expected Behavior
	•	First ESC press: Show confirmation message.
	•	Second ESC press within 3 seconds: Close the database.
	•	No second ESC press: Dismiss confirmation and keep the database open.
	•	Ctrl+W closes the database.

This improves usability and prevents accidental closures.

## Screenshot
![Press ESC again to close this database](https://github.com/user-attachments/assets/2e40e463-06ee-4d98-8c43-735994a347b0)

## Type of change
- ✅ New feature (change that adds functionality)
