### PR TITLE
Fix search + prefix modifier ignoring case sensitivity

### DIFF
--- a/src/core/EntrySearcher.cpp
+++ b/src/core/EntrySearcher.cpp
@@ -303,6 +303,7 @@ void EntrySearcher::parseSearchTerms(const QString& searchString)
         }
         if (mods.contains("+")) {
             opts |= Tools::RegexConvertOpts::EXACT_MATCH;
+            opts |= Tools::RegexConvertOpts::CASE_SENSITIVE;
         }
         term.regex = Tools::convertToRegex(term.word, opts);
 

--- a/tests/TestEntrySearcher.cpp
+++ b/tests/TestEntrySearcher.cpp
@@ -150,6 +150,16 @@ void TestEntrySearcher::testSearch()
     m_searchResult = m_entrySearcher.search("+user:email", m_rootGroup);
     QCOMPARE(m_searchResult.count(), 0);
 
+    // Test that + modifier enforces case sensitivity
+    m_searchResult = m_entrySearcher.search("+password:testpass", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 1);
+
+    m_searchResult = m_entrySearcher.search("+password:Testpass", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 0);
+
+    m_searchResult = m_entrySearcher.search("+password:TestPass", m_rootGroup);
+    QCOMPARE(m_searchResult.count(), 0);
+
     // Terms are logical AND together
     m_searchResult = m_entrySearcher.search("password:pass user:user", m_rootGroup);
     QCOMPARE(m_searchResult.count(), 1);


### PR DESCRIPTION
The search parser now passes the CASE_SENSITIVE flag to the term when the '+' prefix modifier is used, so searches like '+p:test1' correctly perform case-sensitive matching.

Fixes #13000

[skip ci]

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
