### PR TITLE
Add Dark (OLED) pure-black theme

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,7 @@ set(gui_SOURCES
         gui/styles/base/BaseStyle.cpp
         gui/styles/dark/DarkStyle.cpp
         gui/styles/light/LightStyle.cpp
+        gui/styles/oled/OledStyle.cpp
         gui/AboutDialog.cpp
         gui/ActionCollection.cpp
         gui/Application.cpp

--- a/src/gui/Application.cpp
+++ b/src/gui/Application.cpp
@@ -26,6 +26,7 @@
 #include "gui/osutils/OSUtils.h"
 #include "gui/styles/dark/DarkStyle.h"
 #include "gui/styles/light/LightStyle.h"
+#include "gui/styles/oled/OledStyle.h"
 
 #include <QFileInfo>
 #include <QFileOpenEvent>
@@ -174,6 +175,10 @@ void Application::applyTheme()
 #endif
     }
     QPixmapCache::clear();
+    // Clear classic stylesheet so light/dark/oled styles take full effect when switching live
+    if (appTheme != QLatin1String("classic")) {
+        setStyleSheet(QString());
+    }
     if (appTheme == "light") {
         auto* s = new LightStyle;
         setPalette(s->standardPalette());
@@ -181,6 +186,11 @@ void Application::applyTheme()
         m_darkTheme = false;
     } else if (appTheme == "dark") {
         auto* s = new DarkStyle;
+        setPalette(s->standardPalette());
+        setStyle(s);
+        m_darkTheme = true;
+    } else if (appTheme == "oled") {
+        auto* s = new OledStyle;
         setPalette(s->standardPalette());
         setStyle(s);
         m_darkTheme = true;
@@ -199,6 +209,11 @@ void Application::applyTheme()
         }
     }
     applyFontSize();
+
+#ifdef Q_OS_MACOS
+    // Pure-black title bar only for Dark (OLED). Version-gated; soft-fails on unsupported OS.
+    macUtils()->setOledChromeEnabled(appTheme == QLatin1String("oled"));
+#endif
 }
 
 void Application::applyFontSize()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1958,12 +1958,14 @@ void MainWindow::initViewMenu()
     m_ui->actionThemeAuto->setData("auto");
     m_ui->actionThemeLight->setData("light");
     m_ui->actionThemeDark->setData("dark");
+    m_ui->actionThemeOled->setData("oled");
     m_ui->actionThemeClassic->setData("classic");
 
     auto themeActions = new QActionGroup(this);
     themeActions->addAction(m_ui->actionThemeAuto);
     themeActions->addAction(m_ui->actionThemeLight);
     themeActions->addAction(m_ui->actionThemeDark);
+    themeActions->addAction(m_ui->actionThemeOled);
     themeActions->addAction(m_ui->actionThemeClassic);
 
     auto theme = config()->get(Config::GUI_ApplicationTheme).toString();
@@ -1974,9 +1976,13 @@ void MainWindow::initViewMenu()
         }
     }
 
-    connect(themeActions, &QActionGroup::triggered, this, [this, theme](QAction* action) {
-        config()->set(Config::GUI_ApplicationTheme, action->data());
-        if ((action->data() == "classic" || theme == "classic") && action->data() != theme) {
+    // Light / Dark / Dark (OLED) apply live via applyTheme().
+    // Classic uses a different style path and still requires a restart.
+    connect(themeActions, &QActionGroup::triggered, this, [this](QAction* action) {
+        const auto previous = config()->get(Config::GUI_ApplicationTheme).toString();
+        const auto next = action->data().toString();
+        config()->set(Config::GUI_ApplicationTheme, next);
+        if ((next == QLatin1String("classic") || previous == QLatin1String("classic")) && next != previous) {
             restartApp(tr("You must restart the application to apply this setting. Would you like to restart now?"));
         } else {
             kpxcApp->applyTheme();
@@ -2111,6 +2117,7 @@ void MainWindow::initActionCollection()
                     m_ui->actionThemeAuto,
                     m_ui->actionThemeLight,
                     m_ui->actionThemeDark,
+                    m_ui->actionThemeOled,
                     m_ui->actionThemeClassic,
                     m_ui->actionCompactMode,
 #ifndef Q_OS_MACOS

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -386,6 +386,7 @@
      <addaction name="actionThemeAuto"/>
      <addaction name="actionThemeLight"/>
      <addaction name="actionThemeDark"/>
+     <addaction name="actionThemeOled"/>
      <addaction name="actionThemeClassic"/>
     </widget>
     <addaction name="menuTheme"/>
@@ -1175,6 +1176,17 @@
    </property>
    <property name="toolTip">
     <string>Set Theme: Dark</string>
+   </property>
+  </action>
+  <action name="actionThemeOled">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Dark (OLED)</string>
+   </property>
+   <property name="toolTip">
+    <string>Set Theme: Dark (OLED) — pure-black theme for OLED displays</string>
    </property>
   </action>
   <action name="actionThemeClassic">

--- a/src/gui/osutils/macutils/AppKit.h
+++ b/src/gui/osutils/macutils/AppKit.h
@@ -48,6 +48,9 @@ public:
     void toggleForegroundApp(bool foreground);
     void setWindowSecurity(QWindow* window, bool state);
     void configureWindowAndHelpMenus(QMainWindow* mainWindow, QMenu* helpMenu);
+    // Dark (OLED): pure-black title bars when theme is oled (macOS only)
+    void setOledChromeEnabled(bool enabled);
+    void applyOledWindowChrome(QWindow* window);
 
 signals:
     void userSwitched();

--- a/src/gui/osutils/macutils/AppKitImpl.h
+++ b/src/gui/osutils/macutils/AppKitImpl.h
@@ -29,6 +29,9 @@
 - (id) initWithObject:(AppKit*)appkit;
 
 @property (strong) NSRunningApplication *lastActiveApplication;
+// Dark (OLED) native chrome — version-safe, soft-fail on unsupported macOS
+@property (nonatomic, assign) BOOL oledNativeChromeDesired;
+@property (nonatomic, assign) BOOL oledNativeChromeBusy;
 
 - (pid_t) activeProcessId;
 - (pid_t) ownProcessId;
@@ -43,5 +46,9 @@
 - (void) toggleForegroundApp:(bool) foreground;
 - (void) setWindowSecurity:(NSWindow*) window state:(bool) state;
 - (void) configureWindowAndHelpMenus:(QMainWindow*) mainWindow helpMenu:(QMenu*) helpMenu;
+// Dark (OLED) theme: pure-black title bar (macOS, optional)
+- (void) setOledChromeEnabled:(bool) enabled;
+- (void) applyOledWindowChrome:(NSWindow*) window;
+- (void) clearOledWindowChrome:(NSWindow*) window;
 
 @end

--- a/src/gui/osutils/macutils/AppKitImpl.mm
+++ b/src/gui/osutils/macutils/AppKitImpl.mm
@@ -70,6 +70,10 @@
     Q_UNUSED(change)
     Q_UNUSED(context)
     if ([keyPath isEqualToString:@"effectiveAppearance"]) {
+        // Skip while updating OLED window chrome to avoid applyTheme re-entrancy
+        if (self.oledNativeChromeBusy) {
+            return;
+        }
         if (m_appkit) {
 
             void (^emitBlock)(void) = ^{
@@ -253,6 +257,177 @@
     NSApp.helpMenu = helpMenu->toNSMenu();
 }
 
+// Dark (OLED) theme: pure-black titled windows; reversible when leaving OLED.
+//
+// Cross-macOS safety:
+// - Never set NSApp.appearance (KVO → applyTheme recursion / crash on several releases)
+// - Use @available / respondsToSelector; soft-fail so the Qt OLED theme still works
+// - Only style ordinary titled windows (not HUD/panel/tooltips)
+// - Apply on main queue after windows exist (avoids races on older Qt/macOS)
+//
+- (BOOL) oledChromeSupported
+{
+    // Transparent title bar needs 10.10+; DarkAqua appearance 10.14+.
+    // KeePassXC targets modern macOS; if unavailable, leave system chrome alone.
+    if (@available(macOS 10.14, *)) {
+        return YES;
+    }
+    return NO;
+}
+
+- (BOOL) shouldStyleWindowForOled:(NSWindow*) window
+{
+    if (!window) {
+        return NO;
+    }
+    // Titled document-style windows / dialogs only
+    if ((window.styleMask & NSWindowStyleMaskTitled) == 0) {
+        return NO;
+    }
+    // Skip sheets and floating utility panels — chrome APIs differ by release
+    if (window.isSheet) {
+        return NO;
+    }
+    if ([window isKindOfClass:[NSPanel class]]) {
+        NSPanel* panel = static_cast<NSPanel*>(window);
+        if (panel.floatingPanel || panel.becomesKeyOnlyIfNeeded) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
+- (void) setOledChromeEnabled:(bool) enabled
+{
+    // Always record desired state so a in-flight async pass applies the latest value
+    const BOOL wantEnabled = enabled ? YES : NO;
+    self.oledNativeChromeDesired = wantEnabled;
+
+    NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
+    [nc removeObserver:self name:NSWindowDidBecomeKeyNotification object:nil];
+    [nc removeObserver:self name:NSWindowDidBecomeMainNotification object:nil];
+
+    // Soft no-op for native chrome on unsupported OS; Qt OLED theme still applies
+    if (![self oledChromeSupported]) {
+        return;
+    }
+
+    if (wantEnabled) {
+        [nc addObserver:self
+               selector:@selector(oledWindowDidBecomeKey:)
+                   name:NSWindowDidBecomeKeyNotification
+                 object:nil];
+        [nc addObserver:self
+               selector:@selector(oledWindowDidBecomeKey:)
+                   name:NSWindowDidBecomeMainNotification
+                 object:nil];
+    }
+
+    // Already scheduled a pass — it will read the latest oledNativeChromeDesired
+    if (self.oledNativeChromeBusy) {
+        return;
+    }
+    self.oledNativeChromeBusy = YES;
+
+    // Defer to next main-queue turn so NSWindows exist on all macOS + Qt combos.
+    // Strong self is fine under MRC: AppKitImpl lives for the process.
+    AppKitImpl* strongSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        @try {
+            for (NSWindow* window in NSApp.windows) {
+                if (strongSelf.oledNativeChromeDesired) {
+                    [strongSelf applyOledWindowChrome:window];
+                } else {
+                    [strongSelf clearOledWindowChrome:window];
+                }
+            }
+        } @catch (NSException* ex) {
+            NSLog(@"KeePassXC: OLED window chrome update failed: %@", ex);
+        }
+        strongSelf.oledNativeChromeBusy = NO;
+    });
+}
+
+- (void) oledWindowDidBecomeKey:(NSNotification*) notification
+{
+    if (!self.oledNativeChromeDesired || self.oledNativeChromeBusy) {
+        return;
+    }
+    id obj = notification.object;
+    if ([obj isKindOfClass:[NSWindow class]]) {
+        [self applyOledWindowChrome:obj];
+    }
+}
+
+- (void) applyOledWindowChrome:(NSWindow*) window
+{
+    if (!self.oledNativeChromeDesired || ![self oledChromeSupported]) {
+        return;
+    }
+    if (![self shouldStyleWindowForOled:window]) {
+        return;
+    }
+
+    @try {
+        // Per-window dark chrome only (never NSApp.appearance)
+        if (@available(macOS 10.14, *)) {
+            NSAppearance* dark = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+            if (dark != nil) {
+                window.appearance = dark;
+            }
+        }
+
+        // Transparent title bar over pure black content (10.10+)
+        if (@available(macOS 10.10, *)) {
+            if ([window respondsToSelector:@selector(setTitlebarAppearsTransparent:)]) {
+                window.titlebarAppearsTransparent = YES;
+            }
+            if ([window respondsToSelector:@selector(setTitleVisibility:)]) {
+                // Keep title text; hiding it is unnecessary and varies by release
+                window.titleVisibility = NSWindowTitleVisible;
+            }
+        }
+
+        if ([window respondsToSelector:@selector(setBackgroundColor:)]) {
+            window.backgroundColor = [NSColor blackColor];
+        }
+        // Do not set FullSizeContentView — breaks Qt toolbar layout on multiple releases
+    } @catch (NSException* ex) {
+        NSLog(@"KeePassXC: applyOledWindowChrome failed: %@", ex);
+    }
+}
+
+- (void) clearOledWindowChrome:(NSWindow*) window
+{
+    if (![self shouldStyleWindowForOled:window]) {
+        return;
+    }
+
+    @try {
+        if (@available(macOS 10.14, *)) {
+            window.appearance = nil; // follow system again
+        }
+        if (@available(macOS 10.10, *)) {
+            if ([window respondsToSelector:@selector(setTitlebarAppearsTransparent:)]) {
+                window.titlebarAppearsTransparent = NO;
+            }
+            if ([window respondsToSelector:@selector(setTitleVisibility:)]) {
+                window.titleVisibility = NSWindowTitleVisible;
+            }
+        }
+        if ([window respondsToSelector:@selector(setBackgroundColor:)]) {
+            // System document background — correct light/dark adaptive color on 10.14+
+            if (@available(macOS 10.14, *)) {
+                window.backgroundColor = [NSColor windowBackgroundColor];
+            } else {
+                window.backgroundColor = [NSColor windowBackgroundColor];
+            }
+        }
+    } @catch (NSException* ex) {
+        NSLog(@"KeePassXC: clearOledWindowChrome failed: %@", ex);
+    }
+}
+
 @end
 
 
@@ -270,6 +445,7 @@ AppKit::~AppKit()
 {
     [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:static_cast<id>(self)];
     [[NSDistributedNotificationCenter defaultCenter] removeObserver:static_cast<id>(self)];
+    [[NSNotificationCenter defaultCenter] removeObserver:static_cast<id>(self)];
     [NSApp removeObserver:static_cast<id>(self) forKeyPath:@"effectiveAppearance"];
     [static_cast<id>(self) dealloc];
 }
@@ -339,4 +515,20 @@ void AppKit::setWindowSecurity(QWindow* window, bool state)
 void AppKit::configureWindowAndHelpMenus(QMainWindow* window, QMenu* helpMenu)
 {
     [static_cast<id>(self) configureWindowAndHelpMenus:window helpMenu:helpMenu];
+}
+
+void AppKit::setOledChromeEnabled(bool enabled)
+{
+    [static_cast<id>(self) setOledChromeEnabled:enabled];
+}
+
+void AppKit::applyOledWindowChrome(QWindow* window)
+{
+    if (!window) {
+        return;
+    }
+    auto view = reinterpret_cast<NSView*>(window->winId());
+    if (view && view.window) {
+        [static_cast<id>(self) applyOledWindowChrome:view.window];
+    }
 }

--- a/src/gui/osutils/macutils/MacUtils.cpp
+++ b/src/gui/osutils/macutils/MacUtils.cpp
@@ -208,6 +208,16 @@ void MacUtils::configureWindowAndHelpMenus(QMainWindow* mainWindow, QMenu* helpM
     return m_appkit->configureWindowAndHelpMenus(mainWindow, helpMenu);
 }
 
+void MacUtils::setOledChromeEnabled(bool enabled)
+{
+    m_appkit->setOledChromeEnabled(enabled);
+}
+
+void MacUtils::applyOledWindowChrome(QWindow* window)
+{
+    m_appkit->applyOledWindowChrome(window);
+}
+
 bool MacUtils::registerGlobalShortcut(const QString& name, Qt::Key key, Qt::KeyboardModifiers modifiers, QString* error)
 {
     auto keycode = qtToNativeKeyCode(key);

--- a/src/gui/osutils/macutils/MacUtils.h
+++ b/src/gui/osutils/macutils/MacUtils.h
@@ -56,6 +56,8 @@ public:
     void registerNativeEventFilter() override;
 
     void configureWindowAndHelpMenus(QMainWindow* mainWindow, QMenu* helpMenu);
+    void setOledChromeEnabled(bool enabled);
+    void applyOledWindowChrome(QWindow* window);
 
     bool registerGlobalShortcut(const QString& name,
                                 Qt::Key key,

--- a/src/gui/styles/oled/OledStyle.cpp
+++ b/src/gui/styles/oled/OledStyle.cpp
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC contributors (OLED theme)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "OledStyle.h"
+
+#include <QDialog>
+#include <QFile>
+#include <QMainWindow>
+#include <QMenuBar>
+#include <QStatusBar>
+#include <QToolBar>
+
+#ifdef Q_OS_MACOS
+#include "gui/osutils/OSUtils.h"
+#endif
+
+/*
+ * OLED pure-black dark theme.
+ *
+ * True #000000 for primary chrome so OLED pixels can turn off.
+ * Slightly elevated near-black surfaces (#0A0A0A / #121212) keep hierarchy.
+ */
+OledStyle::OledStyle()
+    : BaseStyle()
+{
+#ifdef Q_OS_MACOS
+    m_drawNativeMacOsToolBar = osUtils->isDarkMode();
+#endif
+}
+
+QPalette OledStyle::standardPalette() const
+{
+    auto palette = BaseStyle::standardPalette();
+
+    // Primary window chrome — pure black for OLED
+    palette.setColor(QPalette::Active, QPalette::Window, QRgb(0x000000));
+    palette.setColor(QPalette::Inactive, QPalette::Window, QRgb(0x000000));
+    palette.setColor(QPalette::Disabled, QPalette::Window, QRgb(0x0A0A0A));
+
+    palette.setColor(QPalette::Active, QPalette::WindowText, QRgb(0xE8E8EA));
+    palette.setColor(QPalette::Inactive, QPalette::WindowText, QRgb(0xC8C8CA));
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, QRgb(0x666666));
+
+    palette.setColor(QPalette::Active, QPalette::Text, QRgb(0xE8E8EA));
+    palette.setColor(QPalette::Inactive, QPalette::Text, QRgb(0xC8C8CA));
+    palette.setColor(QPalette::Disabled, QPalette::Text, QRgb(0x666666));
+
+    palette.setColor(QPalette::Active, QPalette::PlaceholderText, QRgb(0x6B6B70));
+    palette.setColor(QPalette::Inactive, QPalette::PlaceholderText, QRgb(0x6B6B70));
+    palette.setColor(QPalette::Disabled, QPalette::PlaceholderText, QRgb(0x555555));
+
+    palette.setColor(QPalette::Active, QPalette::BrightText, QRgb(0xFFFFFF));
+    palette.setColor(QPalette::Inactive, QPalette::BrightText, QRgb(0xF0F0F0));
+    palette.setColor(QPalette::Disabled, QPalette::BrightText, QRgb(0x888888));
+
+    palette.setColor(QPalette::Active, QPalette::Base, QRgb(0x0A0A0A));
+    palette.setColor(QPalette::Inactive, QPalette::Base, QRgb(0x0A0A0A));
+    palette.setColor(QPalette::Disabled, QPalette::Base, QRgb(0x121212));
+
+    palette.setColor(QPalette::Active, QPalette::AlternateBase, QRgb(0x121212));
+    palette.setColor(QPalette::Inactive, QPalette::AlternateBase, QRgb(0x121212));
+    palette.setColor(QPalette::Disabled, QPalette::AlternateBase, QRgb(0x1A1A1A));
+
+    palette.setColor(QPalette::All, QPalette::ToolTipBase, QRgb(0x0D1F0D));
+    palette.setColor(QPalette::All, QPalette::ToolTipText, QRgb(0xD0D0D0));
+
+    palette.setColor(QPalette::Active, QPalette::Button, QRgb(0x141414));
+    palette.setColor(QPalette::Inactive, QPalette::Button, QRgb(0x141414));
+    palette.setColor(QPalette::Disabled, QPalette::Button, QRgb(0x101010));
+
+    palette.setColor(QPalette::Active, QPalette::ButtonText, QRgb(0xE0E0E4));
+    palette.setColor(QPalette::Inactive, QPalette::ButtonText, QRgb(0xA0A0A4));
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, QRgb(0x55555A));
+
+    palette.setColor(QPalette::Active, QPalette::Highlight, QRgb(0x1B5E20));
+    palette.setColor(QPalette::Inactive, QPalette::Highlight, QRgb(0x143D16));
+    palette.setColor(QPalette::Disabled, QPalette::Highlight, QRgb(0x0F2A10));
+
+    palette.setColor(QPalette::Active, QPalette::HighlightedText, QRgb(0xF5F5F5));
+    palette.setColor(QPalette::Inactive, QPalette::HighlightedText, QRgb(0xE0E0E0));
+    palette.setColor(QPalette::Disabled, QPalette::HighlightedText, QRgb(0x666666));
+
+    palette.setColor(QPalette::All, QPalette::Light, QRgb(0x1A1A1A));
+    palette.setColor(QPalette::All, QPalette::Midlight, QRgb(0x141414));
+    palette.setColor(QPalette::All, QPalette::Mid, QRgb(0x0F0F0F));
+    palette.setColor(QPalette::All, QPalette::Dark, QRgb(0x000000));
+    palette.setColor(QPalette::All, QPalette::Shadow, QRgb(0x000000));
+
+    palette.setColor(QPalette::All, QPalette::Link, QRgb(0x6BCF6B));
+    palette.setColor(QPalette::Disabled, QPalette::Link, QRgb(0x4A8A4A));
+    palette.setColor(QPalette::All, QPalette::LinkVisited, QRgb(0x7AD47A));
+    palette.setColor(QPalette::Disabled, QPalette::LinkVisited, QRgb(0x4A8A4A));
+
+    return palette;
+}
+
+QString OledStyle::getAppStyleSheet() const
+{
+    QFile extStylesheetFile(QStringLiteral(":/styles/oled/oledstyle.qss"));
+    if (extStylesheetFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return extStylesheetFile.readAll();
+    }
+    qWarning("Failed to load OLED theme stylesheet.");
+    return {};
+}
+
+void OledStyle::polish(QWidget* widget)
+{
+    if (qobject_cast<QMainWindow*>(widget) || qobject_cast<QDialog*>(widget) || qobject_cast<QMenuBar*>(widget)
+        || qobject_cast<QToolBar*>(widget)) {
+        auto palette = widget->palette();
+        palette.setColor(QPalette::Active, QPalette::Window, QRgb(0x000000));
+        palette.setColor(QPalette::Inactive, QPalette::Window, QRgb(0x000000));
+        palette.setColor(QPalette::Disabled, QPalette::Window, QRgb(0x0A0A0A));
+        widget->setPalette(palette);
+    }
+}

--- a/src/gui/styles/oled/OledStyle.h
+++ b/src/gui/styles/oled/OledStyle.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2020 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC contributors (OLED theme)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_OLEDSTYLE_H
+#define KEEPASSXC_OLEDSTYLE_H
+
+#include "gui/styles/base/BaseStyle.h"
+
+/**
+ * Pure-black OLED-friendly dark theme.
+ * Selectable via View → Theme → Dark (OLED); does not replace stock Dark.
+ */
+class OledStyle : public BaseStyle
+{
+    Q_OBJECT
+
+public:
+    OledStyle();
+    QPalette standardPalette() const override;
+
+    using BaseStyle::polish;
+    void polish(QWidget* widget) override;
+
+protected:
+    QString getAppStyleSheet() const override;
+};
+
+#endif // KEEPASSXC_OLEDSTYLE_H

--- a/src/gui/styles/oled/oledstyle.qss
+++ b/src/gui/styles/oled/oledstyle.qss
@@ -1,0 +1,61 @@
+/* OLED pure-black theme — View → Theme → Dark (OLED) */
+
+DatabaseWidget:!active,
+DatabaseWidget #groupView:!active, DatabaseWidget #tagView:!active,
+EntryPreviewWidget *:!active[blendIn="true"] {
+    background-color: #000000;
+}
+
+DatabaseWidget:disabled,
+DatabaseWidget #groupView:disabled, DatabaseWidget #tagView:disabled,
+EntryPreviewWidget *:disabled[blendIn="true"] {
+    background-color: #0A0A0A;
+}
+
+QMenu {
+    border: 1px solid #1A1A1A;
+    background-color: #000000;
+}
+
+QMenu::separator {
+    height: 1px;
+    background-color: #1A1A1A;
+}
+
+QPushButton:!default:hover {
+    background: #1A1A1A;
+}
+
+QPushButton:default:hover, QPushButton:checked:hover {
+    background: #2E7D32;
+}
+
+QToolTip {
+    color: #D0D0D0;
+    background-color: #0D1F0D;
+    border: 1px solid #1B5E20;
+}
+
+QGroupBox {
+    background-color: #0A0A0A;
+}
+
+QToolBar {
+    background-color: #000000;
+    border: none;
+}
+
+QStatusBar {
+    background-color: #000000;
+}
+
+QHeaderView::section {
+    background-color: #0A0A0A;
+    border: 1px solid #1A1A1A;
+}
+
+QLineEdit, QTextEdit, QPlainTextEdit, QSpinBox, QComboBox {
+    background-color: #0A0A0A;
+    border: 1px solid #1A1A1A;
+    selection-background-color: #1B5E20;
+}

--- a/src/gui/styles/styles.qrc
+++ b/src/gui/styles/styles.qrc
@@ -5,5 +5,6 @@
         <file>base/basestyle.qss</file>
         <file>dark/darkstyle.qss</file>
         <file>light/lightstyle.qss</file>
+        <file>oled/oledstyle.qss</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
## Description

Adds a **Dark (OLED)** theme for pure-black UI, aimed at **macOS OLED machines** (pure black content + matching title bar), without changing the existing **Dark** theme.

Primary design target: **macOS**. The in-app theme uses the same Qt style path as Light/Dark, so Linux/Windows also get the pure-black *window content* if someone selects the theme — but title-bar blending is **macOS-only** and was what we built/tested for.

### User-facing
- **View → Theme → Dark (OLED)** → `GUI/ApplicationTheme=oled`
- Applies **live** via `applyTheme()` (same as Light/Dark)
- Classic still requires restart (unchanged)

### Implementation
- New `OledStyle` + `oledstyle.qss` (true `#000` window chrome, near-black elevated surfaces)
- Stock Dark palette left as-is
- **macOS only:** pure-black title bar / traffic-light strip while OLED is selected
  - Version-gated (`@available`)
  - Soft-fails on unsupported OS (Qt theme still works)
  - Does **not** set `NSApp.appearance` (avoids KVO/`applyTheme` recursion)
  - Skips sheets/floating panels

### Screenshots
(Please test on macOS: View → Theme → Dark (OLED) vs Dark)

## Testing
**macOS (primary)**
- [ ] Select Dark (OLED) — pure black UI + black title bar, no restart
- [ ] Select Dark — stock gray dark + normal title bar restored
- [ ] Select Light / Auto — normal
- [ ] Classic still prompts restart

**Linux/Windows (optional / smoke — not the design focus)**
- [ ] Theme menu includes Dark (OLED) and content goes pure black
- [ ] No macOS-only chrome code runs (ifdef)

## Notes
Local packaging (app rename, update-check off) is **not** included — contribution-only theme change.