### PR TITLE
Fix TestTools failure and clangd deprecation warning.

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -515,7 +515,7 @@ namespace Tools
                                                 "application/protobuf",
                                                 "application/x-zerosize"};
         const static QStringList HtmlFormats = {"text/html"};
-        const static QStringList MarkdownFormats = {"text/markdown"};
+        const static QStringList MarkdownFormats = {"text/markdown", "text/x-web-markdown"};
         const static QStringList ImageFormats = {"image/"};
 
         static auto isCompatible = [](const QString& format, const QStringList& list) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -642,12 +642,12 @@ MainWindow::MainWindow()
     auto* hidePreRelWarn = new QAction(tr("Don't show again for this version"), m_ui->globalMessageWidget);
     m_ui->globalMessageWidget->addAction(hidePreRelWarn);
     auto hidePreRelWarnConn = QSharedPointer<QMetaObject::Connection>::create();
-    *hidePreRelWarnConn = connect(m_ui->globalMessageWidget, &KMessageWidget::hideAnimationFinished, [=] {
+    *hidePreRelWarnConn = connect(m_ui->globalMessageWidget, &KMessageWidget::hideAnimationFinished, [=, this] {
         m_ui->globalMessageWidget->removeAction(hidePreRelWarn);
         disconnect(*hidePreRelWarnConn);
         hidePreRelWarn->deleteLater();
     });
-    connect(hidePreRelWarn, &QAction::triggered, [=] {
+    connect(hidePreRelWarn, &QAction::triggered, [=, this] {
         m_ui->globalMessageWidget->animatedHide();
         config()->set(Config::Messages_HidePreReleaseWarning, KEEPASSXC_VERSION);
     });

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -403,8 +403,8 @@ void TestTools::testGetMimeTypeByFileInfo()
 
     const QStringList Markdowns = {"test.md", "test.markdown"};
 
-    for (const auto& makdown : Markdowns) {
-        QCOMPARE(Tools::getMimeType(QFileInfo(makdown)), Tools::MimeType::Markdown);
+    for (const auto& markdown : Markdowns) {
+        QCOMPARE(Tools::getMimeType(QFileInfo(markdown)), Tools::MimeType::Markdown);
     }
 
     const QStringList UnknownHeaders = {"test.doc", "test.pdf", "test.docx"};


### PR DESCRIPTION
Fixes a failure in TestTools on macOS, because the MIME database returns a non-standard MIME type for Markdown. There is another intermittent failure with a timestamp string mismatch, but I couldn't reproduce it just now.

Also fixes a clangd deprecation warning about implicit capture of `this` by `=`


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
