### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/format/BitwardenReader.cpp
+++ b/src/format/BitwardenReader.cpp
@@ -388,11 +388,11 @@ QSharedPointer<Database> BitwardenReader::convert(const QString& path, const QSt
 
         // Derive the MAC Key
         auto stretched_mac = hkdf->derive_key(32, reinterpret_cast<const uint8_t*>(key.data()), key.size(), "", "mac");
-        auto mac = QByteArray(reinterpret_cast<const char*>(stretched_mac.data()), stretched_mac.size());
+        auto mac = QByteArray(reinterpret_cast<const char*>(stretched_mac.data()), static_cast<int>(stretched_mac.size()));
 
         // Stretch the Master Key
         auto stretched_key = hkdf->derive_key(32, reinterpret_cast<const uint8_t*>(key.data()), key.size(), "", "enc");
-        key = QByteArray(reinterpret_cast<const char*>(stretched_key.data()), stretched_key.size());
+        key = QByteArray(reinterpret_cast<const char*>(stretched_key.data()), static_cast<int>(stretched_key.size()));
 
         // Validate the encryption key
         auto keyList = json.value("encKeyValidation_DO_NOT_EDIT").toString().split(".");

--- a/src/keeshare/KeeShareSettings.cpp
+++ b/src/keeshare/KeeShareSettings.cpp
@@ -374,8 +374,8 @@ namespace KeeShareSettings
         QByteArray rsaKeySerialized;
         QDataStream stream(&rsaKeySerialized, QIODevice::WriteOnly);
         stream.writeBytes("ssh-rsa", 7);
-        stream.writeBytes(reinterpret_cast<const char*>(rsaE.data()), rsaE.size());
-        stream.writeBytes(reinterpret_cast<const char*>(rsaN.data()), rsaN.size());
+        stream.writeBytes(reinterpret_cast<const char*>(rsaE.data()), static_cast<uint>(rsaE.size()));
+        stream.writeBytes(reinterpret_cast<const char*>(rsaN.data()), static_cast<uint>(rsaN.size()));
 
         return xmlSerialize([&](QXmlStreamWriter& writer) {
             writer.writeStartElement("Signature");

--- a/src/keeshare/KeeShareSettings.cpp
+++ b/src/keeshare/KeeShareSettings.cpp
@@ -66,7 +66,7 @@ namespace KeeShareSettings
             return;
         }
         auto berKey = Botan::PKCS8::BER_encode(*certificate.key);
-        auto baKey = QByteArray::fromRawData(reinterpret_cast<const char*>(berKey.data()), berKey.size());
+        auto baKey = QByteArray::fromRawData(reinterpret_cast<const char*>(berKey.data()), static_cast<int>(berKey.size()));
 
         writer.writeStartElement("Signer");
         writer.writeCharacters(certificate.signer);
@@ -148,7 +148,7 @@ namespace KeeShareSettings
             return;
         }
         auto berKey = Botan::PKCS8::BER_encode(*key.key);
-        auto baKey = QByteArray::fromRawData(reinterpret_cast<const char*>(berKey.data()), berKey.size());
+        auto baKey = QByteArray::fromRawData(reinterpret_cast<const char*>(berKey.data()), static_cast<int>(berKey.size()));
         writer.writeCharacters(baKey.toBase64());
     }
 


### PR DESCRIPTION
Fix two compiler warnings in MSVC:

* Warning C4244 'argument': conversion from 'size_t' to 'int', possible loss of data.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
