### PR TITLE
fix(gui): prevent password and key file fields from collapsing on resize

### DIFF
--- a/src/gui/DatabaseOpenWidget.ui
+++ b/src/gui/DatabaseOpenWidget.ui
@@ -135,7 +135,7 @@
           <property name="minimumSize">
            <size>
             <width>650</width>
-            <height>0</height>
+            <height>260</height>
            </size>
           </property>
           <property name="frameShape">

--- a/src/gui/PasswordWidget.ui
+++ b/src/gui/PasswordWidget.ui
@@ -10,6 +10,12 @@
     <height>25</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>25</height>
+   </size>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
     <number>0</number>


### PR DESCRIPTION
## Description
This PR fixes an issue in the database unlock screen (DatabaseOpenWidget) where the password input field and key file selection field collapse and become hidden when the window size (particularly the vertical height) is reduced.

## Screenshots

| Before | After |
| :---: | :---: |
| ![Before](https://raw.githubusercontent.com/cwatanab/keepassxc/fix/unlock-layout/before.png) | ![After](https://raw.githubusercontent.com/cwatanab/keepassxc/fix/unlock-layout/after.png) |

## Changes
1. Increased the minimumSize height of centralStack (QStackedWidget) in DatabaseOpenWidget.ui from 