### PR TITLE
Fixed uninitialized variable m_mode in SymmetricCipher.h

### DIFF
--- a/src/crypto/SymmetricCipher.h
+++ b/src/crypto/SymmetricCipher.h
@@ -49,10 +49,7 @@ public:
         Encrypt
     };
 
-    explicit SymmetricCipher()
-        : m_mode(InvalidMode)
-    {
-    }
+    explicit SymmetricCipher() = default;
     ~SymmetricCipher() = default;
 
     bool isInitialized() const;
@@ -79,7 +76,7 @@ private:
     static QString modeToString(const Mode mode);
 
     QString m_error;
-    Mode m_mode;
+    Mode m_mode{InvalidMode};
     QSharedPointer<Botan::Cipher_Mode> m_cipher;
 
     Q_DISABLE_COPY(SymmetricCipher)

--- a/src/crypto/SymmetricCipher.h
+++ b/src/crypto/SymmetricCipher.h
@@ -49,7 +49,10 @@ public:
         Encrypt
     };
 
-    explicit SymmetricCipher() = default;
+    explicit SymmetricCipher()
+        : m_mode(InvalidMode)
+    {
+    }
     ~SymmetricCipher() = default;
 
     bool isInitialized() const;


### PR DESCRIPTION
## Description

The `SymmetricCipher` class used a defaulted constructor (`= default`), which left the `m_mode` member variable uninitialized. In C++, enum members are **not** automatically zero-initialized, meaning that if `mode()` is called before `init()`, it returns an indeterminate garbage value from the stack.

This issue was identified via static analysis (`cppcheck`) as an `uninitMemberVar` warning in the crypto module.

**Fix:** Replaced the defaulted constructor with an explicit constructor that initializes `m_mode` to `SymmetricCipher::InvalidMode`:

```cpp
explicit SymmetricCipher()
    : m_mode(InvalidMode)
{
}
```

**Impact:**
- **Security & Stability:** Ensures the cryptographic object is in a well-defined state immediately upon construction, before `init()` is called.
- **Logic Integrity:** Prevents other components from receiving unpredictable values if they query the cipher's mode prematurely.
- **Code Quality:** Resolves a static analysis warning in a security-critical area of the codebase.

## Screenshots

N/A — header-only change with no visual output.

## Testing strategy

Run `cppcheck` to confirm the warning is resolved:

```bash
cppcheck --enable=warning src/crypto/SymmetricCipher.h
```

The `uninitMemberVar` warning for `m_mode` should no longer appear. Existing unit tests for the crypto module continue to pass unchanged.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)