### PR TITLE
Fix uninitialized memory when --pw-stdin is used with a pipe

### DIFF
--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -105,7 +105,9 @@ namespace Utils
         SetConsoleMode(hIn, mode);
 #else
         struct termios t;
-        tcgetattr(STDIN_FILENO, &t);
+        if (tcgetattr(STDIN_FILENO, &t) < 0) {
+            return;
+        }
 
         if (enable) {
             t.c_lflag |= ECHO;


### PR DESCRIPTION
When stdin isn't a tty `tcgetattr` will fail and `t` will still be uninitialized. Using `t` for `tcsetattr` below is UB.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
