### PR TITLE
Added new cli flag to enable quick unlock even when --pw-stdin is passed as argument

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -9248,6 +9248,10 @@ This option is deprecated, use --set-key-file instead.</source>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>enable quick unlock also when --pw-stdin is set</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QtIOCompressor</name>

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -326,7 +326,7 @@ QString DatabaseOpenWidget::filename()
     return m_filename;
 }
 
-void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
+void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile, bool explicitQuickUnlock)
 {
     if (unlockingDatabase()) {
         qWarning("Ignoring unlock request for %s because of running unlock action.", qPrintable(m_filename));
@@ -335,7 +335,7 @@ void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
 
     m_ui->editPassword->setText(pw);
     m_ui->keyFileLineEdit->setText(keyFile);
-    m_blockQuickUnlock = true;
+    m_blockQuickUnlock = !explicitQuickUnlock;
     openDatabase();
 }
 

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -49,7 +49,7 @@ public:
     void load(const QString& filename);
     QString filename();
     void clearForms();
-    void enterKey(const QString& pw, const QString& keyFile);
+    void enterKey(const QString& pw, const QString& keyFile, bool explicitQuickUnlock);
     QSharedPointer<Database> database();
     bool unlockingDatabase();
     void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -156,7 +156,8 @@ void DatabaseTabWidget::openDatabase()
 void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
                                        bool inBackground,
                                        const QString& password,
-                                       const QString& keyfile)
+                                       const QString& keyfile,
+                                       bool explicitQuickUnlock)
 {
     QString cleanFilePath = QDir::toNativeSeparators(filePath);
     QFileInfo fileInfo(cleanFilePath);
@@ -173,7 +174,7 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
         Q_ASSERT(dbWidget);
         if (dbWidget
             && dbWidget->database()->canonicalFilePath().compare(canonicalFilePath, FILE_CASE_SENSITIVE) == 0) {
-            dbWidget->performUnlockDatabase(password, keyfile);
+            dbWidget->performUnlockDatabase(password, keyfile, explicitQuickUnlock);
             if (!inBackground) {
                 // switch to existing tab if file is already open
                 setCurrentIndex(indexOf(dbWidget));

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -53,7 +53,8 @@ public slots:
     void addDatabaseTab(const QString& filePath,
                         bool inBackground = false,
                         const QString& password = {},
-                        const QString& keyfile = {});
+                        const QString& keyfile = {},
+                        bool explicitQuickUnlock = false);
     void addDatabaseTab(DatabaseWidget* dbWidget, bool inBackground = false);
     bool closeDatabaseTab(int index);
     bool closeDatabaseTab(DatabaseWidget* dbWidget);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1587,10 +1587,13 @@ void DatabaseWidget::switchToOpenDatabase(const QString& filePath)
     setCurrentWidget(m_databaseOpenWidget);
 }
 
-void DatabaseWidget::switchToOpenDatabase(const QString& filePath, const QString& password, const QString& keyFile)
+void DatabaseWidget::switchToOpenDatabase(const QString& filePath,
+                                          const QString& password,
+                                          const QString& keyFile,
+                                          bool explicitQuickUnlock)
 {
     switchToOpenDatabase(filePath);
-    m_databaseOpenWidget->enterKey(password, keyFile);
+    m_databaseOpenWidget->enterKey(password, keyFile, explicitQuickUnlock);
 }
 
 void DatabaseWidget::switchToEntryEdit()
@@ -1675,7 +1678,7 @@ void DatabaseWidget::removePasskeyFromEntry()
 }
 #endif
 
-void DatabaseWidget::performUnlockDatabase(const QString& password, const QString& keyfile)
+void DatabaseWidget::performUnlockDatabase(const QString& password, const QString& keyfile, bool explicitQuickUnlock)
 {
     if (password.isEmpty() && keyfile.isEmpty()) {
         return;
@@ -1683,7 +1686,7 @@ void DatabaseWidget::performUnlockDatabase(const QString& password, const QStrin
 
     if (!m_db->isInitialized() || isLocked()) {
         switchToOpenDatabase();
-        m_databaseOpenWidget->enterKey(password, keyfile);
+        m_databaseOpenWidget->enterKey(password, keyfile, explicitQuickUnlock);
     }
 }
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -240,8 +240,11 @@ public slots:
 #endif
     void switchToOpenDatabase();
     void switchToOpenDatabase(const QString& filePath);
-    void switchToOpenDatabase(const QString& filePath, const QString& password, const QString& keyFile);
-    void performUnlockDatabase(const QString& password, const QString& keyfile = {});
+    void switchToOpenDatabase(const QString& filePath,
+                              const QString& password,
+                              const QString& keyFile,
+                              bool explicitQuickUnlock);
+    void performUnlockDatabase(const QString& password, const QString& keyfile = {}, bool explicitQuickUnlock = false);
     void emptyRecycleBin();
 
     // Search related slots

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -876,9 +876,12 @@ void MainWindow::clearLastDatabases()
     }
 }
 
-void MainWindow::openDatabase(const QString& filePath, const QString& password, const QString& keyfile)
+void MainWindow::openDatabase(const QString& filePath,
+                              const QString& password,
+                              const QString& keyfile,
+                              bool explicitQuickUnlock)
 {
-    m_ui->tabWidget->addDatabaseTab(filePath, false, password, keyfile);
+    m_ui->tabWidget->addDatabaseTab(filePath, false, password, keyfile, explicitQuickUnlock);
 }
 
 void MainWindow::updateMenuActionState()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -63,17 +63,17 @@ public:
         PasswordGeneratorScreen = 3
     };
 
-    signals:
+signals:
     void databaseUnlocked(DatabaseWidget* dbWidget);
     void databaseLocked(DatabaseWidget* dbWidget);
     void activeDatabaseChanged(DatabaseWidget* dbWidget);
     void databaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
-    public slots:
-        void openDatabase(const QString& filePath,
-            const QString& password = {},
-            const QString& keyfile = {},
-            bool explicitQuickUnlock = false);
+public slots:
+    void openDatabase(const QString& filePath,
+                      const QString& password = {},
+                      const QString& keyfile = {},
+                      bool explicitQuickUnlock = false);
     void appExit();
     bool isHardwareKeySupported();
     bool refreshHardwareKeys();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -63,14 +63,17 @@ public:
         PasswordGeneratorScreen = 3
     };
 
-signals:
+    signals:
     void databaseUnlocked(DatabaseWidget* dbWidget);
     void databaseLocked(DatabaseWidget* dbWidget);
     void activeDatabaseChanged(DatabaseWidget* dbWidget);
     void databaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
-public slots:
-    void openDatabase(const QString& filePath, const QString& password = {}, const QString& keyfile = {});
+    public slots:
+        void openDatabase(const QString& filePath,
+            const QString& password = {},
+            const QString& keyfile = {},
+            bool explicitQuickUnlock = false);
     void appExit();
     bool isHardwareKeySupported();
     bool refreshHardwareKeys();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,7 @@ int main(int argc, char** argv)
     QCommandLineOption lockOption("lock", QObject::tr("lock all open databases"));
     QCommandLineOption keyfileOption("keyfile", QObject::tr("key file of the database"), "keyfile");
     QCommandLineOption pwstdinOption("pw-stdin", QObject::tr("read password of the database from stdin"));
+    QCommandLineOption explicitQuickUnlockOption("quick-unlock", QObject::tr("enable quick unlock also when --pw-stdin is set"));
     QCommandLineOption allowScreenCaptureOption("allow-screencapture",
                                                 QObject::tr("allow screenshots and app recording (Windows/macOS)"));
     QCommandLineOption startMinimized("minimized", QObject::tr("start minimized to the system tray"));
@@ -97,6 +98,7 @@ int main(int argc, char** argv)
     parser.addOption(debugInfoOption);
     parser.addOption(allowScreenCaptureOption);
     parser.addOption(startMinimized);
+    parser.addOption(explicitQuickUnlockOption);
 
     parser.process(app);
 
@@ -196,6 +198,7 @@ int main(int argc, char** argv)
     mainWindow.setAllowScreenCapture(parser.isSet(allowScreenCaptureOption));
 
     const bool pwstdin = parser.isSet(pwstdinOption);
+    const bool explicitQuickUnlock = parser.isSet(explicitQuickUnlockOption);
     for (const QString& filename : fileNames) {
         QString password;
         if (pwstdin) {
@@ -205,7 +208,7 @@ int main(int argc, char** argv)
             out << QObject::tr("Database password: ") << Qt::flush;
             password = Utils::getPassword();
         }
-        mainWindow.openDatabase(filename, password, parser.value(keyfileOption));
+        mainWindow.openDatabase(filename, password, parser.value(keyfileOption), explicitQuickUnlock);
     }
 
     // start minimized if configured

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,7 +82,8 @@ int main(int argc, char** argv)
     QCommandLineOption lockOption("lock", QObject::tr("lock all open databases"));
     QCommandLineOption keyfileOption("keyfile", QObject::tr("key file of the database"), "keyfile");
     QCommandLineOption pwstdinOption("pw-stdin", QObject::tr("read password of the database from stdin"));
-    QCommandLineOption explicitQuickUnlockOption("quick-unlock", QObject::tr("enable quick unlock also when --pw-stdin is set"));
+    QCommandLineOption explicitQuickUnlockOption("quick-unlock",
+                                                 QObject::tr("enable quick unlock also when --pw-stdin is set"));
     QCommandLineOption allowScreenCaptureOption("allow-screencapture",
                                                 QObject::tr("allow screenshots and app recording (Windows/macOS)"));
     QCommandLineOption startMinimized("minimized", QObject::tr("start minimized to the system tray"));


### PR DESCRIPTION
Implements the suggested flag to have quick unlock enabled on demand when unlocking with --pw-stdin .

Right now I only tested this on Linux, the logic that I changed got introduced by the Windows Hello Feature, so I think some more testing needs to be done on windows if the unlock dialog still behaves correctly in all cases.

Fixes:

https://github.com/keepassxreboot/keepassxc/issues/9957
https://github.com/keepassxreboot/keepassxc/issues/9023

Does not fix:
https://github.com/keepassxreboot/keepassxc/issues/9957#issuecomment-1777009121

## Screenshots



## Testing strategy
- Start KeepassXC with --pw-stdin --quick-unlock
- Lock the Database


## Type of change
- ✅ New feature (change that adds functionality)