### PR TITLE
Fix the TOTP Gui test for Ubuntu Jammy

### DIFF
--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -1088,6 +1088,17 @@ void TestGui::testTotp()
 
     auto* editEntryWidget = m_dbWidget->findChild<EditEntryWidget*>("editEntryWidget");
     editEntryWidget->switchToPage(EditEntryWidget::Page::Advanced);
+    QApplication::processEvents();
+    // Find the "TOTP Seed" attribute in the list view
+    auto* attrListView = editEntryWidget->findChild<QListView*>("attributesView");
+    auto index = attrListView->model()->index(0, 0);
+    for (auto i = 0; i < attrListView->model()->rowCount(); ++i) {
+        index = attrListView->model()->index(i, 0);
+        if (attrListView->model()->data(index).toString().compare("TOTP Seed") == 0) {
+            break;
+        }
+    }
+    attrListView->setCurrentIndex(index);
     auto* attrTextEdit = editEntryWidget->findChild<QPlainTextEdit*>("attributesEdit");
     QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("revealAttributeButton"), Qt::LeftButton);
     QCOMPARE(attrTextEdit->toPlainText(), expectedFinalSeed);


### PR DESCRIPTION
* For some reason the C locale setting is not respected in Jammy and the test fails due to attribute sorting

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested locally and will see if CI works

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)