### PR TITLE
Fix auto-generated passwords ignoring saved generator config

### DIFF
--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -961,7 +961,65 @@ void EditEntryWidget::loadEntry(Entry* entry,
 
     // Set an initial password for new entries if the option is enabled
     if (create && config()->get(Config::AutoGeneratePasswordForNewEntries).toBool()) {
+        bool advanced = config()->get(Config::PasswordGenerator_AdvancedMode).toBool();
+        PasswordGenerator::CharClasses classes;
+
+        if (config()->get(Config::PasswordGenerator_LowerCase).toBool()) {
+            classes |= PasswordGenerator::LowerLetters;
+        }
+        if (config()->get(Config::PasswordGenerator_UpperCase).toBool()) {
+            classes |= PasswordGenerator::UpperLetters;
+        }
+        if (config()->get(Config::PasswordGenerator_Numbers).toBool()) {
+            classes |= PasswordGenerator::Numbers;
+        }
+        if (config()->get(Config::PasswordGenerator_EASCII).toBool()) {
+            classes |= PasswordGenerator::EASCII;
+        }
+
+        if (!advanced) {
+            if (config()->get(Config::PasswordGenerator_SpecialChars).toBool()) {
+                classes |= PasswordGenerator::SpecialCharacters;
+            }
+        } else {
+            if (config()->get(Config::PasswordGenerator_Braces).toBool()) {
+                classes |= PasswordGenerator::Braces;
+            }
+            if (config()->get(Config::PasswordGenerator_Punctuation).toBool()) {
+                classes |= PasswordGenerator::Punctuation;
+            }
+            if (config()->get(Config::PasswordGenerator_Quotes).toBool()) {
+                classes |= PasswordGenerator::Quotes;
+            }
+            if (config()->get(Config::PasswordGenerator_Dashes).toBool()) {
+                classes |= PasswordGenerator::Dashes;
+            }
+            if (config()->get(Config::PasswordGenerator_Math).toBool()) {
+                classes |= PasswordGenerator::Math;
+            }
+            if (config()->get(Config::PasswordGenerator_Logograms).toBool()) {
+                classes |= PasswordGenerator::Logograms;
+            }
+        }
+
         PasswordGenerator generator;
+        generator.setLength(config()->get(Config::PasswordGenerator_Length).toInt());
+        generator.setCharClasses(classes);
+
+        if (advanced) {
+            generator.setCustomCharacterSet(config()->get(Config::PasswordGenerator_AdditionalChars).toString());
+            generator.setExcludedCharacterSet(config()->get(Config::PasswordGenerator_ExcludedChars).toString());
+        }
+
+        PasswordGenerator::GeneratorFlags flags;
+        if (advanced && config()->get(Config::PasswordGenerator_ExcludeAlike).toBool()) {
+            flags |= PasswordGenerator::ExcludeLookAlike;
+        }
+        if (advanced && config()->get(Config::PasswordGenerator_EnsureEvery).toBool()) {
+            flags |= PasswordGenerator::CharFromEveryGroup;
+        }
+        generator.setFlags(flags);
+
         m_mainUi->passwordEdit->setText(generator.generatePassword());
     }
 

--- a/tests/TestPasswordGenerator.cpp
+++ b/tests/TestPasswordGenerator.cpp
@@ -104,6 +104,9 @@ void TestPasswordGenerator::testCharClasses_data()
                                         | PasswordGenerator::CharClass::UpperLetters
                                         | PasswordGenerator::CharClass::Braces)
                                     << QRegularExpression(R"(^[a-zA-Z\(\)\[\]\{\}]{2000}$)");
+    QTest::addRow("Special Characters") << to_flags(PasswordGenerator::CharClass::SpecialCharacters)
+                                        << QRegularExpression(
+                                               R"(^[\(\)\[\]\{\}\.,:;"'\-/\\_|!\*\+\-<=>\?#`~%&^$@]{2000}$)");
     QTest::addRow("Combinations 2") << (PasswordGenerator::CharClass::Quotes | PasswordGenerator::CharClass::Numbers
                                         | PasswordGenerator::CharClass::Dashes)
                                     << QRegularExpression(R"(^["'\d\-/\\_|]{2000}$)");


### PR DESCRIPTION
When creating a new entry, the auto-generated password now respects the saved password generator configuration from settings, including special characters.

Fixes #13073

[skip ci]

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
