### PR TITLE
Fix KeePass1 group time field validation

### DIFF
--- a/src/format/KeePass1Reader.cpp
+++ b/src/format/KeePass1Reader.cpp
@@ -499,6 +499,7 @@ Group* KeePass1Reader::readGroup(QIODevice* cipherStream)
         case 0x0005: {
             if (fieldSize != 5) {
                 raiseError(tr("Incorrect group access time field size"));
+                return nullptr;
             }
             QDateTime dateTime = dateFromPackedStruct(fieldData);
             if (dateTime.isValid()) {
@@ -509,6 +510,7 @@ Group* KeePass1Reader::readGroup(QIODevice* cipherStream)
         case 0x0006: {
             if (fieldSize != 5) {
                 raiseError(tr("Incorrect group expiry time field size"));
+                return nullptr;
             }
             QDateTime dateTime = dateFromPackedStruct(fieldData);
             if (dateTime.isValid()) {


### PR DESCRIPTION
Return immediately when KeePass1 group access-time or expiry-time fields have an invalid size. The adjacent creation/modification group time fields already stop parsing on invalid sizes, and the entry time fields do the same.

This keeps malformed KeePass1 input on the existing error path instead of passing invalid field data to the packed date parser.

AI use: I used OpenAI Codex to help identify, implement, and test this small bug fix.

## Screenshots
Not applicable.

## Testing strategy
- Built `testkeepass1reader` with CMake.
- Ran `build/audit-relasan2/tests/testkeepass1reader` successfully.
- Replayed malformed KeePass1 inputs for group access-time and expiry-time fields; both now report the corresponding field-size error instead of crashing.
- Replayed a valid KeePass1 control input; it still completes without reader errors.

## Type of change
- Bug fix (non-breaking change that fixes an issue)