### PR TITLE
feat: Add support to rename tags for all entries (#9142)

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -1656,6 +1656,22 @@ Backup database located at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>The tag name cannot be empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both tag names are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The tag &quot;%1&quot; already exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The tag &quot;%1&quot; was not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recycle Bin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10454,7 +10470,19 @@ This option is deprecated, use --set-key-file instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Rename Tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remove Tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New tag name for &quot;%1&quot;:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -842,6 +842,68 @@ void Database::removeTag(const QString& tag)
     }
 }
 
+bool Database::hasTag(const QString& tag)
+{
+    // First update the tag list because the new test renameExistingTag fails. The existing tag is not detected
+    // because the list is outdated although from manual tests it works fine
+    updateTagList();
+    const auto tags = tagList();
+    for (const auto& t : tags) {
+        if (t.compare(tag, Qt::CaseInsensitive) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Database::renameTag(const QString& oldTag, const QString& newTag, QString* error)
+{
+    const QString cleanOldTag = oldTag.trimmed();
+    const QString cleanNewTag = newTag.trimmed();
+
+    if (cleanOldTag.isEmpty() || cleanNewTag.isEmpty()) {
+        if (error) {
+            *error = tr("The tag name cannot be empty.");
+        }
+        return false;
+    }
+
+    if (cleanOldTag.compare(cleanNewTag, Qt::CaseInsensitive) == 0) {
+        if (error) {
+            *error = tr("Both tag names are the same.");
+        }
+        return false;
+    }
+
+    if (hasTag(cleanNewTag)) {
+        if (error) {
+            *error = tr("The tag \"%1\" already exists.").arg(cleanNewTag);
+        }
+        return false;
+    }
+
+    bool modified = false;
+    for (auto entry : m_rootGroup->entriesRecursive()) {
+        auto tags = entry->tagList();
+        for (int i = 0; i < tags.size(); ++i) {
+            if (tags[i].compare(cleanOldTag, Qt::CaseInsensitive) == 0) {
+                tags[i] = cleanNewTag;
+                entry->setTags(tags.join(","));
+                modified = true;
+                break;
+            }
+        }
+    }
+
+    if (!modified) {
+        if (error) {
+            *error = tr("The tag \"%1\" was not found.").arg(cleanOldTag);
+        }
+    }
+
+    return modified;
+}
+
 const QUuid& Database::cipher() const
 {
     return m_data.cipher;

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -844,13 +844,15 @@ void Database::removeTag(const QString& tag)
 
 bool Database::hasTag(const QString& tag)
 {
-    // First update the tag list because the new test renameExistingTag fails. The existing tag is not detected
-    // because the list is outdated although from manual tests it works fine
-    updateTagList();
-    const auto tags = tagList();
-    for (const auto& t : tags) {
-        if (t.compare(tag, Qt::CaseInsensitive) == 0) {
-            return true;
+    if (!m_rootGroup) {
+        return false;
+    }
+
+    for (auto entry : m_rootGroup->entriesRecursive()) {
+        for (const auto& t : entry->tagList()) {
+            if (t.compare(tag, Qt::CaseInsensitive) == 0) {
+                return true;
+            }
         }
     }
     return false;

--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -849,10 +849,8 @@ bool Database::hasTag(const QString& tag)
     }
 
     for (auto entry : m_rootGroup->entriesRecursive()) {
-        for (const auto& t : entry->tagList()) {
-            if (t.compare(tag, Qt::CaseInsensitive) == 0) {
-                return true;
-            }
+        if (entry->hasTag(tag)) {
+            return true;
         }
     }
     return false;
@@ -884,26 +882,18 @@ bool Database::renameTag(const QString& oldTag, const QString& newTag, QString* 
         return false;
     }
 
-    bool modified = false;
+    bool renamed = false;
     for (auto entry : m_rootGroup->entriesRecursive()) {
-        auto tags = entry->tagList();
-        for (int i = 0; i < tags.size(); ++i) {
-            if (tags[i].compare(cleanOldTag, Qt::CaseInsensitive) == 0) {
-                tags[i] = cleanNewTag;
-                entry->setTags(tags.join(","));
-                modified = true;
-                break;
-            }
-        }
+        renamed |= entry->renameTag(oldTag, newTag);
     }
 
-    if (!modified) {
+    if (!renamed) {
         if (error) {
             *error = tr("The tag \"%1\" was not found.").arg(cleanOldTag);
         }
     }
 
-    return modified;
+    return renamed;
 }
 
 const QUuid& Database::cipher() const

--- a/src/core/Database.h
+++ b/src/core/Database.h
@@ -145,6 +145,8 @@ public:
     const QStringList& commonUsernames() const;
     const QStringList& tagList() const;
     void removeTag(const QString& tag);
+    bool hasTag(const QString& tag);
+    bool renameTag(const QString& oldTag, const QString& newTag, QString* error);
 
     QSharedPointer<const CompositeKey> key() const;
     bool setKey(const QSharedPointer<const CompositeKey>& key,

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -753,6 +753,44 @@ void Entry::removeTag(const QString& tag)
     }
 }
 
+bool Entry::hasTag(const QString& tag)
+{
+    auto cleanTag = tag.trimmed();
+    cleanTag.remove(TagDelimiterRegex);
+
+    auto tagList = m_data.tags;
+    for (const auto& t : tagList) {
+        if (t.compare(tag, Qt::CaseInsensitive) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Entry::renameTag(const QString& oldTag, const QString& newTag)
+{
+    auto cleanOldTag = oldTag.trimmed();
+    cleanOldTag.remove(TagDelimiterRegex);
+
+    auto cleanNewTag = newTag.trimmed();
+    cleanNewTag.remove(TagDelimiterRegex);
+
+    auto tagList = m_data.tags;
+    bool renamed = false;
+    for (int i = 0; i < tagList.size(); i++) {
+        if (tagList[i].compare(cleanOldTag, Qt::CaseInsensitive) == 0) {
+            tagList[i] = cleanNewTag;
+            renamed = true;
+            break;
+        }
+    }
+    if (renamed) {
+        tagList.sort();
+        set(m_data.tags, tagList);
+    }
+    return renamed;
+}
+
 void Entry::setTimeInfo(const TimeInfo& timeInfo)
 {
     m_data.timeInfo = timeInfo;

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -769,6 +769,7 @@ bool Entry::hasTag(const QString& tag)
 
 bool Entry::renameTag(const QString& oldTag, const QString& newTag)
 {
+    beginUpdate();
     auto cleanOldTag = oldTag.trimmed();
     cleanOldTag.remove(TagDelimiterRegex);
 
@@ -788,6 +789,7 @@ bool Entry::renameTag(const QString& oldTag, const QString& newTag)
         tagList.sort();
         set(m_data.tags, tagList);
     }
+    endUpdate();
     return renamed;
 }
 

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -760,7 +760,7 @@ bool Entry::hasTag(const QString& tag)
 
     auto tagList = m_data.tags;
     for (const auto& t : tagList) {
-        if (t.compare(tag, Qt::CaseInsensitive) == 0) {
+        if (t.compare(cleanTag, Qt::CaseInsensitive) == 0) {
             return true;
         }
     }

--- a/src/core/Entry.h
+++ b/src/core/Entry.h
@@ -169,6 +169,8 @@ public:
 
     void addTag(const QString& tag);
     void removeTag(const QString& tag);
+    bool hasTag(const QString& tag);
+    bool renameTag(const QString& oldTag, const QString& newTag);
 
     QList<Entry*> historyItems();
     const QList<Entry*>& historyItems() const;

--- a/src/gui/tag/TagView.cpp
+++ b/src/gui/tag/TagView.cpp
@@ -104,7 +104,7 @@ void TagView::contextMenuRequested(const QPoint& pos)
                                                       tag,
                                                       &ok).trimmed();
 
-                if (ok && !newTag.isEmpty() && newTag != tag) {
+                if (ok && newTag != tag) {
                     QString error;
                     if (!m_db->renameTag(tag, newTag, &error)) {
                         MessageBox::warning(this, tr("Error"), error);

--- a/src/gui/tag/TagView.cpp
+++ b/src/gui/tag/TagView.cpp
@@ -24,6 +24,7 @@
 #include "gui/Icons.h"
 #include "gui/MessageBox.h"
 
+#include <QInputDialog>
 #include <QMenu>
 #include <QPainter>
 #include <QStyledItemDelegate>
@@ -86,17 +87,37 @@ void TagView::contextMenuRequested(const QPoint& pos)
             m_db->metadata()->deleteSavedSearch(index.data(Qt::DisplayRole).toString());
         }
     } else if (type == TagModel::TAG) {
-        // Allow removing tags from all entries in a database
+        // Allow removing and renaming tags from all entries in a database
         QMenu menu;
-        auto action = menu.exec({new QAction(icons()->icon("trash"), tr("Remove Tag"), nullptr)}, mapToGlobal(pos));
+        auto renameAction = menu.addAction(icons()->icon("entry-edit"), tr("Rename Tag"));
+        auto removeAction = menu.addAction(icons()->icon("trash"), tr("Remove Tag"));
+
+        auto action = menu.exec(mapToGlobal(pos));
         if (action) {
             auto tag = index.data(Qt::DisplayRole).toString();
-            auto ans = MessageBox::question(this,
-                                            tr("Confirm Remove Tag"),
-                                            tr("Remove tag \"%1\" from all entries in this database?").arg(tag),
-                                            MessageBox::Remove | MessageBox::Cancel);
-            if (ans == MessageBox::Remove) {
-                m_db->removeTag(tag);
+            if (action == renameAction) {
+                bool ok = false;
+                QString newTag = QInputDialog::getText(this,
+                                                      tr("Rename Tag"),
+                                                      tr("New tag name for \"%1\":").arg(tag),
+                                                      QLineEdit::Normal,
+                                                      tag,
+                                                      &ok).trimmed();
+
+                if (ok && !newTag.isEmpty() && newTag != tag) {
+                    QString error;
+                    if (!m_db->renameTag(tag, newTag, &error)) {
+                        MessageBox::warning(this, tr("Error"), error);
+                    }
+                }
+            } else if (action == removeAction) {
+                auto ans = MessageBox::question(this,
+                                                tr("Confirm Remove Tag"),
+                                                tr("Remove tag \"%1\" from all entries in this database?").arg(tag),
+                                                MessageBox::Remove | MessageBox::Cancel);
+                if (ans == MessageBox::Remove) {
+                    m_db->removeTag(tag);
+                }
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,6 +140,9 @@ add_unit_test(NAME testsharing SOURCES TestSharing.cpp
 add_unit_test(NAME testdatabase SOURCES TestDatabase.cpp
         LIBS testsupport ${TEST_LIBRARIES})
 
+add_unit_test(NAME testtags SOURCES TestTags.cpp
+        LIBS ${TEST_LIBRARIES})
+
 add_unit_test(NAME testtools SOURCES TestTools.cpp
         LIBS testsupport ${TEST_LIBRARIES})
 

--- a/tests/TestTags.cpp
+++ b/tests/TestTags.cpp
@@ -17,7 +17,7 @@
 
 #include "TestTags.h"
 
-#include "QTest"
+#include <QTest>
 
 #include "core/Database.h"
 #include "core/Entry.h"

--- a/tests/TestTags.cpp
+++ b/tests/TestTags.cpp
@@ -96,3 +96,19 @@ void TestTags::testRenameNotExistingTag()
     QVERIFY(!db->renameTag("tag3", "tag3_ren", &error));
     QCOMPARE(error, QObject::tr("The tag \"%1\" was not found.").arg("tag3"));
 }
+
+void TestTags::testRenameTagWithDelimiter()
+{
+    QScopedPointer<Database> db(new Database());
+    QVERIFY(db);
+
+    auto* entry = new Entry();
+    db->rootGroup()->addEntry(entry);
+    entry->setTags("tag1");
+
+    QString error;
+    QVERIFY(db->renameTag("tag,;1", "tag,;1_ren", &error));
+    QVERIFY(error.isEmpty());
+
+    QCOMPARE(entry->tagList(), QStringList({"tag1_ren"}));
+}

--- a/tests/TestTags.cpp
+++ b/tests/TestTags.cpp
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (C) 2026 Brais Couce
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestTags.h"
+
+#include "QTest"
+
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "crypto/Crypto.h"
+
+QTEST_GUILESS_MAIN(TestTags)
+
+void TestTags::initTestCase()
+{
+    QVERIFY(Crypto::init());
+    QLocale::setDefault(QLocale::c());
+}
+
+void TestTags::testRenameTag()
+{
+    QScopedPointer<Database> db(new Database());
+    QVERIFY(db);
+
+    auto* entry1 = new Entry();
+    db->rootGroup()->addEntry(entry1);
+    entry1->setTags("tag1, tag 2");
+
+    auto* entry2 = new Entry();
+    db->rootGroup()->addEntry(entry2);
+    entry2->setTags("TaG 2, tag3");
+
+    QString error;
+    QVERIFY(db->renameTag("tag 2", "tag2_ren", &error));
+    QVERIFY(error.isEmpty());
+
+    QCOMPARE(entry1->tagList(), QStringList({"tag1", "tag2_ren"}));
+    QCOMPARE(entry2->tagList(), QStringList({"tag2_ren", "tag3"}));
+}
+
+void TestTags::renameEmptyTag()
+{
+    QScopedPointer<Database> db(new Database());
+    QVERIFY(db);
+
+    QString error;
+
+    QVERIFY(!db->renameTag("tag1", "   ", &error));
+    QCOMPARE(error, QObject::tr("The tag name cannot be empty."));
+    error.clear();
+
+    QVERIFY(!db->renameTag("   ", "tag1_ren", &error));
+    QCOMPARE(error, QObject::tr("The tag name cannot be empty."));
+    error.clear();
+}
+
+void TestTags::renameExistingTag()
+{
+    QScopedPointer<Database> db(new Database());
+    QVERIFY(db);
+
+    auto* entry = new Entry();
+    db->rootGroup()->addEntry(entry);
+    entry->setTags("tag1, tag2");
+
+    QString error;
+    QVERIFY(!db->renameTag("tag1", "tag2", &error));
+    QCOMPARE(error, QObject::tr("The tag \"%1\" already exists.").arg("tag2"));
+}
+
+void TestTags::testRenameNotExistingTag()
+{
+    QScopedPointer<Database> db(new Database());
+    QVERIFY(db);
+
+    auto* entry = new Entry();
+    db->rootGroup()->addEntry(entry);
+    entry->setTags("tag1, tag2");
+
+    QString error;
+    QVERIFY(!db->renameTag("tag3", "tag3_ren", &error));
+    QCOMPARE(error, QObject::tr("The tag \"%1\" was not found.").arg("tag3"));
+}

--- a/tests/TestTags.cpp
+++ b/tests/TestTags.cpp
@@ -40,17 +40,21 @@ void TestTags::testRenameTag()
     auto* entry1 = new Entry();
     db->rootGroup()->addEntry(entry1);
     entry1->setTags("tag1, tag 2");
+    QCOMPARE(entry1->historyItems().size(), 0);
 
     auto* entry2 = new Entry();
     db->rootGroup()->addEntry(entry2);
     entry2->setTags("TaG 2, tag3");
+    QCOMPARE(entry2->historyItems().size(), 0);
 
     QString error;
     QVERIFY(db->renameTag("tag 2", "tag2_ren", &error));
     QVERIFY(error.isEmpty());
 
     QCOMPARE(entry1->tagList(), QStringList({"tag1", "tag2_ren"}));
+    QCOMPARE(entry1->historyItems().size(), 1);
     QCOMPARE(entry2->tagList(), QStringList({"tag2_ren", "tag3"}));
+    QCOMPARE(entry2->historyItems().size(), 1);
 }
 
 void TestTags::renameEmptyTag()

--- a/tests/TestTags.h
+++ b/tests/TestTags.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2026 Brais Couce
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTTAGS_H
+#define KEEPASSXC_TESTTAGS_H
+
+#include <QObject>
+
+class TestTags : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void testRenameTag();
+    void renameEmptyTag();
+    void renameExistingTag();
+    void testRenameNotExistingTag();
+};
+
+#endif // KEEPASSXC_TESTTAGS_H

--- a/tests/TestTags.h
+++ b/tests/TestTags.h
@@ -30,6 +30,7 @@ private slots:
     void renameEmptyTag();
     void renameExistingTag();
     void testRenameNotExistingTag();
+    void testRenameTagWithDelimiter();
 };
 
 #endif // KEEPASSXC_TESTTAGS_H


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
These changes add support to rename tags for all entries (#9142). I have added a new entry in the contextual menu. When you click on it, you write the new name and confirm or cancel the operation.

The changes introduce new strings that require translations. I have executed the release-tool script but I have to modify it because it expects version 5.x but I have 6.x. Maybe this should be updated after the QT6 migration? I have not changed this in this PR.

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )

<img width="291" height="281" alt="image" src="https://github.com/user-attachments/assets/a840ea37-ab94-468d-a660-4b7ce9c5eb18" />

<img width="442" height="189" alt="image" src="https://github.com/user-attachments/assets/3a8aaaf4-96c5-4f06-9090-c5ce59da3ba2" />


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )

I have manually tested the changes including tags with spaces and mixed upper/lower case. I have also tested that you cannot rename to a existing tag name.

I have implemented automated tests for the core logic. There are no GUI tests for the GUI changes.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- [X] New feature (change that adds functionality)
