### PR TITLE
Fix out-of-memory crash with malformed ssh keys

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -877,6 +877,17 @@ Ctrl+Shift+4 - Copy URL&lt;br/&gt;
     </message>
 </context>
 <context>
+    <name>BinaryStream</name>
+    <message>
+        <source>Failed to read string data: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>String length exceeds 10 MiB limit (requested %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserAccessControlDialog</name>
     <message>
         <source>KeePassXC - Browser Access Request</source>
@@ -6695,10 +6706,6 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to read public key.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Corrupted key file, reading private key failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6784,6 +6791,14 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
     </message>
     <message>
         <source>(encrypted)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to read key file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to read public key: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/sshagent/BinaryStream.cpp
+++ b/src/sshagent/BinaryStream.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "BinaryStream.h"
+#include "core/Tools.h"
 #include <QtEndian>
 
 BinaryStream::BinaryStream(QIODevice* device)
@@ -116,9 +117,16 @@ bool BinaryStream::readString(QByteArray& ba)
         return false;
     }
 
+    // Don't attempt to read strings over 10 MiB
+    if (length > 1024 * 1024 * 10) {
+        m_error = tr("String length exceeds 10 MiB limit (requested %1)").arg(Tools::humanReadableFileSize(length, 0));
+        return false;
+    }
+
     ba.resize(length);
 
     if (!read(ba.data(), ba.length())) {
+        m_error = tr("Failed to read string data: %1").arg(m_device->errorString());
         return false;
     }
 

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -312,9 +312,10 @@ bool OpenSSHKey::parsePKCS1PEM(const QByteArray& in)
             return false;
         }
 
-        stream.readString(m_cipherName);
-        stream.readString(m_kdfName);
-        stream.readString(m_kdfOptions);
+        if (!stream.readString(m_cipherName) || !stream.readString(m_kdfName) || !stream.readString(m_kdfOptions)) {
+            m_error = tr("Failed to read key file: %1").arg(stream.errorString());
+            return false;
+        }
 
         quint32 numberOfKeys;
         stream.read(numberOfKeys);
@@ -327,7 +328,7 @@ bool OpenSSHKey::parsePKCS1PEM(const QByteArray& in)
         for (quint32 i = 0; i < numberOfKeys; ++i) {
             QByteArray publicKey;
             if (!stream.readString(publicKey)) {
-                m_error = tr("Failed to read public key.");
+                m_error = tr("Failed to read public key: %1").arg(stream.errorString());
                 return false;
             }
 


### PR DESCRIPTION
* Reported by @Oblivionsage - thank you!

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
<img width="1448" height="1188" alt="image" src="https://github.com/user-attachments/assets/d510a0ce-88d1-4dce-9183-66b304b5082c" />


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested with proof of concept malformed key provided by @obliviansage

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
