### PR TITLE
Add netrc export option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ set(core_SOURCES
         format/Kdbx4Reader.cpp
         format/Kdbx4Writer.cpp
         format/KdbxXmlWriter.cpp
+        format/NetrcExporter.cpp
         format/OpData01.cpp
         format/OPUXReader.cpp
         format/OpVaultReader.cpp

--- a/src/cli/Export.cpp
+++ b/src/cli/Export.cpp
@@ -22,13 +22,14 @@
 #include "core/Global.h"
 #include "format/CsvExporter.h"
 #include "format/HtmlExporter.h"
+#include "format/NetrcExporter.h"
 
 #include <QCommandLineParser>
 
 const QCommandLineOption Export::FormatOption = QCommandLineOption(
     QStringList() << "f" << "format",
-    QObject::tr("Format to use when exporting. Available choices are 'xml', 'csv' or 'html'. Defaults to 'xml'."),
-    QStringLiteral("xml|csv|html"));
+    QObject::tr("Format to use when exporting. Available choices are 'xml', 'csv', 'netrc' or 'html'. Defaults to 'xml'."),
+    QStringLiteral("xml|csv|netrc|html"));
 
 Export::Export()
 {
@@ -54,6 +55,9 @@ int Export::executeWithDatabase(QSharedPointer<Database> database, QSharedPointe
     } else if (format.startsWith(QStringLiteral("csv"), Qt::CaseInsensitive)) {
         CsvExporter csvExporter;
         out << csvExporter.exportDatabase(database);
+    } else if (format.startsWith(QStringLiteral("netrc"), Qt::CaseInsensitive)) {
+        NetrcExporter netrcExporter;
+        out << netrcExporter.exportDatabase(database);
     } else if (format.startsWith(QStringLiteral("html"), Qt::CaseInsensitive)) {
         HtmlExporter htmlExporter;
         out << htmlExporter.exportDatabase(database);

--- a/src/format/NetrcExporter.cpp
+++ b/src/format/NetrcExporter.cpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2015 Florian Geyer <blueice@fobos.de>
+ *  Copyright (C) 2015 Felix Geyer <debfx@fobos.de>
+ *  Copyright (C) 2026 Efraim Flashner <efraim@flashner.co.il>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "NetrcExporter.h"
+
+#include <QFile>
+
+#include "core/Group.h"
+
+bool NetrcExporter::exportDatabase(const QString& filename, const QSharedPointer<const Database>& db)
+{
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        m_error = file.errorString();
+        return false;
+    }
+    return exportDatabase(&file, db);
+}
+
+bool NetrcExporter::exportDatabase(QIODevice* device, const QSharedPointer<const Database>& db)
+{
+    if (device->write(exportGroup(db->rootGroup()).toUtf8()) == -1) {
+        m_error = device->errorString();
+        return false;
+    }
+
+    return true;
+}
+
+QString NetrcExporter::exportDatabase(const QSharedPointer<const Database>& db)
+{
+    return exportGroup(db->rootGroup());
+}
+
+QString NetrcExporter::errorString() const
+{
+    return m_error;
+}
+
+QString NetrcExporter::exportGroup(const Group* group, QString groupPath)
+{
+    QString response;
+
+    const QList<Entry*>& entryList = group->entries();
+    for (const Entry* entry : entryList) {
+        QString line;
+
+        if (!(entry->title().isEmpty())) {
+            addColumn(line, "machine");
+            addColumn(line, entry->title());
+            addColumn(line, "login");
+            addColumn(line, entry->username());
+            addColumn(line, "password");
+            addColumn(line, entry->password());
+            line.append("\n");
+        }
+
+        // Add it a second time using the URL
+        if (!(entry->url().isEmpty())) {
+            addColumn(line, "machine");
+            addColumn(line, entry->url());
+            addColumn(line, "login");
+            addColumn(line, entry->username());
+            addColumn(line, "password");
+            addColumn(line, entry->password());
+            line.append("\n");
+        }
+
+        response.append(line);
+    }
+
+    const QList<Group*>& children = group->children();
+    for (const Group* child : children) {
+        response.append(exportGroup(child, groupPath));
+    }
+
+    return response;
+}
+
+void NetrcExporter::addColumn(QString& str, const QString& column)
+{
+    str.append(QString(column).replace("\"", "\"\""));
+    str.append("\t");
+}

--- a/src/format/NetrcExporter.h
+++ b/src/format/NetrcExporter.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2015 Florian Geyer <blueice@fobos.de>
+ *  Copyright (C) 2015 Felix Geyer <debfx@fobos.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_NETRCEXPORTER_H
+#define KEEPASSX_NETRCEXPORTER_H
+
+#include <QSharedPointer>
+#include <QString>
+
+class Database;
+class Group;
+class QIODevice;
+
+class NetrcExporter
+{
+public:
+    bool exportDatabase(const QString& filename, const QSharedPointer<const Database>& db);
+    bool exportDatabase(QIODevice* device, const QSharedPointer<const Database>& db);
+    QString exportDatabase(const QSharedPointer<const Database>& db);
+    QString errorString() const;
+
+private:
+    QString exportGroup(const Group* group, QString groupPath = QString());
+    void addColumn(QString& str, const QString& column);
+
+    QString m_error;
+};
+
+#endif // KEEPASSX_NETRCEXPORTER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,9 @@ add_unit_test(NAME testentrysearcher SOURCES TestEntrySearcher.cpp
 add_unit_test(NAME testcsvexporter SOURCES TestCsvExporter.cpp
         LIBS ${TEST_LIBRARIES})
 
+add_unit_test(NAME testnetrcexporter SOURCES TestNetrcExporter.cpp
+        LIBS ${TEST_LIBRARIES})
+
 add_unit_test(NAME testykchallengeresponsekey SOURCES TestYkChallengeResponseKey.cpp
         LIBS ${TEST_LIBRARIES})
 

--- a/tests/TestNetrcExporter.cpp
+++ b/tests/TestNetrcExporter.cpp
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (C) 2015 Florian Geyer <blueice@fobos.de>
+ *  Copyright (C) 2015 Felix Geyer <debfx@fobos.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestNetrcExporter.h"
+
+#include <QBuffer>
+#include <QTest>
+
+#include "core/Group.h"
+#include "core/Tools.h"
+#include "core/Totp.h"
+#include "crypto/Crypto.h"
+#include "format/NetrcExporter.h"
+
+QTEST_GUILESS_MAIN(TestNetrcExporter)
+
+void TestNetrcExporter::init()
+{
+    m_db = QSharedPointer<Database>::create();
+    m_netrcExporter = QSharedPointer<NetrcExporter>::create();
+}
+
+void TestNetrcExporter::initTestCase()
+{
+    Crypto::init();
+}
+
+void TestNetrcExporter::cleanup()
+{
+}
+
+void TestNetrcExporter::testExport()
+{
+    Group* groupRoot = m_db->rootGroup();
+    auto* group = new Group();
+    group->setName("Test Group Name");
+    group->setParent(groupRoot);
+    auto* entry = new Entry();
+    entry->setGroup(group);
+    entry->setTitle("Test Entry Title");
+    entry->setUsername("Test Username");
+    entry->setPassword("Test Password");
+    entry->setUrl("http://test.url");
+    entry->setNotes("Test Notes");
+    entry->setTotp(Totp::createSettings("DFDF", Totp::DEFAULT_DIGITS, Totp::DEFAULT_STEP));
+    entry->setIcon(5);
+
+    QBuffer buffer;
+    QVERIFY(buffer.open(QIODevice::ReadWrite));
+    m_netrcExporter->exportDatabase(&buffer, m_db);
+    auto exported = QString::fromUtf8(buffer.buffer());
+
+    QString expectedResult = QString()
+                                 .append("machine\tTest Entry Title\tlogin\tTest Username\tpassword\tTest Password\t\n"
+                                         "machine\thttp://test.url\tlogin\tTest Username\tpassword\tTest Password\t\n");
+
+    QVERIFY(exported.startsWith(expectedResult));
+}
+
+void TestNetrcExporter::testEmptyDatabase()
+{
+    QBuffer buffer;
+    QVERIFY(buffer.open(QIODevice::ReadWrite));
+    m_netrcExporter->exportDatabase(&buffer, m_db);
+
+    QCOMPARE(QString::fromUtf8(buffer.buffer().constData()), QString(""));
+}
+
+void TestNetrcExporter::testNestedGroups()
+{
+    Group* groupRoot = m_db->rootGroup();
+    auto* group = new Group();
+    group->setName("Test Group Name");
+    group->setParent(groupRoot);
+    auto* childGroup = new Group();
+    childGroup->setName("Test Sub Group Name");
+    childGroup->setParent(group);
+    auto* entry = new Entry();
+    entry->setGroup(childGroup);
+    entry->setTitle("Test Entry Title");
+
+    QBuffer buffer;
+    QVERIFY(buffer.open(QIODevice::ReadWrite));
+    m_netrcExporter->exportDatabase(&buffer, m_db);
+    auto exported = QString::fromUtf8(buffer.buffer());
+    QVERIFY(exported.startsWith(
+        QString()
+            .append("")));
+}

--- a/tests/TestNetrcExporter.h
+++ b/tests/TestNetrcExporter.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2015 Florian Geyer <blueice@fobos.de>
+ *  Copyright (C) 2015 Felix Geyer <debfx@fobos.de>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSX_TESTNETRCEXPORTER_H
+#define KEEPASSX_TESTNETRCEXPORTER_H
+
+#include <QObject>
+#include <QSharedPointer>
+
+class Database;
+class NetrcExporter;
+
+class TestNetrcExporter : public QObject
+{
+    Q_OBJECT
+
+public:
+
+private slots:
+    void init();
+    void initTestCase();
+    void cleanup();
+    void testExport();
+    void testEmptyDatabase();
+    void testNestedGroups();
+
+private:
+    QSharedPointer<Database> m_db;
+    QSharedPointer<NetrcExporter> m_netrcExporter;
+};
+
+#endif // KEEPASSX_TESTNETRCEXPORTER_H


### PR DESCRIPTION
This adds a netrc exporter type to keepassxc-cli and tries to create a netrc file which can be read by other programs.

Fixes #13380 

## Testing strategy
I copied tests/TestCsvExporter.* to tests/TestNetrcExporter.* and modified and removed tests as necessary.

## Type of change
- ✅ New feature (change that adds functionality)