### PR TITLE
FdoSecrets: resolve alias object paths in dispatch

### DIFF
--- a/src/fdosecrets/dbus/DBusDispatch.cpp
+++ b/src/fdosecrets/dbus/DBusDispatch.cpp
@@ -244,7 +244,7 @@ namespace FdoSecrets
                                  const RequestedMethod& req,
                                  const QDBusMessage& msg)
     {
-        auto obj = m_objects.value(path, nullptr);
+        auto obj = objectAtPath(path);
         if (!obj) {
             qDebug() << "DBusMgr::handleMessage with unknown path" << msg;
             return false;

--- a/src/fdosecrets/dbus/DBusMgr.cpp
+++ b/src/fdosecrets/dbus/DBusMgr.cpp
@@ -349,6 +349,27 @@ namespace FdoSecrets
         return ParsedPath{};
     }
 
+    DBusObject* DBusMgr::objectAtPath(const QString& path) const
+    {
+        auto obj = m_objects.value(path, nullptr);
+        if (obj) {
+            return obj;
+        }
+
+        // Resolve alias object paths (e.g. /org/freedesktop/secrets/aliases/default)
+        // through the service so they stay reachable even when the alias entry is
+        // missing from the object map. This is what applications like Evolution use
+        // when they access aliased collections directly instead of via ReadAlias.
+        auto parsed = parsePath(path);
+        if (parsed.type == PathType::Aliases) {
+            auto service = qobject_cast<Service*>(m_objects.value(DBUS_PATH_SECRETS, nullptr));
+            if (service) {
+                return service->findCollection(parsed.id);
+            }
+        }
+        return nullptr;
+    }
+
     QString DBusMgr::introspect(const QString& path) const
     {
         auto parsed = parsePath(path);

--- a/src/fdosecrets/dbus/DBusMgr.h
+++ b/src/fdosecrets/dbus/DBusMgr.h
@@ -178,7 +178,7 @@ namespace FdoSecrets
             if (path.path() == QStringLiteral("/")) {
                 return nullptr;
             }
-            auto obj = qobject_cast<T*>(m_objects.value(path.path(), nullptr));
+            auto obj = qobject_cast<T*>(objectAtPath(path.path()));
             if (!obj) {
                 qDebug() << "object not found at path" << path.path();
                 qDebug() << m_objects;
@@ -262,6 +262,18 @@ namespace FdoSecrets
             }
         };
         static ParsedPath parsePath(const QString& path);
+
+        /**
+         * Resolve an object path to the underlying DBusObject.
+         *
+         * In addition to the direct lookup in m_objects, alias object paths of
+         * the form /org/freedesktop/secrets/aliases/{alias} are resolved through
+         * the service's alias map. This keeps aliased collections reachable even
+         * if the alias registration is temporarily absent from the object map.
+         * See issue #13524.
+         */
+        DBusObject* objectAtPath(const QString& path) const;
+
         bool registerObject(const QString& path, DBusObject* obj, bool primary = true);
 
         // method dispatching

--- a/src/fdosecrets/objects/Service.h
+++ b/src/fdosecrets/objects/Service.h
@@ -146,6 +146,8 @@ namespace FdoSecrets
     private:
         bool initialize();
 
+        friend class DBusMgr;
+
         /**
          * Find collection by alias name
          * @param alias

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -1606,6 +1606,50 @@ void TestGuiFdoSecrets::testDefaultAliasAlwaysPresent()
     DBUS_COMPARE(coll->locked(), false);
 }
 
+void TestGuiFdoSecrets::testAliasObjectPathAccessible()
+{
+    // Applications like Evolution access aliased collections directly through their
+    // alias object path (e.g. /org/freedesktop/secrets/aliases/default) instead of
+    // resolving them via ReadAlias. Verify such direct access works. See issue #13524.
+    auto service = enableService();
+    VERIFY(service);
+
+    // resolve the default collection via ReadAlias for comparison
+    auto collViaReadAlias = getDefaultCollection(service);
+    VERIFY(collViaReadAlias);
+    QString labelViaReadAlias;
+    {
+        DBUS_GET(lbl, collViaReadAlias->label());
+        labelViaReadAlias = lbl;
+    }
+
+    // access the alias object path directly
+    auto collViaAlias = getProxy<CollectionProxy>(QDBusObjectPath(DBUS_PATH_DEFAULT_ALIAS));
+    VERIFY(collViaAlias);
+    VERIFY(collViaAlias->isValid());
+
+    // the aliased collection behaves identically to the primary one
+    DBUS_COMPARE(collViaAlias->locked(), false);
+    DBUS_GET(labelViaAlias, collViaAlias->label());
+    COMPARE(labelViaAlias, labelViaReadAlias);
+
+    // listing items through the alias path works
+    DBUS_GET(itemsViaAlias, collViaAlias->items());
+
+    // creating an item (i.e. storing credentials) through the alias path works
+    auto sess = openSession(service, DhIetf1024Sha256Aes128CbcPkcs7::Algorithm);
+    VERIFY(sess);
+
+    QSignalSpy spyItemCreated(collViaReadAlias.data(), SIGNAL(ItemCreated(QDBusObjectPath)));
+    VERIFY(spyItemCreated.isValid());
+
+    StringStringMap attributes{{"application", "fdosecrets-test"}, {"alias-path", "default"}};
+    auto item = createItem(sess, collViaAlias, "alias-entry", "Password", attributes, false);
+    VERIFY(item);
+
+    VERIFY(waitForSignal(spyItemCreated, 1));
+}
+
 void TestGuiFdoSecrets::testExposeSubgroup()
 {
     auto subgroup = m_db->rootGroup()->findGroupByPath("/Homebanking/Subgroup");

--- a/tests/gui/TestGuiFdoSecrets.h
+++ b/tests/gui/TestGuiFdoSecrets.h
@@ -97,6 +97,7 @@ private slots:
 
     void testAlias();
     void testDefaultAliasAlwaysPresent();
+    void testAliasObjectPathAccessible();
 
     void testExposeSubgroup();
     void testModifyingExposedGroup();


### PR DESCRIPTION
## Summary

Secret Service collections exposed under alias object paths (e.g. `/org/freedesktop/secrets/aliases/default`) were only reachable through the `ReadAlias` method.

Applications such as Gnome Evolution access aliased collections directly through their alias object path instead of resolving them via `ReadAlias` (as noted in the freedesktop Secret Service spec, collections are also accessible through alias object paths of the form `/org/freedesktop/secrets/aliases/{alias}`). This resulted in `No such object path '/org/freedesktop/secrets/aliases/default'` errors and made Evolution fail to store mail credentials.

## Changes

- Centralize object path resolution in `DBusMgr::objectAtPath` (used by both method-call dispatch in `activateObject` and by the `pathToObject` argument converter).
- Resolve alias object paths through the service's alias map as a fallback, so aliased collections stay reachable for direct access even if the alias registration is momentarily absent from the object map.
- Add a regression test `testAliasObjectPathAccessible` that accesses the default alias object path directly (label, items and storing an item via the alias path).

Fixes #13524

## Testing

Added `TestGuiFdoSecrets::testAliasObjectPathAccessible` which creates a `CollectionProxy` directly at `/org/freedesktop/secrets/aliases/default`, verifies it behaves identically to the primary collection, and stores an item through the alias path (the exact Evolution credential-storage scenario).