### PR TITLE
Fix ghost window on Windows by using proper dialog window flags

### DIFF
--- a/src/gui/UpdateCheckDialog.cpp
+++ b/src/gui/UpdateCheckDialog.cpp
@@ -29,7 +29,7 @@ UpdateCheckDialog::UpdateCheckDialog(QWidget* parent)
     , m_ui(new Ui::UpdateCheckDialog())
 {
     m_ui->setupUi(this);
-        setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+    setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
     setAttribute(Qt::WA_DeleteOnClose);
 
     m_ui->iconLabel->setPixmap(icons()->applicationIcon().pixmap(48));

--- a/src/gui/UpdateCheckDialog.cpp
+++ b/src/gui/UpdateCheckDialog.cpp
@@ -29,7 +29,7 @@ UpdateCheckDialog::UpdateCheckDialog(QWidget* parent)
     , m_ui(new Ui::UpdateCheckDialog())
 {
     m_ui->setupUi(this);
-    setWindowFlags(Qt::Window);
+        setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
     setAttribute(Qt::WA_DeleteOnClose);
 
     m_ui->iconLabel->setPixmap(icons()->applicationIcon().pixmap(48));


### PR DESCRIPTION
On Windows 11, the UpdateCheckDialog leaves behind a transparent, non-interactive ghost window frame that persists even after the KeePassXC process has fully exited. The only way to remove this phantom window is to reboot. This has been reported and reproduced by multiple users (see #9493).

The root cause is `setWindowFlags(Qt::Window)` in the `UpdateCheckDialog` constructor. Using bare `Qt::Window` on a `QDialog` causes Windows DWM (Desktop Window Manager) to create an independently managed top-level composition surface for the dialog. If the dialog's native HWND is not cleanly destroyed through the normal `DestroyWindow` -> `WM_NCDESTROY` sequence (e.g., during process exit while the dialog exists, or during an update installation), DWM is left with an orphaned composition surface -- the title bar, borders, and shadow that DWM draws itself -- which persists as a ghost frame even after the owning process is gone.

This change replaces `Qt::Window` with `Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint`, which:
- Keeps the dialog properly associated with its parent window in DWM's composition tree
- Preserves the expected title bar and close button appearance
- Prevents the orphaned DWM frame by ensuring proper dialog window lifecycle management

Fixes #9493

## Screenshots
N/A - This is a window flags change that prevents a ghost window artifact. The dialog's visual appearance remains the same.

## Testing strategy
1. Built and ran KeePassXC on Windows 11
2. Triggered the update check dialog via Help -> Check for Updates
3. Verified the dialog appears correctly with title bar and close button
4. Closed the dialog and exited KeePassXC
5. Confirmed no ghost window frame remains after process exit

Generative AI (Claude) was used to help identify the root cause and suggest the fix.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Refactor (significant modification to existing code)
- [ ] Documentation (non-code change)