### PR TITLE
Fix: CLI: cleanup clipboard on CTRL+C #13549

### DIFF
--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -179,12 +179,7 @@ int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
 
     Utils::clipText("");
     out << '\r' << QString(lastLine.size(), ' ') << '\r';
-
-    if (g_interrupted.load()) {
-        out << QObject::tr("Clipboard cleared!") << Qt::endl;
-    } else {
-        out << QObject::tr("Clipboard cleared!") << Qt::endl;
-    }
+    out << QObject::tr("Clipboard cleared!") << Qt::endl;
 
     std::signal(SIGINT, oldSigInt);
     std::signal(SIGTERM, oldSigTerm);

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -24,6 +24,18 @@
 
 #include <QCommandLineParser>
 
+#include <atomic>
+#include <csignal>
+
+namespace {
+    std::atomic<bool> g_interrupted{false};
+    void handleSignal(int signal)
+    {
+        Q_UNUSED(signal);
+        g_interrupted.store(true);
+    }
+}
+
 #define CLI_DEFAULT_CLIP_TIMEOUT 10
 
 const QCommandLineOption Clip::AttributeOption = QCommandLineOption(
@@ -149,17 +161,33 @@ int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
         return exitCode;
     }
 
+    g_interrupted.store(false);
+    auto oldSigInt = std::signal(SIGINT, handleSignal);
+    auto oldSigTerm = std::signal(SIGTERM, handleSignal);
+
     QString lastLine = "";
-    while (timeout > 0) {
+    while (timeout > 0 && !g_interrupted.load()) {
         out << '\r' << QString(lastLine.size(), ' ') << '\r';
         lastLine = QObject::tr("Clearing the clipboard in %1 second(s)...", "", timeout).arg(timeout);
         out << lastLine << Qt::flush;
-        Tools::sleep(1000);
+
+        for (int i = 0; i < 10 && !g_interrupted.load(); ++i) {
+            Tools::sleep(100);
+        }
         --timeout;
     }
+
     Utils::clipText("");
     out << '\r' << QString(lastLine.size(), ' ') << '\r';
-    out << QObject::tr("Clipboard cleared!") << Qt::endl;
+
+    if (g_interrupted.load()) {
+        out << QObject::tr("Clipboard cleared!") << Qt::endl;
+    } else {
+        out << QObject::tr("Clipboard cleared!") << Qt::endl;
+    }
+
+    std::signal(SIGINT, oldSigInt);
+    std::signal(SIGTERM, oldSigTerm);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Fixes #13549

At the moment, when keepassxc-cli clip is interrupted using Ctrl+C (SIGINT) or SIGTERM before the countdown timeout expires, the OS ends the process immediately, leaving the password available on the clipboard.

This PR adds signal handling to Clip::executeWithDatabase():
- Intercepts SIGINT and SIGTERM using an std::atomic<bool> signal flag.
- Replaces the single 1-second blocking sleep loop with a fine-grained loop (100ms sleep intervals) that continuously polls the atomic flag.
- Calls Utils::clipText("") to ensure that the clipboard is cleared before restoring signal handlers and exiting gracefully upon catching a signal or reaching timeout expiration.

Generative AI was used to refine the code.

## Screenshots
Posting video since clipboard is used and it is difficult to screenshot

https://github.com/user-attachments/assets/bfd56caf-4d98-46f4-b2af-eeabc91d0edd



## Testing strategy
Manually tested on Fedora Linux:
1. Executed "./keepassxc-cli clip <database> <entry> 10".
2. Made sure that the entry's password was correctly copied to the clipboard.
3. Pressed Ctrl+C after a few seconds while the countdown was active.
   - Verified that the loop exited immediately, printed "Clipboard cleared!", and left the clipboard empty(by pressing Ctrl+V).
4. Executed "./keepassxc-cli clip <database> <entry> 3" and allowed the timeout to expire normally(to check if existing function isnt broken).
   - Verified that the countdown is finishing normally and clears the clipboard as it should.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

