### PR TITLE
add a button to copy the text of entry attributes

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3151,6 +3151,14 @@ Would you like to correct it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy text into clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Attachments</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -246,6 +246,7 @@ void EditEntryWidget::setupAdvanced()
     connect(m_advancedUi->removeAttributeButton, SIGNAL(clicked()), SLOT(removeCurrentAttribute()));
     connect(m_advancedUi->protectAttributeButton, SIGNAL(toggled(bool)), SLOT(protectCurrentAttribute(bool)));
     connect(m_advancedUi->revealAttributeButton, SIGNAL(clicked(bool)), SLOT(toggleCurrentAttributeVisibility()));
+    connect(m_advancedUi->copyTextButton, SIGNAL(clicked(bool)), SLOT(copyAttributeText()));
     connect(m_advancedUi->attributesView->selectionModel(),
             SIGNAL(currentChanged(QModelIndex,QModelIndex)),
             SLOT(updateCurrentAttribute()));
@@ -995,6 +996,7 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_advancedUi->addAttributeButton->setEnabled(!m_history);
     m_advancedUi->editAttributeButton->setEnabled(false);
     m_advancedUi->removeAttributeButton->setEnabled(false);
+    m_advancedUi->copyTextButton->setEnabled(false);
     m_advancedUi->attributesEdit->setReadOnly(m_history);
     QAbstractItemView::EditTriggers editTriggers;
     if (m_history) {
@@ -1495,12 +1497,15 @@ void EditEntryWidget::displayAttribute(QModelIndex index, bool showProtected)
         m_advancedUi->protectAttributeButton->setEnabled(!m_history);
         m_advancedUi->editAttributeButton->setEnabled(!m_history);
         m_advancedUi->removeAttributeButton->setEnabled(!m_history);
+
+        m_advancedUi->copyTextButton->setEnabled(true);
     } else {
         m_advancedUi->attributesEdit->setPlainText("");
         m_advancedUi->attributesEdit->setEnabled(false);
         m_advancedUi->revealAttributeButton->setEnabled(false);
         m_advancedUi->protectAttributeButton->setChecked(false);
         m_advancedUi->protectAttributeButton->setEnabled(false);
+        m_advancedUi->copyTextButton->setEnabled(false);
         m_advancedUi->editAttributeButton->setEnabled(false);
         m_advancedUi->removeAttributeButton->setEnabled(false);
     }
@@ -1543,6 +1548,22 @@ void EditEntryWidget::toggleCurrentAttributeVisibility()
         protectCurrentAttribute(true);
         m_advancedUi->revealAttributeButton->setText(tr("Reveal"));
     }
+}
+
+void EditEntryWidget::copyAttributeText()
+{
+    QString value;
+    if (m_advancedUi->attributesEdit->isEnabled()) {
+        value = m_advancedUi->attributesEdit->toPlainText();
+    } else {
+        QModelIndex index = m_advancedUi->attributesView->currentIndex();
+        if (index.isValid()) {
+            QString key = m_attributesModel->keyByIndex(index);
+            value = m_entryAttributes->value(key);
+        }
+    }
+
+    clipboard()->setText(value);
 }
 
 void EditEntryWidget::updateAutoTypeEnabled()

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -107,6 +107,7 @@ private slots:
     void updateCurrentAttribute();
     void protectCurrentAttribute(bool state);
     void toggleCurrentAttributeVisibility();
+    void copyAttributeText();
     void updateAutoTypeEnabled();
     void openAutotypeHelp();
     void insertAutoTypeAssoc();

--- a/src/gui/entry/EditEntryWidgetAdvanced.ui
+++ b/src/gui/entry/EditEntryWidgetAdvanced.ui
@@ -32,7 +32,7 @@
       <item>
        <widget class="QSplitter" name="attributesSplitter">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="childrenCollapsible">
          <bool>false</bool>
@@ -48,10 +48,10 @@
           <string>Attribute selection</string>
          </property>
          <property name="sizeAdjustPolicy">
-          <enum>QAbstractScrollArea::AdjustToContents</enum>
+          <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
          </property>
          <property name="resizeMode">
-          <enum>QListView::Adjust</enum>
+          <enum>QListView::ResizeMode::Adjust</enum>
          </property>
         </widget>
         <widget class="QPlainTextEdit" name="attributesEdit">
@@ -117,7 +117,7 @@
         <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -143,6 +143,16 @@
           </property>
           <property name="checkable">
            <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="copyTextButton">
+          <property name="accessibleName">
+           <string>Copy text into clipboard</string>
+          </property>
+          <property name="text">
+           <string>Copy</string>
           </property>
          </widget>
         </item>
@@ -236,10 +246,10 @@
       <item>
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeType">
-         <enum>QSizePolicy::Maximum</enum>
+         <enum>QSizePolicy::Policy::Maximum</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -284,7 +294,7 @@
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>


### PR DESCRIPTION
This PR adds a button to the entries advanced attributes UI which allows the user to copy their text while using the auto-delete feature of the clipboard.

## Screenshots
<img width="997" height="783" alt="ui" src="https://github.com/user-attachments/assets/fd953b38-e9ca-4c18-8c0f-2de95926bd41" />

## Testing strategy
None other than manually checking that the button works and also gets disabled when no entry is selected.

## Type of change
- ✅ New feature (change that adds functionality)
