### PR TITLE
i18n(de): generate and validate German translations via CuteLingoExpress

### DIFF
--- a/share/translations/keepassxc_de.ts
+++ b/share/translations/keepassxc_de.ts
@@ -578,7 +578,7 @@
     </message>
     <message>
         <source>Auto-generate password for new entries</source>
-        <translation type="unfinished"/>
+        <translation>Passwort für neue Einträge automatisch generieren</translation>
     </message>
 </context>
 <context>
@@ -890,11 +890,11 @@ Strg+Umschalt+4 - URL kopieren&lt;br/&gt;
     <name>BinaryStream</name>
     <message>
         <source>Failed to read string data: %1</source>
-        <translation type="unfinished"/>
+        <translation>String-Daten konnten nicht gelesen werden: %1</translation>
     </message>
     <message>
         <source>String length exceeds 10 MiB limit (requested %1)</source>
-        <translation type="unfinished"/>
+        <translation>Die Zeichenfolgenlänge überschreitet das 10-MiB-Limit (angefordert %1)</translation>
     </message>
 </context>
 <context>
@@ -6834,11 +6834,11 @@ Rechnen Sie mit Fehlern und kleineren Problemen. Diese Version ist für Testzwec
     </message>
     <message>
         <source>Failed to read key file: %1</source>
-        <translation type="unfinished"/>
+        <translation>Schlüsseldatei konnte nicht gelesen werden: %1</translation>
     </message>
     <message>
         <source>Failed to read public key: %1</source>
-        <translation type="unfinished"/>
+        <translation>Der öffentliche Schlüssel konnte nicht gelesen werden: %1</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
- Ran auto_trans.py with CuteLingoExpress (v0.2.0.; https://github.com/marcelpetrick/CuteLingoExpress) to fill five gaps
- Reviewed and corrected output with native German speaker (SWE background)

## Screenshots
None. Please check the diff of the patch.

## Testing strategy
Code not touched.

## Type of change
- ✅ Documentation (non-code change)
