### PR TITLE
Use Background Portal if available for autostart

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,6 +230,7 @@ endif()
 
 if(UNIX AND NOT APPLE)
     list(APPEND gui_SOURCES
+            gui/osutils/nixutils/BackgroundPortal.cpp
             gui/osutils/nixutils/DesktopPortal.cpp
             gui/osutils/nixutils/DeviceListenerLibUsb.cpp
             gui/osutils/nixutils/GlobalShortcutsPortal.cpp
@@ -279,6 +280,10 @@ if(UNIX AND NOT APPLE)
     qt6_add_dbus_interface(core_SOURCES
         gui/osutils/nixutils/dbus/org.freedesktop.portal.Clipboard.xml
         xdp_clipboard
+    )
+    qt6_add_dbus_interface(core_SOURCES
+        gui/osutils/nixutils/dbus/org.freedesktop.portal.Background.xml
+        xdp_background
     )
 endif()
 

--- a/src/gui/osutils/OSUtilsBase.h
+++ b/src/gui/osutils/OSUtilsBase.h
@@ -44,7 +44,7 @@ public:
     /**
      * @return KeePassXC set to launch at system startup (autostart).
      */
-    virtual bool isLaunchAtStartupEnabled() const = 0;
+    virtual bool isLaunchAtStartupEnabled() = 0;
 
     /**
      * @param enable Add or remove KeePassXC from system autostart.

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -121,7 +121,7 @@ QString MacUtils::getLaunchAgentFilename() const
         .fileName();
 }
 
-bool MacUtils::isLaunchAtStartupEnabled() const
+bool MacUtils::isLaunchAtStartupEnabled()
 {
     return QFile::exists(getLaunchAgentFilename());
 }

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -38,7 +38,7 @@ public:
 
     bool isDarkMode() const override;
     bool isStatusBarDark() const override;
-    bool isLaunchAtStartupEnabled() const override;
+    bool isLaunchAtStartupEnabled() override;
     void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
     void setUserInputProtection(bool enable) override;

--- a/src/gui/osutils/nixutils/BackgroundPortal.cpp
+++ b/src/gui/osutils/nixutils/BackgroundPortal.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "BackgroundPortal.h"
+
+#include "xdp_background.h"
+
+#include <QDebug>
+#include <QRandomGenerator>
+
+Q_GLOBAL_STATIC_WITH_ARGS(OrgFreedesktopPortalBackgroundInterface,
+                          s_backgroundInterface,
+                          ("org.freedesktop.portal.Desktop",
+                           "/org/freedesktop/portal/desktop",
+                           QDBusConnection::sessionBus()));
+
+BackgroundPortal::BackgroundPortal(QObject* parent)
+    : DesktopPortal(parent)
+{
+}
+
+bool BackgroundPortal::isAvailable() const
+{
+    return s_backgroundInterface->isValid();
+}
+
+void BackgroundPortal::requestBackground(bool autostart)
+{
+    if (!isAvailable()) {
+        qWarning() << "Background portal is not available";
+        return;
+    }
+
+    auto token = portalRequest([](uint response, const QVariantMap&) {
+        if (response != 0) {
+            qWarning() << "Background portal request failed with response:" << response;
+        }
+    });
+
+    auto reply =
+        s_backgroundInterface->RequestBackground("",
+                                                 QVariantMap{
+                                                     {QLatin1String("autostart"), autostart},
+                                                     {QLatin1String("reason"), tr("Launch KeePassXC at startup")},
+                                                     {QLatin1String("handle_token"), token},
+                                                 });
+    reply.waitForFinished();
+    if (reply.isError()) {
+        qWarning() << "Failed to call RequestBackground:" << reply.error().message();
+    }
+}

--- a/src/gui/osutils/nixutils/BackgroundPortal.h
+++ b/src/gui/osutils/nixutils/BackgroundPortal.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or (at your option)
+ * version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_BACKGROUNDPORTAL_H
+#define KEEPASSXC_BACKGROUNDPORTAL_H
+
+#include "gui/osutils/nixutils/DesktopPortal.h"
+
+class BackgroundPortal : public DesktopPortal
+{
+    Q_OBJECT
+
+public:
+    explicit BackgroundPortal(QObject* parent = nullptr);
+
+    bool isAvailable() const;
+    void requestBackground(bool autostart);
+};
+
+#endif // KEEPASSXC_BACKGROUNDPORTAL_H

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -18,6 +18,7 @@
 #include "NixUtils.h"
 
 #include "autotype/AutoType.h"
+#include "gui/osutils/nixutils/BackgroundPortal.h"
 #include "gui/osutils/nixutils/GlobalShortcutsPortal.h"
 #include "gui/osutils/nixutils/RemoteDesktopPortal.h"
 
@@ -34,7 +35,6 @@
 #include <QMimeData>
 #include <QPointer>
 #include <QProcess>
-#include <QRandomGenerator>
 #include <QStandardPaths>
 #include <QStyle>
 #include <QTextStream>
@@ -134,18 +134,24 @@ QString NixUtils::getAutostartDesktopFilename(bool createDirs) const
         .fileName();
 }
 
-bool NixUtils::isLaunchAtStartupEnabled() const
+bool NixUtils::isLaunchAtStartupEnabled()
 {
-#ifndef KEEPASSXC_DIST_FLATPAK
+    if (backgroundPortal()->isAvailable()) {
+        return config()->get(Config::GUI_LaunchAtStartup).toBool();
+    }
     return QFile::exists(getAutostartDesktopFilename());
-#else
-    return config()->get(Config::GUI_LaunchAtStartup).toBool();
-#endif
 }
 
 void NixUtils::setLaunchAtStartup(bool enable)
 {
-#ifndef KEEPASSXC_DIST_FLATPAK
+    config()->set(Config::GUI_LaunchAtStartup, enable);
+
+    if (backgroundPortal()->isAvailable()) {
+        backgroundPortal()->requestBackground(enable);
+        return;
+    }
+
+    // Fallback: manage autostart via desktop file
     if (enable) {
         QFile desktopFile(getAutostartDesktopFilename(true));
         if (!desktopFile.open(QIODevice::WriteOnly)) {
@@ -176,49 +182,9 @@ void NixUtils::setLaunchAtStartup(bool enable)
                << QStringLiteral("X-KDE-autostart-after=panel") << '\n'
                << QStringLiteral("X-LXQt-Need-Tray=true") << Qt::endl;
         desktopFile.close();
-    } else if (isLaunchAtStartupEnabled()) {
+    } else {
         QFile::remove(getAutostartDesktopFilename());
     }
-#else
-    QDBusConnection sessionBus = QDBusConnection::sessionBus();
-    QDBusMessage msg = QDBusMessage::createMethodCall("org.freedesktop.portal.Desktop",
-                                                      "/org/freedesktop/portal/desktop",
-                                                      "org.freedesktop.portal.Background",
-                                                      "RequestBackground");
-
-    QMap<QString, QVariant> options;
-    options["autostart"] = QVariant(enable);
-    options["reason"] = QVariant("Launch KeePassXC at startup");
-    int token = QRandomGenerator::global()->bounded(1000, 9999);
-    options["handle_token"] = QVariant(QString("org/keepassxc/KeePassXC/%1").arg(token));
-
-    msg << "" << options;
-
-    QDBusMessage response = sessionBus.call(msg);
-
-    QDBusObjectPath handle = response.arguments().at(0).value<QDBusObjectPath>();
-
-    bool res = sessionBus.connect("org.freedesktop.portal.Desktop",
-                                  handle.path(),
-                                  "org.freedesktop.portal.Request",
-                                  "Response",
-                                  this,
-                                  SLOT(launchAtStartupRequested(uint, QVariantMap)));
-
-    if (!res) {
-        qDebug() << "DBus Error: could not connect to org.freedesktop.portal.Request";
-    }
-#endif
-}
-
-void NixUtils::launchAtStartupRequested(uint response, const QVariantMap& results)
-{
-    if (response > 0) {
-        qDebug() << "DBus Error: the request to autostart was cancelled.";
-        return;
-    }
-
-    config()->set(Config::GUI_LaunchAtStartup, results["autostart"].value<bool>());
 }
 
 bool NixUtils::isCapslockEnabled()
@@ -507,6 +473,15 @@ bool NixUtils::externalGlobalShortcutsConfigurator()
 bool NixUtils::isWayland() const
 {
     return QApplication::platformName() == QLatin1String("wayland");
+}
+
+BackgroundPortal* NixUtils::backgroundPortal()
+{
+    if (!m_backgroundPortal) {
+        m_backgroundPortal = new BackgroundPortal(this);
+    }
+
+    return m_backgroundPortal;
 }
 
 GlobalShortcutsPortal* NixUtils::globalShortcutsPortal()

--- a/src/gui/osutils/nixutils/NixUtils.h
+++ b/src/gui/osutils/nixutils/NixUtils.h
@@ -23,6 +23,7 @@
 #include <QSharedPointer>
 #include <QtDBus/QDBusVariant>
 
+class BackgroundPortal;
 class GlobalShortcutsPortal;
 class RemoteDesktopPortal;
 
@@ -35,7 +36,7 @@ public:
 
     bool isDarkMode() const override;
     bool isStatusBarDark() const override;
-    bool isLaunchAtStartupEnabled() const override;
+    bool isLaunchAtStartupEnabled() override;
     void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
     void setUserInputProtection(bool enable) override;
@@ -61,6 +62,7 @@ public:
     bool externalGlobalShortcutsConfigurator() override;
     bool isWayland() const;
 
+    BackgroundPortal* backgroundPortal();
     GlobalShortcutsPortal* globalShortcutsPortal();
     RemoteDesktopPortal* remoteDesktopPortal();
 
@@ -69,7 +71,6 @@ public slots:
 
 private slots:
     void handleColorSchemeChanged(QString ns, QString key, QDBusVariant value);
-    void launchAtStartupRequested(uint response, const QVariantMap& results);
 
 private:
     explicit NixUtils(QObject* parent = nullptr);
@@ -102,6 +103,7 @@ private:
 
     void setColorScheme(QDBusVariant value);
 
+    BackgroundPortal* m_backgroundPortal = nullptr;
     GlobalShortcutsPortal* m_globalShortcutsPortal = nullptr;
     RemoteDesktopPortal* m_remoteDesktopPortal = nullptr;
 

--- a/src/gui/osutils/nixutils/dbus/org.freedesktop.portal.Background.xml
+++ b/src/gui/osutils/nixutils/dbus/org.freedesktop.portal.Background.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<!--
+ SPDX-License-Identifier: LGPL-2.1-or-later
+ SPDX-FileCopyrightText: Copyright © the xdg-desktop-portal contributors
+-->
+
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.portal.Background:
+      @short_description: Portal for requesting autostart and background activity
+
+      This simple interface lets sandboxed applications request that
+      the application is allowed to run in the background or started
+      automatically when the user logs in.
+
+      This documentation describes version 2 of this interface.
+  -->
+  <interface name="org.freedesktop.portal.Background">
+    <!--
+        RequestBackground:
+        @parent_window: Identifier for the application window, see :doc:`window-identifiers`
+        @options: Vardict with optional further information
+        @handle: Object path for the :ref:`org.freedesktop.portal.Request` object representing this call
+
+        Requests that the application is allowed to run in the background.
+
+        Supported keys in the @options vardict include:
+
+        * ``handle_token`` (``s``)
+
+          A string that will be used as the last element of the @handle.
+          Must be a valid object path element. See the
+          :ref:`org.freedesktop.portal.Request` documentation for more
+          information about the @handle.
+
+        * ``reason`` (``s``)
+
+          User-visible reason for the request.
+
+        * ``autostart`` (``b``)
+
+          true if the app also wants to be started automatically at login.
+
+        * ``commandline`` (``as``)
+
+          Commandline to use add when autostarting at login. If this is not
+          specified, the ``Exec`` key from the desktop file will be used.
+
+        * ``dbus-activatable`` (``b``)
+
+          true to use D-Bus activation for autostart.
+
+
+        The following results get returned via the :ref:`org.freedesktop.portal.Request::Response` signal:
+
+        * ``background`` (``b``)
+
+          true if the application is allowed to run in the background.
+
+        * ``autostart`` (``b``)
+
+          true if the application will be autostarted.
+    -->
+    <method name="RequestBackground">
+      <arg type="s" name="parent_window" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="o" name="handle" direction="out"/>
+    </method>
+
+    <!--
+      SetStatus:
+      @options: Vardict with optional further information
+
+      This method was added in version 2 of this interface.
+
+      Sets the status of the application running in background.
+
+      Supported keys in the @options vardict include:
+
+      * ``message`` (``s``)
+
+        A string that will be used as the status message of the application.
+        This should be a single line that can be presented to the user in a
+        list, not a full sentence or paragraph. Must be shorter than 96
+        characters.
+    -->
+    <method name="SetStatus">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+    </method>
+
+    <property name="version" type="u" access="read"/>
+  </interface>
+</node>

--- a/src/gui/osutils/winutils/WinUtils.cpp
+++ b/src/gui/osutils/winutils/WinUtils.cpp
@@ -116,7 +116,7 @@ bool WinUtils::isStatusBarDark() const
     return settings.value("SystemUsesLightTheme", 0).toInt() == 0;
 }
 
-bool WinUtils::isLaunchAtStartupEnabled() const
+bool WinUtils::isLaunchAtStartupEnabled()
 {
     return QSettings(R"(HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run)", QSettings::NativeFormat)
         .contains(qAppName());

--- a/src/gui/osutils/winutils/WinUtils.h
+++ b/src/gui/osutils/winutils/WinUtils.h
@@ -42,7 +42,7 @@ public:
 
     bool isDarkMode() const override;
     bool isStatusBarDark() const override;
-    bool isLaunchAtStartupEnabled() const override;
+    bool isLaunchAtStartupEnabled() override;
     void setLaunchAtStartup(bool enable) override;
     bool isCapslockEnabled() override;
     void setUserInputProtection(bool enable) override;


### PR DESCRIPTION
Refactored to use dbus code generator with the real portal XML spec.

This makes auto-start work "natively" on Wayland desktops like Plasma that provides the portal to non-sandboxed applications as well and avoids us from creating a custom entry.

## Testing strategy
TBD


## Type of change
- ✅ Refactor (significant modification to existing code)

