### PR TITLE
Fix multiple spelling typos across codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@
 * SSH Agent: Add timeout to streams to prevent deadlock [#11290]
 * macOS: Replace legacy code for screen recording permissions [#11428]
 * macOS: Implement Secure Input Mode [#11623]
-* macOS: Fix showing ambigious name in settings [#11373]
+* macOS: Fix showing ambiguous name in settings [#11373]
 * macOS: Fix copy-to-clipboard shortcut in entry preview widget [#10966]
 * Linux: Prevent multiple lock requests [#11306]
 * Snap: Prevent need for snap helper script to configure browser extension [#10924]
@@ -535,7 +535,7 @@
 ### Fixed
 
 - Allow setting MSI properties in unattended install [#6196]
-- Update MainWindow minimum size to enable smaller verticle space [#6196]
+- Update MainWindow minimum size to enable smaller vertical space [#6196]
 - Use application font size when setting default or monospace fonts [#6332]
 - Fix notes not clearing in entry preview panel in some cases [#6481]
 - macOS: Correct window activation when restoring from tray [#6575]

--- a/share/linux/org.keepassxc.KeePassXC.appdata.xml
+++ b/share/linux/org.keepassxc.KeePassXC.appdata.xml
@@ -195,7 +195,7 @@
           <li>SSH Agent: Add timeout to streams to prevent deadlock [#11290]</li>
           <li>macOS: Replace legacy code for screen recording permissions [#11428]</li>
           <li>macOS: Implement Secure Input Mode [#11623]</li>
-          <li>macOS: Fix showing ambigious name in settings [#11373]</li>
+          <li>macOS: Fix showing ambiguous name in settings [#11373]</li>
           <li>macOS: Fix copy-to-clipboard shortcut in entry preview widget [#10966]</li>
           <li>Linux: Prevent multiple lock requests [#11306]</li>
           <li>Snap: Prevent need for snap helper script to configure browser extension [#10924]</li>
@@ -572,7 +572,7 @@
           <li>Save Always on Top setting [#6236]</li>
           <li>Password generator can exclude additional lookalike characters (6/G, 8/B) [#6196]</li>
           <li>Allow setting MSI properties in unattended install [#6196]</li>
-          <li>Update MainWindow minimum size to enable smaller verticle space [#6196]</li>
+          <li>Update MainWindow minimum size to enable smaller vertical space [#6196]</li>
           <li>Use application font size when setting default or monospace fonts [#6332]</li>
           <li>Fix notes not clearing in entry preview panel in some cases [#6481]</li>
           <li>macOS: Correct window activation when restoring from tray [#6575]</li>

--- a/src/fdosecrets/dbus/DBusMgr.h
+++ b/src/fdosecrets/dbus/DBusMgr.h
@@ -28,7 +28,7 @@
 #include <QtDBus>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
-// Include the header only for moc file. Workaround for the class forward definiton error with older Qt 6 versions.
+// Include the header only for moc file. Workaround for the class forward definition error with older Qt 6 versions.
 Q_MOC_INCLUDE("fdosecrets/objects/Item.h")
 #endif
 

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -148,14 +148,14 @@ void NixUtils::setLaunchAtStartup(bool enable)
 
         const QString appImagePath = QString::fromLocal8Bit(qgetenv("APPIMAGE"));
         const bool isAppImage = !appImagePath.isNull() && QFile::exists(appImagePath);
-        const QString executeablePathOrName = isAppImage ? appImagePath : QApplication::applicationName().toLower();
+        const QString executablePathOrName = isAppImage ? appImagePath : QApplication::applicationName().toLower();
 
         QTextStream stream(&desktopFile);
         stream << QStringLiteral("[Desktop Entry]") << '\n'
                << QStringLiteral("Name=") << QApplication::applicationDisplayName() << '\n'
                << QStringLiteral("GenericName=") << tr("Password Manager") << '\n'
-               << QStringLiteral("Exec=") << executeablePathOrName << '\n'
-               << QStringLiteral("TryExec=") << executeablePathOrName << '\n'
+               << QStringLiteral("Exec=") << executablePathOrName << '\n'
+               << QStringLiteral("TryExec=") << executablePathOrName << '\n'
                << QStringLiteral("Icon=") << QApplication::applicationName().toLower() << '\n'
                << QStringLiteral("StartupWMClass=keepassxc") << '\n'
                << QStringLiteral("StartupNotify=false") << '\n'

--- a/src/keeshare/SettingsWidgetKeeShare.cpp
+++ b/src/keeshare/SettingsWidgetKeeShare.cpp
@@ -34,7 +34,7 @@ SettingsWidgetKeeShare::SettingsWidgetKeeShare(QWidget* parent)
     m_ui->setupUi(this);
 
     connect(m_ui->ownCertificateSignerEdit, SIGNAL(textChanged(QString)), SLOT(setVerificationExporter(QString)));
-    connect(m_ui->generateOwnCerticateButton, SIGNAL(clicked(bool)), SLOT(generateCertificate()));
+    connect(m_ui->generateOwnCertificateButton, SIGNAL(clicked(bool)), SLOT(generateCertificate()));
 }
 
 SettingsWidgetKeeShare::~SettingsWidgetKeeShare()

--- a/src/keeshare/SettingsWidgetKeeShare.ui
+++ b/src/keeshare/SettingsWidgetKeeShare.ui
@@ -82,7 +82,7 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QPushButton" name="generateOwnCerticateButton">
+       <widget class="QPushButton" name="generateOwnCertificateButton">
         <property name="accessibleName">
          <string>Generate new certificate</string>
         </property>

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -524,7 +524,7 @@ void TestMerge::testDeletionConflictTemplate(int mergeMode,
 
     QPointer<Group> targetGroupDeletedInTargetAfterEntryUpdatedInSource =
         dbDestination->rootGroup()->findGroupByUuid(identifiers["GroupDeletedInTargetAfterEntryUpdatedInSource"]);
-    QPointer<Entry> sourceEntryDeletedInTargetAfterEntryUpdatedInSoruce =
+    QPointer<Entry> sourceEntryDeletedInTargetAfterEntryUpdatedInSource =
         dbSource->rootGroup()->findEntryByUuid(identifiers["EntryDeletedInTargetAfterEntryUpdatedInSource"]);
 
     // simulate some work in the dbs (manipulate the history)
@@ -538,7 +538,7 @@ void TestMerge::testDeletionConflictTemplate(int mergeMode,
     delete sourceGroupDeletedInSourceBeforeEntryUpdatedInTarget.data();
     changeEntry(targetEntryDeletedInSourceAfterEntryUpdatedInTarget);
     delete targetGroupDeletedInTargetBeforeEntryUpdatedInSource.data();
-    changeEntry(sourceEntryDeletedInTargetAfterEntryUpdatedInSoruce);
+    changeEntry(sourceEntryDeletedInTargetAfterEntryUpdatedInSource);
 
     m_clock->advanceMinute(1);
 
@@ -997,8 +997,8 @@ void TestMerge::testUpdateGroupLocation()
     QVERIFY(group3SourceMoved != nullptr);
     group3SourceMoved->setParent(dbSource->rootGroup()->findChildByName("group2"));
 
-    QDateTime movedLocaltionChanged = group3SourceMoved->timeInfo().locationChanged();
-    QVERIFY(initialLocationChanged < movedLocaltionChanged);
+    QDateTime movedLocationChanged = group3SourceMoved->timeInfo().locationChanged();
+    QVERIFY(initialLocationChanged < movedLocationChanged);
 
     m_clock->advanceSecond(1);
 
@@ -1008,7 +1008,7 @@ void TestMerge::testUpdateGroupLocation()
     QPointer<Group> group3DestinationMerged1 = dbDestination->rootGroup()->findGroupByUuid(group3Uuid);
     QVERIFY(group3DestinationMerged1 != nullptr);
     QCOMPARE(group3DestinationMerged1->parent(), dbDestination->rootGroup()->findChildByName("group2"));
-    QCOMPARE(group3DestinationMerged1->timeInfo().locationChanged(), movedLocaltionChanged);
+    QCOMPARE(group3DestinationMerged1->timeInfo().locationChanged(), movedLocationChanged);
 
     m_clock->advanceSecond(1);
 
@@ -1018,7 +1018,7 @@ void TestMerge::testUpdateGroupLocation()
     QPointer<Group> group3DestinationMerged2 = dbDestination->rootGroup()->findGroupByUuid(group3Uuid);
     QVERIFY(group3DestinationMerged2 != nullptr);
     QCOMPARE(group3DestinationMerged2->parent(), dbDestination->rootGroup()->findChildByName("group2"));
-    QCOMPARE(group3DestinationMerged1->timeInfo().locationChanged(), movedLocaltionChanged);
+    QCOMPARE(group3DestinationMerged1->timeInfo().locationChanged(), movedLocationChanged);
 }
 
 /**

--- a/tests/gui/attachments/TestEditEntryAttachmentsDialog.cpp
+++ b/tests/gui/attachments/TestEditEntryAttachmentsDialog.cpp
@@ -73,7 +73,7 @@ void TestEditEntryAttachmentsDialog::testSetAttachmentTwice()
     QCOMPARE(attachments.data, TestImage.data);
 }
 
-void TestEditEntryAttachmentsDialog::testBottonsBox()
+void TestEditEntryAttachmentsDialog::testButtonsBox()
 {
     const attachments::Attachment TestText{.name = "text.txt", .data = "Test"};
     m_editDialog->setAttachment(TestText);

--- a/tests/gui/attachments/TestEditEntryAttachmentsDialog.h
+++ b/tests/gui/attachments/TestEditEntryAttachmentsDialog.h
@@ -32,7 +32,7 @@ private slots:
     void testSetAttachment();
     void testSetAttachmentTwice();
 
-    void testBottonsBox();
+    void testButtonsBox();
 
 private:
     QScopedPointer<EditEntryAttachmentsDialog> m_editDialog{};

--- a/tests/gui/attachments/TestImageAttachmentsView.cpp
+++ b/tests/gui/attachments/TestImageAttachmentsView.cpp
@@ -12,7 +12,7 @@ void TestImageAttachmentsView::initTestCase()
 {
     m_view.reset(new ImageAttachmentsView());
 
-    // Generate the black rectange.
+    // Generate the black rectangle.
     QImage image(1000, 1000, QImage::Format_RGB32);
     image.fill(Qt::black);
 

--- a/tests/gui/attachments/TestImageAttachmentsWidget.cpp
+++ b/tests/gui/attachments/TestImageAttachmentsWidget.cpp
@@ -18,7 +18,7 @@ void TestImageAttachmentsWidget::initTestCase()
     m_imageAttachmentsView = m_widget->findChild<ImageAttachmentsView*>("imagesView");
     QVERIFY(m_imageAttachmentsView);
 
-    // Generate the black rectange.
+    // Generate the black rectangle.
     QImage image(1000, 1000, QImage::Format_RGB32);
     image.fill(Qt::black);
 

--- a/tests/gui/attachments/TestPreviewEntryAttachmentsDialog.cpp
+++ b/tests/gui/attachments/TestPreviewEntryAttachmentsDialog.cpp
@@ -73,7 +73,7 @@ void TestPreviewEntryAttachmentsDialog::testSetAttachmentTwice()
     QCOMPARE(attachments.data, TestImage.data);
 }
 
-void TestPreviewEntryAttachmentsDialog::testBottonsBox()
+void TestPreviewEntryAttachmentsDialog::testButtonsBox()
 {
     const attachments::Attachment TestText{.name = "text.txt", .data = "Test"};
     m_previewDialog->setAttachment(TestText);

--- a/tests/gui/attachments/TestPreviewEntryAttachmentsDialog.h
+++ b/tests/gui/attachments/TestPreviewEntryAttachmentsDialog.h
@@ -33,7 +33,7 @@ private slots:
     void testSetAttachment();
     void testSetAttachmentTwice();
 
-    void testBottonsBox();
+    void testButtonsBox();
 
 private:
     QScopedPointer<PreviewEntryAttachmentsDialog> m_previewDialog{};

--- a/utils/keepassxc-cr-recovery/main.go
+++ b/utils/keepassxc-cr-recovery/main.go
@@ -170,11 +170,11 @@ func main() {
 	}
 
 	if len(challenge) < 64 {
-		padd := make([]byte, 64-len(challenge))
-		for i, _ := range padd {
-			padd[i] = byte(64-len(challenge))
+		pad := make([]byte, 64-len(challenge))
+		for i, _ := range pad {
+			pad[i] = byte(64-len(challenge))
 		}
-		challenge = append(challenge[:], padd[:]...)
+		challenge = append(challenge[:], pad[:]...)
 	}
 
 	mac := hmac.New(sha1.New, secret)


### PR DESCRIPTION
Closes #13423

## Changes

| Typo | Correction | Files |
|------|-----------|-------|
| `ambigious` | `ambiguous` | CHANGELOG.md, appdata.xml |
| `verticle` | `vertical` | CHANGELOG.md, appdata.xml |
| `definiton` | `definition` | src/fdosecrets/dbus/DBusMgr.h |
| `executeable` | `executable` | src/gui/osutils/nixutils/NixUtils.cpp |
| `Certicate` | `Certificate` | src/keeshare/SettingsWidgetKeeShare.cpp, .ui |
| `Localtion` | `Location` | tests/TestMerge.cpp |
| `Bottons` | `Buttons` | tests/gui/attachments/ |
| `rectange` | `rectangle` | tests/gui/attachments/ |
| `padd` | `pad` | utils/keepassxc-cr-recovery/main.go |
  --head luojiyin1987:fix/typos   --base develop