### PR TITLE
Add URL auto-type and copy options to auto-type selection popup and menus

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -801,15 +801,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;You can use advanced search queries to find any entry in your open databases. The following shortcuts are useful:&lt;br/&gt;
-Ctrl+F - Toggle database search&lt;br/&gt;
-Ctrl+1 - Type username&lt;br/&gt;
-Ctrl+2 - Type password&lt;br/&gt;
-Ctrl+3 - Type TOTP&lt;br/&gt;
-Ctrl+4 - Use Virtual Keyboard (Windows Only)&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Search all open databases</source>
         <translation type="unfinished"></translation>
     </message>
@@ -851,6 +842,24 @@ Ctrl+4 - Use Virtual Keyboard (Windows Only)&lt;/p&gt;</source>
     </message>
     <message>
         <source>Use Virtual Keyboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;You can use advanced search queries to find any entry in your open databases. The following shortcuts are useful:&lt;br/&gt;
+Ctrl+F - Toggle database search&lt;br/&gt;
+Ctrl+1 - Type username&lt;br/&gt;
+Ctrl+2 - Type password&lt;br/&gt;
+Ctrl+3 - Type TOTP&lt;br/&gt;
+Ctrl+4 - Type URL&lt;br/&gt;
+Ctrl+5 - Use Virtual Keyboard (Windows Only)&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type {URL}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy URL</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -37,6 +37,7 @@ enum MENU_FIELD
     USERNAME = 1,
     PASSWORD,
     TOTP,
+    URL,
 };
 
 AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
@@ -265,6 +266,7 @@ void AutoTypeSelectDialog::updateActionMenu(const AutoTypeMatch& match)
     bool hasUsername = !match.first->username().isEmpty();
     bool hasPassword = !match.first->password().isEmpty();
     bool hasTotp = match.first->hasValidTotp();
+    bool hasUrl = !match.first->url().isEmpty();
 
     for (auto action : m_actionMenu->actions()) {
         auto prop = action->property(MENU_FIELD_PROP_NAME);
@@ -279,6 +281,9 @@ void AutoTypeSelectDialog::updateActionMenu(const AutoTypeMatch& match)
             case MENU_FIELD::TOTP:
                 action->setEnabled(hasTotp);
                 break;
+            case MENU_FIELD::URL:
+                action->setEnabled(hasUrl);
+                break;
             }
         }
     }
@@ -290,15 +295,19 @@ void AutoTypeSelectDialog::buildActionMenu()
     auto typeUsernameAction = new QAction(icons()->icon("auto-type"), tr("Type {USERNAME}"), this);
     auto typePasswordAction = new QAction(icons()->icon("auto-type"), tr("Type {PASSWORD}"), this);
     auto typeTotpAction = new QAction(icons()->icon("auto-type"), tr("Type {TOTP}"), this);
+    auto typeUrlAction = new QAction(icons()->icon("auto-type"), tr("Type {URL}"), this);
     auto copyUsernameAction = new QAction(icons()->icon("username-copy"), tr("Copy Username"), this);
     auto copyPasswordAction = new QAction(icons()->icon("password-copy"), tr("Copy Password"), this);
     auto copyTotpAction = new QAction(icons()->icon("totp"), tr("Copy TOTP"), this);
+    auto copyUrlAction = new QAction(icons()->icon("password-copy"), tr("Copy URL"), this);
     m_actionMenu->addAction(typeUsernameAction);
     m_actionMenu->addAction(typePasswordAction);
     m_actionMenu->addAction(typeTotpAction);
+    m_actionMenu->addAction(typeUrlAction);
     m_actionMenu->addAction(copyUsernameAction);
     m_actionMenu->addAction(copyPasswordAction);
     m_actionMenu->addAction(copyTotpAction);
+    m_actionMenu->addAction(copyUrlAction);
 
     typeUsernameAction->setShortcut(Qt::CTRL + Qt::Key_1);
     typeUsernameAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::USERNAME);
@@ -324,10 +333,18 @@ void AutoTypeSelectDialog::buildActionMenu()
         submitAutoTypeMatch(match);
     });
 
+    typeUrlAction->setShortcut(Qt::CTRL + Qt::Key_4);
+    typeUrlAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::URL);
+    connect(typeUrlAction, &QAction::triggered, this, [&] {
+        auto match = m_ui->view->currentMatch();
+        match.second = "{URL}";
+        submitAutoTypeMatch(match);
+    });
+
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     auto typeVirtualAction = new QAction(icons()->icon("auto-type"), tr("Use Virtual Keyboard"), nullptr);
     m_actionMenu->insertAction(copyUsernameAction, typeVirtualAction);
-    typeVirtualAction->setShortcut(Qt::CTRL + Qt::Key_4);
+    typeVirtualAction->setShortcut(Qt::CTRL + Qt::Key_5);
     connect(typeVirtualAction, &QAction::triggered, this, [&] {
         m_virtualMode = true;
         activateCurrentMatch();
@@ -364,17 +381,29 @@ void AutoTypeSelectDialog::buildActionMenu()
         }
     });
 
+    copyUrlAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_4);
+    copyUrlAction->setProperty(MENU_FIELD_PROP_NAME, MENU_FIELD::URL);
+    connect(copyUrlAction, &QAction::triggered, this, [&] {
+        auto entry = m_ui->view->currentMatch().first;
+        if (entry) {
+            clipboard()->setText(entry->resolvePlaceholder(entry->url()));
+            reject();
+        }
+    });
+
     // Qt 5.10 introduced a new "feature" to hide shortcuts in context menus
     // Unfortunately, Qt::AA_DontShowShortcutsInContextMenus is broken, have to manually enable them
     typeUsernameAction->setShortcutVisibleInContextMenu(true);
     typePasswordAction->setShortcutVisibleInContextMenu(true);
     typeTotpAction->setShortcutVisibleInContextMenu(true);
+    typeUrlAction->setShortcutVisibleInContextMenu(true);
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     typeVirtualAction->setShortcutVisibleInContextMenu(true);
 #endif
     copyUsernameAction->setShortcutVisibleInContextMenu(true);
     copyPasswordAction->setShortcutVisibleInContextMenu(true);
     copyTotpAction->setShortcutVisibleInContextMenu(true);
+    copyUrlAction->setShortcutVisibleInContextMenu(true);
 }
 
 void AutoTypeSelectDialog::showEvent(QShowEvent* event)

--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -299,7 +299,7 @@ void AutoTypeSelectDialog::buildActionMenu()
     auto copyUsernameAction = new QAction(icons()->icon("username-copy"), tr("Copy Username"), this);
     auto copyPasswordAction = new QAction(icons()->icon("password-copy"), tr("Copy Password"), this);
     auto copyTotpAction = new QAction(icons()->icon("totp"), tr("Copy TOTP"), this);
-    auto copyUrlAction = new QAction(icons()->icon("password-copy"), tr("Copy URL"), this);
+    auto copyUrlAction = new QAction(icons()->icon("url-copy"), tr("Copy URL"), this);
     m_actionMenu->addAction(typeUsernameAction);
     m_actionMenu->addAction(typePasswordAction);
     m_actionMenu->addAction(typeTotpAction);

--- a/src/autotype/AutoTypeSelectDialog.ui
+++ b/src/autotype/AutoTypeSelectDialog.ui
@@ -56,7 +56,8 @@ Ctrl+F - Toggle database search&lt;br/&gt;
 Ctrl+1 - Type username&lt;br/&gt;
 Ctrl+2 - Type password&lt;br/&gt;
 Ctrl+3 - Type TOTP&lt;br/&gt;
-Ctrl+4 - Use Virtual Keyboard (Windows Only)&lt;/p&gt;</string>
+Ctrl+4 - Type URL&lt;br/&gt;
+Ctrl+5 - Use Virtual Keyboard (Windows Only)&lt;/p&gt;</string>
        </property>
        <property name="styleSheet">
         <string notr="true">QToolButton {

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -924,6 +924,16 @@ void DatabaseWidget::performAutoTypeTOTP()
     performAutoType(QStringLiteral("{TOTP}"));
 }
 
+void DatabaseWidget::performAutoTypeURL()
+{
+    performAutoType(QStringLiteral("{URL}"));
+}
+
+void DatabaseWidget::performAutoTypeURLEnter()
+{
+    performAutoType(QStringLiteral("{URL}{ENTER}"));
+}
+
 void DatabaseWidget::openUrl()
 {
     auto currentEntry = currentSelectedEntry();

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -214,6 +214,8 @@ public slots:
     void performAutoTypePassword();
     void performAutoTypePasswordEnter();
     void performAutoTypeTOTP();
+    void performAutoTypeURL();
+    void performAutoTypeURLEnter();
     void setClipboardTextAndMinimize(const QString& text);
     void openUrl();
     void downloadSelectedFavicons();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -172,6 +172,8 @@ MainWindow::MainWindow()
     autotypeMenu->addAction(m_ui->actionEntryAutoTypePassword);
     autotypeMenu->addAction(m_ui->actionEntryAutoTypePasswordEnter);
     autotypeMenu->addAction(m_ui->actionEntryAutoTypeTOTP);
+    autotypeMenu->addAction(m_ui->actionEntryAutoTypeURL);
+    autotypeMenu->addAction(m_ui->actionEntryAutoTypeURLEnter);
     m_ui->actionEntryAutoType->setMenu(autotypeMenu);
     auto autoTypeButton = qobject_cast<QToolButton*>(m_ui->toolBar->widgetForAction(m_ui->actionEntryAutoType));
     if (autoTypeButton) {
@@ -526,6 +528,10 @@ MainWindow::MainWindow()
     m_actionMultiplexer.connect(
         m_ui->actionEntryAutoTypePasswordEnter, SIGNAL(triggered()), SLOT(performAutoTypePasswordEnter()));
     m_actionMultiplexer.connect(m_ui->actionEntryAutoTypeTOTP, SIGNAL(triggered()), SLOT(performAutoTypeTOTP()));
+    m_actionMultiplexer.connect(
+        m_ui->actionEntryAutoTypeURL, SIGNAL(triggered()), SLOT(performAutoTypeURL()));
+    m_actionMultiplexer.connect(
+        m_ui->actionEntryAutoTypeURLEnter, SIGNAL(triggered()), SLOT(performAutoTypeURLEnter()));
     m_actionMultiplexer.connect(m_ui->actionEntryOpenUrl, SIGNAL(triggered()), SLOT(openUrl()));
     m_actionMultiplexer.connect(m_ui->actionEntryDownloadIcon, SIGNAL(triggered()), SLOT(downloadSelectedFavicons()));
 #ifdef WITH_XC_SSHAGENT
@@ -976,6 +982,8 @@ void MainWindow::updateMenuActionState()
     m_ui->actionEntryAutoTypePassword->setEnabled(singleEntrySelected && dbWidget->currentEntryHasPassword());
     m_ui->actionEntryAutoTypePasswordEnter->setEnabled(singleEntrySelected && dbWidget->currentEntryHasPassword());
     m_ui->actionEntryAutoTypeTOTP->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
+    m_ui->actionEntryAutoTypeURL->setEnabled(singleEntrySelected && dbWidget->currentEntryHasUrl());
+    m_ui->actionEntryAutoTypeURLEnter->setEnabled(singleEntrySelected && dbWidget->currentEntryHasUrl());
     m_ui->actionEntryAutoTypeTOTP->setVisible(singleEntrySelected && dbWidget->currentEntryHasTotp());
     m_ui->actionEntryOpenUrl->setEnabled(singleEntryOrEditing && dbWidget->currentEntryHasUrl());
     m_ui->actionEntryTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -389,6 +389,8 @@ MainWindow::MainWindow()
     m_ui->actionEntryAutoTypePassword->setIcon(icons()->icon("auto-type"));
     m_ui->actionEntryAutoTypePasswordEnter->setIcon(icons()->icon("auto-type"));
     m_ui->actionEntryAutoTypeTOTP->setIcon(icons()->icon("auto-type"));
+    m_ui->actionEntryAutoTypeURL->setIcon(icons()->icon("auto-type"));
+    m_ui->actionEntryAutoTypeURLEnter->setIcon(icons()->icon("auto-type"));
     m_ui->actionEntryMoveUp->setIcon(icons()->icon("move-up"));
     m_ui->actionEntryMoveDown->setIcon(icons()->icon("move-down"));
     m_ui->actionEntryCopyUsername->setIcon(icons()->icon("username-copy"));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -530,8 +530,7 @@ MainWindow::MainWindow()
     m_actionMultiplexer.connect(
         m_ui->actionEntryAutoTypePasswordEnter, SIGNAL(triggered()), SLOT(performAutoTypePasswordEnter()));
     m_actionMultiplexer.connect(m_ui->actionEntryAutoTypeTOTP, SIGNAL(triggered()), SLOT(performAutoTypeTOTP()));
-    m_actionMultiplexer.connect(
-        m_ui->actionEntryAutoTypeURL, SIGNAL(triggered()), SLOT(performAutoTypeURL()));
+    m_actionMultiplexer.connect(m_ui->actionEntryAutoTypeURL, SIGNAL(triggered()), SLOT(performAutoTypeURL()));
     m_actionMultiplexer.connect(
         m_ui->actionEntryAutoTypeURLEnter, SIGNAL(triggered()), SLOT(performAutoTypeURLEnter()));
     m_actionMultiplexer.connect(m_ui->actionEntryOpenUrl, SIGNAL(triggered()), SLOT(openUrl()));

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -859,6 +859,34 @@
     <string>Perform Auto-Type: {TOTP}</string>
    </property>
   </action>
+  <action name="actionEntryAutoTypeURL">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string notr="true">{URL}</string>
+   </property>
+   <property name="iconText">
+    <string notr="true">{URL}</string>
+   </property>
+   <property name="toolTip">
+    <string notr="true">{URL}</string>
+   </property>
+  </action>
+  <action name="actionEntryAutoTypeURLEnter">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string notr="true">{URL}{ENTER}</string>
+   </property>
+   <property name="iconText">
+    <string notr="true">{URL}{ENTER}</string>
+   </property>
+   <property name="toolTip">
+    <string notr="true">{URL}{ENTER}</string>
+   </property>
+  </action>
   <action name="actionEntryDownloadIcon">
    <property name="text">
     <string>Download &amp;Favicon</string>


### PR DESCRIPTION
## Description

This pull request adds URL auto-typing and copying functionality to KeePassXC's auto-type selection popup window to address the missing URL options in the auto-type feature.

**Changes implemented:**
- Added "Type {URL}" option to the auto-type selection popup right-click context menu
- Added "Copy {URL}" option to the auto-type selection popup right-click context menu
- Added keyboard shortcuts: CTRL+4 for "Type {URL}" and CTRL+SHIFT+4 for "Copy {URL}"
- Updated "Use Virtual Keyboard" shortcut from CTRL+4 to CTRL+5 to avoid inconsistency with order of shortcuts
- Added URL auto-type options "{URL}" and "{URL}{ENTER}" to main window entry view right-click menu
- Added URL auto-type options "{URL}" and "{URL}{ENTER}" to toolbar auto-type button dropdown menu
- Added translation strings for "Type {URL}" and "Copy {URL}" to support internationalization

The implementation follows the existing patterns used for username and password auto-type/copy functionality, ensuring consistency across the application. URL options are placed after existing auto-type options (username, password, TOTP) and are properly disabled when entries don't have URL fields.

Fixes #12315

**AI Disclosure:** This pull request was created with assistance from Copilot AI (Claude Sonnet 4 language model) for code generation and implementation guidance.

## Screenshots
![Auto-type_popup_window_context_menu](https://github.com/user-attachments/assets/36168ca0-0ef4-499e-9826-d1a580de8b67)
![auto-type_toolbar_menu](https://github.com/user-attachments/assets/a4631ef9-7124-4fd2-9c15-3485d9f12c3e)

## Testing strategy

**Manual Testing Performed:**
- Verified new URL auto-type and copy options appear in auto-type selection popup context menu
- Tested keyboard shortcuts CTRL+4 and CTRL+SHIFT+4 for URL functionality
- Confirmed "Use Virtual Keyboard" shortcut change from CTRL+4 to CTRL+5 works correctly
- Tested URL auto-type options in main window entry view right-click menu
- Tested URL auto-type options in toolbar auto-type button dropdown menu
- Verified options are properly disabled for entries without URL fields
- Tested with entries containing various URL formats
- Confirmed no regressions in existing auto-type functionality
- Verified translation strings are properly integrated
- Tested on platforms: Windows and Linux (Fedora 42 / KDE / X11)

## Type of change
- ✅ New feature (change that adds functionality)
