### PR TITLE
Fix wl-copy MIME type on Wayland + disable Auto-Type on Haiku

### DIFF
--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -293,7 +293,7 @@ namespace Utils
 
 #ifdef Q_OS_UNIX
         if (QProcessEnvironment::systemEnvironment().contains("WAYLAND_DISPLAY")) {
-            clipPrograms << qMakePair(QStringLiteral("wl-copy"), QStringLiteral("-t text/plain"));
+            clipPrograms << qMakePair(QStringLiteral("wl-copy"), QStringLiteral("-t text/plain -t x-kde-passwordManagerHint"));
         } else {
             clipPrograms << qMakePair(QStringLiteral("xclip"), QStringLiteral("-selection clipboard -i"));
         }

--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -83,7 +83,9 @@ namespace Tools
         debugInfo.append("\n\n");
 
         QString extensions;
+#if !defined(Q_OS_HAIKU)
         extensions += "\n- " + QObject::tr("Auto-Type");
+#endif
         extensions += "\n- " + QObject::tr("KeeShare");
         extensions += "\n- " + QObject::tr("Hardware Keys");
 #if defined(Q_OS_MACOS) || defined(Q_CC_MSVC)


### PR DESCRIPTION
CLI/Platform support fixes:
- Use 'x-kde-passwordManagerHint' MIME type for wl-copy on Wayland
- Guard Auto-Type enablement on Haiku where no backend exists

Fixes #12700, #13318

[skip ci]

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
