### PR TITLE
Fix markdown type for >= QT 5.15.18 and advance vcpkg baseline

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -515,7 +515,7 @@ namespace Tools
                                                 "application/protobuf",
                                                 "application/x-zerosize"};
         const static QStringList HtmlFormats = {"text/html"};
-        const static QStringList MarkdownFormats = {"text/markdown"};
+        const static QStringList MarkdownFormats = {"text/markdown", "text/x-web-markdown"};
         const static QStringList ImageFormats = {"image/"};
 
         static auto isCompatible = [](const QString& format, const QStringList& list) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -642,12 +642,13 @@ MainWindow::MainWindow()
     auto* hidePreRelWarn = new QAction(tr("Don't show again for this version"), m_ui->globalMessageWidget);
     m_ui->globalMessageWidget->addAction(hidePreRelWarn);
     auto hidePreRelWarnConn = QSharedPointer<QMetaObject::Connection>::create();
-    *hidePreRelWarnConn = connect(m_ui->globalMessageWidget, &KMessageWidget::hideAnimationFinished, [=] {
-        m_ui->globalMessageWidget->removeAction(hidePreRelWarn);
-        disconnect(*hidePreRelWarnConn);
-        hidePreRelWarn->deleteLater();
-    });
-    connect(hidePreRelWarn, &QAction::triggered, [=] {
+    *hidePreRelWarnConn = connect(
+        m_ui->globalMessageWidget, &KMessageWidget::hideAnimationFinished, [this, hidePreRelWarn, hidePreRelWarnConn] {
+            m_ui->globalMessageWidget->removeAction(hidePreRelWarn);
+            disconnect(*hidePreRelWarnConn);
+            hidePreRelWarn->deleteLater();
+        });
+    connect(hidePreRelWarn, &QAction::triggered, [this] {
         m_ui->globalMessageWidget->animatedHide();
         config()->set(Config::Messages_HidePreReleaseWarning, KEEPASSXC_VERSION);
     });

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -403,8 +403,8 @@ void TestTools::testGetMimeTypeByFileInfo()
 
     const QStringList Markdowns = {"test.md", "test.markdown"};
 
-    for (const auto& makdown : Markdowns) {
-        QCOMPARE(Tools::getMimeType(QFileInfo(makdown)), Tools::MimeType::Markdown);
+    for (const auto& markdown : Markdowns) {
+        QCOMPARE(Tools::getMimeType(QFileInfo(markdown)), Tools::MimeType::Markdown);
     }
 
     const QStringList UnknownHeaders = {"test.doc", "test.pdf", "test.docx"};

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "keepassxc",
   "version-string": "2.8.0",
-  "builtin-baseline": "74e6536215718009aae747d86d84b78376bf9e09",
+  "builtin-baseline": "dfb72f61c5a066ab75cd0bdcb2e007228bfc3270",
   "dependencies": [
     {
       "name": "argon2",


### PR DESCRIPTION
Due to the update of the MIME database [QTBUG-127148](https://bugreports.qt.io/browse/QTBUG-127148)

## Testing strategy
Manually

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
