### PR TITLE
Add more entry types for Proton Pass importer

### DIFF
--- a/src/format/ProtonPassReader.cpp
+++ b/src/format/ProtonPassReader.cpp
@@ -111,6 +111,32 @@ namespace
                 }
             }
         }
+        // Wifi
+        else if (type.compare("wifi", Qt::CaseInsensitive) == 0) {
+            const auto wifiMap = dataMap.value("content").toMap();
+            entry->setUsername(wifiMap.value("ssid").toString());
+            entry->setPassword(wifiMap.value("password").toString());
+            entry->attributes()->set("wifi_security", wifiMap.value("security").toString());
+        }
+        // SSH Key
+        else if (type.compare("sshKey", Qt::CaseInsensitive) == 0) {
+            const auto sshMap = dataMap.value("content").toMap();
+            entry->attributes()->set("ssh_public_key", sshMap.value("publicKey").toString());
+            entry->attributes()->set("ssh_private_key", sshMap.value("privateKey").toString(), true);
+        }
+        // Unknown Type (not custom or note)
+        else if (type.compare("custom", Qt::CaseInsensitive) != 0 && type.compare("note", Qt::CaseInsensitive) != 0) {
+            entry->setNotes(QString("Unknown entry type '%1'. Content data fields have been added as attributes.\n\n%2")
+                                .arg(type, entry->notes()));
+            // Place all content fields as attributes
+            const auto contentMap = dataMap.value("content").toMap();
+            for (const auto& key : contentMap.keys()) {
+                auto value = contentMap.value(key).toString();
+                if (!value.isEmpty()) {
+                    entry->attributes()->set("content_" + key, value);
+                }
+            }
+        }
 
         // Parse extra fields
         for (const auto& field : dataMap.value("extraFields").toList()) {

--- a/tests/TestImports.cpp
+++ b/tests/TestImports.cpp
@@ -480,4 +480,11 @@ void TestImports::testProtonPass()
     // Confirm second group (vault)
     entry = db->rootGroup()->findEntryByPath("/Test/Other vault login");
     QVERIFY(entry);
+
+    // Confirm unknown type entry
+    entry = db->rootGroup()->findEntryByPath("/Personal/Unknown Type");
+    QVERIFY(entry);
+    attr = entry->attributes();
+    QCOMPARE(attr->value("content_attr1"), QStringLiteral("value1"));
+    QCOMPARE(attr->value("content_attr2"), QStringLiteral("value2"));
 }

--- a/tests/data/protonpass_export.json
+++ b/tests/data/protonpass_export.json
@@ -129,6 +129,30 @@
                     "createTime": 1689182908,
                     "modifyTime": 1689182908,
                     "pinned": false
+                },
+                {
+                    "itemId": "ZmGzd-HNQYTr6wmfWlSfiStXQLqGic_PYB2Q2T_hmuRM2JIA4pKAPJcmFafxJrDpXxLZ2EPjgD6Noc9a0U6AVQ==",
+                    "shareId": "SN5uWo4WZF2uT5wIDqtbdpkjuxCbNTOIdf-JQ_DYZcKYKURHiZB5csS1a1p9lklvju9ni42l08IKzwQG0B2ySg==",
+                    "data": {
+                        "metadata": {
+                            "name": "Unknown Type",
+                            "note": "",
+                            "itemUuid": "f8445370"
+                        },
+                        "extraFields": [],
+                        "type": "unknownType",
+                        "content": {
+                            "attr1": "value1",
+                            "sections": [],
+                            "attr2": "value2"
+                        }
+                    },
+                    "state": 1,
+                    "aliasEmail": null,
+                    "contentFormatVersion": 1,
+                    "createTime": 1691001643,
+                    "modifyTime": 1691001643,
+                    "pinned": false
                 }
             ]
         },


### PR DESCRIPTION
* Fixes #13130

* Add wifi and sshKey import types
* Add catch-all import type to prevent loss of data when Proton Pass introduces new things

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Added test case

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
