### PR TITLE
Fix KeePassXC-Browser extension not connecting to Brave on macOS

### DIFF
--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -48,8 +48,8 @@ namespace
     const QString TARGET_DIR_VIVALDI = QStringLiteral("/Library/Application Support/Vivaldi/NativeMessagingHosts");
     const QString TARGET_DIR_TOR_BROWSER =
         QStringLiteral("/Library/Application Support/TorBrowser-Data/Browser/Mozilla/NativeMessagingHosts");
-    const QString TARGET_DIR_BRAVE =
-        QStringLiteral("/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts");
+    // Brave on macOS uses Chrome's native messaging directory, same as on Windows (keepassxc-browser#2328)
+    const QString TARGET_DIR_BRAVE = TARGET_DIR_CHROME;
     const QString TARGET_DIR_EDGE = QStringLiteral("/Library/Application Support/Microsoft Edge/NativeMessagingHosts");
 #elif defined(Q_OS_WIN)
     const QString TARGET_DIR_CHROME = QStringLiteral(


### PR DESCRIPTION
On macOS, Brave reads native messaging host manifests from Chrome's `NativeMessagingHosts` directory, not its own `BraveSoftware/Brave-Browser` one. KeePassXC writes the Brave manifest to the BraveSoftware path, so the extension never finds it and fails with *"Specified native messaging host not found"*.

### Fix
Map Brave to Chrome's directory on macOS, mirroring the existing **Windows** behavior in this same file (`TARGET_DIR_BRAVE == TARGET_DIR_CHROME`).

### Testing
macOS 26.5 (arm64), Brave 149, keepassxc-browser 1.10.3:
- **Before:** manifest only in the BraveSoftware dir → "Specified native messaging host not found".
- **After:** patched build writes the manifest to Chrome's dir → Brave connects successfully; confirmed it is **not** written to the BraveSoftware dir.

Fixes keepassxreboot/keepassxc-browser#2328