### PR TITLE
Fix flatpak builds

### DIFF
--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -27,9 +27,7 @@
 #include <QProcessEnvironment>
 #include <QScopeGuard>
 #include <QSet>
-#ifdef KEEPASSXC_DIST_FLATPAK
 #include <QStandardPaths>
-#endif
 #include <QTemporaryFile>
 #include <QUrl>
 

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -27,6 +27,9 @@
 #include <QProcessEnvironment>
 #include <QScopeGuard>
 #include <QSet>
+#ifdef KEEPASSXC_DIST_FLATPAK
+#include <QStandardPaths>
+#endif
 #include <QTemporaryFile>
 #include <QUrl>
 


### PR DESCRIPTION
This pull request fixes building with Flatpak after Qt6 upgrade (#11651). 


## Testing strategy
Tested building with `flatpak-builder` and an updated Flatpak manifest:

```bash
flatpak-builder --repo=<repo> --force-clean --user --sandbox --install --install-deps-from=flathub build org.keepassxc.KeePassXC.yml
```

I will also open a pull request at the Flathub manifest repo for the updated manifest. 

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
