### PR TITLE
Close unlock dialog after external unlock

### DIFF
--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -610,6 +610,15 @@ namespace FdoSecrets
             m_unlockingAnyDatabase = false;
             m_unlockingDb.remove(dbWidget);
         } else {
+            // The database may have been unlocked externally while the unlock dialog
+            // was open, in which case no future databaseUnlocked signal will arrive.
+            if (dbWidget && !dbWidget->isLocked()) {
+                emit doneUnlockDatabaseInDialog(true, dbWidget);
+                m_unlockingAnyDatabase = false;
+                m_unlockingDb.remove(dbWidget);
+                return;
+            }
+
             // delay the done signal to when the database is actually done with unlocking
             // this is a oneshot connection to prevent superfluous signals
             auto conn = connect(dbWidget, &DatabaseWidget::databaseUnlocked, this, [dbWidget, this]() {

--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -200,6 +200,26 @@ QSharedPointer<Database> DatabaseOpenDialog::database() const
     return m_db;
 }
 
+void DatabaseOpenDialog::completeExternalUnlock(DatabaseWidget* dbWidget)
+{
+    if (!dbWidget) {
+        return;
+    }
+
+    hide();
+
+    // The database is already unlocked, so do not route this completion back through
+    // DatabaseWidget::unlockDatabase() and replace the database a second time.
+    if (m_currentDbWidget) {
+        disconnect(this, &DatabaseOpenDialog::dialogFinished, m_currentDbWidget, nullptr);
+    }
+
+    emit dialogFinished(true, dbWidget);
+    clearForms();
+
+    QDialog::done(QDialog::Accepted);
+}
+
 void DatabaseOpenDialog::done(int result)
 {
     hide();

--- a/src/gui/DatabaseOpenDialog.h
+++ b/src/gui/DatabaseOpenDialog.h
@@ -52,6 +52,7 @@ public:
     Intent intent() const;
     QSharedPointer<Database> database() const;
     void clearForms();
+    void completeExternalUnlock(DatabaseWidget* dbWidget);
     void showMessage(const QString& text, MessageWidget::MessageType type, int autoHideTimeout);
 
 signals:

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -760,6 +760,12 @@ void DatabaseTabWidget::unlockDatabaseInDialog(DatabaseWidget* dbWidget,
                                                const QString& filePath)
 {
     m_databaseOpenDialog->clearForms();
+
+    // Keep the requested targets outside the dialog because the dialog can be
+    // cleared while an external unlock is still in progress.
+    m_databaseOpenDialogTargets.clear();
+    m_databaseOpenDialogTargets.append(dbWidget);
+
     m_databaseOpenDialog->setIntent(intent);
     m_databaseOpenDialog->setTarget(dbWidget, filePath);
     displayUnlockDialog();
@@ -774,13 +780,15 @@ void DatabaseTabWidget::unlockDatabaseInDialog(DatabaseWidget* dbWidget,
 void DatabaseTabWidget::unlockAnyDatabaseInDialog(DatabaseOpenDialog::Intent intent)
 {
     m_databaseOpenDialog->clearForms();
+    m_databaseOpenDialogTargets.clear();
     m_databaseOpenDialog->setIntent(intent);
 
-    // add a tab to the dialog for each open unlocked database
+    // add a tab to the dialog for each open locked database
     for (int i = 0, c = count(); i < c; ++i) {
         auto* dbWidget = databaseWidgetFromIndex(i);
         if (dbWidget && dbWidget->isLocked()) {
             m_databaseOpenDialog->addDatabaseTab(dbWidget);
+            m_databaseOpenDialogTargets.append(dbWidget);
         }
     }
     // default to the current tab
@@ -836,6 +844,7 @@ void DatabaseTabWidget::handleDatabaseUnlockDialogFinished(bool accepted, Databa
 
     // signal other objects that the dialog finished
     emit databaseUnlockDialogFinished(accepted, dbWidget);
+    m_databaseOpenDialogTargets.clear();
 }
 
 /**
@@ -904,7 +913,16 @@ void DatabaseTabWidget::emitDatabaseLockChanged()
     } else {
         emit databaseUnlocked(dbWidget);
         m_databaseOpenInProgress = false;
+
+        if (m_databaseOpenDialog->isVisible() && isDatabaseOpenDialogTarget(dbWidget)) {
+            m_databaseOpenDialog->completeExternalUnlock(dbWidget);
+        }
     }
+}
+
+bool DatabaseTabWidget::isDatabaseOpenDialogTarget(DatabaseWidget* dbWidget) const
+{
+    return dbWidget && m_databaseOpenDialogTargets.contains(dbWidget);
 }
 
 void DatabaseTabWidget::performGlobalAutoType(const QString& search)

--- a/src/gui/DatabaseTabWidget.h
+++ b/src/gui/DatabaseTabWidget.h
@@ -120,10 +120,12 @@ private:
     void updateLastDatabases(const QSharedPointer<Database>& database);
     bool warnOnExport();
     void displayUnlockDialog();
+    bool isDatabaseOpenDialogTarget(DatabaseWidget* dbWidget) const;
 
     QPointer<DatabaseWidgetStateSync> m_dbWidgetStateSync;
     QPointer<DatabaseWidget> m_dbWidgetPendingLock;
     QPointer<DatabaseOpenDialog> m_databaseOpenDialog;
+    QList<QPointer<DatabaseWidget>> m_databaseOpenDialogTargets;
     QPointer<ImportWizard> m_importWizard;
     QTimer m_lockDelayTimer;
     bool m_databaseOpenInProgress;


### PR DESCRIPTION
Fixes #13327

## Summary

- Close the modal database unlock dialog when its target database is unlocked through another path.
- Keep the unlock dialog target list in DatabaseTabWidget so the dialog can still be completed if its internal state was cleared during the external unlock.
- Complete pending Secret Service unlock requests immediately if the database is already unlocked when the dialog reports success.

## Testing

- Built KeePassXC with CMake/Ninja: cmake --build build-rel
- Manually reproduced on KDE/Wayland with KeePassXC as Secret Service and an external MainWindow D-Bus unlock helper.
- Verified the database unlocks and the stale unlock dialog closes after the external unlock.

## AI Assistance

This patch was developed with assistance from OpenAI Codex, based on GPT-5.5. The final code was manually reviewed, built, and tested on the affected system.