### PR TITLE
Do not show misleading error message if user clicked cancel

### DIFF
--- a/src/gui/databasekey/KeyFileEditWidget.cpp
+++ b/src/gui/databasekey/KeyFileEditWidget.cpp
@@ -132,6 +132,9 @@ void KeyFileEditWidget::browseKeyFile()
     QString filters = QString("%1 (*.keyx *.key);;%2 (*)").arg(tr("Key files"), tr("All files"));
     QString fileName = fileDialog()->getOpenFileName(this, tr("Select a key file"), QString(), filters);
 
+    if (fileName.isEmpty()) { // user clicked on cancel
+        return;
+    }
     if (QFileInfo(fileName).canonicalFilePath() == m_parent->getDatabase()->canonicalFilePath()) {
         MessageBox::critical(getMainWindow(),
                              tr("Invalid Key File"),


### PR DESCRIPTION
Do not show the error message

<img width="502" height="128" alt="grafik" src="https://github.com/user-attachments/assets/3aadcf06-3e70-4655-adc8-d209e0d98cd4" />

if user clicked on cancel in the file browser dialog.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
