### PR TITLE
Mock datetime to avoid test failures on second lapse

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,7 +218,7 @@ add_unit_test(NAME testdatabase SOURCES TestDatabase.cpp
         LIBS testsupport ${TEST_LIBRARIES})
 
 add_unit_test(NAME testtools SOURCES TestTools.cpp
-        LIBS ${TEST_LIBRARIES})
+        LIBS testsupport ${TEST_LIBRARIES})
 
 add_unit_test(NAME testconfig SOURCES TestConfig.cpp
         LIBS testsupport ${TEST_LIBRARIES})

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -19,6 +19,7 @@
 
 #include "core/Clock.h"
 #include "core/Tools.h"
+#include "mock/MockClock.h"
 
 #include <QFileInfo>
 #include <QRegularExpression>
@@ -33,7 +34,22 @@ namespace
     {
         return wholes + QLocale().decimalPoint() + fractions + " " + unit;
     }
+
+    MockClock* s_clock = nullptr;
 } // namespace
+
+void TestTools::initTestCase()
+{
+    Q_ASSERT(s_clock == nullptr);
+    s_clock = new MockClock(2026, 3, 8, 21, 45, 05);
+    MockClock::setup(s_clock);
+}
+
+void TestTools::cleanupTestCase()
+{
+    MockClock::teardown();
+    s_clock = nullptr;
+}
 
 void TestTools::testHumanReadableFileSize()
 {

--- a/tests/TestTools.h
+++ b/tests/TestTools.h
@@ -24,6 +24,8 @@ class TestTools : public QObject
 {
     Q_OBJECT
 private slots:
+    void initTestCase();
+    void cleanupTestCase();
     void testHumanReadableFileSize();
     void testIsHex();
     void testIsBase64();


### PR DESCRIPTION
TestTools had intermittent failures when the second lapsed between the test matrix generation and the test execution. This patch mocks the current datetime to prevent that situation.

Fixes #13059

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
