### PR TITLE
Preserve EntryView scroll and selection state when switching databases in search mode

### DIFF
--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -33,6 +33,9 @@
 #include "gui/Icons.h"
 #include "gui/SortFilterHideProxyModel.h"
 
+#include "core/Entry.h"
+#include <QtCore/QUuid>
+
 #define ICON_ONLY_SECTION_SIZE 26
 
 class PasswordStrengthItemDelegate : public QStyledItemDelegate
@@ -216,14 +219,14 @@ void EntryView::displayGroup(Group* group)
 
 void EntryView::displaySearch(const QList<Entry*>& entries)
 {
+    // Save state before changing
+    saveViewState();
+
     m_model->setEntries(entries);
     header()->showSection(EntryModel::ParentGroup);
 
-    setFirstEntryActive();
-
-    // Reset sort column to 'Group', overrides DatabaseWidgetStateSync
-    m_sortModel->sort(EntryModel::ParentGroup, Qt::AscendingOrder);
-    sortByColumn(EntryModel::ParentGroup, Qt::AscendingOrder);
+    // Restore state after entries change
+    restoreViewState(entries);
 
     m_inSearchMode = true;
 }
@@ -594,4 +597,35 @@ void EntryView::startDrag(Qt::DropActions supportedActions)
 bool EntryView::isColumnHidden(int logicalIndex)
 {
     return header()->isSectionHidden(logicalIndex) || header()->sectionSize(logicalIndex) == 0;
+}
+
+void EntryView::saveViewState()
+{
+    // Save current sort state and selected entry UUID
+    m_lastSortColumn = header()->sortIndicatorSection();
+    m_lastSortOrder = header()->sortIndicatorOrder();
+    Entry* selected = currentEntry();
+    m_lastSelectedEntryUuid = selected ? selected->uuid() : QUuid();
+}
+
+void EntryView::restoreViewState(const QList<Entry*>& entries)
+{
+    // Restore sort state if previously saved
+    if (m_lastSortColumn >= 0) {
+        m_sortModel->sort(m_lastSortColumn, m_lastSortOrder);
+        sortByColumn(m_lastSortColumn, m_lastSortOrder);
+    }
+
+    // Try to restore selection by UUID
+    if (!m_lastSelectedEntryUuid.isNull()) {
+        for (Entry* entry : entries) {
+            if (entry->uuid() == m_lastSelectedEntryUuid) {
+                setCurrentEntry(entry);
+                return;
+            }
+        }
+    }
+
+    // Fallback: select first entry if no previous selection found
+    setFirstEntryActive();
 }

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -612,7 +612,6 @@ void EntryView::restoreViewState(const QList<Entry*>& entries)
 {
     // Restore sort state if previously saved
     if (m_lastSortColumn >= 0) {
-        m_sortModel->sort(m_lastSortColumn, m_lastSortOrder);
         sortByColumn(m_lastSortColumn, m_lastSortOrder);
     }
 

--- a/src/gui/entry/EntryView.h
+++ b/src/gui/entry/EntryView.h
@@ -23,6 +23,8 @@
 
 #include "gui/entry/EntryModel.h"
 
+#include <QtCore/QUuid>
+
 class Entry;
 class EntryModel;
 class Group;
@@ -51,6 +53,9 @@ public:
 
     void displayGroup(Group* group);
     void displaySearch(const QList<Entry*>& entries);
+
+    void saveViewState();
+    void restoreViewState(const QList<Entry*>& entries);
 
 signals:
     void entryActivated(Entry* entry, EntryModel::ModelColumn column);
@@ -87,6 +92,10 @@ private:
 
     QMenu* m_headerMenu;
     QActionGroup* m_columnActions;
+
+    int m_lastSortColumn = -1;
+    Qt::SortOrder m_lastSortOrder = Qt::AscendingOrder;
+    QUuid m_lastSelectedEntryUuid;
 };
 
 #endif // KEEPASSX_ENTRYVIEW_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )

## Fix: Preserve EntryView Scroll and Selection State in Search Mode

### Description

This pull request fixes a long-standing issue where the entry list scroll position and selection jump to the wrong location when switching between open databases in search mode, especially if sorting is set to anything other than "Group." The bug is described in detail in [#12001](https://github.com/keepassxreboot/keepassxc/issues/12001).

#### Problem

When switching between databases with search active, the entry view always resets sort order to "Group" and selects the first entry, ignoring the user's prior sort and selection. This causes the scroll position to jump unexpectedly, breaking user workflow and expectations.

#### Solution

- The entry view now preserves the user's chosen sort column and order in search mode when switching between databases.
- The previously selected entry is restored by UUID after updating the entry list, if possible.
- If the previous selection cannot be restored, the first entry is selected as a fallback.
- The code no longer forcibly resets sorting to "Group" when displaying search results.

This change ensures consistent and expected navigation when using multiple databases, search mode, and custom sort orders.

### Steps to Reproduce (Before Fix)

See [#12001](https://github.com/keepassxreboot/keepassxc/issues/12001) for detailed steps and screenshots.

### Testing strategy

1. Open two or more databases.
2. In each, use search mode and set a sort order other than "Group."
3. Select an entry in one database and switch between databases.
4. Observe that the scroll position and selected entry remain consistent and as expected.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

---

### Additional Notes

- This PR does **not** introduce any new dependencies or break existing UI/UX patterns.
- Fixes: #12001

### AI Assistance Disclosure

Parts of this contribution were generated or reviewed using GitHub Copilot (OpenAI GPT-4o), an AI service, to assist with code search, patch suggestion, and documentation refinement. All code was written and fully reviewed by the contributor before submission, in accordance with [KeePassXC's contributing guidelines](https://github.com/keepassxreboot/keepassxc/blob/develop/.github/CONTRIBUTING.md#using-ai).

- **AI Service Used:** GitHub Copilot
- **Model:** OpenAI GPT-4o