### PR TITLE
Fix incorrect model reset

### DIFF
--- a/src/gui/entry/EntryURLModel.cpp
+++ b/src/gui/entry/EntryURLModel.cpp
@@ -33,8 +33,6 @@ EntryURLModel::EntryURLModel(QObject* parent)
 
 void EntryURLModel::setEntryAttributes(EntryAttributes* entryAttributes)
 {
-    beginResetModel();
-
     if (m_entryAttributes) {
         m_entryAttributes->disconnect(this);
     }
@@ -50,9 +48,9 @@ void EntryURLModel::setEntryAttributes(EntryAttributes* entryAttributes)
         connect(m_entryAttributes, SIGNAL(renamed(QString,QString)), SLOT(updateAttributes()));
         connect(m_entryAttributes, SIGNAL(reset()), SLOT(updateAttributes()));
         // clang-format on
+    } else {
+        clear();
     }
-
-    endResetModel();
 }
 
 QVariant EntryURLModel::data(const QModelIndex& index, int role) const


### PR DESCRIPTION
beginResetModel/endResetModel in a QStandardItemModel doesn't make sense

Fixes following warnings

beginResetModel called on EntryURLModel(0x55c23c0dec40) without calling endResetModel first endResetModel called on EntryURLModel(0x55c23c0dec40) without calling beginResetModel first beginResetModel called on EntryURLModel(0x55c23c861120) without calling endResetModel first endResetModel called on EntryURLModel(0x55c23c861120) without calling beginResetModel first beginResetModel called on EntryURLModel(0x55c23cd1ab30) without calling endResetModel first endResetModel called on EntryURLModel(0x55c23cd1ab30) without calling beginResetModel first

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
