### PR TITLE
Rename Chinese language items to "Simplified/Traditional Chinese"

### DIFF
--- a/src/core/Translator.cpp
+++ b/src/core/Translator.cpp
@@ -121,8 +121,11 @@ QList<QPair<QString, QString>> Translator::availableLanguages()
             if (langcode == "la") {
                 // langcode "la" (Latin) is translated into "C" by QLocale::languageToString()
                 languageStr = "Latin";
-            }
-            if (langcode.contains("_")) {
+            } else if (langcode == "zh_CN") {
+                languageStr = "Chinese (Simplified)";
+            } else if (langcode == "zh_TW") {
+                languageStr = "Chinese (Traditional)";
+            } else if (langcode.contains("_")) {
                 languageStr += QString(" (%1)").arg(QLocale::countryToString(locale.country()));
             }
 

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -285,8 +285,8 @@ static const QString aboutContributors = R"(
 <h3>Translations:</h3>
 <ul>
     <li><strong>Arabic:</strong> kmutahar</li>
-    <li><strong>Chinese (China):</strong> Biggulu, Brandon_c, hoilc, ligyxy, Small_Ku, umi_neko, vc5</li>
-    <li><strong>Chinese (Taiwan):</strong> BestSteve, flachesis, MiauLightouch, Small_Ku, yan12125, ymhuang0808</li>
+    <li><strong>Chinese (Simplified):</strong> Biggulu, Brandon_c, hoilc, ligyxy, Small_Ku, umi_neko, vc5</li>
+    <li><strong>Chinese (Traditional):</strong> BestSteve, flachesis, MiauLightouch, Small_Ku, yan12125, ymhuang0808</li>
     <li><strong>Czech:</strong> DanielMilde, pavelb, tpavelek</li>
     <li><strong>English (United Kingdom):</strong> YCMHARHZ</li>
     <li><strong>English (United States):</strong> alexandercrice, DarkHolme, nguyenlekhtn</li>


### PR DESCRIPTION
Fixes #13127 
The previous labels "Chinese (China)" and "Chinese (Taiwan)" could be misinterpreted as political divisions, while the actual difference is the writing script. Changing to "Simplified Chinese" and "Traditional Chinese" is more accurate and inclusive.

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )

<img width="411" height="151" alt="2026-03-11_09-09" src="https://github.com/user-attachments/assets/2e38606d-6bd0-466e-8ec8-bb5e7afb3cbe" />
<img width="496" height="308" alt="2026-03-11_09-22" src="https://github.com/user-attachments/assets/4bbba10a-ff3b-4cb2-a2f0-a9cdff0b8b67" />

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )

Try build KeepassXC and see"Chinese (China)/(Taiwan)" becomes to "Simplified/Traditional Chinese" in below. 
- In Help -> About -> Contributors -> Translations
- Tools -> Settings -> Basic Settings -> User Interface -> Language 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
