### PR TITLE
Fix missing app icon in macOS bundle

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -431,6 +431,9 @@ elseif(APPLE AND WITH_APP_BUNDLE)
             "${CMAKE_SOURCE_DIR}/share/macosx/Assets.car"
             "${CMAKE_SOURCE_DIR}/share/macosx/keepassxc.icns"
     )
+    target_sources(${PROGNAME} PRIVATE ${MACOSX_BUNDLE_RESOURCE_FILES})
+    set_source_files_properties(${MACOSX_BUNDLE_RESOURCE_FILES}
+            PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     set_target_properties(${PROGNAME} PROPERTIES
             MACOSX_BUNDLE ON
             MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist"


### PR DESCRIPTION
MACOSX_BUNDLE_RESOURCE_FILES was set but never consumed, so keepassxc.icns and Assets.car were never copied into Contents/Resources/. Add them as target sources with MACOSX_PACKAGE_LOCATION so they land in the bundle.

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
