### PR TITLE
Browser: Add macOS support for Phi Browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.8.0 (Pending)
 * Placeholder for future release notes
+- Browser: Add macOS support for Phi Browser
 
 ## 2.7.12 (2026-03-10)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ KeePassXC has numerous features for novice and power users alike. Our goal is to
 * TOTP storage and generation
 * YubiKey/OnlyKey challenge-response support
 * Auto-Type passwords into applications
-* Browser integration with Google Chrome, Mozilla Firefox, Microsoft Edge, Chromium, Vivaldi, Brave, and Tor-Browser
+* Browser integration with Google Chrome, Mozilla Firefox, Microsoft Edge, Chromium, Vivaldi, Brave, Tor-Browser, and Phi Browser (macOS only)
 * Support for passkeys using the browser integration
 * Entry icon download
 * Import databases from CSV, 1Password, Bitwarden, Proton Pass, and KeePass1 formats

--- a/src/browser/BrowserSettingsWidget.cpp
+++ b/src/browser/BrowserSettingsWidget.cpp
@@ -32,11 +32,15 @@ BrowserSettingsWidget::BrowserSettingsWidget(QWidget* parent)
 
     // clang-format off
     m_ui->extensionLabel->setOpenExternalLinks(true);
+#ifdef Q_OS_MACOS
+    const QString chromiumFamilyLabel = QStringLiteral("Google Chrome / Chromium / Vivaldi / Brave / Phi Browser");
+#else
+    const QString chromiumFamilyLabel = QStringLiteral("Google Chrome / Chromium / Vivaldi / Brave");
+#endif
     m_ui->extensionLabel->setText(
         tr("KeePassXC-Browser is needed for the browser integration to work. <br />Download it for %1 and %2 and %3.")
             .arg("<a href=\"https://addons.mozilla.org/firefox/addon/keepassxc-browser/\">Firefox</a>",
-                 "<a href=\"https://chromewebstore.google.com/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">"
-                 "Google Chrome / Chromium / Vivaldi / Brave</a>",
+                 QStringLiteral("<a href=\"https://chromewebstore.google.com/detail/keepassxc-browser/oboonakemofpalcgghocfoadofidjkkk\">%1</a>").arg(chromiumFamilyLabel),
                  "<a href=\"https://microsoftedge.microsoft.com/addons/detail/pdffhmdngciaglkoonimfcmckehcpafo\">Microsoft Edge</a>"));
     // clang-format on
 
@@ -84,6 +88,10 @@ BrowserSettingsWidget::BrowserSettingsWidget(QWidget* parent)
     m_ui->firefoxSupport->setText("Firefox and Tor Browser");
 #endif
 
+#ifndef Q_OS_MACOS
+    m_ui->phiBrowserSupport->setHidden(true);
+#endif
+
 #ifndef QT_DEBUG
     m_ui->customExtensionId->setVisible(false);
     m_ui->customExtensionLabel->setVisible(false);
@@ -124,6 +132,9 @@ void BrowserSettingsWidget::loadSettings()
     m_ui->chromiumSupport->setChecked(settings->browserSupport(BrowserShared::CHROMIUM));
     m_ui->firefoxSupport->setChecked(settings->browserSupport(BrowserShared::FIREFOX));
     m_ui->edgeSupport->setChecked(settings->browserSupport(BrowserShared::EDGE));
+#ifdef Q_OS_MACOS
+    m_ui->phiBrowserSupport->setChecked(settings->browserSupport(BrowserShared::PHI_BROWSER));
+#endif
 #ifndef Q_OS_WIN
     m_ui->braveSupport->setChecked(settings->browserSupport(BrowserShared::BRAVE));
     m_ui->vivaldiSupport->setChecked(settings->browserSupport(BrowserShared::VIVALDI));
@@ -250,6 +261,9 @@ void BrowserSettingsWidget::saveSettings()
     settings->setBrowserSupport(BrowserShared::CHROMIUM, m_ui->chromiumSupport->isChecked());
     settings->setBrowserSupport(BrowserShared::FIREFOX, m_ui->firefoxSupport->isChecked());
     settings->setBrowserSupport(BrowserShared::EDGE, m_ui->edgeSupport->isChecked());
+#ifdef Q_OS_MACOS
+    settings->setBrowserSupport(BrowserShared::PHI_BROWSER, m_ui->phiBrowserSupport->isChecked());
+#endif
 #ifndef Q_OS_WIN
     settings->setBrowserSupport(BrowserShared::BRAVE, m_ui->braveSupport->isChecked());
     settings->setBrowserSupport(BrowserShared::VIVALDI, m_ui->vivaldiSupport->isChecked());

--- a/src/browser/BrowserSettingsWidget.ui
+++ b/src/browser/BrowserSettingsWidget.ui
@@ -154,6 +154,16 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="3">
+           <widget class="QCheckBox" name="phiBrowserSupport">
+            <property name="text">
+             <string>Phi Browser</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="4">
            <spacer name="horizontalSpacer">
             <property name="orientation">

--- a/src/browser/BrowserShared.h
+++ b/src/browser/BrowserShared.h
@@ -33,6 +33,7 @@ namespace BrowserShared
         TOR_BROWSER,
         BRAVE,
         EDGE,
+        PHI_BROWSER,
         CUSTOM,
         MAX_SUPPORTED
     };

--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -51,6 +51,8 @@ namespace
     const QString TARGET_DIR_BRAVE =
         QStringLiteral("/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts");
     const QString TARGET_DIR_EDGE = QStringLiteral("/Library/Application Support/Microsoft Edge/NativeMessagingHosts");
+    const QString TARGET_DIR_PHI_BROWSER =
+        QStringLiteral("/Library/Application Support/com.phibrowser.Mac/NativeMessagingHosts");
 #elif defined(Q_OS_WIN)
     const QString TARGET_DIR_CHROME = QStringLiteral(
         "HKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\\org.keepassxc.keepassxc_browser");
@@ -160,6 +162,10 @@ QString NativeMessageInstaller::getTargetPath(SupportedBrowsers browser) const
         return TARGET_DIR_BRAVE;
     case SupportedBrowsers::EDGE:
         return TARGET_DIR_EDGE;
+#if defined(Q_OS_MACOS)
+    case SupportedBrowsers::PHI_BROWSER:
+        return TARGET_DIR_PHI_BROWSER;
+#endif
     case SupportedBrowsers::CUSTOM:
         return browserSettings()->customBrowserLocation();
     default:
@@ -191,6 +197,10 @@ QString NativeMessageInstaller::getBrowserName(SupportedBrowsers browser) const
         return QStringLiteral("brave");
     case SupportedBrowsers::EDGE:
         return QStringLiteral("edge");
+#if defined(Q_OS_MACOS)
+    case SupportedBrowsers::PHI_BROWSER:
+        return QStringLiteral("phi-browser");
+#endif
     case SupportedBrowsers::CUSTOM:
         return QStringLiteral("custom");
     default:


### PR DESCRIPTION
[Phi Browser](https://phibrowser.com) is a Chromium-based browser that stores its native messaging host manifests under its own Application Support directory, not Chromium's, so enabling "Chromium" in the Browser Integration settings does not make KeePassXC reachable from extensions running in Phi Browser. Add a dedicated `SupportedBrowsers::PHI_BROWSER` entry and install the manifest to `~/Library/Application Support/com.phibrowser.Mac/NativeMessagingHosts/`.

The extension ID matches the Chrome Web Store entry already listed in `ALLOWED_ORIGINS`, so no extension-side changes are needed. The option is macOS-only for now; the checkbox is hidden and the load/save paths are compiled out on other platforms.

I completed all the work for this PR using Claude Code (Claude Opus 4.7).

## Screenshots

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/9ca84a1c-a7af-46c6-ad28-f4ef0ee74270" />


## Testing strategy

I tested it on Phi Browser, and the password autofill and Passkey features worked correctly.

<img width="488" height="215" alt="image" src="https://github.com/user-attachments/assets/fead0a4c-0c7f-4e18-b809-fcb191e7c913" />

<img width="1079" height="501" alt="image" src="https://github.com/user-attachments/assets/56aecbd0-a412-41f4-95db-fcc8ce436ca2" />


## Type of change

- ✅ New feature (change that adds functionality)
