### PR TITLE
Actual version of the Transifex client

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -95,6 +95,7 @@ If you open a Pull Request with new strings that require translations, you will 
 ./release-tool i18n lupdate
 ```
 This will make the new strings available for translation in Transifex.
+This command requires the [Transifex command-line client](https://github.com/transifex/cli/releases) installed.
 
 ## Styleguides
 

--- a/release-tool
+++ b/release-tool
@@ -335,7 +335,7 @@ checkAppStreamInfo() {
 
 checkTransifexCommandExists() {
     if ! cmdExists tx; then
-        exitError "Transifex tool 'tx' not installed! Please install it using 'pip install transifex-client'."
+        exitError "Transifex tool 'tx' not installed! Please install it from <https://github.com/transifex/cli/releases>."
     fi
 }
 


### PR DESCRIPTION
The [currently specified version of Transifex client](https://pypi.org/project/transifex-client/) is outdated. Transifex has changed the API.

Currently, it is not possible to update translations according to the proposed instructions:

```
$ ./release-tool i18n tx-pull

KeePassXC Release Preparation Helper
Copyright (C) 2021 KeePassXC Team <https://keepassxc.org/>

[ INFO ] Pulling updated translations from Transifex...
tx ERROR: not enough values to unpack (expected 2, got 1)
[ INFO ] Checking out original branch...
[ INFO ] Leaving source directory...
[ ERROR ] Error occurred!
```

[The official website](https://developers.transifex.com/docs/cli) contains a link to an actual version.

## Testing strategy
Retry pull with the official version

## Type of change
- ✅ Documentation (non-code change)
