### PR TITLE
Fix setting entitlements on KeePassXC executable

### DIFF
--- a/cmake/MacOSCodesign.cmake.in
+++ b/cmake/MacOSCodesign.cmake.in
@@ -31,7 +31,7 @@ if(NOT CPACK_PACKAGE_FILES)     # PRE_BUILD: Sign binaries
 
     # Sign all binaries
     execute_process(
-        COMMAND xcrun codesign --sign=${CODESIGN_IDENTITY} --force --options=runtime --deep ${APP_DIR}
+        COMMAND xcrun codesign --sign=${CODESIGN_IDENTITY} --force --options=runtime --deep "${APP_DIR}"
         RESULT_VARIABLE SIGN_RESULT
         OUTPUT_VARIABLE SIGN_OUTPUT
         ERROR_VARIABLE SIGN_ERROR
@@ -45,7 +45,7 @@ if(NOT CPACK_PACKAGE_FILES)     # PRE_BUILD: Sign binaries
 
     # (Re-)Sign main executable with --entitlements
     execute_process(
-        COMMAND xcrun codesign --sign=${CODESIGN_IDENTITY} --force --options=runtime --deep --entitlements=${ENTITLEMENTS} ${APP_DIR}
+        COMMAND xcrun codesign --sign=${CODESIGN_IDENTITY} --force --options=runtime --entitlements=${ENTITLEMENTS} "${APP_DIR}/Contents/MacOS/${PROGNAME}"
         RESULT_VARIABLE SIGN_RESULT
         OUTPUT_VARIABLE SIGN_OUTPUT
         ERROR_VARIABLE SIGN_ERROR
@@ -61,42 +61,41 @@ if(NOT CPACK_PACKAGE_FILES)     # PRE_BUILD: Sign binaries
 
 else()       # POST_BUILD: Notarize DMG
     set(KEYCHAIN_PROFILE "@WITH_XC_NOTARY_KEYCHAIN_PROFILE@")
-    file(GLOB_RECURSE DMG_FILE "${CPACK_PACKAGE_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}.dmg")
-
     if(NOT KEYCHAIN_PROFILE)
         message(FATAL_ERROR "No notarization credentials keychain profile specified.")
     endif()
 
-    # Submit for notarization
-    message(STATUS "Submitting DMG bundle for notarization, this may take while...")
-    execute_process(
-            COMMAND xcrun notarytool submit --keychain-profile=${KEYCHAIN_PROFILE} --wait ${DMG_FILE}
-            RESULT_VARIABLE NOTARIZE_RESULT
-            OUTPUT_VARIABLE NOTARIZE_OUTPUT
-            ERROR_VARIABLE NOTARIZE_ERROR
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_STRIP_TRAILING_WHITESPACE
-            ECHO_OUTPUT_VARIABLE
-    )
-    if (NOT NOTARIZE_RESULT EQUAL 0)
-        message(FATAL_ERROR "Notarization failed: ${NOTARIZE_ERROR}")
-    endif()
-    message(STATUS "DMG bundle notarized successfully.")
+    foreach(DMG_FILE ${CPACK_PACKAGE_FILES})
+        # Submit for notarization
+        message(STATUS "Submitting DMG bundle for notarization, this may take while...")
+        execute_process(
+                COMMAND xcrun notarytool submit --keychain-profile=${KEYCHAIN_PROFILE} --wait "${DMG_FILE}"
+                RESULT_VARIABLE NOTARIZE_RESULT
+                OUTPUT_VARIABLE NOTARIZE_OUTPUT
+                ERROR_VARIABLE NOTARIZE_ERROR
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_STRIP_TRAILING_WHITESPACE
+                ECHO_OUTPUT_VARIABLE
+        )
+        if (NOT NOTARIZE_RESULT EQUAL 0)
+            message(FATAL_ERROR "Notarization failed: ${NOTARIZE_ERROR}")
+        endif()
+        message(STATUS "DMG bundle notarized successfully.")
 
-    # Staple tickets
-    message(STATUS "Stapling notarization ticket...")
-    execute_process(
-            COMMAND xcrun stapler staple ${DMG_FILE} && xcrun stapler validate ${DMG_FILE}
-            RESULT_VARIABLE STAPLE_RESULT
-            OUTPUT_VARIABLE STAPLE_OUTPUT
-            ERROR_VARIABLE STAPLE_ERROR
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_STRIP_TRAILING_WHITESPACE
-            ECHO_OUTPUT_VARIABLE
-    )
-    if (NOT STAPLE_RESULT EQUAL 0)
-        message(FATAL_ERROR "Stapling failed: ${STAPLE_ERROR}")
-    endif()
-    message(STATUS "DMG bundle notarization ticket stapled successfully.")
-
+        # Staple tickets
+        message(STATUS "Stapling notarization ticket...")
+        execute_process(
+                COMMAND xcrun stapler staple "${DMG_FILE}" && xcrun stapler validate "${DMG_FILE}"
+                RESULT_VARIABLE STAPLE_RESULT
+                OUTPUT_VARIABLE STAPLE_OUTPUT
+                ERROR_VARIABLE STAPLE_ERROR
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_STRIP_TRAILING_WHITESPACE
+                ECHO_OUTPUT_VARIABLE
+        )
+        if (NOT STAPLE_RESULT EQUAL 0)
+            message(FATAL_ERROR "Stapling failed: ${STAPLE_ERROR}")
+        endif()
+        message(STATUS "DMG bundle notarization ticket stapled successfully.")
+    endforeach()
 endif()


### PR DESCRIPTION
* Fixes #12713
* Also fixes motorization to use the built packages instead of glob discovery

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested on macOS. Needs a full run through test with the proper provisioning profile to ensure full success.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
