### PR TITLE
Prevent launch on installer finish when run as SYSTEM

### DIFF
--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -121,6 +121,8 @@
         <SetProperty Id="AUTOSTARTPROGRAM" After="AppSearch" Value="" Sequence="first">AUTOSTARTPROGRAM="0" OR (WIX_UPGRADE_DETECTED AND NOT AUTOSTARTPROGRAM_REGISTRY)</SetProperty>
         <SetProperty Id="ADDTOPATH" After="AppSearch" Value="" Sequence="first">ADDTOPATH="0" OR (WIX_UPGRADE_DETECTED AND NOT ADDTOPATH_REGISTRY)</SetProperty>
         <SetProperty Id="LicenseAccepted" After="AppSearch" Value="1">WIX_UPGRADE_DETECTED</SetProperty>
+        <!-- Prevent launch on installer exit if run as SYSTEM user -->
+        <SetProperty Id="LAUNCHAPPONEXIT" After="AppSearch" Value="">UserSID = "S-1-5-18"</SetProperty>
 
         <FeatureRef Id="ProductFeature">
             <ComponentRef Id="ApplicationShortcuts" />


### PR DESCRIPTION
* This condition will only happen when KeePassXC is installed by MECM or similar deployment tool. This prevents accidental launch on exit if the packager forgot to set LAUNCHAPPONEXIT=0 in the msiexec call. Allowing launch on exit in these conditions would potentially allow a non-privileged user to assume the role of SYSTEM through the KeePassXC application.

* Fixes weakness reported by @HackAndPwn, thank you!

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested using `psiexec -i -s msiexec /i .\KeePassXC-2.8.0-snapshot-Win64.msi`

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
