### PR TITLE
Add URL double-click action option to Settings

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -562,10 +562,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open browser on double clicking URL field in entry view</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Font size:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,6 +571,26 @@
     </message>
     <message>
         <source>Skip confirmation for main window Auto-Type actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Double-click action for URL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Double-click action for URL field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open entry URL in browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy entry URL to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -493,8 +493,8 @@ void Config::migrate()
     }
 
     // Migrate from boolean OpenURLOnDoubleClick to enum URLDoubleClickAction
-    if (m_settings->contains(configStrings[OpenURLOnDoubleClick].name) && 
-        !m_settings->contains(configStrings[URLDoubleClickAction].name)) {
+    if (m_settings->contains(configStrings[OpenURLOnDoubleClick].name)
+        && !m_settings->contains(configStrings[URLDoubleClickAction].name)) {
         bool openUrlOnDoubleClick = get(OpenURLOnDoubleClick).toBool();
         // Convert: true (open browser) -> 1, false (edit entry) -> 0
         set(URLDoubleClickAction, openUrlOnDoubleClick ? 1 : 0);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -67,6 +67,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::SearchLimitGroup,{QS("SearchLimitGroup"), Roaming, false}},
     {Config::MinimizeOnOpenUrl,{QS("MinimizeOnOpenUrl"), Roaming, false}},
     {Config::OpenURLOnDoubleClick, {QS("OpenURLOnDoubleClick"), Roaming, true}},
+    {Config::URLDoubleClickAction, {QS("URLDoubleClickAction"), Roaming, 1}},
     {Config::HideWindowOnCopy,{QS("HideWindowOnCopy"), Roaming, false}},
     {Config::MinimizeOnCopy,{QS("MinimizeOnCopy"), Roaming, true}},
     {Config::AutoGeneratePasswordForNewEntries,{QS("AutoGeneratePasswordForNewEntries"), Roaming, false}},
@@ -489,6 +490,15 @@ void Config::migrate()
 
         // Reset database columns if upgrading from pre 2.6.0
         remove(GUI_ListViewState);
+    }
+
+    // Migrate from boolean OpenURLOnDoubleClick to enum URLDoubleClickAction
+    if (m_settings->contains(configStrings[OpenURLOnDoubleClick].name) && 
+        !m_settings->contains(configStrings[URLDoubleClickAction].name)) {
+        bool openUrlOnDoubleClick = get(OpenURLOnDoubleClick).toBool();
+        // Convert: true (open browser) -> 1, false (edit entry) -> 0
+        set(URLDoubleClickAction, openUrlOnDoubleClick ? 1 : 0);
+        // Keep the old setting for now for compatibility
     }
 
     m_settings->setValue("ConfigVersion", CONFIG_VERSION);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -67,7 +67,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::SearchLimitGroup,{QS("SearchLimitGroup"), Roaming, false}},
     {Config::MinimizeOnOpenUrl,{QS("MinimizeOnOpenUrl"), Roaming, false}},
     {Config::OpenURLOnDoubleClick, {QS("OpenURLOnDoubleClick"), Roaming, true}},
-    {Config::URLDoubleClickAction, {QS("URLDoubleClickAction"), Roaming, 1}},
+    {Config::URLDoubleClickAction, {QS("URLDoubleClickAction"), Roaming, 0}},
     {Config::HideWindowOnCopy,{QS("HideWindowOnCopy"), Roaming, false}},
     {Config::MinimizeOnCopy,{QS("MinimizeOnCopy"), Roaming, true}},
     {Config::AutoGeneratePasswordForNewEntries,{QS("AutoGeneratePasswordForNewEntries"), Roaming, false}},
@@ -496,8 +496,8 @@ void Config::migrate()
     if (m_settings->contains(configStrings[OpenURLOnDoubleClick].name)
         && !m_settings->contains(configStrings[URLDoubleClickAction].name)) {
         bool openUrlOnDoubleClick = get(OpenURLOnDoubleClick).toBool();
-        // Convert: true (open browser) -> 1, false (edit entry) -> 0
-        set(URLDoubleClickAction, openUrlOnDoubleClick ? 1 : 0);
+        // Convert: true (open browser) -> 0, false (edit entry) -> 2
+        set(URLDoubleClickAction, openUrlOnDoubleClick ? 0 : 2);
         // Keep the old setting for now for compatibility
     }
 

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -50,6 +50,7 @@ public:
         SearchLimitGroup,
         MinimizeOnOpenUrl,
         OpenURLOnDoubleClick,
+        URLDoubleClickAction,
         HideWindowOnCopy,
         MinimizeOnCopy,
         MinimizeAfterUnlock,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -211,7 +211,7 @@ void ApplicationSettingsWidget::loadSettings()
     m_generalUi->autoReloadOnChangeCheckBox->setChecked(config()->get(Config::AutoReloadOnChange).toBool());
     m_generalUi->minimizeAfterUnlockCheckBox->setChecked(config()->get(Config::MinimizeAfterUnlock).toBool());
     m_generalUi->minimizeOnOpenUrlCheckBox->setChecked(config()->get(Config::MinimizeOnOpenUrl).toBool());
-    m_generalUi->openUrlOnDoubleClick->setChecked(config()->get(Config::OpenURLOnDoubleClick).toBool());
+    m_generalUi->urlDoubleClickComboBox->setCurrentIndex(config()->get(Config::URLDoubleClickAction).toInt());
     m_generalUi->hideWindowOnCopyCheckBox->setChecked(config()->get(Config::HideWindowOnCopy).toBool());
     hideWindowOnCopyCheckBoxToggled(m_generalUi->hideWindowOnCopyCheckBox->isChecked());
     m_generalUi->minimizeOnCopyRadioButton->setChecked(config()->get(Config::MinimizeOnCopy).toBool());
@@ -389,7 +389,7 @@ void ApplicationSettingsWidget::saveSettings()
     config()->set(Config::AutoReloadOnChange, m_generalUi->autoReloadOnChangeCheckBox->isChecked());
     config()->set(Config::MinimizeAfterUnlock, m_generalUi->minimizeAfterUnlockCheckBox->isChecked());
     config()->set(Config::MinimizeOnOpenUrl, m_generalUi->minimizeOnOpenUrlCheckBox->isChecked());
-    config()->set(Config::OpenURLOnDoubleClick, m_generalUi->openUrlOnDoubleClick->isChecked());
+    config()->set(Config::URLDoubleClickAction, m_generalUi->urlDoubleClickComboBox->currentIndex());
     config()->set(Config::HideWindowOnCopy, m_generalUi->hideWindowOnCopyCheckBox->isChecked());
     config()->set(Config::MinimizeOnCopy, m_generalUi->minimizeOnCopyRadioButton->isChecked());
     config()->set(Config::DropToBackgroundOnCopy, m_generalUi->dropToBackgroundOnCopyRadioButton->isChecked());

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -554,14 +554,59 @@
                </widget>
               </item>
               <item>
-               <widget class="QCheckBox" name="openUrlOnDoubleClick">
-                <property name="text">
-                 <string>Open browser on double clicking URL field in entry view</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
+               <layout class="QHBoxLayout" name="urlDoubleClickLayout">
+                <item>
+                 <widget class="QLabel" name="urlDoubleClickLabel">
+                  <property name="text">
+                   <string>Double-click action for URL:</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>urlDoubleClickComboBox</cstring>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="urlDoubleClickComboBox">
+                  <property name="focusPolicy">
+                   <enum>Qt::StrongFocus</enum>
+                  </property>
+                  <property name="accessibleName">
+                   <string>Double-click action for URL field</string>
+                  </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToContents</enum>
+                  </property>
+                  <item>
+                   <property name="text">
+                    <string>Edit entry</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Open entry URL in browser</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Copy entry URL to clipboard</string>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="urlDoubleClickSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
               </item>
               <item>
                <widget class="QCheckBox" name="useGroupIconOnEntryCreationCheckBox">
@@ -1439,7 +1484,7 @@
   <tabstop>alternativeSaveComboBox</tabstop>
   <tabstop>ConfirmMoveEntryToRecycleBinCheckBox</tabstop>
   <tabstop>EnableCopyOnDoubleClickCheckBox</tabstop>
-  <tabstop>openUrlOnDoubleClick</tabstop>
+  <tabstop>urlDoubleClickComboBox</tabstop>
   <tabstop>useGroupIconOnEntryCreationCheckBox</tabstop>
   <tabstop>minimizeOnOpenUrlCheckBox</tabstop>
   <tabstop>hideWindowOnCopyCheckBox</tabstop>

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -578,17 +578,17 @@
                   </property>
                   <item>
                    <property name="text">
-                    <string>Edit entry</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
                     <string>Open entry URL in browser</string>
                    </property>
                   </item>
                   <item>
                    <property name="text">
                     <string>Copy entry URL to clipboard</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Edit entry</string>
                    </property>
                   </item>
                  </widget>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1584,23 +1584,20 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
     //    break;
     case EntryModel::Url:
         if (!entry->url().isEmpty()) {
-            int action = config()->get(Config::URLDoubleClickAction).toInt();
-            switch (action) {
-            case 1: // Open entry URL in browser
-                openUrlForEntry(entry);
-                break;
-            case 2: // Copy entry URL to clipboard
-                setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->url()));
-                break;
-            case 0: // Edit entry (fallthrough)
-            default:
+            switch (config()->get(Config::URLDoubleClickAction).toInt()) {
+            case 2: // Edit entry
                 switchToEntryEdit(entry);
                 break;
+            case 1: // Copy entry URL to clipboard
+                setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->url()));
+                break;
+            case 0: // Open entry URL in browser (default)
+            default:
+                openUrlForEntry(entry);
+                break;
             }
-            break;
         }
-        // Note, order matters here. We want to fall into the default case.
-        [[fallthrough]];
+        break;
     default:
         switchToEntryEdit(entry);
     }

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1583,8 +1583,20 @@ void DatabaseWidget::entryActivationSignalReceived(Entry* entry, EntryModel::Mod
     // case EntryModel::Attachments:
     //    break;
     case EntryModel::Url:
-        if (!entry->url().isEmpty() && config()->get(Config::OpenURLOnDoubleClick).toBool()) {
-            openUrlForEntry(entry);
+        if (!entry->url().isEmpty()) {
+            int action = config()->get(Config::URLDoubleClickAction).toInt();
+            switch (action) {
+            case 1: // Open entry URL in browser
+                openUrlForEntry(entry);
+                break;
+            case 2: // Copy entry URL to clipboard
+                setClipboardTextAndMinimize(entry->resolveMultiplePlaceholders(entry->url()));
+                break;
+            case 0: // Edit entry (fallthrough)
+            default:
+                switchToEntryEdit(entry);
+                break;
+            }
             break;
         }
         // Note, order matters here. We want to fall into the default case.

--- a/tests/TestConfig.cpp
+++ b/tests/TestConfig.cpp
@@ -56,8 +56,8 @@ void TestConfig::testURLDoubleClickMigration()
 
     Config::createConfigFromFile(tempFile.fileName());
 
-    // Should migrate to URLDoubleClickAction = 1 (open browser)
-    QCOMPARE(config()->get(Config::URLDoubleClickAction).toInt(), 1);
+    // Should migrate to URLDoubleClickAction = 0 (open browser)
+    QCOMPARE(config()->get(Config::URLDoubleClickAction).toInt(), 0);
 
     tempFile.remove();
 
@@ -72,8 +72,8 @@ void TestConfig::testURLDoubleClickMigration()
 
     Config::createConfigFromFile(tempFile2.fileName());
 
-    // Should migrate to URLDoubleClickAction = 0 (edit entry)
-    QCOMPARE(config()->get(Config::URLDoubleClickAction).toInt(), 0);
+    // Should migrate to URLDoubleClickAction = 2 (edit entry)
+    QCOMPARE(config()->get(Config::URLDoubleClickAction).toInt(), 2);
 
     tempFile2.remove();
 }

--- a/tests/TestConfig.cpp
+++ b/tests/TestConfig.cpp
@@ -17,8 +17,8 @@
 
 #include "TestConfig.h"
 
-#include <QTest>
 #include <QSettings>
+#include <QTest>
 
 #include "config-keepassx-tests.h"
 #include "util/TemporaryFile.h"
@@ -47,33 +47,33 @@ void TestConfig::testURLDoubleClickMigration()
     // Test migration from OpenURLOnDoubleClick to URLDoubleClickAction
     TemporaryFile tempFile;
     tempFile.open();
-    
+
     // Create a config with old setting = true (open browser)
     QSettings oldConfig(tempFile.fileName(), QSettings::IniFormat);
     oldConfig.setValue("OpenURLOnDoubleClick", true);
     oldConfig.sync();
     tempFile.close();
-    
+
     Config::createConfigFromFile(tempFile.fileName());
-    
+
     // Should migrate to URLDoubleClickAction = 1 (open browser)
     QCOMPARE(config()->get(Config::URLDoubleClickAction).toInt(), 1);
-    
+
     tempFile.remove();
-    
+
     // Test migration from OpenURLOnDoubleClick = false (edit entry)
     TemporaryFile tempFile2;
     tempFile2.open();
-    
+
     QSettings oldConfig2(tempFile2.fileName(), QSettings::IniFormat);
     oldConfig2.setValue("OpenURLOnDoubleClick", false);
     oldConfig2.sync();
     tempFile2.close();
-    
+
     Config::createConfigFromFile(tempFile2.fileName());
-    
+
     // Should migrate to URLDoubleClickAction = 0 (edit entry)
     QCOMPARE(config()->get(Config::URLDoubleClickAction).toInt(), 0);
-    
+
     tempFile2.remove();
 }

--- a/tests/TestConfig.cpp
+++ b/tests/TestConfig.cpp
@@ -18,6 +18,7 @@
 #include "TestConfig.h"
 
 #include <QTest>
+#include <QSettings>
 
 #include "config-keepassx-tests.h"
 #include "util/TemporaryFile.h"
@@ -39,4 +40,40 @@ void TestConfig::testUpgrade()
     QVERIFY(config()->get(Config::Security_PasswordEmptyPlaceholder).toBool());
 
     tempFile.remove();
+}
+
+void TestConfig::testURLDoubleClickMigration()
+{
+    // Test migration from OpenURLOnDoubleClick to URLDoubleClickAction
+    TemporaryFile tempFile;
+    tempFile.open();
+    
+    // Create a config with old setting = true (open browser)
+    QSettings oldConfig(tempFile.fileName(), QSettings::IniFormat);
+    oldConfig.setValue("OpenURLOnDoubleClick", true);
+    oldConfig.sync();
+    tempFile.close();
+    
+    Config::createConfigFromFile(tempFile.fileName());
+    
+    // Should migrate to URLDoubleClickAction = 1 (open browser)
+    QCOMPARE(config()->get(Config::URLDoubleClickAction).toInt(), 1);
+    
+    tempFile.remove();
+    
+    // Test migration from OpenURLOnDoubleClick = false (edit entry)
+    TemporaryFile tempFile2;
+    tempFile2.open();
+    
+    QSettings oldConfig2(tempFile2.fileName(), QSettings::IniFormat);
+    oldConfig2.setValue("OpenURLOnDoubleClick", false);
+    oldConfig2.sync();
+    tempFile2.close();
+    
+    Config::createConfigFromFile(tempFile2.fileName());
+    
+    // Should migrate to URLDoubleClickAction = 0 (edit entry)
+    QCOMPARE(config()->get(Config::URLDoubleClickAction).toInt(), 0);
+    
+    tempFile2.remove();
 }

--- a/tests/TestConfig.h
+++ b/tests/TestConfig.h
@@ -25,6 +25,7 @@ class TestConfig : public QObject
     Q_OBJECT
 private slots:
     void testUpgrade();
+    void testURLDoubleClickMigration();
 };
 
 #endif // KEEPASSX_TESTCONFIG_H


### PR DESCRIPTION
## Description
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
This pull request adds an option in Application Settings to configure the double-click action for the URL field in the entry view. Instead of the previous "Open browser on double clicking URL field in entry view" checkbox, there is now a dropdown selector allowing users to choose the desired double-click action for the URL field:
- Open in browser (default, preserves previous behavior)
- Edit entry
- Copy entry URL to clipboard (new)

This brings the URL field in line with the double-click behavior already available for username and password fields, allowing for a more consistent and customizable user experience.

Code changes include:
- Replaced the `Open browser on double clicking URL field in entry view` checkbox in the Settings dialog with a dropdown menu to select the double-click action for the URL field.
- Updated the settings UI and logic to support the new dropdown and persist the chosen option.
- Refactored the double-click event handler for the URL field to perform the selected action.
- Maintained backwards compatibility: the default is "Open in browser", so previous configurations are preserved unless the user changes the setting.
- Updated relevant settings serialization, tests, and UI strings.

The feature was originally requested in [#4717](https://github.com/keepassxreboot/keepassxc/issues/4717) 

**AI Notice:**  
The majority of this code was written with the help of generative AI tools (GitHub Copilot / Claude Sonnet 4). 

---

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )

<!-- Before: (if available) -->

<!-- After: -->
<!-- This screenshot demonstrates the new dropdown option for URL double-click action. -->
<img width="978" height="721" alt="URL-double-click-action-settingsmenu" src="https://github.com/user-attachments/assets/50502537-41bd-4c7b-9730-960efa54b781" />

---

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
- Manual testing: verified that double-clicking the URL field performs the selected action (edit, open, copy).
- Confirmed that existing double-click actions for username and password fields are unaffected.
- Checked that the new setting persists after app restart.

---

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)

## Additional notes
- Fixes: #4717