### PR TITLE
Explicitly allow access to newly created browser group

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -330,6 +330,7 @@ QJsonObject BrowserService::createNewGroup(const QString& groupName, bool isPass
             }
 #endif
             name = newGroup->name();
+            newGroup->setCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY, Group::Disable);
             uuid = Tools::uuidToHex(newGroup->uuid());
             previousGroup = newGroup;
             continue;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
When creating a new subgroup via browser extension under a group that's hidden from browser extension, the new group inherits the hide option, and credentials are not visible fro the extension.

Fixes #12115.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Manually:
1. Create a group "Hidden" and enable the option to hide it from browser extension.
2. Add group "Hidden/Browser" to extension settings for the group for new credentials.
3. Save new credentials from browser. The group should have the hide option disabled.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
