### PR TITLE
Fix hiding KeePassXC to system tray on macOS

### DIFF
--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -672,6 +672,7 @@ QJsonObject BrowserService::showPasskeysRegisterPrompt(const QJsonObject& public
             browserPasskeys()->buildRegisterPublicKeyCredential(credentialCreationOptions);
         if (publicKeyCredentials.credentialId.isEmpty() || publicKeyCredentials.key.isEmpty()
             || publicKeyCredentials.response.isEmpty()) {
+            hideWindow();
             return getPasskeyError(ERROR_PASSKEYS_UNKNOWN_ERROR);
         }
 
@@ -693,6 +694,7 @@ QJsonObject BrowserService::showPasskeysRegisterPrompt(const QJsonObject& public
                                                                      tr("Register a new passkey to this entry:"),
                                                                      tr("Register"));
                 if (!result) {
+                    hideWindow();
                     return getPasskeyError(ERROR_PASSKEYS_REQUEST_CANCELED);
                 }
             } else {
@@ -1660,7 +1662,11 @@ void BrowserService::hideWindow() const
         if (m_prevWindowState == WindowState::Hidden) {
             macUtils()->hideOwnWindow();
         } else {
-            macUtils()->raiseLastActiveWindow();
+            if (m_prevWindowState == WindowState::HiddenInSystemTray) {
+                getMainWindow()->hideWindow();
+            } else {
+                macUtils()->raiseLastActiveWindow();
+            }
         }
 #else
         if (m_prevWindowState == WindowState::Hidden) {
@@ -1683,6 +1689,8 @@ void BrowserService::raiseWindow(const bool force)
 
     if (macUtils()->isHidden()) {
         m_prevWindowState = WindowState::Hidden;
+    } else if (getMainWindow()->isMinimizedToSystemTray()) {
+        m_prevWindowState = WindowState::HiddenInSystemTray;
     }
     macUtils()->raiseOwnWindow();
     Tools::wait(500);
@@ -1706,6 +1714,8 @@ void BrowserService::updateWindowState()
 #ifdef Q_OS_MACOS
     if (macUtils()->isHidden()) {
         m_prevWindowState = WindowState::Hidden;
+    } else if (getMainWindow()->isMinimizedToSystemTray()) {
+        m_prevWindowState = WindowState::HiddenInSystemTray;
     }
 #else
     if (getMainWindow()->isHidden()) {

--- a/src/browser/BrowserService.h
+++ b/src/browser/BrowserService.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2017 Sami Vänttinen <sami.vanttinen@protonmail.com>
  *  Copyright (C) 2013 Francois Ferrand
  *
@@ -160,7 +160,8 @@ private:
     {
         Normal,
         Minimized,
-        Hidden
+        Hidden,
+        HiddenInSystemTray
     };
 
     QList<Entry*> searchEntries(const QSharedPointer<Database>& db,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -1785,6 +1785,7 @@ void MainWindow::hideWindow()
         if (QGuiApplication::platformName() != "xcb" && QGuiApplication::platformName() != "cocoa") {
             setWindowState(windowState() | Qt::WindowMinimized);
         }
+        m_minimizedToSystemTray = true;
         hide();
     } else {
         showMinimized();
@@ -1864,11 +1865,17 @@ void MainWindow::hideYubiKeyPopup()
 
 void MainWindow::bringToFront()
 {
+    m_minimizedToSystemTray = false;
     ensurePolished();
     setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
     show();
     raise();
     activateWindow();
+}
+
+bool MainWindow::isMinimizedToSystemTray()
+{
+    return m_minimizedToSystemTray;
 }
 
 void MainWindow::handleScreenLock()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 KeePassXC Team <team@keepassxc.org>
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
  *  Copyright (C) 2010 Felix Geyer <debfx@fobos.de>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -91,6 +91,7 @@ public slots:
     void minimizeOrHide();
     void toggleWindow();
     void bringToFront();
+    bool isMinimizedToSystemTray();
     void closeAllDatabases();
     void lockAllDatabases();
     void closeModalWindow();
@@ -199,6 +200,7 @@ private:
     bool m_contextMenuFocusLock = false;
     bool m_showToolbarSeparator = false;
     bool m_allowScreenCapture = false;
+    bool m_minimizedToSystemTray = false;
     qint64 m_lastFocusOutTime = 0;
     qint64 m_lastShowTime = 0;
     QTimer m_updateCheckTimer;


### PR DESCRIPTION
[NOTE]: # ( Describe your changes in detail. Explain large or complex code modifications. )
[NOTE]: # ( If it fixes an open issue, please add "Fixes #XXX". )
[NOTE]: # ( If you used Generative AI to write the majority of your code, you must state this. )
Fixes raising and hiding the KeePassXC application window on macOS with all three scenarios:
- Minimized to the Dock using the yellow minimize button from the window buttons (window is added to the minimized section to the Dock, next to the recycle bin).
- Minimized to the system tray (no Dock icon visible), if system tray icon is used, and hide to system tray option is enabled.
- Hidden (icon stays in the Dock in its normal place).

The behavior is seen when raising both Access Confirm Dialog, or passkey register/authentication dialog, and then hiding them.

* Fixes #13589

## Testing strategy
[NOTE]: # ( Please describe in detail how you tested your changes. )
[TIP]:  # ( We expect new code to be covered by unit tests and include helpful comments. )
Test all three scenarios described above. For the system tray one, these settings must be enabled in KeePassXC:
- Minimize window at application startup
- Minimize window after unlocking database
- Show system tray icon
- Hide window to system tray when minimized

## Type of change
[NOTE]: # ( Please remove all lines which don't apply. )
- ✅ Bug fix (non-breaking change that fixes an issue)