### PR TITLE
Add an option to add KeePassXC to PATH during installation

### DIFF
--- a/share/windows/KPXC_InstallDirDlg.wxs
+++ b/share/windows/KPXC_InstallDirDlg.wxs
@@ -24,7 +24,7 @@
                 <!-- Custom Controls for KPXC Installer -->
                 <Control Id="DesktopShortcutCheckBox" Type="CheckBox" X="20" Y="150" Width="290" Height="17" Property="INSTALLDESKTOPSHORTCUT" CheckBoxValue="1" Text="Create a shortcut on the desktop" />
                 <Control Id="AutostartCheckBox" Type="CheckBox" X="20" Y="170" Width="290" Height="17" Property="AUTOSTARTPROGRAM" CheckBoxValue="1" Text="Autostart KeePassXC on login" />
-                <Control Id="KEEPASSXC_IN_PATH_CheckBox" Type="CheckBox" X="20" Y="190" Width="290" Height="17" CheckBoxValue="1" Property="KEEPASSXC_IN_PATH" Text="Add KeePassXC to the PATH environment variable" />
+                <Control Id="AddToPathCheckBox" Type="CheckBox" X="20" Y="190" Width="290" Height="17" Property="ADDTOPATH" CheckBoxValue="1" Text="Add KeePassXC to the PATH environment variable" />
             </Dialog>
         </UI>
     </Fragment>

--- a/share/windows/KPXC_InstallDirDlg.wxs
+++ b/share/windows/KPXC_InstallDirDlg.wxs
@@ -24,6 +24,7 @@
                 <!-- Custom Controls for KPXC Installer -->
                 <Control Id="DesktopShortcutCheckBox" Type="CheckBox" X="20" Y="150" Width="290" Height="17" Property="INSTALLDESKTOPSHORTCUT" CheckBoxValue="1" Text="Create a shortcut on the desktop" />
                 <Control Id="AutostartCheckBox" Type="CheckBox" X="20" Y="170" Width="290" Height="17" Property="AUTOSTARTPROGRAM" CheckBoxValue="1" Text="Autostart KeePassXC on login" />
+                <Control Id="KEEPASSXC_IN_PATH_CheckBox" Type="CheckBox" X="20" Y="190" Width="290" Height="17" CheckBoxValue="1" Property="KEEPASSXC_IN_PATH" Text="Add KeePassXC to the PATH environment variable" />
             </Dialog>
         </UI>
     </Fragment>

--- a/share/windows/wix-patch.xml
+++ b/share/windows/wix-patch.xml
@@ -6,8 +6,5 @@
         <Verb Id="open" Command="Open" TargetFile="CM_FP_KeePassXC.exe" Argument="&quot;%1&quot;"/>
       </Extension>
     </ProgId>
-     <Environment Id="KeePassXCSystemPathEntryENV" Action="set" Part="last"
-        Name="PATH" Value="[INSTALL_ROOT]"
-        System="yes"/>
   </CPackWiXFragment>
 </CPackWiXPatch>

--- a/share/windows/wix-patch.xml
+++ b/share/windows/wix-patch.xml
@@ -6,5 +6,8 @@
         <Verb Id="open" Command="Open" TargetFile="CM_FP_KeePassXC.exe" Argument="&quot;%1&quot;"/>
       </Extension>
     </ProgId>
+     <Environment Id="KeePassXCSystemPathEntryENV" Action="set" Part="last"
+        Name="PATH" Value="[INSTALL_ROOT]"
+        System="yes"/>
   </CPackWiXFragment>
 </CPackWiXPatch>

--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -57,6 +57,11 @@
         </Component>
 
         <DirectoryRef Id="TARGETDIR">
+            <!-- Save the "KEEPASSXC_IN_PATH" checkbox value persistently in the registry.  -->
+            <Component Id="KeePassXCRegistry_InstallInPATH">
+                <!-- Use a leading "0" so the value parses as an integer even when the property is unset.  -->
+                <RegistryValue Root="HKLM" Key="Software\KeePassXC" Name="InstallInPATH" Type="integer" Value="0[KEEPASSXC_IN_PATH]" />
+            </Component>
             <!-- Startmenu shortcuts -->
             <Directory Id="ProgramMenuFolder">
                 <Directory Id="ApplicationProgramsFolder" Name="KeePassXC">
@@ -106,6 +111,31 @@
         </Property>
         <Property Id="INSTALLDESKTOPSHORTCUT" Secure="yes" />
 
+        <!-- Hold the "KEEPASSXC_IN_PATH" checkbox value in a public property to propagate to the InstallExecuteSequence. -->
+        <Property Id="KEEPASSXC_IN_PATH" Value="Init" />
+
+        <!-- Always initialize the checkbox value so it cannot be directly overridden from the command line.  -->
+        <SetProperty Action="Set_KEEPASSXC_IN_PATH_Init"       Id="KEEPASSXC_IN_PATH" After="AppSearch"                    Sequence="first" Value="1" />
+
+        <!-- Read the "KEEPASSXC_IN_PATH" checkbox value from the registry, if it was stored previously.
+             Properties using RegistrySearch cannot be private, so use a private-looking public name. -->
+        <Property Id="_KEEPASSXC_IN_PATH_REG">
+            <RegistrySearch Id="KEEPASSXC_IN_PATH_RegistrySearch_HKLM" Root="HKLM" Key="Software\KeePassXC" Name="InstallInPATH" Type="raw" />
+        </Property>
+
+        <!-- Override the default "KEEPASSXC_IN_PATH" checkbox with a value read from the registry, if any.  -->
+        <SetProperty Action="Set_KEEPASSXC_IN_PATH_REG_0"      Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_Init"       Sequence="first" Value="{}"> _KEEPASSXC_IN_PATH_REG = "#0"                    </SetProperty>
+        <SetProperty Action="Set_KEEPASSXC_IN_PATH_REG_1"      Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_REG_0"      Sequence="first" Value="1">  _KEEPASSXC_IN_PATH_REG = "#1"                    </SetProperty>
+
+        <!-- Override the default "KEEPASSXC_IN_PATH" checkbox with a value specified on the command line, if any.  -->
+        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_0"      Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_REG_1"      Sequence="first" Value="{}">  ADD_KEEPASSXC_TO_PATH = "0"                     </SetProperty>
+        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_1"      Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_CMD_0"      Sequence="first" Value="1">   ADD_KEEPASSXC_TO_PATH = "1"                     </SetProperty>
+        <!-- Support legacy values too.  -->
+        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_None"   Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_CMD_1"      Sequence="first" Value="{}">  ADD_KEEPASSXC_TO_PATH = "None"                  </SetProperty>
+        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_System" Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_CMD_None"   Sequence="first" Value="1">   ADD_KEEPASSXC_TO_PATH = "System" AND ALLUSERS   </SetProperty>
+        <!-- Per-user installation is not implemented, but reserve the old value for future use.  -->
+        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_User"   Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_CMD_System" Sequence="first" Value="1">   ADD_KEEPASSXC_TO_PATH = "User" AND NOT ALLUSERS </SetProperty>
+
         <!-- Set properties based on existing conditions, prevents changing state on upgrade -->
         <SetProperty Id="AUTOSTARTPROGRAM" After="AppSearch" Value="">AUTOSTARTPROGRAM="0" OR (WIX_UPGRADE_DETECTED AND NOT AUTOSTARTPROGRAM_REGISTRY)</SetProperty>
         <SetProperty Id="LicenseAccepted" After="AppSearch" Value="1">WIX_UPGRADE_DETECTED</SetProperty>
@@ -114,6 +144,7 @@
             <ComponentRef Id="ApplicationShortcuts" />
             <ComponentRef Id="Autostart" />
             <ComponentRef Id="DesktopShortcut" />
+            <ComponentRef Id="KeePassXCRegistry_InstallInPATH"/>
         </FeatureRef>
 
         <!-- Action to launch application after installer exits -->

--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -56,12 +56,14 @@
             <Condition>AUTOSTARTPROGRAM</Condition>
         </Component>
 
+        <!-- Add KeePassXC to PATH -->
+        <Component Id="AddKeePassXCToPath" Guid="*" Directory="INSTALL_ROOT">
+            <Condition>ADDTOPATH</Condition>
+            <Environment Id="KeePassXCSystemPathEntryENV" Action="set" Part="last" Name="PATH" Value="[INSTALL_ROOT]" System="yes"/>
+            <RegistryValue Root="HKCU" Key="Software\KeePassXC" Name="AddedToPATH" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+
         <DirectoryRef Id="TARGETDIR">
-            <!-- Save the "KEEPASSXC_IN_PATH" checkbox value persistently in the registry.  -->
-            <Component Id="KeePassXCRegistry_InstallInPATH">
-                <!-- Use a leading "0" so the value parses as an integer even when the property is unset.  -->
-                <RegistryValue Root="HKLM" Key="Software\KeePassXC" Name="InstallInPATH" Type="integer" Value="0[KEEPASSXC_IN_PATH]" />
-            </Component>
             <!-- Startmenu shortcuts -->
             <Directory Id="ProgramMenuFolder">
                 <Directory Id="ApplicationProgramsFolder" Name="KeePassXC">
@@ -110,41 +112,21 @@
             <RegistrySearch Id="AutoStartSearch" Root="HKCU" Key="Software\Microsoft\Windows\CurrentVersion\Run" Name="$(var.CPACK_PACKAGE_NAME)" Type="raw" />
         </Property>
         <Property Id="INSTALLDESKTOPSHORTCUT" Secure="yes" />
-
-        <!-- Hold the "KEEPASSXC_IN_PATH" checkbox value in a public property to propagate to the InstallExecuteSequence. -->
-        <Property Id="KEEPASSXC_IN_PATH" Value="Init" />
-
-        <!-- Always initialize the checkbox value so it cannot be directly overridden from the command line.  -->
-        <SetProperty Action="Set_KEEPASSXC_IN_PATH_Init"       Id="KEEPASSXC_IN_PATH" After="AppSearch"                    Sequence="first" Value="1" />
-
-        <!-- Read the "KEEPASSXC_IN_PATH" checkbox value from the registry, if it was stored previously.
-             Properties using RegistrySearch cannot be private, so use a private-looking public name. -->
-        <Property Id="_KEEPASSXC_IN_PATH_REG">
-            <RegistrySearch Id="KEEPASSXC_IN_PATH_RegistrySearch_HKLM" Root="HKLM" Key="Software\KeePassXC" Name="InstallInPATH" Type="raw" />
+        <Property Id="ADDTOPATH" Value="1" Secure="yes" />
+        <Property Id="ADDTOPATH_REGISTRY">
+            <RegistrySearch Id="AddToPathSearch" Root="HKCU" Key="Software\KeePassXC" Name="AddedToPATH" Type="raw" />
         </Property>
 
-        <!-- Override the default "KEEPASSXC_IN_PATH" checkbox with a value read from the registry, if any.  -->
-        <SetProperty Action="Set_KEEPASSXC_IN_PATH_REG_0"      Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_Init"       Sequence="first" Value="{}"> _KEEPASSXC_IN_PATH_REG = "#0"                    </SetProperty>
-        <SetProperty Action="Set_KEEPASSXC_IN_PATH_REG_1"      Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_REG_0"      Sequence="first" Value="1">  _KEEPASSXC_IN_PATH_REG = "#1"                    </SetProperty>
-
-        <!-- Override the default "KEEPASSXC_IN_PATH" checkbox with a value specified on the command line, if any.  -->
-        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_0"      Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_REG_1"      Sequence="first" Value="{}">  ADD_KEEPASSXC_TO_PATH = "0"                     </SetProperty>
-        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_1"      Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_CMD_0"      Sequence="first" Value="1">   ADD_KEEPASSXC_TO_PATH = "1"                     </SetProperty>
-        <!-- Support legacy values too.  -->
-        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_None"   Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_CMD_1"      Sequence="first" Value="{}">  ADD_KEEPASSXC_TO_PATH = "None"                  </SetProperty>
-        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_System" Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_CMD_None"   Sequence="first" Value="1">   ADD_KEEPASSXC_TO_PATH = "System" AND ALLUSERS   </SetProperty>
-        <!-- Per-user installation is not implemented, but reserve the old value for future use.  -->
-        <SetProperty Action="Set_KEEPASSXC_IN_PATH_CMD_User"   Id="KEEPASSXC_IN_PATH" After="Set_KEEPASSXC_IN_PATH_CMD_System" Sequence="first" Value="1">   ADD_KEEPASSXC_TO_PATH = "User" AND NOT ALLUSERS </SetProperty>
-
         <!-- Set properties based on existing conditions, prevents changing state on upgrade -->
-        <SetProperty Id="AUTOSTARTPROGRAM" After="AppSearch" Value="">AUTOSTARTPROGRAM="0" OR (WIX_UPGRADE_DETECTED AND NOT AUTOSTARTPROGRAM_REGISTRY)</SetProperty>
+        <SetProperty Id="AUTOSTARTPROGRAM" After="AppSearch" Value="" Sequence="first">AUTOSTARTPROGRAM="0" OR (WIX_UPGRADE_DETECTED AND NOT AUTOSTARTPROGRAM_REGISTRY)</SetProperty>
+        <SetProperty Id="ADDTOPATH" After="AppSearch" Value="" Sequence="first">ADDTOPATH="0" OR (WIX_UPGRADE_DETECTED AND NOT ADDTOPATH_REGISTRY)</SetProperty>
         <SetProperty Id="LicenseAccepted" After="AppSearch" Value="1">WIX_UPGRADE_DETECTED</SetProperty>
 
         <FeatureRef Id="ProductFeature">
             <ComponentRef Id="ApplicationShortcuts" />
             <ComponentRef Id="Autostart" />
             <ComponentRef Id="DesktopShortcut" />
-            <ComponentRef Id="KeePassXCRegistry_InstallInPATH"/>
+            <ComponentRef Id="AddKeePassXCToPath"/>
         </FeatureRef>
 
         <!-- Action to launch application after installer exits -->


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail, why is this change required? )
[NOTE]: # ( Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )

This will make life easier for those running keepassxc-cli in the terminal.
## Screenshots

![image](https://github.com/user-attachments/assets/f5cb39c2-7a4b-42ad-a1bb-6376d6a8882b)

[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )

## Testing strategy
I tested my modification with the msi installer, but I was unable to build the exe installer. I haven't tested it myself, but the CMake documentation states that it should work.

>   [CPACK_NSIS_MODIFY_PATH](https://cmake.org/cmake/help/v3.1/module/CPackNSIS.html#variable:CPACK_NSIS_MODIFY_PATH)
    Modify PATH toggle. If this is set to “ON”, then an extra page will appear in the installer that will allow the user to choose whether the program directory should be added to the system PATH variable


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
