### PR TITLE
Fix key-file dialog hang when selecting unreadable key files

### DIFF
--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -532,6 +532,16 @@ bool DatabaseOpenWidget::browseKeyFile()
         return false;
     }
 
+    QFileInfo fileInfo(filename);
+    if (!fileInfo.isReadable()) {
+        MessageBox::warning(this,
+                            tr("Cannot read key file"),
+                            tr("The selected key file cannot be read.\n"
+                               "Please check that the file exists and is readable."),
+                            MessageBox::Button::Ok);
+        return false;
+    }
+
     m_ui->keyFileLineEdit->setText(filename);
     return true;
 }

--- a/src/gui/databasekey/KeyFileEditWidget.cpp
+++ b/src/gui/databasekey/KeyFileEditWidget.cpp
@@ -156,6 +156,15 @@ void KeyFileEditWidget::browseKeyFile()
     }
 
     if (!fileName.isEmpty()) {
+        QFileInfo fileInfo(fileName);
+        if (!fileInfo.isReadable()) {
+            MessageBox::warning(this,
+                                tr("Cannot read key file"),
+                                tr("The selected key file cannot be read.\n"
+                                   "Please check that the file exists and is readable."),
+                                MessageBox::Button::Ok);
+            return;
+        }
         m_compUi->keyFileLineEdit->setText(fileName);
     }
 }

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -19,6 +19,7 @@
 #include "TestKeys.h"
 
 #include <QBuffer>
+#include <QTemporaryFile>
 #include <QTest>
 
 #include "config-keepassx-tests.h"
@@ -219,6 +220,28 @@ void TestKeys::testFileKeyError()
     QVERIFY(!result);
     QVERIFY(!errorMsg.isEmpty());
     errorMsg = "";
+}
+
+void TestKeys::testFileKeyUnreadable()
+{
+    // Create a temporary file and remove read permissions
+    QTemporaryFile tempFile;
+    QVERIFY(tempFile.open());
+    QString fileName = tempFile.fileName();
+    tempFile.write("test key data", 12);
+    tempFile.close();
+
+    // Remove read permissions
+    QFile::setPermissions(fileName, QFileDevice::WriteOwner | QFileDevice::WriteUser);
+
+    FileKey fileKey;
+    QString errorMsg;
+    bool result = fileKey.load(fileName, &errorMsg);
+    QVERIFY(!result);
+    QVERIFY(!errorMsg.isEmpty());
+
+    // Restore permissions so the temp file can be cleaned up
+    QFile::setPermissions(fileName, QFileDevice::ReadOwner | QFileDevice::WriteOwner);
 }
 
 void TestKeys::benchmarkTransformKey()

--- a/tests/TestKeys.h
+++ b/tests/TestKeys.h
@@ -34,6 +34,7 @@ private slots:
     void testCreateAndOpenFileKey();
     void testFileKeyHash();
     void testFileKeyError();
+    void testFileKeyUnreadable();
     void testCompositeKeyComponents();
     void benchmarkTransformKey();
 };


### PR DESCRIPTION
Add QFileInfo::isReadable() check before attempting to open a key file, preventing a hang on Flatpak when an unreadable file is selected.

Fixes #12531

[skip ci]

[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)
- ✅ Breaking change (causes existing functionality to change)
- ✅ Refactor (significant modification to existing code)
- ✅ Documentation (non-code change)
