### PR TITLE
Fix CMakeFiles for BSDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,12 +499,14 @@ find_package(PCSC REQUIRED)
 include_directories(SYSTEM ${PCSC_INCLUDE_DIRS})
 
 if(UNIX AND NOT APPLE)
-    find_library(LIBUSB_LIBRARIES NAMES usb-1.0 REQUIRED)
+    find_library(LIBUSB_LIBRARIES NAMES usb-1.0 usb REQUIRED)
     find_path(LIBUSB_INCLUDE_DIR NAMES libusb.h PATH_SUFFIXES "libusb-1.0" "libusb" REQUIRED)
     include_directories(SYSTEM ${LIBUSB_INCLUDE_DIR})
 
     # For PolKit QuickUnlock
-    find_library(KEYUTILS_LIBRARIES NAMES keyutils REQUIRED)
+    if("${CMAKE_SYSTEM}" MATCHES "Linux")
+        find_library(KEYUTILS_LIBRARIES NAMES keyutils REQUIRED)
+    endif()
 endif()
 
 # Find zxcvbn or use the bundled version

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -336,7 +336,6 @@ target_link_libraries(keepassxc_core
         ${ZLIB_LIBRARIES}
         ${MINIZIP_LIBRARIES}
         ${ARGON2_LIBRARIES}
-        ${KEYUTILS_LIBRARIES}
         ${thirdparty_LIBRARIES})
 
 # GUI Library Definition
@@ -363,6 +362,9 @@ if(HAIKU)
 endif()
 if(UNIX AND NOT APPLE)
     target_link_libraries(keepassxc_core Qt5::DBus ${LIBUSB_LIBRARIES})
+    if("${CMAKE_SYSTEM}" MATCHES "Linux")
+        target_link_libraries(keepassxc_core ${KEYUTILS_LIBRARIES})
+    endif()
     if(WITH_X11)
         target_link_libraries(keepassxc_gui Qt5::X11Extras X11)
     endif()

--- a/src/thirdparty/ykcore/CMakeLists.txt
+++ b/src/thirdparty/ykcore/CMakeLists.txt
@@ -1,4 +1,4 @@
-#  Copyright (C) 2021 KeePassXC Team <team@keepassxc.org>
+#  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ elseif(UNIX AND NOT APPLE)
 
     find_package(Threads REQUIRED)
 
-    find_library(LIBUSB_LIBRARY NAMES usb-1.0)
+    find_library(LIBUSB_LIBRARY NAMES usb-1.0 usb)
     find_path(LIBUSB_INCLUDE_DIR NAMES libusb.h PATH_SUFFIXES "libusb-1.0" "libusb")
     if(NOT LIBUSB_LIBRARY OR NOT LIBUSB_INCLUDE_DIR)
         message(FATAL_ERROR "libusb-1.0 dev package required, but not found")


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
CMake files has a regression from https://github.com/keepassxreboot/keepassxc/pull/11003 and the configuration fails with OpenBSD and FreeBSD.

`KEYUTILS_LIBRARIES` should be included only with Linux. The sources for that require `KEYUTILS_LIBRARIES` are already included only with Linux at https://github.com/keepassxreboot/keepassxc/blob/develop/src/CMakeLists.txt#L237.

FreeBSD also requires `usb` to be added for `LIBUSB_LIBRARIES` when trying to find them using `find_library()`.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Manually using a OpenBSD and FreeBSD VMs.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
