### PR TITLE
Fix: Sanitize username to prevent single-instance detection failure

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -426,6 +426,29 @@ namespace Tools
         return filename.trimmed();
     }
 
+    QString cleanUsername()
+    {
+#if defined(Q_OS_WIN)
+        QString userName = qgetenv("USERNAME");
+        if (userName.isEmpty()) {
+            userName = qgetenv("USER");
+        }
+#else
+        QString userName = qgetenv("USER");
+        if (userName.isEmpty()) {
+            userName = qgetenv("USERNAME");
+        }
+#endif
+        // Sanitize username for file safety
+        userName = userName.trimmed();
+        // Replace <>:"/\|?* with _
+        userName.replace(QRegularExpression(R"([<>:\"\/\\|?*])"), "_");
+        // Remove trailing dots and spaces
+        userName.replace(QRegularExpression(R"([.\s]+$)"), "");
+
+        return userName;
+    }
+
     QVariantMap qo2qvm(const QObject* object, const QStringList& ignoredProperties)
     {
         QVariantMap result;

--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -48,6 +48,7 @@ namespace Tools
     QString envSubstitute(const QString& filepath,
                           QProcessEnvironment environment = QProcessEnvironment::systemEnvironment());
     QString cleanFilename(QString filename);
+    QString cleanUsername();
 
     template <class T> QSet<T> asSet(const QList<T>& a)
     {

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -76,26 +76,26 @@ Application::Application(int& argc, char** argv)
     }
 #endif
 
-
+    // Sanitize the username to create a valid filename component
     static const QRegularExpression invalidFileChars(R"([<>:\"/\\|?*])");
     userName.replace(invalidFileChars, "_");
 
-    // Remove leading/trailing whitespace and trailing dots/spaces
+    // Remove leading/trailing whitespace and trailing dots/spaces which are invalid on Windows
     userName = userName.trimmed();
-     while (!userName.isEmpty() && (userName.endsWith('.') || userName.endsWith(' '))) {
-     userName.chop(1);
+    while (!userName.isEmpty() && (userName.endsWith('.') || userName.endsWith(' '))) {
+        userName.chop(1);
     }
 
-    // Build identifier for lock/socket file naming
+    // Build identifier for lock/socket file naming using the sanitized username
     QString identifier = QStringLiteral("keepassxc");
     if (!userName.isEmpty()) {
-       identifier += QChar('-') + userName;
+        identifier += QChar('-') + userName;
     }
 #ifdef QT_DEBUG
     identifier += QStringLiteral("-DEBUG");
 #endif
     QString lockName   = identifier + QStringLiteral(".lock");
-    m_socketName       = identifier + QStringLiteral(".socket");
+    m_socketName       = identifier + QStringLiteral(".socket")
 
     QString identifier = "keepassxc";
     if (!userName.isEmpty()) {

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -31,9 +31,9 @@
 #include <QLocalSocket>
 #include <QLockFile>
 #include <QPixmapCache>
+#include <QRegularExpression>
 #include <QSocketNotifier>
 #include <QStandardPaths>
-#include <QRegularExpression>
 
 #if defined(Q_OS_UNIX)
 #include <csignal>
@@ -77,17 +77,17 @@ Application::Application(int& argc, char** argv)
 #endif
 
     // Sanitize username for file safety
-     static const QRegularExpression invalidFileChars(R"([<>:\"/\\|?*])");
-     userName.replace(invalidFileChars, "_");
+    static const QRegularExpression invalidFileChars(R"([<>:\"/\\|?*])");
+    userName.replace(invalidFileChars, "_");
 
-     // Trim whitespace and invalid trailing characters
+    // Trim whitespace and invalid trailing characters
     userName = userName.trimmed();
-      while (!userName.isEmpty() && (userName.endsWith('.') || userName.endsWith(' '))) {
+    while (!userName.isEmpty() && (userName.endsWith('.') || userName.endsWith(' '))) {
         userName.chop(1);
     }
 
-     // Build identifier
-        // Build identifier
+    // Build identifier
+    // Build identifier
     QString identifier = QStringLiteral("keepassxc");
     if (!userName.isEmpty()) {
         identifier += QChar('-') + userName;
@@ -97,9 +97,8 @@ Application::Application(int& argc, char** argv)
     identifier += QStringLiteral("-DEBUG");
 #endif
 
-    QString lockName   = identifier + QStringLiteral(".lock");
-    m_socketName       = identifier + QStringLiteral(".socket");
-
+    QString lockName = identifier + QStringLiteral(".lock");
+    m_socketName = identifier + QStringLiteral(".socket");
 
     // According to documentation we should use RuntimeLocation on *nixes, but even Qt doesn't respect
     // this and creates sockets in TempLocation, so let's be consistent.

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -63,10 +63,20 @@ Application::Application(int& argc, char** argv)
     registerUnixSignals();
 #endif
 
+#if defined(Q_OS_WIN)
+    QString userName = qgetenv("USERNAME");
+    if (userName.isEmpty()) {
+        userName = qgetenv("USER");
+    }
+#else
     QString userName = qgetenv("USER");
     if (userName.isEmpty()) {
         userName = qgetenv("USERNAME");
     }
+#endif
+
+userName.replace('/', '_');
+userName.replace('\\', '_');
     QString identifier = "keepassxc";
     if (!userName.isEmpty()) {
         identifier += "-" + userName;

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -33,6 +33,7 @@
 #include <QPixmapCache>
 #include <QSocketNotifier>
 #include <QStandardPaths>
+#include <QRegularExpression>
 
 #if defined(Q_OS_UNIX)
 #include <csignal>

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -75,8 +75,27 @@ Application::Application(int& argc, char** argv)
     }
 #endif
 
-userName.replace('/', '_');
-userName.replace('\\', '_');
+
+    static const QRegularExpression invalidFileChars(R"([<>:\"/\\|?*])");
+    userName.replace(invalidFileChars, "_");
+
+    // Remove leading/trailing whitespace and trailing dots/spaces
+    userName = userName.trimmed();
+     while (!userName.isEmpty() && (userName.endsWith('.') || userName.endsWith(' '))) {
+     userName.chop(1);
+    }
+
+    // Build identifier for lock/socket file naming
+    QString identifier = QStringLiteral("keepassxc");
+    if (!userName.isEmpty()) {
+       identifier += QChar('-') + userName;
+    }
+#ifdef QT_DEBUG
+    identifier += QStringLiteral("-DEBUG");
+#endif
+    QString lockName   = identifier + QStringLiteral(".lock");
+    m_socketName       = identifier + QStringLiteral(".socket");
+
     QString identifier = "keepassxc";
     if (!userName.isEmpty()) {
         identifier += "-" + userName;

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -20,6 +20,7 @@
 #include "Application.h"
 
 #include "core/Bootstrap.h"
+#include "core/Tools.h"
 #include "gui/MainWindow.h"
 #include "gui/MessageBox.h"
 #include "gui/osutils/OSUtils.h"
@@ -64,33 +65,11 @@ Application::Application(int& argc, char** argv)
     registerUnixSignals();
 #endif
 
-#if defined(Q_OS_WIN)
-    QString userName = qgetenv("USERNAME");
-    if (userName.isEmpty()) {
-        userName = qgetenv("USER");
-    }
-#else
-    QString userName = qgetenv("USER");
-    if (userName.isEmpty()) {
-        userName = qgetenv("USERNAME");
-    }
-#endif
-
-    // Sanitize username for file safety
-    static const QRegularExpression invalidFileChars(R"([<>:\"/\\|?*])");
-    userName.replace(invalidFileChars, "_");
-
-    // Trim whitespace and invalid trailing characters
-    userName = userName.trimmed();
-    while (!userName.isEmpty() && (userName.endsWith('.') || userName.endsWith(' '))) {
-        userName.chop(1);
-    }
-
     // Build identifier
-    // Build identifier
-    QString identifier = QStringLiteral("keepassxc");
-    if (!userName.isEmpty()) {
-        identifier += QChar('-') + userName;
+    auto identifier = QStringLiteral("keepassxc");
+    auto username = Tools::cleanUsername();
+    if (!username.isEmpty()) {
+        identifier += QChar('-') + username;
     }
 #ifdef QT_DEBUG
     // In DEBUG mode don’t interfere with Release instances

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -76,37 +76,30 @@ Application::Application(int& argc, char** argv)
     }
 #endif
 
-    // Sanitize the username to create a valid filename component
-    static const QRegularExpression invalidFileChars(R"([<>:\"/\\|?*])");
-    userName.replace(invalidFileChars, "_");
+    // Sanitize username for file safety
+     static const QRegularExpression invalidFileChars(R"([<>:\"/\\|?*])");
+     userName.replace(invalidFileChars, "_");
 
-    // Remove leading/trailing whitespace and trailing dots/spaces which are invalid on Windows
+     // Trim whitespace and invalid trailing characters
     userName = userName.trimmed();
-    while (!userName.isEmpty() && (userName.endsWith('.') || userName.endsWith(' '))) {
+      while (!userName.isEmpty() && (userName.endsWith('.') || userName.endsWith(' '))) {
         userName.chop(1);
     }
 
-    // Build identifier for lock/socket file naming using the sanitized username
+     // Build identifier
+        // Build identifier
     QString identifier = QStringLiteral("keepassxc");
     if (!userName.isEmpty()) {
         identifier += QChar('-') + userName;
     }
 #ifdef QT_DEBUG
+    // In DEBUG mode don’t interfere with Release instances
     identifier += QStringLiteral("-DEBUG");
 #endif
-    QString lockName   = identifier + QStringLiteral(".lock");
-    m_socketName       = identifier + QStringLiteral(".socket")
 
-    QString identifier = "keepassxc";
-    if (!userName.isEmpty()) {
-        identifier += "-" + userName;
-    }
-#ifdef QT_DEBUG
-    // In DEBUG mode don't interfere with Release instances
-    identifier += "-DEBUG";
-#endif
-    QString lockName = identifier + ".lock";
-    m_socketName = identifier + ".socket";
+    QString lockName   = identifier + QStringLiteral(".lock");
+    m_socketName       = identifier + QStringLiteral(".socket");
+
 
     // According to documentation we should use RuntimeLocation on *nixes, but even Qt doesn't respect
     // this and creates sockets in TempLocation, so let's be consistent.

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -428,3 +428,26 @@ void TestTools::testIsTextMimeType()
         QVERIFY(!Tools::isTextMimeType(noText));
     }
 }
+
+// Test sanitization logic for Tools::cleanUsername
+void TestTools::testCleanUsername()
+{
+    // Test vars
+    QFETCH(QString, input);
+    QFETCH(QString, expected);
+
+    qputenv("USER", input.toUtf8());
+    qputenv("USERNAME", input.toUtf8());
+    QCOMPARE(Tools::cleanUsername(), expected);
+}
+
+void TestTools::testCleanUsername_data()
+{
+    QTest::addColumn<QString>("input");
+    QTest::addColumn<QString>("expected");
+
+    QTest::newRow("Leading and trailing spaces") << "  user  " << "user";
+    QTest::newRow("Special characters") << R"(user<>:"/\|?*name)" << "user_________name";
+    QTest::newRow("Trailing dots and spaces") << "username...   " << "username";
+    QTest::newRow("Combination of issues") << R"(  user<>:"/\|?*name...   )" << "user_________name";
+}

--- a/tests/TestTools.h
+++ b/tests/TestTools.h
@@ -41,6 +41,8 @@ private slots:
     void testGetMimeType();
     void testGetMimeTypeByFileInfo();
     void testIsTextMimeType();
+    void testCleanUsername();
+    void testCleanUsername_data();
 };
 
 #endif // KEEPASSX_TESTTOOLS_H


### PR DESCRIPTION
Fixes #12049 

The single-instance detection feature fails on systems where the environment variable used for the username (USER or USERNAME) contains characters that are invalid in filenames (e.g., /, \).

This prevents the .lock file from being created, which causes the application to allow multiple instances to run simultaneously, even when the option is disabled.

Solution:

This PR resolves the issue by sanitizing the username string before it is used to construct the lock file identifier. It uses a regular expression to find and replace all invalid filename characters with an underscore (_).

This approach is more robust as it protects against invalid characters from any source, ensuring the lock file can always be created.