### PR TITLE
Resolve REF:P@I during healthCheck

### DIFF
--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -20,10 +20,12 @@
 #include "ui_PasswordWidget.h"
 
 #include "core/Config.h"
+#include "core/Entry.h"
 #include "core/PasswordHealth.h"
 #include "gui/Font.h"
 #include "gui/Icons.h"
 #include "gui/PasswordGeneratorWidget.h"
+#include "gui/entry/EditEntryWidget.h"
 #include "gui/osutils/OSUtils.h"
 #include "gui/styles/StateColorPalette.h"
 
@@ -107,6 +109,11 @@ PasswordWidget::~PasswordWidget()
 void PasswordWidget::setQualityVisible(bool state)
 {
     m_ui->qualityProgressBar->setVisible(state);
+}
+
+void PasswordWidget::setEntry(Entry* entry)
+{
+    m_entry = entry;
 }
 
 QString PasswordWidget::text()
@@ -270,7 +277,14 @@ void PasswordWidget::updatePasswordStrength(const QString& password)
         return;
     }
 
-    PasswordHealth health(password);
+    QString passwordToCheck = password;
+    if (m_entry) {
+        QString resolvedPwd = m_entry->resolvePlaceholder(passwordToCheck);
+        if (!resolvedPwd.isEmpty()) {
+            passwordToCheck = resolvedPwd;
+        }
+    }
+    PasswordHealth health(passwordToCheck);
 
     m_ui->qualityProgressBar->setValue(std::min(int(health.entropy()), m_ui->qualityProgressBar->maximum()));
 

--- a/src/gui/PasswordWidget.h
+++ b/src/gui/PasswordWidget.h
@@ -24,6 +24,8 @@
 #include <QPointer>
 #include <QWidget>
 
+class Entry;
+
 namespace Ui
 {
     class PasswordWidget;
@@ -40,6 +42,7 @@ public:
     void enablePasswordGenerator();
     void setRepeatPartner(PasswordWidget* repeatPartner);
     void setQualityVisible(bool state);
+    void setEntry(Entry* entry);
 
     bool isPasswordVisible() const;
     QString text();
@@ -77,6 +80,7 @@ private:
     QPointer<QAction> m_capslockAction;
     QPointer<PasswordWidget> m_repeatPasswordWidget;
     QPointer<PasswordWidget> m_parentPasswordWidget;
+    QPointer<Entry> m_entry;
 
     bool m_capslockState = false;
 };

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1005,6 +1005,7 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
 
     m_mainUi->titleEdit->setText(entry->title());
     m_mainUi->usernameComboBox->lineEdit()->setText(entry->username());
+    m_mainUi->passwordEdit->setEntry(entry);
     m_mainUi->urlEdit->setText(entry->url());
     m_mainUi->passwordEdit->setText(entry->password());
     m_mainUi->passwordEdit->setShowPassword(!config()->get(Config::Security_PasswordsHidden).toBool());
@@ -1252,6 +1253,7 @@ bool EditEntryWidget::commitEntry()
     setPageHidden(m_historyWidget, m_history || m_entry->historyItems().count() < 1);
     m_advancedUi->attachmentsWidget->linkAttachments(m_entry->attachments());
 
+    m_mainUi->passwordEdit->setEntry(m_entry);
     showMessage(tr("Entry updated successfully."), MessageWidget::Positive);
     setModified(false);
     // Prevent a reload due to entry modified signals


### PR DESCRIPTION
Add reference to current entry to PasswordWiget, which resolves `{REF:P@I:....}` if it exists, if not it will treat the input as raw text and pass through PasswordHealth check.
FIXES #12671 

## Screenshots
<img width="794" height="626" alt="image" src="https://github.com/user-attachments/assets/2e66d29a-4c1e-4a7c-ba04-bf639beda1b2" />


## Testing strategy
`make test ARGS+="--output-on-failure" ARGS+=-j8 ARGS+="-E testgui"`
`100% tests passed, 0 tests failed out of 42`


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
