### PR TITLE
Use native user temporary directory path for the browser socket in macOS

### DIFF
--- a/src/browser/BrowserShared.cpp
+++ b/src/browser/BrowserShared.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,9 +24,32 @@
 #if defined(KEEPASSXC_DIST_SNAP)
 #include <QProcessEnvironment>
 #endif
+#if defined(Q_OS_MACOS)
+#include <unistd.h>
+#endif
 
 namespace BrowserShared
 {
+    // Get user's temporary directory. Bypasses $TMPDIR on macOS.
+    QString getUserTemporaryDirectory()
+    {
+#if defined(Q_OS_MACOS)
+        // In macOS QStandardPaths::TempLocation can be overridden with $TMPDIR. Use the location provided by the OS.
+        // Otherwise the socket will be created to incorrect path, and connection with the browser extension breaks.
+        const auto len = confstr(_CS_DARWIN_USER_TEMP_DIR, nullptr, 0);
+        if (len > 0 && len <= 1024) {
+            char rawPath[1024];
+            confstr(_CS_DARWIN_USER_TEMP_DIR, rawPath, len);
+            auto temporaryDirectory = QString::fromUtf8(rawPath);
+            if (temporaryDirectory.endsWith("/")) {
+                temporaryDirectory.chop(1);
+            }
+            return temporaryDirectory;
+        }
+#endif
+        return QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+    }
+
     QString localServerPath()
     {
         const auto serverName = QStringLiteral("/org.keepassxc.KeePassXC.BrowserServer");
@@ -54,7 +77,7 @@ namespace BrowserShared
         // Windows uses named pipes
         return serverName + "_" + qgetenv("USERNAME");
 #else // Q_OS_MACOS and others
-        return QStandardPaths::writableLocation(QStandardPaths::TempLocation) + serverName;
+        return getUserTemporaryDirectory() + serverName;
 #endif
     }
 } // namespace BrowserShared

--- a/src/browser/BrowserShared.h
+++ b/src/browser/BrowserShared.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -38,6 +38,7 @@ namespace BrowserShared
     };
 
     QString localServerPath();
+    QString getUserTemporaryDirectory();
 } // namespace BrowserShared
 
 #endif // KEEPASSXC_BROWSERSHARED_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
In macOS for example Homebrew can override the user's temporary directory using the `$TMPDIR` environment variable. Qt's internal functions will resolve that path instead of the one we actually want to create the socket for browser integration.

Added a new function to BrowserShared that returns the native temporary directory from `_CS_DARWIN_USER_TEMP_DIR` directly. It will always return the randomly generated temporary directory under `/var/`.

* Fixes #13481

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
For debugging, you can start e.g. CLion with:
`env TMPDIR=/private/tmp /Applications/CLion.app/Contents/MacOS/clion` and see that that Qt's own function will respect the `$TMPDIR` environment variable. The new implementation still returns the correct path.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
