### PR TITLE
revert baseline to recover full build from scratch (with VCPKG install)

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "keepassxc",
   "version-string": "2.8.0",
-  "builtin-baseline": "f9c128a6f7a96f5fa2f6f089f37ed6788a90e4b0",
+  "builtin-baseline": "2a6371b01420d8820d158b4707e79931feba27aa",
   "dependencies": [
     {
       "name": "argon2",


### PR DESCRIPTION
The builtin-baseline used in the last commit breaks the build whenever a `vcpkg install` is needed.

After merging commit 2c2b686593a695f06628676b69c455410d88ca6b my build failed. I cleaned the cache (of the build) and it still failed with the same error message (see failed build link bellow). When I reverted the baseline hash (almost equivalent to reverting completely 2c2b686593a695f06628676b69c455410d88ca6b, the build recovered. 

Is it possible that after the last change the `vcpkg install` was not run (manually on developer machine) and then not run by the automatic build (because the build does not take care of _installs_) ... or that the cache of the builds is good to make it succeed?


 - Here is the link that failed: https://github.com/blessio/keepassxc-B/actions/runs/16245876021/job/45869821422#step:17:606 
 - here is the **success** immediately after this cherrypicked commit: https://github.com/blessio/keepassxc-B/actions/runs/16272709793

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

## Test strategy
  - all automatic unit tests are run as part of the build itself