### PR TITLE
release-tool: Move appimage zsync file to output dir

### DIFF
--- a/release-tool.py
+++ b/release-tool.py
@@ -832,6 +832,10 @@ class Build(Command):
               f'KeePassXC-*-{platform_target}.AppImage.zsync',
               app_dir.as_posix(), (output_dir.absolute() / appimage_name).as_posix()],
              cwd=build_dir, capture_output=False, path=env_path, **docker_args, docker_privileged=True)
+        # Move appimage zsync file to output dir
+        zsync_file = next(Path(build_dir).glob('*.AppImage.zsync'), None)
+        if zsync_file and zsync_file.is_file():
+            zsync_file.rename(output_dir.absolute() / zsync_file.name)
 
 
 class BuildSrc(Command):

--- a/release-tool.py
+++ b/release-tool.py
@@ -835,7 +835,7 @@ class Build(Command):
         # Move appimage zsync file to output dir
         zsync_file = next(Path(build_dir).glob('*.AppImage.zsync'), None)
         if zsync_file and zsync_file.is_file():
-            zsync_file.rename(output_dir.absolute() / zsync_file.name)
+            shutil.move(zsync_file.absolute(), output_dir.absolute() / zsync_file.name)
 
 
 class BuildSrc(Command):


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
Moves the zsync file from the temporary build folder to the output directory.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
