### PR TITLE
Add additional markdown mime type

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -515,7 +515,7 @@ namespace Tools
                                                 "application/protobuf",
                                                 "application/x-zerosize"};
         const static QStringList HtmlFormats = {"text/html"};
-        const static QStringList MarkdownFormats = {"text/markdown"};
+        const static QStringList MarkdownFormats = {"text/markdown", "text/x-web-markdown"};
         const static QStringList ImageFormats = {"image/"};
 
         static auto isCompatible = [](const QString& format, const QStringList& list) {


### PR DESCRIPTION
* Fixes TestTools.cpp
* Latest version of Qt returns this mime type for markdown files

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Test cases are already up to date

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)