### PR TITLE
fdosecrets: allow inactive tabs to be considered

### DIFF
--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -170,7 +170,19 @@ namespace FdoSecrets
         m_insideEnsureDefaultAlias = true;
 
         auto coll = findCollection(m_databases->currentDatabaseWidget());
-        if (coll) {
+
+        // Fallback: If the active database isn't valid for Secret Service or is unregistered,
+        // fallback to ANY valid collection to ensure 'default' alias isn't lost.
+        if (!coll || coll->objectPath().path() == "/") {
+            for (auto* c : qAsConst(m_collections)) {
+                if (c->objectPath().path() != "/") {
+                    coll = c;
+                    break;
+                }
+            }
+        }
+
+        if (coll && coll->objectPath().path() != "/") {
             // adding alias will automatically remove the association with previous collection.
             coll->addAlias(DEFAULT_ALIAS).okOrDie();
         }


### PR DESCRIPTION
Closing this hack for now, as a better fix is available in #12252

When using https://keepassxc.org/docs/KeePassXC_UserGuide#_automatic_database_opening, and autostart at login is enabled for keepassxc, only the active tab, which is usually `AutoOpen.kdbx` is considered for freedesktop secret service.

Fixes https://github.com/keepassxreboot/keepassxc/issues/9174. Related https://github.com/keepassxreboot/keepassxc/issues/8611.

I used generative AI google's Gemini to find the issue I was facing but I wrote this code by hand.

## Screenshots

[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]: # ( Use View -> Allow Screen Capture )

## Testing strategy

[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]: # ( We expect new code to be covered by unit tests and include helpful comments. )

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)
