### PR TITLE
gui: replace flat group ComboBox with tree view in PasskeyImportDialog

### DIFF
--- a/src/gui/passkeys/PasskeyImportDialog.cpp
+++ b/src/gui/passkeys/PasskeyImportDialog.cpp
@@ -21,8 +21,55 @@
 #include "browser/BrowserService.h"
 #include "core/Metadata.h"
 #include "gui/MainWindow.h"
+#include "gui/group/GroupModel.h"
 #include <QCloseEvent>
 #include <QFileInfo>
+#include <QSortFilterProxyModel>
+
+// ---------------------------------------------------------------------------
+// GroupModelNoRecycle
+// Thin QSortFilterProxyModel that hides the recycle bin group (same pattern
+// as DatabaseSettingsWidgetFdoSecrets::GroupModelNoRecycle).
+// ---------------------------------------------------------------------------
+class PasskeyImportDialog::GroupModelNoRecycle : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+    Database* m_db;
+
+public:
+    explicit GroupModelNoRecycle(Database* db, QObject* parent = nullptr)
+        : QSortFilterProxyModel(parent)
+        , m_db(db)
+    {
+        Q_ASSERT(db);
+        setSourceModel(new GroupModel(m_db, this));
+    }
+
+    Group* groupFromIndex(const QModelIndex& index) const
+    {
+        auto* groupModel = qobject_cast<GroupModel*>(sourceModel());
+        Q_ASSERT(groupModel);
+        return groupModel->groupFromIndex(mapToSource(index));
+    }
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override
+    {
+        const auto sourceIdx = sourceModel()->index(sourceRow, 0, sourceParent);
+        if (!sourceIdx.isValid()) {
+            return false;
+        }
+        auto* groupModel = qobject_cast<GroupModel*>(sourceModel());
+        Q_ASSERT(groupModel);
+        const auto* group = groupModel->groupFromIndex(sourceIdx);
+        const auto* recycleBin = m_db->metadata()->recycleBin();
+        return group && !group->isRecycled()
+               && (!recycleBin || group->uuid() != recycleBin->uuid());
+    }
+};
+
+// ---------------------------------------------------------------------------
 
 PasskeyImportDialog::PasskeyImportDialog(QWidget* parent)
     : QDialog(parent)
@@ -38,7 +85,26 @@ PasskeyImportDialog::PasskeyImportDialog(QWidget* parent)
     connect(m_ui->cancelButton, SIGNAL(clicked()), SLOT(reject()));
     connect(m_ui->selectDatabaseCombobBox, SIGNAL(currentIndexChanged(int)), SLOT(changeDatabase(int)));
     connect(m_ui->selectEntryComboBox, SIGNAL(currentIndexChanged(int)), SLOT(changeEntry(int)));
-    connect(m_ui->selectGroupComboBox, SIGNAL(currentIndexChanged(int)), SLOT(changeGroup(int)));
+
+    // When the user toggles between "default group" and "select group",
+    // re-evaluate which group UUID is current.
+    connect(m_ui->useDefaultGroupRadio, &QRadioButton::toggled,
+            this, &PasskeyImportDialog::onGroupSelectionChanged);
+
+    // When "Select group" becomes checked and nothing is selected yet,
+    // auto-select the root item so the user always has a valid destination.
+    connect(m_ui->selectCustomGroupRadio, &QRadioButton::toggled, this, [this](bool checked) {
+        if (checked && m_groupModel
+                && !m_ui->selectGroupTreeView->selectionModel()->hasSelection()) {
+            const auto rootIdx = m_groupModel->index(0, 0);
+            if (rootIdx.isValid()) {
+                m_ui->selectGroupTreeView->selectionModel()->select(
+                    rootIdx, QItemSelectionModel::SelectCurrent);
+                m_ui->selectGroupTreeView->setCurrentIndex(rootIdx);
+            }
+        }
+        onGroupSelectionChanged();
+    });
 }
 
 PasskeyImportDialog::~PasskeyImportDialog()
@@ -169,16 +235,29 @@ void PasskeyImportDialog::addGroups()
         return;
     }
 
-    m_ui->selectGroupComboBox->clear();
-    m_ui->selectGroupComboBox->addItem(tr("Default passkeys group (Imported Passkeys)"), {});
-
-    for (const auto& group : m_selectedDatabase->rootGroup()->groupsRecursive(true)) {
-        if (!group || group->isRecycled() || group == m_selectedDatabase->metadata()->recycleBin()) {
-            continue;
-        }
-
-        m_ui->selectGroupComboBox->addItem(group->fullPath(), group->uuid());
+    // Disconnect any signal still bound to the old selection model.
+    if (auto* sm = m_ui->selectGroupTreeView->selectionModel()) {
+        disconnect(sm, nullptr, this, nullptr);
     }
+
+    // Reset to the default group and uncheck any custom selection.
+    m_selectedGroupUuid = QUuid();
+    {
+        QSignalBlocker b(m_ui->useDefaultGroupRadio);
+        m_ui->useDefaultGroupRadio->setChecked(true);
+    }
+
+    // (Re-)build the tree model, filtering out the recycle bin.
+    m_groupModel.reset(new GroupModelNoRecycle(m_selectedDatabase.data(), this));
+    m_ui->selectGroupTreeView->setModel(m_groupModel.data());
+    m_ui->selectGroupTreeView->expandAll();
+
+    connect(m_ui->selectGroupTreeView->selectionModel(),
+            &QItemSelectionModel::selectionChanged,
+            this,
+            &PasskeyImportDialog::onGroupSelectionChanged);
+
+    emit updateEntries();
 }
 
 void PasskeyImportDialog::changeDatabase(int index)
@@ -193,8 +272,18 @@ void PasskeyImportDialog::changeEntry(int index)
     m_selectedEntryUuid = m_ui->selectEntryComboBox->itemData(index).value<QUuid>();
 }
 
-void PasskeyImportDialog::changeGroup(int index)
+void PasskeyImportDialog::onGroupSelectionChanged()
 {
-    m_selectedGroupUuid = m_ui->selectGroupComboBox->itemData(index).value<QUuid>();
+    if (m_ui->useDefaultGroupRadio->isChecked()) {
+        m_selectedGroupUuid = QUuid();
+    } else if (m_groupModel) {
+        const auto indexes = m_ui->selectGroupTreeView->selectionModel()->selectedIndexes();
+        if (!indexes.isEmpty()) {
+            const auto* group = m_groupModel->groupFromIndex(indexes.first());
+            m_selectedGroupUuid = group ? group->uuid() : QUuid();
+        }
+    }
     emit updateEntries();
 }
+
+#include "PasskeyImportDialog.moc"

--- a/src/gui/passkeys/PasskeyImportDialog.h
+++ b/src/gui/passkeys/PasskeyImportDialog.h
@@ -52,6 +52,8 @@ public:
 private:
     void addDatabases();
 
+    class GroupModelNoRecycle;
+
 signals:
     void updateEntries();
     void updateGroups();
@@ -61,10 +63,11 @@ private slots:
     void addGroups();
     void changeDatabase(int index);
     void changeEntry(int index);
-    void changeGroup(int index);
+    void onGroupSelectionChanged();
 
 private:
     QScopedPointer<Ui::PasskeyImportDialog> m_ui;
+    QScopedPointer<GroupModelNoRecycle> m_groupModel;
     QSharedPointer<Database> m_selectedDatabase;
     QUuid m_selectedDatabaseUuid;
     QUuid m_selectedEntryUuid;

--- a/src/gui/passkeys/PasskeyImportDialog.ui
+++ b/src/gui/passkeys/PasskeyImportDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>300</height>
+    <height>500</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>400</width>
-    <height>300</height>
+    <height>420</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -89,10 +89,62 @@
             <property name="text">
              <string>Group</string>
             </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QComboBox" name="selectGroupComboBox"/>
+           <layout class="QVBoxLayout" name="groupSelectionLayout">
+            <property name="spacing">
+             <number>4</number>
+            </property>
+            <item>
+             <widget class="QRadioButton" name="useDefaultGroupRadio">
+              <property name="text">
+               <string>Default passkeys group (Imported Passkeys)</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">groupButtonGroup</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="selectCustomGroupRadio">
+              <property name="text">
+               <string>Select group:</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">groupButtonGroup</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QTreeView" name="selectGroupTreeView">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>120</height>
+               </size>
+              </property>
+              <property name="editTriggers">
+               <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="uniformRowHeights">
+               <bool>true</bool>
+              </property>
+              <attribute name="headerVisible">
+               <bool>false</bool>
+              </attribute>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="entryLabel">
@@ -170,5 +222,25 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>selectCustomGroupRadio</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>selectGroupTreeView</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>249</x>
+     <y>150</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>249</x>
+     <y>220</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <buttongroups>
+  <buttongroup name="groupButtonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
Hi again, and apologies in advance because I have a couple of recent closed PRs (#13317, #13335) where I was wrong on the merits, and I want to be upfront about that history before asking you to spend time on this one. Please feel free to close this just as quickly if it's already been considered, or if I'm again missing something obvious.

This change aims to fix #13336. It replaces the `QComboBox` group selector in `PasskeyImportDialog` with a `QTreeView` backed by a small `QSortFilterProxyModel` (`GroupModelNoRecycle`) — the same pattern already used by `DatabaseSettingsWidgetFdoSecrets` for "Expose entries under this group". For databases with many nested groups, the flat slash-separated list (`Root`, `Root/SaaS`, `Root/SaaS/AWS`, …) can be hard to scan, and I thought it might be worth offering that hierarchical affordance here too. That said, I realize the two contexts are not identical (Secret Service is a config one-shot; the passkey dialog is a live registration flow), and I may be wrong about whether the comparison really holds.

Concretely:

- `PasskeyImportDialog.ui`: the `Group` row's `QComboBox` is replaced with two `QRadioButton`s ("Default passkeys group (Imported Passkeys)" and "Select group:") plus a `QTreeView` that is enabled only when the second radio is chosen. Dialog minimum height bumped from 300 to 420 to leave room for the tree.
- `PasskeyImportDialog.{h,cpp}`: nested `GroupModelNoRecycle` proxy (verbatim pattern from `src/fdosecrets/widgets/DatabaseSettingsWidgetFdoSecrets.cpp`); recycle bin is filtered out. `changeGroup(int)` becomes `onGroupSelectionChanged()` driven by the tree's selection model and the radio toggles. When "Select group" is first checked and nothing is selected, the root is auto-selected so the import button always has a valid destination.

I want to be transparent that this patch was drafted by Claude (Opus 4.7), and I reviewed and tested the result myself. Given my recent track record I'd completely understand reluctance to merge AI-assisted UI changes from me, and I'm not asking for special consideration.

## Screenshots

Please see 13336.

## Testing strategy

Built locally on Linux (Qt5, commit base `703855b` for code-equivalence; tree-view rebased onto current `develop` at `7c7ca45`) with `-DKPXC_FEATURE_BROWSER=ON -DKPXC_FEATURE_FDOSECRETS=ON`. Verified manually:

- Default radio is checked on open; tree view disabled; import goes to "Imported Passkeys" as before.
- Switching to "Select group:" enables the tree and auto-selects the root so the import button is never armed with an invalid destination.
- Selecting a nested group updates the entry combo box (existing `updateEntries` flow is preserved).
- Recycle bin is filtered out (matches `DatabaseSettingsWidgetFdoSecrets` behaviour).
- Switching the database resets the tree model cleanly (old selection-model signals disconnected; new model installed; default radio re-checked under a `QSignalBlocker` to avoid a redundant `addEntries()`).

I did not add unit tests for the new path. If this direction is acceptable I'm willing to add one to `tests/`; I held off because I wasn't sure the change would be wanted at all.

## Type of change

- ✅ Refactor (significant modification to existing code)

Thanks for taking a look, and sorry again for the noise on the previous two.