### PR TITLE
Prevent deleting entries and groups when modal dialog open on macOS

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -585,6 +585,11 @@ void DatabaseWidget::expireSelectedEntries()
 
 void DatabaseWidget::deleteSelectedEntries()
 {
+    // Prevent deletion when a modal dialog (e.g., file save dialog) is active
+    if (QApplication::activeModalWidget()) {
+        return;
+    }
+
     const QModelIndexList selected = m_entryView->selectionModel()->selectedRows();
     if (selected.isEmpty()) {
         return;
@@ -1100,6 +1105,11 @@ void DatabaseWidget::cloneGroup()
 
 void DatabaseWidget::deleteGroup()
 {
+    // Prevent deletion when a modal dialog is active
+    if (QApplication::activeModalWidget()) {
+        return;
+    }
+
     Group* currentGroup = m_groupView->currentGroup();
     Q_ASSERT(currentGroup && canDeleteCurrentGroup());
     if (!currentGroup || !canDeleteCurrentGroup()) {

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -21,6 +21,7 @@
 
 #include <QCheckBox>
 #include <QClipboard>
+#include <QDialog>
 #include <QListWidget>
 #include <QMenu>
 #include <QMenuBar>
@@ -2502,6 +2503,68 @@ void TestGui::testMenuActionStates()
     QVERIFY(isActionEnabled("actionImport"));
     QVERIFY(isActionEnabled("actionSettings"));
     QVERIFY(isActionEnabled("actionPasswordGenerator"));
+}
+
+void TestGui::testDeleteEntryDuringModalDialog()
+{
+    // Delete key in native file dialogs on macOS
+    // should not delete password entries
+
+    // Add canned entries for consistent testing
+    addCannedEntries();
+
+    auto* entryView = m_dbWidget->findChild<EntryView*>("entryView");
+    auto* entryDeleteAction = m_mainWindow->findChild<QAction*>("actionEntryDelete");
+
+    // Count initial entries
+    int initialEntryCount = entryView->model()->rowCount();
+    QVERIFY(initialEntryCount > 0);
+
+    // Select the first entry
+    clickIndex(entryView->model()->index(0, 1), entryView, Qt::LeftButton);
+    entryView->setFocus();
+    QApplication::processEvents();
+
+    // Create and show a modal dialog to simulate the file save dialog
+    QDialog modalDialog(m_mainWindow.data());
+    modalDialog.setModal(true);
+
+    // Use a timer to trigger the delete action while modal dialog is shown
+    bool deleteTriggered = false;
+    QTimer::singleShot(50, [&]() {
+        // Verify modal dialog is active
+        QVERIFY(QApplication::activeModalWidget() == &modalDialog);
+
+        // Trigger delete action while modal is open
+        entryDeleteAction->trigger();
+        deleteTriggered = true;
+
+        // Close the modal dialog
+        modalDialog.accept();
+    });
+
+    // Show modal dialog (blocks until closed)
+    modalDialog.exec();
+
+    QVERIFY(deleteTriggered);
+    QApplication::processEvents();
+
+    // Verify entry count unchanged - delete should have been blocked
+    QCOMPARE(entryView->model()->rowCount(), initialEntryCount);
+
+    // Now verify normal deletion still works after modal closes
+    clickIndex(entryView->model()->index(0, 1), entryView, Qt::LeftButton);
+    entryView->setFocus();
+    QApplication::processEvents();
+
+    if (!config()->get(Config::Security_NoConfirmMoveEntryToRecycleBin).toBool()) {
+        MessageBox::setNextAnswer(MessageBox::Move);
+    }
+    entryDeleteAction->trigger();
+    QApplication::processEvents();
+
+    // Verify entry was deleted normally
+    QCOMPARE(entryView->model()->rowCount(), initialEntryCount - 1);
 }
 
 void TestGui::addCannedEntries()

--- a/tests/gui/TestGui.h
+++ b/tests/gui/TestGui.h
@@ -71,6 +71,7 @@ private slots:
     void testTrayRestoreHide();
     void testShortcutConfig();
     void testMenuActionStates();
+    void testDeleteEntryDuringModalDialog();
 
 private:
     void addCannedEntries();


### PR DESCRIPTION
Hi there!  Re-filing from #12979 

Fixes #12631; I bumped into this as well.  

I just added activeModalWidget() checks in `src/gui/DatabaseWidget.cpp`; AFAICT this is all that is needed, though I am newish to this codebase.  

Testing strategy
- added a test to verify activeModalWidget()'s intended blocking behavior in TestGui; noting I am unfamiliar with this test setup.
-  Ran through the tests locally on 26.2 (25C56), apple silicon (m3).  Would appreciate some pointers on how others are running local multiarch tests.

What changed
- Guard entry deletion and group deletion when `QApplication::activeModalWidget()` is active.
- Add GUI coverage for triggering entry deletion while a modal dialog is active.
- Keep normal deletion behavior unchanged after the modal closes.

## Type of change
- ✅ Bug fix 