### PR TITLE
Add "Search Here..." to group context menu

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -6433,11 +6433,11 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
         </translation>
     </message>
     <message>
-        <source>Search Here...</source>
+        <source>Search Entries in selected Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Search Entries in selected Group</source>
+        <source>Search Here…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -6432,6 +6432,14 @@ Expect some bugs and minor issues, this version is meant for testing purposes.</
             <numerusform></numerusform>
         </translation>
     </message>
+    <message>
+        <source>Search Here...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search Entries in selected Group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ManageDatabase</name>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -46,6 +46,7 @@
 #include "gui/SearchWidget.h"
 #include "gui/ShortcutSettingsPage.h"
 #include "gui/entry/EntryView.h"
+#include "gui/group/GroupView.h"
 #include "gui/osutils/OSUtils.h"
 #include "gui/remote/RemoteSettings.h"
 
@@ -412,6 +413,7 @@ MainWindow::MainWindow()
     m_ui->actionEntryDownloadIcon->setIcon(icons()->icon("favicon-download"));
     m_ui->actionGroupSortAsc->setIcon(icons()->icon("sort-alphabetical-ascending"));
     m_ui->actionGroupSortDesc->setIcon(icons()->icon("sort-alphabetical-descending"));
+    m_ui->actionGroupSearchHere->setIcon(icons()->icon("system-search"));
 
     m_ui->actionGroupNew->setIcon(icons()->icon("group-new"));
     m_ui->actionGroupEdit->setIcon(icons()->icon("group-edit"));
@@ -550,6 +552,7 @@ MainWindow::MainWindow()
     m_actionMultiplexer.connect(m_ui->actionGroupSortAsc, SIGNAL(triggered()), SLOT(sortGroupsAsc()));
     m_actionMultiplexer.connect(m_ui->actionGroupSortDesc, SIGNAL(triggered()), SLOT(sortGroupsDesc()));
     m_actionMultiplexer.connect(m_ui->actionGroupDownloadFavicons, SIGNAL(triggered()), SLOT(downloadAllFavicons()));
+    connect(m_ui->actionGroupSearchHere, SIGNAL(triggered()), this, SLOT(searchInGroup()));
 
     connect(m_ui->actionSettings, SIGNAL(toggled(bool)), SLOT(switchToSettings(bool)));
     connect(m_ui->actionPasswordGenerator, SIGNAL(toggled(bool)), SLOT(togglePasswordGenerator(bool)));
@@ -1533,6 +1536,16 @@ void MainWindow::clearSSHAgent()
     auto ret = agent->clearAllAgentIdentities();
     displayGlobalMessage(agent->errorString(), ret ? MessageWidget::Positive : KMessageWidget::Error, false);
 #endif
+}
+
+void MainWindow::searchInGroup()
+{
+    auto dbWidget = m_ui->tabWidget->currentDatabaseWidget();
+    if (dbWidget && dbWidget->isVisible() && dbWidget->isEntryViewActive()) {
+        focusSearchWidget();
+        Group* currentGroup = dbWidget->groupView()->currentGroup();
+        m_searchWidget->setSearchGroupName(currentGroup->name());
+    }
 }
 
 void MainWindow::saveWindowInformation()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1042,6 +1042,7 @@ void MainWindow::updateMenuActionState()
     m_ui->actionGroupDownloadFavicons->setVisible(!inRecycleBin);
 #endif
     m_ui->actionGroupDownloadFavicons->setEnabled(groupSelected && groupHasEntries && !inRecycleBin);
+    m_ui->actionGroupSearchHere->setEnabled(groupSelected);
 
     // Database Menu
     m_ui->actionDatabaseSave->setEnabled(databaseUnlocked && m_ui->tabWidget->canSave());
@@ -1541,10 +1542,10 @@ void MainWindow::clearSSHAgent()
 void MainWindow::searchInGroup()
 {
     auto dbWidget = m_ui->tabWidget->currentDatabaseWidget();
-    if (dbWidget && dbWidget->isVisible() && dbWidget->isEntryViewActive()) {
+    if (dbWidget && dbWidget->isVisible() && dbWidget->isEntryViewActive() && dbWidget->groupView()->currentGroup()) {
         focusSearchWidget();
         Group* currentGroup = dbWidget->groupView()->currentGroup();
-        m_searchWidget->setSearchGroupName(currentGroup->name());
+        m_searchWidget->setSearchGroupName(currentGroup->fullPath());
     }
 }
 
@@ -2169,6 +2170,7 @@ void MainWindow::initActionCollection()
                     m_ui->actionGroupSortAsc,
                     m_ui->actionGroupSortDesc,
                     m_ui->actionGroupEmptyRecycleBin,
+                    m_ui->actionGroupSearchHere,
                     // Tools Menu
                     m_ui->actionPasswordGenerator,
                     m_ui->actionClearSSHAgent,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -155,6 +155,7 @@ private slots:
     void enableMenuAndToolbar();
     void disableMenuAndToolbar();
     void clearSSHAgent();
+    void searchInGroup();
 
 private:
     static const QString BaseWindowTitle;

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -1371,7 +1371,7 @@
   </action>
   <action name="actionGroupSearchHere">
    <property name="text">
-    <string>Search Here...</string>
+    <string>Search Here…</string>
    </property>
    <property name="toolTip">
     <string>Search Entries in selected Group</string>

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -366,6 +366,8 @@
     <addaction name="actionGroupSortDesc"/>
     <addaction name="separator"/>
     <addaction name="actionGroupDownloadFavicons"/>
+    <addaction name="separator"/>
+    <addaction name="actionGroupSearchHere"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -1365,6 +1367,14 @@
    </property>
    <property name="menuRole">
     <enum>QAction::TextHeuristicRole</enum>
+   </property>
+  </action>
+  <action name="actionGroupSearchHere">
+   <property name="text">
+    <string>Search Here...</string>
+   </property>
+   <property name="toolTip">
+    <string>Search Entries in selected Group</string>
    </property>
   </action>
  </widget>

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -223,6 +223,14 @@ void SearchWidget::setLimitGroup(bool state)
     updateLimitGroup();
 }
 
+void SearchWidget::setSearchGroupName(const QString& name)
+{
+    QString searchText = QString("g:") + name + QString(" ");
+    m_ui->searchEdit->clear();
+    m_ui->searchEdit->setText(searchText);
+    m_ui->searchEdit->setFocus();
+}
+
 void SearchWidget::focusSearch()
 {
     m_ui->searchEdit->setFocus();

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -228,7 +228,6 @@ void SearchWidget::setSearchGroupName(const QString& name)
     // Quote and escape the group name so it is treated as a single group term,
     // even if it contains spaces or special characters.
     QString escapedName = name;
-    escapedName.replace("\\", "\\\\");
     escapedName.replace("\"", "\\\"");
     QString searchText = QStringLiteral("g:\"") + escapedName + QStringLiteral("\" ");
 

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -225,7 +225,13 @@ void SearchWidget::setLimitGroup(bool state)
 
 void SearchWidget::setSearchGroupName(const QString& name)
 {
-    QString searchText = QString("g:") + name + QString(" ");
+    // Quote and escape the group name so it is treated as a single group term,
+    // even if it contains spaces or special characters.
+    QString escapedName = name;
+    escapedName.replace("\\", "\\\\");
+    escapedName.replace("\"", "\\\"");
+    QString searchText = QStringLiteral("g:\"") + escapedName + QStringLiteral("\" ");
+
     m_ui->searchEdit->clear();
     m_ui->searchEdit->setText(searchText);
     m_ui->searchEdit->setFocus();

--- a/src/gui/SearchWidget.cpp
+++ b/src/gui/SearchWidget.cpp
@@ -231,7 +231,6 @@ void SearchWidget::setSearchGroupName(const QString& name)
     escapedName.replace("\"", "\\\"");
     QString searchText = QStringLiteral("g:\"") + escapedName + QStringLiteral("\" ");
 
-    m_ui->searchEdit->clear();
     m_ui->searchEdit->setText(searchText);
     m_ui->searchEdit->setFocus();
 }

--- a/src/gui/SearchWidget.h
+++ b/src/gui/SearchWidget.h
@@ -46,6 +46,7 @@ public:
     void connectSignals(SignalMultiplexer& mx);
     void setCaseSensitive(bool state);
     void setLimitGroup(bool state);
+    void setSearchGroupName(const QString& name);
 
 protected:
     // Filter key presses in the search field

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -2500,6 +2500,17 @@ void TestGui::addCannedEntries()
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
     QTest::keyClicks(titleEdit, "something 3");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+
+    addGroup("Finance");
+    addGroup("Entertainment");
+
+    addEntry("Finance", "Chase", "user1", "password");
+    addEntry("Finance", "Amex", "user1", "password123");
+    addEntry("Finance", "Capital One", "user1", "password456");
+
+    addEntry("Entertainment", "Netflix", "user1", "password");
+    addEntry("Entertainment", "Hulu", "user1", "password321");
+    addEntry("Entertainment", "Apple TV", "user1", "password123");
 }
 
 void TestGui::addGroup(const QString& name)
@@ -2545,20 +2556,6 @@ void TestGui::addEntry(const QString& groupName, const QString& title, const QSt
 
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
     m_dbWidget->groupView()->setCurrentGroup(m_db->rootGroup());
-}
-
-void TestGui::addCannedGroupsAndEntries()
-{
-    addGroup("Finance");
-    addGroup("Entertainment");
-
-    addEntry("Finance", "Chase", "user1", "password");
-    addEntry("Finance", "Amex", "user1", "password123");
-    addEntry("Finance", "Capital One", "user1", "password456");
-
-    addEntry("Entertainment", "Netflix", "user1", "password");
-    addEntry("Entertainment", "Hulu", "user1", "password321");
-    addEntry("Entertainment", "Apple TV", "user1", "password123");
 }
 
 void TestGui::checkDatabase(const QString& filePath, const QString& expectedDbName)
@@ -2646,7 +2643,7 @@ void TestGui::clickIndex(const QModelIndex& index,
 
 void TestGui::testSearchHere()
 {
-    addCannedGroupsAndEntries();
+    addCannedEntries();
 
     QToolBar* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
     SearchWidget* searchWidget = toolBar->findChild<SearchWidget*>("SearchWidget");
@@ -2659,5 +2656,6 @@ void TestGui::testSearchHere()
     QVERIFY(searchWidget->hasFocus());
 
     QLineEdit* searchEdit = searchWidget->findChild<QLineEdit*>("searchEdit");
-    QCOMPARE(searchEdit->text(), QString("g:\"/NewDatabase/Entertainment\" "));
+    QString expectedText = QString("g:\"") + entertainmentGroup->fullPath() + QString("\" ");
+    QCOMPARE(searchEdit->text(), expectedText);
 }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -2502,6 +2502,65 @@ void TestGui::addCannedEntries()
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
 }
 
+void TestGui::addGroup(const QString& name)
+{
+    // Find buttons for group creation
+    auto* editGroupWidget = m_dbWidget->findChild<EditGroupWidget*>("editGroupWidget");
+    auto* nameEdit = editGroupWidget->findChild<QLineEdit*>("editName");
+    auto* editGroupWidgetButtonBox = editGroupWidget->findChild<QDialogButtonBox*>("buttonBox");
+
+    // Add group with specified name
+    Group* rootGroup = m_db->rootGroup();
+    m_dbWidget->groupView()->setCurrentGroup(rootGroup); // Add group on root level
+    m_dbWidget->createGroup();
+    QTest::keyClicks(nameEdit, name);
+    QTest::mouseClick(editGroupWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+    m_dbWidget->groupView()->setCurrentGroup(rootGroup); // Reset to root level
+}
+
+void TestGui::addEntry(const QString& groupName, const QString& title, const QString& username, const QString& password)
+{
+    // Find buttons
+    auto* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
+    QWidget* entryNewWidget = toolBar->widgetForAction(m_mainWindow->findChild<QAction*>("actionEntryNew"));
+    auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
+    auto* titleEdit = editEntryWidget->findChild<QLineEdit*>("titleEdit");
+    auto* usernameComboBox = editEntryWidget->findChild<QComboBox*>("usernameComboBox");
+    auto* passwordEdit =
+        editEntryWidget->findChild<PasswordWidget*>("passwordEdit")->findChild<QLineEdit*>("passwordEdit");
+    auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
+
+    // Add entry to specified group
+    QVERIFY(m_dbWidget->currentGroup());
+    Group* group = m_dbWidget->currentGroup()->findChildByName(groupName);
+    m_dbWidget->groupView()->setCurrentGroup(group);
+
+    QTest::mouseClick(entryNewWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditEntryMode);
+
+    QTest::keyClicks(titleEdit, title);
+    QTest::keyClicks(usernameComboBox, username);
+    QTest::keyClicks(passwordEdit, password);
+    QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
+
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
+    m_dbWidget->groupView()->setCurrentGroup(m_db->rootGroup());
+}
+
+void TestGui::addCannedGroupsAndEntries()
+{
+    addGroup("Finance");
+    addGroup("Entertainment");
+
+    addEntry("Finance", "Chase", "user1", "password");
+    addEntry("Finance", "Amex", "user1", "password123");
+    addEntry("Finance", "Capital One", "user1", "password456");
+
+    addEntry("Entertainment", "Netflix", "user1", "password");
+    addEntry("Entertainment", "Hulu", "user1", "password321");
+    addEntry("Entertainment", "Apple TV", "user1", "password123");
+}
+
 void TestGui::checkDatabase(const QString& filePath, const QString& expectedDbName)
 {
     auto key = QSharedPointer<CompositeKey>::create();
@@ -2583,4 +2642,22 @@ void TestGui::clickIndex(const QModelIndex& index,
 {
     view->scrollTo(index);
     QTest::mouseClick(view->viewport(), button, stateKey, view->visualRect(index).center());
+}
+
+void TestGui::testSearchHere()
+{
+    addCannedGroupsAndEntries();
+
+    QToolBar* toolBar = m_mainWindow->findChild<QToolBar*>("toolBar");
+    SearchWidget* searchWidget = toolBar->findChild<SearchWidget*>("SearchWidget");
+    QVERIFY(searchWidget->isEnabled());
+
+    Group* entertainmentGroup = m_dbWidget->currentGroup()->findChildByName("Entertainment");
+    m_dbWidget->groupView()->setCurrentGroup(entertainmentGroup);
+
+    triggerAction("actionGroupSearchHere");
+    QVERIFY(searchWidget->hasFocus());
+
+    QLineEdit* searchEdit = searchWidget->findChild<QLineEdit*>("searchEdit");
+    QCOMPARE(searchEdit->text(), QString("g:Entertainment "));
 }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -2659,5 +2659,5 @@ void TestGui::testSearchHere()
     QVERIFY(searchWidget->hasFocus());
 
     QLineEdit* searchEdit = searchWidget->findChild<QLineEdit*>("searchEdit");
-    QCOMPARE(searchEdit->text(), QString("g:Entertainment "));
+    QCOMPARE(searchEdit->text(), QString("g:\"/NewDatabase/Entertainment\" "));
 }

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -77,7 +77,6 @@ private:
     void addCannedEntries();
     void addGroup(const QString& name);
     void addEntry(const QString& groupName, const QString& title, const QString& username, const QString& password);
-    void addCannedGroupsAndEntries();
     void checkDatabase(const QString& filePath, const QString& expectedDbName);
     void checkDatabase(const QString& filePath = {});
     void triggerAction(const QString& name);

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -71,9 +71,13 @@ private slots:
     void testTrayRestoreHide();
     void testShortcutConfig();
     void testMenuActionStates();
+    void testSearchHere();
 
 private:
     void addCannedEntries();
+    void addGroup(const QString& name);
+    void addEntry(const QString& groupName, const QString& title, const QString& username, const QString& password);
+    void addCannedGroupsAndEntries();
     void checkDatabase(const QString& filePath, const QString& expectedDbName);
     void checkDatabase(const QString& filePath = {});
     void triggerAction(const QString& name);


### PR DESCRIPTION
When the user clicks "Search Here...", the search bar is populated with with `g:<group-name>`.

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
<img width="1030" height="763" alt="Screenshot_search-here" src="https://github.com/user-attachments/assets/5eb6d868-356f-403c-bed4-f998f2fa4a11" />


## Testing strategy
I added a test in `TestGui.cpp` that tests the functionality. I also tested it manually.

## Type of change
- ✅ New feature (change that adds functionality)
- Fixes #12945 