### PR TITLE
Add Window menu for macOS and specify Help menu to AppKit

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -158,6 +158,25 @@
     </message>
 </context>
 <context>
+    <name>AppKit</name>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bring All to Front</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ApplicationSettingsWidget</name>
     <message>
         <source>Application Settings</source>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -93,6 +93,10 @@ MainWindow::MainWindow()
 
     m_ui->setupUi(this);
 
+#ifdef Q_OS_MACOS
+    macUtils()->configureWindowAndHelpMenus(this, m_ui->menuHelp);
+#endif
+
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) && !defined(QT_NO_DBUS)
     new MainWindowAdaptor(this);
     QDBusConnection dbus = QDBusConnection::sessionBus();

--- a/src/gui/osutils/macutils/AppKit.h
+++ b/src/gui/osutils/macutils/AppKit.h
@@ -21,6 +21,8 @@
 
 #include <QColor>
 #include <QObject>
+#include <QMenu>
+#include <QMainWindow>
 #include <unistd.h>
 
 class QWindow;
@@ -45,6 +47,7 @@ public:
     bool enableScreenRecording();
     void toggleForegroundApp(bool foreground);
     void setWindowSecurity(QWindow* window, bool state);
+    void configureWindowAndHelpMenus(QMainWindow* mainWindow, QMenu* helpMenu);
 
 signals:
     void userSwitched();

--- a/src/gui/osutils/macutils/AppKitImpl.h
+++ b/src/gui/osutils/macutils/AppKitImpl.h
@@ -42,5 +42,6 @@
 - (bool) enableScreenRecording;
 - (void) toggleForegroundApp:(bool) foreground;
 - (void) setWindowSecurity:(NSWindow*) window state:(bool) state;
+- (void) configureWindowAndHelpMenus:(QMainWindow*) mainWindow helpMenu:(QMenu*) helpMenu;
 
 @end

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -186,7 +186,7 @@
 //
 // Check if screen recording is enabled, may show an popup asking for permissions
 //
-- (bool) enableScreenRecording 
+- (bool) enableScreenRecording
 {
 #if __clang_major__ >= 13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_3
     if (@available(macOS 12.3, *)) {
@@ -194,7 +194,7 @@
         dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
         // Attempt to use SCShareableContent to check for screen recording permission
-        [SCShareableContent getShareableContentWithCompletionHandler:^(SCShareableContent * _Nullable content, 
+        [SCShareableContent getShareableContentWithCompletionHandler:^(SCShareableContent * _Nullable content,
                                                                         NSError * _Nullable error) {
             Q_UNUSED(error);
             if (content) {
@@ -238,10 +238,13 @@
     QMenu *qtWindowMenu = new QMenu(AppKit::tr("Window"));
     NSMenu *nsWindowMenu = qtWindowMenu->toNSMenu();
 
-    [nsWindowMenu addItemWithTitle:AppKit::tr("Minimize").toNSString() action:@selector(performMiniaturize:) keyEquivalent:@""];
-    [nsWindowMenu addItemWithTitle:AppKit::tr("Zoom").toNSString() action:@selector(performZoom:) keyEquivalent:@""];
+    QString minimizeStr = AppKit::tr("Minimize");
+    [nsWindowMenu addItemWithTitle:minimizeStr.toNSString() action:@selector(performMiniaturize:) keyEquivalent:@""];
+    QString zoomStr = AppKit::tr("Zoom");
+    [nsWindowMenu addItemWithTitle:zoomStr.toNSString() action:@selector(performZoom:) keyEquivalent:@""];
     [nsWindowMenu addItem:[NSMenuItem separatorItem]];
-    [nsWindowMenu addItemWithTitle:AppKit::tr("Bring All to Front").toNSString() action:@selector(arrangeInFront:) keyEquivalent:@""];
+    QString bringAllToFrontStr = AppKit::tr("Bring All to Front");
+    [nsWindowMenu addItemWithTitle:bringAllToFrontStr.toNSString() action:@selector(arrangeInFront:) keyEquivalent:@""];
 
     NSApp.windowsMenu = nsWindowMenu;
 

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -18,6 +18,8 @@
 
 #import "AppKitImpl.h"
 #import <QWindow>
+#import <QMenu>
+#import <QMenuBar>
 #import <Cocoa/Cocoa.h>
 #if __clang_major__ >= 13 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_3
 #import <ScreenCaptureKit/ScreenCaptureKit.h>
@@ -231,7 +233,25 @@
     [window setSharingType: state ? NSWindowSharingNone : NSWindowSharingReadOnly];
 }
 
+- (void) configureWindowAndHelpMenus:(QMainWindow*) mainWindow helpMenu:(QMenu*) helpMenu
+{
+    QMenu *qtWindowMenu = new QMenu(AppKit::tr("Window"));
+    NSMenu *nsWindowMenu = qtWindowMenu->toNSMenu();
+
+    [nsWindowMenu addItemWithTitle:AppKit::tr("Minimize").toNSString() action:@selector(performMiniaturize:) keyEquivalent:@""];
+    [nsWindowMenu addItemWithTitle:AppKit::tr("Zoom").toNSString() action:@selector(performZoom:) keyEquivalent:@""];
+    [nsWindowMenu addItem:[NSMenuItem separatorItem]];
+    [nsWindowMenu addItemWithTitle:AppKit::tr("Bring All to Front").toNSString() action:@selector(arrangeInFront:) keyEquivalent:@""];
+
+    NSApp.windowsMenu = nsWindowMenu;
+
+    mainWindow->menuBar()->insertMenu(helpMenu->menuAction(), qtWindowMenu);
+
+    NSApp.helpMenu = helpMenu->toNSMenu();
+}
+
 @end
+
 
 //
 // ------------------------- C++ Trampolines -------------------------
@@ -311,4 +331,9 @@ void AppKit::setWindowSecurity(QWindow* window, bool state)
 {
     auto view = reinterpret_cast<NSView*>(window->winId());
     [static_cast<id>(self) setWindowSecurity:view.window state:state];
+}
+
+void AppKit::configureWindowAndHelpMenus(QMainWindow* window, QMenu* helpMenu)
+{
+    [static_cast<id>(self) configureWindowAndHelpMenus:window helpMenu:helpMenu];
 }

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -24,6 +24,7 @@
 #include <QStandardPaths>
 #include <QTimer>
 #include <QWindow>
+#include <QMenu>
 
 #include <ApplicationServices/ApplicationServices.h>
 
@@ -200,6 +201,11 @@ void MacUtils::registerNativeEventFilter()
     eventSpec.eventClass = kEventClassKeyboard;
     eventSpec.eventKind = kEventHotKeyPressed;
     ::InstallApplicationEventHandler(MacUtils::hotkeyHandler, 1, &eventSpec, this, nullptr);
+}
+
+void MacUtils::configureWindowAndHelpMenus(QMainWindow* mainWindow, QMenu* helpMenu)
+{
+    return m_appkit->configureWindowAndHelpMenus(mainWindow, helpMenu);
 }
 
 bool MacUtils::registerGlobalShortcut(const QString& name, Qt::Key key, Qt::KeyboardModifiers modifiers, QString* error)

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -54,6 +54,8 @@ public:
 
     void registerNativeEventFilter() override;
 
+    void configureWindowAndHelpMenus(QMainWindow* mainWindow, QMenu* helpMenu);
+
     bool registerGlobalShortcut(const QString& name,
                                 Qt::Key key,
                                 Qt::KeyboardModifiers modifiers,


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
This PR adds proper integration of the Window and Help menus on macOS to align with standard macOS application behavior.

A native Window menu is now added to the application menu on macOS with Minimize, Zoom, Window Tiling buttons, and Bring All to Front menus automatically inserted by AppKit. 

The Help menu now integrates with AppKit installing a Spotlight search item automatically.

Fixes #7028

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )

The new Window menu item with most items added automatically by AppKit:
<img width="795" height="285" alt="image" src="https://github.com/user-attachments/assets/b5a309b9-307f-4dfb-ab4f-fe2eea65b59c" />

A spotlight search item are automatically added by AppKit:
<img width="882" height="221" alt="image" src="https://github.com/user-attachments/assets/dc0c484e-b71f-4d47-9b61-335dac24edad" />

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)