### PR TITLE
CLI: Add netrc formatted option to show command.

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -9424,6 +9424,10 @@ This option is deprecated, use --set-key-file instead.</source>
         <source>Confirm Replace Entry References</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show a .netrc formatted output of the entry. Note that this option implies --show-protected.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QtIOCompressor</name>

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -114,14 +114,19 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
 
     // First we do the special case for showNetrc.
     if (showNetrcFormat) {
-        const QString entryUrl = entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::URLKey));
+        const QString entryUrl =
+            entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::URLKey));
         if (entryUrl.isEmpty()) {
             out << QString("default ");
         } else {
             out << QString("machine ") << entryUrl << QString(" ");
         }
-        out << QString("login \"") << entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::UserNameKey)) << QString("\" ");
-        out << QString("password \"") << entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::PasswordKey)) << QString("\"") << Qt::endl;
+        out << QString("login \"")
+            << entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::UserNameKey))
+            << QString("\" ");
+        out << QString("password \"")
+            << entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::PasswordKey))
+            << QString("\"") << Qt::endl;
         return encounteredError ? EXIT_FAILURE : EXIT_SUCCESS;
     }
     for (const QString& attributeName : asConst(attributes)) {

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -44,6 +44,10 @@ const QCommandLineOption Show::AttributesOption = QCommandLineOption(
         "If no attributes are specified, a summary of the default attributes is given."),
     QObject::tr("attribute"));
 
+const QCommandLineOption Show::NetrcOption =
+    QCommandLineOption(QStringList() << "format-netrc",
+    QObject::tr("Show a .netrc formatted output of the entry. Note that this option implies --show-protected."));
+
 Show::Show()
 {
     name = QString("show");
@@ -53,6 +57,7 @@ Show::Show()
     options.append(Show::ProtectedAttributesOption);
     options.append(Show::AllAttributesOption);
     options.append(Show::AttachmentsOption);
+    options.append(Show::NetrcOption);
     positionalArguments.append({QString("entry"), QObject::tr("Name of the entry to show."), QString("")});
 }
 
@@ -66,6 +71,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     bool showTotp = parser->isSet(Show::TotpOption);
     bool showProtectedAttributes = parser->isSet(Show::ProtectedAttributesOption);
     bool showAllAttributes = parser->isSet(Show::AllAttributesOption);
+    bool showNetrcFormat = parser->isSet(Show::NetrcOption);
     QStringList attributes = parser->values(Show::AttributesOption);
 
     Entry* entry = database->rootGroup()->findEntryByPath(entryPath);
@@ -80,7 +86,11 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     }
 
     bool attributesWereSpecified = true;
-    if (showAllAttributes) {
+    if (showNetrcFormat) {
+        attributes = QStringList() << EntryAttributes::URLKey
+                                   << EntryAttributes::UserNameKey
+                                   << EntryAttributes::PasswordKey;
+    } else if (showAllAttributes) {
         attributesWereSpecified = false;
         attributes = EntryAttributes::DefaultAttributes;
         for (QString fieldName : Utils::EntryFieldNames) {
@@ -129,15 +139,27 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         QString canonicalName = attrs[0];
         if (!attributesWereSpecified) {
             out << canonicalName << ": ";
+        } else if (showNetrcFormat) {
+            QString netrcField = canonicalName;
+            if (canonicalName == "URL") {
+                netrcField = QString("machine");
+            } else if (canonicalName == "UserName") {
+                netrcField = QString("login");
+            } else if (canonicalName == "Password") {
+                netrcField = QString("password");
+            }
+            out << netrcField << " ";
         }
         if (entry->attributes()->isProtected(canonicalName) && !attributesWereSpecified && !showProtectedAttributes) {
             out << "PROTECTED" << Qt::endl;
+        } else if (showNetrcFormat) {
+            out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << QString(" ");
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << Qt::endl;
         }
     }
 
-    if (parser->isSet(Show::AttachmentsOption)) {
+    if (parser->isSet(Show::AttachmentsOption) && !showNetrcFormat) {
         // Separate attachment output from attributes output via a newline.
         out << Qt::endl;
 
@@ -156,8 +178,11 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         }
     }
 
-    if (showTotp) {
+    if (showTotp && !showNetrcFormat) {
         out << entry->totp() << Qt::endl;
+    }
+    if (showNetrcFormat) {
+        out << Qt::endl;
     }
 
     return encounteredError ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -44,8 +44,8 @@ const QCommandLineOption Show::AttributesOption = QCommandLineOption(
         "If no attributes are specified, a summary of the default attributes is given."),
     QObject::tr("attribute"));
 
-const QCommandLineOption Show::NetrcOption =
-    QCommandLineOption(QStringList() << "format-netrc",
+const QCommandLineOption Show::NetrcOption = QCommandLineOption(
+    QStringList() << "format-netrc",
     QObject::tr("Show a .netrc formatted output of the entry. Note that this option implies --show-protected."));
 
 Show::Show()
@@ -87,8 +87,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
 
     bool attributesWereSpecified = true;
     if (showNetrcFormat) {
-        attributes = QStringList() << EntryAttributes::URLKey
-                                   << EntryAttributes::UserNameKey
+        attributes = QStringList() << EntryAttributes::URLKey << EntryAttributes::UserNameKey
                                    << EntryAttributes::PasswordKey;
     } else if (showAllAttributes) {
         attributesWereSpecified = false;

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -86,10 +86,7 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     }
 
     bool attributesWereSpecified = true;
-    if (showNetrcFormat) {
-        attributes = QStringList() << EntryAttributes::URLKey << EntryAttributes::UserNameKey
-                                   << EntryAttributes::PasswordKey;
-    } else if (showAllAttributes) {
+    if (showAllAttributes) {
         attributesWereSpecified = false;
         attributes = EntryAttributes::DefaultAttributes;
         for (QString fieldName : Utils::EntryFieldNames) {
@@ -114,6 +111,19 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
 
     // Iterate over the attributes and output them line-by-line.
     bool encounteredError = false;
+
+    // First we do the special case for showNetrc.
+    if (showNetrcFormat) {
+        const QString entryUrl = entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::URLKey));
+        if (entryUrl.isEmpty()) {
+            out << QString("default ");
+        } else {
+            out << QString("machine ") << entryUrl << QString(" ");
+        }
+        out << QString("login \"") << entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::UserNameKey)) << QString("\" ");
+        out << QString("password \"") << entry->resolveMultiplePlaceholders(entry->attributes()->value(EntryAttributes::PasswordKey)) << QString("\"") << Qt::endl;
+        return encounteredError ? EXIT_FAILURE : EXIT_SUCCESS;
+    }
     for (const QString& attributeName : asConst(attributes)) {
         if (Utils::EntryFieldNames.contains(attributeName)) {
             if (!attributesWereSpecified) {
@@ -138,27 +148,15 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         QString canonicalName = attrs[0];
         if (!attributesWereSpecified) {
             out << canonicalName << ": ";
-        } else if (showNetrcFormat) {
-            QString netrcField = canonicalName;
-            if (canonicalName == "URL") {
-                netrcField = QString("machine");
-            } else if (canonicalName == "UserName") {
-                netrcField = QString("login");
-            } else if (canonicalName == "Password") {
-                netrcField = QString("password");
-            }
-            out << netrcField << " ";
         }
         if (entry->attributes()->isProtected(canonicalName) && !attributesWereSpecified && !showProtectedAttributes) {
             out << "PROTECTED" << Qt::endl;
-        } else if (showNetrcFormat) {
-            out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << QString(" ");
         } else {
             out << entry->resolveMultiplePlaceholders(entry->attributes()->value(canonicalName)) << Qt::endl;
         }
     }
 
-    if (parser->isSet(Show::AttachmentsOption) && !showNetrcFormat) {
+    if (parser->isSet(Show::AttachmentsOption)) {
         // Separate attachment output from attributes output via a newline.
         out << Qt::endl;
 
@@ -177,11 +175,8 @@ int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         }
     }
 
-    if (showTotp && !showNetrcFormat) {
+    if (showTotp) {
         out << entry->totp() << Qt::endl;
-    }
-    if (showNetrcFormat) {
-        out << Qt::endl;
     }
 
     return encounteredError ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/src/cli/Show.h
+++ b/src/cli/Show.h
@@ -32,6 +32,7 @@ public:
     static const QCommandLineOption AttributesOption;
     static const QCommandLineOption ProtectedAttributesOption;
     static const QCommandLineOption AttachmentsOption;
+    static const QCommandLineOption NetrcOption;
 };
 
 #endif // KEEPASSXC_SHOW_H

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -2209,8 +2209,8 @@ void TestCli::testShow()
 
     // Netrc formatted output shouldn't change regardless of extra options.
     QByteArray expectedNetrcOutput = QByteArray("machine http://www.somesite.com/ "
-                                                "login User Name "
-                                                "password Password \n");
+                                                "login \"User Name\" "
+                                                "password \"Password\"\n");
 
     setInput("a");
     execCmd(showCmd, {"show", "--format-netrc", m_dbFile->fileName(), "/Sample Entry"});

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -2241,7 +2241,6 @@ void TestCli::testShow()
     m_stderr->readLine(); // Skip password prompt
     QCOMPARE(m_stderr->readAll(), QByteArray());
     QCOMPARE(m_stdout->readAll(), expectedNetrcOutput);
-
 }
 
 void TestCli::testInvalidDbFiles()

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -2206,6 +2206,42 @@ void TestCli::testShow()
                         "TOTP Settings: 30;6\n"
                         "TestAttribute1: b\n"
                         "testattribute1: a\n"));
+
+    // Netrc formatted output shouldn't change regardless of extra options.
+    QByteArray expectedNetrcOutput = QByteArray("machine http://www.somesite.com/ "
+                                                "login User Name "
+                                                "password Password \n");
+
+    setInput("a");
+    execCmd(showCmd, {"show", "--format-netrc", m_dbFile->fileName(), "/Sample Entry"});
+    m_stderr->readLine(); // Skip password prompt
+    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QCOMPARE(m_stdout->readAll(), expectedNetrcOutput);
+
+    setInput("a");
+    execCmd(showCmd, {"show", "-a", "DoesNotExist", "--format-netrc", m_dbFile->fileName(), "/Sample Entry"});
+    m_stderr->readLine(); // Skip password prompt
+    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QCOMPARE(m_stdout->readAll(), expectedNetrcOutput);
+
+    setInput("a");
+    execCmd(showCmd, {"show", "--all", "--format-netrc", m_dbFile->fileName(), "/Sample Entry"});
+    m_stderr->readLine(); // Skip password prompt
+    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QCOMPARE(m_stdout->readAll(), expectedNetrcOutput);
+
+    setInput("a");
+    execCmd(showCmd, {"show", "--totp", "--format-netrc", m_dbFile->fileName(), "/Sample Entry"});
+    m_stderr->readLine(); // Skip password prompt
+    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QCOMPARE(m_stdout->readAll(), expectedNetrcOutput);
+
+    setInput("a");
+    execCmd(showCmd, {"show", "--format-netrc", "--show-attachments", m_dbFile->fileName(), "/Sample Entry"});
+    m_stderr->readLine(); // Skip password prompt
+    QCOMPARE(m_stderr->readAll(), QByteArray());
+    QCOMPARE(m_stdout->readAll(), expectedNetrcOutput);
+
 }
 
 void TestCli::testInvalidDbFiles()


### PR DESCRIPTION
Fixes #13380

## Testing strategy
Added tests to the TestCli::testShow() test case.

## Type of change
- ✅ New feature (change that adds functionality)

This follows some comments on #13381 which pointed out that it's exposing the entire database for the one line that's needed, so it'd be better to be an option in 'show'. Also because it's meant to be ephemeral, not a full dump of all the data.