### PR TITLE
Fix two problems with URL wildcard matching

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1572,11 +1572,11 @@ bool BrowserService::handleURLWithWildcards(const QUrl& entryQUrl, const QString
         }
 
         // Escape illegal characters
-        auto re = firstPart.replace(QRegularExpression(R"(([!\^\$\+\-\(\)@<>]))"), "\\\\1");
+        auto re = Tools::escapeRegex(firstPart);
 
         if (hostnameUsed) {
             // Replace all host parts with wildcards
-            re = re.replace(QString("%1.").arg(UrlTools::URL_WILDCARD), "(.*?)");
+            re = re.replace(QString("%1.").arg(UrlTools::URL_WILDCARD), "(.*?)\\.");
         }
 
         // Append a + to the end of regex to match all paths after the last asterisk

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -411,6 +411,7 @@ void TestBrowser::testSearchEntriesWithWildcardURLs()
         "https://subdomain.*.github.com/*/second",
         "https://*.sub.github.com/*",
         "https://********", // Invalid wildcard URL
+        "https://*.thub.com/", // Partial suffix URL
         "https://subdomain.yes.github.com/*",
         "https://example.com:8448/*",
         "https://example.com/*/*",
@@ -433,13 +434,12 @@ void TestBrowser::testSearchEntriesWithWildcardURLs()
 
     auto result = m_browserService->searchEntries(
         db, "https://github.com/login_page/second", "https://github.com/login_page/second");
-    QCOMPARE(result.length(), 6);
+    QCOMPARE(result.length(), 5);
     QCOMPARE(firstUrl(result[0]), QString("https://github.com/login_page/*"));
     QCOMPARE(firstUrl(result[1]), QString("https://github.com/*/second"));
     QCOMPARE(firstUrl(result[2]), QString("https://github.com/*"));
     QCOMPARE(firstUrl(result[3]), QString("http://github.com/*"));
     QCOMPARE(firstUrl(result[4]), QString("github.com/*"));
-    QCOMPARE(firstUrl(result[5]), QString("https://*.github.com/*"));
 
     result = m_browserService->searchEntries(
         db, "https://subdomain.sub.github.com/login_page/second", "https://subdomain.sub.github.com/login_page/second");
@@ -503,12 +503,11 @@ void TestBrowser::testSearchEntriesWithWildcardURLs()
     result = m_browserService->searchEntries(
         db, "https://github.com/login_page/second", "https://github.com/login_page/second");
 
-    QCOMPARE(result.length(), 5);
+    QCOMPARE(result.length(), 4);
     QCOMPARE(firstUrl(result[0]), QString("https://github.com/login_page/*"));
     QCOMPARE(firstUrl(result[1]), QString("https://github.com/*/second"));
     QCOMPARE(firstUrl(result[2]), QString("https://github.com/*"));
     QCOMPARE(firstUrl(result[3]), QString("github.com/*")); // Defaults to https
-    QCOMPARE(firstUrl(result[4]), QString("https://*.github.com/*"));
 }
 
 void TestBrowser::testInvalidEntries()


### PR DESCRIPTION
* Fixes #12255
* Periods were not being escaped in the url string before being used in a regex resulting in matching 'any character' between domain parts
* Wildcards entered as `*.` were being replaced with simply `*` resulting in unexpected matches to occur. Fixing this has a side effect of `https://*.github.com` NOT matching `https://github.com` which should be the expected behavior. Users can enter both url's if they desire to match the primary and all sub domains or leave out the wildcard entirely to use normal matching behavior.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Updated unit tests to conform with new expected behavior

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
