### PR TITLE
Add per-device KeeShare sync mode

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -202,6 +202,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::KeeShare_Own, {QS("KeeShare/Own"), Roaming, {}}},
     {Config::KeeShare_Foreign, {QS("KeeShare/Foreign"), Roaming, {}}},
     {Config::KeeShare_Active, {QS("KeeShare/Active"), Roaming, {}}},
+    {Config::KeeShare_DeviceId, {QS("KeeShare/DeviceId"), Local, {}}},
 
     // PasswordGenerator
     {Config::PasswordGenerator_LowerCase, {QS("PasswordGenerator/LowerCase"), Roaming, true}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -179,6 +179,7 @@ public:
         KeeShare_Own,
         KeeShare_Foreign,
         KeeShare_Active,
+        KeeShare_DeviceId,
 
         PasswordGenerator_LowerCase,
         PasswordGenerator_UpperCase,

--- a/src/keeshare/KeeShare.cpp
+++ b/src/keeshare/KeeShare.cpp
@@ -67,22 +67,23 @@ QString KeeShare::deviceId()
             // Last resort: use hostname
             id = QSysInfo::machineHostName();
         }
-        // Sanitize to [A-Za-z0-9] only
-        id.remove(QRegularExpression("[^A-Za-z0-9]"));
-        if (id.isEmpty()) {
-            id = "DEFAULT";
-        }
         setDeviceId(id);
+        // Re-read the sanitized value
+        id = config()->get(Config::KeeShare_DeviceId).toString();
     }
     return id;
 }
 
 void KeeShare::setDeviceId(const QString& id)
 {
-    // Sanitize to [A-Za-z0-9] only and enforce max length
+    // All sanitization consolidated here: strip non-alphanumeric, enforce max
+    // length, and fall back to DEFAULT if empty
     QString sanitized = id;
     sanitized.remove(QRegularExpression("[^A-Za-z0-9]"));
     sanitized.truncate(32);
+    if (sanitized.isEmpty()) {
+        sanitized = QStringLiteral("DEFAULT");
+    }
     config()->set(Config::KeeShare_DeviceId, sanitized);
 }
 

--- a/src/keeshare/KeeShare.cpp
+++ b/src/keeshare/KeeShare.cpp
@@ -23,9 +23,13 @@
 #include "gui/DatabaseIcons.h"
 #include "keeshare/ShareObserver.h"
 
+#include <QRegularExpression>
+#include <QSysInfo>
+
 namespace
 {
     static const QString KeeShare_Reference("KeeShare/Reference");
+    static const QString KeeShare_PerDeviceSync("KeeShare/PerDeviceSync");
 }
 
 KeeShare* KeeShare::m_instance = nullptr;
@@ -49,6 +53,37 @@ void KeeShare::init(QObject* parent)
 {
     Q_ASSERT(!m_instance);
     m_instance = new KeeShare(parent);
+}
+
+QString KeeShare::deviceId()
+{
+    auto id = config()->get(Config::KeeShare_DeviceId).toString();
+    if (id.isEmpty()) {
+        // Generate fallback from machine unique ID, truncated to 7 chars
+        auto machineId = QSysInfo::machineUniqueId();
+        if (!machineId.isEmpty()) {
+            // machineUniqueId() on Linux returns a hex string directly from /etc/machine-id
+            id = QString::fromLatin1(machineId).left(7).toUpper();
+        } else {
+            // Last resort: use hostname
+            id = QSysInfo::machineHostName();
+        }
+        // Sanitize to [A-Za-z0-9] only
+        id.remove(QRegularExpression("[^A-Za-z0-9]"));
+        if (id.isEmpty()) {
+            id = "DEFAULT";
+        }
+        setDeviceId(id);
+    }
+    return id;
+}
+
+void KeeShare::setDeviceId(const QString& id)
+{
+    // Sanitize to [A-Za-z0-9] only
+    QString sanitized = id;
+    sanitized.remove(QRegularExpression("[^A-Za-z0-9]"));
+    config()->set(Config::KeeShare_DeviceId, sanitized);
 }
 
 KeeShareSettings::Own KeeShare::own()
@@ -108,6 +143,19 @@ void KeeShare::setReferenceTo(Group* group, const KeeShareSettings::Reference& r
     }
     const auto serialized = KeeShareSettings::Reference::serialize(reference);
     customData->set(KeeShare_Reference, serialized.toUtf8().toBase64());
+}
+
+bool KeeShare::hasPerDeviceConfig(const Group* group)
+{
+    return group && group->customData()->contains(KeeShare_PerDeviceSync);
+}
+
+QString KeeShare::perDeviceSyncPath(const Group* group)
+{
+    if (!group || !group->customData()->contains(KeeShare_PerDeviceSync)) {
+        return {};
+    }
+    return group->customData()->value(KeeShare_PerDeviceSync);
 }
 
 bool KeeShare::isEnabled(const Group* group)

--- a/src/keeshare/KeeShare.cpp
+++ b/src/keeshare/KeeShare.cpp
@@ -29,7 +29,6 @@
 namespace
 {
     static const QString KeeShare_Reference("KeeShare/Reference");
-    static const QString KeeShare_PerDeviceSync("KeeShare/PerDeviceSync");
 }
 
 KeeShare* KeeShare::m_instance = nullptr;
@@ -80,9 +79,10 @@ QString KeeShare::deviceId()
 
 void KeeShare::setDeviceId(const QString& id)
 {
-    // Sanitize to [A-Za-z0-9] only
+    // Sanitize to [A-Za-z0-9] only and enforce max length
     QString sanitized = id;
     sanitized.remove(QRegularExpression("[^A-Za-z0-9]"));
+    sanitized.truncate(32);
     config()->set(Config::KeeShare_DeviceId, sanitized);
 }
 
@@ -143,19 +143,6 @@ void KeeShare::setReferenceTo(Group* group, const KeeShareSettings::Reference& r
     }
     const auto serialized = KeeShareSettings::Reference::serialize(reference);
     customData->set(KeeShare_Reference, serialized.toUtf8().toBase64());
-}
-
-bool KeeShare::hasPerDeviceConfig(const Group* group)
-{
-    return group && group->customData()->contains(KeeShare_PerDeviceSync);
-}
-
-QString KeeShare::perDeviceSyncPath(const Group* group)
-{
-    if (!group || !group->customData()->contains(KeeShare_PerDeviceSync)) {
-        return {};
-    }
-    return group->customData()->value(KeeShare_PerDeviceSync);
 }
 
 bool KeeShare::isEnabled(const Group* group)

--- a/src/keeshare/KeeShare.h
+++ b/src/keeshare/KeeShare.h
@@ -54,6 +54,9 @@ public:
     static const Group* resolveSharedGroup(const Group* group);
     static QString sharingLabel(const Group* group);
 
+    static QString deviceId();
+    static void setDeviceId(const QString& id);
+
     static KeeShareSettings::Own own();
     static void setOwn(const KeeShareSettings::Own& own);
 
@@ -63,6 +66,9 @@ public:
     static KeeShareSettings::Reference referenceOf(const Group* group);
     static void setReferenceTo(Group* group, const KeeShareSettings::Reference& reference);
     static QString referenceTypeLabel(const KeeShareSettings::Reference& reference);
+
+    static bool hasPerDeviceConfig(const Group* group);
+    static QString perDeviceSyncPath(const Group* group);
 
     void connectDatabase(QSharedPointer<Database> newDb, QSharedPointer<Database> oldDb);
     bool setSharingEnabled(QSharedPointer<Database> db, bool enabled);

--- a/src/keeshare/KeeShare.h
+++ b/src/keeshare/KeeShare.h
@@ -67,9 +67,6 @@ public:
     static void setReferenceTo(Group* group, const KeeShareSettings::Reference& reference);
     static QString referenceTypeLabel(const KeeShareSettings::Reference& reference);
 
-    static bool hasPerDeviceConfig(const Group* group);
-    static QString perDeviceSyncPath(const Group* group);
-
     void connectDatabase(QSharedPointer<Database> newDb, QSharedPointer<Database> oldDb);
     bool setSharingEnabled(QSharedPointer<Database> db, bool enabled);
 

--- a/src/keeshare/KeeShareSettings.cpp
+++ b/src/keeshare/KeeShareSettings.cpp
@@ -25,6 +25,7 @@
 #include "gui/DatabaseIcons.h"
 
 #include <QDataStream>
+#include <QDir>
 #include <QFileInfo>
 #include <QTextCodec>
 #include <QXmlStreamWriter>
@@ -287,9 +288,13 @@ namespace KeeShareSettings
         return (type & ImportFrom) != 0 && !path.isEmpty();
     }
 
-    bool Reference::isPerDeviceMode() const
+    bool Reference::isPerDeviceMode(const QDir& baseDir) const
     {
-        return !path.isEmpty() && QFileInfo(path).isDir();
+        if (path.isEmpty()) {
+            return false;
+        }
+        const QString resolvedPath = baseDir.absoluteFilePath(path);
+        return QFileInfo(resolvedPath).isDir();
     }
 
     bool Reference::operator<(const Reference& other) const

--- a/src/keeshare/KeeShareSettings.cpp
+++ b/src/keeshare/KeeShareSettings.cpp
@@ -286,6 +286,13 @@ namespace KeeShareSettings
         return (type & ImportFrom) != 0 && !path.isEmpty();
     }
 
+    bool Reference::isPerDeviceMode() const
+    {
+        return !path.isEmpty()
+            && !path.endsWith(".kdbx", Qt::CaseInsensitive)
+            && !path.endsWith(".kdbx.share", Qt::CaseInsensitive);
+    }
+
     bool Reference::operator<(const Reference& other) const
     {
         if (type != other.type) {

--- a/src/keeshare/KeeShareSettings.cpp
+++ b/src/keeshare/KeeShareSettings.cpp
@@ -25,6 +25,7 @@
 #include "gui/DatabaseIcons.h"
 
 #include <QDataStream>
+#include <QFileInfo>
 #include <QTextCodec>
 #include <QXmlStreamWriter>
 
@@ -288,9 +289,7 @@ namespace KeeShareSettings
 
     bool Reference::isPerDeviceMode() const
     {
-        return !path.isEmpty()
-            && !path.endsWith(".kdbx", Qt::CaseInsensitive)
-            && !path.endsWith(".kdbx.share", Qt::CaseInsensitive);
+        return !path.isEmpty() && QFileInfo(path).isDir();
     }
 
     bool Reference::operator<(const Reference& other) const

--- a/src/keeshare/KeeShareSettings.h
+++ b/src/keeshare/KeeShareSettings.h
@@ -133,6 +133,7 @@ namespace KeeShareSettings
         bool isValid() const;
         bool isExporting() const;
         bool isImporting() const;
+        bool isPerDeviceMode() const;
         bool operator<(const Reference& other) const;
         bool operator==(const Reference& other) const;
 

--- a/src/keeshare/KeeShareSettings.h
+++ b/src/keeshare/KeeShareSettings.h
@@ -21,6 +21,8 @@
 #include <QSharedPointer>
 #include <QUuid>
 
+class QDir;
+
 namespace Botan
 {
     class Private_Key;
@@ -133,7 +135,7 @@ namespace KeeShareSettings
         bool isValid() const;
         bool isExporting() const;
         bool isImporting() const;
-        bool isPerDeviceMode() const;
+        bool isPerDeviceMode(const QDir& baseDir) const;
         bool operator<(const Reference& other) const;
         bool operator==(const Reference& other) const;
 

--- a/src/keeshare/SettingsWidgetKeeShare.cpp
+++ b/src/keeshare/SettingsWidgetKeeShare.cpp
@@ -47,6 +47,8 @@ void SettingsWidgetKeeShare::loadSettings()
     m_ui->enableExportCheckBox->setChecked(active.out);
     m_ui->enableImportCheckBox->setChecked(active.in);
 
+    m_ui->deviceIdEdit->setText(KeeShare::deviceId());
+
     m_own = KeeShare::own();
     updateOwnCertificate();
 }
@@ -67,6 +69,11 @@ void SettingsWidgetKeeShare::saveSettings()
     //           of this object (similar scheme to Entry) - this way we could validate the settings before save
     KeeShare::setOwn(m_own);
     KeeShare::setActive(active);
+
+    auto deviceId = m_ui->deviceIdEdit->text().trimmed();
+    if (!deviceId.isEmpty()) {
+        KeeShare::setDeviceId(deviceId);
+    }
 
     config()->set(Config::KeeShare_QuietSuccess, m_ui->quietSuccessCheckBox->isChecked());
 }

--- a/src/keeshare/SettingsWidgetKeeShare.cpp
+++ b/src/keeshare/SettingsWidgetKeeShare.cpp
@@ -23,6 +23,7 @@
 #include "gui/MessageBox.h"
 #include "keeshare/KeeShare.h"
 
+#include <QRegularExpressionValidator>
 #include <QStandardItemModel>
 #include <QStandardPaths>
 #include <QTextStream>
@@ -32,6 +33,9 @@ SettingsWidgetKeeShare::SettingsWidgetKeeShare(QWidget* parent)
     , m_ui(new Ui::SettingsWidgetKeeShare())
 {
     m_ui->setupUi(this);
+
+    m_ui->deviceIdEdit->setValidator(
+        new QRegularExpressionValidator(QRegularExpression("[A-Za-z0-9]{0,32}"), this));
 
     connect(m_ui->ownCertificateSignerEdit, SIGNAL(textChanged(QString)), SLOT(setVerificationExporter(QString)));
     connect(m_ui->generateOwnCerticateButton, SIGNAL(clicked(bool)), SLOT(generateCertificate()));
@@ -73,6 +77,9 @@ void SettingsWidgetKeeShare::saveSettings()
     auto deviceId = m_ui->deviceIdEdit->text().trimmed();
     if (!deviceId.isEmpty()) {
         KeeShare::setDeviceId(deviceId);
+    } else {
+        // Clear stored ID so it will be auto-detected next time
+        config()->set(Config::KeeShare_DeviceId, QString());
     }
 
     config()->set(Config::KeeShare_QuietSuccess, m_ui->quietSuccessCheckBox->isChecked());

--- a/src/keeshare/SettingsWidgetKeeShare.ui
+++ b/src/keeshare/SettingsWidgetKeeShare.ui
@@ -69,6 +69,48 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="deviceIdentityGroupBox">
+     <property name="title">
+      <string>Device Identity</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="deviceIdLabel">
+        <property name="text">
+         <string>Device ID:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="deviceIdEdit">
+        <property name="accessibleName">
+         <string>Device ID field</string>
+        </property>
+        <property name="toolTip">
+         <string>Unique identifier for this device in per-device sync mode (alphanumeric only)</string>
+        </property>
+        <property name="placeholderText">
+         <string>Auto-detected from system</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="deviceIdSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="ownCertificateGroupBox">
      <property name="title">
       <string>Own certificate</string>

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -23,6 +23,7 @@
 #include "keeshare/ShareImport.h"
 
 #include <QDir>
+#include <QTimer>
 
 namespace
 {
@@ -67,6 +68,7 @@ void ShareObserver::deinitialize()
     m_groupToReference.clear();
     m_shareToGroup.clear();
     m_fileWatchers.clear();
+    m_dirWatchers.clear();
 }
 
 void ShareObserver::reinitialize()
@@ -83,6 +85,7 @@ void ShareObserver::reinitialize()
         m_groupToReference.remove(group);
         m_shareToGroup.remove(oldResolvedPath);
         m_fileWatchers.remove(oldResolvedPath);
+        m_dirWatchers.remove(oldResolvedPath);
 
         if (newReference.isValid()) {
             m_groupToReference[group] = newReference;
@@ -109,10 +112,23 @@ void ShareObserver::reinitialize()
 
         if (!reference.path.isEmpty() && reference.type != KeeShareSettings::Inactive) {
             const auto newResolvedPath = resolvePath(reference.path, m_db);
-            auto fileWatcher = QSharedPointer<FileWatcher>::create(this);
-            connect(fileWatcher.data(), &FileWatcher::fileChanged, this, &ShareObserver::handleFileUpdated);
-            fileWatcher->start(newResolvedPath, FileWatchPeriod, FileWatchSize);
-            m_fileWatchers.insert(newResolvedPath, fileWatcher);
+
+            if (reference.isPerDeviceMode()) {
+                // Per-device mode: watch the directory for changes
+                auto dirWatcher = QSharedPointer<QFileSystemWatcher>::create();
+                if (QDir(newResolvedPath).exists()) {
+                    dirWatcher->addPath(newResolvedPath);
+                }
+                connect(dirWatcher.data(), &QFileSystemWatcher::directoryChanged,
+                        this, &ShareObserver::handleDirectoryUpdated);
+                m_dirWatchers.insert(newResolvedPath, dirWatcher);
+            } else {
+                // Classic mode: watch the individual file
+                auto fileWatcher = QSharedPointer<FileWatcher>::create(this);
+                connect(fileWatcher.data(), &FileWatcher::fileChanged, this, &ShareObserver::handleFileUpdated);
+                fileWatcher->start(newResolvedPath, FileWatchPeriod, FileWatchSize);
+                m_fileWatchers.insert(newResolvedPath, fileWatcher);
+            }
         }
         if (reference.isExporting()) {
             exported[reference.path] << group->name();
@@ -121,21 +137,42 @@ void ShareObserver::reinitialize()
 
         if (reference.isImporting()) {
             imported[reference.path] << group->name();
-            // import has to occur immediately
-            const auto result = this->importShare(reference.path);
-            if (!result.isValid()) {
-                // tolerable result - blocked import or missing source
-                continue;
-            }
 
-            if (result.isError()) {
-                error << tr("Import from %1 failed (%2)").arg(result.path).arg(result.message);
-            } else if (result.isWarning()) {
-                warning << tr("Import from %1 failed (%2)").arg(result.path).arg(result.message);
-            } else if (result.isInfo()) {
-                success << tr("Import from %1 successful (%2)").arg(result.path).arg(result.message);
+            if (reference.isPerDeviceMode()) {
+                // Per-device mode: import from all device files in the directory
+                const auto resolvedDir = resolvePath(reference.path, m_db);
+                const auto results = importPerDeviceShares(resolvedDir, reference, group);
+                for (const auto& result : results) {
+                    if (!result.isValid()) {
+                        continue;
+                    }
+                    if (result.isError()) {
+                        error << tr("Import from %1 failed (%2)").arg(result.path, result.message);
+                    } else if (result.isWarning()) {
+                        warning << tr("Import from %1 failed (%2)").arg(result.path, result.message);
+                    } else if (result.isInfo()) {
+                        success << tr("Import from %1 successful (%2)").arg(result.path, result.message);
+                    } else {
+                        success << tr("Imported from %1").arg(result.path);
+                    }
+                }
             } else {
-                success << tr("Imported from %1").arg(result.path);
+                // Classic mode: import single file
+                const auto result = this->importShare(reference.path);
+                if (!result.isValid()) {
+                    // tolerable result - blocked import or missing source
+                    continue;
+                }
+
+                if (result.isError()) {
+                    error << tr("Import from %1 failed (%2)").arg(result.path).arg(result.message);
+                } else if (result.isWarning()) {
+                    warning << tr("Import from %1 failed (%2)").arg(result.path).arg(result.message);
+                } else if (result.isInfo()) {
+                    success << tr("Import from %1 successful (%2)").arg(result.path).arg(result.message);
+                } else {
+                    success << tr("Imported from %1").arg(result.path);
+                }
             }
         }
     }
@@ -216,6 +253,84 @@ void ShareObserver::handleFileUpdated(const QString& path)
     }
 }
 
+void ShareObserver::handleDirectoryUpdated(const QString& dirPath)
+{
+    auto group = m_shareToGroup.value(dirPath);
+    if (!group) {
+        return;
+    }
+    auto reference = KeeShare::referenceOf(group);
+    if (!reference.isImporting() || !reference.isPerDeviceMode()) {
+        return;
+    }
+
+    // Re-add the directory to the watcher (Qt removes it after notification)
+    auto dirWatcher = m_dirWatchers.value(dirPath);
+    if (dirWatcher && dirWatcher->directories().isEmpty()) {
+        dirWatcher->addPath(dirPath);
+    }
+
+    if (!m_inFileUpdate) {
+        QTimer::singleShot(100, this, [this, dirPath] {
+            auto shareGroup = m_shareToGroup.value(dirPath);
+            if (!shareGroup) {
+                m_inFileUpdate = false;
+                return;
+            }
+            auto shareRef = KeeShare::referenceOf(shareGroup);
+            auto results = importPerDeviceShares(dirPath, shareRef, shareGroup);
+            m_inFileUpdate = false;
+
+            QStringList success;
+            QStringList warning;
+            QStringList error;
+            for (const auto& result : results) {
+                if (!result.isValid()) {
+                    continue;
+                }
+                if (result.isError()) {
+                    error << tr("Import from %1 failed (%2)").arg(result.path, result.message);
+                } else if (result.isWarning()) {
+                    warning << tr("Import from %1 failed (%2)").arg(result.path, result.message);
+                } else if (result.isInfo()) {
+                    success << tr("Import from %1 successful (%2)").arg(result.path, result.message);
+                } else {
+                    success << tr("Imported from %1").arg(result.path);
+                }
+            }
+            notifyAbout(success, warning, error);
+        });
+        m_inFileUpdate = true;
+    }
+}
+
+QList<ShareObserver::Result> ShareObserver::importPerDeviceShares(
+    const QString& resolvedDir,
+    const KeeShareSettings::Reference& reference,
+    Group* targetGroup)
+{
+    QList<Result> results;
+    if (!KeeShare::active().in) {
+        return results;
+    }
+
+    const QString ownFile = KeeShare::deviceId() + ".kdbx";
+    QDir dir(resolvedDir);
+    if (!dir.exists()) {
+        return results;
+    }
+
+    const auto files = dir.entryList({"*.kdbx"}, QDir::Files, QDir::Name);
+    for (const auto& fileName : files) {
+        if (fileName.compare(ownFile, Qt::CaseInsensitive) == 0) {
+            continue; // Skip own device's file
+        }
+        const auto filePath = dir.absoluteFilePath(fileName);
+        results << ShareImport::containerInto(filePath, reference, targetGroup);
+    }
+    return results;
+}
+
 ShareObserver::Result ShareObserver::importShare(const QString& path)
 {
     if (!KeeShare::active().in) {
@@ -286,16 +401,40 @@ QList<ShareObserver::Result> ShareObserver::exportShares()
     for (auto it = references.cbegin(); it != references.cend(); ++it) {
         auto reference = it.value().first();
         const QString resolvedPath = resolvePath(reference.config.path, m_db);
-        auto watcher = m_fileWatchers.value(resolvedPath);
-        if (watcher) {
-            watcher->stop();
-        }
 
-        // TODO: save new path into group settings if not saving to signed container anymore
-        results << ShareExport::intoContainer(resolvedPath, reference.config, reference.group);
+        if (reference.config.isPerDeviceMode()) {
+            // Per-device mode: export to {directory}/{DEVICE_ID}.kdbx
+            QDir dir(resolvedPath);
+            if (!dir.exists()) {
+                dir.mkpath(".");
+            }
+            const auto deviceFile = dir.absoluteFilePath(KeeShare::deviceId() + ".kdbx");
 
-        if (watcher) {
-            watcher->start(resolvedPath, FileWatchPeriod, FileWatchSize);
+            // Pause directory watcher during export
+            auto dirWatcher = m_dirWatchers.value(resolvedPath);
+            if (dirWatcher) {
+                dirWatcher->removePath(resolvedPath);
+            }
+
+            results << ShareExport::intoContainer(deviceFile, reference.config, reference.group);
+
+            // Resume directory watcher
+            if (dirWatcher) {
+                dirWatcher->addPath(resolvedPath);
+            }
+        } else {
+            // Classic mode: export to the file directly
+            auto watcher = m_fileWatchers.value(resolvedPath);
+            if (watcher) {
+                watcher->stop();
+            }
+
+            // TODO: save new path into group settings if not saving to signed container anymore
+            results << ShareExport::intoContainer(resolvedPath, reference.config, reference.group);
+
+            if (watcher) {
+                watcher->start(resolvedPath, FileWatchPeriod, FileWatchSize);
+            }
         }
     }
     return results;

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -270,16 +270,16 @@ void ShareObserver::handleDirectoryUpdated(const QString& dirPath)
         dirWatcher->addPath(dirPath);
     }
 
-    if (!m_inFileUpdate) {
+    if (!m_inDirUpdate) {
         QTimer::singleShot(100, this, [this, dirPath] {
             auto shareGroup = m_shareToGroup.value(dirPath);
             if (!shareGroup) {
-                m_inFileUpdate = false;
+                m_inDirUpdate = false;
                 return;
             }
             auto shareRef = KeeShare::referenceOf(shareGroup);
             auto results = importPerDeviceShares(dirPath, shareRef, shareGroup);
-            m_inFileUpdate = false;
+            m_inDirUpdate = false;
 
             QStringList success;
             QStringList warning;
@@ -300,7 +300,7 @@ void ShareObserver::handleDirectoryUpdated(const QString& dirPath)
             }
             notifyAbout(success, warning, error);
         });
-        m_inFileUpdate = true;
+        m_inDirUpdate = true;
     }
 }
 
@@ -406,7 +406,12 @@ QList<ShareObserver::Result> ShareObserver::exportShares()
             // Per-device mode: export to {directory}/{DEVICE_ID}.kdbx
             QDir dir(resolvedPath);
             if (!dir.exists()) {
-                dir.mkpath(".");
+                if (!dir.mkpath(".")) {
+                    results << Result{resolvedPath,
+                                      Result::Error,
+                                      tr("Could not create directory %1").arg(resolvedPath)};
+                    continue;
+                }
             }
             const auto deviceFile = dir.absoluteFilePath(KeeShare::deviceId() + ".kdbx");
 
@@ -418,7 +423,7 @@ QList<ShareObserver::Result> ShareObserver::exportShares()
 
             results << ShareExport::intoContainer(deviceFile, reference.config, reference.group);
 
-            // Resume directory watcher
+            // Resume directory watcher (also add path if it was newly created)
             if (dirWatcher) {
                 dirWatcher->addPath(resolvedPath);
             }

--- a/src/keeshare/ShareObserver.cpp
+++ b/src/keeshare/ShareObserver.cpp
@@ -102,6 +102,8 @@ void ShareObserver::reinitialize()
     QMap<QString, QStringList> imported;
     QMap<QString, QStringList> exported;
 
+    const QDir baseDir = QFileInfo(m_db->filePath()).absoluteDir();
+
     for (const auto& share : shares) {
         auto group = share.first;
         auto& reference = share.second;
@@ -113,7 +115,7 @@ void ShareObserver::reinitialize()
         if (!reference.path.isEmpty() && reference.type != KeeShareSettings::Inactive) {
             const auto newResolvedPath = resolvePath(reference.path, m_db);
 
-            if (reference.isPerDeviceMode()) {
+            if (reference.isPerDeviceMode(baseDir)) {
                 // Per-device mode: watch the directory for changes
                 auto dirWatcher = QSharedPointer<QFileSystemWatcher>::create();
                 if (QDir(newResolvedPath).exists()) {
@@ -137,10 +139,10 @@ void ShareObserver::reinitialize()
 
         if (reference.isImporting()) {
             imported[reference.path] << group->name();
+            const auto resolvedDir = resolvePath(reference.path, m_db);
 
-            if (reference.isPerDeviceMode()) {
+            if (reference.isPerDeviceMode(baseDir)) {
                 // Per-device mode: import from all device files in the directory
-                const auto resolvedDir = resolvePath(reference.path, m_db);
                 const auto results = importPerDeviceShares(resolvedDir, reference, group);
                 for (const auto& result : results) {
                     if (!result.isValid()) {
@@ -260,7 +262,8 @@ void ShareObserver::handleDirectoryUpdated(const QString& dirPath)
         return;
     }
     auto reference = KeeShare::referenceOf(group);
-    if (!reference.isImporting() || !reference.isPerDeviceMode()) {
+    const QDir handleBaseDir = QFileInfo(m_db->filePath()).absoluteDir();
+    if (!reference.isImporting() || !reference.isPerDeviceMode(handleBaseDir)) {
         return;
     }
 
@@ -326,7 +329,9 @@ QList<ShareObserver::Result> ShareObserver::importPerDeviceShares(
             continue; // Skip own device's file
         }
         const auto filePath = dir.absoluteFilePath(fileName);
-        results << ShareImport::containerInto(filePath, reference, targetGroup);
+        auto result = ShareImport::containerInto(filePath, reference, targetGroup);
+        result.path = filePath;
+        results << result;
     }
     return results;
 }
@@ -398,11 +403,13 @@ QList<ShareObserver::Result> ShareObserver::exportShares()
         return results;
     }
 
+    const QDir exportBaseDir = QFileInfo(m_db->filePath()).absoluteDir();
+
     for (auto it = references.cbegin(); it != references.cend(); ++it) {
         auto reference = it.value().first();
         const QString resolvedPath = resolvePath(reference.config.path, m_db);
 
-        if (reference.config.isPerDeviceMode()) {
+        if (reference.config.isPerDeviceMode(exportBaseDir)) {
             // Per-device mode: export to {directory}/{DEVICE_ID}.kdbx
             QDir dir(resolvedPath);
             if (!dir.exists()) {

--- a/src/keeshare/ShareObserver.h
+++ b/src/keeshare/ShareObserver.h
@@ -89,6 +89,7 @@ private:
     QMap<QString, QSharedPointer<FileWatcher>> m_fileWatchers;
     QMap<QString, QSharedPointer<QFileSystemWatcher>> m_dirWatchers;
     bool m_inFileUpdate = false;
+    bool m_inDirUpdate = false;
     bool m_enabled = true;
 };
 

--- a/src/keeshare/ShareObserver.h
+++ b/src/keeshare/ShareObserver.h
@@ -18,6 +18,7 @@
 #ifndef KEEPASSXC_SHAREOBSERVER_H
 #define KEEPASSXC_SHAREOBSERVER_H
 
+#include <QFileSystemWatcher>
 #include <QMap>
 #include <QObject>
 
@@ -68,10 +69,14 @@ private slots:
     void handleDatabaseChanged();
     void handleDatabaseSaved();
     void handleFileUpdated(const QString& path);
+    void handleDirectoryUpdated(const QString& dirPath);
 
 private:
     Result importShare(const QString& path);
     QList<Result> exportShares();
+    QList<Result> importPerDeviceShares(const QString& resolvedDir,
+                                        const KeeShareSettings::Reference& reference,
+                                        Group* targetGroup);
 
     void deinitialize();
     void reinitialize();
@@ -82,6 +87,7 @@ private:
     QMap<QPointer<Group>, KeeShareSettings::Reference> m_groupToReference;
     QMap<QString, QPointer<Group>> m_shareToGroup;
     QMap<QString, QSharedPointer<FileWatcher>> m_fileWatchers;
+    QMap<QString, QSharedPointer<QFileSystemWatcher>> m_dirWatchers;
     bool m_inFileUpdate = false;
     bool m_enabled = true;
 };

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -149,8 +149,12 @@ void EditGroupWidgetKeeShare::updateSharingState()
             }
             multipleImport |= other.isImporting() && reference.isImporting();
             conflictExport |= other.isExporting() && reference.isExporting();
-            cycleImportExport |=
-                (other.isImporting() && reference.isExporting()) || (other.isExporting() && reference.isImporting());
+            // In per-device mode, import+export to the same directory is expected
+            // (export writes own device file, import reads other devices' files)
+            if (!reference.isPerDeviceMode()) {
+                cycleImportExport |=
+                    (other.isImporting() && reference.isExporting()) || (other.isExporting() && reference.isImporting());
+            }
         }
         if (conflictExport) {
             m_ui->messageWidget->showMessage(tr("%1 is already being exported by this database.").arg(reference.path),

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -111,19 +111,28 @@ void EditGroupWidgetKeeShare::updateSharingState()
     // Custom message for active KeeShare reference
     const auto reference = KeeShare::referenceOf(m_temporaryGroup);
     if (!reference.path.isEmpty()) {
-        bool supported = false;
-        for (const auto& extension : supportedExtensions) {
-            if (reference.path.endsWith(extension, Qt::CaseInsensitive)) {
-                supported = true;
-                break;
+        if (reference.isPerDeviceMode()) {
+            // Per-device mode: path is a directory, show info message
+            m_ui->messageWidget->showMessage(
+                tr("Per-device sync mode: each device writes its own container in this directory.\n"
+                   "Device ID: %1").arg(KeeShare::deviceId()),
+                MessageWidget::Information);
+        } else {
+            // Classic mode: validate file extension
+            bool supported = false;
+            for (const auto& extension : supportedExtensions) {
+                if (reference.path.endsWith(extension, Qt::CaseInsensitive)) {
+                    supported = true;
+                    break;
+                }
             }
-        }
-        if (!supported) {
-            m_ui->messageWidget->showMessage(tr("Your KeePassXC version does not support sharing this container type.\n"
-                                                "Supported extensions are: %1.")
-                                                 .arg(supportedExtensions.join(", ")),
-                                             MessageWidget::Warning);
-            return;
+            if (!supported) {
+                m_ui->messageWidget->showMessage(tr("Your KeePassXC version does not support sharing this container type.\n"
+                                                    "Supported extensions are: %1.")
+                                                     .arg(supportedExtensions.join(", ")),
+                                                 MessageWidget::Warning);
+                return;
+            }
         }
 
         const auto groups = m_database->rootGroup()->groupsRecursive(true);
@@ -239,6 +248,23 @@ void EditGroupWidgetKeeShare::launchPathSelectionDialog()
     if (filename.isEmpty()) {
         filename = m_temporaryGroup->name();
     }
+
+    // For SynchronizeWith, offer both file and directory selection
+    if (reference.type == KeeShareSettings::SynchronizeWith) {
+        // Try directory selection first for per-device sync
+        auto dirPath = fileDialog()->getExistingDirectory(
+            this, tr("Select per-device sync directory"), defaultDirPath);
+        if (!dirPath.isEmpty()) {
+            // Directory selected: per-device mode
+            m_ui->pathEdit->setText(dirPath);
+            selectPath();
+            FileDialog::saveLastDir("keeshare", dirPath);
+            updateSharingState();
+            return;
+        }
+        // User cancelled directory dialog; fall through to file dialog
+    }
+
     switch (reference.type) {
     case KeeShareSettings::ImportFrom:
         filename = fileDialog()->getOpenFileName(this, tr("Select import source"), defaultDirPath, filters);

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -24,6 +24,7 @@
 #include "keeshare/KeeShare.h"
 
 #include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
 
 EditGroupWidgetKeeShare::EditGroupWidgetKeeShare(QWidget* parent)
@@ -110,8 +111,9 @@ void EditGroupWidgetKeeShare::updateSharingState()
 
     // Custom message for active KeeShare reference
     const auto reference = KeeShare::referenceOf(m_temporaryGroup);
+    const QDir uiBaseDir = QFileInfo(m_database->filePath()).absoluteDir();
     if (!reference.path.isEmpty()) {
-        if (reference.isPerDeviceMode()) {
+        if (reference.isPerDeviceMode(uiBaseDir)) {
             // Per-device mode: path is a directory, show info message
             m_ui->messageWidget->showMessage(
                 tr("Per-device sync mode: each device writes its own container in this directory.\n"
@@ -151,7 +153,7 @@ void EditGroupWidgetKeeShare::updateSharingState()
             conflictExport |= other.isExporting() && reference.isExporting();
             // In per-device mode, import+export to the same directory is expected
             // (export writes own device file, import reads other devices' files)
-            if (!reference.isPerDeviceMode()) {
+            if (!reference.isPerDeviceMode(uiBaseDir)) {
                 cycleImportExport |=
                     (other.isImporting() && reference.isExporting()) || (other.isExporting() && reference.isImporting());
             }

--- a/src/keeshare/group/EditGroupWidgetKeeShare.ui
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.ui
@@ -100,6 +100,9 @@
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
+       <property name="toolTip">
+        <string>File path for classic mode, or directory path for per-device sync</string>
+       </property>
       </widget>
      </item>
      <item row="1" column="1">

--- a/src/keeshare/group/EditGroupWidgetKeeShare.ui
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.ui
@@ -100,9 +100,6 @@
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
-       <property name="toolTip">
-        <string>File path for classic mode, or directory path for per-device sync</string>
-       </property>
       </widget>
      </item>
      <item row="1" column="1">
@@ -126,6 +123,9 @@
          </property>
          <property name="accessibleName">
           <string>Path to share file field</string>
+         </property>
+         <property name="toolTip">
+          <string>File path for classic mode, or directory path for per-device sync</string>
          </property>
         </widget>
        </item>

--- a/src/quickunlock/Polkit.cpp
+++ b/src/quickunlock/Polkit.cpp
@@ -48,6 +48,7 @@ Polkit::Polkit()
 {
     PolkitSubject::registerMetaType();
     PolkitAuthorizationResults::registerMetaType();
+    qDBusRegisterMetaType<QMap<QString, QString>>();
 
     /* Note we explicitly use our own dbus path here, as the ::systemBus() method could be overridden
        through an environment variable to return an alternative bus path. This bus could have an application

--- a/tests/TestSharing.cpp
+++ b/tests/TestSharing.cpp
@@ -187,42 +187,49 @@ void TestSharing::testSettingsSerialization_data()
 void TestSharing::testPerDeviceMode()
 {
     QFETCH(QString, path);
+    QFETCH(QString, baseDir);
     QFETCH(bool, expectedPerDevice);
 
     KeeShareSettings::Reference reference;
     reference.path = path;
     reference.type = KeeShareSettings::SynchronizeWith;
 
-    QCOMPARE(reference.isPerDeviceMode(), expectedPerDevice);
+    QCOMPARE(reference.isPerDeviceMode(QDir(baseDir)), expectedPerDevice);
 }
 
 void TestSharing::testPerDeviceMode_data()
 {
     QTest::addColumn<QString>("path");
+    QTest::addColumn<QString>("baseDir");
     QTest::addColumn<bool>("expectedPerDevice");
 
-    // Classic mode paths (file-based — don't need to exist on disk)
-    QTest::newRow("kdbx file") << "/some/path/share.kdbx" << false;
-    QTest::newRow("kdbx.share file") << "/some/path/share.kdbx.share" << false;
-    QTest::newRow("KDBX uppercase") << "/some/path/share.KDBX" << false;
-    QTest::newRow("KDBX.SHARE uppercase") << "/some/path/share.KDBX.SHARE" << false;
-    QTest::newRow("empty path") << "" << false;
-    QTest::newRow("nonexistent path") << "/nonexistent/path/nowhere" << false;
-
-    // Per-device mode paths (real directories on disk)
     auto base = m_tempDir->path();
 
+    // Classic mode paths (file-based — don't need to exist on disk)
+    QTest::newRow("kdbx file") << "/some/path/share.kdbx" << base << false;
+    QTest::newRow("kdbx.share file") << "/some/path/share.kdbx.share" << base << false;
+    QTest::newRow("KDBX uppercase") << "/some/path/share.KDBX" << base << false;
+    QTest::newRow("KDBX.SHARE uppercase") << "/some/path/share.KDBX.SHARE" << base << false;
+    QTest::newRow("empty path") << "" << base << false;
+    QTest::newRow("nonexistent path") << "/nonexistent/path/nowhere" << base << false;
+
+    // Per-device mode paths (real directories on disk — absolute)
     QDir(base).mkpath("syncdir");
-    QTest::newRow("directory path") << base + "/syncdir" << true;
+    QTest::newRow("directory path") << base + "/syncdir" << base << true;
 
     QDir(base).mkpath("syncdir_slash");
-    QTest::newRow("directory trailing slash") << base + "/syncdir_slash/" << true;
+    QTest::newRow("directory trailing slash") << base + "/syncdir_slash/" << base << true;
 
     QDir(base).mkpath("sub/shared");
-    QTest::newRow("nested directory") << base + "/sub/shared" << true;
+    QTest::newRow("nested directory") << base + "/sub/shared" << base << true;
 
     QDir(base).mkpath("path.d/sync");
-    QTest::newRow("directory with dots") << base + "/path.d/sync" << true;
+    QTest::newRow("directory with dots") << base + "/path.d/sync" << base << true;
+
+    // Per-device mode with relative path (regression test: must resolve against baseDir)
+    QDir(base).mkpath("reldir");
+    QTest::newRow("relative directory") << "reldir" << base << true;
+    QTest::newRow("relative file") << "share.kdbx" << base << false;
 }
 
 void TestSharing::testPerDeviceModeImportExport()

--- a/tests/TestSharing.cpp
+++ b/tests/TestSharing.cpp
@@ -17,6 +17,7 @@
 
 #include "TestSharing.h"
 
+#include <QDir>
 #include <QTest>
 #include <QXmlStreamReader>
 
@@ -35,6 +36,14 @@ Q_DECLARE_METATYPE(KeeShareSettings::Certificate)
 void TestSharing::initTestCase()
 {
     QVERIFY(Crypto::init());
+    m_tempDir = new QTemporaryDir();
+    QVERIFY(m_tempDir->isValid());
+}
+
+void TestSharing::cleanupTestCase()
+{
+    delete m_tempDir;
+    m_tempDir = nullptr;
 }
 
 void TestSharing::testNullObjects()
@@ -192,18 +201,28 @@ void TestSharing::testPerDeviceMode_data()
     QTest::addColumn<QString>("path");
     QTest::addColumn<bool>("expectedPerDevice");
 
-    // Classic mode paths (file-based)
+    // Classic mode paths (file-based — don't need to exist on disk)
     QTest::newRow("kdbx file") << "/some/path/share.kdbx" << false;
     QTest::newRow("kdbx.share file") << "/some/path/share.kdbx.share" << false;
     QTest::newRow("KDBX uppercase") << "/some/path/share.KDBX" << false;
     QTest::newRow("KDBX.SHARE uppercase") << "/some/path/share.KDBX.SHARE" << false;
     QTest::newRow("empty path") << "" << false;
+    QTest::newRow("nonexistent path") << "/nonexistent/path/nowhere" << false;
 
-    // Per-device mode paths (directory-based)
-    QTest::newRow("directory path") << "/some/sync/dir" << true;
-    QTest::newRow("directory trailing slash") << "/some/sync/dir/" << true;
-    QTest::newRow("relative directory") << "sync/shared" << true;
-    QTest::newRow("directory with dots") << "/some/path.d/sync" << true;
+    // Per-device mode paths (real directories on disk)
+    auto base = m_tempDir->path();
+
+    QDir(base).mkpath("syncdir");
+    QTest::newRow("directory path") << base + "/syncdir" << true;
+
+    QDir(base).mkpath("syncdir_slash");
+    QTest::newRow("directory trailing slash") << base + "/syncdir_slash/" << true;
+
+    QDir(base).mkpath("sub/shared");
+    QTest::newRow("nested directory") << base + "/sub/shared" << true;
+
+    QDir(base).mkpath("path.d/sync");
+    QTest::newRow("directory with dots") << base + "/path.d/sync" << true;
 }
 
 void TestSharing::testPerDeviceModeImportExport()
@@ -228,16 +247,20 @@ void TestSharing::testPerDeviceModeImportExport_data()
     QTest::addColumn<bool>("expectedImporting");
     QTest::addColumn<bool>("expectedExporting");
 
+    auto base = m_tempDir->path();
+    QDir(base).mkpath("importexport");
+    auto dir = base + "/importexport";
+
     QTest::newRow("per-device sync imports")
-        << "/some/dir" << int(KeeShareSettings::SynchronizeWith) << true << true;
+        << dir << int(KeeShareSettings::SynchronizeWith) << true << true;
     QTest::newRow("per-device import only")
-        << "/some/dir" << int(KeeShareSettings::ImportFrom) << true << false;
+        << dir << int(KeeShareSettings::ImportFrom) << true << false;
     QTest::newRow("per-device export only")
-        << "/some/dir" << int(KeeShareSettings::ExportTo) << false << true;
+        << dir << int(KeeShareSettings::ExportTo) << false << true;
     QTest::newRow("classic file sync")
-        << "/some/dir/share.kdbx" << int(KeeShareSettings::SynchronizeWith) << true << true;
+        << dir + "/share.kdbx" << int(KeeShareSettings::SynchronizeWith) << true << true;
     QTest::newRow("inactive per-device")
-        << "/some/dir" << int(KeeShareSettings::Inactive) << false << false;
+        << dir << int(KeeShareSettings::Inactive) << false << false;
 }
 
 const QSharedPointer<Botan::RSA_PrivateKey> TestSharing::stubkey(int index)

--- a/tests/TestSharing.cpp
+++ b/tests/TestSharing.cpp
@@ -206,6 +206,40 @@ void TestSharing::testPerDeviceMode_data()
     QTest::newRow("directory with dots") << "/some/path.d/sync" << true;
 }
 
+void TestSharing::testPerDeviceModeImportExport()
+{
+    QFETCH(QString, path);
+    QFETCH(int, type);
+    QFETCH(bool, expectedImporting);
+    QFETCH(bool, expectedExporting);
+
+    KeeShareSettings::Reference reference;
+    reference.path = path;
+    reference.type = static_cast<KeeShareSettings::Type>(type);
+
+    QCOMPARE(reference.isImporting(), expectedImporting);
+    QCOMPARE(reference.isExporting(), expectedExporting);
+}
+
+void TestSharing::testPerDeviceModeImportExport_data()
+{
+    QTest::addColumn<QString>("path");
+    QTest::addColumn<int>("type");
+    QTest::addColumn<bool>("expectedImporting");
+    QTest::addColumn<bool>("expectedExporting");
+
+    QTest::newRow("per-device sync imports")
+        << "/some/dir" << int(KeeShareSettings::SynchronizeWith) << true << true;
+    QTest::newRow("per-device import only")
+        << "/some/dir" << int(KeeShareSettings::ImportFrom) << true << false;
+    QTest::newRow("per-device export only")
+        << "/some/dir" << int(KeeShareSettings::ExportTo) << false << true;
+    QTest::newRow("classic file sync")
+        << "/some/dir/share.kdbx" << int(KeeShareSettings::SynchronizeWith) << true << true;
+    QTest::newRow("inactive per-device")
+        << "/some/dir" << int(KeeShareSettings::Inactive) << false << false;
+}
+
 const QSharedPointer<Botan::RSA_PrivateKey> TestSharing::stubkey(int index)
 {
     static QMap<int, QSharedPointer<Botan::RSA_PrivateKey>> keys;

--- a/tests/TestSharing.cpp
+++ b/tests/TestSharing.cpp
@@ -175,6 +175,37 @@ void TestSharing::testSettingsSerialization_data()
     QTest::newRow("5") << false << false << certificate0 << key0;
 }
 
+void TestSharing::testPerDeviceMode()
+{
+    QFETCH(QString, path);
+    QFETCH(bool, expectedPerDevice);
+
+    KeeShareSettings::Reference reference;
+    reference.path = path;
+    reference.type = KeeShareSettings::SynchronizeWith;
+
+    QCOMPARE(reference.isPerDeviceMode(), expectedPerDevice);
+}
+
+void TestSharing::testPerDeviceMode_data()
+{
+    QTest::addColumn<QString>("path");
+    QTest::addColumn<bool>("expectedPerDevice");
+
+    // Classic mode paths (file-based)
+    QTest::newRow("kdbx file") << "/some/path/share.kdbx" << false;
+    QTest::newRow("kdbx.share file") << "/some/path/share.kdbx.share" << false;
+    QTest::newRow("KDBX uppercase") << "/some/path/share.KDBX" << false;
+    QTest::newRow("KDBX.SHARE uppercase") << "/some/path/share.KDBX.SHARE" << false;
+    QTest::newRow("empty path") << "" << false;
+
+    // Per-device mode paths (directory-based)
+    QTest::newRow("directory path") << "/some/sync/dir" << true;
+    QTest::newRow("directory trailing slash") << "/some/sync/dir/" << true;
+    QTest::newRow("relative directory") << "sync/shared" << true;
+    QTest::newRow("directory with dots") << "/some/path.d/sync" << true;
+}
+
 const QSharedPointer<Botan::RSA_PrivateKey> TestSharing::stubkey(int index)
 {
     static QMap<int, QSharedPointer<Botan::RSA_PrivateKey>> keys;

--- a/tests/TestSharing.h
+++ b/tests/TestSharing.h
@@ -38,6 +38,8 @@ private slots:
     void testSettingsSerialization_data();
     void testPerDeviceMode();
     void testPerDeviceMode_data();
+    void testPerDeviceModeImportExport();
+    void testPerDeviceModeImportExport_data();
 
 private:
     const QSharedPointer<Botan::RSA_PrivateKey> stubkey(int index = 0);

--- a/tests/TestSharing.h
+++ b/tests/TestSharing.h
@@ -19,6 +19,7 @@
 #define KEEPASSXC_TESTSHARING_H
 
 #include <QObject>
+#include <QTemporaryDir>
 
 namespace Botan
 {
@@ -30,6 +31,7 @@ class TestSharing : public QObject
 
 private slots:
     void initTestCase();
+    void cleanupTestCase();
     void testNullObjects();
     void testKeySerialization();
     void testReferenceSerialization();
@@ -43,6 +45,7 @@ private slots:
 
 private:
     const QSharedPointer<Botan::RSA_PrivateKey> stubkey(int index = 0);
+    QTemporaryDir* m_tempDir = nullptr;
 };
 
 #endif // KEEPASSXC_TESTSHARING_H

--- a/tests/TestSharing.h
+++ b/tests/TestSharing.h
@@ -36,6 +36,8 @@ private slots:
     void testReferenceSerialization_data();
     void testSettingsSerialization();
     void testSettingsSerialization_data();
+    void testPerDeviceMode();
+    void testPerDeviceMode_data();
 
 private:
     const QSharedPointer<Botan::RSA_PrivateKey> stubkey(int index = 0);


### PR DESCRIPTION
## Summary

- Adds a per-device sync mode for KeeShare where each device writes its own container file (`{DEVICE_ID}.kdbx`) into a shared directory, eliminating file conflicts when syncing via Syncthing/Nextcloud/etc.
- Classic single-file mode is completely unchanged — if the path ends in `.kdbx` or `.kdbx.share`, it works exactly as before
- Also fixes a Quick Unlock Polkit D-Bus marshalling bug (separate cherry-pickable commit)

## How per-device mode works

When a KeeShare reference path points to a **directory** (instead of a `.kdbx` file), KeePassXC treats it as per-device mode:
- **Export**: writes to `{syncDir}/{DEVICE_ID}.kdbx`
- **Import**: reads all `*.kdbx` files in the directory except the device's own file
- Device ID is auto-detected from the system's machine ID, or can be set manually in KeeShare settings

The existing `ShareObserver` separation (import on directory change, export on database save) naturally prevents feedback loops between devices.

## Commits

| Commit | Description |
|--------|-------------|
| Add per-device KeeShare sync mode | Config, KeeShare, KeeShareSettings, ShareObserver, group sharing UI, 9 new unit tests |
| fix Quick Unlock QMap D-Bus marshalling | Register `QMap<QString, QString>` as D-Bus metatype — fixes "Unregistered type" error on Polkit `CheckAuthorization`. Independent fix, cherry-pickable separately |

## Interop

Matching KeePassDX (Android) implementation: https://github.com/Kunzisoft/KeePassDX/pull/2438

Discussion: https://github.com/keepassxreboot/keepassxc/discussions/13080

Tested with real Syncthing sync between Fedora desktop and Pixel 7 running KeePassDX.

## Test plan

- [x] All existing tests pass
- [x] 9 new unit tests for per-device mode detection, path generation, device ID
- [x] Classic single-file mode unchanged (path ending in `.kdbx`)
- [x] Directory path triggers per-device mode
- [x] Each device exports only its own container file
- [x] Import reads all other devices' containers
- [x] No sync storm between devices over Syncthing
- [x] Quick Unlock via Polkit works after D-Bus fix