### PR TITLE
Add native Windows Arm64 support on Qt-vcpkg builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,24 +469,43 @@ if(APPLE)
     set(CMAKE_MACOSX_RPATH TRUE)
     list(APPEND CMAKE_INSTALL_RPATH "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
 elseif(WIN32)
-    set(_deployqt_exe_name windeployqt)
+    set(_deployqt_exe_name windeployqt.exe)
 endif()
 
 if(WITH_BUILD_QT)
     get_filename_component(Qt6_PREFIX "${Qt6_DIR}/../.." REALPATH)
-    set(_host_triplet "${CMAKE_HOST_SYSTEM_PROCESSOR}-${CMAKE_HOST_SYSTEM_NAME}")
-    string(TOLOWER "${_host_triplet}" _host_triplet)
-    string(REPLACE "darwin" "osx" _host_triplet "${_host_triplet}")
     set(Qt6_TOOLS_PREFIX "${Qt6_PREFIX}/tools/Qt6")
 
     if(_deployqt_exe_name)
         # vcpkg installs *deployqt to the host triplet install dir, which prevents it from
         # finding the Qt libraries and plugins from the target triplet install dir.
         # Here, we copy it to the target dir to fix that. A qt.conf exists there already.
-        configure_file(
-                "${VCPKG_INSTALLED_DIR}/${_host_triplet}/tools/Qt6/bin/${_deployqt_exe_name}"
-                "${Qt6_PREFIX}/tools/Qt6/bin/${_deployqt_exe_name}"
-                COPYONLY)
+        if(WIN32)
+            # On Windows, VCPKG_TARGET_TRIPLET may be cross-compiled (e.g. arm64-windows),
+            # so the host triplet must come from vcpkg's own VCPKG_HOST_TRIPLET rather than
+            # being re-derived from CMAKE_HOST_SYSTEM_PROCESSOR/NAME (which does not match
+            # vcpkg's triplet naming, e.g. "AMD64" vs. "x64").
+            include(cmake/KPXCWindowsDeployQt.cmake)
+            kpxc_resolve_windows_deployqt_host_triplet(_host_triplet)
+            set(KPXC_VCPKG_EXECUTABLE "${Z_VCPKG_EXECUTABLE}")
+            if(NOT KPXC_VCPKG_EXECUTABLE)
+                find_program(KPXC_VCPKG_EXECUTABLE vcpkg
+                        HINTS "$ENV{VCPKG_ROOT}" "$ENV{VCPKG_INSTALLATION_ROOT}")
+            endif()
+            if(NOT KPXC_VCPKG_EXECUTABLE)
+                message(FATAL_ERROR "vcpkg executable is required for Windows runtime deployment.")
+            endif()
+        else()
+            set(_host_triplet "${CMAKE_HOST_SYSTEM_PROCESSOR}-${CMAKE_HOST_SYSTEM_NAME}")
+            string(TOLOWER "${_host_triplet}" _host_triplet)
+            string(REPLACE "darwin" "osx" _host_triplet "${_host_triplet}")
+        endif()
+        if(NOT _host_triplet STREQUAL VCPKG_TARGET_TRIPLET)
+            configure_file(
+                    "${VCPKG_INSTALLED_DIR}/${_host_triplet}/tools/Qt6/bin/${_deployqt_exe_name}"
+                    "${Qt6_PREFIX}/tools/Qt6/bin/${_deployqt_exe_name}"
+                    COPYONLY)
+        endif()
     endif()
 else()
     get_filename_component(Qt6_PREFIX "${Qt6_DIR}/../../.." REALPATH)

--- a/cmake/KPXCWindowsDeployQt.cmake
+++ b/cmake/KPXCWindowsDeployQt.cmake
@@ -1,0 +1,12 @@
+# vcpkg builds *deployqt (e.g. windeployqt.exe) for the host triplet only, which can
+# differ from VCPKG_TARGET_TRIPLET when cross-compiling for Windows on Arm64 (e.g. a
+# x64-windows host building an arm64-windows target). VCPKG_HOST_TRIPLET is set
+# automatically by the vcpkg toolchain file and must be used as-is: it must not be
+# re-derived from CMAKE_HOST_SYSTEM_PROCESSOR/NAME, which does not match vcpkg's
+# triplet naming (e.g. "AMD64" vs. "x64").
+function(kpxc_resolve_windows_deployqt_host_triplet out_var)
+    if(NOT VCPKG_HOST_TRIPLET)
+        message(FATAL_ERROR "VCPKG_HOST_TRIPLET is not set; cannot locate a Windows *deployqt tool.")
+    endif()
+    set(${out_var} "${VCPKG_HOST_TRIPLET}" PARENT_SCOPE)
+endfunction()

--- a/release-tool.py
+++ b/release-tool.py
@@ -234,6 +234,23 @@ def _cmd_exists(cmd, path=None):
     return shutil.which(cmd, path=path) is not None
 
 
+def _cmake_option_is_set(options, name):
+    """Return whether a CMake -D option was explicitly supplied."""
+    option = re.compile(rf'^-D{re.escape(name)}(?::[^=]+)?(?:=|$)')
+    return any(option.match(str(value)) for value in options)
+
+
+def _add_windows_vcpkg_triplet(cmake_opts, platform_target):
+    """Map --platform-target to the built-in vcpkg Windows triplet, without
+    overriding an explicit VCPKG_TARGET_TRIPLET CMake option."""
+    triplets = {
+        'amd64': 'x64-windows',
+        'arm64': 'arm64-windows',
+    }
+    if not _cmake_option_is_set(cmake_opts, 'VCPKG_TARGET_TRIPLET'):
+        cmake_opts.append(f'-DVCPKG_TARGET_TRIPLET={triplets[platform_target]}')
+
+
 def _git_working_dir_clean(*, cwd):
     """Check whether the Git working directory is clean."""
     return _run(['git', 'diff-index', '--quiet', 'HEAD', '--'], check=False, cwd=cwd).returncode == 0
@@ -754,13 +771,19 @@ class Build(Command):
 
     # noinspection PyMethodMayBeStatic
     def build_windows(self, version, src_dir, output_dir, *, parallelism, cmake_opts, platform_target,
-                      sign, sign_identity, sign_timestamp_url, with_tests, mingw, **_):
+                      sign, sign_identity, sign_timestamp_url, with_tests, mingw, use_system_deps,
+                      build_qt, **_):
         # Setup build signing if requested
         if sign:
             cmake_opts.append(f'-DWITH_XC_CODESIGN_IDENTITY={sign_identity}')
             cmake_opts.append(f'-DWITH_XC_CODESIGN_TIMESTAMP_URL={sign_timestamp_url}')
-        # Use vcpkg for dependency deployment
-        cmake_opts.append('-DX_VCPKG_APPLOCAL_DEPS_INSTALL=ON')
+        # windeployqt must run before app-local copying when Qt comes from
+        # vcpkg, otherwise it can lock DLLs that it subsequently replaces.
+        app_local_install = 'OFF' if build_qt else 'ON'
+        cmake_opts.append(f'-DX_VCPKG_APPLOCAL_DEPS_INSTALL={app_local_install}')
+
+        if not mingw and not use_system_deps:
+            _add_windows_vcpkg_triplet(cmake_opts, platform_target)
 
         if mingw:
             vs_env = os.environ.copy()

--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -13,7 +13,7 @@
         Manufacturer="$(var.CPACK_PACKAGE_VENDOR)"
         UpgradeCode="$(var.CPACK_WIX_UPGRADE_GUID)">
 
-        <Package InstallScope="perMachine" InstallerVersion="301" Compressed="yes"/>
+        <Package InstallScope="perMachine" InstallerVersion="500" Compressed="yes"/>
 
         <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -403,7 +403,16 @@ if(WIN32)
 endif()
 
 # Main Executable Definition
+unset(_restore_vcpkg_applocal_deps)
+if(WIN32 AND WITH_BUILD_QT AND VCPKG_APPLOCAL_DEPS)
+    set(VCPKG_APPLOCAL_DEPS OFF)
+    set(_restore_vcpkg_applocal_deps ON)
+endif()
 add_executable(${PROGNAME} main.cpp)
+if(_restore_vcpkg_applocal_deps)
+    set(VCPKG_APPLOCAL_DEPS ON)
+    unset(_restore_vcpkg_applocal_deps)
+endif()
 target_link_libraries(${PROGNAME} keepassxc_gui)
 set_target_properties(${PROGNAME} PROPERTIES ENABLE_EXPORTS ON)
 
@@ -531,6 +540,19 @@ if(WIN32)
             "${CMAKE_SOURCE_DIR}/share/windows/KPXC_ExitDlg.wxs")
     set(CPACK_WIX_PROPERTY_ARPURLINFOABOUT  "https://keepassxc.org")
     set(CPACK_WIX_EXTENSIONS "WixUtilExtension.dll")
+    string(TOLOWER "${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" _windows_package_arch)
+    if(NOT _windows_package_arch)
+        string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _windows_package_arch)
+    endif()
+    if(_windows_package_arch MATCHES "^(arm64|aarch64)$")
+        set(CPACK_WIX_ARCHITECTURE arm64)
+    elseif(_windows_package_arch MATCHES "^(amd64|x64|x86_64)$")
+        set(CPACK_WIX_ARCHITECTURE x64)
+    else()
+        message(FATAL_ERROR
+                "Unsupported Windows package architecture: "
+                "${CMAKE_CXX_COMPILER_ARCHITECTURE_ID} (${CMAKE_SYSTEM_PROCESSOR})")
+    endif()
     include(CPack)
 
     
@@ -551,6 +573,29 @@ if(WIN32)
             message(FATAL_ERROR \"windeployqt failed with exit code \${_wdqt_result}\")
         endif()"
         COMPONENT Runtime)
+
+    if(WITH_BUILD_QT)
+        install(CODE "
+            if(\"\${CMAKE_INSTALL_CONFIG_NAME}\" STREQUAL \"Debug\")
+                set(_vcpkg_bin_dir \"${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin\")
+            else()
+                set(_vcpkg_bin_dir \"${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin\")
+            endif()
+            file(GLOB _installed_executables \"\${CMAKE_INSTALL_PREFIX}/*.exe\")
+            foreach(_installed_executable IN LISTS _installed_executables)
+                execute_process(
+                    COMMAND \"${KPXC_VCPKG_EXECUTABLE}\" z-applocal
+                            \"--target-binary=\${_installed_executable}\"
+                            \"--installed-bin-dir=\${_vcpkg_bin_dir}\"
+                    RESULT_VARIABLE _applocal_result
+                )
+                if(NOT \${_applocal_result} EQUAL 0)
+                    message(FATAL_ERROR
+                            \"vcpkg app-local failed for \${_installed_executable} with exit code \${_applocal_result}\")
+                endif()
+            endforeach()"
+            COMPONENT Runtime)
+    endif()
 
     if(NOT VCPKG_INSTALLED_DIR)
         install(CODE "set(gp_tool \"objdump\")" COMPONENT Runtime)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,20 @@ function(add_unit_test)
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "LANG=en_US.UTF-8")
 endfunction()
 
+# Regression coverage for the Windows Arm64 windeployqt host-triplet resolution
+# (see cmake/KPXCWindowsDeployQt.cmake). Pure CMake script tests, so they can run
+# on any host platform, not just Windows.
+add_test(NAME test_windows_deployqt_host_triplet_set
+        COMMAND ${CMAKE_COMMAND} -DTEST_CASE=host-triplet-set
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_windows_deployqt_host_triplet.cmake")
+add_test(NAME test_windows_deployqt_host_triplet_arm64
+        COMMAND ${CMAKE_COMMAND} -DTEST_CASE=host-triplet-arm64
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_windows_deployqt_host_triplet.cmake")
+add_test(NAME test_windows_deployqt_host_triplet_unset
+        COMMAND ${CMAKE_COMMAND} -DTEST_CASE=host-triplet-unset
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_windows_deployqt_host_triplet.cmake")
+set_tests_properties(test_windows_deployqt_host_triplet_unset PROPERTIES WILL_FAIL TRUE)
+
 set(TEST_LIBRARIES keepassxc_gui Qt6::Test)
 
 set(testsupport_SOURCES

--- a/tests/cmake/test_windows_deployqt_host_triplet.cmake
+++ b/tests/cmake/test_windows_deployqt_host_triplet.cmake
@@ -1,0 +1,25 @@
+# Regression test for kpxc_resolve_windows_deployqt_host_triplet() (see
+# cmake/KPXCWindowsDeployQt.cmake), which is required for locating windeployqt.exe
+# when cross-compiling for the arm64-windows target on an x64-windows host.
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/KPXCWindowsDeployQt.cmake")
+
+if(TEST_CASE STREQUAL "host-triplet-set")
+    # Native or cross builds alike: vcpkg's own VCPKG_HOST_TRIPLET must be used as-is.
+    set(VCPKG_HOST_TRIPLET "x64-windows")
+    kpxc_resolve_windows_deployqt_host_triplet(result)
+    if(NOT result STREQUAL "x64-windows")
+        message(FATAL_ERROR "Expected x64-windows, got: ${result}")
+    endif()
+elseif(TEST_CASE STREQUAL "host-triplet-arm64")
+    set(VCPKG_HOST_TRIPLET "arm64-windows")
+    kpxc_resolve_windows_deployqt_host_triplet(result)
+    if(NOT result STREQUAL "arm64-windows")
+        message(FATAL_ERROR "Expected arm64-windows, got: ${result}")
+    endif()
+elseif(TEST_CASE STREQUAL "host-triplet-unset")
+    # Must fail loudly rather than silently falling back to a possibly wrong triplet.
+    unset(VCPKG_HOST_TRIPLET)
+    kpxc_resolve_windows_deployqt_host_triplet(result)
+else()
+    message(FATAL_ERROR "Unknown TEST_CASE: ${TEST_CASE}")
+endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,6 +35,11 @@
           "platform": "linux | freebsd",
           "features": ["wayland"]
         },
+        {
+          "name": "qtbase",
+          "platform": "windows",
+          "features": ["windeployqt"]
+        },
         "qtdeclarative",
         "qtimageformats",
         "qtsvg",


### PR DESCRIPTION
## Status

**Minimal stacked draft on #13473.** This PR contains only the source-level Windows Arm64 changes required beyond `feature/qt-feature`.

After maintainer feedback, all GitHub workflow/validation scripts, cache instrumentation, GnuPG changes, test retries/timeouts, macOS changes, dependency trimming, custom release triplets, cross-volume handling, and upgrade harness code were removed.

## Scope: 8 files, one commit

- `release-tool.py`: map `--platform-target amd64|arm64` to built-in `x64-windows|arm64-windows`, preserving explicit user overrides; order app-local installation when Qt is built through vcpkg.
- `vcpkg.json`: request Windows `qtbase[windeployqt]`; all other #13473 Qt dependencies remain unchanged.
- `CMakeLists.txt` + `cmake/KPXCWindowsDeployQt.cmake`: use vcpkg's host triplet to locate `windeployqt.exe`; avoid copying when host/target triplets match; resolve a real vcpkg executable for runtime deployment. macOS behavior is unchanged.
- `src/CMakeLists.txt`: prevent duplicate build/install DLL copying, run `windeployqt` before explicit vcpkg app-local deployment, select debug/release DLL directories correctly, and fail closed on unknown Windows package architectures.
- `share/windows/wix-template.xml`: set InstallerVersion/PageCount 500 for Arm64 MSI support.
- `tests/CMakeLists.txt` + focused CMake script: cover x64, native Arm64, and missing host-triplet behavior.

Current diff: **8 files, +155/-12, one commit (`ff6c8f50`)**.

## Copilot review

The minimal branch was reviewed on fork PR https://github.com/yeelam-gordon/keepassxc/pull/3 using the `copilot-pr-autopilot` loop.

- Fixed non-Qt runtime DLL deployment ordering.
- Added fail-closed architecture fallback and debug/release app-local paths.
- Declined adding unsupported 32-bit packaging because KeePassXC's Windows release interface supports only amd64 and arm64.
- Final Copilot review at `dce2fb21` generated zero new comments with zero open threads.
- The reviewed tree was squashed without content changes to `ff6c8f50` (tree `dd755f9897d5ecbc94266312e2064549c0890920`).

## Validation

- Focused CMake tests pass for x64 host, native Arm64 host, and missing-host expected failure.
- Python, JSON, and XML syntax checks pass.
- `git diff --check` passes.

A broader verification branch previously proved native x64/Arm64 build, 45/45 tests, ZIP/MSI, PE architecture, CLI execution, install/uninstall, and x64-to-Arm64 upgrade in run https://github.com/yeelam-gordon/keepassxc/actions/runs/33249788933. This pruned stacked tree must still pass the repository's own CI before final review.

## Dependency on #13473

This PR intentionally targets #13473's `feature/qt-feature` branch. After #13473 merges, retarget/rebase this PR to `develop`; generic Qt-vcpkg changes are not duplicated here.

## Post-merge release work (not PR blockers)

Signing, publication, download-page updates, and broader physical-device smoke testing are normal maintainer release operations after source acceptance.

## AI disclosure and attribution

This work used GitHub Copilot CLI and the `copilot-pr-autopilot` review loop. All findings were fixed or explicitly declined with rationale before the reviewed tree was squashed to one commit. The commit credits Janek Bevendorff for #13473 and includes the Copilot co-author trailer.

Addresses #4022.