### PR TITLE
Hide Auto-Type from debug info when no backend is built

### DIFF
--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -83,7 +83,9 @@ namespace Tools
         debugInfo.append("\n\n");
 
         QString extensions;
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || (defined(WITH_X11) && !defined(Q_OS_HAIKU))
         extensions += "\n- " + QObject::tr("Auto-Type");
+#endif
         extensions += "\n- " + QObject::tr("KeeShare");
         extensions += "\n- " + QObject::tr("Hardware Keys");
 #if defined(Q_OS_MACOS) || defined(Q_CC_MSVC)


### PR DESCRIPTION
Tools::debugInfo() listed Auto-Type unconditionally, even on builds where no backend was compiled. The Auto-Type backend is [only built on Apple, Windows, and Linux/BSD-with-X11](https://github.com/keepassxreboot/keepassxc/blob/develop/src/autotype/CMakeLists.txt#L14-L30). This patch guards the debug info listing with the same condition.

Fixes #13318

Drafted with assistance from Claude, reviewed and tested manually.


## Screenshots

<img width="446" height="766" alt="image" src="https://github.com/user-attachments/assets/55144766-0577-4f10-8b64-8acb21b2ae1c" />


## Testing strategy

Locally verified that a build configured with `-DWITH_X11=OFF` no longer lists `Auto-Type` in `--debug-info` output, or in Help -> About (see screenshot above). `Q_OS_MACOS`, `Q_OS_WIN` branches were inspected visually but not exercised (no macOS/Windows host available at the moment).

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
