### PR TITLE
Fix directory creation error handling

### DIFF
--- a/src/gui/entry/EntryAttachmentsWidget.cpp
+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
@@ -358,7 +358,7 @@ void EntryAttachmentsWidget::saveSelectedAttachments()
 
     QDir saveDir(saveDirPath);
     if (!saveDir.exists()) {
-        if (saveDir.mkpath(saveDir.absolutePath())) {
+        if (!saveDir.mkpath(saveDir.absolutePath())) {
             errorOccurred(tr("Unable to create directory:\n%1").arg(saveDir.absolutePath()));
             return;
         }


### PR DESCRIPTION
When a directory is created successfully for saving attachments, do not error.

Fixes (or is at least related to) #13504.

Simply corrects the sense of the QT mkpath return value check

## Testing strategy

None, trivial fix.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
