### PR TITLE
Backport/Fix background color error for invalid autotype shortcut

### DIFF
--- a/src/autotype/ShortcutWidget.cpp
+++ b/src/autotype/ShortcutWidget.cpp
@@ -21,6 +21,7 @@
 #include <QToolTip>
 
 #include "autotype/AutoType.h"
+#include "gui/styles/StateColorPalette.h"
 
 ShortcutWidget::ShortcutWidget(QWidget* parent)
     : QLineEdit(parent)
@@ -54,7 +55,9 @@ void ShortcutWidget::setShortcut(Qt::Key key, Qt::KeyboardModifiers modifiers)
         setStyleSheet("");
     } else {
         QToolTip::showText(mapToGlobal(rect().bottomLeft()), error);
-        setStyleSheet("background-color: #FF9696;");
+        StateColorPalette statePalette;
+        auto color = statePalette.color(StateColorPalette::ColorRole::Error);
+        setStyleSheet(QString("QLineEdit { background: %1; }").arg(color.name()));
     }
 }
 


### PR DESCRIPTION
This [fix](https://github.com/keepassxreboot/keepassxc/pull/11967/commits/559eccf03b2b12796cdb10303a49776cc92bbf1b) from this [pull request](https://github.com/keepassxreboot/keepassxc/pull/11967) has not yet been backported to the release version.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
