### PR TITLE
Fix health check reused password count tooltip (#13075)

### DIFF
--- a/src/core/PasswordHealth.cpp
+++ b/src/core/PasswordHealth.cpp
@@ -151,12 +151,11 @@ QSharedPointer<PasswordHealth> HealthChecker::evaluate(const Entry* entry) const
         health->adjustScore(-penalty * (count - 1));
         health->addScoreReason(QObject::tr("Password is used %1 time(s)", "", count).arg(QString::number(count)));
         // Add the first 20 uses of the password to prevent the details display from growing too large
-        for (int i = 0; i < used.size(); ++i) {
+        for (int i = 0; i < (count < 20 ? count : 20); ++i) {
             health->addScoreDetails(used[i]);
-            if (i == 19) {
-                health->addScoreDetails("…");
-                break;
-            }
+        }
+        if (count > 20) {
+            health->addScoreDetails("...");
         }
 
         // Don't allow re-used passwords to be considered "good"

--- a/src/core/PasswordHealth.cpp
+++ b/src/core/PasswordHealth.cpp
@@ -151,11 +151,12 @@ QSharedPointer<PasswordHealth> HealthChecker::evaluate(const Entry* entry) const
         health->adjustScore(-penalty * (count - 1));
         health->addScoreReason(QObject::tr("Password is used %1 time(s)", "", count).arg(QString::number(count)));
         // Add the first 20 uses of the password to prevent the details display from growing too large
-        for (int i = 0; i < (count < 20 ? count : 20); ++i) {
+        for (int i = 0; i < used.size(); ++i) {
+            if (i == 20) {
+                health->addScoreDetails("…");
+                break;
+            }
             health->addScoreDetails(used[i]);
-        }
-        if (count > 20) {
-            health->addScoreDetails("...");
         }
 
         // Don't allow re-used passwords to be considered "good"


### PR DESCRIPTION
Fixes #13075
Removed if-break check from detail display loop; moved entry display limit to the loop definition.
Added specific check (after loop) if >20 duplicates before showing ellipsis.

## Screenshots
Current release build:
<img width="1914" height="672" alt="image" src="https://github.com/user-attachments/assets/6dce570c-5923-40fa-9401-c6ea1b85970e" />

Build with changes applied (with 20 entries sharing password):
<img width="1917" height="670" alt="image" src="https://github.com/user-attachments/assets/ae174c96-2ce8-4e29-adf4-4c512f255a46" />

Build with changes applied (with 21 entries sharing password):
<img width="1910" height="703" alt="image" src="https://github.com/user-attachments/assets/876a8150-cff9-4e84-8b0d-56406eb04b3b" />

## Testing strategy
Manual.
1. Opened test database
2. Create 19 entries sharing the same password
3. Add 20th entry, check for ellipsis
4. Add 21st entry, check for ellipsis

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
