### PR TITLE
feat: Add the number of passkeys and TOTP entries to the statistics of the database report

### DIFF
--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -10073,6 +10073,14 @@ This option is deprecated, use --set-key-file instead.</source>
         <source>Average password length is less than ten characters. Longer passwords provide more security.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Number of passkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Entries with TOTP setup</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
         <source>%1 character(s)</source>
         <translation type="unfinished">

--- a/share/translations/keepassxc_en.ts
+++ b/share/translations/keepassxc_en.ts
@@ -8168,6 +8168,14 @@ Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Number of passkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Entries with TOTP setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Word count for the diceware passphrase.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/cli/DatabaseInfo.cpp
+++ b/src/cli/DatabaseInfo.cpp
@@ -69,6 +69,8 @@ int DatabaseInfo::executeWithDatabase(QSharedPointer<Database> database, QShared
     out << QObject::tr("Entries excluded from reports") << ": " << QString::number(stats.excludedEntries) << Qt::endl;
     out << QObject::tr("Average password length") << ": "
         << QObject::tr("%1 character(s)", "", stats.averagePwdLength()).arg(stats.averagePwdLength()) << Qt::endl;
+    out << QObject::tr("Number of passkeys") << ": " << QString::number(stats.numberOfPasskeys) << Qt::endl;
+    out << QObject::tr("Entries with TOTP setup") << ": " << QString::number(stats.numberOfTotpEntries) << Qt::endl;
 
     return EXIT_SUCCESS;
 }

--- a/src/core/DatabaseStats.cpp
+++ b/src/core/DatabaseStats.cpp
@@ -114,6 +114,14 @@ void DatabaseStats::gatherStats(const QList<Group*>& groups)
                 totalPasswordLength += pwd.size();
                 m_passwords[pwd]++;
             }
+
+            if (entry->hasPasskey()) {
+                numberOfPasskeys++;
+            }
+
+            if (entry->hasTotp()) {
+                numberOfTotpEntries++;
+            }
         }
     }
 }

--- a/src/core/DatabaseStats.h
+++ b/src/core/DatabaseStats.h
@@ -35,6 +35,8 @@ public:
     int uniquePasswords = 0; // Number of unique passwords
     int reusedPasswords = 0; // Number of non-unique passwords
     int totalPasswordLength = 0; // Total length of all passwords
+    int numberOfPasskeys = 0; // Number of passkeys
+    int numberOfTotpEntries = 0; // Number of entries with TOTP setup
 
     explicit DatabaseStats(QSharedPointer<Database> db);
 

--- a/src/gui/reports/ReportsWidgetStatistics.cpp
+++ b/src/gui/reports/ReportsWidgetStatistics.cpp
@@ -125,6 +125,8 @@ void ReportsWidgetStatistics::calculateStats()
                 tr("%1 character(s)", "", stats->averagePwdLength()).arg(stats->averagePwdLength()),
                 stats->isAvgPwdTooShort(),
                 tr("Average password length is less than ten characters. Longer passwords provide more security."));
+    addStatsRow(tr("Number of passkeys"), QString::number(stats->numberOfPasskeys));
+    addStatsRow(tr("Entries with TOTP setup"), QString::number(stats->numberOfTotpEntries));
 }
 
 void ReportsWidgetStatistics::saveSettings()

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -1025,6 +1025,8 @@ void TestCli::testInfo()
     QCOMPARE(m_stdout->readLine(), QByteArray("Number of weak passwords: 2\n"));
     QCOMPARE(m_stdout->readLine(), QByteArray("Entries excluded from reports: 0\n"));
     QCOMPARE(m_stdout->readLine(), QByteArray("Average password length: 11 character(s)\n"));
+    QCOMPARE(m_stdout->readLine(), QByteArray("Number of passkeys: 0\n"));
+    QCOMPARE(m_stdout->readLine(), QByteArray("Entries with TOTP setup: 1\n"));
 
     // Test with quiet option.
     setInput("a");


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )

These changes add the number of passkeys and TOPT entries to the statistics of the database report. They are added for the GUI and the CLI tool.

Before these changes you could get this info using the search filter "TOTP entries" and the tag "Passkey". However, I think it is useful to have this information in the database report.

## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )

I have tested this manually comparing the results of the search filters with the database report.

I have updated the existing test for the CLI tool to expect the new info.

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- [x] New feature (change that adds functionality)
