### PR TITLE
SSH Agent: Add support for ML-DSA 44 + Ed25519 keys

### DIFF
--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -556,6 +556,7 @@ bool OpenSSHKey::readPublic(BinaryStream& stream)
         { "ssh-ed25519",                        {STR_PART} },
         { "sk-ecdsa-sha2-nistp256@openssh.com", {STR_PART, STR_PART, STR_PART} },
         { "sk-ssh-ed25519@openssh.com",         {STR_PART, STR_PART} },
+        { "ssh-mldsa44-ed25519@openssh.com",    {STR_PART} },
     };
     // clang-format on
 
@@ -587,6 +588,7 @@ bool OpenSSHKey::readPrivate(BinaryStream& stream)
         { "ssh-ed25519",                        {STR_PART, STR_PART} },
         { "sk-ecdsa-sha2-nistp256@openssh.com", {STR_PART, STR_PART, STR_PART, UINT8_PART, STR_PART, STR_PART} },
         { "sk-ssh-ed25519@openssh.com",         {STR_PART, STR_PART, UINT8_PART, STR_PART, STR_PART} },
+        { "ssh-mldsa44-ed25519@openssh.com",    {STR_PART, STR_PART} },
     };
     // clang-format on
 

--- a/src/sshagent/OpenSSHKeyGen.cpp
+++ b/src/sshagent/OpenSSHKeyGen.cpp
@@ -25,7 +25,9 @@
 #include <botan/ec_group.h>
 #include <botan/ecdsa.h>
 #include <botan/ed25519.h>
+#include <botan/ml_dsa.h>
 #include <botan/rsa.h>
+#include <botan/system_rng.h>
 #include <botan/version.h>
 #if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3, 11, 0)
 #include <botan/ec_group.h>
@@ -148,5 +150,49 @@ namespace OpenSSHKeyGen
         } catch (const std::exception&) {
             return false;
         }
+    }
+
+    bool generateMLDSA44Ed25519(OpenSSHKey& key)
+    {
+        // Generate ML-DSA-44 key pair
+        Botan::ML_DSA_PrivateKey mldsaKey(Botan::system_rng(), Botan::ML_DSA_Mode(Botan::DilithiumMode::ML_DSA_4x4));
+
+        // Generate Ed25519 key pair
+        auto rng = randomGen()->getRng();
+        Botan::Ed25519_PrivateKey ed25519Key(*rng);
+
+        // Composite public key: ML-DSA public key (1312 bytes) || Ed25519 public key (32 bytes)
+        QByteArray compositePublicKey;
+        compositePublicKey.append(reinterpret_cast<const char*>(mldsaKey.raw_public_key_bits().data()),
+                                  mldsaKey.raw_public_key_bits().size());
+        compositePublicKey.append(reinterpret_cast<const char*>(ed25519Key.get_public_key().data()),
+                                  ed25519Key.get_public_key().size());
+
+        QByteArray publicData;
+        BinaryStream publicStream(&publicData);
+        std::vector<uint8_t> pubVec(compositePublicKey.begin(), compositePublicKey.end());
+        vectorToStream(pubVec, publicStream);
+
+        // Private key data: composite public key || ML-DSA seed (32 bytes) || Ed25519 seed (32 bytes)
+        QByteArray compositePrivateKey;
+        compositePrivateKey.append(reinterpret_cast<const char*>(mldsaKey.raw_private_key_bits().data()),
+                                   mldsaKey.raw_private_key_bits().size());
+        // Ed25519 private key is 64 bytes (public key || seed), but we only need the 32-byte seed
+        auto ed25519Priv = ed25519Key.raw_private_key_bits();
+        compositePrivateKey.append(reinterpret_cast<const char*>(ed25519Priv.data() + 32), 32);
+
+        QByteArray privateData;
+        BinaryStream privateStream(&privateData);
+        std::vector<uint8_t> pubVec2(compositePublicKey.begin(), compositePublicKey.end());
+        std::vector<uint8_t> privVec(compositePrivateKey.begin(), compositePrivateKey.end());
+        vectorToStream(pubVec2, privateStream);
+        vectorToStream(privVec, privateStream);
+
+        key.setType("ssh-mldsa44-ed25519@openssh.com");
+        key.setCheck(randomGen()->randomUInt(std::numeric_limits<quint32>::max() - 1) + 1);
+        key.setPublicData(publicData);
+        key.setPrivateData(privateData);
+        key.setComment("id_mldsa44_ed25519");
+        return true;
     }
 } // namespace OpenSSHKeyGen

--- a/src/sshagent/OpenSSHKeyGen.h
+++ b/src/sshagent/OpenSSHKeyGen.h
@@ -25,6 +25,7 @@ namespace OpenSSHKeyGen
     bool generateRSA(OpenSSHKey& key, int bits);
     bool generateECDSA(OpenSSHKey& key, int bits);
     bool generateEd25519(OpenSSHKey& key);
+    bool generateMLDSA44Ed25519(OpenSSHKey& key);
 } // namespace OpenSSHKeyGen
 
 #endif

--- a/src/sshagent/OpenSSHKeyGenDialog.cpp
+++ b/src/sshagent/OpenSSHKeyGenDialog.cpp
@@ -37,6 +37,7 @@ OpenSSHKeyGenDialog::OpenSSHKeyGenDialog(QWidget* parent)
     m_ui->typeComboBox->addItem("Ed25519");
     m_ui->typeComboBox->addItem("RSA");
     m_ui->typeComboBox->addItem("ECDSA");
+    m_ui->typeComboBox->addItem("ML-DSA 44 + Ed25519");
 
     QString user = QProcessEnvironment::systemEnvironment().value("USER");
     m_ui->commentLineEdit->setText(user + "@" + QHostInfo::localHostName());
@@ -67,6 +68,8 @@ void OpenSSHKeyGenDialog::typeChanged()
         m_ui->bitsComboBox->addItem("384");
         m_ui->bitsComboBox->addItem("521");
         m_ui->bitsComboBox->setCurrentText("256");
+    } else if (m_ui->typeComboBox->currentText() == QString("ML-DSA 44 + Ed25519")) {
+        // No bits selection needed for ML-DSA 44 + Ed25519
     }
 }
 
@@ -84,6 +87,8 @@ void OpenSSHKeyGenDialog::accept()
         OpenSSHKeyGen::generateRSA(*m_key, bits);
     } else if (m_ui->typeComboBox->currentText() == QString("ECDSA")) {
         OpenSSHKeyGen::generateECDSA(*m_key, bits);
+    } else if (m_ui->typeComboBox->currentText() == QString("ML-DSA 44 + Ed25519")) {
+        OpenSSHKeyGen::generateMLDSA44Ed25519(*m_key);
     } else {
         reject();
         return;

--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -566,3 +566,76 @@ void TestOpenSSHKey::testParseED25519SecurityKey()
     QCOMPARE(key.fingerprint(), QString("SHA256:PGtS5WvbnYmNqFIeRbzO6cVP9GLh8eEzENgkHp02XIA"));
     QCOMPARE(keyString, key.privateKey());
 }
+
+void TestOpenSSHKey::testParseMLDSA44Ed25519()
+{
+    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                                      "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAFZwAAAB9zc2gtbW\n"
+                                      "xkc2E0NC1lZDI1NTE5QG9wZW5zc2guY29tAAAFQC3FuaSh0davMqgfw/lbJi8XUxGaB451\n"
+                                      "8bTUfuVn+u7oObwSK1CQCsLTYQB4VnHLGjqf0AKOUSjmpnqQQYISb+GwWFcpl7MWvUEA1m\n"
+                                      "hxeeBqoMq75cZfnKh3CfV/GGfKbeSJqiwxrPhLE/Tr9SCGft+kuIZLQR6XwaM8yPFfPQJv\n"
+                                      "ngpYLQmiIJqoG0QpWPtbK5m0K4sklR4AnNrrwuD4AEibkFfPdZNayDjESXv76QsyGl94oU\n"
+                                      "kOFzFWeZeUQSt4JE2QlO/20HJN3Bo8b3LkDHYA7H9KaEh8kwc9uRnNG35RADGi4qQg4alH\n"
+                                      "QO5Cz3qq2ubpnJgn4KT1ZtHxn3kEuxqGgDjnLQuWDzIjqNZ/bnwTC5HMsQHIEAM1ouBJHh\n"
+                                      "TRTxCEx9Ujoe51vMtO23D7nfg6fiZ8M8euV2vXrZ3krla87Bgyn1SkuDV8Thll2aU9BMQ3\n"
+                                      "mO9MOElbRRIRfU5xmlQ2yLZD4BJGPpTGqqDjmvoivaZdF7bNLoPGOIOVW9DJ1pskr95LD/\n"
+                                      "14LtqyKQFLKSdar9JQRwOGV64RK8tdsqMYbZzzAcV3w6tnS3ZmwCppG47XQSWtge9zyxuH\n"
+                                      "A9V6/jbOKAJpJJglP7fh0N2OBerxllN8i4blysLBs7hf7gBf+eictIzypj1HGeoMB0CmRj\n"
+                                      "DEe/+tvq+/q5NNBfrB9yY+qTi7Wl062ZxPlHZCeRCglQj5JQ0Ig3fsrd4gYrC5rVTefAm6\n"
+                                      "kBRxfVZhjwLDrveknXSYEAaw/zfiRdTeq+myRckFdj58PG2OzBQjqryvnMCZxCnZLf7KPv\n"
+                                      "tSULo39/74P2Lk+qui/JCklRJnQNM+Z6SAo6Em3FdimVPkukW3Q+/n71f89Zx/WjGEo0M6\n"
+                                      "SkMQQkwzsqUp6xhEe7yngiPBcb3gGeMxdxIaLXDyhC+u2QmhMzD/OCaw3yYn7zaFmCZXYS\n"
+                                      "RsRPNKT3YatxDzH/XIK3XW2BQ9Ur0QtIhlfA3mMdZjYSp2Eb2KNYi6M2w/M75A9Gb38OdM\n"
+                                      "91yxiX4/GvuxGuALPLgjcX50VB2VWsCRNduByOx6M+VzYb0hRurxfPgez90Svluqbb3X0+\n"
+                                      "ISqoxxZUqxZDSg2FT+NBnR3ASwc2fP4WP7BLrhzmojWeyvHhtBN4ZKG/TYCLzjNvi4W0Jg\n"
+                                      "wp2IAAT4NlgdLnv4AIdsZWY/mozdzgeQtsmTNyK5aXpECkWE7/TL3VPeX7yflbEJEOB3Ny\n"
+                                      "NDk+iEoqqOVcuE+uPXWT/hKWd7N2Wpjcth4095VzPqxO2knCTDeg3cDfEkC7i7dSG3vuLb\n"
+                                      "zvb8NjX22f9iJJrbjIUFaT0u0WN6zOoIJxTZMvVHAoOAGt008DWemg3JaCx1BtZjT9hc2a\n"
+                                      "GOHb7o+5XpbVPeHA7BLehxk9KLk92+X9yOEap3rZPtvxPleSsSWGdT+ISxLHlvrW8gBd2j\n"
+                                      "f4GcWI1+EVws5ukyd+QmV1FUMW/2SIY15sF4RgcsxuBSxUQ0vWYHZJKooGaN3Nf4GfzeKL\n"
+                                      "hPHnC5l5mEz75q/LyPJvqNAtWg5kmQPLqlI2K5ugD0ZqdTNYVWjt3W6U/GRqZVCdB0PioP\n"
+                                      "yiI2zblxfC/Nzvd6YqO8QDt3vz5j5GIIRMJb+Krtccury9ZKDR93DqTXLMwPaxtaZ3jyFX\n"
+                                      "vn03lyYywERTvh0qPKwNYcxWOd/cbSyJvMQSq2f0L0EYgKF2SbqtmtA/1kT/stiTXBpc2O\n"
+                                      "yNDWcFW/6Eap4eZPzljpw8r0OqpvMjePo4fInJxl+sM4MrDBgaRtx/b2GUzzWTut5g9nFm\n"
+                                      "I1zGUS8ckiZAAABdB34p30d+Kd9AAAAB9zc2gtbWxkc2E0NC1lZDI1NTE5QG9wZW5zc2gu\n"
+                                      "Y29tAAAFQC3FuaSh0davMqgfw/lbJi8XUxGaB4518bTUfuVn+u7oObwSK1CQCsLTYQB4Vn\n"
+                                      "HLGjqf0AKOUSjmpnqQQYISb+GwWFcpl7MWvUEA1mhxeeBqoMq75cZfnKh3CfV/GGfKbeSJ\n"
+                                      "qiwxrPhLE/Tr9SCGft+kuIZLQR6XwaM8yPFfPQJvngpYLQmiIJqoG0QpWPtbK5m0K4sklR\n"
+                                      "4AnNrrwuD4AEibkFfPdZNayDjESXv76QsyGl94oUkOFzFWeZeUQSt4JE2QlO/20HJN3Bo8\n"
+                                      "b3LkDHYA7H9KaEh8kwc9uRnNG35RADGi4qQg4alHQO5Cz3qq2ubpnJgn4KT1ZtHxn3kEux\n"
+                                      "qGgDjnLQuWDzIjqNZ/bnwTC5HMsQHIEAM1ouBJHhTRTxCEx9Ujoe51vMtO23D7nfg6fiZ8\n"
+                                      "M8euV2vXrZ3krla87Bgyn1SkuDV8Thll2aU9BMQ3mO9MOElbRRIRfU5xmlQ2yLZD4BJGPp\n"
+                                      "TGqqDjmvoivaZdF7bNLoPGOIOVW9DJ1pskr95LD/14LtqyKQFLKSdar9JQRwOGV64RK8td\n"
+                                      "sqMYbZzzAcV3w6tnS3ZmwCppG47XQSWtge9zyxuHA9V6/jbOKAJpJJglP7fh0N2OBerxll\n"
+                                      "N8i4blysLBs7hf7gBf+eictIzypj1HGeoMB0CmRjDEe/+tvq+/q5NNBfrB9yY+qTi7Wl06\n"
+                                      "2ZxPlHZCeRCglQj5JQ0Ig3fsrd4gYrC5rVTefAm6kBRxfVZhjwLDrveknXSYEAaw/zfiRd\n"
+                                      "Teq+myRckFdj58PG2OzBQjqryvnMCZxCnZLf7KPvtSULo39/74P2Lk+qui/JCklRJnQNM+\n"
+                                      "Z6SAo6Em3FdimVPkukW3Q+/n71f89Zx/WjGEo0M6SkMQQkwzsqUp6xhEe7yngiPBcb3gGe\n"
+                                      "MxdxIaLXDyhC+u2QmhMzD/OCaw3yYn7zaFmCZXYSRsRPNKT3YatxDzH/XIK3XW2BQ9Ur0Q\n"
+                                      "tIhlfA3mMdZjYSp2Eb2KNYi6M2w/M75A9Gb38OdM91yxiX4/GvuxGuALPLgjcX50VB2VWs\n"
+                                      "CRNduByOx6M+VzYb0hRurxfPgez90Svluqbb3X0+ISqoxxZUqxZDSg2FT+NBnR3ASwc2fP\n"
+                                      "4WP7BLrhzmojWeyvHhtBN4ZKG/TYCLzjNvi4W0Jgwp2IAAT4NlgdLnv4AIdsZWY/mozdzg\n"
+                                      "eQtsmTNyK5aXpECkWE7/TL3VPeX7yflbEJEOB3NyNDk+iEoqqOVcuE+uPXWT/hKWd7N2Wp\n"
+                                      "jcth4095VzPqxO2knCTDeg3cDfEkC7i7dSG3vuLbzvb8NjX22f9iJJrbjIUFaT0u0WN6zO\n"
+                                      "oIJxTZMvVHAoOAGt008DWemg3JaCx1BtZjT9hc2aGOHb7o+5XpbVPeHA7BLehxk9KLk92+\n"
+                                      "X9yOEap3rZPtvxPleSsSWGdT+ISxLHlvrW8gBd2jf4GcWI1+EVws5ukyd+QmV1FUMW/2SI\n"
+                                      "Y15sF4RgcsxuBSxUQ0vWYHZJKooGaN3Nf4GfzeKLhPHnC5l5mEz75q/LyPJvqNAtWg5kmQ\n"
+                                      "PLqlI2K5ugD0ZqdTNYVWjt3W6U/GRqZVCdB0PioPyiI2zblxfC/Nzvd6YqO8QDt3vz5j5G\n"
+                                      "IIRMJb+Krtccury9ZKDR93DqTXLMwPaxtaZ3jyFXvn03lyYywERTvh0qPKwNYcxWOd/cbS\n"
+                                      "yJvMQSq2f0L0EYgKF2SbqtmtA/1kT/stiTXBpc2OyNDWcFW/6Eap4eZPzljpw8r0OqpvMj\n"
+                                      "ePo4fInJxl+sM4MrDBgaRtx/b2GUzzWTut5g9nFmI1zGUS8ckiZAAAAEBv2UdlYL3UVTSG\n"
+                                      "5HMErtVNdWiFdp/ToMR3tay3f+iC4UukHTk1UCkpU/oS9gfIkk5/cA1WZP2CaUUomEGoXL\n"
+                                      "e7AAAAGW1sZHNhNDQtZWQyNTUxOUBrZWVwYXNzeGM=\n"
+                                      "-----END OPENSSH PRIVATE KEY-----\n");
+
+    const QByteArray keyData = keyString.toLatin1();
+
+    OpenSSHKey key;
+    QVERIFY(key.parsePKCS1PEM(keyData));
+    QVERIFY(!key.encrypted());
+    QCOMPARE(key.cipherName(), QString("none"));
+    QCOMPARE(key.type(), QString("ssh-mldsa44-ed25519@openssh.com"));
+    QCOMPARE(key.comment(), QString("mldsa44-ed25519@keepassxc"));
+    QCOMPARE(key.fingerprint(), QString("SHA256:F5imRdKQQaF6niGeOUvxl884hGxB9TUKSE62f8h+dSE"));
+    QCOMPARE(keyString, key.privateKey());
+}

--- a/tests/TestOpenSSHKey.h
+++ b/tests/TestOpenSSHKey.h
@@ -43,6 +43,7 @@ private slots:
     void testDecryptUTF8();
     void testParseECDSASecurityKey();
     void testParseED25519SecurityKey();
+    void testParseMLDSA44Ed25519();
 };
 
 #endif // TESTOPENSSHKEY_H

--- a/tests/TestSSHAgent.cpp
+++ b/tests/TestSSHAgent.cpp
@@ -293,6 +293,27 @@ void TestSSHAgent::testKeyGenEd25519()
     QVERIFY(agent.checkIdentity(key, keyInAgent) && !keyInAgent);
 }
 
+void TestSSHAgent::testKeyGenMLDSA44Ed25519()
+{
+    SSHAgent agent;
+    agent.setEnabled(true);
+    agent.setAuthSockOverride(m_agentSocketFileName);
+
+    QVERIFY(agent.isAgentRunning());
+
+    OpenSSHKey key;
+    KeeAgentSettings settings;
+    bool keyInAgent;
+
+    QVERIFY(OpenSSHKeyGen::generateMLDSA44Ed25519(key));
+    QCOMPARE(key.type(), QString("ssh-mldsa44-ed25519@openssh.com"));
+
+    QVERIFY(agent.addIdentity(key, settings, m_uuid));
+    QVERIFY(agent.checkIdentity(key, keyInAgent) && keyInAgent);
+    QVERIFY(agent.removeIdentity(key));
+    QVERIFY(agent.checkIdentity(key, keyInAgent) && !keyInAgent);
+}
+
 void TestSSHAgent::cleanupTestCase()
 {
     if (m_agentProcess.state() != QProcess::NotRunning) {

--- a/tests/TestSSHAgent.h
+++ b/tests/TestSSHAgent.h
@@ -39,6 +39,7 @@ private slots:
     void testKeyGenRSA();
     void testKeyGenECDSA();
     void testKeyGenEd25519();
+    void testKeyGenMLDSA44Ed25519();
     void cleanupTestCase();
 
 private:


### PR DESCRIPTION
Closes #13507

I have not actually tested this properly yet, just pushing the PR out. The generation bit looks sketchy but it passes its own tests and is 100% LLM written.

This also depends on OpenSSH 10.4 so the tests will likely fail on our CI for now: https://www.openssh.org/txt/release-10.4

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
Added tests plus tested by hand that ssh-agent accepts the keys and they indeed have the correct fingerprint. No full end-to-end testing yet.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ New feature (change that adds functionality)

