### PR TITLE
Reject invalid padding in Base32::decode

### DIFF
--- a/src/core/Base32.cpp
+++ b/src/core/Base32.cpp
@@ -53,11 +53,11 @@ QByteArray Base32::decode(const QByteArray& encodedData)
         return {};
     }
 
+    // Count the trailing run of pad characters only; a '=' anywhere else is
+    // not padding and is rejected below.
     int nPads = 0;
-    for (int i = -1; i > -7; --i) {
-        if ('=' == encodedData[encodedData.size() + i]) {
-            ++nPads;
-        }
+    while (nPads < encodedData.size() && '=' == encodedData[encodedData.size() - nPads - 1]) {
+        ++nPads;
     }
 
     int specialOffset;
@@ -80,9 +80,13 @@ QByteArray Base32::decode(const QByteArray& encodedData)
         nSpecialBytes = 1;
         specialOffset = 2;
         break;
-    default:
+    case 0:
         nSpecialBytes = 0;
         specialOffset = 0;
+        break;
+    default:
+        // RFC 4648 only allows 1, 3, 4 or 6 pad characters
+        return {};
     }
 
     Q_ASSERT(encodedData.size() > 0);
@@ -111,6 +115,10 @@ QByteArray Base32::decode(const QByteArray& encodedData)
                     ch += ALPH_POS_2;
                 } else {
                     if (ASCII_EQ == ch) {
+                        if (i <= encodedData.size() - nPads) {
+                            // '=' outside the trailing run of pad characters
+                            return {};
+                        }
                         if (i == encodedData.size()) {
                             // finished with special quantum
                             quantum >>= specialOffset;

--- a/tests/TestBase32.cpp
+++ b/tests/TestBase32.cpp
@@ -110,6 +110,25 @@ void TestBase32::testDecode()
     data = Base32::decode(encodedData);
     QVERIFY(data.isEmpty());
 
+    // error: pad count is not one of 1, 3, 4 or 6
+    encodedData = "MZXW6Y==";
+    data = Base32::decode(encodedData);
+    QVERIFY(data.isEmpty());
+
+    encodedData = "MZX=====";
+    data = Base32::decode(encodedData);
+    QVERIFY(data.isEmpty());
+
+    // error: whole final quantum is padding
+    encodedData = "MZXW6YTB========";
+    data = Base32::decode(encodedData);
+    QVERIFY(data.isEmpty());
+
+    // error: pad character outside the trailing padding
+    encodedData = "MZ=W6YQ=";
+    data = Base32::decode(encodedData);
+    QVERIFY(data.isEmpty());
+
     // RFC 4648 test vectors
     encodedData = "";
     data = Base32::decode(encodedData);


### PR DESCRIPTION
`Base32::decode()` counts pad characters by looking at the last six positions and accepting whatever number it finds:

```cpp
for (int i = -1; i > -7; --i) {
    if ('=' == encodedData[encodedData.size() + i]) { ++nPads; }
}
switch (nPads) { // in {0, 1, 3, 4, 6}
...
default:
    nSpecialBytes = 0;   // 2 and 5 land here as if unpadded
```

With two or five pad characters and a length that is still a multiple of 8, e.g. `MZXW6Y==`, the final `'='` sets `nQuantumBytes = nSpecialBytes = 0`. Then `offset` becomes `(0 - 1) * 8 == -8`, so `quint64(0xFF) << offset` shifts by a negative amount (UBSan: `shift exponent -8 is negative`), the write loop never runs, and the `QByteArray(nBytes, Qt::Uninitialized)` is returned with `nBytes - o` bytes never written. `Q_ASSERT(nBytes == o)` catches it in a debug build; a release build returns the uninitialised bytes. A `'='` that is not part of the trailing run (`MZ=W6YQ=`) reaches the same place, and `MZXW6YTB========` currently decodes to `"fooba\0"`.

Fix: count only the trailing run, reject counts RFC 4648 does not allow, and reject a `'='` outside that run.

**This is not reachable from the application.** Both `Base32::decode` call sites in `Totp.cpp` wrap the input in `Base32::sanitizeInput`, which strips `'='` entirely and re-pads to a count in {1,3,4,6}. Reported here as a defect in a public helper, not as a security issue.

## Testing strategy

Qt was not available to build locally, so `Base32.cpp` was compiled unmodified against a small `QByteArray` stand-in and driven directly. The harness first reproduces all 17 decode vectors already in `TestBase32.cpp` exactly, which is what makes the rest meaningful.

Over 109,873 inputs (encodings of random data at every length residue, plus random alphabet+`=` strings at lengths 8/16/24/32):

* 76,898 are accepted by Python's `base64.b32decode`. Patched output matches that reference on **76,898 of 76,898** — no regressions.
* 32,975 are rejected by it. The current code accepts **all** of them, firing `Q_ASSERT(nBytes == o)` on 4,810. Patched rejects all 32,975 and fires the assert 0 times.
* Through the real app path, `sanitizeInput` then `decode`, over 170,000 strings including mangled TOTP secrets (spaces, stripped padding, lowercase, `0/1/8` substitutions): **0 differing results**, so TOTP behaviour is unchanged.

Four cases added to `TestBase32::testDecode`. The existing negative tests only cover an illegal character and a wrong total length, both of which return before the padding logic, which is why this went unseen.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

Generative AI (Claude, Anthropic) was used to write this change.
