### PR TITLE
Support {MODE=VIRTUAL} on macOS

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -855,6 +855,13 @@
     </message>
 </context>
 <context>
+    <name>AutoTypePlatformMac</name>
+    <message>
+        <source>Unable to get valid keycode for key: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AutoTypePlatformWayland</name>
     <message>
         <source>No symbol found for key: &apos;%1&apos;</source>

--- a/src/autotype/mac/AutoTypeMac.cpp
+++ b/src/autotype/mac/AutoTypeMac.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "AutoTypeMac.h"
+#include "AutoTypeMac_p.h"
 #include "core/Tools.h"
 #include "gui/osutils/macutils/MacUtils.h"
 #include "gui/MessageBox.h"
@@ -24,6 +25,85 @@
 #include <ApplicationServices/ApplicationServices.h>
 
 #define INVALID_KEYCODE 0xFFFF
+
+//
+// Resolve macOS virtual key code and modifier flags for a unicode character
+// using the current keyboard layout via UCKeyTranslate.
+// Returns false if no single-keystroke mapping is found.
+//
+bool charToNativeKeyCode(const UCKeyboardLayout* layout,
+                         UInt32 keyboardType,
+                         const QChar& ch,
+                         uint16_t& outKeyCode,
+                         CGEventFlags& outFlags)
+{
+    UInt32 deadKeyState = 0;
+    UniCharCount actualLen = 0;
+    UniChar unicode[4];
+
+    static const UInt32 kUCTShift  = shiftKey >> 8;
+    static const UInt32 kUCTOption = optionKey >> 8;
+
+    static const UInt32 modifierCombinations[] = {
+        0,
+        kUCTShift,
+        kUCTOption,
+        kUCTShift | kUCTOption,
+    };
+
+    for (uint16_t keyCode = 0; keyCode < 128; keyCode++) {
+        for (UInt32 mods : modifierCombinations) {
+            deadKeyState = 0;
+            OSStatus status = UCKeyTranslate(layout,
+                                             keyCode,
+                                             kUCKeyActionDown,
+                                             mods,
+                                             keyboardType,
+                                             kUCKeyTranslateNoDeadKeysBit,
+                                             &deadKeyState,
+                                             4,
+                                             &actualLen,
+                                             unicode);
+            if (status == noErr && actualLen == 1 && unicode[0] == ch.unicode()) {
+                outKeyCode = keyCode;
+                outFlags = 0;
+                if (mods & kUCTShift) {
+                    outFlags |= kCGEventFlagMaskShift;
+                }
+                if (mods & kUCTOption) {
+                    outFlags |= kCGEventFlagMaskAlternate;
+                }
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+static bool charToNativeKeyCode(const QChar& ch, uint16_t& outKeyCode, CGEventFlags& outFlags)
+{
+    TISInputSourceRef keyboard = TISCopyCurrentKeyboardLayoutInputSource();
+    if (!keyboard) {
+        keyboard = TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
+    }
+    if (!keyboard) {
+        return false;
+    }
+
+    CFDataRef layoutData =
+        static_cast<CFDataRef>(TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData));
+    if (!layoutData) {
+        CFRelease(keyboard);
+        return false;
+    }
+
+    const UCKeyboardLayout* layout = reinterpret_cast<const UCKeyboardLayout*>(CFDataGetBytePtr(layoutData));
+    bool result = charToNativeKeyCode(layout, LMGetKbdType(), ch, outKeyCode, outFlags);
+
+    CFRelease(keyboard);
+    return result;
+}
 
 AutoTypePlatformMac::AutoTypePlatformMac()
 {
@@ -159,6 +239,18 @@ bool AutoTypePlatformMac::raiseOwnWindow()
 }
 
 //
+// Send raw keycode event
+//
+void AutoTypePlatformMac::sendRawKey(uint16_t keyCode, bool isKeyDown)
+{
+    CGEventRef keyEvent = ::CGEventCreateKeyboardEvent(nullptr, keyCode, isKeyDown);
+    if (keyEvent != nullptr) {
+        ::CGEventPost(kCGSessionEventTap, keyEvent);
+        ::CFRelease(keyEvent);
+    }
+}
+
+//
 // Send unicode character to active window
 // see: Quartz Event Services
 //
@@ -171,6 +263,53 @@ void AutoTypePlatformMac::sendChar(const QChar& ch, bool isKeyDown)
         ::CGEventPost(kCGSessionEventTap, keyEvent);
         ::CFRelease(keyEvent);
     }
+}
+
+//
+// Send unicode character as native keycode + modifiers
+// see: Quartz Event Services
+//
+bool AutoTypePlatformMac::sendCharVirtual(const QChar& ch, bool isKeyDown)
+{
+    uint16_t keyCode = 0;
+    CGEventFlags flags = 0;
+
+    if (!charToNativeKeyCode(ch, keyCode, flags)) {
+        // Couldn't determine which keys to press to make the character
+        return false;
+    }
+
+    // Send physical modifier key events for VNC/Screen Sharing compatibility
+    if (isKeyDown) {
+        if (flags & kCGEventFlagMaskShift) {
+            sendRawKey(kVK_Shift, true);
+        }
+        if (flags & kCGEventFlagMaskAlternate) {
+            sendRawKey(kVK_Option, true);
+        }
+    }
+
+    CGEventRef keyEvent = ::CGEventCreateKeyboardEvent(nullptr, keyCode, isKeyDown);
+    if (keyEvent != nullptr) {
+        if (flags != 0) {
+            ::CGEventSetFlags(keyEvent, flags);
+        }
+        UniChar unicode = ch.unicode();
+        ::CGEventKeyboardSetUnicodeString(keyEvent, 1, &unicode);
+        ::CGEventPost(kCGSessionEventTap, keyEvent);
+        ::CFRelease(keyEvent);
+    }
+
+    // Release modifier keys
+    if (!isKeyDown) {
+        if (flags & kCGEventFlagMaskAlternate) {
+            sendRawKey(kVK_Option, false);
+        }
+        if (flags & kCGEventFlagMaskShift) {
+            sendRawKey(kVK_Shift, false);
+        }
+    }
+    return true;
 }
 
 //
@@ -243,8 +382,6 @@ AutoTypeAction::Result AutoTypeExecutorMac::execBegin(const AutoTypeBegin* actio
 
 AutoTypeAction::Result AutoTypeExecutorMac::execType(const AutoTypeKey* action)
 {
-
-
     if (action->key != Qt::Key_unknown) {
         m_platform->sendKey(action->key, true, action->modifiers);
         m_platform->sendKey(action->key, false, action->modifiers);
@@ -256,9 +393,11 @@ AutoTypeAction::Result AutoTypeExecutorMac::execType(const AutoTypeKey* action)
             m_platform->sendKey(static_cast<Qt::Key>(ch), true, action->modifiers);
             m_platform->sendKey(static_cast<Qt::Key>(ch), false, action->modifiers);
         } else if (mode == Mode::VIRTUAL) {
-            int ch = action->character.toLatin1();
-            m_platform->sendKey(static_cast<Qt::Key>(ch), true, action->modifiers);
-            m_platform->sendKey(static_cast<Qt::Key>(ch), false, action->modifiers);
+            if (!m_platform->sendCharVirtual(action->character, true)) {
+                return AutoTypeAction::Result::Failed(AutoTypePlatformMac::tr("Unable to get valid keycode for key: ")
+                                                          + action->character);
+            }
+            m_platform->sendCharVirtual(action->character, false);
         } else {
             m_platform->sendChar(action->character, true);
             m_platform->sendChar(action->character, false);

--- a/src/autotype/mac/AutoTypeMac.h
+++ b/src/autotype/mac/AutoTypeMac.h
@@ -48,6 +48,8 @@ public:
     bool raiseOwnWindow() override;
 
     void sendChar(const QChar& ch, bool isKeyDown);
+    bool sendCharVirtual(const QChar& ch, bool isKeyDown);
+    void sendRawKey(uint16_t keyCode, bool isKeyDown);
     void sendKey(Qt::Key key, bool isKeyDown, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
 
 private:

--- a/src/autotype/mac/AutoTypeMac_p.h
+++ b/src/autotype/mac/AutoTypeMac_p.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_AUTOTYPEMAC_P_H
+#define KEEPASSXC_AUTOTYPEMAC_P_H
+
+#include <ApplicationServices/ApplicationServices.h>
+#include <Carbon/Carbon.h>
+#include <QChar>
+
+/* Internal helper for reverse-looking a character to a native keycode. */
+
+bool charToNativeKeyCode(const UCKeyboardLayout* layout,
+                         UInt32 keyboardType,
+                         const QChar& ch,
+                         uint16_t& outKeyCode,
+                         CGEventFlags& outFlags);
+
+#endif // KEEPASSXC_AUTOTYPEMAC_P_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,12 @@ add_unit_test(NAME testautotype SOURCES TestAutoType.cpp
         LIBS testsupport ${TEST_LIBRARIES})
 set_target_properties(testautotype PROPERTIES ENABLE_EXPORTS ON)
 
+if(APPLE)
+    add_unit_test(NAME testautotypemac SOURCES TestAutoTypeMac.cpp
+                   ${CMAKE_SOURCE_DIR}/src/autotype/mac/AutoTypeMac.cpp
+            LIBS ${TEST_LIBRARIES} "-framework Carbon" "-framework ApplicationServices" "-framework CoreFoundation")
+endif()
+
 add_unit_test(NAME testentry SOURCES TestEntry.cpp
         LIBS ${TEST_LIBRARIES})
 
@@ -177,7 +183,7 @@ if(KPXC_FEATURE_NETWORK)
     add_unit_test(NAME testupdatecheck SOURCES TestUpdateCheck.cpp
         LIBS ${TEST_LIBRARIES})
 
-    add_unit_test(NAME testicondownloader SOURCES TestIconDownloader.cpp 
+    add_unit_test(NAME testicondownloader SOURCES TestIconDownloader.cpp
         LIBS ${TEST_LIBRARIES})
 endif()
 

--- a/tests/TestAutoTypeMac.cpp
+++ b/tests/TestAutoTypeMac.cpp
@@ -1,0 +1,161 @@
+/*
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestAutoTypeMac.h"
+
+#include "autotype/mac/AutoTypeMac_p.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <QTest>
+
+void TestAutoTypeMac::initTestCase()
+{
+    QLocale::setDefault(QLocale::c());
+}
+
+// Forward lookup: produce a glyph from a keycode + UCKeyTranslate modifier state
+static bool
+translateKeyCode(const UCKeyboardLayout* layout, UInt32 keyboardType, uint16_t keyCode, UInt32 mods, QChar& outGlyph)
+{
+    UInt32 deadKeyState = 0;
+    UniCharCount actualLen = 0;
+    UniChar unicode[4];
+
+    OSStatus status = UCKeyTranslate(layout,
+                                     keyCode,
+                                     kUCKeyActionDown,
+                                     mods,
+                                     keyboardType,
+                                     kUCKeyTranslateNoDeadKeysBit,
+                                     &deadKeyState,
+                                     4,
+                                     &actualLen,
+                                     unicode);
+    if (status != noErr || actualLen != 1) {
+        return false;
+    }
+    outGlyph = QChar(unicode[0]);
+    return true;
+}
+
+// Load a specific keyboard layout by its input source ID (e.g. "com.apple.keylayout.US")
+static const UCKeyboardLayout* layoutById(const char* sourceId)
+{
+    CFStringRef idRef = CFStringCreateWithCString(kCFAllocatorDefault, sourceId, kCFStringEncodingUTF8);
+    CFStringRef key = kTISPropertyInputSourceID;
+    CFDictionaryRef filter = CFDictionaryCreate(kCFAllocatorDefault,
+                                                reinterpret_cast<const void**>(&key),
+                                                reinterpret_cast<const void**>(&idRef),
+                                                1,
+                                                &kCFTypeDictionaryKeyCallBacks,
+                                                &kCFTypeDictionaryValueCallBacks);
+    CFArrayRef sources = TISCreateInputSourceList(filter, true);
+    CFRelease(idRef);
+    CFRelease(filter);
+    if (!sources || CFArrayGetCount(sources) == 0) {
+        if (sources)
+            CFRelease(sources);
+        return nullptr;
+    }
+
+    TISInputSourceRef keyboard = static_cast<TISInputSourceRef>(const_cast<void*>(CFArrayGetValueAtIndex(sources, 0)));
+    CFDataRef layoutData =
+        static_cast<CFDataRef>(TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData));
+    const UCKeyboardLayout* layout = nullptr;
+    if (layoutData) {
+        layout = reinterpret_cast<const UCKeyboardLayout*>(CFDataGetBytePtr(layoutData));
+    }
+    CFRelease(sources);
+    return layout;
+}
+
+void TestAutoTypeMac::testReverseLookupRoundTrip()
+{
+    auto layout = layoutById("com.apple.keylayout.US");
+    QVERIFY2(layout, "U.S. keyboard layout not available");
+    UInt32 kbType = LMGetKbdType();
+
+    static const UInt32 kUCTShift = shiftKey >> 8;
+    static const UInt32 kUCTOption = optionKey >> 8;
+    static const UInt32 mods[] = {0, kUCTShift, kUCTOption, kUCTShift | kUCTOption};
+
+    for (uint16_t keyCode = 0; keyCode < 128; keyCode++) {
+        for (UInt32 mod : mods) {
+            QChar glyph;
+            if (!translateKeyCode(layout, kbType, keyCode, mod, glyph)) {
+                continue;
+            }
+
+            // Reverse-lookup the glyph
+            uint16_t resolvedKeyCode = 0;
+            CGEventFlags resolvedFlags = 0;
+            QVERIFY2(charToNativeKeyCode(layout, kbType, glyph, resolvedKeyCode, resolvedFlags),
+                     qPrintable(QString("charToNativeKeyCode returned false for '%1' (U+%2)")
+                                    .arg(glyph)
+                                    .arg(static_cast<int>(glyph.unicode()), 4, 16, QChar('0'))));
+
+            // Feed the resolved keycode+flags back through UCKeyTranslate
+            // and verify we get the same glyph
+            UInt32 resolvedMods = 0;
+            if (resolvedFlags & kCGEventFlagMaskShift) {
+                resolvedMods |= kUCTShift;
+            }
+            if (resolvedFlags & kCGEventFlagMaskAlternate) {
+                resolvedMods |= kUCTOption;
+            }
+
+            QChar roundTripGlyph;
+            QVERIFY2(translateKeyCode(layout, kbType, resolvedKeyCode, resolvedMods, roundTripGlyph),
+                     qPrintable(QString("Round-trip UCKeyTranslate failed for '%1'").arg(glyph)));
+            QCOMPARE(roundTripGlyph, glyph);
+        }
+    }
+}
+
+void TestAutoTypeMac::testUnmappableReturnsFalse()
+{
+    auto layout = layoutById("com.apple.keylayout.US");
+    QVERIFY2(layout, "U.S. keyboard layout not available");
+    UInt32 kbType = LMGetKbdType();
+
+    uint16_t keyCode = 0;
+    CGEventFlags flags = 0;
+    // U+4E2D (中, CJK ideograph) — not a single keystroke on U.S. layout
+    QVERIFY(!charToNativeKeyCode(layout, kbType, QChar(0x4E2D), keyCode, flags));
+}
+
+void TestAutoTypeMac::testModifierMapping()
+{
+    auto layout = layoutById("com.apple.keylayout.US");
+    QVERIFY2(layout, "U.S. keyboard layout not available");
+    UInt32 kbType = LMGetKbdType();
+
+    // 'A' (uppercase) should require shift
+    uint16_t keyCode = 0;
+    CGEventFlags flags = 0;
+    QVERIFY(charToNativeKeyCode(layout, kbType, QChar('A'), keyCode, flags));
+    QVERIFY2(flags & kCGEventFlagMaskShift,
+             qPrintable(QString("Expected Shift flag for 'A', got flags=0x%1").arg(flags, 0, 16)));
+
+    // 'a' (lowercase) should not require shift
+    flags = 0;
+    QVERIFY(charToNativeKeyCode(layout, kbType, QChar('a'), keyCode, flags));
+    QVERIFY2(!(flags & kCGEventFlagMaskShift),
+             qPrintable(QString("Expected no Shift flag for 'a', got flags=0x%1").arg(flags, 0, 16)));
+}
+
+QTEST_GUILESS_MAIN(TestAutoTypeMac)

--- a/tests/TestAutoTypeMac.h
+++ b/tests/TestAutoTypeMac.h
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTAUTOTYPEMAC_H
+#define KEEPASSXC_TESTAUTOTYPEMAC_H
+
+#include <QObject>
+
+class TestAutoTypeMac : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void testReverseLookupRoundTrip();
+    void testUnmappableReturnsFalse();
+    void testModifierMapping();
+};
+
+#endif // KEEPASSXC_TESTAUTOTYPEMAC_H


### PR DESCRIPTION
This adds support for typing through Screen Sharing (and presumably VNC and similar keyboard passthrough windows) https://github.com/keepassxreboot/keepassxc/issues/8433
It works similarly to the windows approach except VkKeyScanExW doesn't exist on OSX. (as far as I can tell) and so we have to enumerate through all the keycodes * modifiers to find the keyboard event to character mapping. This could be more efficient with caching it but it was fast enough as is so I thought it wasn't worth the complexity of caching the mapping. This still uses the `else if (mode == Mode::VIRTUAL)` branch to gate everything so these changes shouldn't impact regular use.

There are a couple limitations to this approach:
* It doesn't work if the keyboard of the host and the remote differ with regard to any of the text being typed.
* It can't type passwords that take more than a keypress and a modifier

I didn't see a way to avoid the limitations when the keypresses are being forwarded to the remote.

An alternative approach would be to always do the key to text mapping lookup, this would let the remote typing to work in a lot of situations without needing {MODE=VIRTUAL}, but that doesn't allow for error messages when the mapping fails and I didn't want to make this kind of change on the main autotype path, if you want that change I can do that but it'll swallow errors.

On that note, I made {MODE=VIRTUAL} fail with an error if the key to text mapping failed, the error has the same text as a similar failure in `AutoTypeXCB.cpp`. **I didn't wire up the translations as I thought that might make the PR harder to read. Do you want me to add the translations or maybe do something else?**

Generative AI was used extensively. I am not deeply familiar with either qt or cocoa.

## Testing strategy
Ran autotype from an osx laptop to a osx remote via Screen Sharing
* {MODE=VIRTUAL} with over the enumerations of combinations of username,password,enter,tab. Worked as expected
* {MODE=VIRTUAL} with a password that wasn't typeable, got an error message as expected.
* same without {MODE=VIRTUAL}, writes 'a' instead as expected
Ran autotype from an osx laptop to the local console window
* Same tests as above, same results for the first two, and for the third everything works (no {MODE=VIRTUAL})

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)