### PR TITLE
Allow read-only native message files

### DIFF
--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -372,16 +372,30 @@ bool NativeMessageInstaller::createNativeMessageFile(SupportedBrowsers browser)
 
     QFile scriptFile(path);
     if (!scriptFile.open(QIODevice::WriteOnly)) {
-        qWarning() << "Browser Plugin: Failed to open native message file for writing at " << scriptFile.fileName();
-        qWarning() << scriptFile.errorString();
-        return false;
+        if (!scriptFile.open(QIODevice::ReadOnly)) {
+            qWarning() << "Browser Plugin: Failed to open native message file at " << scriptFile.fileName();
+            qWarning() << scriptFile.errorString();
+            return false;
+        }
+
+        // We failed to write to `scriptFile`, but we can read it, so we assume that it's a read-only file.
+        // The write is considered to have succeeded if that read-only file already contains the content we would have written.
+        QJsonDocument expectedDoc(constructFile(browser));
+        QJsonDocument actualDoc = QJsonDocument::fromJson(scriptFile.readAll());
+
+        if (expectedDoc != actualDoc) {
+            qWarning() << "Browser Plugin: Unexpected (read-only) native message file at " << scriptFile.fileName();
+            qWarning() << "Expected contents: " << expectedDoc;
+            return false;
+        }
+    } else {
+        QJsonDocument doc(constructFile(browser));
+        if (scriptFile.write(doc.toJson()) < 0) {
+            qWarning() << "Browser Plugin: Failed to write native message file at " << scriptFile.fileName();
+            qWarning() << scriptFile.errorString();
+            return false;
+        }
     }
 
-    QJsonDocument doc(constructFile(browser));
-    if (scriptFile.write(doc.toJson()) < 0) {
-        qWarning() << "Browser Plugin: Failed to write native message file at " << scriptFile.fileName();
-        qWarning() << scriptFile.errorString();
-        return false;
-    }
     return true;
 }

--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -379,7 +379,7 @@ bool NativeMessageInstaller::createNativeMessageFile(SupportedBrowsers browser)
         }
 
         // We failed to write to `scriptFile`, but we can read it, so we assume that it's a read-only file.
-        // The write is considered to have succeeded if that read-only file already contains the content we would have written.
+        // Consider success if the read-only file already contains the content we would have written.
         QJsonDocument expectedDoc(constructFile(browser));
         QJsonDocument actualDoc = QJsonDocument::fromJson(scriptFile.readAll());
 


### PR DESCRIPTION
Allow read-only native message files when the on-disk JSON matches the JSON `keepassxc` wants to write.

I use  [home-manager](https://nix-community.github.io/home-manager/index.xhtml#preface) to manage my system. I found that it's most reliable when I let home-manager manage `~/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json`. Instead of writing the file directly, home-manager creates a symlink to a read-only file in the [Nix store](https://zero-to-nix.com/concepts/nix-store/). Current versions of `keepassxc` report an error when they encounter this, because they unconditionally write to that file. This change prevents that error when the read-only file matches what `keepassxc` would have written (up to formatting differences).

## Testing strategy

Manual inspection; recompiled `keepassxc` and checked that it does what I want.

## Type of change

- ✅ New feature (change that adds functionality)