### PR TITLE
Update sponsors list and translators fetch script

### DIFF
--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -44,29 +44,43 @@ static const QString aboutContributors = R"(
     <li>Sergey Vilgelm</li>
     <li>Victor Engmark</li>
     <li>NarwhalOfAges</li>
+    <li>No Name</li>
+    <li>SG</li>
+    <li>Riley Moses</li>
+    <li>Esteban Martinez</li>
+    <li>Marc Morocutti</li>
+    <li>Zivix</li>
+    <li>Benedikt Heine</li>
+    <li>Hugo Locurcio</li>
+    <li>William Petrides</li>
+    <li>Gunar Gessner</li>
+    <li>Christian Wittenhorst</li>
+    <li>Matt Cardarelli</li>
+    <li>Paul Ammann</li>
+    <li>Steve Isom</li>
+    <li>GodSpell</li>
+    <li>Lionel Laské</li>
+    <li>Daniel Epp</li>
+    <li>Oleksii Aleksieiev</li>
+    <li>Julian Stier</li>
+    <li>Ruben Schade</li>
+    <li>Bernhard</li>
+    <li>Wojciech Kozlowski</li>
     <li>Caleb Currie</li>
     <li>Morgan Courbet</li>
     <li>Kyle Kneitinger</li>
     <li>Chris Sohns</li>
     <li>Shmavon Gazanchyan</li>
     <li>xjdwc</li>
-    <li>Riley Moses</li>
     <li>Igor Zinovik</li>
     <li>Jeff</li>
-    <li>Esteban Martinez</li>
     <li>Max Andersen</li>
-    <li>Zivix</li>
-    <li>Marc Morocutti</li>
     <li>super scampy</li>
-    <li>Hugo Locurcio</li>
-    <li>Benedikt Heine</li>
     <li>Mischa Peters</li>
     <li>Rainer-Maria Fritsch</li>
     <li>Micha Ober</li>
     <li>Ivan Gromov</li>
-    <li>William Petrides</li>
     <li>Joshua Go</li>
-    <li>Gunar Gessner</li>
     <li>pancakeplant</li>
     <li>Hans-Joachim Forker</li>
     <li>Nicolas Vandemaele</li>
@@ -75,30 +89,66 @@ static const QString aboutContributors = R"(
     <li>Mike</li>
     <li>Thomas Renz</li>
     <li>Toby Cline</li>
-    <li>Christian Wittenhorst</li>
-    <li>Paul Ammann</li>
-    <li>Matt Cardarelli</li>
-    <li>Steve Isom</li>
     <li>Emre Dessoi</li>
-    <li>Wojciech Kozlowski</li>
     <li>Michael Babnick</li>
     <li>kernellinux</li>
     <li>Patrick Evans</li>
     <li>Marco</li>
-    <li>GodSpell</li>
     <li>Jeremy Rubin</li>
     <li>Korbi</li>
     <li>andreas</li>
     <li>Tyche's tidings</li>
     <li>Daniel Kuebler</li>
     <li>Brandon Corujo</li>
+    <li>AheroX</li>
+    <li>Alexandre G</li>
+    <li>AshinaGa</li>
+    <li>BYTEBOLT</li>
+    <li>CEH</li>
+    <li>Chris Stone</li>
+    <li>Christof Böckler</li>
+    <li>Claude</li>
+    <li>CzLer</li>
+    <li>Daniel Burridge</li>
+    <li>dark</li>
+    <li>Dave G</li>
+    <li>David Bowers</li>
+    <li>dickv</li>
+    <li>fp4</li>
+    <li>Huser IT Solutions GmbH</li>
+    <li>irf</li>
+    <li>Isaiah Rahmany</li>
+    <li>JackNYC</li>
+    <li>Jacob Emmert-Aronson</li>
+    <li>John Donadeo</li>
+    <li>Kosta Medinsky</li>
+    <li>leinad987</li>
+    <li>Lux</li>
+    <li>marek</li>
+    <li>mattlongname</li>
+    <li>mattock</li>
+    <li>Max Christian Pohle</li>
+    <li>nta/norma</li>
+    <li>picatsv</li>
+    <li>proto</li>
+    <li>Raymond Lau</li>
+    <li>Waido</li>
+    <li>Weinmann Willy</li>
+    <li>WildMage</li>
+</ul>
+<h3>VIP GitHub Sponsors:</h3>
+<ul>
+    <li>mercedes-benz</li>
+    <li>tiangolo</li>
+    <li>mrniko</li>
+    <li>rszamszur</li>
 </ul>
 <h3>Notable Code Contributions:</h3>
 <ul>
     <li>droidmonkey</li>
     <li>phoerious</li>
-    <li>louib (CLI)</li>
     <li>varjolintu (Browser Integration)</li>
+    <li>louib (CLI)</li>
     <li>hifi (SSH Agent)</li>
     <li>xvallspl (Tags)</li>
     <li>Aetf (FdoSecrets Storage Server)</li>
@@ -109,6 +159,8 @@ static const QString aboutContributors = R"(
     <li>brainplot (many improvements)</li>
     <li>kneitinger (many improvements)</li>
     <li>frostasm (many improvements)</li>
+    <li>libklein (many improvements)</li>
+    <li>w15eacre (many improvements)</li>
     <li>fonic (Entry Table View)</li>
     <li>kylemanna (YubiKey)</li>
     <li>c4rlo (Offline HIBP Checker)</li>
@@ -121,179 +173,145 @@ static const QString aboutContributors = R"(
 </ul>
 <h3>Patreon Supporters:</h3>
 <ul>
-    <li>Richard Ames</li>
-    <li>Bernhard</li>
-    <li>Christian Rasmussen</li>
-    <li>Nuutti Toivola</li>
-    <li>Lionel Laské</li>
-    <li>Tyler Gass</li>
-    <li>NZSmartie</li>
-    <li>Darren</li>
-    <li>Brad</li>
-    <li>Oleksii Aleksieiev</li>
-    <li>Julian Stier</li>
-    <li>Daniel Epp</li>
-    <li>Ruben Schade</li>
-    <li>William Komanetsky</li>
-    <li>Niels Ganser</li>
-    <li>judd</li>
-    <li>Tarek Sherif</li>
-    <li>Eugene</li>
-    <li>CYB3RL4MBD4</li>
-    <li>Alexanderjb</li>
-    <li>Justin Carroll</li>
-    <li>Bart Libert</li>
     <li>Shintaro Matsushima</li>
-    <li>Thammachart Chinvarapon</li>
-    <li>Gernot Premper</li>
-    <li>SLmanDR</li>
     <li>Paul Ellenbogen</li>
     <li>John C</li>
-    <li>Markus Wochnik</li>
-    <li>Clark Henry</li>
-    <li>zapscribe</li>
-    <li>Salt Rock Lamp</li>
-    <li>Steven Crowley</li>
-    <li>Ralph Azucena</li>
-    <li>Guruprasad Kulkarni</li>
-    <li>jose</li>
-    <li>Michael Gulick</li>
-    <li>J Doty</li>
-    <li>Synchro11</li>
-    <li>Michael Soares</li>
-    <li>Johannes Felko</li>
-    <li>Ellie</li>
-    <li>David Walluscheck</li>
-    <li>Anthony Avina</li>
-    <li>pro</li>
-    <li>Mark Luxton</li>
+    <li>Markus</li>
     <li>Crimson Idol</li>
-    <li>Björn König</li>
-    <li>René Weselowski</li>
-    <li>gonczor</li>
+    <li>Steven</li>
+    <li>Ellie</li>
+    <li>Anthony Avina</li>
     <li>PlushElderGod</li>
-    <li>gilgwath</li>
-    <li>Tobias</li>
+    <li>zapscribe</li>
     <li>Christopher Hillenbrand</li>
-    <li>Daddy's c$sh</li>
-    <li>Ashura</li>
-    <li>Florian</li>
-    <li>Alexandre</li>
     <li>Dave Jones</li>
     <li>Brett</li>
-    <li>Jim Vanderbilt</li>
-    <li>Brian McGuire</li>
-    <li>Sid Beske</li>
-    <li>Dmitrii Galinskii</li>
-    <li>Johannes Erchen</li>
-    <li>Brandon Zhang</li>
-    <li>Maxley Fraser</li>
-    <li>Nikul Savasadia</li>
-    <li>Claude</li>
-    <li>alga</li>
-    <li>Philipp Jetschina</li>
+    <li>Ralph Azucena</li>
+    <li>Florian</li>
     <li>Kristoffer Winther Balling</li>
     <li>Peter Link</li>
-    <li>Vlastimil Vondra</li>
-    <li>Tony Wang</li>
-    <li>John Sivak</li>
-    <li>Nol Aders</li>
-    <li>Charlie Drake</li>
-    <li>Ryan Goldstein</li>
-    <li>Doug Witt</li>
     <li>David S H Rosenthal</li>
-    <li>Lance Simmons</li>
-    <li>Mathew Woodyard</li>
-    <li>GanderPL</li>
-    <li>Neša</li>
-    <li>tolias</li>
+    <li>Michael Soares</li>
+    <li>Vlad Didenko</li>
+    <li>henloo</li>
+    <li>Erik Rigtorp</li>
+    <li>Barry McKenzie</li>
+    <li>Sebastian van der Est</li>
+    <li>J.C. Polanycia</li>
+    <li>Peter Upfold</li>
+    <li>Josh Yates-Walker</li>
     <li>Adam</li>
+    <li>HJ</li>
+    <li>bjorndown</li>
+    <li>Tony Wang</li>
+    <li>Nol Aders</li>
+    <li>Dirk Bergstrom</li>
+    <li>proco</li>
+    <li>Philipp Baderschneider</li>
+    <li>Neša</li>
+    <li>Dimitris Kogias</li>
+    <li>Robin Hellsten</li>
+    <li>Scott Williams</li>
+    <li>klepto68</li>
+    <li>Uwe S.</li>
+    <li>codiflow</li>
+    <li>eugene</li>
+    <li>Anton Fisher</li>
+    <li>David Daly</li>
+    <li>Crispy_Steak</li>
+    <li>Cilestin</li>
+    <li>Benjamin</li>
+    <li>Daniel Lakeland</li>
+    <li>erinacio</li>
+    <li>Leo</li>
+    <li>Payton</li>
+    <li>Saicxs</li>
+    <li>Gorund O</li>
+    <li>Tony G</li>
+    <li>Simonas S.</li>
+    <li>LordKnoppers</li>
+    <li>Fabien Duchaussois</li>
+    <li>Tim Bahnes</li>
+    <li>Aleksei Gusev</li>
+    <li>J Hanssen</li>
+    <li>schoepp</li>
+    <li>Klaus</li>
+    <li>Eric</li>
+    <li>Griffondale</li>
+    <li>Andy D</li>
+    <li>YAMAMOTO Yuji</li>
+    <li>elmiko</li>
+    <li>David</li>
+    <li>Nate Wynd</li>
+    <li>Nicolas</li>
+    <li>magila</li>
+    <li>Bryan Fisher</li>
+    <li>Mark Nicholson</li>
+    <li>Asperatus</li>
+    <li>Patrick Buchan-Hepburn</li>
+    <li>Richárd Faragó</li>
+    <li>David Koch</li>
+    <li>cheese_cake</li>
+    <li>duke_money</li>
+    <li>lund</li>
+    <li>Ivana Kellyer</li>
+    <li>Skullzam</li>
+    <li>Chris Bier</li>
+    <li>Gustavo</li>
+    <li>Henning_IdB</li>
+    <li>Edd</li>
+    <li>Net</li>
+    <li>Sergei Slipchenko</li>
+    <li>Amanita</li>
+    <li>Gaara</li>
+    <li>Max</li>
+    <li>5h4d3</li>
+    <li>James Taylor</li>
+    <li>Alexei Bond</li>
+    <li>cck</li>
+    <li>David L</li>
+    <li>devNull</li>
+    <li>Erica</li>
+    <li>Matthew O</li>
+    <li>Druggo Yang</li>
+    <li>Eric Stokes</li>
+</ul>
+<h3>GitHub Sponsors:</h3>
+<ul>
+    <li>rszamszur</li>
+    <li>Sidicas</li>
+    <li>Mr-NH</li>
 </ul>
 <h3>Translations:</h3>
 <ul>
-    <li><strong>العربية (Arabic)</strong>: 3eani, 3nad, AboShanab, butterflyoffire_temp, jBailony, kmutahar, m.hemoudi,
-        Marouane87, microtaha, mohame1d, muha_abdulaziz, Night1, omar.nsy, TheAhmed, zer0x</li>
-    <li><strong>euskara (Basque)</strong>: azken_tximinoa, Galaipa, Hey_neken, porrumentzio</li>
-    <li><strong>বাংলা (Bengali)</strong>: codesmite, Foxom, rediancool, RHJihan</li>
-    <li><strong>ဗမာစာ (Burmese)</strong>: Christine.Ivy, hafe14, Snooooowwwwwman, tuntunaung</li>
-    <li><strong>català (Catalan)</strong>: antoniopolonio, benLabcat, capitantrueno, dsoms, Ecron, jamalinu, jmaribau,
-        MarcRiera, mcus, raulua, zeehio, ZJaume</li>
-    <li><strong>中文 (Chinese (Simplified))</strong>: Biacke, Biggulu, Brandon_c, carp0129, Clafiok, deluxghost, Dy64,
-        ef6, Felix2yu, hoilc, jy06308127, kikyous, kofzhanganguo, ligyxy, lxx4380, oksjd, remonli, ShuiHuo, sjdhome,
-        slgray, Small_Ku, snhun, umi_neko, vc5, Wylmer_Wang, Z4HD</li>
-    <li><strong>中文 (台灣) (Chinese (Traditional))</strong>: BestSteve, Biacke, flachesis, gojpdchx, ligyxy, MiauLightouch,
-        plesry, priv, raymondtau, Siriusmart, Small_Ku, ssuhung, Superbil, th3lusive, yan12125, ymhuang0808</li>
-    <li><strong>hrvatski jezik (Croatian)</strong>: krekrekre, mladenuzelac</li>
-    <li><strong>čeština (Czech)</strong>: DanielMilde, jiri.jagos, pavelb, pavelz, S474N, stps, tpavelek, vojtechjurcik</li>
-    <li><strong>dansk (Danish)</strong>: alfabetacain, dovecode, ebbe, ERYpTION, GimliDk, Grooty12, JakobPP, KalleDK,
-        MannVera, nlkl, Saustrup, thniels</li>
-    <li><strong>Nederlands (Dutch)</strong>: apie, bartlibert, Bubbel, bython, Dr.Default, e2jk, evanoosten, fourwood,
-        fvw, glotzbach, JCKalman, keunes, KnooL, ms.vd.linden, ovisicnarf, pietermj, pvdl, rigrig, srgvg, Stephan_P,
-        stijndubrul, theniels17, ThomasChurchman, timschreinemachers, Vistaus, wanderingidea, Zombaya1</li>
-    <li><strong>Esperanto (Esperanto)</strong>: batisteo</li>
-    <li><strong>eesti (Estonian)</strong>: Hermanio, okul, sarnane, tlend, V6lur</li>
-    <li><strong>suomi (Finnish)</strong>: artnay, hif1, MawKKe, petri, tomisalmi, uusijani, varjolintu</li>
-    <li><strong>français (French)</strong>: ayiniho, Beatussum, butterflyoffire_temp, Cabirto, francoisa, iannick,
-        jean_pierre_raumer, John.Mickael, Jojo6375, lacnic, Marouane87, mohame1d, orion78fr, stephanecodes, swarmpan,
-        t0mmy742, TakeÃ§i, tenzap, webafrancois, x0rld</li>
-    <li><strong>Galego (Galician)</strong>: damufo, enfeitizador, mustek</li>
-    <li><strong>Deutsch (German)</strong>: andreas.maier, antsas, archer_321, ASDFGamer, Atalanttore, BasicBaer, blacksn0w,
-        bwolkchen, Calyrx, clonejo, codejunky, DavidHamburg, eth0, fahstat, FlotterCodername, for1real, frlan, funny0facer,
-        Gyges, h_h, Hativ, heynemax, hjonas, HoferJulian, hueku, janis91, jensrutschmann, jhit, joe776, kflesch, man_at_home,
-        marcbone, MarcEdinger, markusd112, Marouane87, maxwxyz, mcliquid, mfernau77, mircsicz, montilo, MuehlburgPhoenix,
-        muellerma, nautilusx, neon64, Nerzahd, Nightwriter, noodles101, NotAName, nursoda, OLLI_S, omnisome4, origin_de,
-        pcrcoding, PFischbeck, phallobst, philje, pqtjhhBzDd5NuJ9, r3drock, rakekniven, revoltek, rgloor, Rheggie, RogueThorn,
-        rugk, ScholliYT, scotwee, Silas_229, spacemanspiff, SteffoSpieler, testarossa47, TheForcer, thillux, transi_222, traschke,
-        Unkn0wnCat, vlenzer, vpav, waster, wolfram.roesler, Wyrrrd, xf</li>
-    <li><strong>ελληνικά (Greek)</strong>: anvo, arttor, Dkafetzis, giwrgosmant, GorianM, Jason_M, magkopian, nplatis, saglogog,
-        tassos.b, xinomilo</li>
-    <li><strong>עברית (Hebrew)</strong>: avimar, ronyala, shemeshg, shmag18, ThunderB0lt, tryandtry, ztwersky</li>
-    <li><strong>magyar (Hungarian)</strong>: andras_tim, bubu, entaevau, kempelen, meskobalazs, spammy, typingseashell, urbalazs</li>
-    <li><strong>Íslenska (Icelandic)</strong>: MannVera</li>
-    <li><strong>Bahasa Indonesia (Indonesian)</strong>: achmad, algustionesa, bora_ach, racrbmr, zk</li>
-    <li><strong>Italiano (Italian)</strong>: aleb2000, amaxis, bovirus, duncanmid, FranzMari, Gringoarg, idetao, lucaim, NITAL, Peo,
-        Pietrog, salvatorecordiano, seatedscribe, Stemby, the.sailor, tosky, VosaxAlo</li>
-    <li><strong>日本語 (Japanese)</strong>: AlCooo, gojpdchx, helloguys, masoo, p2635, Shinichirou_Yamada, shortarrow, ssuhung, tadasu,
-        take100yen, Umoxfo, vargas.peniel, vmemjp, WatanabeShint, yukinakato</li>
-    <li><strong>қазақ тілі (Kazakh)</strong>: sotrud_nik</li>
-    <li><strong>한국어 (Korean)</strong>: BraINstinct0, cancantun, peremen</li>
-    <li><strong>latine (Latin)</strong>: alexandercrice</li>
-    <li><strong>latviešu valoda (Latvian)</strong>: andis.luksho, victormeirans, wakeeshi</li>
-    <li><strong>lietuvių kalba (Lithuanian)</strong>: Kornelijus, Moo, pauliusbaulius, rookwood101, wakeeshi</li>
-    <li><strong>Norsk Bokmål (Norwegian Bokmål)</strong>: bkvamme, eirikl, eothred, haarek, JardarBolin, jumpingmushroom, sattor,
-        torgeirf, ysteinalver</li>
-    <li><strong>ਪੰਜਾਬੀ (Punjabi)</strong>: aalam</li>
-    <li><strong>فارسی (Farsi)</strong>: gnulover, siamax</li>
-    <li><strong>فارسی (Farsi (Iran))</strong>: magnifico</li>
-    <li><strong>język polski (Polish)</strong>: AreYouLoco, dedal123, EsEnZeT, hoek, keypress, konradmb, mrerexx, pabli, ply,
-        psobczak, SebJez, verahawk</li>
-    <li><strong>Português (Portuguese)</strong>: diraol, hugok, pfialho, rudahximenes, weslly, xendez</li>
-    <li><strong>Português (Portuguese (Brazil))</strong>: alinda, amalvarenga, andersoniop, danielbibit, diraol, fabiom, flaviobn,
-        fmilagres, furious_, gabrieljcs, Guilherme.Peev, guilherme__sr, Havokdan, igorruckert, josephelias94, keeBR, kiskadee, lecalam,
-        lucasjsoliveira, mauri.andres, newmanisaac, rafaelnp, ruanmed, rudahximenes, ul1sses, vitor895, weslly, wtuemura, xendez,
-        zodSilence</li>
-    <li><strong>Português (Portuguese (Portugal))</strong>: a.santos, American_Jesus, arainho, hds, hugok, lecalam, lmagomes, pfialho,
-        smarquespt, smiguel, xendez, xnenjm</li>
-    <li><strong>Română (Romanian)</strong>: _parasite_, aduzsardi, alexminza, polearnik</li>
-    <li><strong>русский (Russian)</strong>: 3nad, _nomoretears_, agag11507, alexandersokol, alexminza, anm, artemkonenko, ashed,
-        BANOnotIT, burningalchemist, cl0ne, cnide, denoos, DG, DmitriyMaksimov, egorrabota, injseon, Japet, JayDi85, KekcuHa, kerastinell,
-        laborxcom, leo9uinuo98, Mogost, Mr.GreyWolf, MustangDSG, netforhack, NetWormKido, nibir, Olesya_Gerasimenko, onix, Orianti,
-        RKuchma, ruslan.denisenko, ShareDVI, Shevchuk, solodyagin, talvind, treylav, upupa, VictorR2007, vsvyatski, wakeeshi, Walter.S,
-        wkill95, wtigga, zOrg1331</li>
-    <li><strong>српски језик (Serbian)</strong>: ArtBIT, ozzii</li>
-    <li><strong>Slovenčina (Slovak)</strong>: Asprotes, crazko, jose1711, l.martinicky, pecer, reisuya, Slavko</li>
-    <li><strong>Slovenščina (Slovenian)</strong>: asasdasd, samodekleva</li>
-    <li><strong>Español (Spanish)</strong>: adolfogc, antifaz, capitantrueno, cquike, cyphra, DarkHolme, doubleshuffle, e2jk,
-        EdwardNavarro, fserrador, gabeweb, gonrial, jjtp, jorpilo, LeoBeltran, mauri.andres, piegope, pquin, puchrojo, rodolfo.guagnini,
-        tierracomun, vsvyatski</li>
-    <li><strong>Svenska (Swedish)</strong>: 0x9fff00, aiix, Anders_Bergqvist, ArmanB, Autom, baxtex, eson, henziger, jpyllman, malkus,
-        merikan, peron, peterkz, Thelin, theschitz, victorhggqvst</li>
-    <li><strong>ไทย (Thai)</strong>: arthit, ben_cm, chumaporn.t, darika, digitalthailandproject, GitJirasamatakij, ll3an, minoplhy,
-        muhammadmumean, nimid, nipattra, ordinaryjane, rayg, sirawat, Socialister, Wipanee</li>
-    <li><strong>Türkçe (Turkish)</strong>: abcmen, ahmed.ulusoy, cagries, denizoglu, desc4rtes, etc, ethem578, kayazeren, mcveri, N3pp,
-        rgucluer, SeLeNLeR, sprlptr48, TeknoMobil, Ven_Zallow, veysiertekin</li>
-    <li><strong>Українська (Ukrainian)</strong>: brisk022, chulivska, cl0ne, exlevan, m0stik, moudrick, netforhack, olko, onix, paul_sm,
-        ShareDVI, upupa, zoresvit</li>
+    <li><strong>Arabic:</strong> kmutahar</li>
+    <li><strong>Chinese (China):</strong> Biggulu, Brandon_c, hoilc, ligyxy, Small_Ku, umi_neko, vc5</li>
+    <li><strong>Chinese (Taiwan):</strong> BestSteve, flachesis, MiauLightouch, Small_Ku, yan12125, ymhuang0808</li>
+    <li><strong>Czech:</strong> DanielMilde, pavelb, tpavelek</li>
+    <li><strong>English (United Kingdom):</strong> YCMHARHZ</li>
+    <li><strong>English (United States):</strong> alexandercrice, DarkHolme, nguyenlekhtn</li>
+    <li><strong>Finnish:</strong> artnay, hif1, MawKKe, varjolintu</li>
+    <li><strong>German:</strong> antsas, BasicBaer, Calyrx, codejunky, DavidHamburg, eth0, for1real, jensrutschmann,
+        joe776, kflesch, marcbone, MarcEdinger, mcliquid, mfernau77, montilo, nursoda, omnisome4, origin_de, pcrcoding,
+        rgloor, vlenzer, waster, Wyrrrd</li>
+    <li><strong>Greek:</strong> magkopian, nplatis, tassos.b, xinomilo</li>
+    <li><strong>Hungarian:</strong> bubu, meskobalazs, urbalazs</li>
+    <li><strong>Indonesian:</strong> zk</li>
+    <li><strong>Italian:</strong> amaxis, duncanmid, FranzMari, lucaim, NITAL, Peo, tosky, VosaxAlo</li>
+    <li><strong>Japanese:</strong> masoo, p2635, Shinichirou_Yamada, vmemjp, yukinakato</li>
+    <li><strong>Korean:</strong> cancantun, peremen</li>
+    <li><strong>Lithuanian:</strong> Moo</li>
+    <li><strong>Norwegian Bokmål:</strong> eothred, haarek, torgeirf</li>
+    <li><strong>Polish:</strong> keypress, mrerexx, psobczak</li>
+    <li><strong>Portuguese (Brazil):</strong> danielbibit, fabiom, flaviobn, newmanisaac, vitor895, weslly</li>
+    <li><strong>Portuguese (Portugal):</strong> a.santos, American_Jesus, hds, lmagomes, smarquespt</li>
+    <li><strong>Romanian:</strong> alexminza</li>
+    <li><strong>Russian:</strong> _nomoretears_, agag11507, alexminza, anm, artemkonenko, denoos, KekcuHa, Mogost,
+        netforhack, NetWormKido, RKuchma, ShareDVI, talvind, VictorR2007, vsvyatski, wkill95</li>
+    <li><strong>Serbian:</strong> ArtBIT</li>
+    <li><strong>Swedish:</strong> Anders_Bergqvist, henziger, jpyllman, peron, Thelin</li>
+    <li><strong>Turkish:</strong> etc, N3pp</li>
+    <li><strong>Ukrainian:</strong> brisk022, netforhack, ShareDVI, zoresvit</li>
 </ul>
 )";
 

--- a/utils/transifex_translators.py
+++ b/utils/transifex_translators.py
@@ -1,77 +1,70 @@
 #!/usr/bin/env python3
+from collections import defaultdict
 import json
-import os
+import sys
+from pathlib import Path
+from urllib import request
 
-# Download Transifex languages dump at: https://www.transifex.com/api/2/project/keepassxc/languages
-# Language information from https://www.wikiwand.com/en/List_of_ISO_639-1_codes and http://www.lingoes.net/en/translator/langcode.htm
+txrc = Path.home() / '.transifexrc'
+if not txrc.exists():
+    print('No Transifex config found. Run tx init first.')
+    sys.exit(1)
 
-LANGS = {
-    "ar" : "العربية (Arabic)",
-    "bn" : "বাংলা (Bengali)",
-    "ca" : "català (Catalan)",
-    "cs" : "čeština (Czech)",
-    "da" : "dansk (Danish)",
-    "de" : "Deutsch (German)",
-    "el" : "ελληνικά (Greek)",
-    "eo" : "Esperanto (Esperanto)",
-    "es" : "Español (Spanish)",
-    "et" : "eesti (Estonian)",
-    "eu" : "euskara (Basque)",
-    "fa" : "فارسی (Farsi)",
-    "fa_IR" : "فارسی (Farsi (Iran))",
-    "fi" : "suomi (Finnish)",
-    "fr" : "français (French)",
-    "gl" : "Galego (Galician)",
-    "he" : "עברית (Hebrew)",
-    "hr_HR" : "hrvatski jezik (Croatian)",
-    "hu" : "magyar (Hungarian)",
-    "id" : "Bahasa Indonesia (Indonesian)",
-    "is_IS" : "Íslenska (Icelandic)",
-    "it" : "Italiano (Italian)",
-    "ja" : "日本語 (Japanese)",
-    "kk" : "қазақ тілі (Kazakh)",
-    "ko" : "한국어 (Korean)",
-    "la" : "latine (Latin)",
-    "lt" : "lietuvių kalba (Lithuanian)",
-    "lv" : "latviešu valoda (Latvian)",
-    "nb" : "Norsk Bokmål (Norwegian Bokmål)",
-    "nl_NL" : "Nederlands (Dutch)",
-    "my" : "ဗမာစာ (Burmese)",
-    "pa" : "ਪੰਜਾਬੀ (Punjabi)",
-    "pa_IN" : "ਪੰਜਾਬੀ (Punjabi (India))",
-    "pl" : "język polski (Polish)",
-    "pt" : "Português (Portuguese)",
-    "pt_BR" : "Português (Portuguese (Brazil))",
-    "pt_PT" : "Português (Portuguese (Portugal))",
-    "ro" : "Română (Romanian)",
-    "ru" : "русский (Russian)",
-    "sk" : "Slovenčina (Slovak)",
-    "sl_SI" : "Slovenščina (Slovenian)",
-    "sr" : "српски језик (Serbian)",
-    "sv" : "Svenska (Swedish)",
-    "th" : "ไทย (Thai)",
-    "tr" : "Türkçe (Turkish)",
-    "uk" : "Українська (Ukrainian)",
-    "zh_CN" : "中文 (Chinese (Simplified))",
-    "zh_TW" : "中文 (台灣) (Chinese (Traditional))",
-}
+org = 'o:keepassxc'
+proj = f'{org}:p:keepassxc'
+resource = f'{proj}:r:share-translations-keepassxc-en-ts--master'
+token = [l for l in open(txrc, 'r') if l.startswith('token')][0].split('=', 1)[1].strip()
+member_blacklist = ['u:droidmonkey', 'u:phoerious']
 
-TEMPLATE = "<li><strong>{0}</strong>: {1}</li>\n"
 
-if not os.path.exists("languages.json"):
-    print("Could not find 'languages.json' in current directory!")
-    print("Save the output from https://www.transifex.com/api/2/project/keepassxc/languages")
-    exit(0)
+def get_url(url):
+    req = request.Request(url)
+    req.add_header('Content-Type', 'application/vnd.api+json')
+    req.add_header('Authorization', f'Bearer {token}')
+    with request.urlopen(req) as resp:
+        return json.load(resp)
 
-with open("languages.json") as json_file:
-    output = open("translators.html", "w", encoding="utf-8")
-    languages = json.load(json_file)
-    for lang in languages:
-        code = lang["language_code"]
-        if code not in LANGS:
-            print("WARNING: Could not find language code:", code)
-            continue
-        translators = ", ".join(sorted(lang["reviewers"] + lang["translators"], key=str.casefold))
-        output.write(TEMPLATE.format(LANGS[code], translators))
-    output.close()
-    print("Language translators written to 'translators.html'!")
+
+print('Fetching languages...', file=sys.stderr)
+languages_json = get_url(f'https://rest.api.transifex.com/projects/{proj}/languages')
+languages = {}
+for lang in languages_json['data']:
+    languages[lang['id']] = lang['attributes']['name']
+
+print('Fetching language stats...', file=sys.stderr)
+language_stats_json = get_url('https://rest.api.transifex.com/resource_language_stats?'
+                              f'filter[project]={proj}&filter[resource]={resource}')
+completion = {}
+for stat in language_stats_json['data']:
+    completion = stat['attributes']['translated_strings'] / stat['attributes']['total_strings']
+    if completion < .6:
+        languages.pop(stat['relationships']['language']['data']['id'])
+
+print('Fetching language members...', end='', file=sys.stderr)
+members_json = get_url(f'https://rest.api.transifex.com/team_memberships?filter[organization]={org}')
+members = defaultdict(set)
+for member in members_json['data']:
+    print('.', end='', file=sys.stderr)
+    if member['relationships']['user']['data']['id'] in member_blacklist:
+        continue
+    lid = member['relationships']['language']['data']['id']
+    if lid not in languages:
+        continue
+    user = get_url(member['relationships']['user']['links']['related'])['data']['attributes']['username']
+    members[lid].add(user)
+print(file=sys.stderr)
+
+print('<ul>')
+for lang in sorted(languages, key=lambda x: languages[x]):
+    if not members[lang]:
+        continue
+    lines = [f'    <li><strong>{languages[lang]}:</strong> ']
+    for i, m in enumerate(sorted(members[lang], key=lambda x: x.lower())):
+        if len(lines[-1]) + len(m) >= 120:
+            lines.append('        ')
+        lines[-1] += m
+        if i < len(members[lang]) - 1:
+            lines[-1] += ', '
+    lines[-1] += '</li>'
+    print('\n'.join(lines))
+print('</ul>')


### PR DESCRIPTION
- Added (non-private) premium tier GitHub sponsors
- Updated list of translators
- Updated fetch script for translator names (v2 API has been sunset)

@droidmonkey You should update your sponsor list as well before merging.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
