### PR TITLE
Use kbd macro in docs for keys

### DIFF
--- a/docs/GettingStarted.adoc
+++ b/docs/GettingStarted.adoc
@@ -7,6 +7,7 @@ KeePassXC Team <team@keepassxc.org>
 :imagesdir: images
 :stylesheet: styles/dark.css
 :toc: left
+:experimental:
 ifdef::backend-pdf[]
 :title-page:
 :title-logo-image: {imagesdir}/kpxc_logo.png

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -7,6 +7,7 @@ KeePassXC Team <team@keepassxc.org>
 :stylesheet: styles/dark.css
 :toc: left
 :sectanchors:
+:experimental:
 ifdef::backend-pdf[]
 :title-page:
 :title-logo-image: {imagesdir}/kpxc_logo.png

--- a/docs/topics/.sharedheader
+++ b/docs/topics/.sharedheader
@@ -4,3 +4,4 @@ KeePassXC Team <team@keepassxc.org>
 :stylesheet: ../styles/dark.css
 :icons: font
 :toc: left
+:experimental:

--- a/docs/topics/AutoType.adoc
+++ b/docs/topics/AutoType.adoc
@@ -24,13 +24,13 @@ You can also set the time to remember the last used entry between presses of the
 === Configure Auto-Type Sequences
 Each entry in your database can have multiple Auto-Type sequences associated with various window titles. Simulated key presses can be sent to any other currently open window of your choice (web browser windows, login dialogs boxes, and so on). When the Global Auto-Type hotkey is pressed, KeePassXC will search your database for entries matching the current selected window title.
 
-NOTE: The default Auto-Type sequence is `{USERNAME}{TAB}{PASSWORD}{ENTER}`. This means that it first types the username of the selected entry, then presses the `Tab` key, then types the password of the entry and finally presses the `Enter` key.
+NOTE: The default Auto-Type sequence is `{USERNAME}{TAB}{PASSWORD}{ENTER}`. This means that it first types the username of the selected entry, then presses the kbd:[Tab] key, then types the password of the entry and finally presses the kbd:[Enter] key.
 
 TIP: To change the default Auto-Type sequence for all entries of your database, edit the root (top-most) group of your database and set a specific sequence. Child groups and entries will inherit this sequence by default.
 
 To configure Auto-Type sequences for your entries, perform the following steps:
 
-1.	Navigate to the entries list and open the desired entry for editing. Click the _Auto-Type_ item from the left-hand menu bar *(1)*. Press the `+` button *(2)* to add a new sequence entry. Select the desired window using the drop-down menu, or simply type a window title in the box *(3)*.
+1.	Navigate to the entries list and open the desired entry for editing. Click the _Auto-Type_ item from the left-hand menu bar *(1)*. Press the kbd:[+] button *(2)* to add a new sequence entry. Select the desired window using the drop-down menu, or simply type a window title in the box *(3)*.
 +
 TIP: You can use an asterisk (`\*`) to match any value (e.g., when a window title contains a dynamic filename or website name). Set the window title to `*` to match all windows. Leave the window title blank to offer additional default Auto-Type sequences, such as custom attributes.
 +
@@ -60,7 +60,7 @@ image::autotype_entry_sequences.png[]
 |Press the corresponding keyboard key
 
 |{UP}, {DOWN}, {LEFT}, {RIGHT}  |Press the corresponding arrow key
-|{LEFTBRACE}, {RIGHTBRACE}      |Press `{` or `}`, respectively
+|{LEFTBRACE}, {RIGHTBRACE}      |Press kbd:[{] or kbd:[}], respectively
 |{&lt;KEY&gt; X}     |Repeat &lt;KEY&gt; X times (e.g., {SPACE 5} inserts five spaces)
 |{DELAY=X}     |Set delay between key presses to X milliseconds
 |{DELAY X}     |Pause typing for X milliseconds
@@ -89,7 +89,7 @@ When you press the global Auto-Type hotkey, KeePassXC searches all unlocked data
 .Auto-Type sequence selection
 image::autotype_selection_dialog.png[,70%]
 
-Perform the selected Auto-Type sequence by double clicking the desired row or pressing _Enter_. Press the up and down arrows to navigate the list. Sequences can be filtered through the text edit field.
+Perform the selected Auto-Type sequence by double clicking the desired row or pressing kbd:[Enter]. Press the up and down arrows to navigate the list. Sequences can be filtered through the text edit field.
 
 .Auto-Type search database
 image::autotype_selection_dialog_search.png[,70%]
@@ -104,7 +104,7 @@ The option to type just the username, password, or current TOTP value is availab
 TIP: On Windows, you will see an option to use a virtual keyboard in this sub-menu. This is an experimental feature that allows you to type into virtual machines by simulating actual keyboard presses. Some international keyboards may be unsupported due to limitations in the Windows API.
 
 === Performing Entry-Level Auto-Type
-You can quickly activate the default Auto-Type sequence for a particular entry using Entry-Level Auto-Type. For this operation, the KeePassXC window will be minimized and the Auto-Type sequence occurs in the previously selected window. You can perform Entry-Level Auto-Type from the toolbar icon *(A)*, entry context menu *(B)*, or by pressing `Ctrl+Shift+V`.
+You can quickly activate the default Auto-Type sequence for a particular entry using Entry-Level Auto-Type. For this operation, the KeePassXC window will be minimized and the Auto-Type sequence occurs in the previously selected window. You can perform Entry-Level Auto-Type from the toolbar icon *(A)*, entry context menu *(B)*, or by pressing kbd:[Ctrl+Shift+V].
 
 WARNING: Be careful when using Entry-Level Auto-Type as you can inadvertently type into the wrong window. For example, a chat window or email.
 

--- a/docs/topics/DatabaseOperations.adoc
+++ b/docs/topics/DatabaseOperations.adoc
@@ -75,7 +75,7 @@ NOTE: On Windows, you will be prompted to authenticate to Windows Hello after un
 .Windows Hello example
 image::quick_unlock_windows_hello.png[]
 
-When your database is locked, you will see the following unlock dialog. Simply press _Enter_ or click on _Unlock Database_ to initiate the biometric authentication process. If you are using a hardware key (e.g. Yubikey), it must be connected to your computer to complete the unlock.
+When your database is locked, you will see the following unlock dialog. Simply press kbd:[Enter] or click on _Unlock Database_ to initiate the biometric authentication process. If you are using a hardware key (e.g. Yubikey), it must be connected to your computer to complete the unlock.
 
 .Quick Unlock
 image::quick_unlock.png[]
@@ -92,7 +92,7 @@ All the details such as usernames, passwords, URLs, attachments, notes, and so o
 
 To add an entry, perform the following step:
 
-1. Navigate to Entries > New Entry (Or, press Ctrl+N). The following screen appears:
+1. Navigate to Entries > New Entry (or press kbd:[Ctrl+N]). The following screen appears:
 +
 .Adding a new entry
 image::edit_entry.png[]
@@ -115,7 +115,7 @@ To edit the details in an entry, perform the following steps:
 
 1. Select the entry you want to edit.
 
-2. Press `Enter`, click the edit toolbar icon, or right-click and select Edit Entry from the menu.
+2. Press kbd:[Enter], click the edit toolbar icon, or right-click and select Edit Entry from the menu.
 
 3. Make the desired changes.
 
@@ -156,13 +156,13 @@ TIP: Each KeePass application has different default icons. If you use a mobile a
 ==== Deleting an Entry
 To delete an entry, perform the following steps:
 
-1. Select the entry you want to delete and press the `Delete` button on your keyboard.
+1. Select the entry you want to delete and press the kbd:[Del] button on your keyboard.
 
 2. You will be prompted to move the entry to the Recycle Bin (if enabled).
 +
 NOTE: You can disable the recycle bin within the Database Settings. If the recycle bin is disabled then deleted entries will be permanently removed from the database.
 
-3. To permanently delete the entry, navigate to the Recycle Bin, select the entry you want to delete and press the `Delete` button on your keyboard.
+3. To permanently delete the entry, navigate to the Recycle Bin, select the entry you want to delete and press the kbd:[Del] button on your keyboard.
 
 // tag::advanced[]
 ==== Clone an Entry
@@ -170,7 +170,7 @@ Creating a clone of an entry provides you a ready-to-use template for creating n
 
 To create a clone of an existing entry, perform the following steps:
 
-1.	Right-click on the entry for which you want to create a clone and select _Clone Entry_. Alternatively, select the desired entry and press `Ctrl+K`.
+1.	Right-click on the entry for which you want to create a clone and select _Clone Entry_. Alternatively, select the desired entry and press kbd:[Ctrl+K].
 +
 .Clone entry from context menu
 image::clone_entry.png[]

--- a/docs/topics/KeyboardShortcuts.adoc
+++ b/docs/topics/KeyboardShortcuts.adoc
@@ -3,52 +3,62 @@ include::.sharedheader[]
 :imagesdir: ../images
 
 // tag::content[]
-NOTE: On macOS please substitute `Ctrl` with `Cmd` (aka `⌘`).
+NOTE: On macOS please substitute kbd:[Ctrl] with kbd:[Cmd] (AKA kbd:[⌘]).
 
 [grid=rows, frame=none, width=75%]
 |===
-|Action                       | Keyboard Shortcut
+|Action                          | Keyboard Shortcut
 
-|Settings                     | Ctrl + ,
-|Open Database                | Ctrl + O
-|Save Database                | Ctrl + S
-|Save Database As             | Ctrl + Shift + S
-|New Database                 | Ctrl + Shift + N
-|Close Database               | Ctrl + W ; Ctrl + F4
-|Lock Current Database        | Ctrl + L
-|Lock All Databases           | Ctrl + Shift + L
-|Database Settings            | Ctrl + Shift + ,
-|Database Reports             | Ctrl + Shift + R
-|Quit                         | Ctrl + Q
-|New Entry                    | Ctrl + N
-|Edit Entry                   | Enter ; Ctrl + E
-|Delete Entry                 | Delete
-|Clone Entry                  | Ctrl + D
-|Copy Username                | Ctrl + B
-|Copy Password                | Ctrl + C
-|Copy URL                     | Ctrl + U
-|Open URL                     | Ctrl + Shift + U
-|Copy TOTP                    | Ctrl + T
-|Copy Password and TOTP       | Ctrl + Y
-|Show TOTP                    | Ctrl + Shift + T
-|Trigger AutoType             | Ctrl + Shift + V
-|Add key to SSH Agent         | Ctrl + H
-|Remove key from SSH Agent    | Ctrl + Shift + H
-|Move entry up (if unsorted)   | Ctrl + Alt + Up
-|Move entry down (if unsorted) | Ctrl + Alt + Down
-|Sort Groups A-Z              | Ctrl + Down
-|Sort Groups Z-A              | Ctrl + Up
-|Minimize Window              | Ctrl + M
-|Hide Window                  | Ctrl + Shift + M
-|Select Next Database Tab     | Ctrl + Tab ; Ctrl + PageDn
-|Select Previous Database Tab | Ctrl + Shift + Tab ; Ctrl + PageUp
-|Select the nth database      | Ctrl + n, where n is the number of the database tab
-|Toggle Passwords Hidden      | Ctrl + Shift + C
-|Toggle Usernames Hidden      | Ctrl + Shift + B
-|Focus Groups (edit if focused)  | F1
-|Focus Entries (edit if focused) | F2
-|Focus Search                 | F3 ; Ctrl + F
-|Clear Search                 | Escape
-|Show Keyboard Shortcuts      | Ctrl + /
+|Settings                        | kbd:[Ctrl + ,]
+|Open Database                   | kbd:[Ctrl + O]
+|Save Database                   | kbd:[Ctrl + S]
+|Save Database As                | kbd:[Ctrl + Shift + S]
+|New Database                    | kbd:[Ctrl + Shift + N]
+|Close Database                  | kbd:[Ctrl + W] +
+_or_ +
+kbd:[Ctrl + F4]
+|Lock Current Database           | kbd:[Ctrl + L]
+|Lock All Databases              | kbd:[Ctrl + Shift + L]
+|Database Settings               | kbd:[Ctrl + Shift + ,]
+|Database Reports                | kbd:[Ctrl + Shift + R]
+|Quit                            | kbd:[Ctrl + Q]
+|New Entry                       | kbd:[Ctrl + N]
+|Edit Entry                      | kbd:[Enter] +
+_or_ +
+kbd:[Ctrl + E]
+|Delete Entry                    | kbd:[Del]
+|Clone Entry                     | kbd:[Ctrl + D]
+|Copy Username                   | kbd:[Ctrl + B]
+|Copy Password                   | kbd:[Ctrl + C]
+|Copy URL                        | kbd:[Ctrl + U]
+|Open URL                        | kbd:[Ctrl + Shift + U]
+|Copy TOTP                       | kbd:[Ctrl + T]
+|Copy Password and TOTP          | kbd:[Ctrl + Y]
+|Show TOTP                       | kbd:[Ctrl + Shift + T]
+|Trigger AutoType                | kbd:[Ctrl + Shift + V]
+|Add key to SSH Agent            | kbd:[Ctrl + H]
+|Remove key from SSH Agent       | kbd:[Ctrl + Shift + H]
+|Move entry up (if unsorted)     | kbd:[Ctrl + Alt + Up]
+|Move entry down (if unsorted)   | kbd:[Ctrl + Alt + Down]
+|Sort Groups A-Z                 | kbd:[Ctrl + Down]
+|Sort Groups Z-A                 | kbd:[Ctrl + Up]
+|Minimize Window                 | kbd:[Ctrl + M]
+|Hide Window                     | kbd:[Ctrl + Shift + M]
+|Select Next Database Tab        | kbd:[Ctrl + Tab] +
+_or_ +
+kbd:[Ctrl + PgDn]
+|Select Previous Database Tab    | kbd:[Ctrl + Shift + Tab] +
+_or_ +
+kbd:[Ctrl + PgUp]
+|Select the nth database         | kbd:[Ctrl + &lt;n&gt;], where kbd:[&lt;n&gt;] is the number of the database tab
+|Toggle Passwords Hidden         | kbd:[Ctrl + Shift + C]
+|Toggle Usernames Hidden         | kbd:[Ctrl + Shift + B]
+|Focus Groups (edit if focused)  | kbd:[F1]
+|Focus Entries (edit if focused) | kbd:[F2]
+|Focus Search                    | kbd:[F3] +
+_or_ +
+kbd:[Ctrl + F]
+|Clear Search                    | kbd:[Esc]
+|Show Keyboard Shortcuts         | kbd:[Ctrl + /]
 |===
 // end::content[]

--- a/docs/topics/PasswordGenerator.adoc
+++ b/docs/topics/PasswordGenerator.adoc
@@ -19,8 +19,8 @@ image::password_generator.png[]
 
 3. Select the length of the desired password by dragging the Length slider.
 4. Select the character-sets that you want to include in your password.
-5. Use the regenerate button (Ctrl + R) to make a new password using the chosen options.
-6. Use the clipboard button (Ctrl + C) to copy the generated password to the clipboard.
+5. Use the regenerate button (kbd:[Ctrl + R]) to make a new password using the chosen options.
+6. Use the clipboard button (kbd:[Ctrl + C]) to copy the generated password to the clipboard.
 7. Click the Advanced button to specify additional conditions for your desired password.
 +
 .Advanced Password Generator Options
@@ -39,6 +39,6 @@ Word Count slider.
 3. In the Word Separator field, enter a character, word, number, or space that you want to use as a separator between the words in your passphrase.
 4. _(Optional)_ You can choose a word case between lower, upper, and title case options.
 5. _(Optional)_ You can also load your own custom word lists. Click the plus sign button to the right of the wordlist selection dialog to choose a custom word list. You can download alternative lists from the https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases[EFF's Website] or from https://github.com/redacted/XKCD-password-generator#additional-languages[GitHub].
-6. Click the Regenerate button (Ctrl + R) to generate a new random passphrase.
-7. Click the Clipboard button (Ctrl + C) to copy the passphrase to the clipboard.
+6. Click the Regenerate button (kbd:[Ctrl + R]) to generate a new random passphrase.
+7. Click the Clipboard button (kbd:[Ctrl + C]) to copy the passphrase to the clipboard.
 // end::content[]

--- a/docs/topics/Reference.adoc
+++ b/docs/topics/Reference.adoc
@@ -77,8 +77,8 @@ Examples: +
 |Press the corresponding keyboard key
 
 |{UP}, {DOWN}, {LEFT}, {RIGHT}  |Press the corresponding arrow key
-|{F1}, {F2}, ..., {F16}         |Press F1, F2, etc.
-|{LEFTBRACE}, {RIGHTBRACE}      |Press `{` or `}`, respectively
+|{F1}, {F2}, ..., {F16}         |Press kbd:[F1], kbd:[F2], etc.
+|{LEFTBRACE}, {RIGHTBRACE}      |Press kbd:[{] or kbd:[}], respectively
 |{&lt;KEY&gt; X}  |Repeat &lt;KEY&gt; X times (e.g., {SPACE 5} inserts five spaces)
 |{DELAY=X}     |Set delay between key presses to X milliseconds
 |{DELAY X}     |Pause typing for X milliseconds
@@ -90,10 +90,10 @@ Examples: +
 |===
 |Modifier |Description
 
-|+        |SHIFT
-|^        |CTRL
-|%        |ALT
-|#        |WIN/CMD
+|+        |kbd:[Shift]
+|^        |kbd:[Ctrl]
+|%        |kbd:[Alt]
+|#        |kbd:[Win]/kbd:[Cmd]
 |===
 *Text Conversions:*
 


### PR DESCRIPTION
This PR adds the `kbd` macro for keys, which marks up keyboard instructions more correctly to use `<kbd>` in HTML.
I used Asciidoc's built-in syntax which as smart support for multi-key sequences. For example, `kbd:[Ctrl+E]` outputs to `<span class="keyseq"><kbd>Ctrl</kbd>+<kbd>E</kbd></span>`, which is the recommended way to mark it up in HTML and gives <kbd>Ctrl</kbd>+<kbd>E</kbd>.

Notes:

* I added `:experimental:` to each document's header so that the macro renders. [Asciidoc's own documentation]( https://docs.asciidoctor.org/asciidoc/latest/macros/keyboard-macro/) describes this name as a misnomer, and notes the feature has been considered stable for some time:
  > In order to use the UI macros, you must set the experimental document attribute. Although this attribute is named experimental, the UI macros are considered a stable feature of the AsciiDoc language. The requirement to specify the attribute is merely an optimization for the processor.
* I changed a few keys to resemble the way they are printed on the keyboard e.g. all instances of _Delete_ now say <kbd>Del</kbd>
* I introduced line breaks to the _Keyboard Shortcuts_ section, for instances where one action has more than one shortcut. This made it much more readable in my testing.
* For one particular keyboard shortcut, I changed <kbd>Ctrl</kbd>+<kbd>n</kbd> (where <kbd>n</kbd> represents a number) to <kbd>Ctrl</kbd>+<kbd>&lt;n&gt;</kbd>, in accordance with documentation elsewhere on the page.

## Screenshots

The following is not complete, but it gives an idea of what it will look like within documentation.

You already had a style defined for `kbd` in _dark.css_, so all screenshots use that.

| Old (public website) | New (local build) |
| ----- | ------ |
| ![User Guide - OLD](https://github.com/user-attachments/assets/8e23b4f5-f0bd-418e-bf47-6278c0fa708a) | ![User Guide - NEW](https://github.com/user-attachments/assets/8e57d777-15db-4609-a1bf-b773bee1b7e0) |
![Configure Auto-Type - OLD](https://github.com/user-attachments/assets/c6d994bb-81ef-4d6a-8901-3354b079b094)  | ![Configure Auto-Type - NEW](https://github.com/user-attachments/assets/313614ca-9ffc-4d56-8330-05e2712698bf) |
| ![Auto-Type Actions - OLD](https://github.com/user-attachments/assets/6ef8ff66-ac41-4b41-a7e2-95f20f873b02)  | ![Auto-Type Actions - NEW](https://github.com/user-attachments/assets/18123462-8a60-4b82-8a0a-b129941f34a2) | | 
| ![Keyboard Shortcuts - OLD](https://github.com/user-attachments/assets/6d959838-7ffd-44ea-8d60-33a4e41df2a3) | ![Keyboard Shortcuts - NEW](https://github.com/user-attachments/assets/ae316636-ce5a-468c-8ed7-e38a02bb8497)  |

## Testing strategy

I built and personally viewed each and every change. I took all screenshots on Firefox for Linux version 138.0.4.

```fish
mkdir build
cd build/
cmake ../
cmake --build . --target docs
```

## Type of change

✅ Documentation (non-code change)
