### PR TITLE
Fix inheriting browser group settings

### DIFF
--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -1132,6 +1132,24 @@ bool Group::resolveAutoTypeEnabled() const
         } else {
             return m_parent->resolveAutoTypeEnabled();
         }
+    case Enable:
+        return true;
+    case Disable:
+        return false;
+    default:
+        Q_ASSERT(false);
+        return false;
+    }
+}
+
+bool Group::resolveBrowserOptionEnabled(const QString& option) const
+{
+    switch (resolveCustomDataTriState(option, true)) {
+    case Inherit:
+        if (!m_parent) {
+            return false;
+        }
+        return m_parent->resolveBrowserOptionEnabled(option);
     case Enable:
         return true;
     case Disable:

--- a/src/core/Group.h
+++ b/src/core/Group.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -94,6 +94,7 @@ public:
     Group::MergeMode mergeMode() const;
     bool resolveSearchingEnabled() const;
     bool resolveAutoTypeEnabled() const;
+    bool resolveBrowserOptionEnabled(const QString& option) const;
     Entry* lastTopVisibleEntry() const;
     bool isExpired() const;
     bool isRecycled() const;

--- a/src/gui/group/EditGroupWidget.cpp
+++ b/src/gui/group/EditGroupWidget.cpp
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2011 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2022 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -200,11 +200,11 @@ void EditGroupWidget::loadGroup(Group* group, bool create, const QSharedPointer<
 
         auto parent = group->parentGroup();
         if (parent) {
-            inheritHideEntries = parent->resolveCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY);
-            inheritSkipSubmit = parent->resolveCustomDataTriState(BrowserService::OPTION_SKIP_AUTO_SUBMIT);
-            inheritOnlyHttp = parent->resolveCustomDataTriState(BrowserService::OPTION_ONLY_HTTP_AUTH);
-            inheritNoHttp = parent->resolveCustomDataTriState(BrowserService::OPTION_NOT_HTTP_AUTH);
-            inheritOmitWww = parent->resolveCustomDataTriState(BrowserService::OPTION_OMIT_WWW);
+            inheritHideEntries = parent->resolveBrowserOptionEnabled(BrowserService::OPTION_HIDE_ENTRY);
+            inheritSkipSubmit = parent->resolveBrowserOptionEnabled(BrowserService::OPTION_SKIP_AUTO_SUBMIT);
+            inheritOnlyHttp = parent->resolveBrowserOptionEnabled(BrowserService::OPTION_ONLY_HTTP_AUTH);
+            inheritNoHttp = parent->resolveBrowserOptionEnabled(BrowserService::OPTION_NOT_HTTP_AUTH);
+            inheritOmitWww = parent->resolveBrowserOptionEnabled(BrowserService::OPTION_OMIT_WWW);
             inheritRestrictKey = parent->resolveCustomDataString(BrowserService::OPTION_RESTRICT_KEY);
         }
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
Fixes inheriting browser related group settings. The `TriState` enum was actually casted to `boolean` values. The boolean value must be properly parsed based on the `TriState` setting, similar to what Search and Auto-Type settings are doing.

Fixes #12360 

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Manually, creating a new group with subgroup, and subgroups subgroups, with different group settings.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
