### PR TITLE
Fix: Disable 'Remove' button in Plugin Data when no row is selected

### DIFF
--- a/src/gui/EditWidgetProperties.cpp
+++ b/src/gui/EditWidgetProperties.cpp
@@ -116,7 +116,6 @@ void EditWidgetProperties::update()
             m_customDataModel->appendRow(QList<QStandardItem*>()
                                          << new QStandardItem(key) << new QStandardItem(m_customData->value(key)));
         }
-        //m_ui->removeCustomDataButton->setEnabled(!m_customData->isEmpty());
-        m_ui->removeCustomDataButton->setEnabled(!m_ui->customDataTable->selectionModel()->selectedIndexes().isEmpty());
+        m_ui->removeCustomDataButton->setEnabled(m_ui->customDataTable->selectionModel()->hasSelection());
     }
 }

--- a/src/gui/EditWidgetProperties.cpp
+++ b/src/gui/EditWidgetProperties.cpp
@@ -116,6 +116,7 @@ void EditWidgetProperties::update()
             m_customDataModel->appendRow(QList<QStandardItem*>()
                                          << new QStandardItem(key) << new QStandardItem(m_customData->value(key)));
         }
-        m_ui->removeCustomDataButton->setEnabled(!m_customData->isEmpty());
+        //m_ui->removeCustomDataButton->setEnabled(!m_customData->isEmpty());
+        m_ui->removeCustomDataButton->setEnabled(!m_ui->customDataTable->selectionModel()->selectedIndexes().isEmpty());
     }
 }


### PR DESCRIPTION
## Overview
Fixed a UI consistency issue in the "Properties" tab of the entry editor. Previously, the "Remove" button in the Plugin Data section was enabled by default if any data existed, even if no specific row was selected.

## Changes
- Modified `EditWidgetProperties::update()` in `src/gui/EditWidgetProperties.cpp`.
- Updated the logic to check for an active selection in `customDataTable` instead of just checking if the underlying data container is non-empty.
- This ensures the "Remove" button remains disabled until the user explicitly selects a row to delete.

## Screenshots
[Paste your "Before" and "After" screenshots here by dragging them into the box]

## Testing strategy
- **Manual Verification:** Built the application on Windows 11 with Qt 5.15.18 and verified that the button state now correctly reflects the selection state.
- **Persistence:** Verified the button correctly re-disables after a successful deletion or when the selection is cleared.
- **Regression:** Ran `ctest` to ensure no core logic was affected (95% pass rate, failures were unrelated to this UI change).

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- Fixes #12891
<img width="1919" height="1030" alt="remove_active" src="https://github.com/user-attachments/assets/7b470b8e-8eea-45aa-bae6-8c2b27e3227e" />
<img width="1919" height="1034" alt="remove_inactive" src="https://github.com/user-attachments/assets/97a0f3bc-3431-42ef-b14b-bde0bf87fc14" />
