### PR TITLE
Prevent hiding menubar on macOS

### DIFF
--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -157,6 +157,11 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
     m_generalUi->trayIconAppearance->installEventFilter(mouseWheelFilter);
     m_generalUi->fontSizeComboBox->installEventFilter(mouseWheelFilter);
 
+#ifdef Q_OS_MACOS
+    // The menubar is always shown on macOS, so hide the option to avoid confusion
+    m_generalUi->menubarShowCheckBox->setVisible(false);
+#endif
+
 #ifdef WITH_XC_UPDATECHECK
     connect(m_generalUi->checkForUpdatesOnStartupCheckBox, SIGNAL(toggled(bool)), SLOT(checkUpdatesToggled(bool)));
 #else

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1705,9 +1705,11 @@ void MainWindow::applySettingsChanges()
     m_ui->actionShowToolbar->setChecked(!hideToolbar);
     m_ui->actionShowMenubar->setChecked(!hideMenubar);
 
+#ifndef Q_OS_MACOS
     // When menubar is hidden with setHidden() the menu keyboard shortcuts are disabled on Wayland,
     // so force height of 0 instead and use maximumHeight() > 0 instead of isVisible() elsewhere
     m_ui->menubar->setMaximumHeight(hideMenubar ? 0 : QWIDGETSIZE_MAX);
+#endif
 
     m_ui->toolBar->setHidden(config()->get(Config::GUI_HideToolbar).toBool());
     auto movable = config()->get(Config::GUI_MovableToolbar).toBool();
@@ -2271,6 +2273,10 @@ bool MainWindowEventFilter::eventFilter(QObject* watched, QEvent* event)
         }
 #endif
     } else if (eventType == QEvent::KeyRelease && watched == mainWindow) {
+#ifdef Q_OS_MACOS
+        // On macOS, the menubar is always visible, so no need to toggle it
+        return false;
+#endif
         auto keyEvent = dynamic_cast<QKeyEvent*>(event);
 #ifdef Q_OS_WIN
         // Windows translates AltGr into CTRL + ALT, this breaks using AltGr when the menubar is hidden


### PR DESCRIPTION
* Fixes #10706

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested on macOS, phantom menu no longer appears even if `HideMenubar=true` is set in the config.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
