### PR TITLE
Revert uiaccess=true due to runtime issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,7 +427,6 @@ set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)
 
 if(WIN32)
     set_target_properties(${PROGNAME} PROPERTIES WIN32_EXECUTABLE ON)
-    set_target_properties(${PROGNAME} PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='asInvoker' uiAccess='true'\"")
     include(GenerateProductVersion)
     generate_product_version(
             WIN32_ResourceFiles


### PR DESCRIPTION
After building KeePassXC, it is impossible to run the program successfully from a user-writable location. This will prevent us from releasing the portable version.

Reverts #13070

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
Running the executable without meeting explicit criteria results in the following popup:

<img width="701" height="258" alt="image" src="https://github.com/user-attachments/assets/1c696b65-a431-46e1-af36-5b01da13a2d7" />

