### PR TITLE
Add TOTP Entry via QR Code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,14 @@ option(KPXC_MINIMAL "Build KeePassXC with the minimal feature set required for b
 option(KPXC_FEATURE_BROWSER "Browser integration and passkeys support" ON)
 option(KPXC_FEATURE_SSHAGENT "SSH Agent integration" ON)
 option(KPXC_FEATURE_FDOSECRETS "freedesktop.org Secret Service integration; replace system keyring" ON)
+option(KPXC_FEATURE_QRDECODER "Read TOTP configuration from QR codes" ON)
 
 if(KPXC_MINIMAL)
     # Disable advanced features in minimal mode
     set(KPXC_FEATURE_BROWSER OFF)
     set(KPXC_FEATURE_SSHAGENT OFF)
     set(KPXC_FEATURE_FDOSECRETS OFF)
+    set(KPXC_FEATURE_QRDECODER OFF)
 endif()
 
 # Minor Feature Flags
@@ -88,6 +90,7 @@ endif()
 add_feature_info("Networking" KPXC_FEATURE_NETWORK "Code that can reach out to external networks is included (e.g. downloading icons)")
 add_feature_info("Update Checks" KPXC_FEATURE_UPDATES "Periodic update checks can be performed")
 add_feature_info("Documentation" KPXC_FEATURE_DOCS "Offline documentation")
+add_feature_info("QR Decoder" KPXC_FEATURE_QRDECODER "Read TOTP configuration from QR codes")
 
 # Retrieve git HEAD revision hash
 set(GIT_HEAD_OVERRIDE "" CACHE STRING "Manually set the Git HEAD hash when missing (eg, when no .git folder exists)")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,6 +82,7 @@ KeePassXC comes with a variety of build options that can turn on/off features. E
 -DKPXC_FEATURE_BROWSER=[ON|OFF] Browser integration and passkeys support (default: ON)
 -DKPXC_FEATURE_SSHAGENT=[ON|OFF] SSH Agent integration (default: ON)
 -DKPXC_FEATURE_FDOSECRETS=[ON|OFF] (Linux Only) freedesktop.org Secret Service integration; replace system keyring (default:ON)
+-DKPXC_FEATURE_QRDECODER=[ON|OFF] Read TOTP configuration from QR codes (default:ON)
 
 -DKPXC_FEATURE_NETWORK=[ON|OFF] Include code that reaches out to external networks (e.g. downloading icons) (default: ON)
 -DKPXC_FEATURE_UPDATES=[ON|OFF] Include automatic update checks; disable for managed distributions (requires networking) (default: ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -342,6 +342,11 @@ if(KPXC_FEATURE_FDOSECRETS)
     set(fdosecrets_LIB fdosecrets)
 endif()
 
+add_subdirectory(qrdecoder)
+if(KPXC_FEATURE_QRDECODER)
+    set(qrdecoder_LIB qrdecoder)
+endif()
+
 configure_file(config-keepassx.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-keepassx.h)
 configure_file(git-info.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/git-info.h)
 
@@ -374,7 +379,9 @@ target_link_libraries(keepassxc_gui
         ${browser_LIB}
         ${fdosecrets_LIB}
         ${keeshare_LIB}
-        ${sshagent_LIB})
+        ${sshagent_LIB}
+        ${qrdecoder_LIB}
+        )
 
 if(APPLE)
     target_link_libraries(keepassxc_gui "-framework Foundation -framework AppKit -framework Carbon -framework Security -framework LocalAuthentication -framework ScreenCaptureKit")

--- a/src/config-keepassx.h.cmake
+++ b/src/config-keepassx.h.cmake
@@ -20,6 +20,7 @@
 #cmakedefine KPXC_FEATURE_BROWSER
 #cmakedefine KPXC_FEATURE_SSHAGENT
 #cmakedefine KPXC_FEATURE_FDOSECRETS
+#cmakedefine KPXC_FEATURE_QRDECODER
 
 /* Minor Features */
 #cmakedefine KPXC_FEATURE_NETWORK

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -72,6 +72,10 @@
 #include "gui/passkeys/PasskeyImporter.h"
 #endif
 
+#ifdef KPXC_FEATURE_QRDECODER
+#include "qrdecoder/QrTotpSetupDialog.h"
+#endif
+
 DatabaseWidget::DatabaseWidget(QSharedPointer<Database> db, QWidget* parent)
     : QStackedWidget(parent)
     , m_db(std::move(db))
@@ -562,7 +566,11 @@ void DatabaseWidget::setupTotp()
         return;
     }
 
+#ifdef KPXC_FEATURE_QRDECODER
+    auto setupTotpDialog = new QrDecoder::QrTotpSetupDialog(this, currentEntry);
+#else
     auto setupTotpDialog = new TotpSetupDialog(this, currentEntry);
+#endif
     connect(setupTotpDialog, SIGNAL(totpUpdated()), SIGNAL(entrySelectionChanged()));
     if (currentWidget() == m_editEntryWidget) {
         // Entry is being edited, tell it when we are finished updating TOTP

--- a/src/gui/TotpSetupDialog.cpp
+++ b/src/gui/TotpSetupDialog.cpp
@@ -133,3 +133,21 @@ void TotpSetupDialog::init()
         m_ui->invalidKeyLabel->setVisible(!error.isEmpty());
     }
 }
+
+void TotpSetupDialog::setSettings(const Totp::Settings& settings)
+{
+    m_ui->seedEdit->setText(settings.key);
+
+    m_ui->radioCustom->setChecked(true);
+    m_ui->customSettingsGroup->setEnabled(true);
+
+    const auto algorithmIndex = m_ui->algorithmComboBox->findData(settings.algorithm);
+    if (algorithmIndex >= 0) {
+        m_ui->algorithmComboBox->setCurrentIndex(algorithmIndex);
+    }
+
+    m_ui->stepSpinBox->setValue(settings.step);
+    m_ui->digitsSpinBox->setValue(settings.digits);
+
+    m_ui->seedEdit->setFocus();
+}

--- a/src/gui/TotpSetupDialog.h
+++ b/src/gui/TotpSetupDialog.h
@@ -22,6 +22,7 @@
 #include <QDialog>
 
 #include "core/Database.h"
+#include "core/Totp.h"
 #include "gui/DatabaseWidget.h"
 
 namespace Ui
@@ -37,6 +38,7 @@ public:
     explicit TotpSetupDialog(QWidget* parent = nullptr, Entry* entry = nullptr);
     ~TotpSetupDialog() override;
     void init();
+    void setSettings(const Totp::Settings& settings);
 
 signals:
     void totpUpdated();

--- a/src/qrdecoder/CMakeLists.txt
+++ b/src/qrdecoder/CMakeLists.txt
@@ -16,9 +16,16 @@
 if(KPXC_FEATURE_QRDECODER)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-    set(qrdecoder_SOURCES
-        qrdecoder.cpp
-        qrdecoder.h
+    # set(qrdecoder_SOURCES
+    #     QrDecoder.cpp
+    #     QrDecoder.h
+    #     QrTotpSetupDialog.cpp
+    #     QrTotpSetupDialog.h
+    # )
+
+    file(GLOB qrdecoder_SOURCES CONFIGURE_DEPENDS
+        "*.cpp"
+        "*.h"
     )
 
     add_library(qrdecoder STATIC ${qrdecoder_SOURCES})

--- a/src/qrdecoder/CMakeLists.txt
+++ b/src/qrdecoder/CMakeLists.txt
@@ -1,0 +1,28 @@
+#  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 or (at your option)
+#  version 3 of the License.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+if(KPXC_FEATURE_QRDECODER)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+
+    set(qrdecoder_SOURCES
+        qrdecoderr.cpp
+        qrdecoderr.h
+    )
+
+    add_library(qrdecoder STATIC ${qrdecoder_SOURCES})
+
+    find_package(ZXing CONFIG REQUIRED)
+    target_link_libraries(qrdecoder Qt6::Core Qt6::Widgets ZXing::ZXing)
+endif()

--- a/src/qrdecoder/CMakeLists.txt
+++ b/src/qrdecoder/CMakeLists.txt
@@ -16,16 +16,13 @@
 if(KPXC_FEATURE_QRDECODER)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-    # set(qrdecoder_SOURCES
-    #     QrDecoder.cpp
-    #     QrDecoder.h
-    #     QrTotpSetupDialog.cpp
-    #     QrTotpSetupDialog.h
-    # )
-
-    file(GLOB qrdecoder_SOURCES CONFIGURE_DEPENDS
-        "*.cpp"
-        "*.h"
+    set(qrdecoder_SOURCES
+        QrDecoder.cpp
+        QrDecoder.h
+        QrTotpSetupDialog.cpp
+        QrTotpSetupDialog.h
+        QrTotpWidget.cpp
+        QrTotpWidget.h
     )
 
     add_library(qrdecoder STATIC ${qrdecoder_SOURCES})

--- a/src/qrdecoder/CMakeLists.txt
+++ b/src/qrdecoder/CMakeLists.txt
@@ -17,8 +17,8 @@ if(KPXC_FEATURE_QRDECODER)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
     set(qrdecoder_SOURCES
-        qrdecoderr.cpp
-        qrdecoderr.h
+        qrdecoder.cpp
+        qrdecoder.h
     )
 
     add_library(qrdecoder STATIC ${qrdecoder_SOURCES})

--- a/src/qrdecoder/QrDecoder.cpp
+++ b/src/qrdecoder/QrDecoder.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "QrDecoder.h"
+
+
+namespace UrlOverride
+{
+
+} 

--- a/src/qrdecoder/QrDecoder.cpp
+++ b/src/qrdecoder/QrDecoder.cpp
@@ -1,21 +1,7 @@
-/*
- *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
- *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 #include "QrDecoder.h"
+
+#include <QImage>
+#include <QString>
 
 #include <ZXing/BarcodeFormat.h>
 #include <ZXing/ImageView.h>
@@ -37,13 +23,10 @@ QString QrDecoder::decode(const QImage& input)
         image.width(),
         image.height(),
         ZXing::ImageFormat::Lum,
-        static_cast<int>(image.bytesPerLine())
-    );
+        static_cast<int>(image.bytesPerLine()));
 
     ZXing::ReaderOptions options;
-    options.setFormats(
-        ZXing::BarcodeFormats{ZXing::BarcodeFormat::QRCode}
-    );
+    options.setFormats(ZXing::BarcodeFormat::QRCode);
 
     const auto barcodes = ZXing::ReadBarcodes(imageView, options);
 

--- a/src/qrdecoder/QrDecoder.cpp
+++ b/src/qrdecoder/QrDecoder.cpp
@@ -17,8 +17,40 @@
 
 #include "QrDecoder.h"
 
+#include <ZXing/BarcodeFormat.h>
+#include <ZXing/ImageView.h>
+#include <ZXing/ReadBarcode.h>
+#include <ZXing/ReaderOptions.h>
 
-namespace UrlOverride
+namespace QrDecoder
 {
+QString QrDecoder::decode(const QImage& input)
+{
+    if (input.isNull()) {
+        return {};
+    }
 
-} 
+    const auto image = input.convertToFormat(QImage::Format_Grayscale8);
+
+    const auto imageView = ZXing::ImageView(
+        image.constBits(),
+        image.width(),
+        image.height(),
+        ZXing::ImageFormat::Lum,
+        static_cast<int>(image.bytesPerLine())
+    );
+
+    ZXing::ReaderOptions options;
+    options.setFormats(
+        ZXing::BarcodeFormats{ZXing::BarcodeFormat::QRCode}
+    );
+
+    const auto barcodes = ZXing::ReadBarcodes(imageView, options);
+
+    if (barcodes.empty()) {
+        return {};
+    }
+
+    return QString::fromStdString(barcodes.front().text());
+}
+} // namespace QrDecoder

--- a/src/qrdecoder/QrDecoder.cpp
+++ b/src/qrdecoder/QrDecoder.cpp
@@ -10,30 +10,29 @@
 
 namespace QrDecoder
 {
-QString QrDecoder::decode(const QImage& input)
-{
-    if (input.isNull()) {
-        return {};
+    QString QrDecoder::decode(const QImage& input)
+    {
+        if (input.isNull()) {
+            return {};
+        }
+
+        const auto image = input.convertToFormat(QImage::Format_Grayscale8);
+
+        const auto imageView = ZXing::ImageView(image.constBits(),
+                                                image.width(),
+                                                image.height(),
+                                                ZXing::ImageFormat::Lum,
+                                                static_cast<int>(image.bytesPerLine()));
+
+        ZXing::ReaderOptions options;
+        options.setFormats(ZXing::BarcodeFormat::QRCode);
+
+        const auto barcodes = ZXing::ReadBarcodes(imageView, options);
+
+        if (barcodes.empty()) {
+            return {};
+        }
+
+        return QString::fromStdString(barcodes.front().text());
     }
-
-    const auto image = input.convertToFormat(QImage::Format_Grayscale8);
-
-    const auto imageView = ZXing::ImageView(
-        image.constBits(),
-        image.width(),
-        image.height(),
-        ZXing::ImageFormat::Lum,
-        static_cast<int>(image.bytesPerLine()));
-
-    ZXing::ReaderOptions options;
-    options.setFormats(ZXing::BarcodeFormat::QRCode);
-
-    const auto barcodes = ZXing::ReadBarcodes(imageView, options);
-
-    if (barcodes.empty()) {
-        return {};
-    }
-
-    return QString::fromStdString(barcodes.front().text());
-}
 } // namespace QrDecoder

--- a/src/qrdecoder/QrDecoder.h
+++ b/src/qrdecoder/QrDecoder.h
@@ -1,33 +1,12 @@
-/*
- *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
- *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 #ifndef KEEPASSXC_QRDECODER_H
 #define KEEPASSXC_QRDECODER_H
 
-#include <QImage>
-#include <QString>
+class QImage;
+class QString;
 
 namespace QrDecoder
 {
-    class QrDecoder
-    {
-    public:
-        static QString decode(const QImage& image);
-    };
-} // namespace QrDecoder
+    QString decode(const QImage& image);
+}
 
 #endif // KEEPASSXC_QRDECODER_H

--- a/src/qrdecoder/QrDecoder.h
+++ b/src/qrdecoder/QrDecoder.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_QRDECODER_H
+#define KEEPASSXC_QRDECODER_H
+
+
+namespace QrDecoder
+{
+
+} 
+
+#endif // KEEPASSXC_QRDECODER_H

--- a/src/qrdecoder/QrTotpSetupDialog.cpp
+++ b/src/qrdecoder/QrTotpSetupDialog.cpp
@@ -31,6 +31,7 @@ namespace QrDecoder
         , m_totpSetupDialog(new TotpSetupDialog(this, entry))
         , m_qrTotpWidget(new QrTotpWidget(this))
     {
+        Q_ASSERT(entry);
         auto layout = new QVBoxLayout(this);
         layout->addWidget(m_tabWidget);
 

--- a/src/qrdecoder/QrTotpSetupDialog.cpp
+++ b/src/qrdecoder/QrTotpSetupDialog.cpp
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "QrTotpSetupDialog.h"
+
+#include "gui/TotpSetupDialog.h"
+#include "core/Totp.h"
+#include "QrTotpWidget.h"
+
+#include <QLineEdit>
+#include <QTabWidget>
+#include <QVBoxLayout>
+#include <QComboBox>
+#include <QGroupBox>
+#include <QLineEdit>
+#include <QRadioButton>
+#include <QSpinBox>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+namespace QrDecoder
+{
+    QrTotpSetupDialog::QrTotpSetupDialog(QWidget* parent, Entry* entry)
+        : QDialog(parent)
+        , m_tabWidget(new QTabWidget(this))
+        , m_totpSetupDialog(new TotpSetupDialog(this, entry))
+        , m_qrTotpWidget(new QrTotpWidget(this))
+    {
+        auto layout = new QVBoxLayout(this);
+        layout->addWidget(m_tabWidget);
+
+        m_totpSetupDialog->setWindowFlags(Qt::Widget);
+
+        m_tabWidget->addTab(m_totpSetupDialog, tr("Manual"));
+        m_tabWidget->addTab(m_qrTotpWidget, tr("QR Code"));
+
+connect(m_qrTotpWidget,
+        &QrTotpWidget::settingsReady,
+        this,
+        [this](const QSharedPointer<Totp::Settings>& settings) {
+            if (!settings) {
+                return;
+            }
+
+            auto seedEdit =
+                m_totpSetupDialog->findChild<QLineEdit*>(QStringLiteral("seedEdit"));
+            auto radioCustom =
+                m_totpSetupDialog->findChild<QRadioButton*>(QStringLiteral("radioCustom"));
+            auto customSettingsGroup =
+                m_totpSetupDialog->findChild<QGroupBox*>(QStringLiteral("customSettingsGroup"));
+            auto algorithmComboBox =
+                m_totpSetupDialog->findChild<QComboBox*>(QStringLiteral("algorithmComboBox"));
+            auto stepSpinBox =
+                m_totpSetupDialog->findChild<QSpinBox*>(QStringLiteral("stepSpinBox"));
+            auto digitsSpinBox =
+                m_totpSetupDialog->findChild<QSpinBox*>(QStringLiteral("digitsSpinBox"));
+
+            if (!seedEdit || !radioCustom || !customSettingsGroup || !algorithmComboBox
+                || !stepSpinBox || !digitsSpinBox) {
+                return;
+            }
+
+            // Secret
+            seedEdit->setText(settings->key);
+
+            // Parsed otpauth:// parameters
+            radioCustom->setChecked(true);
+            customSettingsGroup->setEnabled(true);
+
+            const auto algorithmIndex = algorithmComboBox->findData(settings->algorithm);
+            if (algorithmIndex >= 0) {
+                algorithmComboBox->setCurrentIndex(algorithmIndex);
+            }
+
+            stepSpinBox->setValue(settings->step);
+            digitsSpinBox->setValue(settings->digits);
+
+            // Go back to the normal TOTP setup page.
+            m_tabWidget->setCurrentWidget(m_totpSetupDialog);
+            seedEdit->setFocus();
+        });
+
+        connect(m_totpSetupDialog,
+                &TotpSetupDialog::totpUpdated,
+                this,
+                &QrTotpSetupDialog::totpUpdated);
+
+        connect(m_totpSetupDialog, &QDialog::accepted, this, &QDialog::accept);
+        connect(m_totpSetupDialog, &QDialog::rejected, this, &QDialog::reject);
+    }
+} // namespace QrDecoder

--- a/src/qrdecoder/QrTotpSetupDialog.cpp
+++ b/src/qrdecoder/QrTotpSetupDialog.cpp
@@ -3,8 +3,8 @@
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 or (at your option)
- *  version 3 of the License.
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -15,21 +15,11 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "QrTotpSetupDialog.h"
 
-#include "gui/TotpSetupDialog.h"
-#include "core/Totp.h"
 #include "QrTotpWidget.h"
+#include "gui/TotpSetupDialog.h"
 
-#include <QLineEdit>
-#include <QTabWidget>
-#include <QVBoxLayout>
-#include <QComboBox>
-#include <QGroupBox>
-#include <QLineEdit>
-#include <QRadioButton>
-#include <QSpinBox>
 #include <QTabWidget>
 #include <QVBoxLayout>
 
@@ -49,58 +39,20 @@ namespace QrDecoder
         m_tabWidget->addTab(m_totpSetupDialog, tr("Manual"));
         m_tabWidget->addTab(m_qrTotpWidget, tr("QR Code"));
 
-connect(m_qrTotpWidget,
-        &QrTotpWidget::settingsReady,
-        this,
-        [this](const QSharedPointer<Totp::Settings>& settings) {
-            if (!settings) {
-                return;
-            }
+        connect(
+            m_qrTotpWidget, &QrTotpWidget::settingsReady, this, [this](const QSharedPointer<Totp::Settings>& settings) {
+                if (!settings) {
+                    return;
+                }
 
-            auto seedEdit =
-                m_totpSetupDialog->findChild<QLineEdit*>(QStringLiteral("seedEdit"));
-            auto radioCustom =
-                m_totpSetupDialog->findChild<QRadioButton*>(QStringLiteral("radioCustom"));
-            auto customSettingsGroup =
-                m_totpSetupDialog->findChild<QGroupBox*>(QStringLiteral("customSettingsGroup"));
-            auto algorithmComboBox =
-                m_totpSetupDialog->findChild<QComboBox*>(QStringLiteral("algorithmComboBox"));
-            auto stepSpinBox =
-                m_totpSetupDialog->findChild<QSpinBox*>(QStringLiteral("stepSpinBox"));
-            auto digitsSpinBox =
-                m_totpSetupDialog->findChild<QSpinBox*>(QStringLiteral("digitsSpinBox"));
+                m_totpSetupDialog->setSettings(*settings);
+                m_tabWidget->setCurrentWidget(m_totpSetupDialog);
+            });
 
-            if (!seedEdit || !radioCustom || !customSettingsGroup || !algorithmComboBox
-                || !stepSpinBox || !digitsSpinBox) {
-                return;
-            }
-
-            // Secret
-            seedEdit->setText(settings->key);
-
-            // Parsed otpauth:// parameters
-            radioCustom->setChecked(true);
-            customSettingsGroup->setEnabled(true);
-
-            const auto algorithmIndex = algorithmComboBox->findData(settings->algorithm);
-            if (algorithmIndex >= 0) {
-                algorithmComboBox->setCurrentIndex(algorithmIndex);
-            }
-
-            stepSpinBox->setValue(settings->step);
-            digitsSpinBox->setValue(settings->digits);
-
-            // Go back to the normal TOTP setup page.
-            m_tabWidget->setCurrentWidget(m_totpSetupDialog);
-            seedEdit->setFocus();
-        });
-
-        connect(m_totpSetupDialog,
-                &TotpSetupDialog::totpUpdated,
-                this,
-                &QrTotpSetupDialog::totpUpdated);
+        connect(m_totpSetupDialog, &TotpSetupDialog::totpUpdated, this, &QrTotpSetupDialog::totpUpdated);
 
         connect(m_totpSetupDialog, &QDialog::accepted, this, &QDialog::accept);
+
         connect(m_totpSetupDialog, &QDialog::rejected, this, &QDialog::reject);
     }
 } // namespace QrDecoder

--- a/src/qrdecoder/QrTotpSetupDialog.h
+++ b/src/qrdecoder/QrTotpSetupDialog.h
@@ -3,8 +3,8 @@
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
  *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -15,19 +15,34 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KEEPASSXC_QRDECODER_H
-#define KEEPASSXC_QRDECODER_H
+#ifndef KEEPASSXC_QRDECODER_QRTOTPSETUPDIALOG_H
+#define KEEPASSXC_QRDECODER_QRTOTPSETUPDIALOG_H
 
-#include <QImage>
-#include <QString>
+#include <QDialog>
+
+class Entry;
+class QTabWidget;
+class TotpSetupDialog;
 
 namespace QrDecoder
 {
-    class QrDecoder
+    class QrTotpWidget;
+
+    class QrTotpSetupDialog : public QDialog
     {
+        Q_OBJECT
+
     public:
-        static QString decode(const QImage& image);
+        explicit QrTotpSetupDialog(QWidget* parent = nullptr, Entry* entry = nullptr);
+
+    signals:
+        void totpUpdated();
+
+    private:
+        QTabWidget* m_tabWidget;
+        TotpSetupDialog* m_totpSetupDialog;
+        QrTotpWidget* m_qrTotpWidget;
     };
 } // namespace QrDecoder
 
-#endif // KEEPASSXC_QRDECODER_H
+#endif // KEEPASSXC_QRDECODER_QRTOTPSETUPDIALOG_H

--- a/src/qrdecoder/QrTotpSetupDialog.h
+++ b/src/qrdecoder/QrTotpSetupDialog.h
@@ -3,8 +3,8 @@
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 or (at your option)
- *  version 3 of the License.
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/qrdecoder/QrTotpWidget.cpp
+++ b/src/qrdecoder/QrTotpWidget.cpp
@@ -20,9 +20,6 @@
 #include "core/Totp.h"
 #include "QrDecoder.h"
 
-#include <ZXing/ReadBarcode.h>
-#include <ZXing/ReaderOptions.h>
-
 #include <QApplication>
 #include <QClipboard>
 #include <QEvent>
@@ -44,7 +41,7 @@ QrTotpWidget::QrTotpWidget(QWidget* parent)
 
     m_uriEdit->setPlaceholderText(QStringLiteral("otpauth://totp/..."));
 
-    auto pasteButton = new QPushButton(tr("Paste QR code"), this);
+    auto pasteButton = new QPushButton(tr("Paste QR code from Clipboard"), this);
     auto applyButton = new QPushButton(tr("Apply"), this);
 
     pasteButton->installEventFilter(this);
@@ -139,40 +136,20 @@ void QrTotpWidget::pasteImage()
 
 void QrTotpWidget::decodeImage(const QImage& image)
 {
-    if (image.isNull()) {
+    const auto text = QrDecoder::decode(image);
+
+    if (text.isEmpty() || !text.startsWith(QStringLiteral("otpauth://"), Qt::CaseInsensitive)) {
         return;
     }
 
-    const auto converted = image.convertToFormat(QImage::Format_RGBA8888);
+    const auto settings = Totp::parseSettings(text, {});
 
-    ZXing::ImageView imageView(converted.constBits(),
-                               converted.width(),
-                               converted.height(),
-                               ZXing::ImageFormat::RGBA,
-                               converted.bytesPerLine());
-
-    ZXing::ReaderOptions options;
-    options.setFormats(ZXing::BarcodeFormat::QRCode);
-
-    const auto barcodes = ZXing::ReadBarcodes(imageView, options);
-
-    for (const auto& barcode : barcodes) {
-        const auto text = QString::fromStdString(barcode.text()).trimmed();
-
-        if (!text.startsWith(QStringLiteral("otpauth://"), Qt::CaseInsensitive)) {
-            continue;
-        }
-
-        const auto settings = Totp::parseSettings(text, {});
-
-        if (!settings) {
-            continue;
-        }
-
-        m_uriEdit->setText(text);
-        emit settingsReady(settings);
+    if (!settings) {
         return;
     }
+
+    m_uriEdit->setText(text);
+    emit settingsReady(settings);
 }
 
 } // namespace QrDecoder

--- a/src/qrdecoder/QrTotpWidget.cpp
+++ b/src/qrdecoder/QrTotpWidget.cpp
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "QrTotpWidget.h"
+
+#include "core/Totp.h"
+#include "qrdecoder.h"
+
+#include <ZXing/ReadBarcode.h>
+#include <ZXing/ReaderOptions.h>
+
+#include <QApplication>
+#include <QClipboard>
+#include <QEvent>
+#include <QImage>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QMimeData>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+namespace QrDecoder
+{
+
+QrTotpWidget::QrTotpWidget(QWidget* parent)
+    : QWidget(parent)
+    , m_uriEdit(new QLineEdit(this))
+{
+    m_uriEdit->installEventFilter(this);
+
+    m_uriEdit->setPlaceholderText(QStringLiteral("otpauth://totp/..."));
+
+    auto pasteButton = new QPushButton(tr("Paste QR code"), this);
+    auto applyButton = new QPushButton(tr("Apply"), this);
+
+    pasteButton->installEventFilter(this);
+    applyButton->installEventFilter(this);
+
+    auto layout = new QVBoxLayout(this);
+    layout->addWidget(m_uriEdit);
+    layout->addWidget(pasteButton);
+    layout->addWidget(applyButton);
+    layout->addStretch();
+
+    connect(pasteButton, &QPushButton::clicked, this, &QrTotpWidget::pasteImage);
+
+    connect(applyButton, &QPushButton::clicked, this, [this] {
+        const auto uri = m_uriEdit->text().trimmed();
+
+        if (uri.isEmpty()) {
+            return;
+        }
+
+        const auto settings = Totp::parseSettings(uri, {});
+
+        if (!settings) {
+            return;
+        }
+
+        emit settingsReady(settings);
+    });
+}
+
+bool QrTotpWidget::eventFilter(QObject* watched, QEvent* event)
+{
+    Q_UNUSED(watched);
+
+    if (event->type() == QEvent::KeyPress) {
+        auto* keyEvent = static_cast<QKeyEvent*>(event);
+
+        if (keyEvent->matches(QKeySequence::Paste)) {
+            pasteClipboard();
+            keyEvent->accept();
+            return true;
+        }
+    }
+
+    return QWidget::eventFilter(watched, event);
+}
+
+void QrTotpWidget::pasteClipboard()
+{
+    const auto* clipboard = QApplication::clipboard();
+    if (!clipboard) {
+        return;
+    }
+
+    const auto* mimeData = clipboard->mimeData();
+    if (!mimeData) {
+        return;
+    }
+
+    // First try plain text. This allows directly pasting:
+    //
+    // otpauth://totp/keepassxc:test%40lab.com?secret=...&issuer=keepassxc&period=60
+    //
+    if (mimeData->hasText()) {
+        const auto text = mimeData->text().trimmed();
+
+        if (text.startsWith(QStringLiteral("otpauth://"), Qt::CaseInsensitive)) {
+            const auto settings = Totp::parseSettings(text, {});
+
+            if (settings) {
+                m_uriEdit->setText(text);
+                emit settingsReady(settings);
+                return;
+            }
+        }
+    }
+
+    // Otherwise try an image containing a QR code.
+    if (mimeData->hasImage()) {
+        const auto image = qvariant_cast<QImage>(mimeData->imageData());
+
+        if (!image.isNull()) {
+            decodeImage(image);
+        }
+    }
+}
+
+void QrTotpWidget::pasteImage()
+{
+    pasteClipboard();
+}
+
+void QrTotpWidget::decodeImage(const QImage& image)
+{
+    if (image.isNull()) {
+        return;
+    }
+
+    const auto converted = image.convertToFormat(QImage::Format_RGBA8888);
+
+    ZXing::ImageView imageView(converted.constBits(),
+                               converted.width(),
+                               converted.height(),
+                               ZXing::ImageFormat::RGBA,
+                               converted.bytesPerLine());
+
+    ZXing::ReaderOptions options;
+    options.setFormats(ZXing::BarcodeFormat::QRCode);
+
+    const auto barcodes = ZXing::ReadBarcodes(imageView, options);
+
+    for (const auto& barcode : barcodes) {
+        const auto text = QString::fromStdString(barcode.text()).trimmed();
+
+        if (!text.startsWith(QStringLiteral("otpauth://"), Qt::CaseInsensitive)) {
+            continue;
+        }
+
+        const auto settings = Totp::parseSettings(text, {});
+
+        if (!settings) {
+            continue;
+        }
+
+        m_uriEdit->setText(text);
+        emit settingsReady(settings);
+        return;
+    }
+}
+
+} // namespace QrDecoder

--- a/src/qrdecoder/QrTotpWidget.cpp
+++ b/src/qrdecoder/QrTotpWidget.cpp
@@ -18,7 +18,7 @@
 #include "QrTotpWidget.h"
 
 #include "core/Totp.h"
-#include "qrdecoder.h"
+#include "QrDecoder.h"
 
 #include <ZXing/ReadBarcode.h>
 #include <ZXing/ReaderOptions.h>

--- a/src/qrdecoder/QrTotpWidget.cpp
+++ b/src/qrdecoder/QrTotpWidget.cpp
@@ -17,8 +17,8 @@
 
 #include "QrTotpWidget.h"
 
-#include "core/Totp.h"
 #include "QrDecoder.h"
+#include "core/Totp.h"
 
 #include <QApplication>
 #include <QClipboard>
@@ -33,123 +33,123 @@
 namespace QrDecoder
 {
 
-QrTotpWidget::QrTotpWidget(QWidget* parent)
-    : QWidget(parent)
-    , m_uriEdit(new QLineEdit(this))
-{
-    m_uriEdit->installEventFilter(this);
+    QrTotpWidget::QrTotpWidget(QWidget* parent)
+        : QWidget(parent)
+        , m_uriEdit(new QLineEdit(this))
+    {
+        m_uriEdit->installEventFilter(this);
 
-    m_uriEdit->setPlaceholderText(QStringLiteral("otpauth://totp/..."));
+        m_uriEdit->setPlaceholderText(QStringLiteral("otpauth://totp/..."));
 
-    auto pasteButton = new QPushButton(tr("Paste QR code from Clipboard"), this);
-    auto applyButton = new QPushButton(tr("Apply"), this);
+        auto pasteButton = new QPushButton(tr("Paste QR code from Clipboard"), this);
+        auto applyButton = new QPushButton(tr("Apply"), this);
 
-    pasteButton->installEventFilter(this);
-    applyButton->installEventFilter(this);
+        pasteButton->installEventFilter(this);
+        applyButton->installEventFilter(this);
 
-    auto layout = new QVBoxLayout(this);
-    layout->addWidget(m_uriEdit);
-    layout->addWidget(pasteButton);
-    layout->addWidget(applyButton);
-    layout->addStretch();
+        auto layout = new QVBoxLayout(this);
+        layout->addWidget(m_uriEdit);
+        layout->addWidget(pasteButton);
+        layout->addWidget(applyButton);
+        layout->addStretch();
 
-    connect(pasteButton, &QPushButton::clicked, this, &QrTotpWidget::pasteImage);
+        connect(pasteButton, &QPushButton::clicked, this, &QrTotpWidget::pasteImage);
 
-    connect(applyButton, &QPushButton::clicked, this, [this] {
-        const auto uri = m_uriEdit->text().trimmed();
+        connect(applyButton, &QPushButton::clicked, this, [this] {
+            const auto uri = m_uriEdit->text().trimmed();
 
-        if (uri.isEmpty()) {
+            if (uri.isEmpty()) {
+                return;
+            }
+
+            const auto settings = Totp::parseSettings(uri, {});
+
+            if (!settings) {
+                return;
+            }
+
+            emit settingsReady(settings);
+        });
+    }
+
+    bool QrTotpWidget::eventFilter(QObject* watched, QEvent* event)
+    {
+        Q_UNUSED(watched);
+
+        if (event->type() == QEvent::KeyPress) {
+            auto* keyEvent = static_cast<QKeyEvent*>(event);
+
+            if (keyEvent->matches(QKeySequence::Paste)) {
+                pasteClipboard();
+                keyEvent->accept();
+                return true;
+            }
+        }
+
+        return QWidget::eventFilter(watched, event);
+    }
+
+    void QrTotpWidget::pasteClipboard()
+    {
+        const auto* clipboard = QApplication::clipboard();
+        if (!clipboard) {
             return;
         }
 
-        const auto settings = Totp::parseSettings(uri, {});
+        const auto* mimeData = clipboard->mimeData();
+        if (!mimeData) {
+            return;
+        }
+
+        // First try plain text. This allows directly pasting:
+        //
+        // otpauth://totp/keepassxc:test%40lab.com?secret=...&issuer=keepassxc&period=60
+        //
+        if (mimeData->hasText()) {
+            const auto text = mimeData->text().trimmed();
+
+            if (text.startsWith(QStringLiteral("otpauth://"), Qt::CaseInsensitive)) {
+                const auto settings = Totp::parseSettings(text, {});
+
+                if (settings) {
+                    m_uriEdit->setText(text);
+                    emit settingsReady(settings);
+                    return;
+                }
+            }
+        }
+
+        // Otherwise try an image containing a QR code.
+        if (mimeData->hasImage()) {
+            const auto image = qvariant_cast<QImage>(mimeData->imageData());
+
+            if (!image.isNull()) {
+                decodeImage(image);
+            }
+        }
+    }
+
+    void QrTotpWidget::pasteImage()
+    {
+        pasteClipboard();
+    }
+
+    void QrTotpWidget::decodeImage(const QImage& image)
+    {
+        const auto text = QrDecoder::decode(image);
+
+        if (text.isEmpty() || !text.startsWith(QStringLiteral("otpauth://"), Qt::CaseInsensitive)) {
+            return;
+        }
+
+        const auto settings = Totp::parseSettings(text, {});
 
         if (!settings) {
             return;
         }
 
+        m_uriEdit->setText(text);
         emit settingsReady(settings);
-    });
-}
-
-bool QrTotpWidget::eventFilter(QObject* watched, QEvent* event)
-{
-    Q_UNUSED(watched);
-
-    if (event->type() == QEvent::KeyPress) {
-        auto* keyEvent = static_cast<QKeyEvent*>(event);
-
-        if (keyEvent->matches(QKeySequence::Paste)) {
-            pasteClipboard();
-            keyEvent->accept();
-            return true;
-        }
     }
-
-    return QWidget::eventFilter(watched, event);
-}
-
-void QrTotpWidget::pasteClipboard()
-{
-    const auto* clipboard = QApplication::clipboard();
-    if (!clipboard) {
-        return;
-    }
-
-    const auto* mimeData = clipboard->mimeData();
-    if (!mimeData) {
-        return;
-    }
-
-    // First try plain text. This allows directly pasting:
-    //
-    // otpauth://totp/keepassxc:test%40lab.com?secret=...&issuer=keepassxc&period=60
-    //
-    if (mimeData->hasText()) {
-        const auto text = mimeData->text().trimmed();
-
-        if (text.startsWith(QStringLiteral("otpauth://"), Qt::CaseInsensitive)) {
-            const auto settings = Totp::parseSettings(text, {});
-
-            if (settings) {
-                m_uriEdit->setText(text);
-                emit settingsReady(settings);
-                return;
-            }
-        }
-    }
-
-    // Otherwise try an image containing a QR code.
-    if (mimeData->hasImage()) {
-        const auto image = qvariant_cast<QImage>(mimeData->imageData());
-
-        if (!image.isNull()) {
-            decodeImage(image);
-        }
-    }
-}
-
-void QrTotpWidget::pasteImage()
-{
-    pasteClipboard();
-}
-
-void QrTotpWidget::decodeImage(const QImage& image)
-{
-    const auto text = QrDecoder::decode(image);
-
-    if (text.isEmpty() || !text.startsWith(QStringLiteral("otpauth://"), Qt::CaseInsensitive)) {
-        return;
-    }
-
-    const auto settings = Totp::parseSettings(text, {});
-
-    if (!settings) {
-        return;
-    }
-
-    m_uriEdit->setText(text);
-    emit settingsReady(settings);
-}
 
 } // namespace QrDecoder

--- a/src/qrdecoder/QrTotpWidget.h
+++ b/src/qrdecoder/QrTotpWidget.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_QRTOTPWIDGET_H
+#define KEEPASSXC_QRTOTPWIDGET_H
+
+#include <QSharedPointer>
+#include <QWidget>
+
+class QImage;
+class QLineEdit;
+
+namespace Totp
+{
+    struct Settings;
+}
+
+namespace QrDecoder
+{
+
+class QrTotpWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit QrTotpWidget(QWidget* parent = nullptr);
+
+signals:
+    void settingsReady(const QSharedPointer<Totp::Settings>& settings);
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    void pasteClipboard();
+    void pasteImage();
+    void decodeImage(const QImage& image);
+
+    QLineEdit* m_uriEdit = nullptr;
+};
+
+} // namespace QrDecoder
+
+#endif // KEEPASSXC_QRTOTPWIDGET_H

--- a/src/qrdecoder/QrTotpWidget.h
+++ b/src/qrdecoder/QrTotpWidget.h
@@ -32,26 +32,26 @@ namespace Totp
 namespace QrDecoder
 {
 
-class QrTotpWidget : public QWidget
-{
-    Q_OBJECT
+    class QrTotpWidget : public QWidget
+    {
+        Q_OBJECT
 
-public:
-    explicit QrTotpWidget(QWidget* parent = nullptr);
+    public:
+        explicit QrTotpWidget(QWidget* parent = nullptr);
 
-signals:
-    void settingsReady(const QSharedPointer<Totp::Settings>& settings);
+    signals:
+        void settingsReady(const QSharedPointer<Totp::Settings>& settings);
 
-protected:
-    bool eventFilter(QObject* watched, QEvent* event) override;
+    protected:
+        bool eventFilter(QObject* watched, QEvent* event) override;
 
-private:
-    void pasteClipboard();
-    void pasteImage();
-    void decodeImage(const QImage& image);
+    private:
+        void pasteClipboard();
+        void pasteImage();
+        void decodeImage(const QImage& image);
 
-    QLineEdit* m_uriEdit = nullptr;
-};
+        QLineEdit* m_uriEdit = nullptr;
+    };
 
 } // namespace QrDecoder
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -184,6 +184,15 @@ if(KPXC_FEATURE_NETWORK)
         LIBS ${TEST_LIBRARIES})
 endif()
 
+if(KPXC_FEATURE_QRDECODER)
+    add_unit_test(NAME testqrdecoder SOURCES TestQrDecoder.cpp
+            LIBS qrdecoder testsupport ${TEST_LIBRARIES})
+    add_unit_test(NAME testqrtotpsetupdialog SOURCES TestQrTotpSetupDialog.cpp
+            LIBS qrdecoder testsupport ${TEST_LIBRARIES})
+    add_unit_test(NAME testqrtotpwidget SOURCES TestQrTotpWidget.cpp
+            LIBS qrdecoder testsupport ${TEST_LIBRARIES})
+endif()
+
 if(WITH_GUI_TESTS)
     add_subdirectory(gui)
 endif()

--- a/tests/TestQrDecoder.cpp
+++ b/tests/TestQrDecoder.cpp
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestQrDecoder.h"
+
+#include <QBuffer>
+#include <QImage>
+#include <QPainter>
+#include <QSvgRenderer>
+#include <QTest>
+
+#include "qrcode/QrCode.h"
+#include "qrdecoder/QrDecoder.h"
+
+QTEST_GUILESS_MAIN(TestQrDecoder)
+
+void TestQrDecoder::testNullImage()
+{
+    const QImage image;
+
+    QVERIFY(image.isNull());
+    QVERIFY(QrDecoder::decode(image).isEmpty());
+}
+
+void TestQrDecoder::testEmptyImage()
+{
+    QImage image(200, 200, QImage::Format_RGB32);
+    image.fill(Qt::white);
+
+    QVERIFY(QrDecoder::decode(image).isEmpty());
+}
+
+void TestQrDecoder::testDecodeTotpQrCode()
+{
+    const QString secret =
+        "otpauth://totp/"
+        "ACME%20Co:john@example.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm="
+        "SHA1&digits=6&period=30";
+
+    QrCode qrCode(secret, QrCode::Version::AUTO, QrCode::ErrorCorrectionLevel::MEDIUM);
+
+    QVERIFY(qrCode.isValid());
+
+    QByteArray svgData;
+    QBuffer buffer(&svgData);
+
+    QVERIFY(buffer.open(QIODevice::WriteOnly));
+
+    qrCode.writeSvg(&buffer, 96);
+    buffer.close();
+
+    QVERIFY(!svgData.isEmpty());
+
+    QSvgRenderer renderer(svgData);
+    QVERIFY(renderer.isValid());
+
+    constexpr int imageSize = 512;
+
+    QImage image(imageSize, imageSize, QImage::Format_ARGB32);
+    image.fill(Qt::white);
+
+    QPainter painter(&image);
+    QVERIFY(painter.isActive());
+
+    renderer.render(&painter);
+    painter.end();
+
+    QCOMPARE(QrDecoder::decode(image), secret);
+}

--- a/tests/TestQrDecoder.h
+++ b/tests/TestQrDecoder.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTQRDECODER_H
+#define KEEPASSXC_TESTQRDECODER_H
+
+#include <QObject>
+
+class TestQrDecoder : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testNullImage();
+    void testEmptyImage();
+    void testDecodeTotpQrCode();
+};
+
+#endif // KEEPASSXC_TESTQRDECODER_H

--- a/tests/TestQrTotpSetupDialog.cpp
+++ b/tests/TestQrTotpSetupDialog.cpp
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestQrTotpSetupDialog.h"
+
+#include <QComboBox>
+#include <QLineEdit>
+#include <QSignalSpy>
+#include <QSpinBox>
+#include <QTabWidget>
+#include <QTest>
+
+#include "core/Entry.h"
+#include "core/Totp.h"
+#include "gui/TotpSetupDialog.h"
+#include "qrdecoder/QrTotpSetupDialog.h"
+#include "qrdecoder/QrTotpWidget.h"
+
+
+QTEST_MAIN(TestQrTotpSetupDialog)
+
+void TestQrTotpSetupDialog::testInitialTabs()
+{
+    Entry entry;
+    QrDecoder::QrTotpSetupDialog dialog(nullptr, &entry);
+
+    auto* tabWidget = dialog.findChild<QTabWidget*>();
+    QVERIFY(tabWidget);
+
+    QCOMPARE(tabWidget->count(), 2);
+    QCOMPARE(tabWidget->tabText(0), QStringLiteral("Manual"));
+    QCOMPARE(tabWidget->tabText(1), QStringLiteral("QR Code"));
+
+    QCOMPARE(tabWidget->currentIndex(), 0);
+}
+
+void TestQrTotpSetupDialog::testSettingsReady()
+{
+    Entry entry;
+    QrDecoder::QrTotpSetupDialog dialog(nullptr, &entry);
+
+    auto* tabWidget = dialog.findChild<QTabWidget*>();
+    QVERIFY(tabWidget);
+
+    auto* qrWidget = dialog.findChild<QrDecoder::QrTotpWidget*>();
+    QVERIFY(qrWidget);
+
+    auto* totpDialog = dialog.findChild<TotpSetupDialog*>();
+    QVERIFY(totpDialog);
+
+    auto* seedEdit = totpDialog->findChild<QLineEdit*>("seedEdit");
+    QVERIFY(seedEdit);
+
+    auto* algorithmComboBox = totpDialog->findChild<QComboBox*>("algorithmComboBox");
+    QVERIFY(algorithmComboBox);
+
+    auto* stepSpinBox = totpDialog->findChild<QSpinBox*>("stepSpinBox");
+    QVERIFY(stepSpinBox);
+
+    auto* digitsSpinBox = totpDialog->findChild<QSpinBox*>("digitsSpinBox");
+    QVERIFY(digitsSpinBox);
+
+    Totp::Settings settings;
+    settings.key = QStringLiteral("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ");
+    settings.step = 60;
+    settings.digits = 8;
+
+    // Keep the algorithm from the default Settings object. We only need
+    // to verify that setSettings() copies it to the combo box.
+    const auto algorithm = settings.algorithm;
+
+    const auto expectedAlgorithmIndex = algorithmComboBox->findData(algorithm);
+    QVERIFY(expectedAlgorithmIndex >= 0);
+
+    // The QR widget normally emits this signal after decoding and parsing
+    // an otpauth URI. Here we trigger the same signal directly so this test
+    // focuses only on QrTotpSetupDialog.
+    emit qrWidget->settingsReady(QSharedPointer<Totp::Settings>::create(settings));
+
+    QCOMPARE(tabWidget->currentWidget(), totpDialog);
+
+    QCOMPARE(seedEdit->text(), settings.key);
+    QCOMPARE(algorithmComboBox->currentIndex(), expectedAlgorithmIndex);
+    QCOMPARE(stepSpinBox->value(), settings.step);
+    QCOMPARE(digitsSpinBox->value(), settings.digits);
+}
+
+void TestQrTotpSetupDialog::testTotpUpdated()
+{
+    Entry entry;
+    QrDecoder::QrTotpSetupDialog dialog(nullptr, &entry);
+
+    auto* totpDialog = dialog.findChild<TotpSetupDialog*>();
+    QVERIFY(totpDialog);
+
+    QSignalSpy spy(&dialog, &QrDecoder::QrTotpSetupDialog::totpUpdated);
+
+    emit totpDialog->totpUpdated();
+
+    QCOMPARE(spy.count(), 1);
+}

--- a/tests/TestQrTotpSetupDialog.h
+++ b/tests/TestQrTotpSetupDialog.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTQRTOTPSETUPDIALOG_H
+#define KEEPASSXC_TESTQRTOTPSETUPDIALOG_H
+
+#include <QObject>
+
+class TestQrTotpSetupDialog : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testInitialTabs();
+    void testSettingsReady();
+    void testTotpUpdated();
+};
+
+#endif // KEEPASSXC_TESTQRTOTPSETUPDIALOG_H

--- a/tests/TestQrTotpWidget.cpp
+++ b/tests/TestQrTotpWidget.cpp
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestQrTotpWidget.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QTest>
+
+#include "core/Totp.h"
+#include "qrdecoder/QrTotpWidget.h"
+
+QTEST_MAIN(TestQrTotpWidget)
+
+namespace
+{
+    const QString validUri = QStringLiteral("otpauth://totp/"
+                                            "ACME%20Co:john@example.com"
+                                            "?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"
+                                            "&issuer=ACME%20Co"
+                                            "&algorithm=SHA1"
+                                            "&digits=6"
+                                            "&period=30");
+
+    QPushButton* findButton(QWidget* widget, const QString& text)
+    {
+        const auto buttons = widget->findChildren<QPushButton*>();
+
+        for (auto* button : buttons) {
+            if (button->text() == text) {
+                return button;
+            }
+        }
+
+        return nullptr;
+    }
+} // namespace
+
+void TestQrTotpWidget::init()
+{
+    m_clipboardText = QApplication::clipboard()->text();
+    qRegisterMetaType<QSharedPointer<Totp::Settings>>();
+}
+
+void TestQrTotpWidget::cleanup()
+{
+    QApplication::clipboard()->setText(m_clipboardText);
+}
+
+void TestQrTotpWidget::testInitialState()
+{
+    QrDecoder::QrTotpWidget widget;
+
+    auto* uriEdit = widget.findChild<QLineEdit*>();
+    QVERIFY(uriEdit);
+
+    QCOMPARE(uriEdit->text(), QString());
+    QCOMPARE(uriEdit->placeholderText(), QStringLiteral("otpauth://totp/..."));
+}
+
+void TestQrTotpWidget::testApplyValidUri()
+{
+    QrDecoder::QrTotpWidget widget;
+
+    auto* uriEdit = widget.findChild<QLineEdit*>();
+    QVERIFY(uriEdit);
+
+    auto* applyButton = findButton(&widget, QStringLiteral("Apply"));
+    QVERIFY(applyButton);
+
+    QSignalSpy spy(&widget, &QrDecoder::QrTotpWidget::settingsReady);
+
+    uriEdit->setText(validUri);
+
+    QTest::mouseClick(applyButton, Qt::LeftButton);
+
+    QCOMPARE(spy.count(), 1);
+
+    const auto settings = spy.at(0).at(0).value<QSharedPointer<Totp::Settings>>();
+    QVERIFY(settings);
+
+    QCOMPARE(settings->key, QStringLiteral("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
+    QCOMPARE(settings->digits, 6);
+    QCOMPARE(settings->step, 30);
+}
+
+void TestQrTotpWidget::testApplyInvalidUri()
+{
+    QrDecoder::QrTotpWidget widget;
+
+    auto* uriEdit = widget.findChild<QLineEdit*>();
+    QVERIFY(uriEdit);
+
+    auto* applyButton = findButton(&widget, QStringLiteral("Apply"));
+    QVERIFY(applyButton);
+
+    QSignalSpy spy(&widget, &QrDecoder::QrTotpWidget::settingsReady);
+
+    uriEdit->setText(QStringLiteral("not-a-totp-uri"));
+
+    QTest::mouseClick(applyButton, Qt::LeftButton);
+
+    QCOMPARE(spy.count(), 0);
+}
+
+void TestQrTotpWidget::testPasteValidUri()
+{
+    QrDecoder::QrTotpWidget widget;
+
+    QSignalSpy spy(&widget, &QrDecoder::QrTotpWidget::settingsReady);
+
+    QApplication::clipboard()->setText(validUri);
+
+    auto* uriEdit = widget.findChild<QLineEdit*>();
+    QVERIFY(uriEdit);
+
+    // Trigger the same paste path used by Ctrl+V.
+    QTest::keyClick(uriEdit, Qt::Key_V, Qt::ControlModifier);
+
+    QCOMPARE(spy.count(), 1);
+
+    QCOMPARE(uriEdit->text(), validUri);
+
+    const auto settings = spy.at(0).at(0).value<QSharedPointer<Totp::Settings>>();
+    QVERIFY(settings);
+
+    QCOMPARE(settings->key, QStringLiteral("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
+    QCOMPARE(settings->digits, 6);
+    QCOMPARE(settings->step, 30);
+}
+
+void TestQrTotpWidget::testPasteInvalidText()
+{
+    QrDecoder::QrTotpWidget widget;
+
+    QSignalSpy spy(&widget, &QrDecoder::QrTotpWidget::settingsReady);
+
+    QApplication::clipboard()->setText(QStringLiteral("hello world"));
+
+    auto* uriEdit = widget.findChild<QLineEdit*>();
+    QVERIFY(uriEdit);
+
+    QTest::keyClick(uriEdit, Qt::Key_V, Qt::ControlModifier);
+
+    QCOMPARE(spy.count(), 0);
+    QCOMPARE(uriEdit->text(), QString());
+}
+
+void TestQrTotpWidget::testKeyboardPasteValidUri()
+{
+    QrDecoder::QrTotpWidget widget;
+
+    QSignalSpy spy(&widget, &QrDecoder::QrTotpWidget::settingsReady);
+
+    QApplication::clipboard()->setText(QStringLiteral("  ") + validUri + QStringLiteral("  "));
+
+    auto* uriEdit = widget.findChild<QLineEdit*>();
+    QVERIFY(uriEdit);
+
+    QTest::keyClick(uriEdit, Qt::Key_V, Qt::ControlModifier);
+
+    QCOMPARE(spy.count(), 1);
+
+    // pasteClipboard() trims the clipboard text before parsing/storing it.
+    QCOMPARE(uriEdit->text(), validUri);
+
+    const auto settings = spy.at(0).at(0).value<QSharedPointer<Totp::Settings>>();
+    QVERIFY(settings);
+
+    QCOMPARE(settings->key, QStringLiteral("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
+    QCOMPARE(settings->digits, 6);
+    QCOMPARE(settings->step, 30);
+}

--- a/tests/TestQrTotpWidget.h
+++ b/tests/TestQrTotpWidget.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTQRTOTPWIDGET_H
+#define KEEPASSXC_TESTQRTOTPWIDGET_H
+
+#include <QObject>
+#include <QString>
+
+class TestQrTotpWidget : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+
+    void testInitialState();
+    void testApplyValidUri();
+    void testApplyInvalidUri();
+    void testPasteValidUri();
+    void testPasteInvalidText();
+    void testKeyboardPasteValidUri();
+
+private:
+    QString m_clipboardText;
+};
+
+#endif // KEEPASSXC_TESTQRTOTPWIDGET_H

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
     "libqrencode",
     "readline",
     "zlib",
+    "nu-book-zxing-cpp",
     {
       "name": "libusb",
       "platform": "linux | freebsd"


### PR DESCRIPTION
## Description

Fixes #4825

Add optional QR code support for TOTP setup.

When the QR decoder feature is enabled, the TOTP setup dialog now provides a
separate "QR Code" tab. Users can paste either an `otpauth://` URI or an image
containing a TOTP QR code from the clipboard. The QR code is decoded using
ZXing-C++ and the resulting TOTP settings are populated into the existing
manual TOTP setup dialog for review before being applied.

This addresses the use case described in #4825, where a service provides only
a QR code for configuring TOTP and there is currently no convenient way to
create the TOTP entry in KeePassXC from that QR code.

ZXing-C++ is used for QR code decoding. Since ZXing-C++ also provides QR code
generation, the existing `libqrencode` dependency can be removed if it is only
used for QR code generation, reducing the number of QR code libraries required
by the project.

The feature is controlled by `KPXC_FEATURE_QRDECODER` and is disabled in
minimal builds. The existing manual TOTP setup flow remains unchanged when QR
decoder support is disabled.

A natural next step for this feature would be to support capturing the desktop
or a specific window and allowing the user to select a region containing the
QR code. This would make it possible to scan TOTP QR codes directly from
another application or browser without requiring the user to take a screenshot
first.

Generative AI was used to write the majority of the code in this PR.

## Screenshots


https://github.com/user-attachments/assets/b5fac744-c895-4143-9e56-988f43442824



## Testing strategy

Added unit tests covering:

- QR decoder handling of null and empty images
- Decoding a generated TOTP QR code
- Initial state of the QR TOTP widget
- Applying a valid `otpauth://` URI
- Rejecting invalid TOTP URIs
- Pasting a valid TOTP URI from the clipboard
- Handling invalid clipboard text
- Keyboard paste handling
- Populating the manual TOTP setup dialog from decoded settings
- Propagating the `totpUpdated` signal from the embedded manual setup dialog
- Initial tabs and QR/manual setup dialog integration

The QR decoder test generates a TOTP QR code and renders it to a `QImage`
before passing it through ZXing-C++.

## Type of change

- New feature
- Documentation