### PR TITLE
Fix saving SSH Agent settings

### DIFF
--- a/src/sshagent/KeeAgentSettings.cpp
+++ b/src/sshagent/KeeAgentSettings.cpp
@@ -329,12 +329,7 @@ QByteArray KeeAgentSettings::toXml() const
     writer.writeEndElement(); // EntrySettings
     writer.writeEndDocument();
 
-    // Real KeeAgent can only read UTF-16
-    auto toDecUtf16 = QStringDecoder(QStringConverter::Utf8);
-    auto sUtf16 = toDecUtf16(ba);
-    auto toEncUtf16 = QStringEncoder(QStringEncoder::Utf16);
-    auto baUtf16 = toEncUtf16(sUtf16);
-    return baUtf16;
+    return ba;
 }
 
 /**


### PR DESCRIPTION
* Fixes #13351
* This unfortunately breaks backwards compatibility with the _original_ KeeAgent plugin for KeePass2. Qt6 refuses to write XML in UTF-16 format, so we have to use UTF-8. This should not be a big deal at all since our SSH agent integration has surpassed the original KeeAgent with features at this point.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Tested with 2.7.12 and 2.8.0 snapshot. Both versions can read/write settings properly so we are backwards compatible with ourselves.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)