### PR TITLE
Fix tag dropdown not finalizing selection

### DIFF
--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -262,6 +262,11 @@ void PasswordWidget::checkCapslockState()
     }
 }
 
+void PasswordWidget::setPasswordStrength(const QString& password)
+{
+    updatePasswordStrength(password);
+}
+
 void PasswordWidget::updatePasswordStrength(const QString& password)
 {
     if (password.isEmpty()) {

--- a/src/gui/PasswordWidget.h
+++ b/src/gui/PasswordWidget.h
@@ -57,6 +57,7 @@ public slots:
     void selectAll();
     void setReadOnly(bool state);
     void setEchoMode(QLineEdit::EchoMode mode);
+    void setPasswordStrength(const QString& password);
     void setClearButtonEnabled(bool enabled);
 
 private slots:

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1024,6 +1024,9 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_mainUi->usernameComboBox->lineEdit()->setText(entry->username());
     m_mainUi->urlEdit->setText(entry->url());
     m_mainUi->passwordEdit->setText(entry->password());
+    if (entry->isAttributeReference("Password")) {
+        m_mainUi->passwordEdit->setPasswordStrength(entry->resolveMultiplePlaceholders(entry->password()));
+    }
     m_mainUi->passwordEdit->setShowPassword(!config()->get(Config::Security_PasswordsHidden).toBool());
     if (!m_history) {
         m_mainUi->passwordEdit->enablePasswordGenerator();

--- a/src/gui/tag/TagsEdit.cpp
+++ b/src/gui/tag/TagsEdit.cpp
@@ -411,7 +411,10 @@ struct TagsEdit::Impl
         completer->setCaseSensitivity(Qt::CaseInsensitive);
         connect(completer.get(),
                 static_cast<void (QCompleter::*)(QString const&)>(&QCompleter::activated),
-                [this](QString const& text) { currentText(text); });
+                [this](QString const& text) {
+                    currentText(text);
+                    editNewTag(editing_index + 1);
+                });
     }
 
     QVector<QTextLayout::FormatRange> formatting() const


### PR DESCRIPTION
When selecting a tag from the completer dropdown, the selection now immediately finalizes into a tag pill instead of requiring an extra action.

Fixes #13444

[skip ci] Fix 2 of 10 — GUI entry fixes

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
