### PR TITLE
Fix setting browser related values to customData

### DIFF
--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -158,7 +158,6 @@ void CustomData::copyDataFrom(const CustomData* other)
 
     m_data = other->m_data;
 
-    updateLastModified();
     emit reset();
     emitModified();
 }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -350,25 +350,31 @@ void EditEntryWidget::updateBrowser()
         return;
     }
 
+    auto changeValue = [&](const QString& option, const bool newValue) {
+        // If value is false and no customData exists, make no edits
+        if (!m_customData->hasKey(option) && !newValue) {
+            return;
+        }
+
+        // If customData exists, set the value
+        m_customData->set(option, (newValue ? TRUE_STR : FALSE_STR));
+    };
+
     // Only update the custom data if no group level settings are used (checkbox is enabled)
     if (m_browserUi->hideEntryCheckbox->isEnabled()) {
-        auto hide = m_browserUi->hideEntryCheckbox->isChecked();
-        m_customData->set(BrowserService::OPTION_HIDE_ENTRY, (hide ? TRUE_STR : FALSE_STR));
+        changeValue(BrowserService::OPTION_HIDE_ENTRY, m_browserUi->hideEntryCheckbox->isChecked());
     }
 
     if (m_browserUi->skipAutoSubmitCheckbox->isEnabled()) {
-        auto skip = m_browserUi->skipAutoSubmitCheckbox->isChecked();
-        m_customData->set(BrowserService::OPTION_SKIP_AUTO_SUBMIT, (skip ? TRUE_STR : FALSE_STR));
+        changeValue(BrowserService::OPTION_SKIP_AUTO_SUBMIT, m_browserUi->skipAutoSubmitCheckbox->isChecked());
     }
 
     if (m_browserUi->onlyHttpAuthCheckbox->isEnabled()) {
-        auto onlyHttpAuth = m_browserUi->onlyHttpAuthCheckbox->isChecked();
-        m_customData->set(BrowserService::OPTION_ONLY_HTTP_AUTH, (onlyHttpAuth ? TRUE_STR : FALSE_STR));
+        changeValue(BrowserService::OPTION_ONLY_HTTP_AUTH, m_browserUi->onlyHttpAuthCheckbox->isChecked());
     }
 
     if (m_browserUi->notHttpAuthCheckbox->isEnabled()) {
-        auto notHttpAuth = m_browserUi->notHttpAuthCheckbox->isChecked();
-        m_customData->set(BrowserService::OPTION_NOT_HTTP_AUTH, (notHttpAuth ? TRUE_STR : FALSE_STR));
+        changeValue(BrowserService::OPTION_NOT_HTTP_AUTH, m_browserUi->notHttpAuthCheckbox->isChecked());
     }
 }
 
@@ -810,7 +816,6 @@ void EditEntryWidget::addKeyToAgent()
 
     if (!sshAgent()->addIdentity(key, settings, m_db->uuid())) {
         showMessage(sshAgent()->errorString(), MessageWidget::Error);
-        return;
     }
 }
 
@@ -824,7 +829,6 @@ void EditEntryWidget::removeKeyFromAgent()
 
     if (!sshAgent()->removeIdentity(key)) {
         showMessage(sshAgent()->errorString(), MessageWidget::Error);
-        return;
     }
 }
 
@@ -1080,6 +1084,7 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
             setupBrowser();
         }
 
+        m_browserSettingsChanged = false;
         auto hideEntriesCheckBoxEnabled = true;
         auto skipAutoSubmitCheckBoxEnabled = true;
         auto onlyHttpAuthCheckBoxEnabled = true;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
Fixed a bug with entries saving browser integration related data even when nothing has been changed. The culprit was the `m_browserSettingsChanged` that is not reset after the first save. The value must be set to false every time entry data is loaded.

Also, we shouldn't write any custom data for browser integration if the option doesn't exist in custom data, and values are not changed (remain false). This allows user to delete plugin data manually even if some other options exists.

Removed `updateLastModified()` from `CustomData::copyDataFrom()` function. It is not actually needed there. That function is called often and it should not update the modified time. I assume it's put there originally because when cloning entries or groups, that timestamp was updated too. Not sure if that's necessary at all with custom data.

* Fixes #12981

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
The shortest way to reproduce and test this:
- Create two entries.
- Modify some browser option in entry one, press Ok.
- Open entry two and just press Ok.
- Data shouldn't be changed in entry two. Previously browser values were written to custom data.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
