### PR TITLE
Support TIMEOTP autotype and entry  placeholder

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -645,7 +645,7 @@ AutoType::parseSequence(const QString& entrySequence, const Entry* entry, QStrin
         } else if (placeholder == "clearfield") {
             // Platform-specific field clearing
             actions << QSharedPointer<AutoTypeClearField>::create();
-        } else if (placeholder == "totp") {
+        } else if (placeholder == "totp" || placeholder == "timeotp") {
             if (entry->hasValidTotp()) {
                 // Calculate TOTP at the time of typing including delays
                 bool isValid = false;

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1594,6 +1594,7 @@ Entry::PlaceholderType Entry::placeholderType(const QString& placeholder) const
         {QStringLiteral("{PASSWORD}"), PlaceholderType::Password},
         {QStringLiteral("{NOTES}"), PlaceholderType::Notes},
         {QStringLiteral("{TOTP}"), PlaceholderType::Totp},
+        {QStringLiteral("{TIMEOTP}"), PlaceholderType::Totp},
         {QStringLiteral("{URL}"), PlaceholderType::Url},
         {QStringLiteral("{UUID}"), PlaceholderType::Uuid},
         {QStringLiteral("{URL:RMVSCM}"), PlaceholderType::UrlWithoutScheme},

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -475,7 +475,7 @@ void TestAutoType::testAutoTypeEmptyWindowAssociation()
     QVERIFY(assoc.isEmpty());
 }
 
-void TestAutoType::testAutoTypeTotpDelay()
+void TestAutoType::testAutoTypeTotp()
 {
     // Get the TOTP time step in milliseconds
     auto totpStep = m_entry1->totpSettings()->step * 1000;
@@ -494,4 +494,24 @@ void TestAutoType::testAutoTypeTotpDelay()
              QString("Typed TOTP (%1) should differ from current TOTP (%2) due to delay")
                  .arg(totpParts[0], totpParts[1])
                  .toLatin1());
+
+    m_test->clearActions();
+
+    // Test TIMEOTP placeholder (KeePass2 Compatibility)
+    m_autoType->performAutoTypeWithSequence(m_entry1, "{TIMEOTP}");
+    typedChars = m_test->actionChars();
+    QCOMPARE(typedChars.size(), m_entry1->totpSettings()->digits);
+    // Verify that the typedchars are all numbers
+    QRegularExpression re("^\\d+$");
+    QVERIFY(re.match(typedChars).hasMatch());
+
+    m_test->clearActions();
+
+    // Test that TIMEOTP also works as an entry placeholder
+    m_entry1->setPassword("{TIMEOTP}");
+    m_autoType->performAutoTypeWithSequence(m_entry1, "{PASSWORD}");
+    typedChars = m_test->actionChars();
+    QCOMPARE(typedChars.size(), m_entry1->totpSettings()->digits);
+    // Verify that the typedchars are all numbers
+    QVERIFY(re.match(typedChars).hasMatch());
 }

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -19,6 +19,7 @@
 #include "TestAutoType.h"
 
 #include <QPluginLoader>
+#include <QRegularExpression>
 #include <QTest>
 
 #include "autotype/AutoType.h"

--- a/tests/TestAutoType.h
+++ b/tests/TestAutoType.h
@@ -52,7 +52,7 @@ private slots:
     void testAutoTypeSyntaxChecks();
     void testAutoTypeEffectiveSequences();
     void testAutoTypeEmptyWindowAssociation();
-    void testAutoTypeTotpDelay();
+    void testAutoTypeTotp();
 
 private:
     AutoTypePlatformInterface* m_platform;


### PR DESCRIPTION
* Additional fix for #7263 to support KeePass2 placeholder for TOTP

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Added test case

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)