### PR TITLE
appimage: add `ARGV0` check in `AppRun`

### DIFF
--- a/release-tool
+++ b/release-tool
@@ -672,7 +672,9 @@ appimage() {
 export PATH="$(dirname $0)/usr/bin:${PATH}"
 export LD_LIBRARY_PATH="$(dirname $0)/usr/lib:${LD_LIBRARY_PATH}"
 
-if [ "$1" == "cli" ]; then
+if command -v "${ARGV0#./}" >/dev/null 2>&1; then
+    exec "${ARGV0#./}" "$@"
+elif [ "$1" == "cli" ]; then
     shift
     exec keepassxc-cli "$@"
 elif [ "$1" == "proxy" ]; then


### PR DESCRIPTION
This lets the AppImage be renamed or symlink as the internal binary you want to launch without having to do stuff like passing `cli` as the first argument. 

See [info about](https://docs.appimage.org/packaging-guide/environment-variables.html#type-2-appimage-runtime) `ARGV0` for more details

![image](https://github.com/user-attachments/assets/0604777f-93c5-48ad-b347-fdbe6aa6e6e7)



- ✅ New feature (change that adds functionality)



-------------------------------------------------------------------------------

**EDIT** Also is there a reason `LD_LIBRARY_PATH` is being set in the `AppRun`? The variable should not be needed at all since linuxdeploy changes the rpath of all the ELFs to point to that location already. The variable is often problematic since it gets inherited by child processes. 
