### PR TITLE
FdoSecrets: fix use-after-free when the database locks while the item access dialog is open

### DIFF
--- a/src/fdosecrets/objects/Prompt.cpp
+++ b/src/fdosecrets/objects/Prompt.cpp
@@ -240,6 +240,11 @@ namespace FdoSecrets
         }
         for (const auto& item : asConst(items)) {
             m_items[item->collection()] << item;
+            // an item may retire (its database locking or closing) while the prompt
+            // is pending. Clear our references right away: a retired item lingers
+            // until its deleteLater is delivered, with its backend entry already
+            // gone, so a non-null item must always imply a usable backend.
+            connect(item, &Item::itemAboutToDelete, this, [this, item]() { itemRetired(item); });
         }
     }
 
@@ -342,6 +347,24 @@ namespace FdoSecrets
         }
     }
 
+    void UnlockPrompt::itemRetired(Item* item)
+    {
+        // the item is going away (already removed from DBus, backend about to reset);
+        // stop referencing it. A null item is treated as rejected, same as a destroyed one.
+        for (auto& items : m_items) {
+            for (auto& p : items) {
+                if (p == item) {
+                    p = nullptr;
+                }
+            }
+        }
+        for (auto& p : m_entryToItems) {
+            if (p == item) {
+                p = nullptr;
+            }
+        }
+    }
+
     void UnlockPrompt::unlockItems()
     {
         // may be reached from multiple paths (last collection resolving vs retiring)
@@ -358,8 +381,9 @@ namespace FdoSecrets
 
         // flatten to list of entries
         QList<Entry*> entries;
-        for (const auto& itemsPerColl : asConst(m_items)) {
-            for (const auto& item : itemsPerColl) {
+        QSet<Collection*> collections;
+        for (auto collIt = m_items.constBegin(); collIt != m_items.constEnd(); ++collIt) {
+            for (const auto& item : collIt.value()) {
                 if (!item) {
                     m_numRejected += 1;
                     continue;
@@ -373,8 +397,9 @@ namespace FdoSecrets
                     // Already saw this entry
                     continue;
                 }
-                m_entryToItems[uuid] = item.data();
+                m_entryToItems[uuid] = item;
                 entries << entry;
+                collections << collIt.key();
             }
         }
         if (!entries.isEmpty()) {
@@ -383,13 +408,24 @@ namespace FdoSecrets
                 findWindow(m_windowId), entries, app, client->processInfo(), AuthOption::Remember);
             connect(ac, &AccessControlDialog::finished, this, &UnlockPrompt::itemUnlockFinished);
             connect(ac, &AccessControlDialog::finished, ac, &AccessControlDialog::deleteLater);
+            // the dialog is asking about entries that do not survive the database
+            // locking or closing. Withdraw the question in that case, as if the
+            // user rejected it.
+            for (const auto& coll : collections) {
+                connect(coll, &Collection::collectionLockChanged, ac, [ac](bool locked) {
+                    if (locked) {
+                        ac->reject();
+                    }
+                });
+                connect(coll, &Collection::collectionAboutToDelete, ac, &AccessControlDialog::reject);
+            }
             ac->open();
         } else {
             itemUnlockFinished({}, AuthDecision::Undecided);
         }
     }
 
-    void UnlockPrompt::itemUnlockFinished(const QHash<Entry*, AuthDecision>& decisions, AuthDecision forFutureEntries)
+    void UnlockPrompt::itemUnlockFinished(const QHash<QUuid, AuthDecision>& decisions, AuthDecision forFutureEntries)
     {
         auto client = m_client.lock();
         if (!client) {
@@ -398,11 +434,12 @@ namespace FdoSecrets
             return;
         }
         for (auto it = decisions.constBegin(); it != decisions.constEnd(); ++it) {
-            auto entry = it.key();
-            auto uuid = entry->uuid();
+            const auto& uuid = it.key();
             // get back the corresponding item
             auto item = m_entryToItems.value(uuid);
             if (!item) {
+                // the item retired while the dialog was open, it can no longer be unlocked
+                m_numRejected += 1;
                 continue;
             }
 

--- a/src/fdosecrets/objects/Prompt.h
+++ b/src/fdosecrets/objects/Prompt.h
@@ -173,12 +173,13 @@ namespace FdoSecrets
 
         void collectionUnlockFinished(bool accepted);
         void collectionRetired(Collection* coll);
-        void itemUnlockFinished(const QHash<Entry*, AuthDecision>& results, AuthDecision forFutureEntries);
+        void itemRetired(Item* item);
+        void itemUnlockFinished(const QHash<QUuid, AuthDecision>& results, AuthDecision forFutureEntries);
         void unlockItems();
 
         QList<QPointer<Collection>> m_collections;
         QHash<Collection*, QList<QPointer<Item>>> m_items;
-        QHash<QUuid, Item*> m_entryToItems;
+        QHash<QUuid, QPointer<Item>> m_entryToItems;
 
         // collections whose doUnlock was issued and whose outcome is still awaited
         QSet<Collection*> m_pendingCollections;

--- a/src/fdosecrets/widgets/AccessControlDialog.cpp
+++ b/src/fdosecrets/widgets/AccessControlDialog.cpp
@@ -25,7 +25,6 @@
 
 #include "core/Entry.h"
 #include "core/Global.h"
-#include "core/Tools.h"
 #include "gui/Icons.h"
 
 #include <QWindow>
@@ -158,9 +157,9 @@ void AccessControlDialog::setupDetails(const FdoSecrets::PeerInfo& info)
     m_ui->detailsContainer->hide();
 }
 
-void AccessControlDialog::denyEntryClicked(Entry* entry, const QModelIndex& index)
+void AccessControlDialog::denyEntryClicked(const QUuid& uuid, const QModelIndex& index)
 {
-    m_decisions.insert(entry, AuthDecision::Denied);
+    m_decisions.insert(uuid, AuthDecision::Denied);
     m_model->removeRow(index.row());
     if (m_model->rowCount({}) == 0) {
         reject();
@@ -189,32 +188,35 @@ void AccessControlDialog::dialogFinished(int result)
     }
 
     for (int row = 0; row != m_model->rowCount({}); ++row) {
-        auto entry = m_model->data(m_model->index(row, 2), Qt::EditRole).value<Entry*>();
+        auto uuid = m_model->data(m_model->index(row, 2), Qt::EditRole).value<QUuid>();
         auto selected = m_model->data(m_model->index(row, 0), Qt::CheckStateRole).value<Qt::CheckState>();
-        Q_ASSERT(entry);
+        Q_ASSERT(!uuid.isNull());
 
         auto undecided = result == AllowSelected && !selected;
-        m_decisions.insert(entry, undecided ? AuthDecision::Undecided : decision);
+        m_decisions.insert(uuid, undecided ? AuthDecision::Undecided : decision);
     }
 
     emit finished(m_decisions, futureDecision);
 }
 
-QHash<Entry*, AuthDecision> AccessControlDialog::decisions() const
+QHash<QUuid, AuthDecision> AccessControlDialog::decisions() const
 {
     return m_decisions;
 }
 
-AccessControlDialog::EntryModel::EntryModel(QList<Entry*> entries, QObject* parent)
+AccessControlDialog::EntryModel::EntryModel(const QList<Entry*>& entries, QObject* parent)
     : QAbstractTableModel(parent)
-    , m_entries(std::move(entries))
-    , m_selected(Tools::asSet(m_entries))
 {
+    m_entryDataList.reserve(entries.size());
+    for (const auto& entry : entries) {
+        m_entryDataList.append({entry->uuid(), entry->title(), entry->username(), Icons::entryIconPixmap(entry)});
+        m_selected.insert(entry->uuid());
+    }
 }
 
 int AccessControlDialog::EntryModel::rowCount(const QModelIndex& parent) const
 {
-    return isValid(parent) ? 0 : m_entries.count();
+    return isValid(parent) ? 0 : m_entryDataList.count();
 }
 
 int AccessControlDialog::EntryModel::columnCount(const QModelIndex& parent) const
@@ -232,11 +234,11 @@ void AccessControlDialog::EntryModel::toggleCheckState(const QModelIndex& index)
     if (!isValid(index)) {
         return;
     }
-    auto entry = m_entries.at(index.row());
+    const auto& entry = m_entryDataList.at(index.row());
     // click anywhere in the row to check/uncheck the item
-    auto it = m_selected.find(entry);
+    auto it = m_selected.find(entry.uuid);
     if (it == m_selected.end()) {
-        m_selected.insert(entry);
+        m_selected.insert(entry.uuid);
     } else {
         m_selected.erase(it);
     }
@@ -249,31 +251,31 @@ QVariant AccessControlDialog::EntryModel::data(const QModelIndex& index, int rol
     if (!isValid(index)) {
         return {};
     }
-    auto entry = m_entries.at(index.row());
+    const auto& entry = m_entryDataList.at(index.row());
 
     switch (index.column()) {
     case 0:
         switch (role) {
         case Qt::DisplayRole:
-            return entry->title();
+            return entry.title;
         case Qt::DecorationRole:
-            return Icons::entryIconPixmap(entry);
+            return entry.icon;
         case Qt::CheckStateRole:
-            return QVariant::fromValue(m_selected.contains(entry) ? Qt::Checked : Qt::Unchecked);
+            return QVariant::fromValue(m_selected.contains(entry.uuid) ? Qt::Checked : Qt::Unchecked);
         default:
             return {};
         }
     case 1:
         switch (role) {
         case Qt::DisplayRole:
-            return entry->username();
+            return entry.username;
         default:
             return {};
         }
     case 2:
         switch (role) {
         case Qt::EditRole:
-            return QVariant::fromValue(entry);
+            return QVariant::fromValue(entry.uuid);
         default:
             return {};
         }
@@ -286,7 +288,7 @@ bool AccessControlDialog::EntryModel::removeRows(int row, int count, const QMode
 {
     beginRemoveRows(parent, row, row + count - 1);
     while (count--) {
-        m_entries.removeAt(row);
+        m_entryDataList.removeAt(row);
     }
     endRemoveRows();
     return true;
@@ -295,18 +297,18 @@ bool AccessControlDialog::EntryModel::removeRows(int row, int count, const QMode
 AccessControlDialog::DenyButton::DenyButton(QWidget* p, const QModelIndex& idx)
     : QPushButton(p)
     , m_index(idx)
-    , m_entry()
+    , m_uuid()
 {
     setText(tr("Deny for this program"));
-    connect(this, &QPushButton::clicked, [this]() { emit clicked(entry(), m_index); });
+    connect(this, &QPushButton::clicked, [this]() { emit clicked(uuid(), m_index); });
 }
 
-void AccessControlDialog::DenyButton::setEntry(Entry* e)
+void AccessControlDialog::DenyButton::setUuid(const QUuid& uuid)
 {
-    m_entry = e;
+    m_uuid = uuid;
 }
 
-Entry* AccessControlDialog::DenyButton::entry() const
+QUuid AccessControlDialog::DenyButton::uuid() const
 {
-    return m_entry;
+    return m_uuid;
 }

--- a/src/fdosecrets/widgets/AccessControlDialog.h
+++ b/src/fdosecrets/widgets/AccessControlDialog.h
@@ -23,9 +23,11 @@
 #include <QAbstractTableModel>
 #include <QCheckBox>
 #include <QDialog>
+#include <QPixmap>
 #include <QPointer>
 #include <QPushButton>
 #include <QSet>
+#include <QUuid>
 
 #include "core/Global.h"
 
@@ -70,13 +72,13 @@ public:
         DenyAll,
     };
 
-    QHash<Entry*, AuthDecision> decisions() const;
+    QHash<QUuid, AuthDecision> decisions() const;
 
 signals:
-    void finished(const QHash<Entry*, AuthDecision>& results, AuthDecision forFutureEntries);
+    void finished(const QHash<QUuid, AuthDecision>& results, AuthDecision forFutureEntries);
 
 private slots:
-    void denyEntryClicked(Entry* entry, const QModelIndex& index);
+    void denyEntryClicked(const QUuid& uuid, const QModelIndex& index);
     void dialogFinished(int result);
 
 private:
@@ -88,14 +90,14 @@ private:
     QScopedPointer<Ui::AccessControlDialog> m_ui;
     QPointer<QCheckBox> m_rememberCheck;
     QScopedPointer<EntryModel> m_model;
-    QHash<Entry*, AuthDecision> m_decisions;
+    QHash<QUuid, AuthDecision> m_decisions;
 };
 
 class AccessControlDialog::EntryModel : public QAbstractTableModel
 {
     Q_OBJECT
 public:
-    explicit EntryModel(QList<Entry*> entries, QObject* parent = nullptr);
+    explicit EntryModel(const QList<Entry*>& entries, QObject* parent = nullptr);
 
     int rowCount(const QModelIndex& parent) const override;
     int columnCount(const QModelIndex& parent) const override;
@@ -106,29 +108,40 @@ public slots:
     void toggleCheckState(const QModelIndex& index);
 
 private:
+    // A snapshot of everything shown about an entry, taken at construction.
+    // The dialog must not keep Entry pointers: the entries are destroyed if
+    // the database locks or closes while the dialog is open.
+    struct EntryData
+    {
+        QUuid uuid;
+        QString title;
+        QString username;
+        QPixmap icon;
+    };
+
     bool isValid(const QModelIndex& index) const;
 
-    QList<Entry*> m_entries;
-    QSet<Entry*> m_selected;
+    QList<EntryData> m_entryDataList;
+    QSet<QUuid> m_selected;
 };
 
 class AccessControlDialog::DenyButton : public QPushButton
 {
     Q_OBJECT
 
-    Q_PROPERTY(Entry* entry READ entry WRITE setEntry USER true)
+    Q_PROPERTY(QUuid uuid READ uuid WRITE setUuid USER true)
 
     QPersistentModelIndex m_index;
-    QPointer<Entry> m_entry;
+    QUuid m_uuid;
 
 public:
     explicit DenyButton(QWidget* p, const QModelIndex& idx);
 
-    void setEntry(Entry* e);
-    Entry* entry() const;
+    void setUuid(const QUuid& uuid);
+    QUuid uuid() const;
 
 signals:
-    void clicked(Entry*, const QModelIndex& idx);
+    void clicked(const QUuid& uuid, const QModelIndex& idx);
 };
 
 #endif // KEEPASSXC_FDOSECRETS_ACCESSCONTROLDIALOG_H

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -811,6 +811,68 @@ void TestGuiFdoSecrets::testServiceUnlockItemsIncludeFutureEntries()
     }
 }
 
+void TestGuiFdoSecrets::testServiceUnlockItemsConcurrentLock()
+{
+    FdoSecrets::settings()->setConfirmAccessItem(true);
+
+    auto service = enableService();
+    VERIFY(service);
+    auto coll = getDefaultCollection(service);
+    VERIFY(coll);
+    auto item = getFirstItem(coll);
+    VERIFY(item);
+
+    DBUS_COMPARE(item->locked(), true);
+
+    DBUS_GET2(unlocked, promptPath, service->Unlock({QDBusObjectPath(item->path())}));
+    // nothing is unlocked immediately without user's action
+    COMPARE(unlocked, {});
+
+    auto prompt = getProxy<PromptProxy>(promptPath);
+    VERIFY(prompt);
+    QSignalSpy spyPromptCompleted(prompt.data(), SIGNAL(Completed(bool, QDBusVariant)));
+    VERIFY(spyPromptCompleted.isValid());
+
+    // drive the prompt to show the access confirmation dialog, but do not answer it
+    DBUS_VERIFY(prompt->Prompt(""));
+    processEvents();
+
+    QPointer<AccessControlDialog> dlg;
+    for (auto w : QApplication::topLevelWidgets()) {
+        auto acd = qobject_cast<AccessControlDialog*>(w);
+        if (acd && acd->isVisible()) {
+            dlg = acd;
+            break;
+        }
+    }
+    VERIFY(dlg);
+
+    // while the dialog is open, the database locks, destroying the entries
+    // the dialog was asking about
+    lockDatabaseInBackend();
+
+    // the dialog should have withdrawn itself, as the entries it was asking
+    // about no longer exist
+    bool dialogWithdrawn = !dlg || !dlg->isVisible();
+
+    // canceling whatever remains of the dialog must not crash
+    if (dlg) {
+        dlg->reject();
+        processEvents();
+    }
+    VERIFY(dialogWithdrawn);
+
+    // the prompt completes as dismissed with nothing unlocked
+    VERIFY(waitForSignal(spyPromptCompleted, 1));
+    {
+        auto args = spyPromptCompleted.takeFirst();
+        COMPARE(args.count(), 2);
+        COMPARE(args.at(0).toBool(), true);
+        auto unlockedResult = getSignalVariantArgument<QList<QDBusObjectPath>>(args.at(1));
+        VERIFY(unlockedResult.isEmpty());
+    }
+}
+
 void TestGuiFdoSecrets::testServiceLock()
 {
     auto service = enableService();

--- a/tests/gui/TestGuiFdoSecrets.h
+++ b/tests/gui/TestGuiFdoSecrets.h
@@ -75,6 +75,7 @@ private slots:
     void testServiceUnlockConcurrentDelete();
     void testServiceUnlockItems();
     void testServiceUnlockItemsIncludeFutureEntries();
+    void testServiceUnlockItemsConcurrentLock();
     void testServiceLock();
     void testServiceLockConcurrent();
 


### PR DESCRIPTION
Fixes #9104.

## Root cause

`AccessControlDialog` (the fdosecrets item access confirmation dialog) held raw `Entry*` everywhere: in its table model, in the per-row deny buttons, and in the `finished` signal payload. When the database locks (or the tab closes) while the dialog is open, `DatabaseWidget::lock()` replaces the `Database` and destroys every `Entry` — but the widget and the `Collection` stay alive, so nothing closed the dialog. Any subsequent use dereferenced freed entries:

- answering/canceling the dialog → `dialogFinished()` reads `Entry*` back from the model and `UnlockPrompt::itemUnlockFinished()` calls `Entry::uuid()` on it — this is the backtrace in #9104;
- merely repainting the dialog → the model reads `title()`/`icon()` from freed entries.

Note that lock ≠ close: on lock the `Collection` does not retire, so the prompt lifetime fixes in #13598 do not cover this path.

## Fix

- **Make the dialog self-contained.** `AccessControlDialog` snapshots each entry's uuid and display data (title, username, icon pixmap) at construction and reports decisions as `QHash<QUuid, AuthDecision>`. After it is shown, the dialog never touches an `Entry` again, so no lifetime of the underlying objects can affect it.
- **Restore the item-lifetime invariant in `UnlockPrompt`.** `m_entryToItems` was also holding raw `Item*` that dangle after lock (items are destroyed via `Item::removeFromDBus`). Items are now tracked with `QPointer`, and all references are cleared as soon as an item retires (`Item::itemAboutToDelete`), mirroring the existing `collectionRetired` handling from #13598. A decision arriving for a retired item counts as rejected, so the prompt completes as dismissed instead of reporting success for nothing.
- **Match browser behavior (UX).** The dialog now withdraws itself (auto-rejects) when a collection it is asking about locks or goes away, instead of leaving a stale question on screen. This is only safe after the first point, because `databaseLocked` fires after the entries are already destroyed.

## Testing

New regression test `testServiceUnlockItemsConcurrentLock`: triggers the item access confirmation dialog, locks the database in the backend while the dialog is open, cancels whatever remains, and asserts the dialog withdrew itself and the prompt completes as dismissed with nothing unlocked.

- Without the fix the test crashes under ASan with a heap-use-after-free exactly at the #9104 site (`UnlockPrompt::itemUnlockFinished` → `Entry::uuid()`).
- With the fix, the test and the full `testguifdosecrets` suite (38 tests) pass under ASan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqHu6RpvLpaoH2aUGSYQzR
