### PR TITLE
Fix macOS bundle icon installation for IDE builds

### DIFF
--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -67,11 +67,6 @@ if(UNIX AND NOT APPLE AND NOT HAIKU)
     install(FILES linux/${APP_ID}.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 endif(UNIX AND NOT APPLE AND NOT HAIKU)
 
-if(APPLE)
-  install(FILES macosx/Assets.car DESTINATION ${DATA_INSTALL_DIR})
-  install(FILES macosx/keepassxc.icns DESTINATION ${DATA_INSTALL_DIR})
-endif()
-
 if(WIN32)
   install(FILES windows/qt.conf DESTINATION ${BIN_INSTALL_DIR})
 endif()

--- a/share/macosx/Info.plist.cmake
+++ b/share/macosx/Info.plist.cmake
@@ -13,11 +13,11 @@
   <key>CFBundleExecutable</key>
   <string>${PROGNAME}</string>
   <key>CFBundleIconFile</key>
-  <string>keepassxc.icns</string>
+  <string>${MACOSX_BUNDLE_ICON_NAME}.icns</string>
   <key>CFBundleIconName</key>
-  <string>keepassxc</string>
+  <string>${MACOSX_BUNDLE_ICON_NAME}</string>
   <key>CFBundleIdentifier</key>
-  <string>org.keepassxc.keepassxc</string>
+  <string>${MACOSX_BUNDLE_IDENTIFIER}</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -421,7 +421,12 @@ if(WIN32)
 endif()
 
 # Main Executable Definition
+add_executable(${PROGNAME} main.cpp)
+target_link_libraries(${PROGNAME} keepassxc_gui)
+set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)
+
 if(WIN32)
+    set_target_properties(${PROGNAME} PROPERTIES WIN32 ON)
     include(GenerateProductVersion)
     generate_product_version(
             WIN32_ResourceFiles
@@ -432,20 +437,24 @@ if(WIN32)
             VERSION_PATCH ${KEEPASSXC_VERSION_PATCH}
     )
     list(APPEND WIN32_ResourceFiles "${CMAKE_SOURCE_DIR}/share/windows/icon.rc")
-endif()
+    target_sources(${PROGNAME} PUBLIC ${WIN32_ResourceFiles})
 
-add_executable(${PROGNAME} WIN32 main.cpp ${WIN32_ResourceFiles})
-target_link_libraries(${PROGNAME} keepassxc_gui)
-set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)
-
-# macOS App Bundle
-if(APPLE AND WITH_APP_BUNDLE)
-    install(FILES ${CMAKE_SOURCE_DIR}/share/macosx/embedded.provisionprofile DESTINATION ${BUNDLE_INSTALL_DIR})
-    configure_file(${CMAKE_SOURCE_DIR}/share/macosx/Info.plist.cmake ${CMAKE_CURRENT_BINARY_DIR}/Info.plist)
+elseif(APPLE AND WITH_APP_BUNDLE)
+    set(MACOSX_BUNDLE_IDENTIFIER org.keepassxc.keepassxc)
+    set(MACOSX_BUNDLE_ICON_NAME keepassxc)
+    configure_file("${CMAKE_SOURCE_DIR}/share/macosx/Info.plist.cmake" ${CMAKE_CURRENT_BINARY_DIR}/Info.plist)
+    install(FILES "${CMAKE_SOURCE_DIR}/share/macosx/embedded.provisionprofile" DESTINATION ${BUNDLE_INSTALL_DIR})
+    set(MACOSX_BUNDLE_RESOURCE_FILES
+            "${CMAKE_SOURCE_DIR}/share/macosx/Assets.car"
+            "${CMAKE_SOURCE_DIR}/share/macosx/keepassxc.icns"
+    )
     set_target_properties(${PROGNAME} PROPERTIES
             MACOSX_BUNDLE ON
-            MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
-            CPACK_BUNDLE_APPLE_ENTITLEMENTS "${CMAKE_SOURCE_DIR}/share/macosx/keepassxc.entitlements")
+            MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist"
+            CPACK_BUNDLE_APPLE_ENTITLEMENTS "${CMAKE_SOURCE_DIR}/share/macosx/keepassxc.entitlements"
+            RESOURCE "${MACOSX_BUNDLE_RESOURCE_FILES}"
+    )
+    target_sources(${PROGNAME} PUBLIC ${MACOSX_BUNDLE_RESOURCE_FILES})
 
     if(QT_MAC_USE_COCOA AND EXISTS "${QT_LIBRARY_DIR}/Resources/qt_menu.nib")
         install(DIRECTORY "${QT_LIBRARY_DIR}/Resources/qt_menu.nib"


### PR DESCRIPTION
Installs bundle icons to the Resources folder during the build stage andmnot during the install stage. This ensures that the app has an icon when run directly from the .app folder inside the IDE. Previously, the icon would be installed only when running make install or cpack.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)