### PR TITLE
fix build with botan 3.11

### DIFF
--- a/src/sshagent/OpenSSHKeyGen.cpp
+++ b/src/sshagent/OpenSSHKeyGen.cpp
@@ -25,8 +25,8 @@
 #include <botan/ed25519.h>
 #include <botan/rsa.h>
 #include <botan/version.h>
-#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3,11,0)
-  #include <botan/ec_group.h>
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 11, 0)
+#include <botan/ec_group.h>
 #endif
 
 namespace OpenSSHKeyGen

--- a/src/sshagent/OpenSSHKeyGen.cpp
+++ b/src/sshagent/OpenSSHKeyGen.cpp
@@ -24,6 +24,10 @@
 #include <botan/ecdsa.h>
 #include <botan/ed25519.h>
 #include <botan/rsa.h>
+#include <botan/version.h>
+#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3,11,0)
+  #include <botan/ec_group.h>
+#endif
 
 namespace OpenSSHKeyGen
 {


### PR DESCRIPTION
adding missing <botan/ec_group.h> include for botan 3.11

Fixes #13160 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
