### PR TITLE
 Fix: Password font size does not follow app settings #13536

### DIFF
--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -318,3 +318,13 @@ void PasswordWidget::updatePasswordStrength(const QString& password)
         break;
     }
 }
+
+void PasswordWidget::changeEvent(QEvent* event)
+{
+    if (event->type() == QEvent::FontChange) {
+        QFont passwordFont = Font::fixedFont();
+        passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
+        m_ui->passwordEdit->setFont(passwordFont);
+    }
+    QWidget::changeEvent(event);
+}

--- a/src/gui/PasswordWidget.h
+++ b/src/gui/PasswordWidget.h
@@ -44,6 +44,7 @@ public:
     bool isPasswordVisible() const;
     QString text();
 
+protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
 signals:


### PR DESCRIPTION
I overrode `changeEvent` in `PasswordWidget` to listen for `QEvent::FontChange`. The point was to make sure that the password field font size varies according to the font settings in the App Settings. 

Fixes #13536

## Screenshots
Font set to Large:
<img width="985" height="787" alt="L" src="https://github.com/user-attachments/assets/7bb5b494-4745-4e5d-baea-3f5a78522edd" />
Font set to Small:
<img width="979" height="772" alt="S" src="https://github.com/user-attachments/assets/89e76113-a95e-4cf2-b469-38842d9365ce" />



## Testing strategy
1. Opened App Settings and changed the global font size to Large.
2. Opened the Add Entry/Edit Entry dialog.
3. Verified that text entered into the password field scales up properly to match the updated application font settings(Took a screenshot).
4. Then repeated the same with global font size set to small(Took a screenshot).
5. The differences were clear

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)