### PR TITLE
Fix main entry URL validation when using placeholders

### DIFF
--- a/src/gui/URLEdit.cpp
+++ b/src/gui/URLEdit.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -37,16 +37,22 @@ void URLEdit::enableVerifyMode()
 {
     updateStylesheet();
 
-    connect(this, SIGNAL(textChanged(QString)), SLOT(updateStylesheet()));
+    connect(this, SIGNAL(textChanged(QString)), SLOT(updateStylesheet(QString)));
 }
 
-void URLEdit::updateStylesheet()
+void URLEdit::setEntry(Entry* entry)
+{
+    m_entry = entry;
+}
+
+void URLEdit::updateStylesheet(const QString& url)
 {
     const QString stylesheetTemplate("QLineEdit { background: %1; }");
+    const auto resolvedUrl = m_entry ? m_entry->resolveMultiplePlaceholders(url) : url;
 
-    if (!urlTools()->isUrlValid(text())) {
-        StateColorPalette statePalette;
-        QColor color = statePalette.color(StateColorPalette::ColorRole::Error);
+    if (!urlTools()->isUrlValid(resolvedUrl)) {
+        const StateColorPalette statePalette;
+        const auto color = statePalette.color(StateColorPalette::ColorRole::Error);
         setStyleSheet(stylesheetTemplate.arg(color.name()));
         m_errorAction->setVisible(true);
     } else {

--- a/src/gui/URLEdit.h
+++ b/src/gui/URLEdit.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2014 Felix Geyer <debfx@fobos.de>
- *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,6 +23,8 @@
 #include <QLineEdit>
 #include <QPointer>
 
+#include "core/Entry.h"
+
 class URLEdit : public QLineEdit
 {
     Q_OBJECT
@@ -30,12 +32,14 @@ class URLEdit : public QLineEdit
 public:
     explicit URLEdit(QWidget* parent = nullptr);
     void enableVerifyMode();
+    void setEntry(Entry* entry);
 
 private slots:
-    void updateStylesheet();
+    void updateStylesheet(const QString& url = {});
 
 private:
     QPointer<QAction> m_errorAction;
+    QPointer<Entry> m_entry;
 };
 
 #endif // KEEPASSX_URLEDIT_H

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -1003,6 +1003,7 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_autoTypeUi->windowSequenceEdit->setReadOnly(m_history);
     m_historyWidget->setEnabled(!m_history);
 
+    m_mainUi->urlEdit->setEntry(entry);
     m_mainUi->titleEdit->setText(entry->title());
     m_mainUi->usernameComboBox->lineEdit()->setText(entry->username());
     m_mainUi->urlEdit->setText(entry->url());


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
If the entry main URL as placeholders defined, the URL validation always fails. As a solution, give the entry pointer to URLEdit class and resolve the URL there before validation.

* Fixes #12717

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Manually using some URL with placeholder, e.g. `scp://{USERNAME}@myHost.name`

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
