### PR TITLE
Auto-Type into the Windows credential prompt via a uiAccess helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,14 @@ endif()
 option(KPXC_FEATURE_NETWORK "Include code that reaches out to external networks (e.g. downloading icons)" ON)
 option(KPXC_FEATURE_UPDATES "Include automatic update checks; disable for managed distributions" ON)
 option(KPXC_FEATURE_DOCS "Build offline documentation; requires asciidoctor tool" ON)
+# Windows only, and MSVC only: the helper needs an embedded manifest carrying
+# uiAccess, which is how a process becomes exempt from UIPI without being
+# elevated. Without it Auto-Type behaves as before and cannot reach credential
+# prompts.
+option(KPXC_FEATURE_UIACCESS_HELPER "Build the uiAccess helper used to Auto-Type into credential prompts" ON)
+if(NOT WIN32)
+    set(KPXC_FEATURE_UIACCESS_HELPER OFF)
+endif()
 
 # Reconcile update feature with overall network feature
 if(NOT KPXC_FEATURE_NETWORK AND KPXC_FEATURE_UPDATES)

--- a/share/windows/wix-template.xml
+++ b/share/windows/wix-template.xml
@@ -139,8 +139,8 @@
         <Property Id="WixQuietExecCmdLine" Value='"[SystemFolder]taskkill.exe" /IM KeePassXC.exe' />
         <CustomAction Id="KillKeePassXC" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="ignore" />
 
-        <!-- Action to kill running keepassxc-proxy processes -->
-        <Property Id="WixSilentExecCmdLine" Value='"[SystemFolder]taskkill.exe" /IM keepassxc-proxy.exe /F' />
+        <!-- Action to kill running keepassxc-proxy and keepassxc-uiaccess-helper processes -->
+        <Property Id="WixSilentExecCmdLine" Value='"[SystemFolder]taskkill.exe" /IM keepassxc-proxy.exe /IM keepassxc-uiaccess-helper.exe /F' />
         <CustomAction Id="KillKeePassXCProxy" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="ignore" />
 
         <InstallExecuteSequence>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,6 +323,7 @@ add_subdirectory(cli)
 add_subdirectory(thirdparty)
 
 add_subdirectory(autotype)
+add_subdirectory(uiaccess-helper)
 set(autotype_LIB autotype)
 
 # TODO: Refactor to gui sources

--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -21,6 +21,9 @@
 #include <QApplication>
 #include <QDebug>
 #include <QRegularExpression>
+#if defined(Q_OS_WIN32)
+#include <QScopeGuard>
+#endif
 
 #include "config-keepassx.h"
 
@@ -344,40 +347,66 @@ void AutoType::executeAutoTypeActions(const Entry* entry,
         window = m_platform->activeWindow();
     }
 
-    for (const auto& action : asConst(actions)) {
-        // Cancel Auto-Type if the active window changed
-        if (m_platform->activeWindow() != window) {
-            qWarning("Active window changed, interrupting auto-type.");
-            break;
-        }
+    // Scoped: on Windows the helper is torn down before the lock is released and
+    // autotypeFinished() fires, so a synchronously started next sequence is not
+    // torn down by this guard.
+    {
+#if defined(Q_OS_WIN32)
+        // The first point at which the target is known on both paths.
+        m_platform->beginSequence(window);
+        // Guarded: the loop pumps events and can be left through a nested loop or a quit.
+        bool ended = false;
+        const QScopeGuard endSequence = qScopeGuard([this, &ended] {
+            if (!ended) {
+                m_platform->endSequence();
+            }
+        });
+#endif
 
-        bool failed = false;
-        constexpr int max_retries = 5;
-        for (int i = 1; i <= max_retries; i++) {
-            auto result = action->exec(m_platform->executor());
-
-            QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
-
-            if (result.isOk()) {
+        for (const auto& action : asConst(actions)) {
+            // Cancel Auto-Type if the active window changed
+            if (m_platform->activeWindow() != window) {
+                qWarning("Active window changed, interrupting auto-type.");
                 break;
             }
 
-            if (!result.canRetry() || i == max_retries) {
-                if (getMainWindow()) {
-                    MessageBox::critical(getMainWindow(), tr("Auto-Type Error"), result.errorString());
+            bool failed = false;
+            constexpr int max_retries = 5;
+            for (int i = 1; i <= max_retries; i++) {
+                auto result = action->exec(m_platform->executor());
+
+                QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+
+                if (result.isOk()) {
+                    break;
                 }
-                failed = true;
-                break;
+
+                if (!result.canRetry() || i == max_retries) {
+                    if (getMainWindow()) {
+                        MessageBox::critical(getMainWindow(), tr("Auto-Type Error"), result.errorString());
+                    }
+                    failed = true;
+                    break;
+                }
+
+                // Retry wait delay
+                Tools::wait(100);
             }
 
-            // Retry wait delay
-            Tools::wait(100);
+            // Last action failed to complete, cancel the rest of the sequence
+            if (failed) {
+                break;
+            }
         }
 
-        // Last action failed to complete, cancel the rest of the sequence
-        if (failed) {
-            break;
+#if defined(Q_OS_WIN32)
+        // Explicit so the result can be shown; the guard covers the other exits.
+        ended = true;
+        const auto endResult = m_platform->endSequence();
+        if (!endResult.isOk() && getMainWindow()) {
+            MessageBox::critical(getMainWindow(), tr("Auto-Type Error"), endResult.errorString());
         }
+#endif
     }
 
     m_inAutoType.unlock();

--- a/src/autotype/AutoTypePlatform.h
+++ b/src/autotype/AutoTypePlatform.h
@@ -44,6 +44,20 @@ public:
     {
     }
 
+#if defined(Q_OS_WIN32)
+    // Called once the target window is known. Distinct from prepareAutoType(),
+    // which carries no window, and raiseWindow(), which the entry-level path skips.
+    virtual void beginSequence(WId window)
+    {
+        Q_UNUSED(window);
+    }
+    // Called when the sequence is over. May report a failure only the teardown can know.
+    virtual AutoTypeAction::Result endSequence()
+    {
+        return AutoTypeAction::Result::Ok();
+    }
+#endif
+
     virtual AutoTypeExecutor& executor() const = 0;
 
 #if defined(Q_OS_MACOS)

--- a/src/autotype/CMakeLists.txt
+++ b/src/autotype/CMakeLists.txt
@@ -35,6 +35,10 @@ elseif(APPLE)
 elseif(WIN32)
     list(APPEND autotype_SOURCES
             windows/AutoTypeWindows.cpp)
+    if(KPXC_FEATURE_UIACCESS_HELPER)
+        list(APPEND autotype_SOURCES
+                windows/UiAccessInjector.cpp)
+    endif()
 endif()
 
 add_library(autotype STATIC ${autotype_SOURCES})
@@ -47,4 +51,11 @@ if(UNIX AND NOT APPLE AND NOT HAIKU)
     endif()
 elseif(APPLE)
     target_link_libraries(autotype "-framework Foundation" "-framework AppKit" "-framework Carbon" "-framework ScreenCaptureKit")
+elseif(WIN32)
+    # shell32: ShellExecuteEx, the only way to start a uiAccess binary.
+    target_link_libraries(autotype shell32 advapi32)
+    if(MINGW)
+        # FOLDERID_* GUIDs used by UiAccessInjector live in libuuid on MinGW.
+        target_link_libraries(autotype uuid)
+    endif()
 endif()

--- a/src/autotype/windows/AutoTypeWindows.cpp
+++ b/src/autotype/windows/AutoTypeWindows.cpp
@@ -17,6 +17,10 @@
  */
 
 #include "AutoTypeWindows.h"
+#include "core/Config.h"
+#ifdef KPXC_FEATURE_UIACCESS_HELPER
+#include "UiAccessInjector.h"
+#endif
 #include "core/Tools.h"
 #include "gui/osutils/OSUtils.h"
 #include "gui/osutils/winutils/WinUtils.h"
@@ -33,8 +37,14 @@
 //
 AutoTypePlatformWin::AutoTypePlatformWin()
     : m_executor(new AutoTypeExecutorWin(this))
+#ifdef KPXC_FEATURE_UIACCESS_HELPER
+    , m_injector(new UiAccessInjector)
+#endif
 {
 }
+
+// Out of line so QScopedPointer sees the complete UiAccessInjector.
+AutoTypePlatformWin::~AutoTypePlatformWin() = default;
 
 //
 // Test if os version is Windows 7 or later
@@ -88,6 +98,95 @@ bool AutoTypePlatformWin::raiseWindow(WId window)
 }
 
 //
+// Delegation for the sequence about to be typed. Without a helper: ::SendInput, as before.
+//
+void AutoTypePlatformWin::beginSequence(WId window)
+{
+#ifndef KPXC_FEATURE_UIACCESS_HELPER
+    Q_UNUSED(window);
+#else
+    if (!m_injector) {
+        return;
+    }
+    HWND hwnd = reinterpret_cast<HWND>(window);
+    m_injector->end();
+    m_delegating = false;
+    m_delegationFailed = false;
+    if (!UiAccessInjector::isBrokeredCredentialDialog(hwnd)) {
+        return;
+    }
+    if (!config()->get(Config::Security_AutoTypeCredentialPrompts).toBool()) {
+        qWarning("Auto-Type: this window only accepts input from a privileged process; set "
+                 "Security/AutoTypeCredentialPrompts to allow delegating to the uiAccess helper");
+        return;
+    }
+    m_delegating = m_injector->begin(hwnd);
+    if (!m_delegating) {
+        qWarning("Auto-Type: this window only accepts input from a privileged process, "
+                 "and no uiAccess helper is available");
+    }
+#endif
+}
+
+AutoTypeAction::Result AutoTypePlatformWin::endSequence()
+{
+    const bool failed = m_delegating && m_delegationFailed;
+    const bool delegated = m_delegating;
+    m_delegating = false;
+    m_delegationFailed = false;
+    auto result = AutoTypeAction::Result::Ok();
+#ifdef KPXC_FEATURE_UIACCESS_HELPER
+    if (m_injector) {
+        m_injector->end();
+        // A failure only the helper's exit could report, shown once; a loop that
+        // stopped on the same failure has already shown its message.
+        if (delegated && !failed && m_injector->helperFailed()) {
+            result = AutoTypeAction::Result::Failed(
+                QObject::tr("Auto-Type was interrupted: the privileged helper did not deliver all keystrokes"));
+        }
+        // The helper releases its own modifiers on every abort; this covers one that
+        // died or was terminated. Best effort: UIPI drops it while the prompt holds
+        // the foreground. No Windows key, for the same reason the helper has none.
+        if (failed || m_injector->helperFailed()) {
+            for (const auto key : {Qt::Key_Shift, Qt::Key_Control, Qt::Key_Alt, Qt::Key_AltGr}) {
+                setKeyState(key, false);
+            }
+        }
+    }
+#else
+    Q_UNUSED(delegated);
+    Q_UNUSED(failed);
+#endif
+    return result;
+}
+
+//
+// Single exit for injected input. Delegation is per sequence: no fallback to
+// ::SendInput, which would type the rest into whatever holds the foreground.
+//
+bool AutoTypePlatformWin::sendInputs(INPUT* inputs, int count)
+{
+    if (!m_delegating) {
+        return ::SendInput(count, inputs, sizeof(INPUT)) == static_cast<UINT>(count);
+    }
+#ifdef KPXC_FEATURE_UIACCESS_HELPER
+    if (m_injector && m_injector->active() && m_injector->send(inputs, count)) {
+        return true;
+    }
+    // Target lost the foreground: the same silent stop a sequence without a helper
+    // gets when the active window changes. Everything else is a failure, once.
+    if (m_injector && m_injector->interrupted()) {
+        return false;
+    }
+    if (!m_delegationFailed) {
+        m_delegationFailed = true;
+        qWarning("Auto-Type: the uiAccess helper stopped accepting input, so the sequence was cut short");
+    }
+#endif
+    return false;
+}
+
+//
 // Send unicode character to foreground window
 //
 void AutoTypePlatformWin::sendChar(const QChar& ch)
@@ -103,7 +202,7 @@ void AutoTypePlatformWin::sendChar(const QChar& ch)
     in[1] = in[0];
     in[1].ki.dwFlags |= KEYEVENTF_KEYUP;
 
-    ::SendInput(2, &in[0], sizeof(INPUT));
+    sendInputs(&in[0], 2);
 }
 
 void AutoTypePlatformWin::sendCharVirtual(const QChar& ch)
@@ -140,7 +239,7 @@ void AutoTypePlatformWin::sendCharVirtual(const QChar& ch)
     in[1] = in[0];
     in[1].ki.dwFlags |= KEYEVENTF_KEYUP;
 
-    ::SendInput(2, &in[0], sizeof(INPUT));
+    sendInputs(&in[0], 2);
 
     if (HIBYTE(vKey) & 0x6) {
         setKeyState(Qt::Key_AltGr, false);
@@ -179,7 +278,7 @@ void AutoTypePlatformWin::setKeyState(Qt::Key key, bool down)
     in.ki.time = 0;
     in.ki.dwExtraInfo = ::GetMessageExtraInfo();
 
-    ::SendInput(1, &in, sizeof(INPUT));
+    sendInputs(&in, 1);
 }
 
 //
@@ -287,6 +386,17 @@ AutoTypeAction::Result AutoTypeExecutorWin::execBegin(const AutoTypeBegin* actio
     return AutoTypeAction::Result::Ok();
 }
 
+// The senders are void; this is where a delegated sequence that stopped
+// part-way becomes a failure.
+AutoTypeAction::Result AutoTypePlatformWin::sequenceResult() const
+{
+    if (m_delegationFailed) {
+        return AutoTypeAction::Result::Failed(
+            QObject::tr("Auto-Type was interrupted: the privileged helper stopped accepting input"));
+    }
+    return AutoTypeAction::Result::Ok();
+}
+
 AutoTypeAction::Result AutoTypeExecutorWin::execType(const AutoTypeKey* action)
 {
     if (action->modifiers & Qt::ShiftModifier) {
@@ -327,7 +437,7 @@ AutoTypeAction::Result AutoTypeExecutorWin::execType(const AutoTypeKey* action)
     }
 
     Tools::sleep(execDelayMs);
-    return AutoTypeAction::Result::Ok();
+    return m_platform->sequenceResult();
 }
 
 AutoTypeAction::Result AutoTypeExecutorWin::execClearField(const AutoTypeClearField* action)
@@ -336,5 +446,5 @@ AutoTypeAction::Result AutoTypeExecutorWin::execClearField(const AutoTypeClearFi
     execType(new AutoTypeKey(Qt::Key_Home, Qt::ControlModifier));
     execType(new AutoTypeKey(Qt::Key_End, Qt::ControlModifier | Qt::ShiftModifier));
     execType(new AutoTypeKey(Qt::Key_Backspace));
-    return AutoTypeAction::Result::Ok();
+    return m_platform->sequenceResult();
 }

--- a/src/autotype/windows/AutoTypeWindows.h
+++ b/src/autotype/windows/AutoTypeWindows.h
@@ -27,7 +27,14 @@
 #include "autotype/AutoTypeAction.h"
 #include "autotype/AutoTypePlatform.h"
 
+#include <QScopedPointer>
+
 class WinUtils;
+#include "config-keepassx.h"
+
+#ifdef KPXC_FEATURE_UIACCESS_HELPER
+class UiAccessInjector;
+#endif
 
 class AutoTypePlatformWin : public QObject, public AutoTypePlatformInterface
 {
@@ -35,11 +42,16 @@ class AutoTypePlatformWin : public QObject, public AutoTypePlatformInterface
 
 public:
     explicit AutoTypePlatformWin();
+    // In the .cpp: QScopedPointer needs the complete type there.
+    ~AutoTypePlatformWin() override;
     bool isAvailable() override;
     QStringList windowTitles() override;
     WId activeWindow() override;
     QString activeWindowTitle() override;
     bool raiseWindow(WId window) override;
+    // Decided here rather than in raiseWindow; see AutoTypePlatform.h.
+    void beginSequence(WId window) override;
+    AutoTypeAction::Result endSequence() override;
     AutoTypeExecutor& executor() const override;
 
     void sendCharVirtual(const QChar& ch);
@@ -48,6 +60,21 @@ public:
 
 private:
     AutoTypeExecutor* m_executor = nullptr;
+#ifdef KPXC_FEATURE_UIACCESS_HELPER
+    // Inactive when no helper is available. See UiAccessInjector.
+    QScopedPointer<UiAccessInjector> m_injector;
+#endif
+    // Per sequence; no fallback to ::SendInput once delegated.
+    bool m_delegating = false;
+    bool m_delegationFailed = false;
+
+public:
+    /** Ok, or a failure when a delegated sequence stopped part-way. */
+    AutoTypeAction::Result sequenceResult() const;
+
+private:
+    // The single exit for injected input.
+    bool sendInputs(INPUT* inputs, int count);
 
     static bool isExtendedKey(DWORD nativeKeyCode);
     static bool isAltTabWindow(HWND hwnd);

--- a/src/autotype/windows/UiAccessInjector.cpp
+++ b/src/autotype/windows/UiAccessInjector.cpp
@@ -1,0 +1,432 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "UiAccessInjector.h"
+
+#include "config-keepassx.h"
+#include "core/Tools.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QUuid>
+
+#include <cstring>
+
+#include <sddl.h>
+#include <shellapi.h>
+#include <shlobj.h>
+
+namespace
+{
+    // A constant, not #ifdef: compiling the body out would leave unused static functions (-Werror).
+#ifdef KPXC_FEATURE_UIACCESS_HELPER
+    constexpr bool s_featureEnabled = true;
+#else
+    constexpr bool s_featureEnabled = false;
+#endif
+
+    const char* s_credentialDialogClass = "Credential Dialog Xaml Host";
+    const char* s_brokerImage = "CredentialUIBroker.exe";
+
+    /* One ACE for this user's SID, protected against inherited ACEs. The pipe name
+     * travels on the command line, so the binding rests on the identity checks at
+     * both ends, not on the name. */
+    QString currentUserDacl()
+    {
+        HANDLE token = nullptr;
+        if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY, &token)) {
+            return {};
+        }
+        DWORD size = 0;
+        ::GetTokenInformation(token, TokenUser, nullptr, 0, &size);
+        QByteArray buffer(static_cast<int>(size), 0);
+        QString sddl;
+        if (::GetTokenInformation(token, TokenUser, buffer.data(), size, &size)) {
+            LPWSTR sid = nullptr;
+            const auto* user = reinterpret_cast<const TOKEN_USER*>(buffer.constData());
+            if (::ConvertSidToStringSidW(user->User.Sid, &sid)) {
+                sddl = QStringLiteral("D:P(A;;GA;;;%1)").arg(QString::fromWCharArray(sid));
+                ::LocalFree(sid);
+            }
+        }
+        ::CloseHandle(token);
+        return sddl;
+    }
+
+    /* The directories Windows grants uiAccess from; a standard user cannot write to them. */
+    bool inUiAccessLocation(const QString& directory)
+    {
+        // From the OS, not the environment: %ProgramFiles% is settable by the launcher.
+        QStringList roots;
+        for (const auto& id : {FOLDERID_ProgramFilesX64, FOLDERID_ProgramFilesX86, FOLDERID_ProgramFiles}) {
+            PWSTR folder = nullptr;
+            if (SUCCEEDED(::SHGetKnownFolderPath(id, KF_FLAG_DEFAULT, nullptr, &folder))) {
+                roots << QString::fromWCharArray(folder);
+                ::CoTaskMemFree(folder);
+            }
+        }
+        // Not GetSystemDirectoryW: redirected to SysWOW64 for a 32-bit process.
+        wchar_t windows[MAX_PATH] = {0};
+        const UINT length = ::GetWindowsDirectoryW(windows, MAX_PATH);
+        if (length > 0 && length < MAX_PATH) {
+            roots << QDir(QString::fromWCharArray(windows)).filePath(QStringLiteral("System32"));
+        }
+        // Canonical first: cleanPath does not expand an 8.3 alias.
+        const auto resolved = QFileInfo(directory).canonicalFilePath();
+        const auto path = QDir::cleanPath(resolved.isEmpty() ? directory : resolved) + QLatin1Char('/');
+        for (const auto& root : roots) {
+            if (root.isEmpty()) {
+                continue;
+            }
+            const auto prefix = QDir::cleanPath(root) + QLatin1Char('/');
+            if (path.startsWith(prefix, Qt::CaseInsensitive)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    QString processImagePath(DWORD pid)
+    {
+        HANDLE process = ::OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+        if (!process) {
+            return {};
+        }
+        wchar_t path[MAX_PATH] = {0};
+        DWORD size = MAX_PATH;
+        QString image;
+        if (::QueryFullProcessImageNameW(process, 0, path, &size)) {
+            image = QDir::fromNativeSeparators(QString::fromWCharArray(path, size));
+        }
+        ::CloseHandle(process);
+        return image;
+    }
+
+    /** The full path the real credential broker runs from, or empty. */
+    QString brokerImagePath()
+    {
+        wchar_t windows[MAX_PATH] = {0};
+        const UINT length = ::GetWindowsDirectoryW(windows, MAX_PATH);
+        if (length == 0 || length >= MAX_PATH) {
+            return {};
+        }
+        return QDir(QString::fromWCharArray(windows))
+            .filePath(QStringLiteral("System32/%1").arg(QLatin1String(s_brokerImage)));
+    }
+} // namespace
+
+UiAccessInjector::~UiAccessInjector()
+{
+    end();
+}
+
+QString UiAccessInjector::helperPath()
+{
+    if (!s_featureEnabled) {
+        return {};
+    }
+    // Beside the application only; a second location could yield a writable copy.
+    const auto helper =
+        QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("keepassxc-uiaccess-helper.exe"));
+    if (!QFileInfo::exists(helper)) {
+        return {};
+    }
+    // A writable install (portable ZIP, build tree) cannot hold a trusted helper.
+    if (!inUiAccessLocation(QCoreApplication::applicationDirPath())) {
+        qWarning("Auto-Type: not delegating to a uiAccess helper outside a protected location");
+        return {};
+    }
+    return QDir::toNativeSeparators(helper);
+}
+
+bool UiAccessInjector::isBrokeredCredentialDialog(HWND window)
+{
+    if (!window) {
+        return false;
+    }
+    wchar_t className[256] = {0};
+    if (::GetClassNameW(window, className, 255) <= 0) {
+        return false;
+    }
+    if (QString::fromWCharArray(className) != QLatin1String(s_credentialDialogClass)) {
+        return false;
+    }
+    // The class alone matches a look-alike in any process: the owner must be the
+    // broker in System32. The helper repeats this check.
+    DWORD pid = 0;
+    ::GetWindowThreadProcessId(window, &pid);
+    const auto expected = brokerImagePath();
+    if (expected.isEmpty()) {
+        return false;
+    }
+    return processImagePath(pid).compare(expected, Qt::CaseInsensitive) == 0;
+}
+
+bool UiAccessInjector::begin(HWND target)
+{
+    m_helperFailed = false;
+    m_interrupted = false;
+    if (active() && m_target == target) {
+        return true;
+    }
+    end();
+
+    const auto helper = helperPath();
+    if (helper.isEmpty()) {
+        return false;
+    }
+
+    const auto name = QStringLiteral("keepassxc-uiaccess-%1").arg(QUuid::createUuid().toString(QUuid::Id128));
+    const auto pipeName = QStringLiteral("\\\\.\\pipe\\%1").arg(name);
+
+    const auto sddl = currentUserDacl();
+    if (sddl.isEmpty()) {
+        return false;
+    }
+    PSECURITY_DESCRIPTOR descriptor = nullptr;
+    if (!::ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            reinterpret_cast<LPCWSTR>(sddl.utf16()), SDDL_REVISION_1, &descriptor, nullptr)) {
+        return false;
+    }
+    SECURITY_ATTRIBUTES attributes{};
+    attributes.nLength = sizeof(attributes);
+    attributes.lpSecurityDescriptor = descriptor;
+
+    // FIRST_PIPE_INSTANCE: fail rather than join an existing object. One instance.
+    // Duplex: the helper answers each batch with one byte.
+    m_pipe = ::CreateNamedPipeW(reinterpret_cast<LPCWSTR>(pipeName.utf16()),
+                                PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                                PIPE_TYPE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+                                1,
+                                sizeof(DWORD) + 64 * sizeof(INPUT),
+                                16,
+                                5000,
+                                &attributes);
+    ::LocalFree(descriptor);
+    if (m_pipe == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    // ShellExecuteEx: the uiAccess grant comes from AppInfo, which CreateProcess
+    // does not consult (ERROR_ELEVATION_REQUIRED). Nothing is inherited.
+    const auto arguments = QStringLiteral("--pipe %1 --target %2").arg(name).arg(reinterpret_cast<quintptr>(target));
+
+    SHELLEXECUTEINFOW info{};
+    info.cbSize = sizeof(info);
+    info.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC;
+    info.lpVerb = L"open";
+    info.lpFile = reinterpret_cast<LPCWSTR>(helper.utf16());
+    info.lpParameters = reinterpret_cast<LPCWSTR>(arguments.utf16());
+    // Must not take the foreground from the target.
+    info.nShow = SW_HIDE;
+
+    // Success with a null hProcess leaves no pid to admit and no exit code to read.
+    if (!::ShellExecuteExW(&info) || !info.hProcess) {
+        end();
+        return false;
+    }
+    m_process = info.hProcess;
+
+    if (!waitForHelper()) {
+        end();
+        return false;
+    }
+
+    m_target = target;
+    return true;
+}
+
+bool UiAccessInjector::waitForHelper()
+{
+    // Non-blocking so the wait has a deadline: ConnectNamedPipe returns
+    // ERROR_PIPE_LISTENING until a client arrives.
+    DWORD mode = PIPE_TYPE_BYTE | PIPE_NOWAIT;
+    if (!::SetNamedPipeHandleState(m_pipe, &mode, nullptr, nullptr)) {
+        return false;
+    }
+
+    const DWORD helperPid = m_process ? ::GetProcessId(m_process) : 0;
+    bool connected = false;
+    // Wall clock, not iterations: a client reconnecting in a loop must not spend the budget.
+    const ULONGLONG deadline = ::GetTickCount64() + s_helperConnectTimeoutMs;
+    while (::GetTickCount64() < deadline) {
+        if (::ConnectNamedPipe(m_pipe, nullptr) || ::GetLastError() == ERROR_PIPE_CONNECTED) {
+            // Only the process that was started: the name is readable from its command line.
+            DWORD clientPid = 0;
+            if (::GetNamedPipeClientProcessId(m_pipe, &clientPid) && clientPid == helperPid) {
+                connected = true;
+                break;
+            }
+            // Dropped, not fatal: after the disconnect the pipe listens again
+            // (ConnectNamedPipe reports ERROR_PIPE_LISTENING until the next client).
+            ::DisconnectNamedPipe(m_pipe);
+            Tools::wait(s_helperConnectPollMs);
+            continue;
+        }
+        if (::GetLastError() != ERROR_PIPE_LISTENING) {
+            return false;
+        }
+        // A helper that exited has refused (no uiAccess).
+        if (m_process && ::WaitForSingleObject(m_process, 0) == WAIT_OBJECT_0) {
+            return false;
+        }
+        // Pumped: this runs on the GUI thread.
+        Tools::wait(s_helperConnectPollMs);
+    }
+    if (!connected) {
+        return false;
+    }
+
+    // Left non-blocking: every wait below is bounded and pumped.
+    return true;
+}
+
+bool UiAccessInjector::active() const
+{
+    return m_pipe != INVALID_HANDLE_VALUE && m_target;
+}
+
+bool UiAccessInjector::send(const INPUT* inputs, int count)
+{
+    if (!active() || count <= 0 || count > 64) {
+        return false;
+    }
+    const DWORD records = static_cast<DWORD>(count);
+    const DWORD bytes = records * static_cast<DWORD>(sizeof(INPUT));
+
+    // One write: a header sent alone could leave the helper waiting on a body.
+    char message[sizeof(DWORD) + 64 * sizeof(INPUT)];
+    ::memcpy(message, &records, sizeof(records));
+    ::memcpy(message + sizeof(records), inputs, bytes);
+    const DWORD size = static_cast<DWORD>(sizeof(records) + bytes);
+
+    // NOWAIT byte mode: a full buffer returns TRUE with fewer bytes written (0 or
+    // partial); a closed client fails with ERROR_NO_DATA. Resume what did not
+    // finish -- the helper reads whole messages -- and treat any failure as
+    // final. Bounded by s_sendRetryMs.
+    DWORD offset = 0;
+    bool sent = false;
+    const ULONGLONG deadline = ::GetTickCount64() + s_sendRetryMs;
+    for (;;) {
+        DWORD written = 0;
+        if (!::WriteFile(m_pipe, message + offset, size - offset, &written, nullptr)) {
+            break;
+        }
+        offset += written;
+        if (offset == size) {
+            sent = true;
+            break;
+        }
+        if (::GetTickCount64() >= deadline) {
+            break;
+        }
+        ::Sleep(5);
+    }
+    // The buffer held a password.
+    ::SecureZeroMemory(message, sizeof(message));
+    if (!sent) {
+        end();
+        return false;
+    }
+    // The helper answers once the batch is injected. Waiting for it keeps the
+    // caller's pacing real, puts a dropped batch at the keystroke that dropped it,
+    // and leaves nothing unread when the sequence ends.
+    const char reply = awaitReply();
+    if (reply == 'A') {
+        return true;
+    }
+    if (reply == 'F') {
+        // Target lost the foreground: the sequence stops, as it does without a
+        // helper when the active window changes. Not a failure.
+        m_interrupted = true;
+    } else {
+        qWarning("Auto-Type: the uiAccess helper did not confirm a batch (%s)",
+                 reply == 'S' ? "SendInput dropped part of it"
+                 : reply      ? "unexpected reply"
+                              : "no reply in time");
+    }
+    end();
+    return false;
+}
+
+char UiAccessInjector::awaitReply()
+{
+    const ULONGLONG deadline = ::GetTickCount64() + s_replyTimeoutMs;
+    for (;;) {
+        char code = 0;
+        DWORD read = 0;
+        if (::ReadFile(m_pipe, &code, 1, &read, nullptr) && read == 1) {
+            return code;
+        }
+        // Non-blocking read with nothing to read: ERROR_NO_DATA. Anything else is the pipe gone.
+        const DWORD error = ::GetLastError();
+        if (read == 0 && error != ERROR_NO_DATA && error != ERROR_SUCCESS) {
+            return 0;
+        }
+        if (::GetTickCount64() >= deadline) {
+            return 0;
+        }
+        ::Sleep(1);
+    }
+}
+
+void UiAccessInjector::end()
+{
+    // Describes the helper this call ends; a stale value would release modifiers
+    // after unrelated sequences.
+    m_helperFailed = false;
+    if (m_pipe != INVALID_HANDLE_VALUE) {
+        // Every sent batch was acknowledged: nothing unread is discarded here.
+        ::DisconnectNamedPipe(m_pipe);
+        ::CloseHandle(m_pipe);
+        m_pipe = INVALID_HANDLE_VALUE;
+    }
+    if (m_process) {
+        // Closing the pipe asks the helper to exit. Waited for in pumped slices: GUI thread.
+        const ULONGLONG deadline = ::GetTickCount64() + s_helperExitTimeoutMs;
+        bool exited = ::WaitForSingleObject(m_process, 0) == WAIT_OBJECT_0;
+        while (!exited && ::GetTickCount64() < deadline) {
+            Tools::wait(20);
+            exited = ::WaitForSingleObject(m_process, 0) == WAIT_OBJECT_0;
+        }
+        if (!exited) {
+            // PROCESS_TERMINATE on a uiAccess process is write-up and denied to this
+            // one; the helper's idle backstop ends it then.
+            if (::TerminateProcess(m_process, 1)) {
+                qWarning("Auto-Type: the uiAccess helper did not exit; terminated");
+            } else {
+                qWarning("Auto-Type: the uiAccess helper did not exit and could not be terminated (%lu); "
+                         "it ends on its idle timeout",
+                         ::GetLastError());
+            }
+        }
+        DWORD code = 0;
+        const bool badExit = exited && ::GetExitCodeProcess(m_process, &code) && code != 0;
+        // A target that lost the foreground was answered per batch and is not a
+        // failure; any other exit that is not a clean 0 is.
+        m_helperFailed = !m_interrupted && (!exited || badExit);
+        if (m_helperFailed) {
+            qWarning("Auto-Type: the uiAccess helper ended with %lu; some keystrokes may not have arrived",
+                     exited ? code : 1u);
+        }
+        ::CloseHandle(m_process);
+        m_process = nullptr;
+    }
+    m_target = nullptr;
+}

--- a/src/autotype/windows/UiAccessInjector.h
+++ b/src/autotype/windows/UiAccessInjector.h
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPASSXC_UIACCESSINJECTOR_H
+#define KEEPASSXC_UIACCESSINJECTOR_H
+
+#include <QString>
+#include <windows.h>
+
+/**
+ * Delegates keystrokes to keepassxc-uiaccess-helper for the one window UIPI
+ * shields from a medium-integrity process: the CredentialUIBroker credential
+ * prompt (issue 12956). One helper per sequence; both ends verify each other; the
+ * pipe admits only the current user.
+ */
+class UiAccessInjector
+{
+public:
+    UiAccessInjector() = default;
+    ~UiAccessInjector();
+
+    Q_DISABLE_COPY(UiAccessInjector)
+
+    /** The installed helper, or empty when there is none to trust. */
+    static QString helperPath();
+
+    /** True when @p window is the credential prompt CredentialUIBroker owns. */
+    static bool isBrokeredCredentialDialog(HWND window);
+
+    /**
+     * Starts the helper for @p target.
+     *
+     * False when there is no helper, when Windows declined the grant, or when
+     * it did not connect; the caller must then keep using SendInput.
+     */
+    bool begin(HWND target);
+
+    /** True while a helper is connected and delegation is in effect. */
+    bool active() const;
+
+    /** Hands @p count INPUT records to the helper and waits for it to inject them. False: not injected. */
+    bool send(const INPUT* inputs, int count);
+    /** True when the helper stopped because the target lost the foreground: an interruption, not a failure. */
+    bool interrupted() const
+    {
+        return m_interrupted;
+    }
+
+    /** Closes the pipe, which is how the helper is asked to exit. */
+    void end();
+
+    /** True when the helper this injector last ended failed; set by end(). */
+    bool helperFailed() const
+    {
+        return m_helperFailed;
+    }
+
+private:
+    /** The helper's one-byte answer to the last batch; 0 on timeout or a broken pipe. */
+    char awaitReply();
+    /** Waits for the helper to connect. Never blocks indefinitely. */
+    bool waitForHelper();
+
+    static constexpr int s_helperConnectTimeoutMs = 3000;
+    static constexpr int s_helperConnectPollMs = 50;
+    static constexpr int s_helperExitTimeoutMs = 2000;
+    static constexpr int s_sendRetryMs = 500;
+    static constexpr int s_replyTimeoutMs = 2000;
+
+    bool m_helperFailed = false;
+    bool m_interrupted = false;
+    HANDLE m_pipe = INVALID_HANDLE_VALUE;
+    HANDLE m_process = nullptr;
+    HWND m_target = nullptr;
+};
+
+#endif // KEEPASSXC_UIACCESSINJECTOR_H

--- a/src/config-keepassx.h.in
+++ b/src/config-keepassx.h.in
@@ -25,6 +25,7 @@
 #cmakedefine KPXC_FEATURE_NETWORK
 #cmakedefine KPXC_FEATURE_UPDATES
 #cmakedefine KPXC_FEATURE_DOCS
+#cmakedefine KPXC_FEATURE_UIACCESS_HELPER
 
 /* Distribution */
 #cmakedefine KEEPASSXC_BUILD_TYPE "@KEEPASSXC_BUILD_TYPE@"

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -158,6 +158,8 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::Security_HidePasswordPreviewPanel, {QS("Security/HidePasswordPreviewPanel"), Roaming, true}},
     {Config::Security_HideTotpPreviewPanel, {QS("Security/HideTotpPreviewPanel"), Roaming, false}},
     {Config::Security_AutoTypeAsk, {QS("Security/AutotypeAsk"), Roaming, true}},
+    {Config::Security_AutoTypeCredentialPrompts,
+     {QS("Security/AutoTypeCredentialPrompts"), Roaming, false}},
     {Config::Security_AutoTypeSkipMainWindowConfirmation, {QS("Security/AutoTypeSkipMainWindowConfirmation"), Roaming, false}},
     {Config::Security_IconDownloadFallback, {QS("Security/IconDownloadFallback"), Roaming, false}},
     {Config::Security_NoConfirmMoveEntryToRecycleBin,{QS("Security/NoConfirmMoveEntryToRecycleBin"), Roaming, true}},

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -137,6 +137,7 @@ public:
         Security_HidePasswordPreviewPanel,
         Security_HideTotpPreviewPanel,
         Security_AutoTypeAsk,
+        Security_AutoTypeCredentialPrompts,
         Security_AutoTypeSkipMainWindowConfirmation,
         Security_IconDownloadFallback,
         Security_NoConfirmMoveEntryToRecycleBin,

--- a/src/uiaccess-helper/CMakeLists.txt
+++ b/src/uiaccess-helper/CMakeLists.txt
@@ -1,0 +1,35 @@
+#  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+if(KPXC_FEATURE_UIACCESS_HELPER)
+    # Plain C, no Qt: the binary carries uiAccess. WIN32_EXECUTABLE: no console
+    # window. The .rc embeds the manifest, the only form uiAccess is honoured
+    # from; MSVC would add a default one, MinGW does not.
+    add_executable(keepassxc-uiaccess-helper
+            keepassxc-uiaccess-helper.c
+            keepassxc-uiaccess-helper.rc)
+    target_link_libraries(keepassxc-uiaccess-helper user32 shell32 advapi32)
+    set_target_properties(keepassxc-uiaccess-helper PROPERTIES WIN32_EXECUTABLE ON)
+    if(MSVC)
+        target_link_options(keepassxc-uiaccess-helper PRIVATE "/MANIFEST:NO")
+    elseif(MINGW)
+        # wWinMain entry point.
+        target_link_options(keepassxc-uiaccess-helper PRIVATE "-municode")
+    endif()
+
+    # No BUNDLE destination: the target exists only on Windows.
+    install(TARGETS keepassxc-uiaccess-helper
+            RUNTIME DESTINATION ${BIN_INSTALL_DIR} COMPONENT Runtime)
+endif()

--- a/src/uiaccess-helper/keepassxc-uiaccess-helper.c
+++ b/src/uiaccess-helper/keepassxc-uiaccess-helper.c
@@ -1,0 +1,444 @@
+/*
+ *  Copyright (C) 2026 KeePassXC Team <team@keepassxc.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 or (at your option)
+ *  version 3 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Injects keystrokes into the "Windows Security" credential dialog on behalf of
+ * KeePassXC. UIPI discards SendInput from a medium-integrity process to that
+ * dialog (issue 12956); this binary carries uiAccess, which requires its own signed
+ * executable under a protected path (13070, 13116) and a ShellExecute launch.
+ *
+ * Scope is fixed at startup and re-checked per batch: the pipe server must be
+ * the KeePassXC beside this binary, the target must be a foreground credential
+ * dialog owned by CredentialUIBroker, batches are bounded, nothing is written
+ * to disk, and the process exits with the pipe.
+ *
+ * Usage: keepassxc-uiaccess-helper.exe --pipe <name> --target <hwnd>
+ */
+
+/* FILE_ID_INFO needs the Windows 8 SDK surface. */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0602
+#endif
+#include <windows.h>
+
+#include <shellapi.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/* One Auto-Type action at a time; the caller splits longer sequences. */
+#define MAX_BATCH 64
+
+/* Backstop for a caller that hangs holding the pipe; a sequence normally ends
+ * with the pipe. Long, because {DELAY} tokens are unbounded in count. */
+#define MAX_IDLE_MS 600000
+#define POLL_MS 25
+
+/* Nothing is injected into a window other than the one named at startup. */
+static HWND g_target = NULL;
+
+static void report(const char* format, ...)
+{
+    char message[512];
+    va_list args;
+    va_start(args, format);
+    _vsnprintf_s(message, sizeof(message), _TRUNCATE, format, args);
+    va_end(args);
+    OutputDebugStringA(message);
+}
+
+/* Read, not assumed: without the grant every SendInput is silently discarded. */
+static DWORD ui_access_flag(void)
+{
+    HANDLE token = NULL;
+    DWORD ui_access = 0;
+    DWORD size = 0;
+    if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+        /* TokenUIAccess == 26; older SDK headers have no enumerator for it. */
+        if (!GetTokenInformation(token, (TOKEN_INFORMATION_CLASS)26, &ui_access, sizeof(ui_access), &size)) {
+            report("keepassxc-uiaccess-helper: TokenUIAccess unreadable: %lu\n", GetLastError());
+        }
+        CloseHandle(token);
+    }
+    return ui_access;
+}
+
+/* The caller supplies only the name, so it may not escape the pipe namespace. */
+static int valid_pipe_name(const wchar_t* name)
+{
+    size_t length = 0;
+    if (!name || !*name) {
+        return 0;
+    }
+    for (const wchar_t* c = name; *c; ++c) {
+        if (*c == L'\\' || *c == L'/' || *c < 0x20) {
+            return 0;
+        }
+        if (++length > 64) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int image_path_of(DWORD pid, wchar_t* out, DWORD chars)
+{
+    HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!process) {
+        return 0;
+    }
+    DWORD size = chars;
+    const int ok = QueryFullProcessImageNameW(process, 0, out, &size) ? 1 : 0;
+    CloseHandle(process);
+    return ok;
+}
+
+/* Same file regardless of spelling (8.3, SUBST, junction): volume and file id,
+ * not paths. */
+static HANDLE open_for_identity(const wchar_t* path)
+{
+    /* FILE_SHARE_DELETE: another opener with delete sharing must not fail this open. */
+    return CreateFileW(path,
+                       0,
+                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                       NULL,
+                       OPEN_EXISTING,
+                       FILE_FLAG_BACKUP_SEMANTICS,
+                       NULL);
+}
+
+static int same_file(const wchar_t* left, const wchar_t* right)
+{
+    HANDLE first = open_for_identity(left);
+    if (first == INVALID_HANDLE_VALUE) {
+        return 0;
+    }
+    HANDLE second = open_for_identity(right);
+    if (second == INVALID_HANDLE_VALUE) {
+        CloseHandle(first);
+        return 0;
+    }
+    int ok = 0;
+    /* 128-bit ids where supported (ReFS truncates the 64-bit view); 64-bit otherwise. */
+    FILE_ID_INFO ia;
+    FILE_ID_INFO ib;
+    if (GetFileInformationByHandleEx(first, FileIdInfo, &ia, sizeof(ia))
+        && GetFileInformationByHandleEx(second, FileIdInfo, &ib, sizeof(ib))) {
+        ok = ia.VolumeSerialNumber == ib.VolumeSerialNumber && memcmp(&ia.FileId, &ib.FileId, sizeof(ia.FileId)) == 0;
+    } else {
+        BY_HANDLE_FILE_INFORMATION a;
+        BY_HANDLE_FILE_INFORMATION b;
+        ok = GetFileInformationByHandle(first, &a) && GetFileInformationByHandle(second, &b)
+             && a.dwVolumeSerialNumber == b.dwVolumeSerialNumber && a.nFileIndexHigh == b.nFileIndexHigh
+             && a.nFileIndexLow == b.nFileIndexLow;
+    }
+    CloseHandle(second);
+    CloseHandle(first);
+    return ok;
+}
+
+static int server_is_our_application(HANDLE pipe)
+{
+    DWORD server_pid = 0;
+    if (!GetNamedPipeServerProcessId(pipe, &server_pid)) {
+        report("keepassxc-uiaccess-helper: cannot identify the pipe server: %lu\n", GetLastError());
+        return 0;
+    }
+
+    wchar_t expected[MAX_PATH] = {0};
+    const DWORD own = GetModuleFileNameW(NULL, expected, MAX_PATH);
+    if (own == 0 || own >= MAX_PATH) {
+        return 0; /* truncated: not something to compare paths against */
+    }
+    wchar_t* slash = wcsrchr(expected, L'\\');
+    if (!slash) {
+        return 0;
+    }
+    if (_snwprintf_s(slash + 1, MAX_PATH - (size_t)(slash + 1 - expected), _TRUNCATE, L"KeePassXC.exe") < 0) {
+        return 0;
+    }
+
+    /* Held for the whole check, so the id cannot be reused mid-check. */
+    HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, server_pid);
+    if (!process) {
+        return 0;
+    }
+
+    wchar_t actual[MAX_PATH] = {0};
+    DWORD size = MAX_PATH;
+    if (!QueryFullProcessImageNameW(process, 0, actual, &size)) {
+        CloseHandle(process);
+        return 0;
+    }
+    if (!same_file(actual, expected)) {
+        report("keepassxc-uiaccess-helper: refusing a pipe served by %ls\n", actual);
+        CloseHandle(process);
+        return 0;
+    }
+
+    CloseHandle(process);
+    return 1;
+}
+
+/* The scope is fixed here; the caller cannot widen it. */
+static int target_is_credential_dialog(HWND window)
+{
+    wchar_t class_name[64] = {0};
+    if (!GetClassNameW(window, class_name, 64)) {
+        return 0;
+    }
+    if (wcscmp(class_name, L"Credential Dialog Xaml Host") != 0) {
+        return 0;
+    }
+
+    DWORD pid = 0;
+    GetWindowThreadProcessId(window, &pid);
+    wchar_t image[MAX_PATH] = {0};
+    if (!image_path_of(pid, image, MAX_PATH)) {
+        return 0;
+    }
+    /* Not GetSystemDirectoryW: redirected to SysWOW64 for a 32-bit process. */
+    wchar_t expected[MAX_PATH] = {0};
+    const UINT length = GetWindowsDirectoryW(expected, MAX_PATH);
+    if (length == 0 || length >= MAX_PATH) {
+        return 0;
+    }
+    if (_snwprintf_s(expected + length, MAX_PATH - length, _TRUNCATE, L"\\System32\\CredentialUIBroker.exe") < 0) {
+        return 0;
+    }
+    /* Runs per batch: equal text needs no file-identity check. */
+    if (_wcsicmp(image, expected) == 0) {
+        return 1;
+    }
+    if (!same_file(image, expected)) {
+        return 0;
+    }
+    return 1;
+}
+
+/* Releases the modifiers an aborted sequence may have left down. Not on a normal
+ * ending: the user may still hold the key that started Auto-Type. No Windows
+ * keys: a key-up can open Start. */
+static void release_modifiers(void)
+{
+    static const WORD keys[] = {
+        VK_SHIFT, VK_CONTROL, VK_MENU, VK_LSHIFT, VK_RSHIFT, VK_LCONTROL, VK_RCONTROL, VK_LMENU, VK_RMENU};
+    INPUT up[sizeof(keys) / sizeof(keys[0])];
+    ZeroMemory(up, sizeof(up));
+    for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i) {
+        up[i].type = INPUT_KEYBOARD;
+        up[i].ki.wVk = keys[i];
+        up[i].ki.dwFlags = KEYEVENTF_KEYUP;
+    }
+    SendInput((UINT)(sizeof(up) / sizeof(up[0])), up, sizeof(INPUT));
+}
+
+/* One byte back per batch: 'A' injected, 'F' target lost the foreground, 'S'
+ * SendInput dropped part of it. The caller waits for it before the next batch,
+ * so pacing and failure both land at the keystroke. */
+static void reply(HANDLE pipe, char code)
+{
+    DWORD written = 0;
+    WriteFile(pipe, &code, 1, &written, NULL);
+}
+
+/* Key-ups alone cannot type into the wrong window; they are released even after
+ * the target is gone, so a modifier or the Enter that submitted the prompt does
+ * not stay down. */
+static int keyups_only(const INPUT* batch, DWORD count)
+{
+    for (DWORD i = 0; i < count; ++i) {
+        if (batch[i].type != INPUT_KEYBOARD || !(batch[i].ki.dwFlags & KEYEVENTF_KEYUP)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int pipe_mode(const wchar_t* name)
+{
+    wchar_t path[MAX_PATH];
+    if (_snwprintf_s(path, MAX_PATH, _TRUNCATE, L"\\\\.\\pipe\\%ls", name) < 0) {
+        return 4;
+    }
+
+    /* SECURITY_ANONYMOUS: the server cannot impersonate this process before it is
+     * verified. Retried on ERROR_PIPE_BUSY: one stray client must not end this
+     * process. */
+    HANDLE pipe = INVALID_HANDLE_VALUE;
+    for (int attempt = 0; attempt < 20; ++attempt) {
+        pipe = CreateFileW(path,
+                           GENERIC_READ | GENERIC_WRITE,
+                           0,
+                           NULL,
+                           OPEN_EXISTING,
+                           SECURITY_SQOS_PRESENT | SECURITY_ANONYMOUS,
+                           NULL);
+        if (pipe != INVALID_HANDLE_VALUE || GetLastError() != ERROR_PIPE_BUSY) {
+            break;
+        }
+        WaitNamedPipeW(path, 50);
+    }
+    if (pipe == INVALID_HANDLE_VALUE) {
+        report("keepassxc-uiaccess-helper: pipe open failed: %lu\n", GetLastError());
+        return 4;
+    }
+
+    if (!server_is_our_application(pipe)) {
+        CloseHandle(pipe);
+        return 6;
+    }
+
+    /* Polled: a blocking read would outlive a caller that hangs holding the pipe. */
+    DWORD idle = 0;
+    for (;;) {
+        DWORD available = 0;
+        if (!PeekNamedPipe(pipe, NULL, 0, NULL, &available, NULL)) {
+            break; /* the caller closed the pipe: the sequence is over */
+        }
+        DWORD count = 0;
+        DWORD peeked = 0;
+        if (available >= sizeof(count) && !PeekNamedPipe(pipe, &count, sizeof(count), &peeked, NULL, NULL)) {
+            break;
+        }
+        if (count > MAX_BATCH) {
+            /* Every abort returns non-zero: the exit code is the only channel that
+             * can report a dropped last batch. */
+            report("keepassxc-uiaccess-helper: refusing a batch of %lu records\n", count);
+            release_modifiers();
+            CloseHandle(pipe);
+            return 7;
+        }
+
+        /* Consume nothing until the whole message is here, or a caller that stops
+         * mid-message parks this process past MAX_IDLE_MS. */
+        const DWORD wanted = count * (DWORD)sizeof(INPUT);
+        if (available >= sizeof(count) && count == 0) {
+            report("keepassxc-uiaccess-helper: refusing a batch of 0 records\n");
+            release_modifiers();
+            CloseHandle(pipe);
+            return 7;
+        }
+        if (available < sizeof(count) || available < sizeof(count) + wanted) {
+            if (idle >= MAX_IDLE_MS) {
+                report("keepassxc-uiaccess-helper: idle for %lums, exiting\n", idle);
+                release_modifiers();
+                CloseHandle(pipe);
+                return 8;
+            }
+            Sleep(POLL_MS);
+            idle += POLL_MS;
+            continue;
+        }
+        idle = 0;
+
+        INPUT batch[MAX_BATCH];
+        DWORD got = 0;
+        if (!ReadFile(pipe, &count, sizeof(count), &got, NULL) || got != sizeof(count)) {
+            break;
+        }
+        DWORD total = 0;
+        while (total < wanted) {
+            if (!ReadFile(pipe, ((char*)batch) + total, wanted - total, &got, NULL) || got == 0) {
+                report("keepassxc-uiaccess-helper: short read, %lu of %lu\n", total, wanted);
+                SecureZeroMemory(batch, total);
+                release_modifiers();
+                CloseHandle(pipe);
+                return 5;
+            }
+            total += got;
+        }
+
+        /* Per batch: a window handle can be reused after the dialog is destroyed. */
+        if (!keyups_only(batch, count)
+            && (GetForegroundWindow() != g_target || !target_is_credential_dialog(g_target))) {
+            /* Abort, never skip: a skipped batch is invisible to the caller and the
+             * rest of the sequence still arrives, possibly into the wrong field. */
+            report("keepassxc-uiaccess-helper: target lost the foreground, aborting the sequence\n");
+            SecureZeroMemory(batch, wanted);
+            release_modifiers();
+            reply(pipe, 'F');
+            CloseHandle(pipe);
+            return 9;
+        }
+
+        const UINT sent = SendInput(count, batch, sizeof(INPUT));
+        /* The batch held a password; nothing reads it again. */
+        SecureZeroMemory(batch, wanted);
+        if (sent != count) {
+            report("keepassxc-uiaccess-helper: SendInput queued %u of %lu: %lu\n", sent, count, GetLastError());
+            release_modifiers();
+            reply(pipe, 'S');
+            CloseHandle(pipe);
+            return 10;
+        }
+        reply(pipe, 'A');
+    }
+
+    CloseHandle(pipe);
+    return 0;
+}
+
+/* Windowed (no console on the taskbar); a windowed entry point has no argv. */
+int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, PWSTR command_line, int show)
+{
+    UNREFERENCED_PARAMETER(instance);
+    UNREFERENCED_PARAMETER(previous);
+    UNREFERENCED_PARAMETER(command_line);
+    UNREFERENCED_PARAMETER(show);
+
+    int argc = 0;
+    wchar_t** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (!argv) {
+        return 2;
+    }
+
+    const wchar_t* name = NULL;
+    for (int i = 1; i + 1 < argc; ++i) {
+        if (wcscmp(argv[i], L"--pipe") == 0) {
+            name = argv[++i];
+        } else if (wcscmp(argv[i], L"--target") == 0) {
+            g_target = (HWND)(uintptr_t)_wcstoui64(argv[++i], NULL, 10);
+        }
+    }
+
+    /* Without a target this would inject into whatever holds the foreground. */
+    if (!valid_pipe_name(name) || !g_target) {
+        report("keepassxc-uiaccess-helper: usage: --pipe <name> --target <hwnd>\n");
+        LocalFree(argv);
+        return 2;
+    }
+
+    /* Without uiAccess every SendInput is discarded while the caller believes it
+     * was delivered. */
+    if (!ui_access_flag()) {
+        report("keepassxc-uiaccess-helper: uiAccess was not granted\n");
+        LocalFree(argv);
+        return 3;
+    }
+
+    if (!target_is_credential_dialog(g_target)) {
+        report("keepassxc-uiaccess-helper: the target is not a brokered credential dialog\n");
+        LocalFree(argv);
+        return 3;
+    }
+
+    report("keepassxc-uiaccess-helper: target=%p\n", (void*)g_target);
+    const int rc = pipe_mode(name);
+    LocalFree(argv);
+    return rc;
+}

--- a/src/uiaccess-helper/keepassxc-uiaccess-helper.manifest
+++ b/src/uiaccess-helper/keepassxc-uiaccess-helper.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity version="1.0.0.0" name="org.keepassxc.uiaccess-helper" type="win32"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <!-- uiAccess is the whole point: exempt from UIPI, and no UAC prompt.
+             The granted token is measured at integrity 0x2010: above the
+             credential dialog's 0x200a, far below High's 0x3000, and not an
+             administrator. Windows grants
+             it only when the binary is Authenticode-signed by a certificate the
+             machine trusts *and* lives under a protected path such as
+             %ProgramFiles%; otherwise the launch fails outright. -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="true"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/src/uiaccess-helper/keepassxc-uiaccess-helper.rc
+++ b/src/uiaccess-helper/keepassxc-uiaccess-helper.rc
@@ -1,0 +1,4 @@
+#include <windows.h>
+/* CREATEPROCESS_MANIFEST_RESOURCE_ID / RT_MANIFEST: UAC settings are read only
+   from an embedded manifest. */
+1 24 "keepassxc-uiaccess-helper.manifest"


### PR DESCRIPTION
Since the [January 2026 Windows update](https://support.microsoft.com/en-us/topic/new-behavior-restricting-certain-applications-to-autofill-credentials-introduced-by-the-windows-january-2026-security-update-29c0bc94-2588-41f9-8534-f058aa5214d5) (CVE-2026-20824), Auto-Type no longer reaches the "Windows Security" credential prompt. The prompt belongs to `CredentialUIBroker.exe` at integrity `0x200a`; an ordinary process is `0x2000`, so UIPI drops the input silently (`SendInput` reports success, the fields stay empty).

This adds `keepassxc-uiaccess-helper`, a small `uiAccess` executable built and installed like `keepassxc-proxy`, and `AutoTypePlatform::beginSequence()`/`endSequence()` around the action loop. The helper is started only for a credential prompt (window class **and** owning image `credentialuibroker.exe`) and stopped afterwards. Off by default (`Security/AutoTypeCredentialPrompts`). Without the helper, or where uiAccess cannot be granted, `::SendInput` runs exactly as before and a warning says why. A separate binary is what keeps the portable ZIP working: `uiAccess` cannot be granted from a user-writable path, which is why #13070 was reverted in #13116.

Fixes #12956. This replaces the approach of #13070, reverted in #13116 because an unsigned `uiAccess` build does not start at all, and a signed one only gains the grant under Program Files. The three cases named in that revert behave as follows, each one measured below:

| install | behaviour |
| --- | --- |
| MSI / ZIP unpacked under `Program Files` (signed) | the helper is granted uiAccess; Auto-Type reaches the prompt — code: [the location rule](https://github.com/mangokingTW/keepassxc/blob/5840527aab17b14ee906b9d7bb445ddb992e1fea/src/autotype/windows/UiAccessInjector.cpp#L73-L103); recording: `credui-evidence-patched/session_recording.mp4` in [the run's artifact](https://github.com/mangokingTW/keepassxc/actions/runs/33993674882/artifacts/9977595696) |
| portable ZIP or any user-writable path | no helper is started; Auto-Type behaves exactly as it does today and the warning says why — code: [the location rule](https://github.com/mangokingTW/keepassxc/blob/5840527aab17b14ee906b9d7bb445ddb992e1fea/src/autotype/windows/UiAccessInjector.cpp#L73-L103) refuses, measured by [refusal-writable-location](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_refusals.py#L283-L292) ([copy_to_writable_location](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_refusals.py#L75-L90) moves the install to `%TEMP%`); recording: `credui-evidence-patched/refusals/refusal-writable-location/session_recording.mp4` in [the run's artifact](https://github.com/mangokingTW/keepassxc/actions/runs/33993674882/artifacts/9977595696) |
| unsigned build, or `Security/AutoTypeCredentialPrompts` off | no helper is started; Auto-Type behaves exactly as it does today — code: [the setting check](https://github.com/mangokingTW/keepassxc/blob/5840527aab17b14ee906b9d7bb445ddb992e1fea/src/autotype/windows/AutoTypeWindows.cpp#L118-L121) (unsigned: Windows refuses the uiAccess token and the launch fails, so it ends on the same path); measured by [refusal-opt-in-off](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_refusals.py#L278-L281); recording: `credui-evidence-patched/refusals/refusal-opt-in-off/session_recording.mp4` in [the run's artifact](https://github.com/mangokingTW/keepassxc/actions/runs/33993674882/artifacts/9977595696) |

## About this PR

I have run into this problem before. My [ImeModePersistence](https://github.com/mangokingTW/ImeModePersistence) tool needed to act on windows the main program was not allowed to touch, and the answer there was the same shape as here: a small separate helper that carries the privilege, so the main program does not have to be elevated and does not carry the risk. Building that tool also taught me how badly automated UI testing on Windows goes wrong in CI — which is why [wintegrate](https://github.com/mangokingTW/wintegrate) exists. I believe a PR written with generative AI is only worth a maintainer's time if it is cheap to verify and review, and for UI behaviour that means recordings and measurements a reviewer can open, not descriptions to take on trust. That is what the recordings and measurements below are for.

**Generative AI wrote the majority of the code, the test harness and this text** (Claude Code, model Claude Fable 5.1). I chose what to build, the trust model (peers verified by process identity and install location; the helper's signature is enforced by Windows, with no publisher pinning on top), what to measure and what counts as passing; the AI implemented it and worked through the review rounds. My English is limited, so every sentence here and in the comments is the AI relaying what I mean; if something reads wrong, the fault is mine and I will answer through the same channel. This PR is offered as a complete, end-to-end verified proposal: adopt it, ask for design changes, or decline it on the trade-offs. Nothing in it asks you to trust either of us: every claim about behaviour is backed by a recorded run.

## Screenshots

| `windows-latest` (Windows Server 2025, x64) | `windows-11-arm` (Windows 11 client), the same x64 build under x64 emulation |
|---|---|
| ![Patched build on windows-latest: Auto-Type fills the Windows Security prompt](https://raw.githubusercontent.com/mangokingTW/keepassxc/b6bdf1010dc52837fe3dd63d4619a6fa1b6a07ba/credui-auto-type-patched-x64.gif) | ![Patched build on windows-11-arm: Auto-Type fills the Windows Security prompt](https://raw.githubusercontent.com/mangokingTW/keepassxc/b6bdf1010dc52837fe3dd63d4619a6fa1b6a07ba/credui-auto-type-patched-arm64.gif) |

Where and how these were recorded: GitHub-hosted runners, [run 34001528719](https://github.com/mangokingTW/keepassxc/actions/runs/34001528719), patched build, the same x64 bundles on both machines. The right-hand one is not a native ARM64 build; what it adds is the client SKU the issue's reporters are on, and a second machine on which the OS has to grant uiAccess. The recorder is wintegrate's session recording of the runner's primary monitor; the red circles are its click markers and the strip at the bottom is its key overlay; neither is on the real screen. Real time, not sped up: 9.7 s to 18.7 s and 16.5 s to 27.4 s of the respective `session_recording.mp4` (in the artifacts and in the fork release linked below), from the moment KeePassXC becomes visible to capture — it excludes itself from screen capture until the harness turns that off through the View menu — to just after the prompt is filled. The prompt is a real `CredentialUIBroker` dialog raised by the harness; the credentials are the throwaway database's.

In the run's artifact, not inline: `credui-evidence-patched/{keepassxc-visible,prompt-up,confirmation-dialog,after-auto-type}.png` (KeePassXC unlocked; the `0x200a` prompt empty; the Auto-Type confirmation; the prompt after Auto-Type). The database is a throwaway the workflow creates.

## Testing strategy

A patched and an unpatched build from the same steps, each driven against a real `CredentialUIBroker` prompt on hosted runners. Build and verification: [run 33993674882](https://github.com/mangokingTW/keepassxc/actions/runs/33993674882) on `ca1fe093` (both variants from the same steps) with the test harness at `6e146789`, wintegrate 0.6.2 — fix works, control does not, all four refusal cases pass. [Run 34001528719](https://github.com/mangokingTW/keepassxc/actions/runs/34001528719) then verified the same two bundles again on `windows-latest` and on `windows-11-arm` (Windows 11 client, x64 under emulation; harness `8947d711`): both pairs hold, and the refusal cases pass on both. Actions artifacts in this fork expire after 14 days, so the zips are mirrored as assets of the fork releases [evidence-run-33993674882](https://github.com/mangokingTW/keepassxc/releases/tag/evidence-run-33993674882) and [evidence-run-34001528719](https://github.com/mangokingTW/keepassxc/releases/tag/evidence-run-34001528719) (`credui-evidence-{patched,control}[-arm64].zip`); the paths below are the same inside each. No unit test: the window under test belongs to another process at a higher integrity level.

| artifact → path (recording lengths vary by a few seconds per run) | shows | code (pinned to `6e146789`, harness branch) |
| --- | --- | --- |
| `credui-evidence-patched/session_recording.mp4` (~20 s) | Patched build: open → unlock → allow capture → select entry → raise prompt → Auto-Type; the prompt is filled and submitted. Steps captioned in the video, timed in `session_events.json`. | [open](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L698-L728) · [unlock](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L730-L746) · [allow capture](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L753-L755) · [select entry](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L757-L780) · [raise prompt](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L782-L829) · [auto-type](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L831-L901) · [ForegroundTrace](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L119-L222) · [Run the harness](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L457-L511) |
| `credui-evidence-patched/*.png` | The four stills above. | [keepassxc-visible](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L753-L755) · [prompt-up](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L782-L829) · [confirmation, after-auto-type](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L831-L901) |
| `credui-evidence-patched/helper-watch.log` | `started pid=… keepassxc-uiaccess-helper.exe integrity=uiAccess (0x2010)`. | [Run the harness](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L457-L511) |
| `credui-evidence-patched/harness.log`, `session_events.json` | KeePassXC `0x2000`, prompt `0x200a`, helper started, submitted → `VERDICT = fix works`. | [credui_host.py](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/credui_host.py#L1-L103) started at Medium by [run_at_medium_integrity.py](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/run_at_medium_integrity.py#L128-L205) · [verdict](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L903-L907) · [Judge this variant](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L512-L582) |
| `credui-evidence-control/session_recording.mp4` (~45 s) | Unpatched build, same steps: the prompt stays empty; no helper. | [Remove the patch for the control variant](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L79-L92) |
| `credui-evidence-patched/refusals/control-delegates/session_recording.mp4` (~25 s) | Positive control: the helper starts. | [control-delegates](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_refusals.py#L271-L276) · [run_sequence](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_refusals.py#L205-L248) · [Check what the patch refuses](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L583-L616) |
| `…/refusals/refusal-opt-in-off/session_recording.mp4` (~55 s) | Setting off → no helper. | [refusal-opt-in-off](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_refusals.py#L278-L281) |
| `…/refusals/refusal-writable-location/session_recording.mp4` (~55 s) | Installed where a standard user can write → no helper. | [refusal-writable-location](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_refusals.py#L283-L292) |
| `refusal-bad-target` (job log) | The helper, given a non-credential window, exits without opening the pipe. | [refusal-bad-target](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_refusals.py#L294-L308) |
| `*/preflight.json`, `kill_plan.json`, `READ_THIS_FIRST.md`, `session_events.jsonl`, `recording_anchor.json` | The harness's own record, written before anything can go wrong: console peers, what the sweep planned (nothing), the journal, wall→video time. | written by wintegrate |
| `kpxc-stage-patched`, `kpxc-stage-control` | The installed bundles; `reuse_run_id` re-verifies against them in ~3 min. | [build](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L60-L284) · [install](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L317-L351) · [sign](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L352-L378) · [create the test database](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L379-L414) · [pair](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/.github/workflows/wintegrate-credui-evidence.yml#L627-L664) |

The harness, refusal cases and workflow are in [mangokingTW/keepassxc#5](https://github.com/mangokingTW/keepassxc/pull/5) in my fork, kept out of this PR because they depend on wintegrate.

### What the test harness does, and does not, type

The harness sends keystrokes exactly once, and not into the prompt: the database master password into KeePassXC's own unlock field, in the *unlock* step — [`verify_with_wintegrate.py#L730-L739`](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L730-L739).

The *perform auto-type* step does three things and no more: it invokes KeePassXC's Auto-Type button through UIA, clicks **Yes** on KeePassXC's confirmation dialog, and then only polls the result file written by the credential host — [`verify_with_wintegrate.py#L831-L905`](https://github.com/mangokingTW/keepassxc/blob/6e1467893c7ae6b046ab7c50a8a9177a6acd4ea5/tests/ui-credui/verify_with_wintegrate.py#L831-L905). There is no key injection between the confirmation click and the outcome, so the `probeuser` that appears in the prompt was typed by KeePassXC's Auto-Type, not by the harness.

## Trust model

Both ends verify each other by process identity and install location: the pipe is per-sequence, randomly named, single-instance, local and current-user only; KeePassXC admits only the process it launched, and the helper only the `KeePassXC.exe` beside it, each holding the other's handle across the check. The helper's Authenticode signature is enforced by Windows as a condition of `uiAccess` (trusted chain **and** a secure directory), which is why the verification workflow signs both binaries before anything runs. The PR does not pin a specific publisher on top of that; if you want it, the check belongs beside the two identity checks (`UiAccessInjector::waitForHelper`, `server_is_our_application`) and can compare the certificate subject or a hash — it is one of the questions in the comments.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
- ✅ New feature (change that adds functionality)

New feature as well: an installed executable and two virtual methods on `AutoTypePlatformInterface`, compiled only on Windows. The helper is installed beside `keepassxc-proxy.exe` and is signed by the existing release step, which signs every `.exe`/`.dll` in the install directory; a build without it gets the old behaviour. Other platforms are unchanged. `KPXC_FEATURE_UIACCESS_HELPER` is on for Windows builds with MSVC or MinGW (MinGW links `uuid` for the `FOLDERID_*` GUIDs and the helper with `-municode`).

Design notes follow in the comments below, one topic each.













