### PR TITLE
fix(fdosecrets): handle Secret Service requests during database load

### DIFF
--- a/src/fdosecrets/objects/Collection.cpp
+++ b/src/fdosecrets/objects/Collection.cpp
@@ -79,7 +79,7 @@ namespace FdoSecrets
             return false;
         }
 
-        // populate contents after expose on dbus, because items rely on parent's dbus object path
+        // populate contents after expose on dbus, because items rely on parent's dbus object path.
         if (!backendLocked()) {
             populateContents();
         } else {
@@ -107,7 +107,7 @@ namespace FdoSecrets
 
     DBusResult Collection::ensureUnlocked() const
     {
-        if (backendLocked()) {
+        if (collectionLocked()) {
             return DBusResult(DBUS_ERROR_SECRET_IS_LOCKED);
         }
         return {};
@@ -130,7 +130,7 @@ namespace FdoSecrets
             return ret;
         }
 
-        if (backendLocked()) {
+        if (collectionLocked()) {
             label = name();
         } else {
             label = m_backend->database()->metadata()->name();
@@ -159,7 +159,7 @@ namespace FdoSecrets
         if (ret.err()) {
             return ret;
         }
-        locked = backendLocked();
+        locked = collectionLocked();
         return {};
     }
 
@@ -219,9 +219,9 @@ namespace FdoSecrets
             return ret;
         }
 
-        if (backendLocked()) {
+        if (collectionLocked()) {
             // searchItems should work, whether `this` is locked or not.
-            // however, we can't search items the same way as in gnome-keying,
+            // However, we can't search items the same way as in gnome-keyring,
             // because there's no database at all when locked.
             return {};
         }
@@ -395,7 +395,7 @@ namespace FdoSecrets
             removeFromDBus();
             return;
         }
-        emit collectionLockChanged(backendLocked());
+        emit collectionLockChanged(collectionLocked());
     }
 
     void Collection::populateContents()
@@ -606,7 +606,9 @@ namespace FdoSecrets
             }
         }
 
+        m_exposedGroup = nullptr;
         m_items.clear();
+        m_entryToItem.clear();
     }
 
     QString Collection::backendFilePath() const
@@ -621,7 +623,17 @@ namespace FdoSecrets
 
     bool Collection::backendLocked() const
     {
+        // True when the underlying database is locked, uninitialised, or absent.
         return !m_backend || !m_backend->database()->isInitialized() || m_backend->isLocked();
+    }
+
+    bool Collection::collectionLocked() const
+    {
+        // True when the collection appears locked to DBus clients.
+        // The collection appears locked when the database is locked, and also while
+        // m_exposedGroup is null - between the databaseUnlocked signal and the end of
+        // populateContents().
+        return backendLocked() || !m_exposedGroup;
     }
 
     bool Collection::doDeleteEntry(Entry* entry)

--- a/src/fdosecrets/objects/Collection.h
+++ b/src/fdosecrets/objects/Collection.h
@@ -145,6 +145,7 @@ namespace FdoSecrets
         void cleanupConnections();
 
         bool backendLocked() const;
+        bool collectionLocked() const;
 
         /**
          * Check if the backend is a valid object, send error reply if not.

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -275,7 +275,21 @@ namespace FdoSecrets
             return ret;
         }
 
-        while (unlockedColls.isEmpty() && settings()->unlockBeforeSearch()) {
+        auto anyBackendLocked = [this]() {
+            for (const auto& coll : asConst(m_collections)) {
+                if (auto* db = coll->backend(); db && db->isLocked()) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        // unlockedColls.isEmpty() can be true even when no DatabaseWidget is
+        // locked: a collection that is still being populated counts as locked,
+        // while its database is already on its way to being unlocked. Don't
+        // open the unlock dialog in that case - populate finishes on its own
+        // and the client's next call returns real data.
+        while (unlockedColls.isEmpty() && settings()->unlockBeforeSearch() && anyBackendLocked()) {
             // enable compatibility mode by making sure at least one database is unlocked
             QEventLoop loop;
             bool wasAccepted = false;


### PR DESCRIPTION
A SearchItems call arriving while a database is still being opened crashed
the application. Reading the KDBX4 payload spins a nested event loop, and
Service::onDatabaseTabOpened has inserted the new Collection into
m_collections before Collection::reloadBackend has finished populating it.
In that window the backend database is not locked but m_exposedGroup is
still null, so Collection::searchItems dereferences a null group via the
UUID/path fast paths or EntrySearcher (Group::groupsRecursive with
this == nullptr).

The half-loaded state was also observable as inconsistent state to clients:
the Locked property reported false while SearchItems returned empty, which
a client interprets as "the entry isn't there" and behaves accordingly.

Introduce collectionLocked() as the predicate the public DBus API uses
(Locked, ensureUnlocked, label, SearchItems, and the collectionLockChanged
signal payload). It is true when the database is locked or while
m_exposedGroup is not yet established, so during the populate window
clients consistently see Locked=true and SearchItems empty rather than the
inconsistent mix. backendLocked() keeps its prior meaning (database locked,
uninitialised, or absent) and is used by the bootstrap path in
reloadBackend and by signal-handler guards that run only when
m_exposedGroup is already set.

cleanupConnections() now also clears m_exposedGroup and m_entryToItem.
Without that, after a database reload the collection would still appear
searchable through stale signal wiring, and the UUID/path shortcuts in
searchItems would consult a map pointing at removed Item objects.

KeePassXC has an "unlock before search" setting that prompts the user to
unlock a database whenever SearchItems finds no unlocked collection. With
the consistency fix above, a half-loaded collection counts as locked, so
the populate window now also satisfies that "no unlocked collection"
condition. The prompt would then open for a database already on its way
to being unlocked, with no actually-locked database to offer - an empty
dialog the user cannot act on. Service::searchItems therefore also
requires that at least one DatabaseWidget actually be locked before
opening the prompt. During the populate window SearchItems returns empty
results; populate completes on its own and a follow-up call from the
client returns real data.

Test Plan:
- Build and run testfdosecrets and testentrysearcher with
  WITH_XC_FDOSECRETS=ON and WITH_TESTS=ON.
- Manual: with unlockBeforeSearch=on and an AutoOpen child database,
  SearchItems calls during the load window no longer crash, no empty
  unlock dialog appears, and a retry once populate completes returns
  real data.
- Original crash locally reproduced with gdb --args keepassxc.

Co-Authored-By: Codex GPT-5.5 (xhigh) <noreply@openai.com>
Co-Authored-By: Claude Opus 4.7 (1M context) (xhigh) <noreply@anthropic.com>

AI: The debugging with gdb was done by Codex, the initial fix done by Codex, the improvement of the PR was done together with Claude.

## Testing strategy
- Configured /tmp/keepassxc-codex-build with WITH_XC_FDOSECRETS=ON.
- Built keepassxc, testfdosecrets, and testentrysearcher.
- Ran /tmp/keepassxc-codex-build/tests/testfdosecrets.
- Ran /tmp/keepassxc-codex-build/tests/testentrysearcher.

I tested (and reproduced) this manually:
1) Create two databases: test1 and test2
2) Make test2 have a long unlock time (I used 3s)
3) Create an AutoOpen entry in test1 for test2
4) Create a test secret service entry in test1, configure test1 to use this secret service entry, configure KeePassXC to act as the secret service provider on your system (mine was GNOME, I'm using it instead of GNOME keyring)
5) Close DBs
6) Unlock test1 database
7) While test2 is being unlocked -> `secret-tool lookup label "label-of-your-test-entry"`
8) a) (without fix) Segfault!
   b) (with fix) secret-tool immediately fails to look up the entry as long as test2 is being unlocked. Once everything is unlocked, the secret-tool lookup works as expected.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

## GDB Logs
This was a 2nd debugging run for show by Codex so you can see what was happening under the hood:
[fdosecrets-search-crash-gdb.log](https://github.com/user-attachments/files/27453102/fdosecrets-search-crash-gdb.log)
