### PR TITLE
CLI quiet mode - write database unlock errors to stderr

### DIFF
--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -123,7 +123,7 @@ namespace Utils
                                             const QString& yubiKeySlot,
                                             bool quiet)
     {
-        auto& err = quiet ? DEVNULL : STDERR;
+        auto& err = STDERR;
         auto compositeKey = QSharedPointer<CompositeKey>::create();
 
         QFileInfo dbFileInfo(databaseFilename);

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -320,7 +320,7 @@ void TestCli::testAdd()
     // Quiet option
     setInput("a");
     execCmd(addCmd, {"add", "-q", "-u", "newuser", "-g", "-L", "20", m_dbFile->fileName(), "/newentry-quiet"});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray());
     db = readDatabase();
     entry = db->rootGroup()->findEntryByPath("/newentry-quiet");
@@ -513,8 +513,7 @@ void TestCli::testAttachmentExport()
     execCmd(
         attachmentExportCmd,
         {"attachment-export", "--quiet", "--stdout", m_dbFile->fileName(), "/Sample Entry", "Sample attachment.txt"});
-    m_stderr->readLine(); // skip password prompt
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray("Sample content\n"));
 }
 
@@ -662,7 +661,7 @@ void TestCli::testClip()
     // Quiet option
     setInput("a");
     execCmd(clipCmd, {"clip", m_dbFile->fileName(), "/Sample Entry", "0", "-q"});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray());
     QTRY_COMPARE(clipboard->text(), QString("Password"));
 
@@ -1031,7 +1030,7 @@ void TestCli::testInfo()
     // Test with quiet option.
     setInput("a");
     execCmd(infoCmd, {"db-info", "-q", m_dbFile->fileName()});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QVERIFY(m_stdout->readLine().contains(QByteArray("UUID: ")));
     QCOMPARE(m_stdout->readLine(), QByteArray("Name: \n"));
     QCOMPARE(m_stdout->readLine(), QByteArray("Description: \n"));
@@ -1126,7 +1125,7 @@ void TestCli::testEdit()
     // Quiet option
     setInput("a");
     execCmd(editCmd, {"edit", m_dbFile->fileName(), "-q", "-t", "newertitle", "/newtitle"});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray());
 
     setInput("a");
@@ -1297,7 +1296,7 @@ void TestCli::testExport()
     QScopedPointer<Database> dbQuiet(new Database());
     setInput("a");
     execCmd(exportCmd, {"export", "-f", "xml", "-q", m_dbFile->fileName()});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
 
     xmlOutput.open(QIODevice::WriteOnly);
     xmlOutput.write(m_stdout->readAll());
@@ -1566,7 +1565,7 @@ void TestCli::testList()
     // Quiet option
     setInput("a");
     execCmd(listCmd, {"ls", "-q", m_dbFile->fileName()});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(),
              QByteArray("Sample Entry\n"
                         "General/\n"
@@ -1711,7 +1710,7 @@ void TestCli::testMerge()
     // the dry run option can be used with the quiet option
     setInput("a");
     execCmd(mergeCmd, {"merge", "--dry-run", "-s", "-q", targetFile2.fileName(), sourceFile.fileName()});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray());
 
     mergedDb = QSharedPointer<Database>::create();
@@ -1743,13 +1742,13 @@ void TestCli::testMerge()
     // Quiet option
     setInput("a");
     execCmd(mergeCmd, {"merge", "-q", "-s", sourceFile.fileName(), sourceFile.fileName()});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray());
 
     // Quiet option without the -s option
     setInput({"a", "a"});
     execCmd(mergeCmd, {"merge", "-q", sourceFile.fileName(), sourceFile.fileName()});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray());
 }
 
@@ -1982,7 +1981,7 @@ void TestCli::testRemoveQuiet()
     // delete entry and verify
     setInput("a");
     execCmd(removeCmd, {"rm", "-q", m_dbFile->fileName(), "/Sample Entry"});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray());
 
     auto db = readDatabase();
@@ -1994,7 +1993,7 @@ void TestCli::testRemoveQuiet()
     // remove the entry completely
     setInput("a");
     execCmd(removeCmd, {"rm", "-q", m_dbFile->fileName(), QString("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray());
 
     db = readDatabase();
@@ -2017,7 +2016,7 @@ void TestCli::testSearch()
     // Quiet option
     setInput("a");
     execCmd(searchCmd, {"search", m_dbFile->fileName(), "-q", "Sample"});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(), QByteArray("/Sample Entry\n"));
 
     setInput("a");
@@ -2104,7 +2103,7 @@ void TestCli::testShow()
 
     setInput("a");
     execCmd(showCmd, {"show", m_dbFile->fileName(), "-q", "/Sample Entry"});
-    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QVERIFY(m_stderr->readAll().startsWith("Enter password to unlock"));
     QCOMPARE(m_stdout->readAll(),
              QByteArray("Title: Sample Entry\n"
                         "UserName: User Name\n"


### PR DESCRIPTION
* Fixes #12402

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Updated test cases to account for password prompt being written to stderr in quiet mode

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)