### PR TITLE
Fix sshAgent casacading calls with QSignalBlocker

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -44,6 +44,7 @@
 #include "sshagent/OpenSSHKey.h"
 #include "sshagent/OpenSSHKeyGenDialog.h"
 #include "sshagent/SSHAgent.h"
+#include <QSignalBlocker>
 #endif
 #ifdef WITH_XC_BROWSER
 #include "EntryURLModel.h"
@@ -636,6 +637,7 @@ void EditEntryWidget::setSSHAgentSettings()
     m_sshAgentUi->requireUserConfirmationCheckBox->setChecked(m_sshAgentSettings.useConfirmConstraintWhenAdding());
     m_sshAgentUi->lifetimeCheckBox->setChecked(m_sshAgentSettings.useLifetimeConstraintWhenAdding());
     m_sshAgentUi->lifetimeSpinBox->setValue(m_sshAgentSettings.lifetimeConstraintDuration());
+    QSignalBlocker sshAgent_attachmentComboBox_Blocker(m_sshAgentUi->attachmentComboBox);
     m_sshAgentUi->attachmentComboBox->clear();
     m_sshAgentUi->addToAgentButton->setEnabled(false);
     m_sshAgentUi->removeFromAgentButton->setEnabled(false);
@@ -672,6 +674,7 @@ void EditEntryWidget::updateSSHAgentAttachments()
         setSSHAgentSettings();
     }
 
+    QSignalBlocker sshAgent_attachmentComboBox_Blocker(m_sshAgentUi->attachmentComboBox);
     m_sshAgentUi->attachmentComboBox->clear();
     m_sshAgentUi->attachmentComboBox->addItem("");
 
@@ -684,6 +687,7 @@ void EditEntryWidget::updateSSHAgentAttachments()
     }
 
     m_sshAgentUi->attachmentComboBox->setCurrentText(m_sshAgentSettings.attachmentName());
+    QSignalBlocker sshAgent_externalFileEdit_Blocker(m_sshAgentUi->externalFileEdit);
     m_sshAgentUi->externalFileEdit->setText(m_sshAgentSettings.fileName());
 
     if (m_sshAgentSettings.selectedType() == "attachment") {
@@ -966,6 +970,9 @@ void EditEntryWidget::loadEntry(Entry* entry,
 
 void EditEntryWidget::setForms(Entry* entry, bool restore)
 {
+#ifdef WITH_XC_SSHAGENT
+    QSignalBlocker attachmentsBlocker(m_attachments.data());
+#endif
     m_attachments->copyDataFrom(entry->attachments());
     m_customData->copyDataFrom(entry->customData());
 
@@ -1382,6 +1389,9 @@ void EditEntryWidget::clear()
     m_mainUi->notesEdit->clear();
 
     m_entryAttributes->clear();
+#ifdef WITH_XC_SSHAGENT
+    QSignalBlocker attachmentsBlocker(m_attachments.data());
+#endif
     m_attachments->clear();
     m_customData->clear();
     m_autoTypeAssoc->clear();


### PR DESCRIPTION
fix: block SSH agent signals on programmatic UI updates

Block `attachmentComboBox/externalFileEdit/m_attachments.data()` signals from emitting when changed by code (not user interaction). Uses QSignalBlocker pattern.

**Functions affected:**
- `setForm()`
- `clear()`
- `setSSHAgentSetting()`
- `updateSSHAgentAttachments()`

These modify UI elements, trigger unwanted signals, and recursively call:
- `updateSSHAgentKeyInfo()`
- `updateSSHAgentAttachment()`
- `updateSSHAgentAttachments()`

**Implementation:**
Add QSignalBlocker on programmatic changes:
```cpp
QSignalBlocker sshAgent_attachmentComboBox_Blocker(m_sshAgentUi->attachmentComboBox);
QSignalBlocker sshAgent_externalFileEdit_Blocker(m_sshAgentUi->externalFileEdit);
QSignalBlocker attachmentsBlocker(m_attachments.data());
```


## Testing strategy
- Compile with `-DWITH_XC_SSHAGENT=ON`
- Trace signals and function calls when opening/modifying/closing entries
- See debug branch: [fix/sshAgent-cascading-calls-QSignalBlocker-debug](https://github.com/AlexpFr/keepassxc/tree/fix/sshAgent-cascading-calls-QSignalBlocker-debug)


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
