### PR TITLE
added ability to crosscompile using MXE

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -37,7 +37,7 @@
 #include <algorithm>
 
 #ifdef Q_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 QHash<QUuid, QPointer<Database>> Database::s_uuidMap;
@@ -338,7 +338,7 @@ bool Database::saveAs(const QString& filePath, SaveAction action, const QString&
 
 #ifdef Q_OS_WIN
         if (isHidden) {
-            SetFileAttributes(realFilePath.toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN);
+            SetFileAttributes(static_cast<LPCWSTR>(realFilePath.toStdWString().c_str()), FILE_ATTRIBUTE_HIDDEN);
         }
 #endif
         m_ignoreFileChangesUntilSaved = false;

--- a/src/keys/drivers/YubiKeyInterfacePCSC.cpp
+++ b/src/keys/drivers/YubiKeyInterfacePCSC.cpp
@@ -46,6 +46,8 @@ typedef long RETVAL;
 #define SCardListReaders SCardListReadersA
 #define SCardStatus SCardStatusA
 #define SCardConnect SCardConnectA
+
+#define LPWSTR char *
 #endif
 
 // This namescape contains static wrappers for the smart card API
@@ -114,7 +116,7 @@ namespace
         }
         char* mszReaders = new char[dwReaders + 2];
 
-        rv = SCardListReaders(context, nullptr, mszReaders, &dwReaders);
+        rv = SCardListReaders(context, nullptr, static_cast<LPWSTR>(mszReaders), &dwReaders);
         if (rv == SCARD_S_SUCCESS) {
             char* readhead = mszReaders;
             // Names are separated by a null byte
@@ -150,7 +152,7 @@ namespace
         uint8_t pbAtr[MAX_ATR_SIZE] = {0}; // ATR record
         SCUINT dwAtrLen = sizeof(pbAtr); // ATR record size
 
-        auto rv = SCardStatus(handle, pbReader, &dwReaderLen, &dwState, &dwProt, pbAtr, &dwAtrLen);
+        auto rv = SCardStatus(handle, static_cast<LPWSTR>(pbReader), &dwReaderLen, &dwState, &dwProt, pbAtr, &dwAtrLen);
         if (rv == SCARD_S_SUCCESS) {
             switch (dwProt) {
             case SCARD_PROTOCOL_T0:
@@ -438,7 +440,7 @@ namespace
             SCARDHANDLE hCard;
             SCUINT dwActiveProtocol = SCARD_PROTOCOL_UNDEFINED;
             rv = SCardConnect(context,
-                              reader_name.toStdString().c_str(),
+                              static_cast<const LPWSTR>(reader_name.toStdString().c_str()),
                               SCARD_SHARE_SHARED,
                               SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1,
                               &hCard,
@@ -453,7 +455,7 @@ namespace
                 uint8_t pbAtr[MAX_ATR_SIZE] = {0};
                 SCUINT dwAtrLen = sizeof(pbAtr);
 
-                rv = SCardStatus(hCard, pbReader, &dwReaderLen, &dwState, &dwProt, pbAtr, &dwAtrLen);
+                rv = SCardStatus(hCard, static_cast<LPWSTR>(pbReader), &dwReaderLen, &dwState, &dwProt, pbAtr, &dwAtrLen);
                 if (rv == SCARD_S_SUCCESS && (dwProt == SCARD_PROTOCOL_T0 || dwProt == SCARD_PROTOCOL_T1)) {
                     // Find which AID to use
                     SCardAID satr;
@@ -575,7 +577,7 @@ YubiKey::KeyMap YubiKeyInterfacePCSC::findValidKeys(int& connectedKeys)
         SCARDHANDLE hCard;
         SCUINT dwActiveProtocol = SCARD_PROTOCOL_UNDEFINED;
         auto rv = SCardConnect(m_sc_context,
-                               reader_name.toStdString().c_str(),
+                               static_cast<const LPWSTR>(reader_name.toStdString().c_str()),
                                SCARD_SHARE_SHARED,
                                SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1,
                                &hCard,
@@ -596,7 +598,7 @@ YubiKey::KeyMap YubiKeyInterfacePCSC::findValidKeys(int& connectedKeys)
         uint8_t pbAtr[MAX_ATR_SIZE] = {0};
         SCUINT dwAtrLen = sizeof(pbAtr);
 
-        rv = SCardStatus(hCard, pbReader, &dwReaderLen, &dwState, &dwProt, pbAtr, &dwAtrLen);
+        rv = SCardStatus(hCard, static_cast<LPWSTR>(pbReader), &dwReaderLen, &dwState, &dwProt, pbAtr, &dwAtrLen);
         if (rv != SCARD_S_SUCCESS || (dwProt != SCARD_PROTOCOL_T0 && dwProt != SCARD_PROTOCOL_T1)) {
             // Could not read the ATR record or the protocol is not supported
             continue;


### PR DESCRIPTION
Compiling on Windows is case insensitive, so using a capital "W" in Windows.h is fine. However, when cross compiling for Windows, other operating systems require the case to be correct, which prevents this from being compile with [MXE](mxe.cc).

This change fixes the case of the windows header file in the include statement, and makes some explicit casts to be compatible with MXE.

## Testing strategy

- Compile on Linux for Windows using MXE
- Compile on Windows to verify this change didn't break anything over there
- Compile on Linux, for Linux to verify nothing broke there

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
