### PR TITLE
Replace qdbus with qdbus6 and kwalletd5 with kwalletd6

### DIFF
--- a/utils/keepassxc-kdewallet
+++ b/utils/keepassxc-kdewallet
@@ -9,14 +9,14 @@ KEEPASSXC=$(which -a keepassxc | sed -e "\\,$0,d" -e 'q')
 
 daemon_main() {
   # open kdewallet
-  handle=$(qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.open kdewallet 0 "$PROG")
-  while [[ true != $(qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.isOpen kdewallet) ]]; do
+  handle=$(qdbus6 org.kde.kwalletd6 /modules/kwalletd6 open kdewallet 0 "$PROG")
+  while [[ true != $(qdbus6 org.kde.kwalletd6 /modules/kwalletd6 isOpen kdewallet) ]]; do
     sleep 1
   done
 
   declare -A DBs
   for DBPATH in $(ls -r $KDBX_SEARCH); do
-    DBs[$(realpath $DBPATH)]=$(qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.readPassword "$handle" "Passwords" "${DBPATH##*/}" "$PROG")
+    DBs[$(realpath $DBPATH)]=$(qdbus6 org.kde.kwalletd6 /modules/kwalletd6 readPassword "$handle" "Passwords" "${DBPATH##*/}" "$PROG")
   done
 
   # launch real keepassxc
@@ -24,7 +24,7 @@ daemon_main() {
   "$KEEPASSXC" --pw-stdin "${!DBs[@]}" <<<"${DBs[*]}" &
 
   # done with kdewallet
-  qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.close "$handle" "false" "$PROG"
+  qdbus6 org.kde.kwalletd6 /modules/kwalletd6 close "$handle" "false" "$PROG"
 }
 
 if [[ $1 == '-d' ]]; then


### PR DESCRIPTION
For KDE Plasma 6, kwallet5 migrated to kwallet6, so that will be used. The API is nearly identical too, so not much was changed.

## Testing strategy
I executed the code, and it worked fine, opening kwallet first and then keepassxc.

## Type of change
- ✅ Refactor (significant modification to existing code)
