### PR TITLE
Fix: center unlock dialog on screen when triggered from system tray

### DIFF
--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -19,7 +19,9 @@
 #include "AutoTypeSelectDialog.h"
 #include "ui_AutoTypeSelectDialog.h"
 
+#include <QApplication>
 #include <QCloseEvent>
+#include <QCursor>
 #include <QMenu>
 #include <QScreen>
 #include <QShortcut>
@@ -30,6 +32,7 @@
 #include "core/EntrySearcher.h"
 #include "core/Group.h"
 #include "gui/Clipboard.h"
+#include "gui/GuiTools.h"
 #include "gui/Icons.h"
 
 const auto MENU_FIELD_PROP_NAME = "menu_field";
@@ -407,21 +410,18 @@ void AutoTypeSelectDialog::showEvent(QShowEvent* event)
 {
     QDialog::showEvent(event);
 
+    // Resize to last used size
+    QSize size = config()->get(Config::GUI_AutoTypeSelectDialogSize).toSize();
     auto screen = QApplication::screenAt(QCursor::pos());
     if (!screen) {
-        // screenAt can return a nullptr, default to the primary screen
         screen = QApplication::primaryScreen();
     }
     QRect screenGeometry = screen->availableGeometry();
-
-    // Resize to last used size
-    QSize size = config()->get(Config::GUI_AutoTypeSelectDialogSize).toSize();
     size.setWidth(qMin(size.width(), screenGeometry.width()));
     size.setHeight(qMin(size.height(), screenGeometry.height()));
     resize(size);
 
-    // move dialog to the center of the screen
-    move(screenGeometry.center().x() - (size.width() / 2), screenGeometry.center().y() - (size.height() / 2));
+    GuiTools::centerWidgetOnActiveScreen(this);
 }
 
 void AutoTypeSelectDialog::hideEvent(QHideEvent* event)

--- a/src/autotype/PickcharsDialog.cpp
+++ b/src/autotype/PickcharsDialog.cpp
@@ -18,10 +18,10 @@
 #include "PickcharsDialog.h"
 #include "ui_PickcharsDialog.h"
 
+#include "gui/GuiTools.h"
 #include "gui/Icons.h"
 
 #include <QPushButton>
-#include <QScreen>
 #include <QShortcut>
 
 PickcharsDialog::PickcharsDialog(const QString& string, QWidget* parent)
@@ -152,12 +152,5 @@ void PickcharsDialog::showEvent(QShowEvent* event)
 {
     QDialog::showEvent(event);
 
-    // Center on active screen
-    auto screen = QApplication::screenAt(QCursor::pos());
-    if (!screen) {
-        // screenAt can return a nullptr, default to the primary screen
-        screen = QApplication::primaryScreen();
-    }
-    QRect screenGeometry = screen->availableGeometry();
-    move(screenGeometry.center().x() - (size().width() / 2), screenGeometry.center().y() - (size().height() / 2));
+    GuiTools::centerWidgetOnActiveScreen(this);
 }

--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -20,12 +20,10 @@
 #include "DatabaseOpenWidget.h"
 #include "DatabaseTabWidget.h"
 #include "DatabaseWidget.h"
+#include "GuiTools.h"
 
-#include <QApplication>
-#include <QCursor>
 #include <QFileInfo>
 #include <QLayout>
-#include <QScreen>
 #include <QShortcut>
 
 DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
@@ -81,12 +79,7 @@ void DatabaseOpenDialog::showEvent(QShowEvent* event)
 {
     QDialog::showEvent(event);
 
-    auto screen = QApplication::screenAt(QCursor::pos());
-    if (!screen) {
-        screen = QApplication::primaryScreen();
-    }
-    QRect screenGeometry = screen->availableGeometry();
-    move(screenGeometry.center().x() - (width() / 2), screenGeometry.center().y() - (height() / 2));
+    GuiTools::centerWidgetOnActiveScreen(this);
 
     QTimer::singleShot(100, this, [this] {
         if (m_view->isOnQuickUnlockScreen() && !m_view->unlockingDatabase()) {

--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -21,8 +21,11 @@
 #include "DatabaseTabWidget.h"
 #include "DatabaseWidget.h"
 
+#include <QApplication>
+#include <QCursor>
 #include <QFileInfo>
 #include <QLayout>
+#include <QScreen>
 #include <QShortcut>
 
 DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
@@ -77,6 +80,14 @@ DatabaseOpenDialog::DatabaseOpenDialog(QWidget* parent)
 void DatabaseOpenDialog::showEvent(QShowEvent* event)
 {
     QDialog::showEvent(event);
+
+    auto screen = QApplication::screenAt(QCursor::pos());
+    if (!screen) {
+        screen = QApplication::primaryScreen();
+    }
+    QRect screenGeometry = screen->availableGeometry();
+    move(screenGeometry.center().x() - (width() / 2), screenGeometry.center().y() - (height() / 2));
+
     QTimer::singleShot(100, this, [this] {
         if (m_view->isOnQuickUnlockScreen() && !m_view->unlockingDatabase()) {
             m_view->triggerQuickUnlock();

--- a/src/gui/GuiTools.cpp
+++ b/src/gui/GuiTools.cpp
@@ -21,6 +21,10 @@
 #include "core/Group.h"
 #include "gui/MessageBox.h"
 
+#include <QApplication>
+#include <QCursor>
+#include <QScreen>
+
 namespace GuiTools
 {
     bool confirmDeleteEntries(QWidget* parent, const QList<Entry*>& entries, bool permanent)
@@ -135,5 +139,25 @@ namespace GuiTools
             }
         }
         return selectedEntries.size();
+    }
+
+    void centerWidgetOnActiveScreen(QWidget* widget)
+    {
+        if (!widget) {
+            return;
+        }
+
+        auto screen = QApplication::screenAt(QCursor::pos());
+        if (!screen) {
+            screen = QApplication::primaryScreen();
+        }
+        if (!screen) {
+            return;
+        }
+
+        const QRect screenGeometry = screen->availableGeometry();
+        auto frameGeometry = widget->frameGeometry();
+        frameGeometry.moveCenter(screenGeometry.center());
+        widget->move(frameGeometry.topLeft());
     }
 } // namespace GuiTools

--- a/src/gui/GuiTools.cpp
+++ b/src/gui/GuiTools.cpp
@@ -22,7 +22,6 @@
 #include "gui/MessageBox.h"
 
 #include <QApplication>
-#include <QCursor>
 #include <QScreen>
 
 namespace GuiTools

--- a/src/gui/GuiTools.h
+++ b/src/gui/GuiTools.h
@@ -29,6 +29,7 @@ namespace GuiTools
     bool confirmDeleteEntries(QWidget* parent, const QList<Entry*>& entries, bool permanent);
     bool confirmDeletePluginData(QWidget* parent, const QList<Entry*>& entries);
     size_t deleteEntriesResolveReferences(QWidget* parent, const QList<Entry*>& entries, bool permanent);
+    void centerWidgetOnActiveScreen(QWidget* widget);
 } // namespace GuiTools
 
 /**


### PR DESCRIPTION
When KeePassXC is minimized to the system tray and the unlock dialog is shown (e.g. via global Auto-Type shortcut), the dialog appears in the top-left corner instead of centered because Qt has no valid parent window geometry to position against.

Add centering logic to DatabaseOpenDialog::showEvent() using QApplication::screenAt(QCursor::pos()), consistent with the existing implementation in AutoTypeSelectDialog.

Fixes the issue where popup windows appear in upper left of screen on Windows with Qt6.

Fixes #13375 

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
1. build this branch and run KeePassXC.
2. "Application Settings" -> "Auto-type" -> "Global Auto-Type shortcut": set a shortcut you like (eg: Ctrl + Alt + Space)
3. open a keepass database file. lock the db and minimise the window.
4. use the shortcut to call an unlock window, and can see it located center

[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)