### PR TITLE
Make tags clickable in preview panel

### DIFF
--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -206,6 +206,7 @@ DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     connect(this, SIGNAL(currentModeChanged(DatabaseWidget::Mode)), m_previewView, SLOT(setDatabaseMode(DatabaseWidget::Mode)));
     connect(m_previewView, SIGNAL(entryUrlActivated(Entry*)), SLOT(openUrlForEntry(Entry*)));
     connect(m_previewView, SIGNAL(copyTextRequested(const QString&)), SLOT(setClipboardTextAndMinimize(const QString&)));
+    connect(m_previewView, SIGNAL(tagSearchRequested(QString)), this, SIGNAL(requestSearch(QString)));
     connect(m_entryView, SIGNAL(viewStateChanged()), SIGNAL(entryViewStateChanged()));
     connect(m_groupView, SIGNAL(groupSelectionChanged()), SLOT(onGroupChanged()));
     connect(m_groupView, &GroupView::groupFocused, this, [this] { m_previewView->setGroup(currentGroup()); });

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -69,6 +69,7 @@ EntryPreviewWidget::EntryPreviewWidget(QWidget* parent)
     m_ui->entryTotpLabel->installEventFilter(this);
 
     connect(m_ui->entryTotpButton, SIGNAL(toggled(bool)), m_ui->entryTotp, SLOT(setVisible(bool)));
+    connect(m_ui->entryTagsList, SIGNAL(tagClicked(QString)), this, SIGNAL(tagSearchRequested(QString)));
     connect(m_ui->entryCloseButton, SIGNAL(clicked()), SLOT(hide()));
     connect(m_ui->toggleUsernameButton, SIGNAL(clicked(bool)), SLOT(setUsernameVisible(bool)));
     connect(m_ui->togglePasswordButton, SIGNAL(clicked(bool)), SLOT(setPasswordVisible(bool)));

--- a/src/gui/EntryPreviewWidget.h
+++ b/src/gui/EntryPreviewWidget.h
@@ -47,6 +47,7 @@ public slots:
 signals:
     void entryUrlActivated(Entry* entry);
     void copyTextRequested(const QString& text);
+    void tagSearchRequested(const QString& search);
 
 protected:
     bool eventFilter(QObject* object, QEvent* event) override;

--- a/src/gui/tag/TagsEdit.cpp
+++ b/src/gui/tag/TagsEdit.cpp
@@ -695,6 +695,23 @@ void TagsEdit::timerEvent(QTimerEvent* event)
 
 void TagsEdit::mousePressEvent(QMouseEvent* event)
 {
+    if (m_readOnly) {
+        for (int i = 0; i < impl->tags.size(); ++i) {
+            if (!impl->tags[i].isEmpty()
+                && impl->tags[i]
+                       .rect.translated(-horizontalScrollBar()->value(), -verticalScrollBar()->value())
+                       .contains(event->pos())) {
+                auto tag = impl->tags[i].text;
+                tag.replace("\"", "\\\"");
+                emit tagClicked(QString("tag:\"%1\"").arg(tag));
+                event->accept();
+                return;
+            }
+        }
+        event->ignore();
+        return;
+    }
+
     bool found = false;
     for (int i = 0; i < impl->tags.size(); ++i) {
         if (impl->inCrossArea(i, event->pos())) {
@@ -940,18 +957,30 @@ QStringList TagsEdit::tags() const
 
 void TagsEdit::mouseMoveEvent(QMouseEvent* event)
 {
-    if (!m_readOnly) {
+    if (m_readOnly) {
         for (int i = 0; i < impl->tags.size(); ++i) {
-            if (impl->inCrossArea(i, event->pos())) {
-                viewport()->setCursor(Qt::ArrowCursor);
+            if (!impl->tags[i].isEmpty()
+                && impl->tags[i]
+                       .rect.translated(-horizontalScrollBar()->value(), -verticalScrollBar()->value())
+                       .contains(event->pos())) {
+                viewport()->setCursor(Qt::PointingHandCursor);
                 return;
             }
         }
-        if (impl->contentsRect().contains(event->pos())) {
-            viewport()->setCursor(Qt::IBeamCursor);
-        } else {
-            QAbstractScrollArea::mouseMoveEvent(event);
+        viewport()->setCursor(Qt::ArrowCursor);
+        return;
+    }
+
+    for (int i = 0; i < impl->tags.size(); ++i) {
+        if (impl->inCrossArea(i, event->pos())) {
+            viewport()->setCursor(Qt::ArrowCursor);
+            return;
         }
+    }
+    if (impl->contentsRect().contains(event->pos())) {
+        viewport()->setCursor(Qt::IBeamCursor);
+    } else {
+        QAbstractScrollArea::mouseMoveEvent(event);
     }
 }
 

--- a/src/gui/tag/TagsEdit.h
+++ b/src/gui/tag/TagsEdit.h
@@ -57,6 +57,7 @@ public:
 
 signals:
     void tagsEdited();
+    void tagClicked(const QString& search);
 
 protected:
     // QWidget


### PR DESCRIPTION
Clicking a tag in the preview panel now triggers a search for entries with that tag, matching the behavior of the main tag panel.


## Screenshots
<img width="640" height="490" alt="tags" src="https://github.com/user-attachments/assets/549d1aa9-c40d-4aff-8e34-67ac929ae95c" />


## Testing strategy
Manually

## Type of change
- ✅ New feature (change that adds functionality)
