### PR TITLE
Fix showing correct checkbox value in entry Browser Integration settings

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -1023,8 +1023,8 @@ QList<Entry*> BrowserService::searchEntries(const QSharedPointer<Database>& db,
     }
 
     for (const auto& group : rootGroup->groupsRecursive(true)) {
-        if (group->isRecycled()
-            || group->resolveCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY) == Group::Enable) {
+        const auto groupOptionHideEntry = group->resolveCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY);
+        if (group->isRecycled() || groupOptionHideEntry == Group::Enable) {
             continue;
         }
 
@@ -1039,7 +1039,8 @@ QList<Entry*> BrowserService::searchEntries(const QSharedPointer<Database>& db,
 
         for (auto* entry : group->entries()) {
             if (entry->isRecycled()
-                || (entry->customData()->contains(BrowserService::OPTION_HIDE_ENTRY)
+                || (groupOptionHideEntry == Group::Inherit
+                    && entry->customData()->contains(BrowserService::OPTION_HIDE_ENTRY)
                     && entry->customData()->value(BrowserService::OPTION_HIDE_ENTRY) == TRUE_STR)) {
                 continue;
             }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -816,6 +816,7 @@ void EditEntryWidget::addKeyToAgent()
 
     if (!sshAgent()->addIdentity(key, settings, m_db->uuid())) {
         showMessage(sshAgent()->errorString(), MessageWidget::Error);
+        return;
     }
 }
 
@@ -829,6 +830,7 @@ void EditEntryWidget::removeKeyFromAgent()
 
     if (!sshAgent()->removeIdentity(key)) {
         showMessage(sshAgent()->errorString(), MessageWidget::Error);
+        return;
     }
 }
 
@@ -1084,56 +1086,26 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
             setupBrowser();
         }
 
-        m_browserSettingsChanged = false;
-        auto hideEntriesCheckBoxEnabled = true;
-        auto skipAutoSubmitCheckBoxEnabled = true;
-        auto onlyHttpAuthCheckBoxEnabled = true;
-        auto notHttpAuthCheckBoxEnabled = true;
-        auto hideEntries = false;
-        auto skipAutoSubmit = false;
-        auto onlyHttpAuth = false;
-        auto notHttpAuth = false;
-
         const auto group = m_entry->group();
-        if (group) {
-            hideEntries = group->resolveCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY) == Group::Enable;
-            skipAutoSubmit = group->resolveCustomDataTriState(BrowserService::OPTION_SKIP_AUTO_SUBMIT) == Group::Enable;
-            onlyHttpAuth = group->resolveCustomDataTriState(BrowserService::OPTION_ONLY_HTTP_AUTH) == Group::Enable;
-            notHttpAuth = group->resolveCustomDataTriState(BrowserService::OPTION_NOT_HTTP_AUTH) == Group::Enable;
+        m_browserUi->messageWidget->showMessage(
+            tr("Some Browser Integration settings are overridden by group settings."), MessageWidget::Information);
+        m_browserUi->messageWidget->setVisible(false);
 
-            hideEntriesCheckBoxEnabled =
-                group->resolveCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY) == Group::Inherit;
-            skipAutoSubmitCheckBoxEnabled =
-                group->resolveCustomDataTriState(BrowserService::OPTION_SKIP_AUTO_SUBMIT) == Group::Inherit;
-            onlyHttpAuthCheckBoxEnabled =
-                group->resolveCustomDataTriState(BrowserService::OPTION_ONLY_HTTP_AUTH) == Group::Inherit;
-            notHttpAuthCheckBoxEnabled =
-                group->resolveCustomDataTriState(BrowserService::OPTION_NOT_HTTP_AUTH) == Group::Inherit;
-        }
+        auto updateCheckBoxValue = [&](QCheckBox* checkBox, const QString& option) {
+            const auto optionEnabledInGroup = group ? group->resolveBrowserOptionEnabled(option) : false;
+            const auto optionInherited = group ? group->resolveCustomDataTriState(option) == Group::Inherit : true;
 
-        // Show information about group level settings
-        if (!hideEntriesCheckBoxEnabled || !skipAutoSubmitCheckBoxEnabled || !onlyHttpAuthCheckBoxEnabled
-            || !notHttpAuthCheckBoxEnabled) {
-            m_browserUi->messageWidget->showMessage(
-                tr("Some Browser Integration settings are overridden by group settings."), MessageWidget::Information);
-            m_browserUi->messageWidget->setVisible(true);
-        }
+            if (!optionInherited) {
+                m_browserUi->messageWidget->setVisible(true);
+            }
 
-        // Disable checkboxes based on group level settings
-        updateBrowserIntegrationCheckbox(
-            m_browserUi->hideEntryCheckbox, hideEntriesCheckBoxEnabled, hideEntries, BrowserService::OPTION_HIDE_ENTRY);
-        updateBrowserIntegrationCheckbox(m_browserUi->skipAutoSubmitCheckbox,
-                                         skipAutoSubmitCheckBoxEnabled,
-                                         skipAutoSubmit,
-                                         BrowserService::OPTION_SKIP_AUTO_SUBMIT);
-        updateBrowserIntegrationCheckbox(m_browserUi->onlyHttpAuthCheckbox,
-                                         onlyHttpAuthCheckBoxEnabled,
-                                         onlyHttpAuth,
-                                         BrowserService::OPTION_ONLY_HTTP_AUTH);
-        updateBrowserIntegrationCheckbox(m_browserUi->notHttpAuthCheckbox,
-                                         notHttpAuthCheckBoxEnabled,
-                                         notHttpAuth,
-                                         BrowserService::OPTION_NOT_HTTP_AUTH);
+            updateBrowserIntegrationCheckbox(checkBox, optionInherited, optionEnabledInGroup, option);
+        };
+
+        updateCheckBoxValue(m_browserUi->hideEntryCheckbox, BrowserService::OPTION_HIDE_ENTRY);
+        updateCheckBoxValue(m_browserUi->skipAutoSubmitCheckbox, BrowserService::OPTION_SKIP_AUTO_SUBMIT);
+        updateCheckBoxValue(m_browserUi->onlyHttpAuthCheckbox, BrowserService::OPTION_ONLY_HTTP_AUTH);
+        updateCheckBoxValue(m_browserUi->notHttpAuthCheckbox, BrowserService::OPTION_NOT_HTTP_AUTH);
 
         m_browserUi->addURLButton->setEnabled(!m_history);
         m_browserUi->removeURLButton->setEnabled(false);

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -853,4 +853,57 @@ void TestBrowser::testRestrictBrowserKey()
     QCOMPARE(sorted[1]->url(), QString("https://example.com/2b"));
     QCOMPARE(sorted[2]->url(), QString("https://example.com/2"));
     QCOMPARE(sorted[3]->url(), QString("https://example.com/0"));
+}
+
+void TestBrowser::testHideEntry()
+{
+    const auto db = QSharedPointer<Database>::create();
+    auto* root = db->rootGroup();
+
+    const auto entry = new Entry();
+    entry->setGroup(root);
+    entry->beginUpdate();
+    entry->setUrl(QString("https://github.com/"));
+    entry->setUsername(QString("User 1"));
+    entry->setUuid(QUuid::createUuid());
+    entry->setTitle(QString("Name_ 1"));
+    entry->endUpdate();
+
+    // Entry should be found normally
+    auto result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
+    QCOMPARE(result.length(), 1);
+    QCOMPARE(result[0]->url(), QString("https://github.com/"));
+
+    // Hide entry from entry settings, group setting is inherited
+    entry->customData()->set(BrowserService::OPTION_HIDE_ENTRY, TRUE_STR);
+    result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
+    QCOMPARE(result.length(), 0);
+
+    // Disable hide from group settings, entry should be found
+    root->setCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY, Group::Disable);
+    result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
+    QCOMPARE(result.length(), 1);
+
+    // Enable hide from group setting, entry should not be found
+    root->setCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY, Group::Enable);
+    result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
+    QCOMPARE(result.length(), 0);
+
+    // Remove the hide settings from entry, return group setting to inherit
+    entry->customData()->set(BrowserService::OPTION_HIDE_ENTRY, FALSE_STR);
+    root->setCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY, Group::Inherit);
+
+    // Entry should be found again
+    result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
+    QCOMPARE(result.length(), 1);
+
+    // Enable hide from group setting, entry should not be found
+    root->setCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY, Group::Enable);
+    result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
+    QCOMPARE(result.length(), 0);
+
+    // Disable hide from group settings, entry should be found
+    root->setCustomDataTriState(BrowserService::OPTION_HIDE_ENTRY, Group::Disable);
+    result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
+    QCOMPARE(result.length(), 1);
 }

--- a/tests/TestBrowser.h
+++ b/tests/TestBrowser.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -51,6 +51,7 @@ private slots:
     void testBestMatchingCredentials();
     void testBestMatchingWithAdditionalURLs();
     void testRestrictBrowserKey();
+    void testHideEntry();
 
 private:
     QList<Entry*> createEntries(QStringList& urls, Group* root, bool additionalUrl = false) const;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
Fixes showing the correct checkbox value in entry's Browser Integration settings page. Also checks that the group setting is inherited before checking the entry's own value in BrowserService. Group settings can override the entry options.

For checkbox values, the group's enabled/disabled value is now checked by the new `resolveBrowserOptionEnabled()` function.

* Fixes #12972

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Automatic tests made for the URL matching. Manually tested the UI by checking all possible scenarios:

- Group setting is default (inherited) -> respect the entry setting
- Group setting is enabled -> respect the group setting & enable the checkbox
- Group setting is disabled -> respect the group setting & disable the checkbox

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
