### PR TITLE
Recognize {PGDN} Auto-Type placeholder

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -80,6 +80,7 @@ namespace
                                                         {"end", Qt::Key_End},
                                                         {"pgup", Qt::Key_PageUp},
                                                         {"pgdown", Qt::Key_PageDown},
+                                                        {"pgdn", Qt::Key_PageDown},
                                                         {"backspace", Qt::Key_Backspace},
                                                         {"bs", Qt::Key_Backspace},
                                                         {"bksp", Qt::Key_Backspace},

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -350,6 +350,8 @@ void TestAutoType::testAutoTypeSyntaxChecks()
 
     QVERIFY2(AutoType::verifyAutoTypeSyntax("{NUMPAD1 3}", entry, error), error.toLatin1());
 
+    QVERIFY2(AutoType::verifyAutoTypeSyntax("{PGDN}", entry, error), error.toLatin1());
+
     QVERIFY2(AutoType::verifyAutoTypeSyntax("{S:SPECIALTOKEN}", entry, error), error.toLatin1());
     QVERIFY2(AutoType::verifyAutoTypeSyntax("{S:SPECIAL TOKEN}", entry, error), error.toLatin1());
     QVERIFY2(AutoType::verifyAutoTypeSyntax("{S:SPECIAL_TOKEN}", entry, error), error.toLatin1());


### PR DESCRIPTION
The `{PGDN}` placeholder is listed in the Auto-Type docs, but only `pgup` and `pgdown` are registered in `g_placeholderToKey`. As a result `{PGDN}` never resolves and aborts the rest of the sequence at runtime.

This adds `pgdn` as an alias for `Qt::Key_PageDown`, mirroring the existing `ins`/`insert` and `del`/`delete` aliases. The placeholder is already lowercased before the lookup, so no other change is needed. I also added a `{PGDN}` assertion to the syntax-check test.

Fixes #13379

AI use: I used an AI assistant to help locate the missing alias and write this up; the one-line fix and test were reviewed by me.

## Testing strategy
I could not run a full local build/test on this machine (no CMake/Qt toolchain available here), so I have not executed `TestAutoType` locally. The change is a single QHash entry that follows the exact shape of the surrounding aliases, and the new test line matches the existing `verifyAutoTypeSyntax` assertions in `testAutoTypeSyntaxChecks()`. Happy to adjust if CI flags anything.

## Type of change
- Bug fix (non-breaking change that fixes an issue)