### PR TITLE
Detect outdated VC Redist with MSI Installer

### DIFF
--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -115,6 +115,14 @@
             <ComponentRef Id="DesktopShortcut" />
         </FeatureRef>
 
+        <!-- Detect VCRedist Version -->
+        <Upgrade Id="36F68A90-239C-34DF-B58C-64B30153CE35">
+            <UpgradeVersion OnlyDetect="yes" Property="VCREDISTINSTALLED" Minimum="14.38.33135.0" />
+        </Upgrade>
+        <Condition Message="The installed version of Visual Studio Redistributable is too old. Please install the latest version from: https://aka.ms/vs/17/release/vc_redist.x64.exe">
+            <![CDATA[Installed OR VCREDISTINSTALLED]]>
+        </Condition>
+
         <!-- Action to launch application after installer exits -->
         <Property Id="WixShellExecTarget" Value="[#CM_FP_KeePassXC.exe]" />
         <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />


### PR DESCRIPTION
Fixes https://github.com/keepassxreboot/keepassxc/issues/10974

![1](https://github.com/user-attachments/assets/1fb864a2-067f-43c9-8bf6-f89d6b4e97ce)

This change will prevent installation of KeePassXC until the VC Redist is updated. 
The minimum required version of vcredist is 14.38.33135.0 for correct program launch.

## Testing strategy
Tested on Windows 10 & Windows 11 with different versions of vcredist


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
