### PR TITLE
Fix keyboard shortcuts when menubar is hidden

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1672,9 +1672,16 @@ void MainWindow::applySettingsChanges()
         m_inactivityTimer->deactivate();
     }
 
-    m_ui->actionShowToolbar->setChecked(!config()->get(Config::GUI_HideToolbar).toBool());
-    m_ui->actionShowMenubar->setChecked(!config()->get(Config::GUI_HideMenubar).toBool());
-    m_ui->menubar->setHidden(config()->get(Config::GUI_HideMenubar).toBool());
+    auto hideToolbar = config()->get(Config::GUI_HideToolbar).toBool();
+    auto hideMenubar = config()->get(Config::GUI_HideMenubar).toBool();
+
+    m_ui->actionShowToolbar->setChecked(!hideToolbar);
+    m_ui->actionShowMenubar->setChecked(!hideMenubar);
+
+    // When menubar is hidden with setHidden() the menu keyboard shortcuts are disabled on Wayland,
+    // so force height of 0 instead and use maximumHeight() > 0 instead of isVisible() elsewhere
+    m_ui->menubar->setMaximumHeight(hideMenubar ? 0 : QWIDGETSIZE_MAX);
+
     m_ui->toolBar->setHidden(config()->get(Config::GUI_HideToolbar).toBool());
     auto movable = config()->get(Config::GUI_MovableToolbar).toBool();
     m_ui->toolBar->setMovable(movable);
@@ -2010,7 +2017,7 @@ void MainWindow::initViewMenu()
     });
 
 #ifdef Q_OS_MACOS
-    m_ui->actionShowMenubar->setVisible(false);
+    m_ui->actionShowMenubar->setMaximumHeight(0);
 #else
     m_ui->actionShowMenubar->setChecked(!config()->get(Config::GUI_HideMenubar).toBool());
     connect(m_ui->actionShowMenubar, &QAction::toggled, this, [this](bool checked) {
@@ -2187,10 +2194,10 @@ MainWindowEventFilter::MainWindowEventFilter(QObject* parent)
     m_menubarTimer.setSingleShot(false);
     connect(&m_menubarTimer, &QTimer::timeout, this, [this] {
         auto mainwindow = getMainWindow();
-        if (mainwindow && mainwindow->m_ui->menubar->isVisible() && config()->get(Config::GUI_HideMenubar).toBool()) {
+        if (mainwindow && mainwindow->m_ui->menubar->maximumHeight() > 0 && config()->get(Config::GUI_HideMenubar).toBool()) {
             // If the menu bar is visible with no active menu, hide it
             if (!mainwindow->m_ui->menubar->activeAction()) {
-                mainwindow->m_ui->menubar->setVisible(false);
+                mainwindow->m_ui->menubar->setMaximumHeight(0);
                 m_altCoolDown.start();
                 m_menubarTimer.stop();
             }
@@ -2249,9 +2256,13 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
         if (keyEvent->key() == Qt::Key_Alt && !keyEvent->modifiers() && config()->get(Config::GUI_HideMenubar).toBool()
             && !m_altCoolDown.isActive()) {
             auto menubar = mainWindow->m_ui->menubar;
-            menubar->setVisible(!menubar->isVisible());
-            if (menubar->isVisible()) {
-                menubar->setActiveAction(mainWindow->m_ui->menuFile->menuAction());
+            menubar->setMaximumHeight(menubar->maximumHeight() > 0 ? 0 : QWIDGETSIZE_MAX);
+            if (menubar->maximumHeight() > 0) {
+                QTimer::singleShot(0, [menubar, mainWindow] {
+                    // Run this with a singleshot timer so it's after menubar->setMaximumHeight() has taken effect,
+                    // otherwise it won't be selected and menubarTimer will hide the menubar instantly
+                    menubar->setActiveAction(mainWindow->m_ui->menuFile->menuAction());
+                });
                 m_menubarTimer.start();
             } else {
                 m_menubarTimer.stop();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2194,7 +2194,8 @@ MainWindowEventFilter::MainWindowEventFilter(QObject* parent)
     m_menubarTimer.setSingleShot(false);
     connect(&m_menubarTimer, &QTimer::timeout, this, [this] {
         auto mainwindow = getMainWindow();
-        if (mainwindow && mainwindow->m_ui->menubar->maximumHeight() > 0 && config()->get(Config::GUI_HideMenubar).toBool()) {
+        if (mainwindow && mainwindow->m_ui->menubar->maximumHeight() > 0
+            && config()->get(Config::GUI_HideMenubar).toBool()) {
             // If the menu bar is visible with no active menu, hide it
             if (!mainwindow->m_ui->menubar->activeAction()) {
                 mainwindow->m_ui->menubar->setMaximumHeight(0);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2017,7 +2017,7 @@ void MainWindow::initViewMenu()
     });
 
 #ifdef Q_OS_MACOS
-    m_ui->actionShowMenubar->setMaximumHeight(0);
+    m_ui->actionShowMenubar->setVisible(false);
 #else
     m_ui->actionShowMenubar->setChecked(!config()->get(Config::GUI_HideMenubar).toBool());
     connect(m_ui->actionShowMenubar, &QAction::toggled, this, [this](bool checked) {


### PR DESCRIPTION
Fixes #11779

## Testing strategy
- Check that keyboard shortcuts work beforehand with menubar shown (eg Ctrl+, to toggle settings)
- Disable `View > Show Menubar`
- Check that keyboard shortcuts still work with menubar hidden
- With menubar hidden try pressing Alt, without moving mouse check that the Database menu is shown and highlighted in menubar and the menubar remains open
- Check that moving mouse along menubar opens the other menus
- Click outside menubar, check that menu closes and menubar hides again


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
