### PR TITLE
Fix Auto-Type Help Button Enablement

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1573,7 +1573,7 @@ void EditEntryWidget::updateAutoTypeEnabled()
     m_autoTypeUi->inheritSequenceButton->setEnabled(!m_history && autoTypeEnabled);
     m_autoTypeUi->customSequenceButton->setEnabled(!m_history && autoTypeEnabled);
     m_autoTypeUi->sequenceEdit->setEnabled(autoTypeEnabled && m_autoTypeUi->customSequenceButton->isChecked());
-    m_autoTypeUi->openHelpButton->setEnabled(autoTypeEnabled && m_autoTypeUi->customSequenceButton->isChecked());
+    m_autoTypeUi->openHelpButton->setEnabled(autoTypeEnabled);
 
     m_autoTypeUi->assocView->setEnabled(autoTypeEnabled);
     m_autoTypeUi->assocAddButton->setEnabled(!m_history);

--- a/src/gui/entry/EditEntryWidgetAutoType.ui
+++ b/src/gui/entry/EditEntryWidgetAutoType.ui
@@ -90,9 +90,6 @@
      </item>
      <item>
       <widget class="QToolButton" name="openHelpButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
        <property name="toolTip">
         <string>Open Auto-Type help webpage</string>
        </property>


### PR DESCRIPTION
# Fix Auto-Type Help Button Enablement

This PR fixes an inconsistency in the Auto‑Type configuration widget where the help button was enabled only when a custom sequence was turned on, instead of when the main Auto‑Type feature itself was enabled. Previously, if a user inherited the default Auto‑Type sequence and tried to add a new "Window Association" with a custom Auto‑Type sequence, the help button remained disabled. The user had to manually toggle the "Use custom Auto‑Type sequence" checkbox on and off just to access the help page. With this change, the help button is now always enabled whenever Auto‑Type is active, allowing users to access help documentation whether they are using default sequences or custom window associations.

## Screenshots

Before: 

<img width="1113" height="680" alt="before" src="https://github.com/user-attachments/assets/232f8635-4901-4a15-9380-75acb6068489" />

After: 

<img width="1113" height="680" alt="after" src="https://github.com/user-attachments/assets/57ec75e7-5346-4fe9-bf36-d2ea65b04e80" />

## Testing strategy

Verify that the help button remains enabled whenever the Auto-Type feature is turned on, regardless of other UI states.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)