### PR TITLE
Fix: Windows SDK path resolution without CMAKE implicit link directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,9 +326,25 @@ else()
 endif()
 
 if(WIN32)
+    # Additional search paths for Windows if not building/running in Visual Studio environment (e.g. commandline or VSCode)
+    # 1.Resolve the ambiguity of using two names for one architecture
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x64")
+        set(ARCH_DIR "x64")
+    else()
+       set(ARCH_DIR "${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+    # 2. Locate Windows SDK Paths
+    if (CMAKE_WINDOWS_KITS_10_DIR)
+        set(WINSDKROOTC_INCLUDE "${CMAKE_WINDOWS_KITS_10_DIR}/Include/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um")
+        set(WINSDKROOTC_LIB     "${CMAKE_WINDOWS_KITS_10_DIR}/LIB/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um/${ARCH_DIR}")
+    else()
+        set(WINSDKROOTC_INCLUDE "$ENV{ProgramFiles\(x86\)}/Windows Kits/10/Include/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um")
+        set(WINSDKROOTC_LIB     "$ENV{ProgramFiles\(x86\)}/Windows Kits/10/LIB/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/um/${ARCH_DIR}")
+    endif()
+
     # Determine if we can link against the Windows SDK, used for Windows Hello support
-    find_library(WINSDK WindowsApp.lib)
-    
+    find_library(WINSDK WindowsApp.lib HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES} ${WINSDKROOTC_LIB})
+
     # MSVC specific options
     if(MSVC OR CMAKE_COMPILER_IS_CLANG_MSVC)
         if(MSVC_TOOLSET_VERSION LESS 142)


### PR DESCRIPTION
This commit enhances the CMake configuration for Windows builds by providing more robust path resolution for the Windows SDK.

It should be a re-submission of # [PR#12761](https://github.com/keepassxreboot/keepassxc/pull/12761). I plan to cancel the latter as this here should be easier to integrate into the newest `develop` branch.

Error message is the same fix is the same :)

```
  qrc_wizard.cpp
  keepassxc_gui.vcxproj -> D:\a\keepassxc-B\keepassxc-B\build\src\RelWithDebInfo\keepassxc_gui.lib
  Automatic MOC and UIC for target keepassxc-autotype-test
  Building Custom Rule D:/a/keepassxc-B/keepassxc-B/src/autotype/test/CMakeLists.txt
  AutoTypeTest.cpp
  mocs_compilation_RelWithDebInfo.cpp
     Creating library D:/a/keepassxc-B/keepassxc-B/build/src/autotype/test/RelWithDebInfo/keepassxc-autotype-test.lib and object D:/a/keepassxc-B/keepassxc-B/build/src/autotype/test/RelWithDebInfo/keepassxc-autotype-test.exp
  keepassxc-autotype-test.vcxproj -> D:\a\keepassxc-B\keepassxc-B\build\src\autotype\test\RelWithDebInfo\keepassxc-autotype-test.dll
  Automatic MOC and UIC for target keepassxc-autotype-windows
  Building Custom Rule D:/a/keepassxc-B/keepassxc-B/src/autotype/windows/CMakeLists.txt
  AutoTypeWindows.cpp
  mocs_compilation_RelWithDebInfo.cpp
     Creating library D:/a/keepassxc-B/keepassxc-B/build/src/autotype/windows/RelWithDebInfo/keepassxc-autotype-windows.lib and object D:/a/keepassxc-B/keepassxc-B/build/src/autotype/windows/RelWithDebInfo/keepassxc-autotype-windows.exp
keepassxc_gui.lib(QuickUnlockInterface.obj) : error LNK2001: unresolved external symbol "public: virtual bool __cdecl WindowsHello::isAvailable(void)const " (?isAvailable@WindowsHello@@UEBA_NXZ) [D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\keepassxc-autotype-windows.vcxproj]
keepassxc_gui.lib(QuickUnlockInterface.obj) : error LNK2001: unresolved external symbol "public: virtual class QString __cdecl WindowsHello::errorString(void)const " (?errorString@WindowsHello@@UEBA?AVQString@@XZ) [D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\keepassxc-autotype-windows.vcxproj]
keepassxc_gui.lib(QuickUnlockInterface.obj) : error LNK2001: unresolved external symbol "public: virtual void __cdecl WindowsHello::reset(void)" (?reset@WindowsHello@@UEAAXXZ) [D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\keepassxc-autotype-windows.vcxproj]
keepassxc_gui.lib(QuickUnlockInterface.obj) : error LNK2001: unresolved external symbol "public: virtual bool __cdecl WindowsHello::setKey(class QUuid const &,class QByteArray const &)" (?setKey@WindowsHello@@UEAA_NAEBVQUuid@@AEBVQByteArray@@@Z) [D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\keepassxc-autotype-windows.vcxproj]
keepassxc_gui.lib(QuickUnlockInterface.obj) : error LNK2001: unresolved external symbol "public: virtual bool __cdecl WindowsHello::getKey(class QUuid const &,class QByteArray &)" (?getKey@WindowsHello@@UEAA_NAEBVQUuid@@AEAVQByteArray@@@Z) [D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\keepassxc-autotype-windows.vcxproj]
keepassxc_gui.lib(QuickUnlockInterface.obj) : error LNK2001: unresolved external symbol "public: virtual bool __cdecl WindowsHello::hasKey(class QUuid const &)const " (?hasKey@WindowsHello@@UEBA_NAEBVQUuid@@@Z) [D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\keepassxc-autotype-windows.vcxproj]
keepassxc_gui.lib(QuickUnlockInterface.obj) : error LNK2001: unresolved external symbol "public: virtual void __cdecl WindowsHello::reset(class QUuid const &)" (?reset@WindowsHello@@UEAAXAEBVQUuid@@@Z) [D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\keepassxc-autotype-windows.vcxproj]
D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\RelWithDebInfo\keepassxc-autotype-windows.dll : fatal error LNK1120: 7 unresolved externals [D:\a\keepassxc-B\keepassxc-B\build\src\autotype\windows\keepassxc-autotype-windows.vcxproj]
Error: Process completed with exit code 1.
```
## Testing
I tested the fix by:
  - shortly using the built executable on windows
  - the build itself runs all tests and the result passes all automated test of MacOS. 
  There are no new failed tests on Windows and Linux.

**No side effects are expected** because the CMAKE_C_IMPLICIT_LINK_DIRECTORIES is still used as a priority in the make file and thus a library will be found where it was before not in the new `HINT` place as seen [here](https://github.com/blessio/keepassxc-B/actions/runs/25634950238). 

```cmake
    # Determine if we can link against the Windows SDK, used for Windows Hello support
    find_library(WINSDK WindowsApp.lib
       HINTS                # <<<=== The added `fix`
         ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}
         ${WINSDKROOTC_LIB} # <<<=== The added path is only here 
    )
```

---
<img width="2042" height="2007" alt="image" src="https://github.com/user-attachments/assets/53bafd94-a1ea-4f7a-8074-9fa11a075657" />
