### PR TITLE
Open TOTP setup dialog if entry has no TOTP set

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -559,7 +559,6 @@ void DatabaseWidget::copyTotp()
     // If the entry has no TOTP set, open the setup dialog first
     if (!currentEntry->hasTotp()) {
         setupTotp();
-        return;
     }
 
     setClipboardTextAndMinimize(currentEntry->totp());

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -559,6 +559,7 @@ void DatabaseWidget::copyTotp()
     // If the entry has no TOTP set, open the setup dialog first
     if (!currentEntry->hasTotp()) {
         setupTotp();
+        return;
     }
 
     setClipboardTextAndMinimize(currentEntry->totp());

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -555,6 +555,13 @@ void DatabaseWidget::copyTotp()
     if (!currentEntry) {
         return;
     }
+
+    // If the entry has no TOTP set, open the setup dialog first
+    if (!currentEntry->hasTotp()) {
+        setupTotp();
+        return;
+    }
+
     setClipboardTextAndMinimize(currentEntry->totp());
 }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -557,7 +557,7 @@ void DatabaseWidget::copyTotp()
     }
 
     // If the entry has no TOTP set, open the setup dialog first
-    if (!currentEntry->hasTotp()) {
+    if (!currentEntry->hasValidTotp()) {
         setupTotp();
         return;
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1000,7 +1000,7 @@ void MainWindow::updateMenuActionState()
     m_ui->actionEntryAutoTypeTOTP->setVisible(singleEntrySelected && dbWidget->currentEntryHasTotp());
     m_ui->actionEntryOpenUrl->setEnabled(singleEntryOrEditing && dbWidget->currentEntryHasUrl());
     m_ui->actionEntryTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
-    m_ui->actionEntryCopyTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
+    m_ui->actionEntryCopyTotp->setEnabled(singleEntrySelected);
     m_ui->actionEntryCopyPasswordTotp->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());
     m_ui->actionEntrySetupTotp->setEnabled(singleEntrySelected);
     m_ui->actionEntryTotpQRCode->setEnabled(singleEntrySelected && dbWidget->currentEntryHasTotp());


### PR DESCRIPTION
- When creating a new entry, if TOTP setup is needed, the user previously had to right-click, select “Set up TOTP…”, paste the key, press OK, then press Cmd+T (on macOS) to copy the TOTP.  
- The “Copy TOTP” function was disabled when no TOTP key was set.  
- I changed the behavior as follows:  
  + In the “Copy TOTP” action, if no TOTP key is set, automatically open the “Set up TOTP…” dialog.  
  + New workflow: press Cmd+T, paste the TOTP key (Cmd+V), press Enter (same as OK), then press Cmd+T again to copy the TOTP code.  
  + Benefit: no mouse needed.  

## Screenshots
![Kapture 2025-10-23 at 07 43 40](https://github.com/user-attachments/assets/5174bd05-39a7-4c95-9813-668cfc8fef6e)

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
