### PR TITLE
Add select corresponding group functionality

### DIFF
--- a/share/translations/keepassxc_it.ts
+++ b/share/translations/keepassxc_it.ts
@@ -5978,7 +5978,7 @@ Sei sicuro di voler continuare con questo file?</translation>
         <source>WARNING: You are using an unstable build of KeePassXC.
 There is a high risk of corruption, maintain a backup of your databases.
 This version is not meant for production use.</source>
-        <translation>ATTENZIONE: stau usando una build instabile di KeePassXC.
+        <translation>ATTENZIONE: stai usando una build instabile di KeePassXC.
 C&apos;è un alto rischio di corruzione, mantenere un backup dei database.
 Questa versione non è destinata all&apos;uso in produzione.</translation>
     </message>

--- a/share/translations/keepassxc_it.ts
+++ b/share/translations/keepassxc_it.ts
@@ -6344,6 +6344,14 @@ Aspettatevi alcuni bug e problemi minori, questa versione è pensata per scopi d
         <source>Clear all identities in ssh-agent</source>
         <translation>Cancella tutte le identità in ssh-agent</translation>
     </message>
+    <message>
+        <source>Select corresponding &amp;group</source>
+        <translation>Seleziona &amp;gruppo corrispondente</translation>
+    </message>
+    <message>
+        <source>Select corresponding group</source>
+        <translation>Seleziona gruppo corrispondente</translation>
+    </message>
 </context>
 <context>
     <name>ManageDatabase</name>

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -2807,3 +2807,9 @@ void DatabaseWidget::openDatabaseFromEntry(const Entry* entry, bool inBackground
     // Request to open the database file in the background with a password and keyfile
     emit requestOpenDatabase(dbFileInfo.canonicalFilePath(), inBackground, password, keyFileInfo.canonicalFilePath());
 }
+
+void DatabaseWidget::gotoGroup()
+{
+    Group *group = m_entryView->currentEntry()->group();
+    m_groupView->setCurrentGroup(group);
+}

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -261,6 +261,7 @@ public slots:
     void showErrorMessage(const QString& errorMessage);
     void hideMessage();
     void triggerAutosaveTimer();
+    void gotoGroup();
 
 protected:
     void closeEvent(QCloseEvent* event) override;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -144,6 +144,7 @@ MainWindow::MainWindow()
     m_entryContextMenu->addSeparator();
 #endif
     m_entryContextMenu->addAction(m_ui->actionEntryEdit);
+    m_entryContextMenu->addAction(m_ui->actionGotoGroup);
     m_entryContextMenu->addAction(m_ui->actionEntryExpire);
     m_entryContextMenu->addAction(m_ui->actionEntryClone);
     m_entryContextMenu->addAction(m_ui->actionEntryDelete);
@@ -431,6 +432,7 @@ MainWindow::MainWindow()
     m_ui->actionOnlineHelp->setIcon(icons()->icon("system-help"));
     m_ui->actionKeyboardShortcuts->setIcon(icons()->icon("keyboard-shortcuts"));
     m_ui->actionCheckForUpdates->setIcon(icons()->icon("system-software-update"));
+    m_ui->actionGotoGroup->setIcon(icons()->icon("document-import"));
 
 #ifdef WITH_XC_BROWSER_PASSKEYS
     m_ui->actionPasskeys->setIcon(icons()->icon("passkey"));
@@ -548,6 +550,7 @@ MainWindow::MainWindow()
     m_actionMultiplexer.connect(m_ui->actionGroupSortAsc, SIGNAL(triggered()), SLOT(sortGroupsAsc()));
     m_actionMultiplexer.connect(m_ui->actionGroupSortDesc, SIGNAL(triggered()), SLOT(sortGroupsDesc()));
     m_actionMultiplexer.connect(m_ui->actionGroupDownloadFavicons, SIGNAL(triggered()), SLOT(downloadAllFavicons()));
+    m_actionMultiplexer.connect(m_ui->actionGotoGroup, SIGNAL(triggered()), SLOT(gotoGroup()));
 
     connect(m_ui->actionSettings, SIGNAL(toggled(bool)), SLOT(switchToSettings(bool)));
     connect(m_ui->actionPasswordGenerator, SIGNAL(toggled(bool)), SLOT(togglePasswordGenerator(bool)));
@@ -942,6 +945,7 @@ void MainWindow::updateMenuActionState()
     m_ui->actionEntryNew->setEnabled(inDatabase && !inRecycleBin);
     m_ui->actionEntryClone->setEnabled(singleEntrySelected && !inRecycleBin);
     m_ui->actionEntryEdit->setEnabled(singleEntrySelected);
+    m_ui->actionGotoGroup->setEnabled(singleEntrySelected);
     m_ui->actionEntryExpire->setEnabled(multiEntrySelected);
     m_ui->actionEntryDelete->setEnabled(multiEntrySelected);
     m_ui->actionEntryRestore->setVisible(multiEntrySelected && inRecycleBin);
@@ -2148,7 +2152,8 @@ void MainWindow::initActionCollection()
                     m_ui->actionCheckForUpdates,
                     m_ui->actionDonate,
                     m_ui->actionBugReport,
-                    m_ui->actionAbout});
+                    m_ui->actionAbout,
+                    m_ui->actionGotoGroup});
 
     // Register as default any shortcuts that were set in the .ui file
     for (const auto action : ac->actions()) {

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -439,6 +439,7 @@
    <addaction name="actionEntryCopyUsername"/>
    <addaction name="actionEntryCopyPassword"/>
    <addaction name="actionEntryCopyURL"/>
+   <addaction name="actionGotoGroup"/>
    <addaction name="actionEntryAutoType"/>
    <addaction name="separator"/>
    <addaction name="actionDatabaseSettings"/>
@@ -1353,6 +1354,17 @@
    </property>
    <property name="menuRole">
     <enum>QAction::TextHeuristicRole</enum>
+   </property>
+  </action>
+  <action name="actionGotoGroup">
+   <property name="text">
+    <string>Select corresponding &amp;group</string>
+   </property>
+   <property name="toolTip">
+    <string>Select corresponding group</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+G</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
# Feature description
This feature selects the group a specific entry belongs to.

This is useful when you have many entries and many groups and you're searching for a specific entry you remember was in a group but, for the life of you, cannot remember nor find that pesky group.

I added a button on the top bar and one menu entry in the context menu. Also I added the CTRL+G shortcut.

Also, added (and fixed one) Italian translations

I did NOT use AIs


## Screenshots
Before click the goto group button
<img width="851" height="246" alt="screen1" src="https://github.com/user-attachments/assets/b0ff384f-d473-4195-9b4a-e46a51197ffc" />

After clicking the goto group button
<img width="851" height="246" alt="screen2" src="https://github.com/user-attachments/assets/fc6c93b3-86d4-4a1e-a1e5-d32f8db1f4c7" />


## Testing strategy
Very basic, just searched for something and tested the button, the menu entry (both by clicking and by pressing the `G` menu shortcut key) and the CTRL+G shortcut.


## Type of change
- ✅ New feature (change that adds functionality)