### PR TITLE
Remove redundant root slash for absolute paths

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1195,12 +1195,12 @@ void MainWindow::openBugReportUrl()
 
 void MainWindow::openGettingStartedGuide()
 {
-    customOpenUrl(QString("file:///%1").arg(resources()->dataPath("docs/KeePassXC_GettingStarted.html")));
+    customOpenUrl(QString("file://%1").arg(resources()->dataPath("docs/KeePassXC_GettingStarted.html")));
 }
 
 void MainWindow::openUserGuide()
 {
-    customOpenUrl(QString("file:///%1").arg(resources()->dataPath("docs/KeePassXC_UserGuide.html")));
+    customOpenUrl(QString("file://%1").arg(resources()->dataPath("docs/KeePassXC_UserGuide.html")));
 }
 
 void MainWindow::openOnlineHelp()
@@ -1210,7 +1210,7 @@ void MainWindow::openOnlineHelp()
 
 void MainWindow::openKeyboardShortcuts()
 {
-    customOpenUrl(QString("file:///%1").arg(resources()->dataPath("docs/KeePassXC_KeyboardShortcuts.html")));
+    customOpenUrl(QString("file://%1").arg(resources()->dataPath("docs/KeePassXC_KeyboardShortcuts.html")));
 }
 
 void MainWindow::switchToDatabases()


### PR DESCRIPTION
Having an absolute path with two starting slashes can lead to issues with browsers like Tor Browser and sandboxes like AppArmor.

The former defaults to https:// if two slashes are supplied. Even though the code explicitly states file://, this can still happen on systems like Linux, because the open functions eventually call gio, which removes the file:// prefix before passing the URI as argument to a program.

AppArmor rejects read access even if configuration allows access (configured with one slash), so a contained browser like Firefox, which defaults to file://, could not open the html files.

Since paths are already set to absolute paths through dataPath call, this additional slash can be removed in open functions.

See also [Tails issue 18477](https://gitlab.tails.boum.org/tails/tails/-/issues/18477). This fixes the KeePassXC part, the AppArmor adjustment has to be done in Tails.

## Testing strategy

With a contained AppArmor browser set as default application for HTML files, try to open the user guide through help menu and this configuration, which denies access to everything within /usr/share/keepassxc, but grants access to /usr/share/keepassxc/docs and its files:

```
deny /usr/share/keepassxc/ r,
/usr/share/keepassxc/docs/ r,
/usr/share/keepassxc/docs/** r,
```

Access is denied without this patch.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)