### PR TITLE
Restore macos window proxy icon

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1052,7 +1052,17 @@ void MainWindow::updateWindowTitle()
     if (customWindowTitlePart.isEmpty()) {
         windowTitle = QString("%1[*]").arg(BaseWindowTitle);
     } else {
+        // removing [*] from the QString seems to solve the * problem mentioned in pr #11542
+        // but this was just a hacky see what happens so im not sure its an appropriate fix
         windowTitle = QString("%1[*] - %2").arg(customWindowTitlePart, BaseWindowTitle);
+    }
+
+    // PasswordGeneratorScreen seemed like another place the proxy icon was not needed whilst visually testing
+    if (customWindowTitlePart.isEmpty() || stackedWidgetIndex == StackedWidgetIndex::SettingsScreen
+        || stackedWidgetIndex == StackedWidgetIndex::PasswordGeneratorScreen) {
+        setWindowFilePath("");
+    } else {
+        setWindowFilePath(m_ui->tabWidget->databaseWidgetFromIndex(tabWidgetIndex)->database()->filePath());
     }
 
     setWindowTitle(windowTitle);


### PR DESCRIPTION
Fixes #12189 
Added macOS Proxy icon back. Restoring the previous behaviour shown in issue #12189. This does reintroduce the * problem in the title bar. #11542 removed the proxy icon for this reason as far as I can tell. Removing the `[*]` from the `QString` here:
```        
windowTitle = QString("%1 - %2").arg(customWindowTitlePart, BaseWindowTitle);
```
oddly seemed to fix the problem and, by visual testing, the titles all appeared correct but this does not seem like the proper fix. I could not figure out why it was happening. However, as per the discussion under issue #12189 , proxy icons were never intended to be removed. I understand this may not be an acceptable compromise however. I also used the `StackedWidgetIndex` enum to check against `SettingsScreen` instead of the old magic number used before this feature was removed. As well as checking against the `PasswordGeneratorScreen` as it also did not make sense to have the proxy icon at this location.

## Screenshots
<img width="1920" height="1080" alt="Screenshot 2026-08-30 at 9 01 42 pm" src="https://github.com/user-attachments/assets/23b35148-aee8-43fb-a5ed-b42298b1ab4b" />
Screenshot would not register the actual application for some reason.


## Testing strategy
Visually testing the application. This did confirm that the * only appears right after creating a database and disappears as soon as you click to another screen.
- Confirmed proxy icon appears under saved vault
- Confirmed that it disappears in settings and password generator
- Confirmed it returns after switching back
I could not find a way to actually test in code that the proxy icon was being rendered


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

