### PR TITLE
Correctly restore window geometry when minimised to tray on startup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -194,9 +194,6 @@ MainWindow::MainWindow()
         databaseLockButton->setPopupMode(QToolButton::MenuButtonPopup);
     }
 
-    restoreGeometry(config()->get(Config::GUI_MainWindowGeometry).toByteArray());
-    restoreState(config()->get(Config::GUI_MainWindowState).toByteArray());
-
     connect(m_ui->tabWidget, &DatabaseTabWidget::databaseLocked, this, &MainWindow::databaseLocked);
     connect(m_ui->tabWidget, &DatabaseTabWidget::databaseUnlocked, this, &MainWindow::databaseUnlocked);
     connect(m_ui->tabWidget, &DatabaseTabWidget::activeDatabaseChanged, this, &MainWindow::activeDatabaseChanged);
@@ -1383,6 +1380,12 @@ void MainWindow::showEvent(QShowEvent* event)
     // Qt Hack - Prevent white flicker when showing window
     QTimer::singleShot(50, this, [=] { setProperty("windowOpacity", 1.0); });
 #endif
+
+    // Restore geometry and window state only on the first showEvent to prevent issues with minimized tray startup
+    if (!m_windowInformationRestored) {
+        restoreWindowInformation();
+        m_windowInformationRestored = true;
+    }
 }
 
 void MainWindow::hideEvent(QHideEvent* event)
@@ -1538,6 +1541,12 @@ void MainWindow::saveWindowInformation()
         config()->set(Config::GUI_MainWindowGeometry, saveGeometry());
         config()->set(Config::GUI_MainWindowState, saveState());
     }
+}
+
+void MainWindow::restoreWindowInformation()
+{
+    restoreGeometry(config()->get(Config::GUI_MainWindowGeometry).toByteArray());
+    restoreState(config()->get(Config::GUI_MainWindowState).toByteArray());
 }
 
 bool MainWindow::saveLastDatabases()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -160,6 +160,7 @@ private:
     static const QString BaseWindowTitle;
 
     void saveWindowInformation();
+    void restoreWindowInformation();
     bool saveLastDatabases();
     bool isTrayIconEnabled() const;
     void customOpenUrl(QString url);
@@ -192,6 +193,7 @@ private:
 
     Q_DISABLE_COPY(MainWindow)
 
+    bool m_windowInformationRestored = false;
     bool m_appExitCalled = false;
     bool m_appExiting = false;
     bool m_restartRequested = false;


### PR DESCRIPTION
The window geometry wasn't restored properly when MinimizeOnStartup and MinimizeToTray were activated. The issue affected primarily macOS, but could also occur on other platforms.

Fixes #10537
Fixes #11982

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
