### PR TITLE
Change Security/LockDatabaseIdle default to true

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -139,7 +139,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_ClearSearch, {QS("Security/ClearSearch"), Roaming, false}},
     {Config::Security_ClearSearchTimeout, {QS("Security/ClearSearchTimeout"), Roaming, 5}},
     {Config::Security_HideNotes, {QS("Security/Security_HideNotes"), Roaming, false}},
-    {Config::Security_LockDatabaseIdle, {QS("Security/LockDatabaseIdle"), Roaming, false}},
+    {Config::Security_LockDatabaseIdle, {QS("Security/LockDatabaseIdle"), Roaming, true}},
     {Config::Security_LockDatabaseIdleSeconds, {QS("Security/LockDatabaseIdleSeconds"), Roaming, 240}},
     {Config::Security_LockDatabaseMinimize, {QS("Security/LockDatabaseMinimize"), Roaming, false}},
     {Config::Security_LockDatabaseScreenLock, {QS("Security/LockDatabaseScreenLock"), Roaming, true}},


### PR DESCRIPTION
Changes the default value of the Security/LockDatabaseIdle setting to true.

This came up during a BSI security assessment, and I don't see why this shouldn't be true by default.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)
