### PR TITLE
feat: Add copy password button to password widget

### DIFF
--- a/share/translations/keepassxc_es.ts
+++ b/share/translations/keepassxc_es.ts
@@ -7369,6 +7369,10 @@ Do you want to overwrite it?</source>
         <source>Toggle Password (%1)</source>
         <translation>Conmutar contraseña (%1)</translation>
     </message>
+    <message>  
+        <source>Copy Password</source>  
+        <translation>Copiar contraseña</translation>  
+    </message>
     <message>
         <source>Generate Password (%1)</source>
         <translation>Generar contraseña (%1)</translation>

--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -20,6 +20,7 @@
 #include "ui_PasswordWidget.h"
 
 #include "core/Config.h"
+#include "gui/Clipboard.h"
 #include "core/PasswordHealth.h"
 #include "gui/Font.h"
 #include "gui/Icons.h"
@@ -82,6 +83,13 @@ PasswordWidget::PasswordWidget(QWidget* parent)
     m_passwordGeneratorAction->setShortcutContext(Qt::WidgetShortcut);
     m_ui->passwordEdit->addAction(m_passwordGeneratorAction, QLineEdit::TrailingPosition);
     m_passwordGeneratorAction->setVisible(false);
+
+    m_copyToClipboardAction = new QAction(  
+        icons()->icon("edit-copy"),  
+        tr("Copy Password"),  
+        this);  
+    m_ui->passwordEdit->addAction(m_copyToClipboardAction, QLineEdit::TrailingPosition);  
+    connect(m_copyToClipboardAction, &QAction::triggered, this, &PasswordWidget::copyPasswordToClipboard);
 
     m_capslockAction =
         new QAction(icons()->icon("dialog-warning", true, StateColorPalette().color(StateColorPalette::Error)),
@@ -183,6 +191,11 @@ void PasswordWidget::setShowPassword(bool show)
 bool PasswordWidget::isPasswordVisible() const
 {
     return m_ui->passwordEdit->echoMode() == QLineEdit::Normal;
+}
+
+void PasswordWidget::copyPasswordToClipboard()  
+{  
+    clipboard()->setText(m_ui->passwordEdit->text());
 }
 
 void PasswordWidget::popupPasswordGenerator()

--- a/src/gui/PasswordWidget.h
+++ b/src/gui/PasswordWidget.h
@@ -63,6 +63,7 @@ private slots:
     void popupPasswordGenerator();
     void updateRepeatStatus();
     void updatePasswordStrength(const QString& password);
+    void copyPasswordToClipboard();
 
 private:
     void checkCapslockState();
@@ -74,6 +75,7 @@ private:
     QPointer<QAction> m_correctAction;
     QPointer<QAction> m_toggleVisibleAction;
     QPointer<QAction> m_passwordGeneratorAction;
+    QPointer<QAction> m_copyToClipboardAction;
     QPointer<QAction> m_capslockAction;
     QPointer<PasswordWidget> m_repeatPasswordWidget;
     QPointer<PasswordWidget> m_parentPasswordWidget;


### PR DESCRIPTION
## Summary
Adds a button to the password input widget to allow easily copying the password to the clipboard. This action is available from the edit entry form.

It is common to need to copy the password while editing an entry. This simple button makes this task more practical and easier.

## Screenshots
<img width="1408" height="939" alt="image" src="https://github.com/user-attachments/assets/5ac3f052-28ce-4c38-a57e-df0b346a453d" />

## Testing 
Due to the trivial nature of this button (no new logic, only UI), testing was performed manually. The called handler is already covered by existing tests.



## Type of change
- ✅ New feature (change that adds functionality)