### PR TITLE
changed minimum number of threads in the QThreadPool from 2 to 3

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,8 +75,10 @@ int main(int argc, char** argv)
 
     // HACK: Prevent long-running threads from deadlocking the program with only 1 CPU
     // See https://github.com/keepassxreboot/keepassxc/issues/10391
-    if (QThreadPool::globalInstance()->maxThreadCount() < 2) {
-        QThreadPool::globalInstance()->setMaxThreadCount(2);
+    // HACK: increased to a minimum of 3 threads
+    // See https://github.com/keepassxreboot/keepassxc/issues/12909
+    if (QThreadPool::globalInstance()->maxThreadCount() < 3) {
+        QThreadPool::globalInstance()->setMaxThreadCount(3);
     }
 
     QCommandLineParser parser;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
Changed minimum number of threads in the QThreadPool from 2 to 3 to avoid the application locking up on lower-end devices with up to 2 CPU cores or VMs with up to 2 virtual cores.
Fixes #12909


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)