### PR TITLE
Fix a broken in-page link in the documentation

### DIFF
--- a/docs/topics/SSHAgent.adoc
+++ b/docs/topics/SSHAgent.adoc
@@ -59,7 +59,7 @@ Alternatively, you can use a _Windows PowerShell_ running as _Administrator_ to 
     PS C:\Users\user> Get-Service ssh-agent | Set-Service -StartupType Automatic
     PS C:\Users\user> Start-Service ssh-agent
 
-KeePassXC and other compatible tools can now use the Windows OpenSSH agent. To use it with KeePassXC, update the settings explained in <<Setting up SSH Agent integration>>.
+KeePassXC and other compatible tools can now use the Windows OpenSSH agent. To use it with KeePassXC, update the settings explained in <<Setup SSH Agent Integration>>.
 
 === Setup SSH Agent Integration
 By default the SSH Agent integration plugin is disabled.
@@ -178,3 +178,4 @@ If you chose to not autoload the key on database unlock, you can manually make t
 .SSH Agent Load Key from Context Menu
 image::sshagent_context_menu.png[]
 // end::content[]
+


### PR DESCRIPTION
This is a trivial PR. Please see the file changed.

The heading was changed in #11745, but the link was left untouched. The old heading dates back to [2021](https://github.com/keepassxreboot/keepassxc/commit/5ec26860244cf9d5c7964ec695a34e083455e812) or earlier.

## Type of change
- ✅ Documentation (non-code change)
