### PR TITLE
Security: Prevent loading of openssl.cnf

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,12 @@ int main(int argc, char** argv)
 {
     QT_REQUIRE_VERSION(argc, argv, QT_VERSION_STR)
 
+#ifdef Q_OS_WIN
+    // Set OPENSSL_CONF to an invalid location to prevent DLL injection via openssl.cnf.
+    // vcpkg by default hard-codes this to its packages location, which may be user-writable.
+    qputenv("OPENSSL_CONF", "::");
+#endif
+
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && defined(Q_OS_WIN)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,9 +54,10 @@ int main(int argc, char** argv)
     QT_REQUIRE_VERSION(argc, argv, QT_VERSION_STR)
 
 #ifdef Q_OS_WIN
-    // Set OPENSSL_CONF to an invalid location to prevent DLL injection via openssl.cnf.
+    // Set OPENSSL_CONF and OPENSSL_MODULES to an invalid location to prevent DLL injection via openssl.cnf.
     // vcpkg by default hard-codes this to its packages location, which may be user-writable.
     qputenv("OPENSSL_CONF", "::");
+    qputenv("OPENSSL_MODULES", "::");
 #endif
 
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
Prevent loading openssl.cnf from the originating vcpkg folder tree to avoid DLL injections. This patch force sets the OPENSSL_CONF env var to an invalid directory. This prevents openssl from attempting to load a cnf file which can contain settings to load arbitrary DLL files into KeePassXC memory space.

Thank you to @zdi-disclosures for reporting this finding!

Advisory: https://github.com/keepassxreboot/keepassxc/security/advisories/GHSA-4gr2-cr97-q9fx

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Confirmed through non-replication of exploit chain and via Procmon.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
