### PR TITLE
Remove Last Accessed from GUI

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3876,14 +3876,6 @@ Supported extensions are: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Accessed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Datetime accessed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Uuid:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4257,10 +4249,6 @@ Would you like to overwrite the existing attachment?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Accessed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Attachments</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4294,10 +4282,6 @@ Would you like to overwrite the existing attachment?</source>
     </message>
     <message>
         <source>Last modification date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Last access date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/gui/EditWidgetProperties.cpp
+++ b/src/gui/EditWidgetProperties.cpp
@@ -48,7 +48,6 @@ void EditWidgetProperties::setFields(const TimeInfo& timeInfo, const QUuid& uuid
     static const QString timeFormat("d MMM yyyy HH:mm:ss");
     m_ui->modifiedEdit->setText(timeInfo.lastModificationTime().toLocalTime().toString(timeFormat));
     m_ui->createdEdit->setText(timeInfo.creationTime().toLocalTime().toString(timeFormat));
-    m_ui->accessedEdit->setText(timeInfo.lastAccessTime().toLocalTime().toString(timeFormat));
     m_ui->uuidEdit->setText(uuid.toRfc4122().toHex());
 }
 

--- a/src/gui/EditWidgetProperties.ui
+++ b/src/gui/EditWidgetProperties.ui
@@ -83,27 +83,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="labelAccessed">
-       <property name="text">
-        <string>Accessed:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="accessedEdit">
-       <property name="accessibleName">
-        <string>Datetime accessed</string>
-       </property>
-       <property name="readOnly">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
+    <item row="2" column="0">
       <widget class="QLabel" name="labelUuid">
        <property name="text">
         <string>Uuid:</string>
@@ -113,7 +93,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+    <item row="2" column="1">
       <widget class="QLineEdit" name="uuidEdit">
        <property name="accessibleName">
         <string>Unique ID</string>
@@ -204,7 +184,6 @@
  <tabstops>
   <tabstop>createdEdit</tabstop>
   <tabstop>modifiedEdit</tabstop>
-  <tabstop>accessedEdit</tabstop>
   <tabstop>uuidEdit</tabstop>
  </tabstops>
  <resources/>

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -203,9 +203,6 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
         case Modified:
             result = Clock::toString(entry->timeInfo().lastModificationTime().toLocalTime());
             return result;
-        case Accessed:
-            result = Clock::toString(entry->timeInfo().lastAccessTime().toLocalTime());
-            return result;
         case Attachments: {
             // Display comma-separated list of attachments
             QList<QString> attachments = entry->attachments()->keys();
@@ -266,8 +263,6 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
             return entry->timeInfo().creationTime();
         case Modified:
             return entry->timeInfo().lastModificationTime();
-        case Accessed:
-            return entry->timeInfo().lastAccessTime();
         case Paperclip:
             // Display entries with attachments above those without when
             // sorting ascendingly (and vice versa when sorting descendingly)
@@ -400,8 +395,6 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Created");
         case Modified:
             return tr("Modified");
-        case Accessed:
-            return tr("Accessed");
         case Attachments:
             return tr("Attachments");
         case Size:
@@ -441,8 +434,6 @@ QVariant EntryModel::headerData(int section, Qt::Orientation orientation, int ro
             return tr("Creation date");
         case Modified:
             return tr("Last modification date");
-        case Accessed:
-            return tr("Last access date");
         case Attachments:
             return tr("Attached files");
         case Size:

--- a/src/gui/entry/EntryModel.h
+++ b/src/gui/entry/EntryModel.h
@@ -43,7 +43,7 @@ public:
         Expires = 6,
         Created = 7,
         Modified = 8,
-        Accessed = 9,
+        Accessed = 9, // Kept for compatibility
         Paperclip = 10,
         Attachments = 11,
         Totp = 12,

--- a/src/gui/entry/EntryView.cpp
+++ b/src/gui/entry/EntryView.cpp
@@ -105,12 +105,16 @@ EntryView::EntryView(QWidget* parent)
     m_columnActions->setExclusive(false);
     for (int visualIndex = 0; visualIndex < header()->count(); ++visualIndex) {
         int logicalIndex = header()->logicalIndex(visualIndex);
-        QString caption = m_model->headerData(logicalIndex, Qt::Horizontal, Qt::DisplayRole).toString();
-        if (caption.isEmpty()) {
-            caption = m_model->headerData(logicalIndex, Qt::Horizontal, Qt::ToolTipRole).toString();
+        auto caption = m_model->headerData(logicalIndex, Qt::Horizontal, Qt::DisplayRole);
+        if (!caption.isValid()) {
+            caption = m_model->headerData(logicalIndex, Qt::Horizontal, Qt::ToolTipRole);
+            if (!caption.isValid()) {
+                // Ignored column, skip it
+                continue;
+            }
         }
 
-        auto action = m_headerMenu->addAction(caption);
+        auto action = m_headerMenu->addAction(caption.toString());
         action->setCheckable(true);
         action->setData(logicalIndex);
         m_columnActions->addAction(action);
@@ -478,7 +482,6 @@ void EntryView::resetViewToDefaults()
     header()->hideSection(EntryModel::Password);
     header()->hideSection(EntryModel::Expires);
     header()->hideSection(EntryModel::Created);
-    header()->hideSection(EntryModel::Accessed);
     header()->hideSection(EntryModel::Attachments);
     header()->hideSection(EntryModel::Size);
     header()->hideSection(EntryModel::PasswordStrength);
@@ -515,6 +518,8 @@ void EntryView::resetViewToDefaults()
 void EntryView::onHeaderChanged()
 {
     m_model->setBackgroundColorVisible(isColumnHidden(EntryModel::Color));
+    // Force hide accessed column
+    header()->hideSection(EntryModel::Accessed);
 }
 
 void EntryView::showEvent(QShowEvent* event)


### PR DESCRIPTION
* Closes #2005

NOTE: Because of how we handle headers in the entry view, we have to keep the last accessed header _number_ in place. That ensures previously saved column settings don't show the wrong columns.

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested before/after change, last accessed column is no longer visible or selectable in entry view. Last accessed is also removed from entry properties screen.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
