### PR TITLE
refactor: local config path use GenericStateLocation

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -578,16 +578,7 @@ QPair<QString, QString> Config::defaultConfigFiles()
 #else
     // On case-sensitive Operating Systems, force use of lowercase app directories
     configPath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/keepassxc";
-    // Qt does not support XDG_STATE_HOME yet, change this once XDG_STATE_HOME is added
-    QString xdgStateHome = QFile::decodeName(qgetenv("XDG_STATE_HOME"));
-    if (!xdgStateHome.startsWith(u'/')) {
-        xdgStateHome.clear(); // spec says relative paths should be ignored
-    }
-    if (xdgStateHome.isEmpty()) {
-        xdgStateHome = QDir::homePath() + "/.local/state";
-    }
-
-    localConfigPath = xdgStateHome + "/keepassxc";
+    localConfigPath = QStandardPaths::writableLocation(QStandardPaths::GenericStateLocation) + "/keepassxc";
 #endif
 
     QString suffix;


### PR DESCRIPTION
This is a small refactor, after I added `XDG_STATE_HOME` I realized its missing in qt and [contributed it](https://github.com/qt/qtbase/commit/55f0738f1638356137e6bd60459dc186ceaaabd8) as a new `QStandardPaths` `GenericStateLocation`
Now that we use qt6 we can reduce the code a bit by [using it](https://doc.qt.io/qt-6/qstandardpaths.html#StandardLocation-enum).

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )
<img width="944" height="807" alt="image" src="https://github.com/user-attachments/assets/85ef7252-25a1-446d-bcea-b5bd96e109ad" />


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
built and run app, changed config and made sure ini file is still created/edited in the `.local/state/keepassxc` folder.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Refactor (significant modification to existing code)

