### PR TITLE
Fix CSV import header auto-mapping under non-English UI

### DIFF
--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -80,6 +80,12 @@ CsvImportWidget::CsvImportWidget(QWidget* parent)
                    << QObject::tr("URL") << QObject::tr("Tags") << QObject::tr("Notes") << QObject::tr("TOTP")
                    << QObject::tr("Icon") << QObject::tr("Last Modified") << QObject::tr("Created");
 
+    // Canonical English headers as written by CsvExporter — always match these regardless of UI locale
+    m_columnHeaderEnglish << QStringLiteral("Group") << QStringLiteral("Title") << QStringLiteral("Username")
+                          << QStringLiteral("Password") << QStringLiteral("URL") << QStringLiteral("Tags")
+                          << QStringLiteral("Notes") << QStringLiteral("TOTP") << QStringLiteral("Icon")
+                          << QStringLiteral("Last Modified") << QStringLiteral("Created");
+
     m_fieldSeparatorList << "," << ";" << "-" << ":" << "." << "\t";
 
     m_combos << m_ui->groupCombo << m_ui->titleCombo << m_ui->usernameCombo << m_ui->passwordCombo << m_ui->urlCombo
@@ -184,7 +190,9 @@ void CsvImportWidget::updatePreview()
 
         bool found = false;
         for (int j = 0; j < csvColumns.size(); ++j) {
-            if (m_columnHeader.at(i).compare(csvColumns.at(j), Qt::CaseInsensitive) == 0) {
+            // Match translated UI labels and English/canonical export headers
+            if (m_columnHeader.at(i).compare(csvColumns.at(j), Qt::CaseInsensitive) == 0
+                || m_columnHeaderEnglish.at(i).compare(csvColumns.at(j), Qt::CaseInsensitive) == 0) {
                 m_combos.at(i)->setCurrentIndex(j);
                 found = true;
                 break;

--- a/src/gui/csvImport/CsvImportWidget.h
+++ b/src/gui/csvImport/CsvImportWidget.h
@@ -63,6 +63,7 @@ private:
     QStringListModel* m_comboModel;
     QList<QComboBox*> m_combos;
     QStringList m_columnHeader;
+    QStringList m_columnHeaderEnglish;
     QStringList m_fieldSeparatorList;
     QString m_filename;
     bool m_buildingPreview = false;


### PR DESCRIPTION
## Summary

KeePassXC CSV export always writes English canonical headers (`Group`, `Title`, `Username`, etc.). CSV import auto-mapping only compared against translated UI field labels, so under Simplified Chinese (and other locales) only untranslated names like `URL`/`TOTP` matched.

This change also matches the English/canonical export header names during column association, so re-importing a KeePassXC-exported CSV works regardless of UI language. Localized labels continue to work as aliases.

Fixes #13523

## Testing

- [ ] Import KeePassXC-exported CSV with English UI — all columns auto-map
- [ ] Import same CSV with Simplified Chinese UI — all columns auto-map (not only URL/TOTP)
- [ ] Localized header names (if present) still map correctly