### PR TITLE
fix(BOTAN3): compilation failed due to a bad definition

### DIFF
--- a/src/fdosecrets/objects/SessionCipher.cpp
+++ b/src/fdosecrets/objects/SessionCipher.cpp
@@ -25,7 +25,7 @@
 #include <QDebug>
 #include <botan/dh.h>
 
-#ifdef WITH_XC_BOTAN3
+#ifdef WITH_BOTAN3
 #include <botan/dl_group.h>
 #include <botan/pubkey.h>
 #else
@@ -58,7 +58,7 @@ namespace FdoSecrets
 
         try {
             Botan::secure_vector<uint8_t> salt(32, '\0');
-#ifdef WITH_XC_BOTAN3
+#ifdef WITH_BOTAN3
             Botan::PK_Key_Agreement dhka(*m_privateKey, *randomGen()->getRng(), "HKDF(SHA-256)", "");
             auto aesKey = dhka.derive_key(16,
                                           reinterpret_cast<const uint8_t*>(clientPublicKey.constData()),


### PR DESCRIPTION
Compilation fails because WITH_XC_BOTAN3 was replaced with WITH_BOTAN3.

resolves #13274 

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
