### PR TITLE
Implemented GUI CLI arguments for specifying a smartcard

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -326,7 +326,7 @@ QString DatabaseOpenWidget::filename()
     return m_filename;
 }
 
-void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
+void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile, const QString& yubikey)
 {
     if (unlockingDatabase()) {
         qWarning("Ignoring unlock request for %s because of running unlock action.", qPrintable(m_filename));
@@ -335,11 +335,12 @@ void DatabaseOpenWidget::enterKey(const QString& pw, const QString& keyFile)
 
     m_ui->editPassword->setText(pw);
     m_ui->keyFileLineEdit->setText(keyFile);
+
     m_blockQuickUnlock = true;
-    openDatabase();
+    openDatabase(yubikey);
 }
 
-void DatabaseOpenWidget::openDatabase()
+void DatabaseOpenWidget::openDatabase(const QString& yubikey)
 {
     // Cache this variable for future use then reset
     bool blockQuickUnlock = m_blockQuickUnlock || isOnQuickUnlockScreen();
@@ -350,7 +351,7 @@ void DatabaseOpenWidget::openDatabase()
     m_ui->messageWidget->hide();
     QCoreApplication::processEvents();
 
-    const auto databaseKey = buildDatabaseKey();
+    const auto databaseKey = buildDatabaseKey(yubikey);
     if (!databaseKey) {
         setUserInteractionLock(false);
         return;
@@ -430,7 +431,7 @@ void DatabaseOpenWidget::openDatabase()
     }
 }
 
-QSharedPointer<CompositeKey> DatabaseOpenWidget::buildDatabaseKey()
+QSharedPointer<CompositeKey> DatabaseOpenWidget::buildDatabaseKey(const QString& yubikey)
 {
     auto databaseKey = QSharedPointer<CompositeKey>::create();
 
@@ -490,6 +491,29 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::buildDatabaseKey()
     }
 
 #ifdef WITH_XC_YUBIKEY
+    if (!yubikey.isEmpty()) {
+        unsigned int serial = 0;
+        int slot;
+
+        bool ok = false;
+        auto parts = yubikey.split(":");
+        slot = parts[0].toInt(&ok);
+
+        if (!ok || (slot != 1 && slot != 2)) {
+            return {};
+        }
+
+        if (parts.size() > 1) {
+            serial = parts[1].toUInt(&ok, 10);
+            if (!ok) {
+                return {};
+            }
+        }
+
+        auto crKey = QSharedPointer<ChallengeResponseKey>(new ChallengeResponseKey({serial, slot}));
+        databaseKey->addChallengeResponseKey(crKey);
+    }
+
     auto lastChallengeResponse = config()->get(Config::LastChallengeResponse).toHash();
     lastChallengeResponse.remove(m_filename);
 

--- a/src/gui/DatabaseOpenWidget.h
+++ b/src/gui/DatabaseOpenWidget.h
@@ -49,7 +49,7 @@ public:
     void load(const QString& filename);
     QString filename();
     void clearForms();
-    void enterKey(const QString& pw, const QString& keyFile);
+    void enterKey(const QString& pw, const QString& keyFile, const QString& yubikey = {});
     QSharedPointer<Database> database();
     bool unlockingDatabase();
     void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);
@@ -67,7 +67,7 @@ signals:
 protected:
     bool event(QEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
-    QSharedPointer<CompositeKey> buildDatabaseKey();
+    QSharedPointer<CompositeKey> buildDatabaseKey(const QString& yubikey = {});
     void setUserInteractionLock(bool state);
 
     const QScopedPointer<Ui::DatabaseOpenWidget> m_ui;
@@ -76,7 +76,7 @@ protected:
     bool m_retryUnlockWithEmptyPassword = false;
 
 protected slots:
-    virtual void openDatabase();
+    virtual void openDatabase(const QString& yubikey = {});
     void reject();
 
 private slots:

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -156,7 +156,8 @@ void DatabaseTabWidget::openDatabase()
 void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
                                        bool inBackground,
                                        const QString& password,
-                                       const QString& keyfile)
+                                       const QString& keyfile,
+                                       const QString& yubikey)
 {
     QString cleanFilePath = QDir::toNativeSeparators(filePath);
     QFileInfo fileInfo(cleanFilePath);
@@ -173,7 +174,7 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
         Q_ASSERT(dbWidget);
         if (dbWidget
             && dbWidget->database()->canonicalFilePath().compare(canonicalFilePath, FILE_CASE_SENSITIVE) == 0) {
-            dbWidget->performUnlockDatabase(password, keyfile);
+            dbWidget->performUnlockDatabase(password, keyfile, yubikey);
             if (!inBackground) {
                 // switch to existing tab if file is already open
                 setCurrentIndex(indexOf(dbWidget));
@@ -184,7 +185,7 @@ void DatabaseTabWidget::addDatabaseTab(const QString& filePath,
 
     auto* dbWidget = new DatabaseWidget(QSharedPointer<Database>::create(cleanFilePath), this);
     addDatabaseTab(dbWidget, inBackground);
-    dbWidget->performUnlockDatabase(password, keyfile);
+    dbWidget->performUnlockDatabase(password, keyfile, yubikey);
     updateLastDatabases(dbWidget->database());
 }
 

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -53,7 +53,8 @@ public slots:
     void addDatabaseTab(const QString& filePath,
                         bool inBackground = false,
                         const QString& password = {},
-                        const QString& keyfile = {});
+                        const QString& keyfile = {},
+                        const QString& yubikey = {});
     void addDatabaseTab(DatabaseWidget* dbWidget, bool inBackground = false);
     bool closeDatabaseTab(int index);
     bool closeDatabaseTab(DatabaseWidget* dbWidget);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1704,7 +1704,7 @@ void DatabaseWidget::removePasskeyFromEntry()
 }
 #endif
 
-void DatabaseWidget::performUnlockDatabase(const QString& password, const QString& keyfile)
+void DatabaseWidget::performUnlockDatabase(const QString& password, const QString& keyfile, const QString& yubikey)
 {
     if (password.isEmpty() && keyfile.isEmpty()) {
         return;
@@ -1712,7 +1712,7 @@ void DatabaseWidget::performUnlockDatabase(const QString& password, const QStrin
 
     if (!m_db->isInitialized() || isLocked()) {
         switchToOpenDatabase();
-        m_databaseOpenWidget->enterKey(password, keyfile);
+        m_databaseOpenWidget->enterKey(password, keyfile, yubikey);
     }
 }
 

--- a/src/gui/DatabaseWidget.h
+++ b/src/gui/DatabaseWidget.h
@@ -244,7 +244,7 @@ public slots:
     void switchToOpenDatabase();
     void switchToOpenDatabase(const QString& filePath);
     void switchToOpenDatabase(const QString& filePath, const QString& password, const QString& keyFile);
-    void performUnlockDatabase(const QString& password, const QString& keyfile = {});
+    void performUnlockDatabase(const QString& password, const QString& keyfile = {}, const QString& yubikey = {});
     void emptyRecycleBin();
 
     // Search related slots

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -884,9 +884,9 @@ void MainWindow::clearLastDatabases()
     }
 }
 
-void MainWindow::openDatabase(const QString& filePath, const QString& password, const QString& keyfile)
+void MainWindow::openDatabase(const QString& filePath, const QString& password, const QString& keyfile, const QString& yubikey)
 {
-    m_ui->tabWidget->addDatabaseTab(filePath, false, password, keyfile);
+    m_ui->tabWidget->addDatabaseTab(filePath, false, password, keyfile, yubikey);
 }
 
 void MainWindow::updateMenuActionState()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -70,7 +70,7 @@ signals:
     void databaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget);
 
 public slots:
-    void openDatabase(const QString& filePath, const QString& password = {}, const QString& keyfile = {});
+    void openDatabase(const QString& filePath, const QString& password = {}, const QString& keyfile = {}, const QString& yubikey = {});
     void appExit();
     bool isHardwareKeySupported();
     bool refreshHardwareKeys();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, char** argv)
         "localconfig", QObject::tr("path to a custom local config file"), "localconfig");
     QCommandLineOption lockOption("lock", QObject::tr("lock all open databases"));
     QCommandLineOption keyfileOption("keyfile", QObject::tr("key file of the database"), "keyfile");
+    QCommandLineOption yubikeyOption("yubikey", QObject::tr("Yubikey slot and optional serial used to access the database (e.g., 1:7370001)."), "slot[:serial");
     QCommandLineOption pwstdinOption("pw-stdin", QObject::tr("read password of the database from stdin"));
     QCommandLineOption allowScreenCaptureOption("allow-screencapture",
                                                 QObject::tr("allow screenshots and app recording (Windows/macOS)"));
@@ -93,6 +94,7 @@ int main(int argc, char** argv)
     parser.addOption(localConfigOption);
     parser.addOption(lockOption);
     parser.addOption(keyfileOption);
+    parser.addOption(yubikeyOption);
     parser.addOption(pwstdinOption);
     parser.addOption(debugInfoOption);
     parser.addOption(allowScreenCaptureOption);
@@ -205,7 +207,7 @@ int main(int argc, char** argv)
             out << QObject::tr("Database password: ") << Qt::flush;
             password = Utils::getPassword();
         }
-        mainWindow.openDatabase(filename, password, parser.value(keyfileOption));
+        mainWindow.openDatabase(filename, password, parser.value(keyfileOption), parser.value(yubikeyOption));
     }
 
     // start minimized if configured


### PR DESCRIPTION
Implemented GUI CLI arguments for specifying a smartcard in challenge-response mode to use for unlocking a database.

Resolves: #12528

I achieved this by first adding optional smartcard arguments to the [entry point of the GUI application](https://github.com/Spamtributor/keepassxc-contributions/blob/6d0675e8bf55d1c29e731261f07b5e6434b19cc7/src/main.cpp) before passing it down the call stack all the way to "[DatabaseOpenWidget::buildDatabaseKey](https://github.com/Spamtributor/keepassxc-contributions/blob/6d0675e8bf55d1c29e731261f07b5e6434b19cc7/src/gui/DatabaseOpenWidget.cpp#L434)" and then performing the challenge response procedure both in [exactly the same way as the pure CLI](https://github.com/Spamtributor/keepassxc-contributions/blob/6d0675e8bf55d1c29e731261f07b5e6434b19cc7/src/cli/Utils.cpp#L174).

## Usage:
```
KeePassXC --yubikey 1:12345678 Passwords.kdbx
```

## Testing strategy:
I didn't implement test cases for this new feature because the GUI CLI scope was already uncovered by the existing test cases and was therefore unsure how to proceed however I ran the existing tests and received the same results before and after my modifications as well as tested the following cases, if this is a issue I will be happy to ablidge:
- Failing to unlock a database with a invalid smartcard argument.
- Unlocking a database with a valid smartcard argument.
- Failing to unlock a database with a valid smartcard argument due to it not being connected.
- Failing to unlock a database with a valid smartcard argument due to failing to press the touch sensor.
- Failing to unlock a database with a valid smartcard argument due to it not needing one.

## Type of change:
- ✅ New feature (change that adds functionality)