### PR TITLE
Port remembered Windows Quick Unlock to Qt 6

### DIFF
--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -1,0 +1,33 @@
+# AI Assistance Disclosure
+
+This experimental Qt 6 port was developed with substantial assistance from OpenAI Codex using a GPT-5-based model.
+The exact backend model snapshot was not exposed by the tool.
+
+## Provenance and scope
+
+The design and implementation build on Jonathan White's upstream `feature/remember-quickunlock` branch, especially
+commit `d2ad2a95` ("Add support to remember quick unlock on Windows and macOS"), and on the current KeePassXC Qt 6
+`develop` branch. The AI agent inspected those revisions and the local repository and was used to:
+
+* select and port the Windows-specific subset of the upstream work;
+* implement the opt-in configuration, UI lifecycle, Windows Password Vault persistence, and failure handling;
+* identify and prevent persistence of non-opted session keys after an abnormal process exit;
+* add a configuration regression test and technical documentation;
+* configure, format, build, test, and review the local changes; and
+* analyze security boundaries and upstream integration risks.
+
+The new and modified code in this branch is predominantly AI-generated or AI-modified. Human prompts supplied the
+goal, constraints, corrections, and acceptance decisions. AI assistance must not be treated as a substitute for
+maintainer review, a security audit, or independent Windows testing.
+
+## Data and review responsibility
+
+No real database passwords, production databases, private keys, key files, recovery material, or other intentional
+secrets were supplied to the model. Local source files, Git history, compiler and test output, and local toolchain
+paths were available to the agent.
+
+Every submitted line must be reviewed by the human contributor. In particular, reviewers should independently
+verify the Windows Hello key lifecycle, Password Vault isolation and limits, record replacement and deletion,
+credential-change invalidation, memory handling, cancellation behavior, and compatibility with supported Windows
+and SDK versions. If the patch is split, rewritten, or receives further AI assistance, the pull-request disclosure
+must be updated accordingly.

--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -26,6 +26,11 @@ No real database passwords, production databases, private keys, key files, recov
 secrets were supplied to the model. Local source files, Git history, compiler and test output, and local toolchain
 paths were available to the agent.
 
+During diagnosis, the full isolated manual-test configuration was printed to AI-visible tool output. It contained
+an automatically generated KeeShare private key belonging only to that disposable test configuration. It was not a
+production key and was not associated with a real shared database, but it must be treated as disclosed test material.
+The isolated configuration is to be deleted after testing and must not be reused.
+
 Every submitted line must be reviewed by the human contributor. In particular, reviewers should independently
 verify the Windows Hello key lifecycle, Password Vault isolation and limits, record replacement and deletion,
 credential-change invalidation, memory handling, cancellation behavior, and compatibility with supported Windows

--- a/docs/PERSISTENT_QUICK_UNLOCK_WINDOWS.md
+++ b/docs/PERSISTENT_QUICK_UNLOCK_WINDOWS.md
@@ -54,3 +54,14 @@ testing on real Windows 11 systems.
 The branch configures and builds `KeePassXC.exe` with Qt 6.11.1, MSVC 2022 19.44, the Windows 11 SDK, Ninja, and the
 vcpkg `x64-windows` triplet. `testconfig` verifies that remembered Quick Unlock defaults to disabled. Manual testing
 must use throwaway KDBX4 databases and synthetic password, key-file, challenge-response, and empty-key credentials.
+
+On 2026-08-04, a manual Windows 11 smoke test using an isolated KeePassXC configuration and a throwaway KDBX4
+database verified both primary lifecycle paths:
+
+* after a normal password unlock, Windows Hello enrollment, and a complete process exit, the database unlocked with
+  Windows Hello after KeePassXC was restarted, without requesting the database password; and
+* after remembered Quick Unlock was disabled and KeePassXC exited, reopening the same database displayed the normal
+  password page and did not offer the previously persisted Windows Hello unlock.
+
+This smoke test does not cover key files, challenge-response devices, empty keys, Hello cancellation, credential
+reset, record corruption, or different Windows account and hardware configurations.

--- a/docs/PERSISTENT_QUICK_UNLOCK_WINDOWS.md
+++ b/docs/PERSISTENT_QUICK_UNLOCK_WINDOWS.md
@@ -63,5 +63,14 @@ database verified both primary lifecycle paths:
 * after remembered Quick Unlock was disabled and KeePassXC exited, reopening the same database displayed the normal
   password page and did not offer the previously persisted Windows Hello unlock.
 
-This smoke test does not cover key files, challenge-response devices, empty keys, Hello cancellation, credential
-reset, record corruption, or different Windows account and hardware configurations.
+This smoke test does not cover key files, challenge-response devices, empty keys, credential reset, record corruption,
+or different Windows account and hardware configurations.
+
+Additional manual testing verified that canceling Windows Hello does not open the database, delete the persisted
+record, or force a password retry. The Quick Unlock screen remains available and a second Windows Hello attempt can
+unlock the database. This test exposed and fixed a transient `WindowActivate` race that previously interpreted a
+temporarily unavailable vault record as missing and deleted it.
+
+Creating and saving a new throwaway KDBX4 database now triggers Windows Hello enrollment after the first successful
+save. After a complete process restart, the new database was available through Quick Unlock without an intervening
+password unlock.

--- a/docs/PERSISTENT_QUICK_UNLOCK_WINDOWS.md
+++ b/docs/PERSISTENT_QUICK_UNLOCK_WINDOWS.md
@@ -1,0 +1,56 @@
+# Remembered Quick Unlock on Windows
+
+Status: experimental Qt 6 port for review and Windows 11 testing.
+
+## Scope
+
+This branch ports the Windows portion of KeePassXC's `feature/remember-quickunlock` work to the current Qt 6
+`develop` branch. It deliberately excludes PIN Quick Unlock, the unfinished Polkit interface, and cross-platform
+secret-storage changes.
+
+The application-wide **Remember quick unlock after database is closed** setting is available when the active Quick
+Unlock provider supports persistence. It is disabled by default. When it is disabled, Windows Hello protected
+session keys remain in process memory exactly as before and are removed when the database is closed. They are never
+written to persistent storage, including during the interval before a clean shutdown.
+
+When the setting is enabled, the Windows provider stores `challenge || AES-256-GCM ciphertext` in the current user's
+Windows Password Vault. The AES key is derived from a Windows Hello signature over the random challenge. Every
+unprotect operation requests a new Windows Hello verification. The Windows Hello private key remains managed by
+Windows and is not available to KeePassXC.
+
+## Database keys
+
+The existing database-open path serializes and restores KeePassXC's `CompositeKey`; the Windows provider does not
+interpret or restrict its components. Passwords (including an empty password), key files, challenge-response slot
+metadata, empty composite keys, and supported combinations therefore follow the same serialization path. For
+challenge-response databases, the physical device is still required to answer the live database challenge.
+
+Remembering a key-file component makes its normalized effective key recoverable after Windows Hello verification;
+the original key file is no longer an independently required factor for that unlock path. An empty database key
+remains empty in the KDBX file: Windows Hello gates only this KeePassXC convenience path and does not add KDBX
+protection that other applications must honor.
+
+## Invalidation
+
+Disabling Quick Unlock or remembered Quick Unlock removes both session and Password Vault records. Closing a
+database removes its record unless remembered Quick Unlock is enabled. The existing database-key-change path also
+resets Quick Unlock for that database. Corrupt or truncated records fail before a key is returned; AES-GCM detects
+ciphertext modification.
+
+## Security boundary
+
+This feature trades knowledge of all original database-key components for control of the Windows account/device and
+successful Windows Hello verification. Windows Hello may permit a PIN fallback and protection may be TPM-backed or
+software-backed depending on the system. Malware in the user session can invoke prompts, copy or delete vault data,
+and read restored key material from KeePassXC memory after approval. The master password and original key material
+remain the recovery mechanism if Windows Hello credentials are reset or lost.
+
+The implementation has not received a security audit. Password Vault behavior, Windows Hello credential lifecycle,
+deletion failures, Windows updates, account changes, and supported Windows SDK versions require maintainer review and
+testing on real Windows 11 systems.
+
+## Verification performed
+
+The branch configures and builds `KeePassXC.exe` with Qt 6.11.1, MSVC 2022 19.44, the Windows 11 SDK, Ninja, and the
+vcpkg `x64-windows` triplet. `testconfig` verifies that remembered Quick Unlock defaults to disabled. Manual testing
+must use throwaway KDBX4 databases and synthetic password, key-file, challenge-response, and empty-key credentials.

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -163,6 +163,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},
     {Config::Security_EnableCopyOnDoubleClick,{QS("Security/EnableCopyOnDoubleClick"), Roaming, false}},
     {Config::Security_QuickUnlock, {QS("Security/QuickUnlock"), Local, true}},
+    {Config::Security_QuickUnlockRemember, {QS("Security/QuickUnlockRemember"), Local, false}},
     {Config::Security_DatabasePasswordMinimumQuality, {QS("Security/DatabasePasswordMinimumQuality"), Local, 0}},
 
     // Browser

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -142,6 +142,7 @@ public:
         Security_NoConfirmMoveEntryToRecycleBin,
         Security_EnableCopyOnDoubleClick,
         Security_QuickUnlock,
+        Security_QuickUnlockRemember,
         Security_DatabasePasswordMinimumQuality,
 
         Browser_Enabled,

--- a/src/gui/ApplicationSettingsWidget.cpp
+++ b/src/gui/ApplicationSettingsWidget.cpp
@@ -170,6 +170,9 @@ ApplicationSettingsWidget::ApplicationSettingsWidget(QWidget* parent)
             m_secUi->clearSearchSpinBox, SLOT(setEnabled(bool)));
     connect(m_secUi->lockDatabaseIdleCheckBox, SIGNAL(toggled(bool)),
             m_secUi->lockDatabaseIdleSpinBox, SLOT(setEnabled(bool)));
+    connect(m_secUi->quickUnlockCheckBox, &QCheckBox::toggled, this, [this](bool enabled) {
+        m_secUi->quickUnlockRememberCheckBox->setEnabled(enabled && getQuickUnlock()->canRemember());
+    });
     // clang-format on
 
     connect(m_generalUi->minimizeAfterUnlockCheckBox, &QCheckBox::toggled, this, [this](bool state) {
@@ -416,6 +419,10 @@ void ApplicationSettingsWidget::loadSettings()
 
     m_secUi->quickUnlockCheckBox->setEnabled(getQuickUnlock()->isAvailable());
     m_secUi->quickUnlockCheckBox->setChecked(config()->get(Config::Security_QuickUnlock).toBool());
+    m_secUi->quickUnlockRememberCheckBox->setVisible(getQuickUnlock()->canRemember());
+    m_secUi->quickUnlockRememberCheckBox->setEnabled(m_secUi->quickUnlockCheckBox->isEnabled()
+                                                     && m_secUi->quickUnlockCheckBox->isChecked());
+    m_secUi->quickUnlockRememberCheckBox->setChecked(config()->get(Config::Security_QuickUnlockRemember).toBool());
 
     for (const ExtraPage& page : asConst(m_extraPages)) {
         page.loadSettings();
@@ -553,6 +560,14 @@ void ApplicationSettingsWidget::saveSettings()
 
     if (m_secUi->quickUnlockCheckBox->isEnabled()) {
         config()->set(Config::Security_QuickUnlock, m_secUi->quickUnlockCheckBox->isChecked());
+    }
+    config()->set(Config::Security_QuickUnlockRemember,
+                  getQuickUnlock()->canRemember() && m_secUi->quickUnlockCheckBox->isChecked()
+                      && m_secUi->quickUnlockRememberCheckBox->isChecked());
+
+    if (!config()->get(Config::Security_QuickUnlock).toBool()
+        || !config()->get(Config::Security_QuickUnlockRemember).toBool()) {
+        getQuickUnlock()->reset();
     }
 
     // Security: clear storage if related settings are disabled

--- a/src/gui/ApplicationSettingsWidgetSecurity.ui
+++ b/src/gui/ApplicationSettingsWidgetSecurity.ui
@@ -173,6 +173,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="quickUnlockRememberCheckBox">
+        <property name="text">
+         <string>Remember quick unlock after database is closed</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="lockDatabaseOnScreenLockCheckBox">
         <property name="text">
          <string>Lock databases when session is locked or lid is closed</string>
@@ -282,6 +289,7 @@
   <tabstop>clearSearchCheckBox</tabstop>
   <tabstop>clearSearchSpinBox</tabstop>
   <tabstop>quickUnlockCheckBox</tabstop>
+  <tabstop>quickUnlockRememberCheckBox</tabstop>
   <tabstop>lockDatabaseOnScreenLockCheckBox</tabstop>
   <tabstop>lockDatabasesOnUserSwitchCheckBox</tabstop>
   <tabstop>lockDatabaseMinimizeCheckBox</tabstop>

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -179,10 +179,7 @@ bool DatabaseOpenWidget::event(QEvent* event)
     bool ret = DialogyWidget::event(event);
     auto type = event->type();
 
-    if (type == QEvent::Show || type == QEvent::WindowActivate) {
-        if (isOnQuickUnlockScreen() && (m_db.isNull() || !canPerformQuickUnlock())) {
-            resetQuickUnlock();
-        }
+    if ((type == QEvent::Show || type == QEvent::WindowActivate) && !unlockingDatabase()) {
         toggleQuickUnlockScreen();
 
         if (type == QEvent::Show) {
@@ -423,9 +420,14 @@ QSharedPointer<CompositeKey> DatabaseOpenWidget::buildDatabaseKey()
         // try to retrieve the stored password using Windows Hello
         QByteArray keyData;
         if (!getQuickUnlock()->getKey(m_db->publicUuid(), keyData)) {
-            m_ui->messageWidget->showMessage(
-                tr("Failed to authenticate with Quick Unlock: %1").arg(getQuickUnlock()->errorString()),
-                MessageWidget::Error);
+            const auto error = getQuickUnlock()->errorString();
+            if (!error.isEmpty()) {
+                m_ui->messageWidget->showMessage(tr("Failed to authenticate with Quick Unlock: %1").arg(error),
+                                                 MessageWidget::Error);
+            }
+            if (!getQuickUnlock()->hasKey(m_db->publicUuid())) {
+                toggleQuickUnlockScreen();
+            }
             return {};
         }
         databaseKey->setRawKey(keyData);

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -21,6 +21,7 @@
 #include <QTabBar>
 
 #include "autotype/AutoType.h"
+#include "core/Config.h"
 #include "core/Merger.h"
 #include "core/Tools.h"
 #include "format/CsvExporter.h"
@@ -36,6 +37,7 @@
 #include "gui/osutils/macutils/MacUtils.h"
 #endif
 #include "gui/wizard/NewDatabaseWizard.h"
+#include "quickunlock/QuickUnlockInterface.h"
 
 DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
     : QTabWidget(parent)
@@ -224,6 +226,30 @@ void DatabaseTabWidget::lockAndSwitchToFirstUnlockedDatabase(int index)
 void DatabaseTabWidget::addDatabaseTab(DatabaseWidget* dbWidget, bool inBackground)
 {
     Q_ASSERT(dbWidget->database());
+
+    const auto isNewDatabase =
+        dbWidget->database()->filePath().isEmpty() && !dbWidget->database()->isTemporaryDatabase();
+    if (isNewDatabase) {
+        connect(
+            dbWidget,
+            &DatabaseWidget::databaseSaved,
+            dbWidget,
+            [dbWidget] {
+                const auto db = dbWidget->database();
+                auto quickUnlock = getQuickUnlock();
+                if (!db || !db->key() || !config()->get(Config::Security_QuickUnlock).toBool()
+                    || !config()->get(Config::Security_QuickUnlockRemember).toBool() || !quickUnlock->isAvailable()
+                    || !quickUnlock->canRemember()) {
+                    return;
+                }
+
+                if (!quickUnlock->setKey(db->publicUuid(), db->key()->serialize())
+                    && !quickUnlock->errorString().isEmpty()) {
+                    dbWidget->showMessage(quickUnlock->errorString(), MessageWidget::Warning);
+                }
+            },
+            Qt::SingleShotConnection);
+    }
 
     // emit before index change
     emit databaseOpened(dbWidget);

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -57,6 +57,7 @@
 #include "gui/tag/TagView.h"
 #include "gui/widgets/ElidedLabel.h"
 #include "keeshare/KeeShare.h"
+#include "quickunlock/QuickUnlockInterface.h"
 #include "remote/RemoteHandler.h"
 #include "remote/RemoteSettings.h"
 
@@ -1970,7 +1971,10 @@ void DatabaseWidget::closeEvent(QCloseEvent* event)
         return;
     }
 
-    m_databaseOpenWidget->resetQuickUnlock();
+    if (!config()->get(Config::Security_QuickUnlock).toBool()
+        || !config()->get(Config::Security_QuickUnlockRemember).toBool() || !getQuickUnlock()->canRemember()) {
+        m_databaseOpenWidget->resetQuickUnlock();
+    }
     event->accept();
 }
 

--- a/src/quickunlock/QuickUnlockInterface.cpp
+++ b/src/quickunlock/QuickUnlockInterface.cpp
@@ -33,6 +33,11 @@
 
 QUICKUNLOCK_IMPLEMENTATION* quickUnlockInstance = {nullptr};
 
+bool QuickUnlockInterface::canRemember() const
+{
+    return false;
+}
+
 QuickUnlockInterface* getQuickUnlock()
 {
     if (!quickUnlockInstance) {

--- a/src/quickunlock/QuickUnlockInterface.h
+++ b/src/quickunlock/QuickUnlockInterface.h
@@ -29,6 +29,7 @@ public:
     virtual ~QuickUnlockInterface() = default;
 
     virtual bool isAvailable() const = 0;
+    virtual bool canRemember() const;
     virtual QString errorString() const = 0;
 
     virtual bool setKey(const QUuid& dbUuid, const QByteArray& key) = 0;

--- a/src/quickunlock/WindowsHello.cpp
+++ b/src/quickunlock/WindowsHello.cpp
@@ -19,21 +19,25 @@
 
 #include <Userconsentverifierinterop.h>
 #include <winrt/base.h>
+#include <winrt/windows.foundation.collections.h>
 #include <winrt/windows.foundation.h>
 #include <winrt/windows.security.credentials.h>
 #include <winrt/windows.security.cryptography.h>
 #include <winrt/windows.storage.streams.h>
 
 #include "core/AsyncTask.h"
+#include "core/Config.h"
 #include "crypto/CryptoHash.h"
 #include "crypto/Random.h"
 #include "crypto/SymmetricCipher.h"
 
 #include <QTimer>
 #include <QWindow>
+#include <botan/mem_ops.h>
 
 using namespace winrt;
 using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
 using namespace Windows::Security::Credentials;
 using namespace Windows::Security::Cryptography;
 using namespace Windows::Storage::Streams;
@@ -97,12 +101,77 @@ namespace
             }
         });
     }
+
+    std::wstring credentialName(const QUuid& dbUuid)
+    {
+        return dbUuid.toString(QUuid::WithoutBraces).toStdWString();
+    }
+
+    bool loadCredential(const QUuid& dbUuid, QByteArray& data)
+    {
+        data.clear();
+        try {
+            auto vault = PasswordVault();
+            const auto credential = vault.Retrieve(s_winHelloKeyName, credentialName(dbUuid));
+            data = QByteArray::fromBase64(QByteArray::fromStdString(winrt::to_string(credential.Password())));
+            return !data.isEmpty();
+        } catch (winrt::hresult_error const&) {
+            return false;
+        }
+    }
+
+    bool removeCredential(const QUuid& dbUuid)
+    {
+        try {
+            auto vault = PasswordVault();
+            const auto credential = vault.Retrieve(s_winHelloKeyName, credentialName(dbUuid));
+            vault.Remove(credential);
+            return true;
+        } catch (winrt::hresult_error const&) {
+            return false;
+        }
+    }
+
+    bool storeCredential(const QUuid& dbUuid, const QByteArray& data)
+    {
+        // PasswordVault permits multiple records, so remove an old value before replacing it.
+        removeCredential(dbUuid);
+        try {
+            auto vault = PasswordVault();
+            vault.Add({s_winHelloKeyName, credentialName(dbUuid), winrt::to_hstring(data.toBase64().toStdString())});
+            return true;
+        } catch (winrt::hresult_error const&) {
+            return false;
+        }
+    }
+
+    void resetCredentials()
+    {
+        try {
+            auto vault = PasswordVault();
+            const auto credentials = vault.FindAllByResource(s_winHelloKeyName);
+            for (const auto& credential : credentials) {
+                try {
+                    vault.Remove(credential);
+                } catch (winrt::hresult_error const&) {
+                    // Continue removing the remaining KeePassXC Windows Hello records.
+                }
+            }
+        } catch (winrt::hresult_error const&) {
+            // FindAllByResource also throws when no matching records exist.
+        }
+    }
 } // namespace
 
 bool WindowsHello::isAvailable() const
 {
     auto task = concurrency::create_task([] { return KeyCredentialManager::IsSupportedAsync().get(); });
     return task.get();
+}
+
+bool WindowsHello::canRemember() const
+{
+    return true;
 }
 
 QString WindowsHello::errorString() const
@@ -123,28 +192,42 @@ bool WindowsHello::setKey(const QUuid& dbUuid, const QByteArray& data)
         return false;
     }
 
-    // Encrypt the data using AES-256-CBC
+    // Encrypt the data using AES-256-GCM
     SymmetricCipher cipher;
     if (!cipher.init(SymmetricCipher::Aes256_GCM, SymmetricCipher::Encrypt, key, challenge)) {
+        Botan::secure_scrub_memory(key.data(), key.size());
         m_error = QObject::tr("Failed to init KeePassXC crypto.");
         return false;
     }
     QByteArray encrypted = data;
     if (!cipher.finish(encrypted)) {
+        Botan::secure_scrub_memory(key.data(), key.size());
         m_error = QObject::tr("Failed to encrypt key data.");
         return false;
     }
+    Botan::secure_scrub_memory(key.data(), key.size());
 
     // Prepend the challenge/IV to the encrypted data
     encrypted.prepend(challenge);
-    m_encryptedKeys.insert(dbUuid, encrypted);
+    if (config()->get(Config::Security_QuickUnlockRemember).toBool()) {
+        m_encryptedKeys.remove(dbUuid);
+        if (!storeCredential(dbUuid, encrypted)) {
+            m_error = QObject::tr("Failed to store Windows Hello credential.");
+            return false;
+        }
+    } else {
+        m_encryptedKeys.insert(dbUuid, encrypted);
+    }
     return true;
 }
 
 bool WindowsHello::getKey(const QUuid& dbUuid, QByteArray& data)
 {
     data.clear();
-    if (!hasKey(dbUuid)) {
+    QByteArray keydata;
+    if (m_encryptedKeys.contains(dbUuid)) {
+        keydata = m_encryptedKeys.value(dbUuid);
+    } else if (!config()->get(Config::Security_QuickUnlockRemember).toBool() || !loadCredential(dbUuid, keydata)) {
         m_error = QObject::tr("Failed to get Windows Hello credential.");
         return false;
     }
@@ -153,7 +236,10 @@ bool WindowsHello::getKey(const QUuid& dbUuid, QByteArray& data)
 
     // Read the previously used challenge and encrypted data
     auto ivSize = SymmetricCipher::defaultIvSize(SymmetricCipher::Aes256_GCM);
-    const auto& keydata = m_encryptedKeys.value(dbUuid);
+    if (keydata.size() <= ivSize) {
+        m_error = QObject::tr("Invalid Windows Hello credential.");
+        return false;
+    }
     auto challenge = keydata.left(ivSize);
     auto encrypted = keydata.mid(ivSize);
     QByteArray key;
@@ -165,6 +251,7 @@ bool WindowsHello::getKey(const QUuid& dbUuid, QByteArray& data)
     // Decrypt the data using the generated key and IV from above
     SymmetricCipher cipher;
     if (!cipher.init(SymmetricCipher::Aes256_GCM, SymmetricCipher::Decrypt, key, challenge)) {
+        Botan::secure_scrub_memory(key.data(), key.size());
         m_error = QObject::tr("Failed to init KeePassXC crypto.");
         return false;
     }
@@ -172,10 +259,12 @@ bool WindowsHello::getKey(const QUuid& dbUuid, QByteArray& data)
     // Store the decrypted data into the passed parameter
     data = encrypted;
     if (!cipher.finish(data)) {
+        Botan::secure_scrub_memory(key.data(), key.size());
         data.clear();
         m_error = QObject::tr("Failed to decrypt key data.");
         return false;
     }
+    Botan::secure_scrub_memory(key.data(), key.size());
 
     return true;
 }
@@ -183,14 +272,23 @@ bool WindowsHello::getKey(const QUuid& dbUuid, QByteArray& data)
 void WindowsHello::reset(const QUuid& dbUuid)
 {
     m_encryptedKeys.remove(dbUuid);
+    removeCredential(dbUuid);
 }
 
 bool WindowsHello::hasKey(const QUuid& dbUuid) const
 {
-    return m_encryptedKeys.contains(dbUuid);
+    if (m_encryptedKeys.contains(dbUuid)) {
+        return true;
+    }
+    if (!config()->get(Config::Security_QuickUnlockRemember).toBool()) {
+        return false;
+    }
+    QByteArray data;
+    return loadCredential(dbUuid, data);
 }
 
 void WindowsHello::reset()
 {
     m_encryptedKeys.clear();
+    resetCredentials();
 }

--- a/src/quickunlock/WindowsHello.h
+++ b/src/quickunlock/WindowsHello.h
@@ -28,6 +28,7 @@ class WindowsHello : public QuickUnlockInterface
 public:
     WindowsHello() = default;
     bool isAvailable() const override;
+    bool canRemember() const override;
     QString errorString() const override;
     void reset() override;
 

--- a/tests/TestConfig.cpp
+++ b/tests/TestConfig.cpp
@@ -32,6 +32,16 @@ void TestConfig::initTestCase()
     QLocale::setDefault(QLocale::c());
 }
 
+void TestConfig::testQuickUnlockRememberDefault()
+{
+    TemporaryFile tempFile;
+    QVERIFY(tempFile.open());
+    tempFile.close();
+
+    Config::createConfigFromFile(tempFile.fileName());
+    QVERIFY(!config()->get(Config::Security_QuickUnlockRemember).toBool());
+}
+
 // upgrade config file with deprecated settings (all of which are set to non-default values)
 void TestConfig::testUpgrade()
 {

--- a/tests/TestConfig.h
+++ b/tests/TestConfig.h
@@ -26,6 +26,7 @@ class TestConfig : public QObject
 private slots:
     void initTestCase();
 
+    void testQuickUnlockRememberDefault();
     void testUpgrade();
     void testURLDoubleClickMigration();
 };


### PR DESCRIPTION
Motivation

I believe remembered Quick Unlock can become an important feature for the wider adoption of KeePassXC and the
KeePass ecosystem. Strong, unique master passwords and additional key components provide little practical benefit
if their daily friction leads people to choose weaker credentials, reuse passwords, or avoid a password manager
altogether. An explicit, platform-protected unlock path can make strong database credentials practical in everyday
use while retaining the original credentials as the recovery mechanism.

This is not a claim that convenience automatically increases security. Remembered Quick Unlock deliberately changes
the trust boundary to the local Windows account/device plus Windows Hello, and that trade-off must be opt-in,
transparent, and carefully reviewed. My motivation is to help make the existing upstream work buildable and testable
on current Qt 6 and Windows 11, in a small enough form that the project can review and move it forward.

## Summary

This draft revives the Windows portion of `feature/remember-quickunlock` on the current Qt 6 `develop` branch. It is
based on Jonathan White's existing work, especially commit `d2ad2a95`, and is intended as a small, reviewable first
slice that helps move the canonical feature forward rather than as a competing implementation.

The branch:

* adds an opt-in, local `Security/QuickUnlockRemember` setting that defaults to `false`;
* adds a provider capability flag so unsupported providers retain their existing session-only behavior;
* persists Windows Quick Unlock ciphertext in the current user's Windows Password Vault;
* keeps non-opted Windows session keys strictly in memory, including across abnormal process termination;
* preserves generic `CompositeKey` serialization without a password-only restriction;
* keeps persistent records after Windows Hello cancellation and permits an immediate retry;
* removes records when the feature is disabled or database credentials are changed; and
* enrolls a newly created database after its first successful save.

This draft intentionally excludes PIN Quick Unlock, the unfinished Polkit interface, macOS persistence, and the WIP
cross-platform `OSUtils` secret-storage abstraction. Automatically triggering Windows Hello as soon as a database is
opened is also left as a follow-up so this port stays focused.

The original feature branch is currently far behind `develop`, so targeting it directly would include more than 100
unrelated commits. This draft targets `develop` as a semantic Qt 6 port of the Windows subset. I am happy to adjust
the target or split the commits if the maintainers prefer a different integration path.

## Security notes

Remembered Quick Unlock is disabled by default. Without opt-in, encrypted session keys never enter Password Vault.
With opt-in, KeePassXC stores only a random challenge and AES-256-GCM ciphertext. The AES key is derived from a
Windows Hello signature; the Windows-managed private key is not available to KeePassXC. Every restore requests
Windows Hello verification.

This changes the effective trust boundary from possession of all original database-key components to control of the
Windows account/device plus successful Windows Hello verification. Windows Hello may allow PIN fallback. Persisting
a key-file component makes its normalized effective key recoverable through Windows Hello. Challenge-response slot
metadata can be restored, but the physical device is still required for the live database challenge. Empty database
keys remain unprotected at the KDBX level outside this KeePassXC unlock path.

The implementation has not received a security audit. Password Vault behavior and limits, Windows Hello credential
lifecycle, record deletion, credential reset, memory handling, and Windows/SDK compatibility require independent
review.

## AI usage disclosure

The majority of the new and modified code, tests, and documentation in this branch was generated or modified with
substantial assistance from OpenAI Codex using a GPT-5-based model; the exact backend snapshot was not exposed. The
agent had access to the local source tree and Git history, compared the upstream feature branch, implemented and
revised the port, ran local build/test/format commands, and assisted with security and integration review. Human
prompts supplied the goals, constraints, corrections, and acceptance decisions, and a human operator performed the
reported interactive Windows tests. Every submitted line still requires human and maintainer review.

No real database password, production database, key file, recovery material, or production private key was
intentionally supplied to the model. During diagnosis, AI-visible tool output included an automatically generated
KeeShare private key from the isolated disposable test configuration. It was not associated with a real shared
database; the test configuration is disclosed material and will not be reused. The complete disclosure is also in
`AI_DISCLOSURE.md` on this branch.

## Screenshots

No screenshots are included because the relevant behavior is a native Windows Hello prompt and database unlock
lifecycle. Testing used only disposable databases.

## Testing strategy

Automated/build verification:

* Qt 6.11.1 debug build with Visual Studio 2022 / MSVC 19.44, Windows 11 SDK, Ninja, and vcpkg `x64-windows`;
* `KeePassXC.exe` configures, compiles, links, and deploys successfully; and
* `testconfig` passes and verifies remembered Quick Unlock defaults to disabled.

Manual Windows 11 testing with isolated config and disposable KDBX4 databases verified:

* password enrollment, complete process exit, restart, and Windows Hello unlock without password re-entry;
* disabling remembered Quick Unlock removes access and returns to the password page after restart;
* canceling Windows Hello does not open the database or delete the record, and an immediate second attempt works;
* a newly created database enrolls after its first successful save and works after restart; and
* genuine errors remain visible while normal user cancellation does not display an empty error message.

Not yet tested: key-file-only and combined keys, challenge-response hardware, empty composite keys, Hello credential
reset, corrupt Password Vault records, multiple Windows accounts, and different hardware/SDK configurations.

## Type of change

- New feature
- Bug fix
- Documentation
