### PR TITLE
Fix race in dark mode detection

### DIFF
--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -23,6 +23,7 @@
 
 #include <QApplication>
 #include <QDBusInterface>
+#include <QDBusReply>
 #include <QDebug>
 #include <QDir>
 #include <QPointer>
@@ -81,10 +82,12 @@ NixUtils::NixUtils(QObject* parent)
                        this,
                        SLOT(handleColorSchemeChanged(QString, QString, QDBusVariant)));
 
-    QDBusMessage msg = QDBusMessage::createMethodCall(
-        "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Settings", "Read");
-    msg << QVariant("org.freedesktop.appearance") << QVariant("color-scheme");
-    sessionBus.callWithCallback(msg, this, SLOT(handleColorSchemeRead(QDBusVariant)));
+    QDBusInterface desktopPortal(
+        "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Settings");
+    QDBusReply<QDBusVariant> reply = desktopPortal.call("Read", "org.freedesktop.appearance", "color-scheme");
+    if (reply.isValid()) {
+        handleColorSchemeRead(reply.value());
+    }
 }
 
 NixUtils::~NixUtils() = default;

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -84,9 +84,9 @@ NixUtils::NixUtils(QObject* parent)
 
     QDBusInterface desktopPortal(
         "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Settings");
-    QDBusReply<QDBusVariant> reply = desktopPortal.call("Read", "org.freedesktop.appearance", "color-scheme");
+    QDBusReply<QDBusVariant> reply = desktopPortal.call("ReadOne", "org.freedesktop.appearance", "color-scheme");
     if (reply.isValid()) {
-        handleColorSchemeRead(reply.value());
+        setColorScheme(reply.value());
     }
 }
 
@@ -360,12 +360,6 @@ bool NixUtils::unregisterGlobalShortcut(const QString& name)
     Q_UNUSED(name)
 #endif
     return true;
-}
-
-void NixUtils::handleColorSchemeRead(QDBusVariant value)
-{
-    value = qvariant_cast<QDBusVariant>(value.variant());
-    setColorScheme(value);
 }
 
 void NixUtils::handleColorSchemeChanged(QString ns, QString key, QDBusVariant value)

--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -53,7 +53,6 @@ public:
     quint64 getProcessStartTime() const;
 
 private slots:
-    void handleColorSchemeRead(QDBusVariant value);
     void handleColorSchemeChanged(QString ns, QString key, QDBusVariant value);
     void launchAtStartupRequested(uint response, const QVariantMap& results);
 


### PR DESCRIPTION
The current dark mode detection implementation is prone to a race between an asynchronous D-Bus method call in `NixUtils::NixUtils()` and bootstrap logic in `Bootstrap::bootstrap()`.  This race condition causes dark mode detection to fail intermittently during application startup.

The sequence of events in the failing case is as follows:

1. In the `Application` constructor, `osUtils` is instantiated, causing the `NixUtils` constructor to run.

2. An asynchronous D-Bus method call is issued to query the value of the `org.freedesktop.appearance.color-scheme` key.

3. Bootstrap code runs.  In particular, a `prctl()` system call is issued to set the `keepassxc` process "dumpable" attribute to 0.

4. `xdg-desktop-portal` begins handling the D-Bus method call initiated in step 2.  Flatpak detection logic is invoked, triggering an attempt to access `/proc/<pid>/root`, where `<pid>` is the PID of the `keepassxc` process.

5. Since the `keepassxc` process had its "dumpable" attribute set to 0 in step 3, its `/proc/<pid>/root` entry becomes owned by root.  This causes the access attempt from `xdg-desktop-portal` to fail, which in turn causes the D-Bus method call to fail as well.  As a result, the registered callback (`NixUtils::handleColorSchemeRead()`) is never invoked, effectively breaking dark mode detection.

If `xdg-desktop-portal` completes its permission checks before the `prctl()` system call is issued (that is, if the order of steps 3 and 4 is reversed), everything works correctly.

Fix by replacing the asynchronous D-Bus method call with a synchronous one, preventing bootstrap code from executing while the D-Bus call is still pending.

---

I believe this issue does **not** affect:

  - Snap builds, because setting `KEEPASSXC_DIST_SNAP` compiles out the `prctl()` system call,
  - debug builds, because setting `QT_NO_DEBUG` compiles out the `disableCoreDumps()` call.

I *think* this should fix #10947, but I cannot be certain because I do not observe any relationship between broken dark mode detection and the "Minimize window at application startup" setting.  I do, however, observe the exact same behavior as described in [another comment on that issue](https://github.com/keepassxreboot/keepassxc/issues/10947#issuecomment-4274600647), i.e. random failures of dark mode detection on startup, and this change reliably fixes the problem in my environment.

## Testing strategy

1. Run `gsettings set org.gnome.desktop.interface color-scheme prefer-dark`.
2. Start `keepassxc` and look at the selected theme:
      - unfixed code can incorrectly (and seemingly in a random fashion) load the light theme, even though a dark color scheme is preferred,
      - fixed code reliably loads the dark theme, as configured by desktop settings.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
