### PR TITLE
Fix Alt key handling for menubar toggle and enable Save button on non-data changes

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1902,7 +1902,7 @@ void DatabaseWidget::onDatabaseNonDataChanged()
 {
     // Force mark the database modified if we are not auto-saving non-data changes
     if (!config()->get(Config::AutoSaveNonDataChanges).toBool()) {
-        m_db->markAsModified();
+        emit databaseNonDataChanged();
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2269,12 +2269,25 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
             }
         }
 #endif
+    } else if (eventType == QEvent::KeyPress) {
+        auto keyEvent = static_cast<QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Alt) {
+            m_altKeyAlone = (keyEvent->modifiers() == Qt::AltModifier);
+        } else {
+            m_altKeyAlone = false;
+        }
+        return QObject::eventFilter(watched, event);
     } else if (eventType == QEvent::KeyRelease && watched == mainWindow) {
 #ifdef Q_OS_MACOS
         // On macOS, the menubar is always visible, so no need to toggle it
         return false;
 #endif
         auto keyEvent = dynamic_cast<QKeyEvent*>(event);
+
+        if (keyEvent->key() != Qt::Key_Alt) {
+            m_altKeyAlone = false;
+            return QObject::eventFilter(watched, event);
+        }
 #ifdef Q_OS_WIN
         // Windows translates AltGr into CTRL + ALT, this breaks using AltGr when the menubar is hidden
         // Prevent this by activating the ALT cooldown to ignore the next key event which will be an ALT key
@@ -2284,7 +2297,7 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
             return false;
         }
 #endif
-        if (keyEvent->key() == Qt::Key_Alt && !keyEvent->modifiers() && config()->get(Config::GUI_HideMenubar).toBool()
+        if (keyEvent->key() == Qt::Key_Alt && m_altKeyAlone && config()->get(Config::GUI_HideMenubar).toBool()
             && !m_altCoolDown.isActive()) {
             auto menubar = mainWindow->m_ui->menubar;
             menubar->setMaximumHeight(menubar->maximumHeight() > 0 ? 0 : QWIDGETSIZE_MAX);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1038,7 +1038,11 @@ void MainWindow::updateMenuActionState()
     m_ui->actionGroupDownloadFavicons->setEnabled(groupSelected && groupHasEntries && !inRecycleBin);
 
     // Database Menu
-    m_ui->actionDatabaseSave->setEnabled(databaseUnlocked && m_ui->tabWidget->canSave());
+    bool enableSave = databaseUnlocked
+                      && (m_ui->tabWidget->canSave()
+                          || (dbWidget && dbWidget->database() && dbWidget->database()->hasNonDataChanges()
+                              && !config()->get(Config::AutoSaveNonDataChanges).toBool()));
+    m_ui->actionDatabaseSave->setEnabled(enableSave);
     m_ui->actionDatabaseSaveAs->setEnabled(databaseUnlocked);
     m_ui->actionDatabaseSaveBackup->setEnabled(databaseUnlocked);
     m_ui->actionDatabaseClose->setEnabled(dbWidget);
@@ -1091,7 +1095,12 @@ void MainWindow::updateWindowTitle()
         if (isModified && customWindowTitlePart.endsWith("*")) {
             customWindowTitlePart.remove(customWindowTitlePart.size() - 1, 1);
         }
-        m_ui->actionDatabaseSave->setEnabled(m_ui->tabWidget->canSave(tabWidgetIndex));
+        auto dbWidget = m_ui->tabWidget->databaseWidgetFromIndex(tabWidgetIndex);
+        bool enableSave = (dbWidget && !dbWidget->isLocked())
+                          && (m_ui->tabWidget->canSave(tabWidgetIndex)
+                              || (dbWidget->database() && dbWidget->database()->hasNonDataChanges()
+                                  && !config()->get(Config::AutoSaveNonDataChanges).toBool()));
+        m_ui->actionDatabaseSave->setEnabled(enableSave);
     } else if (stackedWidgetIndex == StackedWidgetIndex::SettingsScreen) {
         customWindowTitlePart = tr("Settings");
     } else if (stackedWidgetIndex == StackedWidgetIndex::PasswordGeneratorScreen) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -219,6 +219,7 @@ public:
 private:
     QTimer m_menubarTimer;
     QTimer m_altCoolDown;
+    bool m_altKeyAlone = false;
 };
 
 /**


### PR DESCRIPTION
1) Fix menubar toggle to react only on Alt
Menubar visibility previously reacted to any key combination involving Alt (e.g. Shift+Alt for keyboard layout switch or Alt+Arrow for moving entries).
Now it only toggles when Alt is pressed and released alone, preventing unintended menu activation during shortcuts.
2) Fixes https://github.com/keepassxreboot/keepassxc/issues/9751. Enable Save button on non-data changes without marking database modified. 

## Testing strategy
Manually

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

