### PR TITLE
Fixed a Secret Service Integration connection dereferencing a nullptr in some cases

### DIFF
--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -603,6 +603,14 @@ namespace FdoSecrets
 
     void Service::onDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget)
     {
+        if (!dbWidget) {
+            if (m_unlockingAnyDatabase) {
+                emit doneUnlockDatabaseInDialog(false, dbWidget);
+                m_unlockingAnyDatabase = false;
+            }
+            return;
+        }
+
         if (!m_unlockingAnyDatabase && !m_unlockingDb.contains(dbWidget)) {
             // not our concern
             return;

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -603,6 +603,7 @@ namespace FdoSecrets
 
     void Service::onDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget)
     {
+
         if (!dbWidget) {
             if (m_unlockingAnyDatabase) {
                 emit doneUnlockDatabaseInDialog(false, dbWidget);

--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -52,11 +52,6 @@ PasswordWidget::PasswordWidget(QWidget* parent)
 
     setEchoMode(QLineEdit::Password);
 
-    // use a monospace font for the password field
-    QFont passwordFont = Font::fixedFont();
-    passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
-    m_ui->passwordEdit->setFont(passwordFont);
-
     // Prevent conflicts with global Mac shortcuts (force Control on all platforms)
 #ifdef Q_OS_MAC
     constexpr auto modifier = Qt::MetaModifier;

--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -52,6 +52,11 @@ PasswordWidget::PasswordWidget(QWidget* parent)
 
     setEchoMode(QLineEdit::Password);
 
+    // use a monospace font for the password field
+    QFont passwordFont = Font::fixedFont();
+    passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
+    m_ui->passwordEdit->setFont(passwordFont);
+
     // Prevent conflicts with global Mac shortcuts (force Control on all platforms)
 #ifdef Q_OS_MAC
     constexpr auto modifier = Qt::MetaModifier;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1005,12 +1005,6 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_mainUi->revealNotesButton->setChecked(false);
     m_mainUi->notesEdit->setReadOnly(m_history);
     m_mainUi->notesEdit->setVisible(!config()->get(Config::Security_HideNotes).toBool());
-
-    // use a monospace font for the password field
-    // moved the font initializer from the constructor to form loader, so the password font gets applied
-    QFont passwordFont = Font::fixedFont();
-    passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
-    m_mainUi->passwordEdit->setFont(passwordFont);
     if (config()->get(Config::GUI_MonospaceNotes).toBool()) {
         m_mainUi->notesEdit->setFont(Font::fixedFont());
     } else {

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1005,6 +1005,12 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_mainUi->revealNotesButton->setChecked(false);
     m_mainUi->notesEdit->setReadOnly(m_history);
     m_mainUi->notesEdit->setVisible(!config()->get(Config::Security_HideNotes).toBool());
+
+    // use a monospace font for the password field
+    // moved the font initializer from the constructor to form loader, so the password font gets applied
+    QFont passwordFont = Font::fixedFont();
+    passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
+    m_mainUi->passwordEdit->setFont(passwordFont);
     if (config()->get(Config::GUI_MonospaceNotes).toBool()) {
         m_mainUi->notesEdit->setFont(Font::fixedFont());
     } else {


### PR DESCRIPTION
# FIX FOR #13265 

This PR resolves the issue where Secret Service request to unlock the database crashes keepassxc in some cases.

The crash happens because if  "Prompt to unlock database before searching" option in SSI is enabled, search requests prompt a database unlock prompt. And if by any chance the database is already unlocked, !m_unlockingAnyDatabase evaluates to true, causing an if statement in a file to evaluate to false. so the function does not return and tries to connect() a value that is nullptr. And the program crashes.

## Screenshots
**Database locked:**
<img width="1763" height="686" alt="Screenshot_20260907_164145" src="https://github.com/user-attachments/assets/f9ef8866-7c53-45b0-9a8a-68d6261957e4" />

**As shown, it doesnt cause any problem, but when the database is unlocked:**
<img width="1762" height="752" alt="Screenshot_20260907_164057" src="https://github.com/user-attachments/assets/37a07cb4-4791-429b-ba09-d24876ed27fa" />

**The program crashes with the output:**
<img width="1087" height="127" alt="image" src="https://github.com/user-attachments/assets/43a067e7-7fe4-4f34-b60e-0602481cc7ef" />

## Warning

I couldn't verify if the fix actually fully applies to the reporter's exact problem. If the issue persists, I will try to implement another fix.

## Testing strategy
I issued a repeated D-Bus search request on a terminal to reproduce the issue. Then asked AI to find the root cause and implemented a fix.


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)
