### PR TITLE
Advance vcpkg baseline to fix macOS Qt building

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "keepassxc",
   "version-string": "2.8.0",
-  "builtin-baseline": "74e6536215718009aae747d86d84b78376bf9e09",
+  "builtin-baseline": "dfb72f61c5a066ab75cd0bdcb2e007228bfc3270",
   "dependencies": [
     {
       "name": "argon2",


### PR DESCRIPTION
Fixes Qt build errors on macOS 26 Tahoe.

See https://github.com/microsoft/vcpkg/pull/48298


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
