### PR TITLE
Add more granular Auto-Type confirmation settings

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -573,6 +573,10 @@
         <source>Font size selection</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Skip confirmation for main window Auto-Type actions</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ApplicationSettingsWidgetSecurity</name>

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -147,6 +147,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_HidePasswordPreviewPanel, {QS("Security/HidePasswordPreviewPanel"), Roaming, true}},
     {Config::Security_HideTotpPreviewPanel, {QS("Security/HideTotpPreviewPanel"), Roaming, false}},
     {Config::Security_AutoTypeAsk, {QS("Security/AutotypeAsk"), Roaming, true}},
+    {Config::Security_AutoTypeSkipMainWindowConfirmation, {QS("Security/AutoTypeSkipMainWindowConfirmation"), Roaming, false}},
     {Config::Security_IconDownloadFallback, {QS("Security/IconDownloadFallback"), Roaming, false}},
     {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},
     {Config::Security_EnableCopyOnDoubleClick,{QS("Security/EnableCopyOnDoubleClick"), Roaming, false}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -129,6 +129,7 @@ public:
         Security_HidePasswordPreviewPanel,
         Security_HideTotpPreviewPanel,
         Security_AutoTypeAsk,
+        Security_AutoTypeSkipMainWindowConfirmation,
         Security_IconDownloadFallback,
         Security_NoConfirmMoveEntryToRecycleBin,
         Security_EnableCopyOnDoubleClick,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -129,6 +129,8 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
     connect(m_generalUi->backupFilePathPicker, SIGNAL(pressed()), SLOT(selectBackupDirectory()));
     connect(m_generalUi->showExpiredEntriesOnDatabaseUnlockCheckBox, SIGNAL(toggled(bool)),
             SLOT(showExpiredEntriesOnDatabaseUnlockToggled(bool)));
+    connect(m_generalUi->autoTypeAskCheckBox, SIGNAL(toggled(bool)),
+            SLOT(autoTypeAskToggled(bool)));
 
     connect(m_secUi->clearClipboardCheckBox, SIGNAL(toggled(bool)),
             m_secUi->clearClipboardSpinBox, SLOT(setEnabled(bool)));
@@ -302,6 +304,8 @@ void ApplicationSettingsWidget::loadSettings()
     showExpiredEntriesOnDatabaseUnlockToggled(m_generalUi->showExpiredEntriesOnDatabaseUnlockCheckBox->isChecked());
 
     m_generalUi->autoTypeAskCheckBox->setChecked(config()->get(Config::Security_AutoTypeAsk).toBool());
+    m_generalUi->autoTypeSkipMainWindowConfirmationCheckBox->setChecked(config()->get(Config::Security_AutoTypeSkipMainWindowConfirmation).toBool());
+    autoTypeAskToggled(m_generalUi->autoTypeAskCheckBox->isChecked());
     m_generalUi->autoTypeRelockDatabaseCheckBox->setChecked(config()->get(Config::Security_RelockAutoType).toBool());
 
     if (autoType()->isAvailable()) {
@@ -445,6 +449,7 @@ void ApplicationSettingsWidget::saveSettings()
                   m_generalUi->showExpiredEntriesOnDatabaseUnlockOffsetSpinBox->value());
 
     config()->set(Config::Security_AutoTypeAsk, m_generalUi->autoTypeAskCheckBox->isChecked());
+    config()->set(Config::Security_AutoTypeSkipMainWindowConfirmation, m_generalUi->autoTypeSkipMainWindowConfirmationCheckBox->isChecked());
     config()->set(Config::Security_RelockAutoType, m_generalUi->autoTypeRelockDatabaseCheckBox->isChecked());
 
     if (autoType()->isAvailable()) {
@@ -616,6 +621,11 @@ void ApplicationSettingsWidget::checkUpdatesToggled(bool checked)
 void ApplicationSettingsWidget::showExpiredEntriesOnDatabaseUnlockToggled(bool checked)
 {
     m_generalUi->showExpiredEntriesOnDatabaseUnlockOffsetSpinBox->setEnabled(checked);
+}
+
+void ApplicationSettingsWidget::autoTypeAskToggled(bool checked)
+{
+    m_generalUi->autoTypeSkipMainWindowConfirmationCheckBox->setEnabled(checked);
 }
 
 void ApplicationSettingsWidget::selectBackupDirectory()

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -304,7 +304,8 @@ void ApplicationSettingsWidget::loadSettings()
     showExpiredEntriesOnDatabaseUnlockToggled(m_generalUi->showExpiredEntriesOnDatabaseUnlockCheckBox->isChecked());
 
     m_generalUi->autoTypeAskCheckBox->setChecked(config()->get(Config::Security_AutoTypeAsk).toBool());
-    m_generalUi->autoTypeSkipMainWindowConfirmationCheckBox->setChecked(config()->get(Config::Security_AutoTypeSkipMainWindowConfirmation).toBool());
+    m_generalUi->autoTypeSkipMainWindowConfirmationCheckBox->setChecked(
+        config()->get(Config::Security_AutoTypeSkipMainWindowConfirmation).toBool());
     autoTypeAskToggled(m_generalUi->autoTypeAskCheckBox->isChecked());
     m_generalUi->autoTypeRelockDatabaseCheckBox->setChecked(config()->get(Config::Security_RelockAutoType).toBool());
 
@@ -449,7 +450,8 @@ void ApplicationSettingsWidget::saveSettings()
                   m_generalUi->showExpiredEntriesOnDatabaseUnlockOffsetSpinBox->value());
 
     config()->set(Config::Security_AutoTypeAsk, m_generalUi->autoTypeAskCheckBox->isChecked());
-    config()->set(Config::Security_AutoTypeSkipMainWindowConfirmation, m_generalUi->autoTypeSkipMainWindowConfirmationCheckBox->isChecked());
+    config()->set(Config::Security_AutoTypeSkipMainWindowConfirmation,
+                  m_generalUi->autoTypeSkipMainWindowConfirmationCheckBox->isChecked());
     config()->set(Config::Security_RelockAutoType, m_generalUi->autoTypeRelockDatabaseCheckBox->isChecked());
 
     if (autoType()->isAvailable()) {

--- a/src/gui/ApplicationSettingsWidget.h
+++ b/src/gui/ApplicationSettingsWidget.h
@@ -63,6 +63,7 @@ private slots:
     void rememberDatabasesToggled(bool checked);
     void checkUpdatesToggled(bool checked);
     void showExpiredEntriesOnDatabaseUnlockToggled(bool checked);
+    void autoTypeAskToggled(bool checked);
     void selectBackupDirectory();
 
 private:

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -1158,6 +1158,42 @@
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="autoTypeSkipMainWindowLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <spacer name="autoTypeSkipMainWindowSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>30</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="autoTypeSkipMainWindowConfirmationCheckBox">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Skip confirmation for main window Auto-Type actions</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QCheckBox" name="autoTypeHideExpiredEntryCheckBox">
          <property name="text">
           <string>Hide expired entries from Auto-Type</string>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -877,12 +877,18 @@ void DatabaseWidget::performAutoType(const QString& sequence)
 {
     auto currentEntry = currentSelectedEntry();
     if (currentEntry) {
-        // TODO: Include name of previously active window in confirmation question
-        if (config()->get(Config::Security_AutoTypeAsk).toBool()
-            && MessageBox::question(
+        // Check if we need to ask for confirmation
+        bool shouldAsk = config()->get(Config::Security_AutoTypeAsk).toBool();
+        bool skipMainWindowConfirmation = config()->get(Config::Security_AutoTypeSkipMainWindowConfirmation).toBool();
+        
+        // Show confirmation if Security_AutoTypeAsk is true AND Security_AutoTypeSkipMainWindowConfirmation is false
+        if (shouldAsk && !skipMainWindowConfirmation) {
+            // TODO: Include name of previously active window in confirmation question
+            if (MessageBox::question(
                    this, tr("Confirm Auto-Type"), tr("Perform Auto-Type into the previously active window?"))
                    != MessageBox::Yes) {
-            return;
+                return;
+            }
         }
 
         if (sequence.isEmpty()) {

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -880,13 +880,13 @@ void DatabaseWidget::performAutoType(const QString& sequence)
         // Check if we need to ask for confirmation
         bool shouldAsk = config()->get(Config::Security_AutoTypeAsk).toBool();
         bool skipMainWindowConfirmation = config()->get(Config::Security_AutoTypeSkipMainWindowConfirmation).toBool();
-        
+
         // Show confirmation if Security_AutoTypeAsk is true AND Security_AutoTypeSkipMainWindowConfirmation is false
         if (shouldAsk && !skipMainWindowConfirmation) {
             // TODO: Include name of previously active window in confirmation question
             if (MessageBox::question(
-                   this, tr("Confirm Auto-Type"), tr("Perform Auto-Type into the previously active window?"))
-                   != MessageBox::Yes) {
+                    this, tr("Confirm Auto-Type"), tr("Perform Auto-Type into the previously active window?"))
+                != MessageBox::Yes) {
                 return;
             }
         }


### PR DESCRIPTION
## Description

This pull request adds a new setting to KeePassXC that allows for more granular control over the Auto-Type confirmation popup. Specifically, it introduces an option to always prompt for confirmation before performing global Auto-Type actions, while allowing users to skip the confirmation when invoking Auto-Type from within the main KeePassXC window.

### Problem

Currently, the "Always ask before performing Auto-Type" setting affects all Auto-Type invocations uniformly:

* When enabled: Shows confirmation for both main window actions AND always opens selection popup for global Auto-Type
* When disabled: No confirmations for any Auto-Type method (Except for global Auto-Type when target window doesn't match any entries or matches multiple ones -> then it opens selection popup window)

This may leave users wanting more granular control to streamline their workflow for routine Auto-Type usage while maintaining security for global Auto-Type.

## Rationale

**Why introduce this feature?**

With global Auto-Type, there is a potential risk of accidentally auto-typing the wrong credentials if the currently focused window title matches a single entry in KeePassXC, when the "Always ask before performing Auto-Type" setting is disabled. This could lead to sensitive information being sent to the wrong application or website.

This new setting gives users more control and safety:
- When Auto-Type is invoked globally (e.g., via a system-wide hotkey), the confirmation popup will always appear, letting the user confirm which credentials will be auto-typed.
- When Auto-Type is invoked from within KeePassXC's main window, the confirmation step can be skipped, since the user already can visually confirm which entry is being auto-typed.

This balances usability and security, reducing friction for intended actions while providing an extra safeguard for potentially ambiguous global Auto-Type triggers.

### AI Disclosure
This pull request was created with assistance from Copilot AI (Claude Sonnet 4 language model) for code generation and implementation guidance.

### Solution
Added a new checkbox setting: "**Skip confirmation for main window Auto-Type actions**"

### Behavior Matrix
| Parent Setting | New Setting    | Main Window Actions | Global Auto-Type         |
| -------------- | -------------- | ------------------- | ------------------------ |
| Unchecked      | N/A (disabled) | No confirmation     | No selection popup       |
| Checked        | Unchecked      | Show confirmation   | Show selection popup     |
| **Checked**    | **Checked**    | **No confirmation** | **Show selection popup** |

### Key Features

- **Granular Control**: Separate confirmation behavior for main window vs. global Auto-Type
- **Security Maintained**: Global Auto-Type (external hotkey) always shows selection popup when parent setting is enabled
- **Backwards Compatible**: Default behavior unchanged (new setting defaults to unchecked)
- New option is indented under parent setting and only enabled when relevant
- Existing users see no behavior change unless they opt-in

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
<img width="917" height="610" alt="auto-type-skip-confirmation-for-mainwindow-actions" src="https://github.com/user-attachments/assets/3c7e2b97-5152-423f-8603-8e36f9e06aa8" />

## Implementation Details

### Technical Changes
**Configuration Storage** (`src/core/Config.h`, `src/core/Config.cpp`):

- Added `Security_AutoTypeSkipMainWindowConfirmation` configuration key
- Defaults to `false` to maintain existing behavior

**Settings UI** (`src/gui/ApplicationSettingsWidgetGeneral.ui`):

- Added new checkbox with proper indentation and spacing
- Positioned directly under the existing "Always ask before performing Auto-Type" setting

**Settings Logic** (`src/gui/ApplicationSettingsWidget.cpp`, `src/gui/ApplicationSettingsWidget.h`):

- Implemented enable/disable logic for the new checkbox
- Added loading/saving functionality
- New checkbox is only enabled when parent setting is checked

**Auto-Type Confirmation Logic** (`src/gui/DatabaseWidget.cpp`):
```
// Modified confirmation logic in performAutoType()
bool shouldAsk = config()->get(Config::Security_AutoTypeAsk).toBool();
bool skipMainWindowConfirmation = config()->get(Config::Security_AutoTypeSkipMainWindowConfirmation).toBool();

// Show confirmation only when both conditions are met:
// 1. Always ask is enabled AND 2. Skip main window confirmation is disabled
if (shouldAsk && !skipMainWindowConfirmation) {
    // Show confirmation dialog
}
```
### Auto-Type Invocation Paths

1. **Main Window Actions** → `DatabaseWidget::performAutoType()` → Uses new granular confirmation logic:
    
    - Context menu Auto-Type
    - Toolbar Auto-Type buttons
    - CTRL+SHIFT+V keyboard shortcut (when entry is selected)
2. **Global Auto-Type** → `AutoType::performGlobalAutoType()` → Unchanged behavior (always shows selection popup)

## Testing strategy
- Manually tested global Auto-Type and main window Auto-Type with the new setting enabled and disabled.
- Verified that the confirmation popup appears as expected only for global Auto-Type when the setting is enabled.
- Checked that main window Auto-Type remains convenient and does not prompt unnecessarily.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)

