### PR TITLE
Add uiAccess=true manifest to fix issue #12956 (KeepassXC cannot autotype into windows password prompts)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,7 +427,7 @@ set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)
 
 if(WIN32)
     set_target_properties(${PROGNAME} PROPERTIES WIN32_EXECUTABLE ON)
-    set_target_properties(${PROGNAME} PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='asInvoker' uiAccess='true'\" /SUBSYSTEM:WINDOWS")
+    set_target_properties(${PROGNAME} PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='asInvoker' uiAccess='true'\"")
     include(GenerateProductVersion)
     generate_product_version(
             WIN32_ResourceFiles

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,6 +427,7 @@ set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)
 
 if(WIN32)
     set_target_properties(${PROGNAME} PROPERTIES WIN32_EXECUTABLE ON)
+    set_target_properties(${PROGNAME} PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='asInvoker' uiAccess='true'\" /SUBSYSTEM:WINDOWS")
     include(GenerateProductVersion)
     generate_product_version(
             WIN32_ResourceFiles


### PR DESCRIPTION
Changes to compile Windows version of KeepassXC with uiAccess=true manifets, fixing issue #12956 

## Testing strategy
Recompiled to be sure, that manifest changes.
Manifest change being effective was tested beforehand by striping existing executable of signature, changing manifest and then resigning it with selfsigned certificated, that was added to trusted certificate. After copying that executable trusted location, it was able to fill those password prompts.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
