### PR TITLE
Fix password strength evaluation for referenced passwords

### DIFF
--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -231,7 +231,7 @@ QString Entry::defaultAutoTypeSequence() const
 const QSharedPointer<PasswordHealth> Entry::passwordHealth()
 {
     if (!m_data.passwordHealth) {
-        m_data.passwordHealth.reset(new PasswordHealth(resolvePlaceholder(password())));
+        m_data.passwordHealth.reset(new PasswordHealth(resolveMultiplePlaceholders(password())));
     }
     return m_data.passwordHealth;
 }
@@ -239,7 +239,7 @@ const QSharedPointer<PasswordHealth> Entry::passwordHealth()
 const QSharedPointer<PasswordHealth> Entry::passwordHealth() const
 {
     if (!m_data.passwordHealth) {
-        return QSharedPointer<PasswordHealth>::create(resolvePlaceholder(password()));
+        return QSharedPointer<PasswordHealth>::create(resolveMultiplePlaceholders(password()));
     }
     return m_data.passwordHealth;
 }

--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -95,7 +95,12 @@ PasswordWidget::PasswordWidget(QWidget* parent)
     m_ui->qualityProgressBar->setVisible(false);
 
     connect(m_ui->passwordEdit, &QLineEdit::textChanged, this, [this](const QString& pwd) {
-        updatePasswordStrength(pwd);
+        QString resolvedPwd = pwd;
+
+        // Making a request to dereference the password
+        emit requestPlaceholderResolution(pwd, resolvedPwd);
+
+        updatePasswordStrength(resolvedPwd);
         emit textChanged(pwd);
     });
 }

--- a/src/gui/PasswordWidget.h
+++ b/src/gui/PasswordWidget.h
@@ -48,6 +48,7 @@ public:
 
 signals:
     void textChanged(QString text);
+    void requestPlaceholderResolution(const QString& rawText, QString& resolvedText);
 
 public slots:
     void setText(const QString& text);

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -140,13 +140,15 @@ EditEntryWidget::EditEntryWidget(QWidget* parent)
 
     m_mainUi->passwordEdit->setQualityVisible(true);
 
-    connect(m_mainUi->passwordEdit, &PasswordWidget::requestPlaceholderResolution, 
-        this, [this](const QString& rawText, QString& resolvedText) {
-    if (m_entry) {
-        // Dereferencing the password of the entry
-        resolvedText = m_entry->resolveMultiplePlaceholders(rawText);
-    }
-    });
+    connect(m_mainUi->passwordEdit,
+            &PasswordWidget::requestPlaceholderResolution,
+            this,
+            [this](const QString& rawText, QString& resolvedText) {
+                if (m_entry) {
+                    // Dereferencing the password of the entry
+                    resolvedText = m_entry->resolveMultiplePlaceholders(rawText);
+                }
+            });
 }
 
 EditEntryWidget::~EditEntryWidget() = default;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -139,6 +139,14 @@ EditEntryWidget::EditEntryWidget(QWidget* parent)
     m_editWidgetProperties->setCustomData(m_customData.data());
 
     m_mainUi->passwordEdit->setQualityVisible(true);
+
+    connect(m_mainUi->passwordEdit, &PasswordWidget::requestPlaceholderResolution, 
+        this, [this](const QString& rawText, QString& resolvedText) {
+    if (m_entry) {
+        // Dereferencing the password of the entry
+        resolvedText = m_entry->resolvePlaceholder(rawText);
+    }
+    });
 }
 
 EditEntryWidget::~EditEntryWidget() = default;
@@ -935,14 +943,6 @@ void EditEntryWidget::loadEntry(Entry* entry,
     m_db = std::move(database);
     m_create = create;
     m_history = history;
-
-    connect(m_mainUi->passwordEdit, &PasswordWidget::requestPlaceholderResolution, 
-        this, [this](const QString& rawText, QString& resolvedText) {
-    if (m_entry) {
-        // Dereferencing the password of the entry
-        resolvedText = m_entry->resolvePlaceholder(rawText);
-    }
-    });
 
     if (history) {
         setHeadline(QString("%1 \u2022 %2").arg(parentName, tr("Entry history")));

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -40,6 +40,7 @@
 #include "core/Metadata.h"
 #include "core/PasswordGenerator.h"
 #include "core/TimeDelta.h"
+#include "gui/PasswordWidget.h"
 #ifdef KPXC_FEATURE_SSHAGENT
 #include "sshagent/OpenSSHKey.h"
 #include "sshagent/OpenSSHKeyGenDialog.h"
@@ -934,6 +935,14 @@ void EditEntryWidget::loadEntry(Entry* entry,
     m_db = std::move(database);
     m_create = create;
     m_history = history;
+
+    connect(m_mainUi->passwordEdit, &PasswordWidget::requestPlaceholderResolution, 
+        this, [this](const QString& rawText, QString& resolvedText) {
+    if (m_entry) {
+        // Dereferencing the password of the entry
+        resolvedText = m_entry->resolvePlaceholder(rawText);
+    }
+    });
 
     if (history) {
         setHeadline(QString("%1 \u2022 %2").arg(parentName, tr("Entry history")));

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -144,7 +144,7 @@ EditEntryWidget::EditEntryWidget(QWidget* parent)
         this, [this](const QString& rawText, QString& resolvedText) {
     if (m_entry) {
         // Dereferencing the password of the entry
-        resolvedText = m_entry->resolvePlaceholder(rawText);
+        resolvedText = m_entry->resolveMultiplePlaceholders(rawText);
     }
     });
 }


### PR DESCRIPTION
Fix for #12671

This PR resolves an issue where the visual password strength indicator (`PasswordWidget`) evaluates the literal length and entropy of reference placeholder wrappers (e.g., `{REF:P@I:...}`) rather than evaluating the actual, underlying password string being referenced.

## Note
This is my first time contributing to an open source project. If you can, please drop a review or give feedback. I appreciate any kind of help.

## Changes
To keep the code clean and avoid complications in the future, this fix avoids tightly coupling the UI layer to the core data layer (i.e., passing raw `Entry*` or database pointers directly down to a generic widget). 

Instead, it implements a native Qt synchronous signal-and-slot pattern utilizing a mutable `QString` reference:
1.**`PasswordWidget`** emits a new signal: `requestPlaceholderResolution(const QString& rawText, QString& resolvedText)`.
2.**'EditEntryWidget'** receives this signal and fetches the requested password. Then sends the new fetched password back to **'PasswordWidget'**
3. **`PasswordWidget`** immediately calculates the visual entropy based on the resolved string, while keeping the original raw text intact inside the `QLineEdit` for database persistence.

## AI
AI assistance was mostly used to detect where the issue comes from, but the code was written mostly by me.


## Screenshots
<img width="1017" height="280" alt="Screenshot_20260629_235804" src="https://github.com/user-attachments/assets/e722f798-1268-4b6a-bb9f-1f5febedd797" />
<img width="944" height="722" alt="Screenshot_20260630_000038" src="https://github.com/user-attachments/assets/3ba6c907-9e7f-45a5-b808-5287ec9739be" />
<img width="988" height="210" alt="Screenshot_20260630_000126" src="https://github.com/user-attachments/assets/264deeae-ada9-4dfe-a3da-09dcdbb40e2d" />
<img width="843" height="170" alt="Screenshot_20260630_000146" src="https://github.com/user-attachments/assets/71da9084-f025-4a93-9392-406c0b218714" />


## Testing strategy
To detect why this issue occured, I wrote a debug function inside PasswordHealth.cpp to test. And as I expected, the issue occured because the password was not fetched while inside the entry edit window. So I searched for the entry editing widget and the password widget file, and wrote a simple signal-and-slot function to fix it, as shown in the screenshots.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)