### PR TITLE
Fix: Auto-dismiss unlock dialog when target database unlocks by other means

### DIFF
--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -605,8 +605,8 @@ namespace FdoSecrets
             return;
         }
 
-        if (!accepted) {
-            emit doneUnlockDatabaseInDialog(false, dbWidget);
+        if (!accepted || !dbWidget->isLocked()) {
+            emit doneUnlockDatabaseInDialog(!dbWidget->isLocked(), dbWidget);
             m_unlockingAnyDatabase = false;
             m_unlockingDb.remove(dbWidget);
         } else {

--- a/src/gui/DatabaseOpenDialog.cpp
+++ b/src/gui/DatabaseOpenDialog.cpp
@@ -171,6 +171,23 @@ DatabaseOpenDialog::Intent DatabaseOpenDialog::intent() const
     return m_intent;
 }
 
+void DatabaseOpenDialog::onDatabaseUnlocked(DatabaseWidget* dbWidget)
+{
+    if (!isVisible()) {
+        return;
+    }
+
+    if (m_currentDbWidget != dbWidget && m_tabDbWidgets.contains(dbWidget)) {
+        setActiveDatabaseTab(dbWidget);
+    }
+
+    if (m_currentDbWidget == dbWidget) {
+        m_db = m_currentDbWidget->database();
+        disconnect(this, &DatabaseOpenDialog::dialogFinished, m_currentDbWidget, nullptr);
+        complete(true);
+    }
+}
+
 void DatabaseOpenDialog::clearForms()
 {
     m_view->clearForms();
@@ -221,7 +238,9 @@ void DatabaseOpenDialog::done(int result)
 void DatabaseOpenDialog::complete(bool accepted)
 {
     // save DB, since DatabaseOpenWidget will reset its data after accept() is called
-    m_db = m_view->database();
+    if (!m_db && m_view->database()) {
+        m_db = m_view->database();
+    }
     if (m_db && m_intent == Intent::RemoteSync) {
         m_db->markAsTemporaryDatabase();
     }

--- a/src/gui/DatabaseOpenDialog.h
+++ b/src/gui/DatabaseOpenDialog.h
@@ -61,6 +61,7 @@ public slots:
     void done(int result) override;
     void complete(bool accepted);
     void tabChanged(int index);
+    void onDatabaseUnlocked(DatabaseWidget* dbWidget);
 
 protected:
     void showEvent(QShowEvent* event) override;

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -61,6 +61,8 @@ DatabaseTabWidget::DatabaseTabWidget(QWidget* parent)
     connect(autoType(), SIGNAL(autotypeFinished()), SLOT(relockPendingDatabase()));
     connect(m_databaseOpenDialog.data(), &DatabaseOpenDialog::dialogFinished,
             this, &DatabaseTabWidget::handleDatabaseUnlockDialogFinished);
+    connect(this, &DatabaseTabWidget::databaseUnlocked,
+            m_databaseOpenDialog.data(), &DatabaseOpenDialog::onDatabaseUnlocked);
     // clang-format on
 
 #ifdef Q_OS_MACOS


### PR DESCRIPTION
Automatically close unlock dialog when target database unlocks by other means

## Description

When an unlock dialog is open, unlocking the target database externally (e.g., via DBus / Secret Service) left the modal dialog stranded on screen.

This change routes `DatabaseTabWidget::databaseUnlocked` directly to `DatabaseOpenDialog::onDatabaseUnlocked`, allowing background unlocks to complete the dialog immediately. It also simplifies the Secret Service unlock handler by immediately completing if the target database is already unlocked.

I leveraged Google Gemini to craft this change.

## Testing strategy

* Trigger an unlock prompt via D-Bus / Secret Service, then unlock the database externally. The modal dialog closes automatically and returns the expected success response.

## Type of change

* ✅ Bug fix (non-breaking change that fixes an issue)