### PR TITLE
Build: Resolve CMake warning CMP0175 for add_custom_command

### DIFF
--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -6,7 +6,7 @@
 #  the Free Software Foundation, either version 2 or (at your option)
 #  version 3 of the License.
 #
-#  This program is distributed in the hope that it will be usefugit add share/CMakeLists.txtl,
+#  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -6,7 +6,7 @@
 #  the Free Software Foundation, either version 2 or (at your option)
 #  version 3 of the License.
 #
-#  This program is distributed in the hope that it will be useful,
+#  This program is distributed in the hope that it will be usefugit add share/CMakeLists.txtl,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
@@ -79,16 +79,19 @@ install(FILES icons/application/256x256/apps/keepassxc.png DESTINATION ${DATA_IN
 
 add_custom_target(icons)
 add_custom_command(TARGET icons
+        POST_BUILD
         COMMAND bash ./icons/minify.sh
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 if(APPLE)
     add_custom_command(TARGET icons
+            POST_BUILD
             COMMAND png2icns macosx/keepassxc.icns icons/application/256x256/apps/keepassxc.png
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
 # ICO for Windows
 add_custom_command(TARGET icons
+    POST_BUILD
     COMMAND bash ./windows/create-ico.sh icons/application/scalable/apps/keepassxc.svg windows/keepassxc.ico
     COMMAND bash ./windows/create-ico.sh icons/application/scalable/mimetypes/application-x-keepassxc.svg windows/keepassxc-kdbx.ico
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This pull request resolves the CMake developer warning for policy CMP0175, which was introduced in CMake 3.31.

The add_custom_command() calls in share/CMakeLists.txt were missing an execution time specifier (PRE_BUILD, PRE_LINK, or POST_BUILD). This change adds the POST_BUILD keyword to explicitly define the command's execution time, which preserves the original behavior while satisfying the new policy and removing the warning.

Fixes #12397







