### PR TITLE
Browser: Do not allow using references when creating or updating credentials

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -7612,6 +7612,10 @@ Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Username or password cannot contain references</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(core_SOURCES
         core/Entry.cpp
         core/EntryAttachments.cpp
         core/EntryAttributes.cpp
+        core/EntryPlaceholders.cpp
         core/EntrySearcher.cpp
         core/FileWatcher.cpp
         core/Group.cpp

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -43,6 +43,7 @@ static const QString BROWSER_REQUEST_PASSKEYS_REGISTER = QStringLiteral("passkey
 static const QString BROWSER_REQUEST_REQUEST_AUTOTYPE = QStringLiteral("request-autotype");
 static const QString BROWSER_REQUEST_SET_LOGIN = QStringLiteral("set-login");
 static const QString BROWSER_REQUEST_TEST_ASSOCIATE = QStringLiteral("test-associate");
+static const QString REF_MARKER = QStringLiteral("{REF:");
 
 QJsonObject BrowserAction::processClientMessage(QLocalSocket* socket, const QJsonObject& json)
 {
@@ -312,6 +313,10 @@ QJsonObject BrowserAction::handleSetLogin(const QJsonObject& json, const QString
     const auto groupUuid = browserRequest.getString("groupUuid");
     const auto downloadFavicon = browserRequest.getString("downloadFavicon");
     const QString realm;
+
+    if (login.contains(REF_MARKER) || password.contains(REF_MARKER)) {
+        return getErrorReply(action, ERROR_KEEPASS_CANNOT_USE_REFERENCES);
+    }
 
     EntryParameters entryParameters;
     entryParameters.dbid = id;

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -43,7 +43,6 @@ static const QString BROWSER_REQUEST_PASSKEYS_REGISTER = QStringLiteral("passkey
 static const QString BROWSER_REQUEST_REQUEST_AUTOTYPE = QStringLiteral("request-autotype");
 static const QString BROWSER_REQUEST_SET_LOGIN = QStringLiteral("set-login");
 static const QString BROWSER_REQUEST_TEST_ASSOCIATE = QStringLiteral("test-associate");
-static const QString REF_MARKER = QStringLiteral("{REF:");
 
 QJsonObject BrowserAction::processClientMessage(QLocalSocket* socket, const QJsonObject& json)
 {

--- a/src/browser/BrowserAction.cpp
+++ b/src/browser/BrowserAction.cpp
@@ -314,7 +314,7 @@ QJsonObject BrowserAction::handleSetLogin(const QJsonObject& json, const QString
     const auto downloadFavicon = browserRequest.getString("downloadFavicon");
     const QString realm;
 
-    if (login.contains(REF_MARKER) || password.contains(REF_MARKER)) {
+    if (EntryPlaceholders::containsPlaceholder(login) || EntryPlaceholders::containsPlaceholder(password)) {
         return getErrorReply(action, ERROR_KEEPASS_CANNOT_USE_REFERENCES);
     }
 

--- a/src/browser/BrowserMessageBuilder.cpp
+++ b/src/browser/BrowserMessageBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -156,6 +156,8 @@ QString BrowserMessageBuilder::getErrorMessage(const int errorCode) const
         return QObject::tr("Challenge is shorter than required minimum length");
     case ERROR_PASSKEYS_INVALID_USER_ID:
         return QObject::tr("user.id does not match the required length");
+    case ERROR_KEEPASS_CANNOT_USE_REFERENCES:
+        return QObject::tr("Username or password cannot contain references");
     default:
         return QObject::tr("Unknown error");
     }

--- a/src/browser/BrowserMessageBuilder.h
+++ b/src/browser/BrowserMessageBuilder.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -63,6 +63,7 @@ namespace
         ERROR_PASSKEYS_UNKNOWN_ERROR = 31,
         ERROR_PASSKEYS_INVALID_CHALLENGE = 32,
         ERROR_PASSKEYS_INVALID_USER_ID = 33,
+        ERROR_KEEPASS_CANNOT_USE_REFERENCES = 34,
     };
 }
 

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1142,7 +1142,7 @@ QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxD
     }
 
     QString result;
-    auto matches = EntryPlaceholders::PlaceholderRegEx.globalMatch(str);
+    auto matches = EntryPlaceholders::placeholderMatches(str);
     int capEnd = 0;
     while (matches.hasNext()) {
         const auto match = matches.next();

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -437,7 +437,7 @@ QString Entry::webUrl() const
 
 QString Entry::displayUrl() const
 {
-    QString url = maskPasswordPlaceholders(m_attributes->value(EntryAttributes::URLKey));
+    QString url = EntryPlaceholders::maskPasswordPlaceholders(m_attributes->value(EntryAttributes::URLKey));
     return resolveMultiplePlaceholders(url);
 }
 
@@ -1127,8 +1127,6 @@ void Entry::updateModifiedSinceBegin()
 
 QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxDepth) const
 {
-    static const QRegularExpression placeholderRegEx("({(?>[^{}]+?|(?1))+?})");
-
     if (--maxDepth < 0) {
         qWarning("Maximum depth of replacement has been reached. Entry uuid: %s", uuid().toString().toLatin1().data());
         return str;
@@ -1144,7 +1142,7 @@ QString Entry::resolveMultiplePlaceholdersRecursive(const QString& str, int maxD
     }
 
     QString result;
-    auto matches = placeholderRegEx.globalMatch(str);
+    auto matches = EntryPlaceholders::PlaceholderRegEx.globalMatch(str);
     int capEnd = 0;
     while (matches.hasNext()) {
         const auto match = matches.next();
@@ -1163,117 +1161,75 @@ QString Entry::resolvePlaceholderRecursive(const QString& placeholder, int maxDe
         return placeholder;
     }
 
-    const PlaceholderType typeOfPlaceholder = placeholderType(placeholder);
+    const EntryPlaceholders::PlaceholderType typeOfPlaceholder = EntryPlaceholders::placeholderType(placeholder);
     switch (typeOfPlaceholder) {
-    case PlaceholderType::NotPlaceholder:
+    case EntryPlaceholders::PlaceholderType::NotPlaceholder:
         return resolveMultiplePlaceholdersRecursive(placeholder, maxDepth);
-    case PlaceholderType::Unknown: {
+    case EntryPlaceholders::PlaceholderType::Unknown: {
         return "{" % resolveMultiplePlaceholdersRecursive(placeholder.mid(1, placeholder.length() - 2), maxDepth) % "}";
     }
-    case PlaceholderType::Title:
+    case EntryPlaceholders::PlaceholderType::Title:
         return resolveMultiplePlaceholdersRecursive(title(), maxDepth);
-    case PlaceholderType::UserName:
+    case EntryPlaceholders::PlaceholderType::UserName:
         return resolveMultiplePlaceholdersRecursive(username(), maxDepth);
-    case PlaceholderType::Password:
+    case EntryPlaceholders::PlaceholderType::Password:
         return resolveMultiplePlaceholdersRecursive(password(), maxDepth);
-    case PlaceholderType::Notes:
+    case EntryPlaceholders::PlaceholderType::Notes:
         return resolveMultiplePlaceholdersRecursive(notes(), maxDepth);
-    case PlaceholderType::Url:
+    case EntryPlaceholders::PlaceholderType::Url:
         return resolveMultiplePlaceholdersRecursive(url(), maxDepth);
-    case PlaceholderType::Uuid:
+    case EntryPlaceholders::PlaceholderType::Uuid:
         return uuidToHex();
-    case PlaceholderType::DbDir: {
+    case EntryPlaceholders::PlaceholderType::DbDir: {
         QFileInfo fileInfo(database()->filePath());
         return fileInfo.absoluteDir().absolutePath();
     }
-    case PlaceholderType::UrlWithoutScheme:
-    case PlaceholderType::UrlScheme:
-    case PlaceholderType::UrlHost:
-    case PlaceholderType::UrlPort:
-    case PlaceholderType::UrlPath:
-    case PlaceholderType::UrlQuery:
-    case PlaceholderType::UrlFragment:
-    case PlaceholderType::UrlUserInfo:
-    case PlaceholderType::UrlUserName:
-    case PlaceholderType::UrlPassword: {
+    case EntryPlaceholders::PlaceholderType::UrlWithoutScheme:
+    case EntryPlaceholders::PlaceholderType::UrlScheme:
+    case EntryPlaceholders::PlaceholderType::UrlHost:
+    case EntryPlaceholders::PlaceholderType::UrlPort:
+    case EntryPlaceholders::PlaceholderType::UrlPath:
+    case EntryPlaceholders::PlaceholderType::UrlQuery:
+    case EntryPlaceholders::PlaceholderType::UrlFragment:
+    case EntryPlaceholders::PlaceholderType::UrlUserInfo:
+    case EntryPlaceholders::PlaceholderType::UrlUserName:
+    case EntryPlaceholders::PlaceholderType::UrlPassword: {
         const QString strUrl = resolveMultiplePlaceholdersRecursive(url(), maxDepth);
-        return resolveUrlPlaceholder(strUrl, typeOfPlaceholder);
+        return EntryPlaceholders::resolveUrlPlaceholder(strUrl, typeOfPlaceholder);
     }
-    case PlaceholderType::Totp:
+    case EntryPlaceholders::PlaceholderType::Totp:
         // totp can't have placeholder inside
         return totp();
-    case PlaceholderType::CustomAttribute: {
+    case EntryPlaceholders::PlaceholderType::CustomAttribute: {
         const QString key = placeholder.mid(3, placeholder.length() - 4); // {S:attr} => mid(3, len - 4)
         return attributes()->hasKey(key) ? resolveMultiplePlaceholdersRecursive(attributes()->value(key), maxDepth)
                                          : QString();
     }
-    case PlaceholderType::Reference:
+    case EntryPlaceholders::PlaceholderType::Reference:
         return resolveReferencePlaceholderRecursive(placeholder, ++maxDepth);
-    case PlaceholderType::DateTimeSimple:
-    case PlaceholderType::DateTimeYear:
-    case PlaceholderType::DateTimeMonth:
-    case PlaceholderType::DateTimeDay:
-    case PlaceholderType::DateTimeHour:
-    case PlaceholderType::DateTimeMinute:
-    case PlaceholderType::DateTimeSecond:
-    case PlaceholderType::DateTimeUtcSimple:
-    case PlaceholderType::DateTimeUtcYear:
-    case PlaceholderType::DateTimeUtcMonth:
-    case PlaceholderType::DateTimeUtcDay:
-    case PlaceholderType::DateTimeUtcHour:
-    case PlaceholderType::DateTimeUtcMinute:
-    case PlaceholderType::DateTimeUtcSecond:
-        return resolveMultiplePlaceholdersRecursive(resolveDateTimePlaceholder(typeOfPlaceholder), maxDepth);
-    case PlaceholderType::Conversion:
+    case EntryPlaceholders::PlaceholderType::DateTimeSimple:
+    case EntryPlaceholders::PlaceholderType::DateTimeYear:
+    case EntryPlaceholders::PlaceholderType::DateTimeMonth:
+    case EntryPlaceholders::PlaceholderType::DateTimeDay:
+    case EntryPlaceholders::PlaceholderType::DateTimeHour:
+    case EntryPlaceholders::PlaceholderType::DateTimeMinute:
+    case EntryPlaceholders::PlaceholderType::DateTimeSecond:
+    case EntryPlaceholders::PlaceholderType::DateTimeUtcSimple:
+    case EntryPlaceholders::PlaceholderType::DateTimeUtcYear:
+    case EntryPlaceholders::PlaceholderType::DateTimeUtcMonth:
+    case EntryPlaceholders::PlaceholderType::DateTimeUtcDay:
+    case EntryPlaceholders::PlaceholderType::DateTimeUtcHour:
+    case EntryPlaceholders::PlaceholderType::DateTimeUtcMinute:
+    case EntryPlaceholders::PlaceholderType::DateTimeUtcSecond:
+        return resolveMultiplePlaceholdersRecursive(EntryPlaceholders::resolveDateTimePlaceholder(typeOfPlaceholder),
+                                                    maxDepth);
+    case EntryPlaceholders::PlaceholderType::Conversion:
         return resolveMultiplePlaceholdersRecursive(resolveConversionPlaceholder(placeholder), maxDepth);
-    case PlaceholderType::Regex:
+    case EntryPlaceholders::PlaceholderType::Regex:
         return resolveMultiplePlaceholdersRecursive(resolveRegexPlaceholder(placeholder), maxDepth);
     }
 
     return placeholder;
-}
-
-QString Entry::resolveDateTimePlaceholder(Entry::PlaceholderType placeholderType) const
-{
-    const QDateTime time = Clock::currentDateTime();
-    const QDateTime time_utc = Clock::currentDateTimeUtc();
-
-    switch (placeholderType) {
-    case PlaceholderType::DateTimeSimple:
-        return time.toString("yyyyMMddhhmmss");
-    case PlaceholderType::DateTimeYear:
-        return time.toString("yyyy");
-    case PlaceholderType::DateTimeMonth:
-        return time.toString("MM");
-    case PlaceholderType::DateTimeDay:
-        return time.toString("dd");
-    case PlaceholderType::DateTimeHour:
-        return time.toString("hh");
-    case PlaceholderType::DateTimeMinute:
-        return time.toString("mm");
-    case PlaceholderType::DateTimeSecond:
-        return time.toString("ss");
-    case PlaceholderType::DateTimeUtcSimple:
-        return time_utc.toString("yyyyMMddhhmmss");
-    case PlaceholderType::DateTimeUtcYear:
-        return time_utc.toString("yyyy");
-    case PlaceholderType::DateTimeUtcMonth:
-        return time_utc.toString("MM");
-    case PlaceholderType::DateTimeUtcDay:
-        return time_utc.toString("dd");
-    case PlaceholderType::DateTimeUtcHour:
-        return time_utc.toString("hh");
-    case PlaceholderType::DateTimeUtcMinute:
-        return time_utc.toString("mm");
-    case PlaceholderType::DateTimeUtcSecond:
-        return time_utc.toString("ss");
-    default: {
-        Q_ASSERT_X(false, "Entry::resolveDateTimePlaceholder", "Bad DateTime placeholder type");
-        break;
-    }
-    }
-
-    return {};
 }
 
 QString Entry::resolveConversionPlaceholder(const QString& str, QString* error) const
@@ -1500,11 +1456,6 @@ Database* Entry::database()
     return nullptr;
 }
 
-QString Entry::maskPasswordPlaceholders(const QString& str) const
-{
-    return QString{str}.replace(QStringLiteral("{PASSWORD}"), QStringLiteral("******"), Qt::CaseInsensitive);
-}
-
 Entry* Entry::resolveReference(const QString& str) const
 {
     QRegularExpressionMatch match = EntryAttributes::matchReference(str);
@@ -1527,101 +1478,6 @@ QString Entry::resolveMultiplePlaceholders(const QString& str) const
 QString Entry::resolvePlaceholder(const QString& placeholder) const
 {
     return resolvePlaceholderRecursive(placeholder, ResolveMaximumDepth);
-}
-
-QString Entry::resolveUrlPlaceholder(const QString& str, Entry::PlaceholderType placeholderType) const
-{
-    if (str.isEmpty()) {
-        return {};
-    }
-
-    const QUrl qurl(str);
-    switch (placeholderType) {
-    case PlaceholderType::UrlWithoutScheme:
-        return qurl.toString(QUrl::RemoveScheme | QUrl::FullyDecoded);
-    case PlaceholderType::UrlScheme:
-        return qurl.scheme();
-    case PlaceholderType::UrlHost:
-        return qurl.host();
-    case PlaceholderType::UrlPort:
-        return QString::number(qurl.port());
-    case PlaceholderType::UrlPath:
-        return qurl.path();
-    case PlaceholderType::UrlQuery:
-        return qurl.query();
-    case PlaceholderType::UrlFragment:
-        return qurl.fragment();
-    case PlaceholderType::UrlUserInfo:
-        return qurl.userInfo();
-    case PlaceholderType::UrlUserName:
-        return qurl.userName();
-    case PlaceholderType::UrlPassword:
-        return qurl.password();
-    default: {
-        Q_ASSERT_X(false, "Entry::resolveUrlPlaceholder", "Bad url placeholder type");
-        break;
-    }
-    }
-
-    return {};
-}
-
-Entry::PlaceholderType Entry::placeholderType(const QString& placeholder) const
-{
-    if (!placeholder.startsWith(QStringLiteral("{")) || !placeholder.endsWith(QStringLiteral("}"))) {
-        return PlaceholderType::NotPlaceholder;
-    }
-    if (placeholder.startsWith(QStringLiteral("{S:"))) {
-        return PlaceholderType::CustomAttribute;
-    }
-    if (placeholder.startsWith(QStringLiteral("{REF:"))) {
-        return PlaceholderType::Reference;
-    }
-    if (placeholder.startsWith(QStringLiteral("{T-CONV:"), Qt::CaseInsensitive)) {
-        return PlaceholderType::Conversion;
-    }
-    if (placeholder.startsWith(QStringLiteral("{T-REPLACE-RX:"), Qt::CaseInsensitive)) {
-        return PlaceholderType::Regex;
-    }
-
-    static const QMap<QString, PlaceholderType> placeholders{
-        {QStringLiteral("{TITLE}"), PlaceholderType::Title},
-        {QStringLiteral("{USERNAME}"), PlaceholderType::UserName},
-        {QStringLiteral("{PASSWORD}"), PlaceholderType::Password},
-        {QStringLiteral("{NOTES}"), PlaceholderType::Notes},
-        {QStringLiteral("{TOTP}"), PlaceholderType::Totp},
-        {QStringLiteral("{TIMEOTP}"), PlaceholderType::Totp},
-        {QStringLiteral("{URL}"), PlaceholderType::Url},
-        {QStringLiteral("{UUID}"), PlaceholderType::Uuid},
-        {QStringLiteral("{URL:RMVSCM}"), PlaceholderType::UrlWithoutScheme},
-        {QStringLiteral("{URL:WITHOUTSCHEME}"), PlaceholderType::UrlWithoutScheme},
-        {QStringLiteral("{URL:SCM}"), PlaceholderType::UrlScheme},
-        {QStringLiteral("{URL:SCHEME}"), PlaceholderType::UrlScheme},
-        {QStringLiteral("{URL:HOST}"), PlaceholderType::UrlHost},
-        {QStringLiteral("{URL:PORT}"), PlaceholderType::UrlPort},
-        {QStringLiteral("{URL:PATH}"), PlaceholderType::UrlPath},
-        {QStringLiteral("{URL:QUERY}"), PlaceholderType::UrlQuery},
-        {QStringLiteral("{URL:FRAGMENT}"), PlaceholderType::UrlFragment},
-        {QStringLiteral("{URL:USERINFO}"), PlaceholderType::UrlUserInfo},
-        {QStringLiteral("{URL:USERNAME}"), PlaceholderType::UrlUserName},
-        {QStringLiteral("{URL:PASSWORD}"), PlaceholderType::UrlPassword},
-        {QStringLiteral("{DT_SIMPLE}"), PlaceholderType::DateTimeSimple},
-        {QStringLiteral("{DT_YEAR}"), PlaceholderType::DateTimeYear},
-        {QStringLiteral("{DT_MONTH}"), PlaceholderType::DateTimeMonth},
-        {QStringLiteral("{DT_DAY}"), PlaceholderType::DateTimeDay},
-        {QStringLiteral("{DT_HOUR}"), PlaceholderType::DateTimeHour},
-        {QStringLiteral("{DT_MINUTE}"), PlaceholderType::DateTimeMinute},
-        {QStringLiteral("{DT_SECOND}"), PlaceholderType::DateTimeSecond},
-        {QStringLiteral("{DT_UTC_SIMPLE}"), PlaceholderType::DateTimeUtcSimple},
-        {QStringLiteral("{DT_UTC_YEAR}"), PlaceholderType::DateTimeUtcYear},
-        {QStringLiteral("{DT_UTC_MONTH}"), PlaceholderType::DateTimeUtcMonth},
-        {QStringLiteral("{DT_UTC_DAY}"), PlaceholderType::DateTimeUtcDay},
-        {QStringLiteral("{DT_UTC_HOUR}"), PlaceholderType::DateTimeUtcHour},
-        {QStringLiteral("{DT_UTC_MINUTE}"), PlaceholderType::DateTimeUtcMinute},
-        {QStringLiteral("{DT_UTC_SECOND}"), PlaceholderType::DateTimeUtcSecond},
-        {QStringLiteral("{DB_DIR}"), PlaceholderType::DbDir}};
-
-    return placeholders.value(placeholder.toUpper(), PlaceholderType::Unknown);
 }
 
 QString Entry::resolveUrl(const QString& url) const

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -27,6 +27,7 @@
 #include "core/CustomData.h"
 #include "core/EntryAttachments.h"
 #include "core/EntryAttributes.h"
+#include "core/EntryPlaceholders.h"
 #include "core/Global.h"
 #include "core/TimeInfo.h"
 
@@ -200,48 +201,6 @@ public:
     };
     Q_DECLARE_FLAGS(CloneFlags, CloneFlag)
 
-    enum class PlaceholderType
-    {
-        NotPlaceholder,
-        Unknown,
-        Title,
-        UserName,
-        Password,
-        Notes,
-        Totp,
-        Url,
-        Uuid,
-        UrlWithoutScheme,
-        UrlScheme,
-        UrlHost,
-        UrlPort,
-        UrlPath,
-        UrlQuery,
-        UrlFragment,
-        UrlUserInfo,
-        UrlUserName,
-        UrlPassword,
-        Reference,
-        CustomAttribute,
-        DateTimeSimple,
-        DateTimeYear,
-        DateTimeMonth,
-        DateTimeDay,
-        DateTimeHour,
-        DateTimeMinute,
-        DateTimeSecond,
-        DateTimeUtcSimple,
-        DateTimeUtcYear,
-        DateTimeUtcMonth,
-        DateTimeUtcDay,
-        DateTimeUtcHour,
-        DateTimeUtcMinute,
-        DateTimeUtcSecond,
-        DbDir,
-        Conversion,
-        Regex
-    };
-
     static const int DefaultIconNumber;
 
     /**
@@ -252,15 +211,11 @@ public:
      */
     Entry* clone(CloneFlags flags = CloneDefault) const;
     void copyDataFrom(const Entry* other);
-    QString maskPasswordPlaceholders(const QString& str) const;
     Entry* resolveReference(const QString& str) const;
     QString resolveMultiplePlaceholders(const QString& str) const;
     QString resolvePlaceholder(const QString& str) const;
-    QString resolveUrlPlaceholder(const QString& str, PlaceholderType placeholderType) const;
-    QString resolveDateTimePlaceholder(PlaceholderType placeholderType) const;
     QString resolveConversionPlaceholder(const QString& str, QString* error = nullptr) const;
     QString resolveRegexPlaceholder(const QString& str, QString* error = nullptr) const;
-    PlaceholderType placeholderType(const QString& placeholder) const;
     QString resolveUrl(const QString& url) const;
 
     /**

--- a/src/core/EntryPlaceholders.cpp
+++ b/src/core/EntryPlaceholders.cpp
@@ -113,7 +113,7 @@ namespace EntryPlaceholders
         case PlaceholderType::UrlPassword:
             return qurl.password();
         default: {
-            Q_ASSERT_X(false, "Entry::resolveUrlPlaceholder", "Bad url placeholder type");
+            Q_ASSERT_X(false, "EntryPlaceholders::resolveUrlPlaceholder", "Bad url placeholder type");
             break;
         }
         }
@@ -156,7 +156,7 @@ namespace EntryPlaceholders
         case PlaceholderType::DateTimeUtcSecond:
             return time_utc.toString("ss");
         default: {
-            Q_ASSERT_X(false, "Entry::resolveDateTimePlaceholder", "Bad DateTime placeholder type");
+            Q_ASSERT_X(false, "EntryPlaceholders::resolveDateTimePlaceholder", "Bad DateTime placeholder type");
             break;
         }
         }
@@ -169,9 +169,15 @@ namespace EntryPlaceholders
         return QString{str}.replace(QStringLiteral("{PASSWORD}"), QStringLiteral("******"), Qt::CaseInsensitive);
     }
 
+    QRegularExpressionMatchIterator placeholderMatches(const QString& str)
+    {
+        static const QRegularExpression placeholderRegEx("({(?>[^{}]+?|(?1))+?})");
+        return placeholderRegEx.globalMatch(str);
+    }
+
     bool containsPlaceholder(const QString& str)
     {
-        auto matches = PlaceholderRegEx.globalMatch(str);
+        auto matches = placeholderMatches(str);
         while (matches.hasNext()) {
             const auto match = matches.next();
             auto captured = match.captured(0);

--- a/src/core/EntryPlaceholders.cpp
+++ b/src/core/EntryPlaceholders.cpp
@@ -1,0 +1,194 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "EntryPlaceholders.h"
+
+#include <QDateTime>
+#include <QMap>
+#include <QStringLiteral>
+#include <QUrl>
+
+#include "Clock.h"
+
+namespace EntryPlaceholders
+{
+    PlaceholderType placeholderType(const QString& placeholder)
+    {
+        if (!placeholder.startsWith(QStringLiteral("{")) || !placeholder.endsWith(QStringLiteral("}"))) {
+            return PlaceholderType::NotPlaceholder;
+        }
+        if (placeholder.startsWith(QStringLiteral("{S:"))) {
+            return PlaceholderType::CustomAttribute;
+        }
+        if (placeholder.startsWith(QStringLiteral("{REF:"))) {
+            return PlaceholderType::Reference;
+        }
+        if (placeholder.startsWith(QStringLiteral("{T-CONV:"), Qt::CaseInsensitive)) {
+            return PlaceholderType::Conversion;
+        }
+        if (placeholder.startsWith(QStringLiteral("{T-REPLACE-RX:"), Qt::CaseInsensitive)) {
+            return PlaceholderType::Regex;
+        }
+
+        static const QMap<QString, PlaceholderType> placeholders{
+            {QStringLiteral("{TITLE}"), PlaceholderType::Title},
+            {QStringLiteral("{USERNAME}"), PlaceholderType::UserName},
+            {QStringLiteral("{PASSWORD}"), PlaceholderType::Password},
+            {QStringLiteral("{NOTES}"), PlaceholderType::Notes},
+            {QStringLiteral("{TOTP}"), PlaceholderType::Totp},
+            {QStringLiteral("{TIMEOTP}"), PlaceholderType::Totp},
+            {QStringLiteral("{URL}"), PlaceholderType::Url},
+            {QStringLiteral("{UUID}"), PlaceholderType::Uuid},
+            {QStringLiteral("{URL:RMVSCM}"), PlaceholderType::UrlWithoutScheme},
+            {QStringLiteral("{URL:WITHOUTSCHEME}"), PlaceholderType::UrlWithoutScheme},
+            {QStringLiteral("{URL:SCM}"), PlaceholderType::UrlScheme},
+            {QStringLiteral("{URL:SCHEME}"), PlaceholderType::UrlScheme},
+            {QStringLiteral("{URL:HOST}"), PlaceholderType::UrlHost},
+            {QStringLiteral("{URL:PORT}"), PlaceholderType::UrlPort},
+            {QStringLiteral("{URL:PATH}"), PlaceholderType::UrlPath},
+            {QStringLiteral("{URL:QUERY}"), PlaceholderType::UrlQuery},
+            {QStringLiteral("{URL:FRAGMENT}"), PlaceholderType::UrlFragment},
+            {QStringLiteral("{URL:USERINFO}"), PlaceholderType::UrlUserInfo},
+            {QStringLiteral("{URL:USERNAME}"), PlaceholderType::UrlUserName},
+            {QStringLiteral("{URL:PASSWORD}"), PlaceholderType::UrlPassword},
+            {QStringLiteral("{DT_SIMPLE}"), PlaceholderType::DateTimeSimple},
+            {QStringLiteral("{DT_YEAR}"), PlaceholderType::DateTimeYear},
+            {QStringLiteral("{DT_MONTH}"), PlaceholderType::DateTimeMonth},
+            {QStringLiteral("{DT_DAY}"), PlaceholderType::DateTimeDay},
+            {QStringLiteral("{DT_HOUR}"), PlaceholderType::DateTimeHour},
+            {QStringLiteral("{DT_MINUTE}"), PlaceholderType::DateTimeMinute},
+            {QStringLiteral("{DT_SECOND}"), PlaceholderType::DateTimeSecond},
+            {QStringLiteral("{DT_UTC_SIMPLE}"), PlaceholderType::DateTimeUtcSimple},
+            {QStringLiteral("{DT_UTC_YEAR}"), PlaceholderType::DateTimeUtcYear},
+            {QStringLiteral("{DT_UTC_MONTH}"), PlaceholderType::DateTimeUtcMonth},
+            {QStringLiteral("{DT_UTC_DAY}"), PlaceholderType::DateTimeUtcDay},
+            {QStringLiteral("{DT_UTC_HOUR}"), PlaceholderType::DateTimeUtcHour},
+            {QStringLiteral("{DT_UTC_MINUTE}"), PlaceholderType::DateTimeUtcMinute},
+            {QStringLiteral("{DT_UTC_SECOND}"), PlaceholderType::DateTimeUtcSecond},
+            {QStringLiteral("{DB_DIR}"), PlaceholderType::DbDir}};
+
+        return placeholders.value(placeholder.toUpper(), PlaceholderType::Unknown);
+    }
+
+    QString resolveUrlPlaceholder(const QString& str, PlaceholderType placeholderType)
+    {
+        if (str.isEmpty()) {
+            return {};
+        }
+
+        const QUrl qurl(str);
+        switch (placeholderType) {
+        case PlaceholderType::UrlWithoutScheme:
+            return qurl.toString(QUrl::RemoveScheme | QUrl::FullyDecoded);
+        case PlaceholderType::UrlScheme:
+            return qurl.scheme();
+        case PlaceholderType::UrlHost:
+            return qurl.host();
+        case PlaceholderType::UrlPort:
+            return QString::number(qurl.port());
+        case PlaceholderType::UrlPath:
+            return qurl.path();
+        case PlaceholderType::UrlQuery:
+            return qurl.query();
+        case PlaceholderType::UrlFragment:
+            return qurl.fragment();
+        case PlaceholderType::UrlUserInfo:
+            return qurl.userInfo();
+        case PlaceholderType::UrlUserName:
+            return qurl.userName();
+        case PlaceholderType::UrlPassword:
+            return qurl.password();
+        default: {
+            Q_ASSERT_X(false, "Entry::resolveUrlPlaceholder", "Bad url placeholder type");
+            break;
+        }
+        }
+
+        return {};
+    }
+
+    QString resolveDateTimePlaceholder(PlaceholderType placeholderType)
+    {
+        const QDateTime time = Clock::currentDateTime();
+        const QDateTime time_utc = Clock::currentDateTimeUtc();
+
+        switch (placeholderType) {
+        case PlaceholderType::DateTimeSimple:
+            return time.toString("yyyyMMddhhmmss");
+        case PlaceholderType::DateTimeYear:
+            return time.toString("yyyy");
+        case PlaceholderType::DateTimeMonth:
+            return time.toString("MM");
+        case PlaceholderType::DateTimeDay:
+            return time.toString("dd");
+        case PlaceholderType::DateTimeHour:
+            return time.toString("hh");
+        case PlaceholderType::DateTimeMinute:
+            return time.toString("mm");
+        case PlaceholderType::DateTimeSecond:
+            return time.toString("ss");
+        case PlaceholderType::DateTimeUtcSimple:
+            return time_utc.toString("yyyyMMddhhmmss");
+        case PlaceholderType::DateTimeUtcYear:
+            return time_utc.toString("yyyy");
+        case PlaceholderType::DateTimeUtcMonth:
+            return time_utc.toString("MM");
+        case PlaceholderType::DateTimeUtcDay:
+            return time_utc.toString("dd");
+        case PlaceholderType::DateTimeUtcHour:
+            return time_utc.toString("hh");
+        case PlaceholderType::DateTimeUtcMinute:
+            return time_utc.toString("mm");
+        case PlaceholderType::DateTimeUtcSecond:
+            return time_utc.toString("ss");
+        default: {
+            Q_ASSERT_X(false, "Entry::resolveDateTimePlaceholder", "Bad DateTime placeholder type");
+            break;
+        }
+        }
+
+        return {};
+    }
+
+    QString maskPasswordPlaceholders(const QString& str)
+    {
+        return QString{str}.replace(QStringLiteral("{PASSWORD}"), QStringLiteral("******"), Qt::CaseInsensitive);
+    }
+
+    bool containsPlaceholder(const QString& str)
+    {
+        auto matches = PlaceholderRegEx.globalMatch(str);
+        while (matches.hasNext()) {
+            const auto match = matches.next();
+            auto captured = match.captured(0);
+
+            // Remove escaped brackets
+            if (captured.startsWith("\\{")) {
+                captured.replace(0, 2, "{");
+            }
+            if (captured.endsWith("\\}")) {
+                captured.replace(captured.size() - 2, 2, "}");
+            }
+
+            const auto placeHolderType = placeholderType(captured);
+            if (placeHolderType != PlaceholderType::NotPlaceholder && placeHolderType != PlaceholderType::Unknown) {
+                return true;
+            }
+        }
+        return false;
+    }
+} // namespace EntryPlaceholders

--- a/src/core/EntryPlaceholders.h
+++ b/src/core/EntryPlaceholders.h
@@ -65,12 +65,11 @@ namespace EntryPlaceholders
         Regex
     };
 
-    static const QRegularExpression PlaceholderRegEx("({(?>[^{}]+?|(?1))+?})");
-
     PlaceholderType placeholderType(const QString& placeholder);
     QString resolveUrlPlaceholder(const QString& str, PlaceholderType placeholderType);
     QString resolveDateTimePlaceholder(PlaceholderType placeholderType);
     QString maskPasswordPlaceholders(const QString& str);
+    QRegularExpressionMatchIterator placeholderMatches(const QString& str);
     bool containsPlaceholder(const QString& str);
 } // namespace EntryPlaceholders
 

--- a/src/core/EntryPlaceholders.h
+++ b/src/core/EntryPlaceholders.h
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_ENTRYPLACEHOLDERS_H
+#define KEEPASSXC_ENTRYPLACEHOLDERS_H
+
+#include <QRegularExpression>
+#include <QString>
+
+namespace EntryPlaceholders
+{
+    enum class PlaceholderType
+    {
+        NotPlaceholder,
+        Unknown,
+        Title,
+        UserName,
+        Password,
+        Notes,
+        Totp,
+        Url,
+        Uuid,
+        UrlWithoutScheme,
+        UrlScheme,
+        UrlHost,
+        UrlPort,
+        UrlPath,
+        UrlQuery,
+        UrlFragment,
+        UrlUserInfo,
+        UrlUserName,
+        UrlPassword,
+        Reference,
+        CustomAttribute,
+        DateTimeSimple,
+        DateTimeYear,
+        DateTimeMonth,
+        DateTimeDay,
+        DateTimeHour,
+        DateTimeMinute,
+        DateTimeSecond,
+        DateTimeUtcSimple,
+        DateTimeUtcYear,
+        DateTimeUtcMonth,
+        DateTimeUtcDay,
+        DateTimeUtcHour,
+        DateTimeUtcMinute,
+        DateTimeUtcSecond,
+        DbDir,
+        Conversion,
+        Regex
+    };
+
+    static const QRegularExpression PlaceholderRegEx("({(?>[^{}]+?|(?1))+?})");
+
+    PlaceholderType placeholderType(const QString& placeholder);
+    QString resolveUrlPlaceholder(const QString& str, PlaceholderType placeholderType);
+    QString resolveDateTimePlaceholder(PlaceholderType placeholderType);
+    QString maskPasswordPlaceholders(const QString& str);
+    bool containsPlaceholder(const QString& str);
+} // namespace EntryPlaceholders
+
+#endif // KEEPASSXC_ENTRYPLACEHOLDERS_H

--- a/src/fdosecrets/objects/Item.cpp
+++ b/src/fdosecrets/objects/Item.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2019 Aetf <aetf@unlimitedcodeworks.xyz>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -25,6 +25,7 @@
 #include "fdosecrets/objects/Session.h"
 
 #include "core/EntryAttributes.h"
+#include "core/EntryPlaceholders.h"
 #include "core/Group.h"
 
 #include <QMimeDatabase>
@@ -111,7 +112,7 @@ namespace FdoSecrets
 
             auto value = entryAttrs->value(attr);
             if (entryAttrs->isReference(attr)) {
-                value = m_backend->maskPasswordPlaceholders(value);
+                value = EntryPlaceholders::maskPasswordPlaceholders(value);
                 value = m_backend->resolveMultiplePlaceholders(value);
             }
             attrs[attr] = value;

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1008,7 +1008,8 @@ void DatabaseWidget::openUrlForEntry(Entry* entry)
 
         // otherwise ask user
         if (!launch && cmdString.length() > 6) {
-            QString cmdTruncated = entry->resolveMultiplePlaceholders(entry->maskPasswordPlaceholders(entry->url()));
+            QString cmdTruncated =
+                entry->resolveMultiplePlaceholders(EntryPlaceholders::maskPasswordPlaceholders(entry->url()));
             cmdTruncated = cmdTruncated.mid(6);
             if (cmdTruncated.length() > 400) {
                 cmdTruncated = cmdTruncated.left(400) + " […]";

--- a/src/gui/entry/AutoTypeAssociationsModel.cpp
+++ b/src/gui/entry/AutoTypeAssociationsModel.cpp
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2012 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -96,7 +97,7 @@ QVariant AutoTypeAssociationsModel::data(const QModelIndex& index, int role) con
                 return tr("(empty)");
             }
             if (m_entry) {
-                window = m_entry->maskPasswordPlaceholders(window);
+                window = EntryPlaceholders::maskPasswordPlaceholders(window);
                 window = m_entry->resolveMultiplePlaceholders(window);
             }
             return window;

--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
  */
 
 #include "ShareExport.h"
+#include "core/EntryPlaceholders.h"
 #include "core/Group.h"
 #include "core/Metadata.h"
 #include "crypto/Random.h"
@@ -42,8 +43,8 @@ namespace
     {
         for (const auto& attribute : EntryAttributes::DefaultAttributes) {
             const auto standardValue = targetEntry->attributes()->value(attribute);
-            const auto type = targetEntry->placeholderType(standardValue);
-            if (type != Entry::PlaceholderType::Reference) {
+            const auto type = EntryPlaceholders::placeholderType(standardValue);
+            if (type != EntryPlaceholders::PlaceholderType::Reference) {
                 // No reference to resolve
                 continue;
             }

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -929,4 +929,28 @@ void TestEntry::testPreviousParentGroup()
     entry->setGroup(group2);
     QVERIFY(entry->previousParentGroupUuid() == group1->uuid());
     QVERIFY(entry->previousParentGroup() == group1);
+}
+
+void TestEntry::testContainsPlaceholder()
+{
+    // Dynamic placeholders
+    QVERIFY(!EntryPlaceholders::containsPlaceholder(""));
+    QVERIFY(!EntryPlaceholders::containsPlaceholder("testString{REF:nothing")); // Placeholder is not finished
+    QVERIFY(EntryPlaceholders::containsPlaceholder("testString{REF:P@T:Other Entry}something"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("{URL:USERNAME}yes"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("{URL:USERNAME}yes{REF:A@O:Attribute 1}"));
+    QVERIFY(!EntryPlaceholders::containsPlaceholder("{NOTAREALPLACEHOLDER:USERNAME}yes")); // Unknown placeholder
+    QVERIFY(EntryPlaceholders::containsPlaceholder("yes{URL:PORT}"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("yes{S:KPEX_PASSKEYS_USER_ID}no"));
+
+    // Static placeholders
+    QVERIFY(EntryPlaceholders::containsPlaceholder("{TITLE}"));
+    QVERIFY(!EntryPlaceholders::containsPlaceholder("{TITLE2}"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("{USERNAME}"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("{PASSWORD}"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("{URL}"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("{NOTES}"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("inthe{NOTES}middle"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("{TOTP}"));
+    QVERIFY(EntryPlaceholders::containsPlaceholder("test\\{TOTP\\}"));
 }

--- a/tests/TestEntry.h
+++ b/tests/TestEntry.h
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2013 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -44,6 +45,7 @@ private slots:
     void testIsRecycled();
     void testMoveUpDown();
     void testPreviousParentGroup();
+    void testContainsPlaceholder();
 };
 
 #endif // KEEPASSX_TESTENTRY_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )

When creating or updating entries using the browser API, do not allow using references in username or password. This could cause unwanted references to other entries, and might lead to data extraction.

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Try using a reference (for example {REF:P@T:Other Entry}) in username or password when creating or updating credentials.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
