### PR TITLE
Refactor: avoid naming lambda expressions and use STL algorithm

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -28,6 +28,8 @@
 #include <QStandardPaths>
 #include <QTemporaryFile>
 
+#include <algorithm>
+
 #define CONFIG_VERSION 2
 #define QS QStringLiteral
 
@@ -319,20 +321,13 @@ bool Config::importSettings(const QString& fileName)
         return false;
     }
 
-    // Only import valid roaming settings
-    auto isValidSetting = [](const QString& key) {
-        for (const auto& value : configStrings.values()) {
-            if (value.type == ConfigType::Roaming && value.name == key) {
-                return true;
-            }
-        }
-        return false;
-    };
-
     // Clear existing settings and set valid items
     m_settings->clear();
     for (const auto& key : settings.allKeys()) {
-        if (isValidSetting(key)) {
+        // Only import valid roaming settings
+        if (std::any_of(configStrings.cbegin(), configStrings.cend(), [&key](const ConfigDirective& directive) -> bool {
+                return directive.type == ConfigType::Roaming && directive.name == key;
+            })) {
             m_settings->setValue(key, settings.value(key));
         }
     }

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -751,10 +751,9 @@ const QList<DeletedObject>& Database::deletedObjects() const
 
 bool Database::containsDeletedObject(const QUuid& uuid) const
 {
-    return std::any_of(m_deletedObjects.cbegin(), m_deletedObjects.cend(),
-                       [&uuid](const DeletedObject& object) -> bool {
-                           return object.uuid == uuid;
-    });
+    return std::any_of(m_deletedObjects.cbegin(),
+                       m_deletedObjects.cend(),
+                       [&uuid](const DeletedObject& object) -> bool { return object.uuid == uuid; });
 }
 
 bool Database::containsDeletedObject(const DeletedObject& object) const

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -34,6 +34,8 @@
 #include <QTemporaryFile>
 #include <QTimer>
 
+#include <algorithm>
+
 #ifdef Q_OS_WIN
 #include <Windows.h>
 #endif
@@ -749,22 +751,15 @@ const QList<DeletedObject>& Database::deletedObjects() const
 
 bool Database::containsDeletedObject(const QUuid& uuid) const
 {
-    for (const DeletedObject& currentObject : m_deletedObjects) {
-        if (currentObject.uuid == uuid) {
-            return true;
-        }
-    }
-    return false;
+    return std::any_of(m_deletedObjects.cbegin(), m_deletedObjects.cend(),
+                       [&uuid](const DeletedObject& object) -> bool {
+                           return object.uuid == uuid;
+    });
 }
 
 bool Database::containsDeletedObject(const DeletedObject& object) const
 {
-    for (const DeletedObject& currentObject : m_deletedObjects) {
-        if (currentObject.uuid == object.uuid) {
-            return true;
-        }
-    }
-    return false;
+    return containsDeletedObject(object.uuid);
 }
 
 void Database::setDeletedObjects(const QList<DeletedObject>& delObjs)

--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -24,6 +24,8 @@
 #include <QPaintDevice>
 #include <QPainter>
 
+#include <algorithm>
+
 #include "config-keepassx.h"
 #include "core/Config.h"
 #include "core/Database.h"
@@ -281,14 +283,9 @@ QString Icons::imageFormatsFilter()
     QStringList formatsStringList;
 
     for (const QByteArray& format : formats) {
-        bool codePointClean = true;
-        for (char codePoint : format) {
-            if (!QChar(codePoint).isLetterOrNumber()) {
-                codePointClean = false;
-                break;
-            }
-        }
-        if (codePointClean) {
+        if (std::all_of(format.cbegin(), format.cend(), [](char codePoint) -> bool {
+                return QChar(codePoint).isLetterOrNumber();
+            })) {
             formatsStringList.append("*." + QString::fromLatin1(format).toLower());
         }
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -31,6 +31,8 @@
 #include <QToolButton>
 #include <QWindow>
 
+#include <algorithm>
+
 #include "config-keepassx.h"
 
 #include "Application.h"
@@ -822,15 +824,6 @@ void MainWindow::updateCopyAttributesMenu()
 
 void MainWindow::updateSetTagsMenu()
 {
-    auto actionForTag = [](const QMenu* menu, const QString& tag) -> QAction* {
-        for (const auto action : menu->actions()) {
-            if (action->text() == tag) {
-                return action;
-            }
-        }
-        return nullptr;
-    };
-
     m_ui->menuTags->setTearOffEnabled(true);
 
     auto dbWidget = m_ui->tabWidget->currentDatabaseWidget();
@@ -853,8 +846,13 @@ void MainWindow::updateSetTagsMenu()
 
         // Add known database tags as actions and set checked if
         // a selected entry has that tag
+        QList<QAction*> actionList = m_ui->menuTags->actions();
         for (const auto& tag : tagList) {
-            auto action = actionForTag(m_ui->menuTags, tag);
+            auto actionForTag = std::find_if(actionList.cbegin(), actionList.cend(),
+                                             [&tag](const QAction* action) -> bool {
+                                                 return action->text() == tag;
+            });
+            QAction* action = actionForTag == actionList.cend() ? nullptr : *actionForTag;
             if (!action) {
                 action = m_ui->menuTags->addAction(icons()->icon("tag"), tag);
                 action->setCheckable(true);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -848,10 +848,9 @@ void MainWindow::updateSetTagsMenu()
         // a selected entry has that tag
         QList<QAction*> actionList = m_ui->menuTags->actions();
         for (const auto& tag : tagList) {
-            auto actionForTag = std::find_if(actionList.cbegin(), actionList.cend(),
-                                             [&tag](const QAction* action) -> bool {
-                                                 return action->text() == tag;
-            });
+            auto actionForTag = std::find_if(actionList.cbegin(),
+                                             actionList.cend(),
+                                             [&tag](const QAction* action) -> bool { return action->text() == tag; });
             QAction* action = actionForTag == actionList.cend() ? nullptr : *actionForTag;
             if (!action) {
                 action = m_ui->menuTags->addAction(icons()->icon("tag"), tag);


### PR DESCRIPTION
Lambda expressions in C++ are designed to be anonymous, lightweight, and local, intended to encapsulate concise logic without the need for formal declarations. Explicitly naming them (e.g., assigning to a variable or using a named `auto`) contradicts their purpose: it introduces redundancy, adds unnecessary weight, and blurs the line between lambdas and regular functions.

This change removes unnecessary lambda names and replaces the custom logic with a standard STL algorithm, making the code more idiomatic, maintainable, and aligned with the STL's philosophy of generic, reusable components.


## Type of change
- ✅ Refactor (significant modification to existing code)