### PR TITLE
Advance vcpkg baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "keepassxc",
   "version-string": "2.8.0",
-  "builtin-baseline": "dfb72f61c5a066ab75cd0bdcb2e007228bfc3270",
+  "builtin-baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1",
   "dependencies": [
     {
       "name": "argon2",


### PR DESCRIPTION
Advances vcpkg baseline to fix potential Qt build errors when more than one macOS SDK is installed.

See https://github.com/microsoft/vcpkg/pull/48988

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
