### PR TITLE
Various AppImage fixes

### DIFF
--- a/share/linux/appimage-apprun.sh
+++ b/share/linux/appimage-apprun.sh
@@ -5,11 +5,41 @@ export PATH="$(dirname $0)/usr/bin:${PATH}"
 if [ "$1" == "cli" ] || [ "$(basename "$ARGV0")" == "keepassxc-cli" ] || [ "$(basename "$ARGV0")" == "keepassxc-cli.AppImage" ]; then
     [ "$1" == "cli" ] && shift
     exec keepassxc-cli "$@"
-elif  [ "$1" == "proxy" ] || [ "$(basename "$ARGV0")" == "keepassxc-proxy" ] || [ "$(basename "$ARGV0")" == "keepassxc-proxy.AppImage" ]; then
+elif [ "$1" == "proxy" ] || [ "$(basename "$ARGV0")" == "keepassxc-proxy" ] || [ "$(basename "$ARGV0")" == "keepassxc-proxy.AppImage" ]; then
     [ "$1" == "proxy" ] && shift
     exec keepassxc-proxy "$@"
 elif [ -v CHROME_WRAPPER ] || [ -v MOZ_LAUNCHED_CHILD ] || [ "$2" == "keepassxc-browser@keepassxc.org" ]; then
     exec keepassxc-proxy "$@"
 else
-    exec keepassxc "$@"
+    # --- Icon file setup ---
+    icon_source="$APPDIR/usr/share/icons/hicolor/256x256/apps/keepassxc.png"
+    icon_target="${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/256x256/apps/keepassxc.png"
+    mkdir -p "$(dirname "$icon_target")"
+
+    # Copy icon if different or missing
+    if [ ! -f "$icon_target" ] || ! cmp -s "$icon_source" "$icon_target"; then
+        cp "$icon_source" "$icon_target"
+    fi
+
+    # --- Desktop file setup ---
+    desktop_source="$APPDIR/usr/share/applications/org.keepassxc.KeePassXC.desktop"
+    desktop_target="${XDG_DATA_HOME:-$HOME/.local/share}/applications/org.keepassxc.KeePassXC.desktop"
+    if [ ! -f "$desktop_target" ]; then
+        mkdir -p "$(dirname "$desktop_target")"
+    fi
+
+    # Substitute Exec and TryExec in memory
+    desktop_content=$(sed "s|Exec=keepassxc %f|Exec=$APPIMAGE %f|;s|TryExec=keepassxc|TryExec=$APPIMAGE|" "$desktop_source")
+
+    # Copy to target if different
+    if ! cmp -s - "$desktop_target" <<<"$desktop_content"; then
+        printf '%s\n' "$desktop_content" >"$desktop_target"
+    fi
+
+    EXEC="exec"
+    if command -v systemd-run &>/dev/null; then
+        EXEC="exec systemd-run --user --scope --slice=app.slice --unit=app-org.keepassxc.KeePassXC-$(cat /proc/sys/kernel/random/uuid | tr -d -).scope"
+    fi
+
+    $EXEC keepassxc "$@"
 fi

--- a/src/gui/ApplicationSettingsWidgetGeneral.ui
+++ b/src/gui/ApplicationSettingsWidgetGeneral.ui
@@ -1172,7 +1172,7 @@
       <attribute name="title">
        <string>Auto-Type</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,0,0,0,0,0,0,0,0,1">
        <property name="leftMargin">
         <number>10</number>
        </property>


### PR DESCRIPTION
The startup script of the AppImage now always installs a desktop file and uses systemd-run to start itself if available. This allows Wayland (portal) Auto-Type to function correctly from the AppImage install on major desktops like GNOME and KDE and it also provides a stable menu entry to start it again later.

Our desktop entry is strictly "owned" by the AppImage and it will aggressively rewrite it. This effectively keeps the menu entry pointing at the last AppImage that has launched KeePassXC so if the user switches between versions or just updates the menu entry will always be up-to-date.

Auto-Type settings dialog stretching was broken after the Wayland merge for some specific Qt6 versions. Adding a stretch policy fixes it.

We still need to build our AppImage against Ubuntu Noble to get recent enough Qt6 for anything to work well on Wayland but these are the changes on this side to make it behave much better.

## Testing strategy
Used some live images of distributions to test the portal registration.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
