### PR TITLE
Fix CLI secret clipboard MIME hints

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(core_SOURCES
         core/Base32.cpp
         core/Bootstrap.cpp
         core/Clock.cpp
+        core/ClipboardMime.cpp
         core/Config.cpp
         core/CustomData.cpp
         core/Database.cpp
@@ -215,9 +216,11 @@ set(gui_SOURCES
         ../share/wizard/wizard.qrc)
 
 if(APPLE)
+    list(APPEND core_SOURCES
+            gui/osutils/macutils/MacPasteboard.cpp)
+
     list(APPEND gui_SOURCES
             gui/osutils/macutils/DeviceListenerMac.cpp
-            gui/osutils/macutils/MacPasteboard.cpp
             gui/osutils/macutils/MacUtils.cpp
             gui/osutils/macutils/ScreenLockListenerMac.cpp
             gui/osutils/macutils/AppKitImpl.mm
@@ -355,6 +358,7 @@ target_link_libraries(keepassxc_gui
         ${sshagent_LIB})
 
 if(APPLE)
+    target_link_libraries(keepassxc_core Qt6::Gui)
     target_link_libraries(keepassxc_gui "-framework Foundation -framework AppKit -framework Carbon -framework Security -framework LocalAuthentication -framework ScreenCaptureKit")
     if(Qt6MacExtras_FOUND)
         target_link_libraries(keepassxc_gui Qt6::MacExtras)

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -45,7 +45,7 @@ set(cli_SOURCES
         Show.cpp)
 
 add_library(cli STATIC ${cli_SOURCES})
-target_link_libraries(cli ${ZXCVBN_LIBRARIES} Qt6::Core)
+target_link_libraries(cli ${ZXCVBN_LIBRARIES} Qt6::Core Qt6::Gui)
 
 find_package(Readline)
 

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -18,13 +18,67 @@
 #include "Clip.h"
 
 #include "Utils.h"
+#include "core/ClipboardMime.h"
 #include "core/EntrySearcher.h"
 #include "core/Group.h"
 #include "core/Tools.h"
 
+#include <QClipboard>
 #include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QMetaObject>
+#include <QThread>
 
 #define CLI_DEFAULT_CLIP_TIMEOUT 10
+
+namespace
+{
+    bool shouldUseGuiClipboard(int timeout)
+    {
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+        // On X11/Wayland, Qt-owned clipboard data may disappear when the CLI exits.
+        // Keep the existing external helper for unlimited copies so they remain persistent.
+        return timeout > 0;
+#else
+        Q_UNUSED(timeout);
+        return true;
+#endif
+    }
+
+    int setGuiClipboardText(const QString& text, bool secret)
+    {
+        auto* clipboard = QGuiApplication::clipboard();
+        if (!clipboard) {
+            return EXIT_FAILURE;
+        }
+
+        if (secret) {
+            clipboard->setMimeData(ClipboardMime::createSecretMimeData(text), QClipboard::Clipboard);
+        } else {
+            clipboard->setText(text, QClipboard::Clipboard);
+        }
+        QCoreApplication::processEvents();
+        return EXIT_SUCCESS;
+    }
+
+    int clipText(const QString& text, bool secret = true, bool useGuiClipboard = true)
+    {
+        auto* app = qobject_cast<QGuiApplication*>(QCoreApplication::instance());
+        if (useGuiClipboard && app) {
+            if (QThread::currentThread() == app->thread()) {
+                return setGuiClipboardText(text, secret);
+            }
+
+            int exitCode = EXIT_FAILURE;
+            QMetaObject::invokeMethod(
+                app, [&] { exitCode = setGuiClipboardText(text, secret); }, Qt::BlockingQueuedConnection);
+            return exitCode;
+        }
+
+        return Utils::clipText(text);
+    }
+} // namespace
 
 const QCommandLineOption Clip::AttributeOption = QCommandLineOption(
     QStringList() << "a" << "attribute",
@@ -138,7 +192,7 @@ int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         return EXIT_FAILURE;
     }
 
-    int exitCode = Utils::clipText(value);
+    int exitCode = clipText(value, true, shouldUseGuiClipboard(timeout));
     if (exitCode != EXIT_SUCCESS) {
         return exitCode;
     }
@@ -154,10 +208,10 @@ int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         out << '\r' << QString(lastLine.size(), ' ') << '\r';
         lastLine = QObject::tr("Clearing the clipboard in %1 second(s)...", "", timeout).arg(timeout);
         out << lastLine << Qt::flush;
-        Tools::sleep(1000);
+        Tools::wait(1000);
         --timeout;
     }
-    Utils::clipText("");
+    clipText("", false);
     out << '\r' << QString(lastLine.size(), ' ') << '\r';
     out << QObject::tr("Clipboard cleared!") << Qt::endl;
 

--- a/src/cli/keepassxc-cli.cpp
+++ b/src/cli/keepassxc-cli.cpp
@@ -16,7 +16,11 @@
  */
 
 #include <QCommandLineParser>
+#include <QCoreApplication>
 #include <QFileInfo>
+#include <QGuiApplication>
+#include <QProcessEnvironment>
+#include <QScopedPointer>
 
 #include "Command.h"
 #include "Open.h"
@@ -37,6 +41,31 @@
 #include <readline/history.h>
 #include <readline/readline.h>
 #endif
+
+namespace
+{
+    bool shouldUseGuiApplication(int argc, char** argv)
+    {
+        for (int i = 1; i < argc; ++i) {
+            const auto arg = QString::fromLocal8Bit(argv[i]);
+            if (arg == QStringLiteral("clip")) {
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+                const auto env = QProcessEnvironment::systemEnvironment();
+                return env.contains(QStringLiteral("DISPLAY")) || env.contains(QStringLiteral("WAYLAND_DISPLAY"))
+                       || env.contains(QStringLiteral("QT_QPA_PLATFORM"));
+#else
+                return true;
+#endif
+            }
+
+            if (!arg.startsWith(QLatin1Char('-'))) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+} // namespace
 
 class LineReader
 {
@@ -179,10 +208,15 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    QCoreApplication app(argc, argv);
+    QScopedPointer<QCoreApplication> app;
+    if (shouldUseGuiApplication(argc, argv)) {
+        app.reset(new QGuiApplication(argc, argv));
+    } else {
+        app.reset(new QCoreApplication(argc, argv));
+    }
     QCoreApplication::setApplicationVersion(KEEPASSXC_VERSION);
     // Cleanup code pages after cli exits
-    QObject::connect(&app, &QCoreApplication::destroyed, &app, [] { Utils::resetTextStreams(); });
+    QObject::connect(app.data(), &QCoreApplication::destroyed, app.data(), [] { Utils::resetTextStreams(); });
 
     Bootstrap::bootstrap(config()->get(Config::GUI_Language).toString());
     Utils::setDefaultTextStreams();

--- a/src/core/ClipboardMime.cpp
+++ b/src/core/ClipboardMime.cpp
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ClipboardMime.h"
+
+#include <QMimeData>
+
+#ifdef Q_OS_MACOS
+#include "gui/osutils/macutils/MacPasteboard.h"
+
+#include <QPointer>
+#endif
+
+namespace
+{
+#if defined(Q_OS_MACOS)
+    QPointer<MacPasteboard> s_pasteboard(nullptr);
+
+    void initializeNativeConverters()
+    {
+        // This object lives for the whole program lifetime and we cannot delete it on exit,
+        // so ignore leak warnings. See https://bugreports.qt.io/browse/QTBUG-54832
+        if (!s_pasteboard) {
+            s_pasteboard = new MacPasteboard();
+        }
+    }
+#else
+    void initializeNativeConverters()
+    {
+    }
+#endif
+} // namespace
+
+namespace ClipboardMime
+{
+    QMimeData* createSecretMimeData(const QString& text)
+    {
+        initializeNativeConverters();
+
+        auto* mime = new QMimeData;
+        mime->setText(text);
+#if defined(Q_OS_MACOS)
+        mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());
+#elif defined(Q_OS_UNIX)
+        mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
+#elif defined(Q_OS_WIN)
+        mime->setData("ExcludeClipboardContentFromMonitorProcessing", QByteArrayLiteral("1"));
+        mime->setData("CanIncludeInClipboardHistory", {4, '\0'});
+        mime->setData("CanUploadToCloudClipboard", {4, '\0'});
+#endif
+        return mime;
+    }
+
+    QStringList secretFormats()
+    {
+#if defined(Q_OS_MACOS)
+        return {QStringLiteral("application/x-nspasteboard-concealed-type")};
+#elif defined(Q_OS_UNIX)
+        return {QStringLiteral("x-kde-passwordManagerHint")};
+#elif defined(Q_OS_WIN)
+        return {QStringLiteral("ExcludeClipboardContentFromMonitorProcessing"),
+                QStringLiteral("CanIncludeInClipboardHistory"),
+                QStringLiteral("CanUploadToCloudClipboard")};
+#else
+        return {};
+#endif
+    }
+} // namespace ClipboardMime

--- a/src/core/ClipboardMime.h
+++ b/src/core/ClipboardMime.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_CLIPBOARDMIME_H
+#define KEEPASSXC_CLIPBOARDMIME_H
+
+#include <QString>
+#include <QStringList>
+
+class QMimeData;
+
+namespace ClipboardMime
+{
+    QMimeData* createSecretMimeData(const QString& text);
+    QStringList secretFormats();
+} // namespace ClipboardMime
+
+#endif // KEEPASSXC_CLIPBOARDMIME_H

--- a/src/gui/Clipboard.cpp
+++ b/src/gui/Clipboard.cpp
@@ -20,26 +20,18 @@
 
 #include <QApplication>
 #include <QClipboard>
-#include <QMimeData>
 #include <QProcess>
 #include <QTimer>
 
+#include "core/ClipboardMime.h"
 #include "core/Config.h"
 
 Clipboard* Clipboard::m_instance(nullptr);
-#ifdef Q_OS_MACOS
-QPointer<MacPasteboard> Clipboard::m_pasteboard(nullptr);
-#endif
 
 Clipboard::Clipboard(QObject* parent)
     : QObject(parent)
     , m_timer(new QTimer(this))
 {
-#ifdef Q_OS_MACOS
-    if (!m_pasteboard) {
-        m_pasteboard = new MacPasteboard();
-    }
-#endif
     connect(m_timer, SIGNAL(timeout()), SLOT(countdownTick()));
     connect(qApp, SIGNAL(aboutToQuit()), SLOT(clearCopiedText()));
 }
@@ -52,17 +44,7 @@ void Clipboard::setText(const QString& text, bool clear)
         return;
     }
 
-    auto* mime = new QMimeData;
-    mime->setText(text);
-#if defined(Q_OS_MACOS)
-    mime->setData("application/x-nspasteboard-concealed-type", text.toUtf8());
-#elif defined(Q_OS_UNIX)
-    mime->setData("x-kde-passwordManagerHint", QByteArrayLiteral("secret"));
-#elif defined(Q_OS_WIN)
-    mime->setData("ExcludeClipboardContentFromMonitorProcessing", QByteArrayLiteral("1"));
-    mime->setData("CanIncludeInClipboardHistory", {4, '\0'});
-    mime->setData("CanUploadToCloudClipboard", {4, '\0'});
-#endif
+    auto* mime = ClipboardMime::createSecretMimeData(text);
 
     if (clipboard->supportsSelection()) {
         clipboard->setMimeData(mime, QClipboard::Selection);

--- a/src/gui/Clipboard.h
+++ b/src/gui/Clipboard.h
@@ -21,10 +21,6 @@
 
 #include <QElapsedTimer>
 #include <QObject>
-#ifdef Q_OS_MACOS
-#include "gui/osutils/macutils/MacPasteboard.h"
-#include <QPointer>
-#endif
 
 class QTimer;
 
@@ -57,11 +53,6 @@ private:
     QTimer* m_timer;
     int m_secondsToClear = 0;
 
-#ifdef Q_OS_MACOS
-    // This object lives for the whole program lifetime and we cannot delete it on exit,
-    // so ignore leak warnings. See https://bugreports.qt.io/browse/QTBUG-54832
-    static QPointer<MacPasteboard> m_pasteboard;
-#endif
     QString m_lastCopied;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,7 @@ add_unit_test(NAME testconfig SOURCES TestConfig.cpp
 add_unit_test(NAME testcli SOURCES TestCli.cpp
         LIBS testsupport cli ${ZXCVBN_LIBRARIES} ${TEST_LIBRARIES})
 target_compile_definitions(testcli PRIVATE KEEPASSX_CLI_PATH="$<TARGET_FILE:keepassxc-cli>")
+add_dependencies(testcli keepassxc-cli)
 
 if(KPXC_FEATURE_SSHAGENT)
     add_unit_test(NAME testopensshkey SOURCES TestOpenSSHKey.cpp

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -19,6 +19,7 @@
 
 #include "config-keepassx-tests.h"
 #include "core/Bootstrap.h"
+#include "core/ClipboardMime.h"
 #include "core/Config.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
@@ -694,6 +695,12 @@ void TestCli::testClip()
     // clang-format on
 
     QTRY_COMPARE(clipboard->text(), QString("Password"));
+    const auto secretFormats = ClipboardMime::secretFormats();
+    const auto* mimeData = clipboard->mimeData(QClipboard::Clipboard);
+    QVERIFY(mimeData);
+    for (const auto& format : secretFormats) {
+        QVERIFY2(mimeData->hasFormat(format), qPrintable(format));
+    }
     QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(""), 3000);
 
     future.waitForFinished();

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -17,12 +17,15 @@
 
 #include "TestTools.h"
 
+#include "core/ClipboardMime.h"
 #include "core/Clock.h"
 #include "core/Tools.h"
 #include "mock/MockClock.h"
 
 #include <QFileInfo>
+#include <QMimeData>
 #include <QRegularExpression>
+#include <QScopedPointer>
 #include <QTest>
 #include <QUuid>
 
@@ -138,6 +141,29 @@ void TestTools::testValidUuid()
     QVERIFY(!Tools::isValidUuid(shortUuid));
     QVERIFY(!Tools::isValidUuid(longUuid));
     QVERIFY(!Tools::isValidUuid(nonHexUuid));
+}
+
+void TestTools::testClipboardMimeData()
+{
+    QScopedPointer<QMimeData> mime(ClipboardMime::createSecretMimeData("Password"));
+    QCOMPARE(mime->text(), QString("Password"));
+
+    const auto secretFormats = ClipboardMime::secretFormats();
+    for (const auto& format : secretFormats) {
+        QVERIFY2(mime->hasFormat(format), qPrintable(format));
+    }
+
+#if defined(Q_OS_MACOS)
+    QCOMPARE(mime->data("application/x-nspasteboard-concealed-type"), QByteArray("Password"));
+#elif defined(Q_OS_UNIX)
+    QCOMPARE(mime->data("x-kde-passwordManagerHint"), QByteArray("secret"));
+#elif defined(Q_OS_WIN)
+    QCOMPARE(mime->data("ExcludeClipboardContentFromMonitorProcessing"), QByteArray("1"));
+    QCOMPARE(mime->data("CanIncludeInClipboardHistory"), QByteArray(4, '\0'));
+    QCOMPARE(mime->data("CanUploadToCloudClipboard"), QByteArray(4, '\0'));
+#else
+    QVERIFY(secretFormats.isEmpty());
+#endif
 }
 
 void TestTools::testBackupFilePatternSubstitution_data()

--- a/tests/TestTools.h
+++ b/tests/TestTools.h
@@ -32,6 +32,7 @@ private slots:
     void testIsAsciiString();
     void testEnvSubstitute();
     void testValidUuid();
+    void testClipboardMimeData();
     void testBackupFilePatternSubstitution_data();
     void testBackupFilePatternSubstitution();
     void testEscapeRegex();


### PR DESCRIPTION
Taking a shot at  #12700; going to do some more testing and thinking, as I am not totally sure this is the best approach but figured I'd share the draft.  


I noticed I started on this a month or two back and had followed the issue, @idoa01's ping this morning reminded me.


Closes #12700



Notes about this:
- retaining the KeePassXC's existing GUI formats and does not add the proposed `text/x-kde-passwordManagerHint` from #12696.
- On Unix/X11/Wayland, `timeout 0` still uses the existing external helper so unlimited copies remain persistent after the CLI exits, which I think is the intended behavior. 
- A companion PR on the way that'll fix a related local macOS `testautotype` failure found while validating with the full test suite


Make timed/default `keepassxc-cli clip` copies use `QClipboard`, so CLI copies carry the same Linux, macOS, and Windows secret clipboard hints as GUI copies.  This is dove by sharing the GUI secret clipboard MIME setup through a core helper, which may or may not be smart.


Tests I've run thus far:

- `xcrun clang-format -i src/core/ClipboardMime.cpp src/core/ClipboardMime.h src/gui/Clipboard.cpp src/gui/Clipboard.h src/cli/Clip.cpp src/cli/keepassxc-cli.cpp tests/TestCli.cpp tests/TestTools.cpp tests/TestTools.h`
- `/opt/homebrew/bin/cmake --build build --target testtools testcli keepassxc-cli`
- `/opt/homebrew/bin/ctest --test-dir build -R '^testtools$' --output-on-failure --timeout 120`
- `/opt/homebrew/bin/ctest --test-dir build -R '^testcli$' --output-on-failure --timeout 180`
- `printf 'a\n' | build/src/cli/keepassxc-cli clip tests/data/NewDatabase.kdbx '/Sample Entry' 0`

Also, these are passing as well.
- `testtools`: passed
- `testcli`: passed
- Smoke test on macOS by copying `/Sample Entry` password 