### PR TITLE
release-tool: Create output dir if it does not exist and revert previous build-src patch

### DIFF
--- a/release-tool.py
+++ b/release-tool.py
@@ -968,11 +968,12 @@ class BuildSrc(Command):
                 tf.add(fver, Path(prefix) / fver.name)
                 tf.add(frev, Path(prefix) / frev.name)
 
-                logger.info('Compressing source tarball...')
-                tmp_comp = tmp_export.with_suffix('.tar.xz')
-                with lzma.open(tmp_comp, 'wb', preset=6) as f:
-                    f.write(tmp_export.read_bytes())
-                tmp_comp.rename(output_file)
+            logger.info('Compressing source tarball...')
+            tmp_comp = tmp_export.with_suffix('.tar.xz')
+            with lzma.open(tmp_comp, 'wb', preset=6) as f:
+                f.write(tmp_export.read_bytes())
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            tmp_comp.rename(output_file)
 
 
 class Notarize(Command):


### PR DESCRIPTION
Revert commit 36a26308d0cf8fc548a57e093b1fb3fc6ebe8a44 and add a proper fix for the issue. The error was not the source file vanishing, it was the target directory not existing.

The previous patch was incorrect and caused truncation issues of the source tarball. The result was a missing .gitrev file.


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)