### PR TITLE
Fix #12372: Replace 'populate' with 'fill' in Browser Integration docs

### DIFF
--- a/docs/topics/BrowserIntegration.adoc
+++ b/docs/topics/BrowserIntegration.adoc
@@ -4,8 +4,7 @@ include::.sharedheader[]
 
 // tag::content[]
 == Browser Integration
-The KeePassXC-Browser extension is installed within your web browser so that you can automatically pull usernames and passwords from KeePassXC and populate them directly into website fields. It is a very useful and secure extension that enhances your productivity while using KeePassXC. With this extension, you do not need to manually copy the data from your KeePassXC database and paste it into the website fields.
-
+The KeePassXC-Browser extension is installed within your web browser so that you can automatically pull usernames and passwords from KeePassXC and fill them directly into website fields. It is a very useful and secure extension that enhances your productivity while using KeePassXC. With this extension, you do not need to manually copy the data from your KeePassXC database and paste it into the website fields.
 The KeePassXC-Browser extension is available on the following web browsers:
 
 * Google Chrome, Vivaldi, and Brave
@@ -62,7 +61,7 @@ image::browser_extension_association.png[,80%]
 WARNING: If you reuse a connection name in a database, the previous browser connection will be overwritten and prevent access.
 
 === Using the Browser Extension
-The KeePassXC-Browser extension lets you automatically populate the entries from your KeePassXC database into the fields on websites you visit. To do so, perform the following steps:
+The KeePassXC-Browser extension lets you automatically fill the entries from your KeePassXC database into the fields on websites you visit. To do so, perform the following steps:
 
 1. Open your KeePassXC desktop application and unlock your database.
 


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes## Summary
This PR fixes issue #12372 by replacing the incorrect usage of 'populate' with 'fill' in the Browser Integration documentation.

## Changes
- Line 7: Changed "populate them directly into website fields" to "fill them directly into website fields"
- Line 64: Changed "automatically populate the entries" to "automatically fill the entries"

## Reason for changes
The verb 'populate' means to fill something (a container/field) WITH something. Using it with 'them' (the credentials) as the object is grammatically incorrect. 'Fill' is the correct verb to use in this context.

## Related issue
Fixes #12372. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
