### PR TITLE
Make browser-triggered dialogue boxes appear on the current workspace (and related clean-up)

### DIFF
--- a/src/browser/BrowserAccessControlDialog.cpp
+++ b/src/browser/BrowserAccessControlDialog.cpp
@@ -23,9 +23,8 @@
 #include "core/Entry.h"
 #include "gui/Icons.h"
 
-BrowserAccessControlDialog::BrowserAccessControlDialog(QWidget* parent)
-    : QDialog(parent)
-    , m_ui(new Ui::BrowserAccessControlDialog())
+BrowserAccessControlDialog::BrowserAccessControlDialog()
+    : m_ui(new Ui::BrowserAccessControlDialog())
 {
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
 

--- a/src/browser/BrowserAccessControlDialog.h
+++ b/src/browser/BrowserAccessControlDialog.h
@@ -41,7 +41,7 @@ class BrowserAccessControlDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit BrowserAccessControlDialog(QWidget* parent = nullptr);
+    explicit BrowserAccessControlDialog();
     ~BrowserAccessControlDialog() override;
 
     void setEntries(const QList<Entry*>& entriesToConfirm, const QString& urlString, bool httpAuth);

--- a/src/browser/BrowserPasskeysConfirmationDialog.cpp
+++ b/src/browser/BrowserPasskeysConfirmationDialog.cpp
@@ -24,9 +24,8 @@
 
 #define STEP 1000
 
-BrowserPasskeysConfirmationDialog::BrowserPasskeysConfirmationDialog(QWidget* parent)
-    : QDialog(parent)
-    , m_ui(new Ui::BrowserPasskeysConfirmationDialog())
+BrowserPasskeysConfirmationDialog::BrowserPasskeysConfirmationDialog()
+    : m_ui(new Ui::BrowserPasskeysConfirmationDialog())
     , m_passkeyUpdated(false)
 {
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);

--- a/src/browser/BrowserPasskeysConfirmationDialog.h
+++ b/src/browser/BrowserPasskeysConfirmationDialog.h
@@ -34,7 +34,7 @@ class BrowserPasskeysConfirmationDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit BrowserPasskeysConfirmationDialog(QWidget* parent = nullptr);
+    explicit BrowserPasskeysConfirmationDialog();
     ~BrowserPasskeysConfirmationDialog() override;
 
     void registerCredential(const QString& username,

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -470,7 +470,7 @@ QList<Entry*> BrowserService::confirmEntries(QList<Entry*>& entriesToConfirm,
 
     m_dialogActive = true;
     updateWindowState();
-    BrowserAccessControlDialog accessControlDialog(m_currentDatabaseWidget);
+    BrowserAccessControlDialog accessControlDialog;
 
     connect(m_currentDatabaseWidget, SIGNAL(databaseLockRequested()), &accessControlDialog, SLOT(reject()));
 
@@ -583,7 +583,7 @@ QString BrowserService::storeKey(const QString& key)
     QString id;
 
     do {
-        QInputDialog keyDialog(m_currentDatabaseWidget);
+        QInputDialog keyDialog;
         connect(m_currentDatabaseWidget, SIGNAL(databaseLockRequested()), &keyDialog, SLOT(reject()));
         keyDialog.setWindowTitle(tr("KeePassXC - New key association request"));
         keyDialog.setLabelText(tr("You have received an association request for the following database:\n%1\n\n"
@@ -607,7 +607,7 @@ QString BrowserService::storeKey(const QString& key)
         contains =
             db->metadata()->customData()->contains(CustomData::getKeyWithPrefix(CustomData::BrowserKeyPrefix, id));
         if (contains) {
-            dialogResult = MessageBox::warning(m_currentDatabaseWidget,
+            dialogResult = MessageBox::warning(nullptr,
                                                tr("KeePassXC - Overwrite existing key?"),
                                                tr("A shared encryption key with the name \"%1\" "
                                                   "already exists.\nDo you want to overwrite it?")
@@ -668,7 +668,7 @@ QJsonObject BrowserService::showPasskeysRegisterPrompt(const QJsonObject& public
     const auto existingEntries = getPasskeyEntriesWithUserHandle(rpId, userId, keyList);
 
     raiseWindow();
-    BrowserPasskeysConfirmationDialog confirmDialog(m_currentDatabaseWidget);
+    BrowserPasskeysConfirmationDialog confirmDialog;
     confirmDialog.registerCredential(username, rpId, existingEntries, timeout);
 
     auto dialogResult = confirmDialog.exec();
@@ -761,7 +761,7 @@ QJsonObject BrowserService::showPasskeysAuthenticationPrompt(const QJsonObject& 
     const auto timeout = publicKeyOptions["timeout"].toInt();
 
     raiseWindow();
-    BrowserPasskeysConfirmationDialog confirmDialog(m_currentDatabaseWidget);
+    BrowserPasskeysConfirmationDialog confirmDialog;
     confirmDialog.authenticateCredential(entries, rpId, timeout);
     auto dialogResult = confirmDialog.exec();
     if (dialogResult == QDialog::Accepted) {

--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -35,12 +35,8 @@ DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
     , m_tabBar(new QTabBar(this))
 {
     setWindowTitle(tr("Unlock Database - KeePassXC"));
-    setWindowFlags(Qt::Dialog);
+    setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint);
     setWindowFlag(Qt::WindowContextHelpButtonHint, false);
-#ifdef Q_OS_LINUX
-    // Linux requires this to overcome some Desktop Environments (also no Quick Unlock)
-    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
-#endif
     // block input to the main window/application while the dialog is open
     setWindowModality(Qt::ApplicationModal);
 #ifdef Q_OS_WIN

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -41,7 +41,7 @@ DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
     : QTabWidget(parent)
     , m_dbWidgetStateSync(new DatabaseWidgetStateSync(this))
     , m_dbWidgetPendingLock(nullptr)
-    , m_databaseOpenDialog(new DatabaseOpenDialog(this))
+    , m_databaseOpenDialog(new DatabaseOpenDialog())
     , m_importWizard(nullptr)
     , m_databaseOpenInProgress(false)
 {


### PR DESCRIPTION
This ensures that various dialogue boxes which are opened in response to in-browser actions appear on the current workspace (and, most likely, centred on the monitor where the pointer currently is) instead of the workspace containing the main window.

Fixes #10328.

There is a related minor clean-up: I noticed that the db unlock dialogue box being placed above other windows was only happening on Linux, but other dboxes had this unconditionally. I have therefore brought it into line with the others.

## Testing strategy
* Ensure in advance that there is at least one password and passkey for the test site with no stored access control info and that there is a saved browser plugin key with the chosen test name.
* Start `keepassxc` or, if running, lock the test database.
* Move its main window to another workspace.
* Ensure that the browser plugin has no connection to the test db.
* Trigger each dbox in turn via the browser plugin:
  * database unlock;
  * key association request (use the chosen test name);
  * key storage confirmation;
  * browser access control;
  * passkey confirmation.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)