### PR TITLE
Fix double space in "Access Request" window title

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -51,10 +51,6 @@
 <context>
     <name>AccessControlDialog</name>
     <message>
-        <source>KeePassXC -  Access Request</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Non-existing/inaccessible executable path. Please double-check the client is legit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -100,6 +96,10 @@
     </message>
     <message>
         <source>Allow All &amp;&amp; &amp;Future</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KeePassXC - Access Request</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/fdosecrets/widgets/AccessControlDialog.ui
+++ b/src/fdosecrets/widgets/AccessControlDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>KeePassXC -  Access Request</string>
+   <string>KeePassXC - Access Request</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
This change removes the double space in the "Access Request" window title in the source string, and ran `./release-tool.py i18n lupdate`.

## Screenshots

Before: (Note the double space after the hyphen)

<img width="687" height="50" alt="unsorted_20260822_13h37m06s" src="https://github.com/user-attachments/assets/0ca6e9a7-cfb3-4b9a-8e9a-38f3d25e6066" />

After:
<img width="685" height="46" alt="unsorted_20260822_13h36m13s" src="https://github.com/user-attachments/assets/af0d3062-0317-4d9f-a996-665411188ac0" />

## Testing strategy

I built KeePassXC locally and compared the Access Request dialog with the stable version. I have only tested the English (United States) translation.

## Type of change

- ✅ Bug fix (non-breaking change that fixes an issue)