### PR TITLE
Refactor to remove type mismatch warnings

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -313,18 +313,18 @@ MainWindow::MainWindow()
     connect(m_ui->menuGroups, SIGNAL(aboutToHide()), SLOT(releaseContextFocusLock()));
 
     // Control window state
-    new QShortcut(Qt::CTRL + Qt::Key_M, this, SLOT(minimizeOrHide()));
-    new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_M, this, SLOT(hideWindow()));
+    new QShortcut({Qt::CTRL, Qt::Key_M}, this, SLOT(minimizeOrHide()));
+    new QShortcut({Qt::CTRL + Qt::SHIFT, Qt::Key_M}, this, SLOT(hideWindow()));
     // Control database tabs
     // Ctrl+Tab is broken on Mac, so use Alt (i.e. the Option key) - https://bugreports.qt.io/browse/QTBUG-8596
     auto dbTabModifier2 = Qt::CTRL;
 #ifdef Q_OS_MACOS
     dbTabModifier2 = Qt::ALT;
 #endif
-    new QShortcut(dbTabModifier2 + Qt::Key_Tab, this, SLOT(selectNextDatabaseTab()));
-    new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(selectNextDatabaseTab()));
-    new QShortcut(dbTabModifier2 + Qt::SHIFT + Qt::Key_Tab, this, SLOT(selectPreviousDatabaseTab()));
-    new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(selectPreviousDatabaseTab()));
+    new QShortcut({dbTabModifier2, Qt::Key_Tab}, this, SLOT(selectNextDatabaseTab()));
+    new QShortcut({Qt::CTRL, Qt::Key_PageDown}, this, SLOT(selectNextDatabaseTab()));
+    new QShortcut({dbTabModifier2 + Qt::SHIFT, Qt::Key_Tab}, this, SLOT(selectPreviousDatabaseTab()));
+    new QShortcut({Qt::CTRL, Qt::Key_PageUp}, this, SLOT(selectPreviousDatabaseTab()));
 
     // Tab selection by number, Windows uses Ctrl, macOS uses Command,
     // and Linux uses Alt to emulate a browser-like experience
@@ -332,23 +332,23 @@ MainWindow::MainWindow()
 #ifdef Q_OS_LINUX
     dbTabModifier = Qt::ALT;
 #endif
-    auto shortcut = new QShortcut(dbTabModifier + Qt::Key_1, this);
+    auto shortcut = new QShortcut({dbTabModifier, Qt::Key_1}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(0); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_2, this);
+    shortcut = new QShortcut({dbTabModifier, Qt::Key_2}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(1); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_3, this);
+    shortcut = new QShortcut({dbTabModifier, Qt::Key_3}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(2); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_4, this);
+    shortcut = new QShortcut({dbTabModifier, Qt::Key_4}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(3); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_5, this);
+    shortcut = new QShortcut({dbTabModifier, Qt::Key_5}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(4); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_6, this);
+    shortcut = new QShortcut({dbTabModifier, Qt::Key_6}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(5); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_7, this);
+    shortcut = new QShortcut({dbTabModifier, Qt::Key_7}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(6); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_8, this);
+    shortcut = new QShortcut({dbTabModifier, Qt::Key_8}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(7); });
-    shortcut = new QShortcut(dbTabModifier + Qt::Key_9, this);
+    shortcut = new QShortcut({dbTabModifier, Qt::Key_9}, this);
     connect(shortcut, &QShortcut::activated, [this]() { selectDatabaseTab(m_ui->tabWidget->count() - 1); });
 
     m_ui->actionDatabaseNew->setIcon(icons()->icon("document-new"));


### PR DESCRIPTION
Remove the warning "Arithmetic between different enumeration types ('Qt::Modifier' and 'Qt::Key') is deprecated" with a more correct use of QKeySequence.

## Type of change
- ✅ Refactor (significant change of existing code)
