### PR TITLE
fixed dead keys in master password input

### DIFF
--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -122,6 +122,9 @@ void PasswordWidget::setText(const QString& text)
 void PasswordWidget::setEchoMode(QLineEdit::EchoMode mode)
 {
     m_ui->passwordEdit->setEchoMode(mode);
+    auto hints = m_ui->passwordEdit->inputMethodHints();
+    hints.setFlag(Qt::ImhHiddenText, false);
+    m_ui->passwordEdit->setInputMethodHints(hints);
 }
 
 void PasswordWidget::clear()


### PR DESCRIPTION
My master key contains a backtick. When showing the password in plain text while entering, I can enter it with the dead key on my German keyboard just fine. But if the input is hidden, the dead key doesn't work and the backtick is simply ommited. I'm using Linux Mint.

I asked Claude to fix it and this PR is what it came up with and it seems to work fine. Looking at the code, the position seems questionable and it might very well not be a desired change if it messes with security. In that case, just close the PR.

Here's the comment that Claude added alongside the code:
```
+    // QLineEdit::setEchoMode() sets Qt::ImhHiddenText whenever the field is
+    // masked (Password/NoEcho). On Linux that hint causes input methods such as
+    // IBus/Fcitx to disable composition for the field, which breaks dead keys
+    // (e.g. the grave accent ` or other accent dead keys): the character is lost
+    // while masked but works once the password is made visible. Masking is done
+    // by the echo mode itself and does not depend on this hint, so clear it while
+    // keeping ImhSensitiveData/ImhNoPredictiveText so the input method still
+    // won't learn or predict the password.
```

## Testing strategy
I tested my password containing a backtick with a German keyboard on the current `develop` branch and with the fix.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
