### PR TITLE
fix: Adding or Removing a tag from context menu or search bar doesn't create a new history entry

### DIFF
--- a/src/core/Database.cpp
+++ b/src/core/Database.cpp
@@ -838,7 +838,9 @@ void Database::removeTag(const QString& tag)
     }
 
     for (auto entry : m_rootGroup->entriesRecursive()) {
+        entry->beginUpdate();
         entry->removeTag(tag);
+        entry->endUpdate();
     }
 }
 

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -799,7 +799,9 @@ void DatabaseWidget::setTag(QAction* action)
     auto tag = action->text();
     auto state = action->isChecked();
     for (auto entry : m_entryView->selectedEntries()) {
+        entry->beginUpdate();
         state ? entry->addTag(tag) : entry->removeTag(tag);
+        entry->endUpdate();
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,6 +140,9 @@ add_unit_test(NAME testsharing SOURCES TestSharing.cpp
 add_unit_test(NAME testdatabase SOURCES TestDatabase.cpp
         LIBS testsupport ${TEST_LIBRARIES})
 
+add_unit_test(NAME testtags SOURCES TestTags.cpp
+        LIBS ${TEST_LIBRARIES})
+
 add_unit_test(NAME testtools SOURCES TestTools.cpp
         LIBS testsupport ${TEST_LIBRARIES})
 

--- a/tests/TestTags.cpp
+++ b/tests/TestTags.cpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2026 Brais Couce
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestTags.h"
+
+#include <QTest>
+
+#include "core/Database.h"
+#include "core/Entry.h"
+#include "core/Group.h"
+#include "crypto/Crypto.h"
+
+QTEST_GUILESS_MAIN(TestTags)
+
+void TestTags::initTestCase()
+{
+    QVERIFY(Crypto::init());
+    QLocale::setDefault(QLocale::c());
+}
+
+void TestTags::testRemoveTag()
+{
+    QScopedPointer<Database> db(new Database());
+    QVERIFY(db);
+
+    auto* entry = new Entry();
+    db->rootGroup()->addEntry(entry);
+    QCOMPARE(entry->historyItems().size(), 0);
+
+    entry->beginUpdate();
+    entry->setTags("tag");
+    entry->endUpdate();
+    QCOMPARE(entry->tagList(), QStringList({"tag"}));
+    QCOMPARE(entry->historyItems().size(), 1);
+
+    db->removeTag("tag");
+    QCOMPARE(entry->tagList().size(), 0);
+    QCOMPARE(entry->historyItems().size(), 2);
+}

--- a/tests/TestTags.h
+++ b/tests/TestTags.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2026 Brais Couce
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_TESTTAGS_H
+#define KEEPASSXC_TESTTAGS_H
+
+#include <QObject>
+
+class TestTags : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void testRemoveTag();
+};
+
+#endif // KEEPASSXC_TESTTAGS_H


### PR DESCRIPTION
Fixes #13435

The fix is similar to the solution of an old issue with the TOTP setup (#1445, commit 17e3f1c2).

My first approach was to fix this directly in the implementation of `Entry::addTag` and `Entry::removeTag` but this breaks the addition of passkeys to the entries. This is because `addPasskeyToEntry` adds the special tag "Passkey" inside an existing update block. This scenario is covered by the existing unit tests (they failed with my first approach). Due to this, I add the fix in the places where `addTag` and `removeTag` is used. This is also done for other modifications.


[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )


## Screenshots
[NOTE]: # ( Do not include screenshots of your actual database! )
[TIP]:  # ( Use View -> Allow Screen Capture )


## Testing strategy

Manually checked the history item size after adding and removing tags from the contextual menu and also after removing the tags from the search section.

Added new tests for the scenario of removing tags from the search section.

[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )


## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)
