### PR TITLE
Load tray icon directly on Linux

### DIFF
--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -100,7 +100,11 @@ QIcon Icons::trayIcon(bool unlocked)
 #elif defined(Q_OS_MACOS)
     i = icon(QString("keepassxc-monochrome-light%1").arg(suffix), false);
 #else
-    i = icon(QString("%1-%2%3").arg(applicationIconName(), iconAppearance, suffix), false);
+    // On Linux/Wayland, QIcon::fromTheme() returns an icon with themeName="application",
+    // which the compositor uses to look up the icon in the system theme (wrong icon).
+    // Load directly from the embedded resource to bypass QIcon::fromTheme().
+    i = QIcon(
+        QString(":/icons/application/scalable/apps/%1-%2%3.svg").arg(applicationIconName(), iconAppearance, suffix));
 #endif
     // Set as mask to allow the operating system to recolour the tray icon. This may look weird
     // if we failed to detect the status bar background colour correctly, but it is certainly


### PR DESCRIPTION
On Wayland specifically it seems that relying on the icon name isn't enough on Qt6 to load the correct icon. It is likely a Qt bug but we can workaround it.

I don't know if this is a good approach but if no one knows any better it at least seems to work. Might need to load the colorful icon like this as well for consistency?

## Testing strategy
Works fine on Wayland KDE now, this might affect X11 as well but haven't yet tested it, if it does it's likely a Qt6 bug.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)

