### PR TITLE
Fix for password font size not following app settings

### DIFF
--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -603,6 +603,14 @@ namespace FdoSecrets
 
     void Service::onDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget)
     {
+        if (!dbWidget) {
+            if (m_unlockingAnyDatabase) {
+                emit doneUnlockDatabaseInDialog(false, dbWidget);
+                m_unlockingAnyDatabase = false;
+            }
+            return;
+        }
+
         if (!m_unlockingAnyDatabase && !m_unlockingDb.contains(dbWidget)) {
             // not our concern
             return;

--- a/src/fdosecrets/objects/Service.cpp
+++ b/src/fdosecrets/objects/Service.cpp
@@ -603,14 +603,6 @@ namespace FdoSecrets
 
     void Service::onDatabaseUnlockDialogFinished(bool accepted, DatabaseWidget* dbWidget)
     {
-        if (!dbWidget) {
-            if (m_unlockingAnyDatabase) {
-                emit doneUnlockDatabaseInDialog(false, dbWidget);
-                m_unlockingAnyDatabase = false;
-            }
-            return;
-        }
-
         if (!m_unlockingAnyDatabase && !m_unlockingDb.contains(dbWidget)) {
             // not our concern
             return;

--- a/src/gui/PasswordWidget.cpp
+++ b/src/gui/PasswordWidget.cpp
@@ -52,11 +52,6 @@ PasswordWidget::PasswordWidget(QWidget* parent)
 
     setEchoMode(QLineEdit::Password);
 
-    // use a monospace font for the password field
-    QFont passwordFont = Font::fixedFont();
-    passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
-    m_ui->passwordEdit->setFont(passwordFont);
-
     // Prevent conflicts with global Mac shortcuts (force Control on all platforms)
 #ifdef Q_OS_MAC
     constexpr auto modifier = Qt::MetaModifier;

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1005,6 +1005,12 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     m_mainUi->revealNotesButton->setChecked(false);
     m_mainUi->notesEdit->setReadOnly(m_history);
     m_mainUi->notesEdit->setVisible(!config()->get(Config::Security_HideNotes).toBool());
+
+    // use a monospace font for the password field
+    // moved the font setter for PaswordWidget from the constructor to here
+    QFont passwordFont = Font::fixedFont();
+    passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
+    m_ui->passwordEdit->setFont(passwordFont);
     if (config()->get(Config::GUI_MonospaceNotes).toBool()) {
         m_mainUi->notesEdit->setFont(Font::fixedFont());
     } else {

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -1010,7 +1010,7 @@ void EditEntryWidget::setForms(Entry* entry, bool restore)
     // moved the font setter for PaswordWidget from the constructor to here
     QFont passwordFont = Font::fixedFont();
     passwordFont.setLetterSpacing(QFont::PercentageSpacing, 110);
-    m_ui->passwordEdit->setFont(passwordFont);
+    m_mainUi->passwordEdit->setFont(passwordFont);
     if (config()->get(Config::GUI_MonospaceNotes).toBool()) {
         m_mainUi->notesEdit->setFont(Font::fixedFont());
     } else {


### PR DESCRIPTION
## Fixes #13536

The reason font size was not changing was because the font size was being initialized in the constructor when opening the app or database. So I moved the initializer from the constructor to the form loader in `EditEntryWidget.cpp`. It is not the perfect fix for it but I decided it was suitable to the principles of this project.

## Testing strategy
1. Open an entry in EditEntryWidget.
2. Change the font size in settings and save the changes.
3. Reopen or reload the entry to verify that the font size now updates as expected without requiring an application restart.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)

