### PR TITLE
docs: document PIN Quick Unlock fallback

### DIFF
--- a/docs/topics/DatabaseOperations.adoc
+++ b/docs/topics/DatabaseOperations.adoc
@@ -70,6 +70,16 @@ image::database_view.png[]
 === Quick Unlock
 On Windows and macOS, subject to hardware availability, your credentials can be securely stored to enable subsequent unlocking of your database through biometric authentication. This is enabled by default on Windows using _Windows Hello_ and on macOS using _Touch ID or Apple Watch_ services. You can disable this feature in the Application Settings under the Security section.
 
+==== PIN Quick Unlock
+
+On platforms without Windows Hello, Touch ID, or a compatible hardware authenticator, KeePassXC offers a PIN-based Quick Unlock fallback. This lets you unlock a previously-opened database with a short PIN instead of your full master password.
+
+The first time you unlock a database with your full credentials, you will be prompted to set a PIN between 4 and 8 digits. This PIN is never stored in plain text; it is combined with a random initialization vector and used to derive an encryption key for your in-memory database credentials via Argon2.
+
+You can enable or disable Quick Unlock (including the PIN fallback) from *Application Settings > Security*, under the Quick Unlock section. This section also lets you choose whether KeePassXC should remember Quick Unlock across application restarts and database open/close cycles. Note that this "remember" option is only available on Windows and macOS, where credentials can be stored in the OS-native credential store (Windows Credential Store / macOS Keychain); it is not supported on Linux due to the lack of a standardized system keyring across distributions.
+
+If you enter the wrong PIN, Quick Unlock will fail and you will need to enter your full master password to unlock the database.
+
 NOTE: On Windows, you will be prompted to authenticate to Windows Hello after unlocking your database with full credentials. This is required to setup Quick Unlock. If you cancel this prompt then Quick Unlock will not be enabled and your database will continue to unlock.
 
 .Windows Hello example


### PR DESCRIPTION
Addresses #12359 (documentation updates request).

#11520 added a PIN-based Quick Unlock fallback and a "remember Quick Unlock across sessions" option, but the User Guide / Getting Started docs still only describe the biometric (Windows Hello / Touch ID) and hardware-key paths. This adds a "PIN Quick Unlock" subsection to DatabaseOperations.adoc covering how the PIN is set, where to configure it, and the platform limitation on the "remember" option.

Related: #13152 is a user requesting this feature as if it doesn't exist — a sign the missing docs are causing real confusion.

## Screenshots
Not applicable — text-only documentation change.

## Testing strategy
Read through the rendered AsciiDoc output locally to confirm formatting and section placement are correct alongside the existing Quick Unlock content.

## Type of change
- Documentation (non-code change)