### PR TITLE
Remove theme-based menubar icon toggle on macOS

### DIFF
--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -92,12 +92,14 @@ QIcon Icons::trayIcon(bool unlocked)
     }
 
     QIcon i;
-#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
     if (osUtils->isStatusBarDark()) {
         i = icon(QString("keepassxc-monochrome-light%1").arg(suffix), false);
     } else {
         i = icon(QString("keepassxc-monochrome-dark%1").arg(suffix), false);
     }
+#elif defined(Q_OS_MACOS)
+    i = icon(QString("keepassxc-monochrome-light%1").arg(suffix), false);
 #else
     i = icon(QString("%1-%2%3").arg(applicationIconName(), iconAppearance, suffix), false);
 #endif


### PR DESCRIPTION
The menubar theme detection on macOS has always been wonky, and with Liquid Glass it has become entirely useless. This removes the icon theme switch and uses the monochrome light icon as a mask until we find a better solution. This should look okay in most cases, unless the user has a very bright wallpaper.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)