### PR TITLE
Refactor: Remove unused variables and member

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -182,7 +182,6 @@ private:
     QPointer<QActionGroup> m_copyAdditionalAttributeActions;
     QPointer<QActionGroup> m_setTagsMenuActions;
     QPointer<InactivityTimer> m_inactivityTimer;
-    QPointer<InactivityTimer> m_touchIDinactivityTimer;
     int m_countDefaultAttributes;
     QPointer<QSystemTrayIcon> m_trayIcon;
     QPointer<ScreenLockListener> m_screenLockListener;

--- a/src/sshagent/OpenSSHKeyGen.cpp
+++ b/src/sshagent/OpenSSHKeyGen.cpp
@@ -77,7 +77,7 @@ namespace OpenSSHKeyGen
             key.setPrivateData(privateData);
             key.setComment("id_rsa");
             return true;
-        } catch (std::exception& e) {
+        } catch (const std::exception&) {
             return false;
         }
     }
@@ -108,7 +108,7 @@ namespace OpenSSHKeyGen
             key.setPrivateData(privateData);
             key.setComment("id_ecdsa");
             return true;
-        } catch (std::exception& e) {
+        } catch (const std::exception&) {
             return false;
         }
     }
@@ -139,7 +139,7 @@ namespace OpenSSHKeyGen
             key.setPrivateData(privateData);
             key.setComment("id_ed25519");
             return true;
-        } catch (std::exception& e) {
+        } catch (const std::exception&) {
             return false;
         }
     }


### PR DESCRIPTION
Use const exceptions

- Remove unused member MainWindow::m_touchIDinactivityTimer
- Unnecessary exceptions variables are removed
- Exceptions should be captured as const


## Type of change
- ✅ Refactor (significant modification to existing code)