### PR TITLE
Add pinned attributes to entry preview panel

### DIFF
--- a/docs/topics/DatabaseOperations.adoc
+++ b/docs/topics/DatabaseOperations.adoc
@@ -214,6 +214,8 @@ A lot of applications and web sites now require providing additional information
 
 To protect an attribute from being displayed by default, activate the _Protect_ checkbox *(A)*. To show the contents of the attribute while keeping it protected, press the _Reveal_ button *(B)*.
 
+To display an attribute on the entry preview panel below the password field, activate the _Pin_ checkbox. Protected attributes remain masked on the preview panel until revealed with the eye button; double click a value to copy it to the clipboard.
+
 .Additional attributes example
 image::edit_entry_attributes.png[]
 

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -3233,6 +3233,18 @@ Would you like to correct it?</source>
         <source>Background color selection</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle attribute display on the entry preview panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show this attribute on the entry preview panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EditEntryWidgetAutoType</name>

--- a/src/core/CustomData.cpp
+++ b/src/core/CustomData.cpp
@@ -27,6 +27,7 @@ const QString CustomData::ExcludeFromReportsLegacy = QStringLiteral("KnownBad");
 const QString CustomData::FdoSecretsExposedGroup = QStringLiteral("FDO_SECRETS_EXPOSED_GROUP");
 const QString CustomData::RandomSlug = QStringLiteral("KPXC_RANDOM_SLUG");
 const QString CustomData::RemoteProgramSettings = QStringLiteral("KPXC_REMOTE_SYNC_SETTINGS");
+const QString CustomData::PinnedAttributes = QStringLiteral("KPXC_PINNED_ATTRIBUTES");
 
 // Fallback item for return by reference
 static const CustomData::CustomDataItem NULL_ITEM{};

--- a/src/core/CustomData.h
+++ b/src/core/CustomData.h
@@ -73,6 +73,7 @@ public:
     static const QString FdoSecretsExposedGroup;
     static const QString RandomSlug;
     static const QString RemoteProgramSettings;
+    static const QString PinnedAttributes;
 
     // Pre-KDBX 4.1
     static const QString ExcludeFromReportsLegacy;

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -28,6 +28,8 @@
 #include "core/Totp.h"
 
 #include <QDir>
+#include <QJsonArray>
+#include <QJsonDocument>
 #include <QRegularExpression>
 #include <QStringBuilder>
 #include <QStringView>
@@ -572,6 +574,55 @@ CustomData* Entry::customData()
 const CustomData* Entry::customData() const
 {
     return m_customData;
+}
+
+QStringList Entry::pinnedAttributes() const
+{
+    return pinnedAttributes(m_customData);
+}
+
+// The pinned attribute list is stored in the entry CustomData under
+// CustomData::PinnedAttributes as a compact JSON array of attribute names,
+// e.g. ["Attr1","Attr2"]. Names may contain any character; unknown or
+// malformed content is ignored so other KDBX clients cannot break parsing.
+QStringList Entry::pinnedAttributes(const CustomData* customData)
+{
+    if (!customData || !customData->contains(CustomData::PinnedAttributes)) {
+        return {};
+    }
+
+    const auto doc = QJsonDocument::fromJson(customData->value(CustomData::PinnedAttributes).toUtf8());
+    if (!doc.isArray()) {
+        return {};
+    }
+
+    QStringList names;
+    for (const auto& value : doc.array()) {
+        if (value.isString() && !value.toString().isEmpty()) {
+            names << value.toString();
+        }
+    }
+    return names;
+}
+
+void Entry::setPinnedAttributes(CustomData* customData, const QStringList& names)
+{
+    if (!customData) {
+        return;
+    }
+
+    QStringList filtered = names;
+    filtered.removeAll(QString());
+    filtered.removeDuplicates();
+    if (filtered.isEmpty()) {
+        if (customData->contains(CustomData::PinnedAttributes)) {
+            customData->remove(CustomData::PinnedAttributes);
+        }
+        return;
+    }
+
+    const auto json = QJsonDocument(QJsonArray::fromStringList(filtered)).toJson(QJsonDocument::Compact);
+    customData->set(CustomData::PinnedAttributes, QString::fromUtf8(json));
 }
 
 bool Entry::hasTotp() const

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -144,6 +144,10 @@ public:
     CustomData* customData();
     const CustomData* customData() const;
 
+    QStringList pinnedAttributes() const;
+    static QStringList pinnedAttributes(const CustomData* customData);
+    static void setPinnedAttributes(CustomData* customData, const QStringList& names);
+
     void setUuid(const QUuid& uuid);
     void setIcon(int iconNumber);
     void setIcon(const QUuid& uuid);

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -143,6 +143,10 @@ public:
     CustomData* customData();
     const CustomData* customData() const;
 
+    QStringList pinnedAttributes() const;
+    static QStringList pinnedAttributes(const CustomData* customData);
+    static void setPinnedAttributes(CustomData* customData, const QStringList& names);
+
     void setUuid(const QUuid& uuid);
     void setIcon(int iconNumber);
     void setIcon(const QUuid& uuid);

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -28,8 +28,11 @@
 #include "keeshare/KeeShare.h"
 #include "keeshare/KeeShareSettings.h"
 
+#include <QHBoxLayout>
+#include <QLabel>
 #include <QScrollBar>
 #include <QTabWidget>
+#include <QToolButton>
 namespace
 {
     constexpr int GeneralTabIndex = 0;
@@ -114,6 +117,13 @@ bool EntryPreviewWidget::eventFilter(QObject* object, QEvent* event)
         if (m_currentEntry && m_currentEntry->hasTotp()) {
             emit copyTextRequested(m_currentEntry->totp());
             m_ui->entryTotpLabel->clearFocus();
+            return true;
+        }
+    } else if (event->type() == QEvent::MouseButtonDblClick) {
+        // Pinned attribute values expose their clear text through this property
+        const auto clearValue = object->property("clearValue");
+        if (clearValue.isValid()) {
+            emit copyTextRequested(clearValue.toString());
             return true;
         }
     }
@@ -401,6 +411,84 @@ void EntryPreviewWidget::updateEntryGeneralTab()
     m_ui->entryExpirationLabel->setText(expires);
     m_ui->entryTagsList->tags(m_currentEntry->tagList());
     m_ui->entryTagsList->setReadOnly(true);
+
+    updateEntryPinnedAttributes();
+}
+
+void EntryPreviewWidget::updateEntryPinnedAttributes()
+{
+    Q_ASSERT(m_currentEntry);
+
+    auto layout = m_ui->entryPinnedAttributesLayout;
+    while (layout->count() > 0) {
+        auto item = layout->takeAt(0);
+        delete item->widget();
+        delete item;
+    }
+
+    const EntryAttributes* attributes = m_currentEntry->attributes();
+    const QStringList customKeys = attributes->customKeys();
+    QStringList pinned;
+    for (const QString& name : m_currentEntry->pinnedAttributes()) {
+        // Silently ignore pinned names that no longer exist as custom attributes
+        if (customKeys.contains(name)) {
+            pinned << name;
+        }
+    }
+
+    m_ui->entryPinnedAttributesWidget->setVisible(!pinned.isEmpty());
+
+    QFont font;
+    font.setBold(true);
+    for (const QString& name : pinned) {
+        auto titleLabel = new QLabel(name, m_ui->entryPinnedAttributesWidget);
+        titleLabel->setTextFormat(Qt::PlainText);
+        titleLabel->setFont(font);
+        const auto value = m_currentEntry->resolveMultiplePlaceholders(attributes->value(name));
+        layout->addRow(titleLabel, createPinnedValueWidget(value, attributes->isProtected(name)));
+    }
+}
+
+QWidget* EntryPreviewWidget::createPinnedValueWidget(const QString& clearValue, bool protect)
+{
+    auto container = new QWidget(m_ui->entryPinnedAttributesWidget);
+    auto layout = new QHBoxLayout(container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(8);
+
+    auto valueLabel = new QLabel(container);
+    valueLabel->setTextFormat(Qt::PlainText);
+    valueLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    valueLabel->setProperty("clearValue", clearValue);
+    valueLabel->setToolTip(tr("Double click to copy value"));
+    valueLabel->installEventFilter(this);
+
+    if (protect) {
+        valueLabel->setText(QString("\u25cf").repeated(6));
+        valueLabel->setFont(Font::fixedFont());
+
+        auto button = new QToolButton(container);
+        button->setCheckable(true);
+        button->setChecked(false);
+        button->setIcon(icons()->onOffIcon("password-show", false));
+        button->setIconSize({12, 12});
+        connect(button, &QToolButton::clicked, this, [valueLabel, button](bool state) {
+            button->setIcon(icons()->onOffIcon("password-show", state));
+            if (state) {
+                valueLabel->setText(valueLabel->property("clearValue").toString());
+                valueLabel->setFont(Font::defaultFont());
+            } else {
+                valueLabel->setText(QString("\u25cf").repeated(6));
+                valueLabel->setFont(Font::fixedFont());
+            }
+        });
+        layout->addWidget(button);
+    } else {
+        valueLabel->setText(clearValue);
+    }
+
+    layout->addWidget(valueLabel, 1);
+    return container;
 }
 
 void EntryPreviewWidget::updateEntryAdvancedTab()

--- a/src/gui/EntryPreviewWidget.h
+++ b/src/gui/EntryPreviewWidget.h
@@ -55,6 +55,7 @@ private slots:
     void updateEntryHeaderLine();
     void updateEntryTotp();
     void updateEntryGeneralTab();
+    void updateEntryPinnedAttributes();
     void updateEntryAdvancedTab();
     void updateEntryAutotypeTab();
     void setUsernameVisible(bool state);
@@ -73,6 +74,7 @@ private slots:
 
 private:
     void setTabEnabled(QTabWidget* tabWidget, QWidget* widget, bool enabled);
+    QWidget* createPinnedValueWidget(const QString& clearValue, bool protect);
 
     static QString hierarchy(const Group* group, const QString& title);
 

--- a/src/gui/EntryPreviewWidget.ui
+++ b/src/gui/EntryPreviewWidget.ui
@@ -219,7 +219,7 @@
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
             <widget class="QWidget" name="entryGeneralWidget" native="true">
-             <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,1" columnstretch="0,1,0,0,0,1">
+             <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,1" columnstretch="0,1,0,0,0,1">
               <property name="leftMargin">
                <number>0</number>
               </property>
@@ -392,7 +392,7 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="1" colspan="5">
+              <item row="4" column="1" colspan="5">
                <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
                 <property name="spacing">
                  <number>6</number>
@@ -440,7 +440,7 @@
                 </item>
                </layout>
               </item>
-              <item row="2" column="0">
+              <item row="3" column="0">
                <widget class="QLabel" name="entryTagsTitleLabel">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -516,7 +516,7 @@
                 </item>
                </layout>
               </item>
-              <item row="2" column="1" colspan="5">
+              <item row="3" column="1" colspan="5">
                <widget class="TagsEdit" name="entryTagsList" native="true">
                 <property name="focusPolicy">
                  <enum>Qt::ClickFocus</enum>
@@ -592,7 +592,7 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
+              <item row="4" column="0">
                <widget class="QLabel" name="entryNotesTitleLabel">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -634,6 +634,33 @@
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
+               </widget>
+              </item>
+              <item row="2" column="0" colspan="6">
+               <widget class="QWidget" name="entryPinnedAttributesWidget" native="true">
+                <layout class="QFormLayout" name="entryPinnedAttributesLayout">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="horizontalSpacing">
+                  <number>8</number>
+                 </property>
+                 <property name="verticalSpacing">
+                  <number>6</number>
+                 </property>
+                 <property name="labelAlignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </layout>
                </widget>
               </item>
               <item row="0" column="4">

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -257,6 +257,8 @@ void EditEntryWidget::setupAdvanced()
     connect(m_advancedUi->editAttributeButton, SIGNAL(clicked()), SLOT(editCurrentAttribute()));
     connect(m_advancedUi->removeAttributeButton, SIGNAL(clicked()), SLOT(removeCurrentAttribute()));
     connect(m_advancedUi->protectAttributeButton, SIGNAL(toggled(bool)), SLOT(protectCurrentAttribute(bool)));
+    connect(m_advancedUi->pinAttributeButton, SIGNAL(toggled(bool)), SLOT(pinCurrentAttribute(bool)));
+    connect(m_entryAttributes, SIGNAL(renamed(QString,QString)), SLOT(updatePinnedAttributeRename(QString,QString)));
     connect(m_advancedUi->revealAttributeButton, SIGNAL(clicked(bool)), SLOT(toggleCurrentAttributeVisibility()));
     connect(m_advancedUi->attributesView->selectionModel(),
             SIGNAL(currentChanged(QModelIndex,QModelIndex)),
@@ -523,6 +525,7 @@ void EditEntryWidget::setupEntryUpdate()
     // Advanced tab
     connect(m_advancedUi->attributesEdit, SIGNAL(textChanged()), this, SLOT(setModified()));
     connect(m_advancedUi->protectAttributeButton, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
+    connect(m_advancedUi->pinAttributeButton, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
     connect(m_advancedUi->excludeReportsCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
     connect(m_advancedUi->fgColorCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
     connect(m_advancedUi->bgColorCheckBox, SIGNAL(stateChanged(int)), this, SLOT(setModified()));
@@ -1471,7 +1474,12 @@ void EditEntryWidget::removeCurrentAttribute()
                                            MessageBox::Cancel);
 
         if (result == MessageBox::Remove) {
-            m_entryAttributes->remove(m_attributesModel->keyByIndex(index));
+            QString key = m_attributesModel->keyByIndex(index);
+            m_entryAttributes->remove(key);
+            auto pinned = Entry::pinnedAttributes(m_customData.data());
+            if (pinned.removeAll(key) > 0) {
+                Entry::setPinnedAttributes(m_customData.data(), pinned);
+            }
             setModified(true);
         }
     }
@@ -1500,11 +1508,14 @@ void EditEntryWidget::displayAttribute(QModelIndex index, bool showProtected)
 {
     // Block signals to prevent modified being set
     m_advancedUi->protectAttributeButton->blockSignals(true);
+    m_advancedUi->pinAttributeButton->blockSignals(true);
     m_advancedUi->attributesEdit->blockSignals(true);
     m_advancedUi->revealAttributeButton->setText(tr("Reveal"));
 
     if (index.isValid()) {
         QString key = m_attributesModel->keyByIndex(index);
+        m_advancedUi->pinAttributeButton->setChecked(Entry::pinnedAttributes(m_customData.data()).contains(key));
+        m_advancedUi->pinAttributeButton->setEnabled(!m_history);
         if (showProtected) {
             m_advancedUi->attributesEdit->setPlainText(tr("[PROTECTED] Press Reveal to view or edit"));
             m_advancedUi->attributesEdit->setEnabled(false);
@@ -1527,11 +1538,14 @@ void EditEntryWidget::displayAttribute(QModelIndex index, bool showProtected)
         m_advancedUi->revealAttributeButton->setEnabled(false);
         m_advancedUi->protectAttributeButton->setChecked(false);
         m_advancedUi->protectAttributeButton->setEnabled(false);
+        m_advancedUi->pinAttributeButton->setChecked(false);
+        m_advancedUi->pinAttributeButton->setEnabled(false);
         m_advancedUi->editAttributeButton->setEnabled(false);
         m_advancedUi->removeAttributeButton->setEnabled(false);
     }
 
     m_advancedUi->protectAttributeButton->blockSignals(false);
+    m_advancedUi->pinAttributeButton->blockSignals(false);
     m_advancedUi->attributesEdit->blockSignals(false);
 }
 
@@ -1550,6 +1564,35 @@ void EditEntryWidget::protectCurrentAttribute(bool state)
 
         // Display the attribute
         displayAttribute(index, state);
+    }
+}
+
+void EditEntryWidget::pinCurrentAttribute(bool state)
+{
+    QModelIndex index = m_advancedUi->attributesView->currentIndex();
+    if (!m_history && index.isValid()) {
+        QString key = m_attributesModel->keyByIndex(index);
+        auto pinned = Entry::pinnedAttributes(m_customData.data());
+        if (state && !pinned.contains(key)) {
+            pinned.append(key);
+        } else if (!state) {
+            pinned.removeAll(key);
+        }
+        Entry::setPinnedAttributes(m_customData.data(), pinned);
+    }
+}
+
+void EditEntryWidget::updatePinnedAttributeRename(const QString& oldKey, const QString& newKey)
+{
+    auto pinned = Entry::pinnedAttributes(m_customData.data());
+    if (pinned.contains(oldKey)) {
+        for (auto& name : pinned) {
+            if (name == oldKey) {
+                name = newKey;
+            }
+        }
+        Entry::setPinnedAttributes(m_customData.data(), pinned);
+        setModified(true);
     }
 }
 

--- a/src/gui/entry/EditEntryWidget.h
+++ b/src/gui/entry/EditEntryWidget.h
@@ -106,6 +106,8 @@ private slots:
     void removeCurrentAttribute();
     void updateCurrentAttribute();
     void protectCurrentAttribute(bool state);
+    void pinCurrentAttribute(bool state);
+    void updatePinnedAttributeRename(const QString& oldKey, const QString& newKey);
     void toggleCurrentAttributeVisibility();
     void updateAutoTypeEnabled();
     void openAutotypeHelp();

--- a/src/gui/entry/EditEntryWidgetAdvanced.ui
+++ b/src/gui/entry/EditEntryWidgetAdvanced.ui
@@ -147,6 +147,25 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="pinAttributeButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="accessibleName">
+           <string>Toggle attribute display on the entry preview panel</string>
+          </property>
+          <property name="toolTip">
+           <string>Show this attribute on the entry preview panel</string>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">margin-left:50%;margin-right:50%</string>
+          </property>
+          <property name="text">
+           <string>Pin</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPushButton" name="revealAttributeButton">
           <property name="enabled">
            <bool>false</bool>
@@ -319,6 +338,7 @@
   <tabstop>removeAttributeButton</tabstop>
   <tabstop>editAttributeButton</tabstop>
   <tabstop>protectAttributeButton</tabstop>
+  <tabstop>pinAttributeButton</tabstop>
   <tabstop>revealAttributeButton</tabstop>
   <tabstop>excludeReportsCheckBox</tabstop>
   <tabstop>fgColorCheckBox</tabstop>

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -20,6 +20,7 @@
 
 #include "TestEntry.h"
 #include "core/Clock.h"
+#include "core/CustomData.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "core/TimeInfo.h"
@@ -105,6 +106,44 @@ void TestEntry::testCopyDataFrom()
     QCOMPARE(entry2->autoTypeAssociations()->size(), 2);
     QCOMPARE(entry2->autoTypeAssociations()->get(0).window, QString("1"));
     QCOMPARE(entry2->autoTypeAssociations()->get(1).window, QString("3"));
+}
+
+void TestEntry::testPinnedAttributes()
+{
+    QScopedPointer<Entry> entry(new Entry());
+
+    // No key set yet
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+
+    // Round-trip with names containing JSON separators, quotes and newlines
+    const QStringList names = {"Simple", "With,Comma", "With\"Quote", "With\nNewline", "Unicode é●"};
+    Entry::setPinnedAttributes(entry->customData(), names);
+    QVERIFY(entry->customData()->contains(CustomData::PinnedAttributes));
+    QCOMPARE(entry->pinnedAttributes(), names);
+    QCOMPARE(Entry::pinnedAttributes(entry->customData()), names);
+
+    // Empty names are filtered out
+    Entry::setPinnedAttributes(entry->customData(), {"", "Kept"});
+    QCOMPARE(entry->pinnedAttributes(), QStringList{"Kept"});
+
+    // Duplicates are removed while preserving order
+    Entry::setPinnedAttributes(entry->customData(), {"A", "B", "A"});
+    QCOMPARE(entry->pinnedAttributes(), (QStringList{"A", "B"}));
+
+    // Empty list removes the key entirely
+    Entry::setPinnedAttributes(entry->customData(), {});
+    QVERIFY(!entry->customData()->contains(CustomData::PinnedAttributes));
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+
+    // Malformed JSON yields an empty list without crashing
+    entry->customData()->set(CustomData::PinnedAttributes, "not json at all");
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+    entry->customData()->set(CustomData::PinnedAttributes, "{\"an\":\"object\"}");
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+
+    // Null CustomData pointers are handled gracefully
+    QVERIFY(Entry::pinnedAttributes(nullptr).isEmpty());
+    Entry::setPinnedAttributes(nullptr, {"NoCrash"});
 }
 
 void TestEntry::testClone()

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -20,6 +20,7 @@
 
 #include "TestEntry.h"
 #include "core/Clock.h"
+#include "core/CustomData.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "core/TimeInfo.h"
@@ -81,6 +82,44 @@ void TestEntry::testCopyDataFrom()
     QCOMPARE(entry2->autoTypeAssociations()->size(), 2);
     QCOMPARE(entry2->autoTypeAssociations()->get(0).window, QString("1"));
     QCOMPARE(entry2->autoTypeAssociations()->get(1).window, QString("3"));
+}
+
+void TestEntry::testPinnedAttributes()
+{
+    QScopedPointer<Entry> entry(new Entry());
+
+    // No key set yet
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+
+    // Round-trip with names containing JSON separators, quotes and newlines
+    const QStringList names = {"Simple", "With,Comma", "With\"Quote", "With\nNewline", "Unicode é●"};
+    Entry::setPinnedAttributes(entry->customData(), names);
+    QVERIFY(entry->customData()->contains(CustomData::PinnedAttributes));
+    QCOMPARE(entry->pinnedAttributes(), names);
+    QCOMPARE(Entry::pinnedAttributes(entry->customData()), names);
+
+    // Empty names are filtered out
+    Entry::setPinnedAttributes(entry->customData(), {"", "Kept"});
+    QCOMPARE(entry->pinnedAttributes(), QStringList{"Kept"});
+
+    // Duplicates are removed while preserving order
+    Entry::setPinnedAttributes(entry->customData(), {"A", "B", "A"});
+    QCOMPARE(entry->pinnedAttributes(), (QStringList{"A", "B"}));
+
+    // Empty list removes the key entirely
+    Entry::setPinnedAttributes(entry->customData(), {});
+    QVERIFY(!entry->customData()->contains(CustomData::PinnedAttributes));
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+
+    // Malformed JSON yields an empty list without crashing
+    entry->customData()->set(CustomData::PinnedAttributes, "not json at all");
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+    entry->customData()->set(CustomData::PinnedAttributes, "{\"an\":\"object\"}");
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+
+    // Null CustomData pointers are handled gracefully
+    QVERIFY(Entry::pinnedAttributes(nullptr).isEmpty());
+    Entry::setPinnedAttributes(nullptr, {"NoCrash"});
 }
 
 void TestEntry::testClone()

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -32,6 +32,7 @@ private slots:
     void testHistoryItemDeletion();
     void testHistoryItemCustomData();
     void testCopyDataFrom();
+    void testPinnedAttributes();
     void testClone();
     void testResolveUrl();
     void testResolveUrlPlaceholders();

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -30,6 +30,7 @@ private slots:
     void initTestCase();
     void testHistoryItemDeletion();
     void testCopyDataFrom();
+    void testPinnedAttributes();
     void testClone();
     void testResolveUrl();
     void testResolveUrlPlaceholders();

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -22,6 +22,7 @@
 #include <QCheckBox>
 #include <QClipboard>
 #include <QDialog>
+#include <QLabel>
 #include <QListWidget>
 #include <QMenu>
 #include <QMenuBar>
@@ -34,6 +35,7 @@
 #include <QTableWidget>
 #include <QTest>
 #include <QToolBar>
+#include <QToolButton>
 
 #include "config-keepassx-tests.h"
 #include "core/PasswordHealth.h"
@@ -729,6 +731,14 @@ void TestGui::testEditEntry()
     QVERIFY(attrTextEdit->toPlainText().contains("PROTECTED"));
     QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("revealAttributeButton"), Qt::LeftButton);
     QCOMPARE(attrTextEdit->toPlainText(), attrText);
+
+    // Test pinning the attribute to the preview panel
+    auto* pinAttributeCheck = editEntryWidget->findChild<QCheckBox*>("pinAttributeButton");
+    QVERIFY(pinAttributeCheck);
+    QVERIFY(pinAttributeCheck->isEnabled());
+    QCOMPARE(pinAttributeCheck->isChecked(), false);
+    QTest::mouseClick(pinAttributeCheck, Qt::LeftButton);
+    QVERIFY(pinAttributeCheck->isChecked());
     editEntryWidget->switchToPage(EditEntryWidget::Page::Main);
 
     // Save the edit (press OK)
@@ -743,6 +753,56 @@ void TestGui::testEditEntry()
     QCOMPARE(entry->backgroundColor().toUpper(), bgColor.name().toUpper());
     QCOMPARE(entryItem.data(Qt::BackgroundRole), QVariant(bgColor));
     QCOMPARE(entry->historyItems().size(), ++editCount);
+
+    // Confirm the pinned attribute is stored and shown on the preview panel
+    QCOMPARE(entry->pinnedAttributes(), QStringList{"New attribute"});
+    auto* previewWidget = m_dbWidget->findChild<EntryPreviewWidget*>("previewWidget");
+    QVERIFY(previewWidget);
+    auto* pinnedWidget = previewWidget->findChild<QWidget*>("entryPinnedAttributesWidget");
+    QVERIFY(pinnedWidget);
+    QVERIFY(pinnedWidget->isVisible());
+    QLabel* pinnedValueLabel = nullptr;
+    for (auto* label : pinnedWidget->findChildren<QLabel*>()) {
+        if (label->property("clearValue").isValid()) {
+            pinnedValueLabel = label;
+            break;
+        }
+    }
+    QVERIFY(pinnedValueLabel);
+    QCOMPARE(pinnedValueLabel->property("clearValue").toString(), attrText);
+    // Protected attribute is masked until the reveal button is toggled
+    QCOMPARE(pinnedValueLabel->text(), QString("\u25cf").repeated(6));
+    auto* pinnedRevealButton = pinnedWidget->findChild<QToolButton*>();
+    QVERIFY(pinnedRevealButton);
+    QTest::mouseClick(pinnedRevealButton, Qt::LeftButton);
+    QCOMPARE(pinnedValueLabel->text(), attrText);
+
+    // Renaming a pinned attribute keeps it pinned under the new name
+    QTest::mouseClick(entryEditWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditEntryMode);
+    okButton = editEntryWidgetButtonBox->button(QDialogButtonBox::Ok);
+    QVERIFY(okButton);
+    editEntryWidget->switchToPage(EditEntryWidget::Page::Advanced);
+    auto* attrListView = editEntryWidget->findChild<QListView*>("attributesView");
+    QVERIFY(attrListView->currentIndex().isValid());
+    QVERIFY(attrListView->model()->setData(attrListView->currentIndex(), "Renamed attribute", Qt::EditRole));
+    QTest::mouseClick(okButton, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
+    QCOMPARE(entry->pinnedAttributes(), QStringList{"Renamed attribute"});
+
+    // Removing the attribute unpins it and hides the preview section
+    QTest::mouseClick(entryEditWidget, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditEntryMode);
+    okButton = editEntryWidgetButtonBox->button(QDialogButtonBox::Ok);
+    QVERIFY(okButton);
+    editEntryWidget->switchToPage(EditEntryWidget::Page::Advanced);
+    QVERIFY(attrListView->currentIndex().isValid());
+    MessageBox::setNextAnswer(MessageBox::Remove);
+    QTest::mouseClick(editEntryWidget->findChild<QAbstractButton*>("removeAttributeButton"), Qt::LeftButton);
+    QTest::mouseClick(okButton, Qt::LeftButton);
+    QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
+    QVERIFY(entry->pinnedAttributes().isEmpty());
+    QVERIFY(!pinnedWidget->isVisible());
 
     // Confirm modified indicator is showing
     QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QString("%1*").arg(m_dbFileName));


### PR DESCRIPTION
This PR adds the ability to pin additional attributes (custom strings) so they are displayed on the entry preview panel, below the password field.

- A new _Pin_ checkbox sits next to _Protect_ in the entry edit Advanced tab.
- Pinned attributes are stored per entry in the standard KDBX4 entry `CustomData` under the key `KPXC_PINNED_ATTRIBUTES`, as a compact JSON array of attribute names (JSON because attribute names may contain any character, including commas and quotes). The KDBX schema and the way custom strings are stored are unchanged.
- On the preview panel, protected attributes are masked with a reveal toggle (same pattern as the Advanced tab); double click copies the value to the clipboard.
- The pinned list follows attribute renames and removals in the editor. Pinned names that no longer exist (e.g. after a merge or an edit by another client) are silently ignored at display time.
- The user guide (Additional Attributes section) is updated.

Design decisions we would like to flag explicitly for review:

1. **The preview stays read-only** (labels + copy on double click), consistent with the rest of the preview panel — we deliberately did not add in-place editing.
2. **Double click copies the clear value even while masked**, which mirrors the existing behaviour of the attributes table in the preview's Advanced tab.
3. **Pinning writes entry `CustomData`**, so a KDBX3 database will be upgraded to KDBX4 on save — the same behaviour as the browser integration settings.
4. Pinned names can become orphaned if an attribute is renamed/removed outside the entry editor; they are ignored at display time and never purged automatically.

Note: this PR is independent of #13573 (`Entry::beginUpdate()` CustomData fix), but that fix is required for the pinned state to be carried into and restored from entry history.

## Screenshots

<img width="1104" height="623" alt="Capture d’écran du 2026-08-06 21-13-27" src="https://github.com/user-attachments/assets/f3bee80b-39e0-4a12-848d-181d4757b019" />
<img width="1104" height="623" alt="Capture d’écran du 2026-08-06 21-14-13" src="https://github.com/user-attachments/assets/1f96a2e6-9a4e-4286-812a-4ee48a1c76a9" />
<img width="1112" height="644" alt="Capture d’écran du 2026-08-06 21-15-18" src="https://github.com/user-attachments/assets/76947445-532a-4f5b-a3e4-d5d2d9c1cd1b" />

## Testing strategy

- New unit test `TestEntry::testPinnedAttributes`: round-trip including names with commas/quotes/newlines/unicode, empty-name filtering, duplicate removal, empty list removing the key, malformed JSON tolerated, null-pointer safety.
- Extended `TestGui::testEditEntry`: pin checkbox, persistence, preview panel display, masking and reveal toggle, rename sync, removal sync and section hiding.
- Locally ran `testentry`, `testmodified`, `testgroup`, `testkdbx2/3/4`, `testmerge`, `testcli`, `testbrowser` and the full `testgui` suite — all passing. `clang-format` clean; translation strings pushed via `lupdate`.

## Type of change
- ✅ New feature (change that adds functionality)

## AI usage disclosure

Per the contribution guidelines: development was done with Claude Code (model: Claude Fable 5, Anthropic); an additional critical code review pass was performed with Kimi-k3. All changes were reviewed, built and tested locally by the submitter.

---

We would very much welcome your feedback: if there are changes you would like, or points we may have missed — naming, UX of the _Pin_ checkbox, the design decisions above, or anything else — we will gladly rework them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
