### PR TITLE
Auto clear after timeout should be x-kde-passwordManagerHint=secret

### DIFF
--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -103,7 +103,7 @@ void Clipboard::clearCopiedText()
     if (!m_lastCopied.isEmpty()
         && (m_lastCopied == clipboard->text(QClipboard::Clipboard)
             || m_lastCopied == clipboard->text(QClipboard::Selection))) {
-#ifdef Q_OS_UNIX
+#ifdef Q_OS_LINUX
         auto* mime = new QMimeData;
         mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
         clipboard->setMimeData(mime, QClipboard::Clipboard);

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -103,11 +103,12 @@ void Clipboard::clearCopiedText()
     if (!m_lastCopied.isEmpty()
         && (m_lastCopied == clipboard->text(QClipboard::Clipboard)
             || m_lastCopied == clipboard->text(QClipboard::Selection))) {
-        clipboard->clear(QClipboard::Clipboard);
-        clipboard->clear(QClipboard::Selection);
+        setText("", false);
 #ifdef Q_OS_UNIX
         // Gnome Wayland doesn't let apps modify the clipboard when not in focus, so force clear
-        if (QProcessEnvironment::systemEnvironment().contains("WAYLAND_DISPLAY")) {
+        if (QProcessEnvironment::systemEnvironment().contains("WAYLAND_DISPLAY")
+            && (m_lastCopied == clipboard->text(QClipboard::Clipboard)
+                || m_lastCopied == clipboard->text(QClipboard::Selection))) {
             QProcess::startDetached("wl-copy", {"-c"});
         }
 #endif

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -103,7 +103,20 @@ void Clipboard::clearCopiedText()
     if (!m_lastCopied.isEmpty()
         && (m_lastCopied == clipboard->text(QClipboard::Clipboard)
             || m_lastCopied == clipboard->text(QClipboard::Selection))) {
-        setText("", false);
+#ifdef Q_OS_UNIX
+        auto* mime = new QMimeData;
+        mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
+        clipboard->setMimeData(mime, QClipboard::Clipboard);
+
+        if (clipboard->supportsSelection()) {
+            auto* selectionMime = new QMimeData;
+            selectionMime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
+            clipboard->setMimeData(selectionMime, QClipboard::Selection);
+        }
+#else
+        clipboard->clear(QClipboard::Clipboard);
+        clipboard->clear(QClipboard::Selection);
+#endif
 #ifdef Q_OS_UNIX
         // Gnome Wayland doesn't let apps modify the clipboard when not in focus, so force clear
         if (QProcessEnvironment::systemEnvironment().contains("WAYLAND_DISPLAY")


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
When copying a password from keepass the password itself was properly marked as x-kde-passwordManagerHint=secret but the clear() signal wasnt which caused keepass to clear phones clipboard through kde connect. Changed it to be marked as secret as well to prevent that. I dont know if there is another way to use qclipboard clear function with mime metadata but that'd prolly be a better solution.

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Built and ran current development branch, which yielded the same effect as ver 2.7.10 which im using currently (clear() sent to my phone). Built and ran version with changed code and confirmed the correct result eg. password nor clear() get sent to the phone.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
